### PR TITLE
Apply default project to rows without project during ingestion

### DIFF
--- a/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
+++ b/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
@@ -279,6 +279,7 @@ public class DataflowJobManager implements JobManager {
     pipelineOptions.setFeatureSetJson(featureSetJsonCompressor.compress(featureSets));
     pipelineOptions.setStoreJson(Collections.singletonList(JsonFormat.printer().print(sink)));
     pipelineOptions.setProject(projectId);
+    pipelineOptions.setDefaultFeastProject(Project.DEFAULT_NAME);
     pipelineOptions.setUpdate(update);
     pipelineOptions.setRunner(DataflowRunner.class);
     pipelineOptions.setJobName(jobName);

--- a/core/src/main/java/feast/core/job/direct/DirectRunnerJobManager.java
+++ b/core/src/main/java/feast/core/job/direct/DirectRunnerJobManager.java
@@ -26,6 +26,7 @@ import feast.core.job.option.FeatureSetJsonByteConverter;
 import feast.core.model.FeatureSet;
 import feast.core.model.Job;
 import feast.core.model.JobStatus;
+import feast.core.model.Project;
 import feast.core.util.TypeConversion;
 import feast.ingestion.ImportJob;
 import feast.ingestion.options.BZip2Compressor;
@@ -105,6 +106,7 @@ public class DirectRunnerJobManager implements JobManager {
     pipelineOptions.setJobName(jobName);
     pipelineOptions.setStoreJson(Collections.singletonList(JsonFormat.printer().print(sink)));
     pipelineOptions.setRunner(DirectRunner.class);
+    pipelineOptions.setDefaultFeastProject(Project.DEFAULT_NAME);
     pipelineOptions.setProject(""); // set to default value to satisfy validation
     if (metrics.isEnabled()) {
       pipelineOptions.setMetricsExporterType(metrics.getType());

--- a/core/src/main/java/feast/core/model/Project.java
+++ b/core/src/main/java/feast/core/model/Project.java
@@ -34,6 +34,7 @@ import lombok.Setter;
 @Entity
 @Table(name = "projects")
 public class Project {
+  public static final String DEFAULT_NAME = "default";
 
   // Name of the project
   @Id

--- a/ingestion/src/main/java/feast/ingestion/ImportJob.java
+++ b/ingestion/src/main/java/feast/ingestion/ImportJob.java
@@ -130,6 +130,7 @@ public class ImportJob {
               .get(FEATURE_ROW_OUT)
               .apply(
                   ProcessAndValidateFeatureRows.newBuilder()
+                      .setDefaultProject(options.getDefaultFeastProject())
                       .setFeatureSetSpecs(featureSetSpecsByKey)
                       .setSuccessTag(FEATURE_ROW_OUT)
                       .setFailureTag(DEADLETTER_OUT)

--- a/ingestion/src/main/java/feast/ingestion/options/ImportOptions.java
+++ b/ingestion/src/main/java/feast/ingestion/options/ImportOptions.java
@@ -28,6 +28,12 @@ import org.apache.beam.sdk.options.Validation.Required;
 public interface ImportOptions extends PipelineOptions, DataflowPipelineOptions, DirectOptions {
 
   @Required
+  @Description("Default feast project to apply to incoming rows that do not specify project in its feature set reference.")
+  String getDefaultFeastProject();
+
+  void setDefaultFeastProject(String defaultProject);
+
+  @Required
   @Description(
       "JSON string representation of the FeatureSet that the import job will process, in BZip2 binary format."
           + "FeatureSet follows the format in feast.core.FeatureSet proto."

--- a/ingestion/src/main/java/feast/ingestion/options/ImportOptions.java
+++ b/ingestion/src/main/java/feast/ingestion/options/ImportOptions.java
@@ -28,7 +28,8 @@ import org.apache.beam.sdk.options.Validation.Required;
 public interface ImportOptions extends PipelineOptions, DataflowPipelineOptions, DirectOptions {
 
   @Required
-  @Description("Default feast project to apply to incoming rows that do not specify project in its feature set reference.")
+  @Description(
+      "Default feast project to apply to incoming rows that do not specify project in its feature set reference.")
   String getDefaultFeastProject();
 
   void setDefaultFeastProject(String defaultProject);

--- a/ingestion/src/main/java/feast/ingestion/transform/ProcessAndValidateFeatureRows.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/ProcessAndValidateFeatureRows.java
@@ -39,6 +39,8 @@ public abstract class ProcessAndValidateFeatureRows
 
   public abstract Map<String, FeatureSetProto.FeatureSetSpec> getFeatureSetSpecs();
 
+  public abstract String getDefaultProject();
+
   public abstract TupleTag<FeatureRow> getSuccessTag();
 
   public abstract TupleTag<FailedElement> getFailureTag();
@@ -52,6 +54,8 @@ public abstract class ProcessAndValidateFeatureRows
 
     public abstract Builder setFeatureSetSpecs(
         Map<String, FeatureSetProto.FeatureSetSpec> featureSets);
+
+    public abstract Builder setDefaultProject(String defaultProject);
 
     public abstract Builder setSuccessTag(TupleTag<FeatureRow> successTag);
 
@@ -69,7 +73,7 @@ public abstract class ProcessAndValidateFeatureRows
             .collect(Collectors.toMap(Pair::getLeft, Pair::getRight));
 
     return input
-        .apply("ProcessFeatureRows", ParDo.of(new ProcessFeatureRowDoFn()))
+        .apply("ProcessFeatureRows", ParDo.of(new ProcessFeatureRowDoFn(getDefaultProject())))
         .apply(
             "ValidateFeatureRows",
             ParDo.of(

--- a/ingestion/src/main/java/feast/ingestion/transform/fn/ProcessFeatureRowDoFn.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/fn/ProcessFeatureRowDoFn.java
@@ -32,8 +32,7 @@ public class ProcessFeatureRowDoFn extends DoFn<FeatureRow, FeatureRow> {
     FeatureRow featureRow = context.element();
     String featureSetId = stripVersion(featureRow.getFeatureSet());
     featureSetId = applyDefaultProject(featureSetId);
-    featureRow =
-        featureRow.toBuilder().setFeatureSet(featureSetId).build();
+    featureRow = featureRow.toBuilder().setFeatureSet(featureSetId).build();
     context.output(featureRow);
   }
 

--- a/ingestion/src/main/java/feast/ingestion/transform/fn/ProcessFeatureRowDoFn.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/fn/ProcessFeatureRowDoFn.java
@@ -21,11 +21,19 @@ import org.apache.beam.sdk.transforms.DoFn;
 
 public class ProcessFeatureRowDoFn extends DoFn<FeatureRow, FeatureRow> {
 
+  private String defaultProject;
+
+  public ProcessFeatureRowDoFn(String defaultProject) {
+    this.defaultProject = defaultProject;
+  }
+
   @ProcessElement
   public void processElement(ProcessContext context) {
     FeatureRow featureRow = context.element();
+    String featureSetId = stripVersion(featureRow.getFeatureSet());
+    featureSetId = applyDefaultProject(featureSetId);
     featureRow =
-        featureRow.toBuilder().setFeatureSet(stripVersion(featureRow.getFeatureSet())).build();
+        featureRow.toBuilder().setFeatureSet(featureSetId).build();
     context.output(featureRow);
   }
 
@@ -33,5 +41,13 @@ public class ProcessFeatureRowDoFn extends DoFn<FeatureRow, FeatureRow> {
   private String stripVersion(String featureSetId) {
     String[] split = featureSetId.split(":");
     return split[0];
+  }
+
+  private String applyDefaultProject(String featureSetId) {
+    String[] split = featureSetId.split("/");
+    if (split.length == 1) {
+      return defaultProject + "/" + featureSetId;
+    }
+    return featureSetId;
   }
 }

--- a/ingestion/src/test/java/feast/ingestion/ImportJobTest.java
+++ b/ingestion/src/test/java/feast/ingestion/ImportJobTest.java
@@ -176,6 +176,7 @@ public class ImportJobTest {
             });
     options.setFeatureSetJson(compressor.compress(spec));
     options.setStoreJson(Collections.singletonList(JsonFormat.printer().print(redis)));
+    options.setDefaultFeastProject("myproject");
     options.setProject("");
     options.setBlockOnRun(false);
 

--- a/ingestion/src/test/java/feast/ingestion/transform/ProcessAndValidateFeatureRowsTest.java
+++ b/ingestion/src/test/java/feast/ingestion/transform/ProcessAndValidateFeatureRowsTest.java
@@ -109,6 +109,7 @@ public class ProcessAndValidateFeatureRowsTest {
             .setCoder(ProtoCoder.of(FeatureRow.class))
             .apply(
                 ProcessAndValidateFeatureRows.newBuilder()
+                    .setDefaultProject("myproject")
                     .setFailureTag(FAILURE_TAG)
                     .setSuccessTag(SUCCESS_TAG)
                     .setFeatureSetSpecs(featureSetSpecs)
@@ -158,10 +159,60 @@ public class ProcessAndValidateFeatureRowsTest {
             .setCoder(ProtoCoder.of(FeatureRow.class))
             .apply(
                 ProcessAndValidateFeatureRows.newBuilder()
+                        .setDefaultProject("myproject")
                     .setFailureTag(FAILURE_TAG)
                     .setSuccessTag(SUCCESS_TAG)
                     .setFeatureSetSpecs(featureSetSpecs)
                     .build());
+
+    PAssert.that(output.get(SUCCESS_TAG)).containsInAnyOrder(expected);
+
+    p.run();
+  }
+
+  @Test
+  public void shouldApplyDefaultProject() {
+    FeatureSetSpec fs1 =
+            FeatureSetSpec.newBuilder()
+                    .setName("feature_set")
+                    .setProject("myproject")
+                    .addEntities(
+                            EntitySpec.newBuilder()
+                                    .setName("entity_id_primary")
+                                    .setValueType(Enum.INT32)
+                                    .build())
+                    .addEntities(
+                            EntitySpec.newBuilder()
+                                    .setName("entity_id_secondary")
+                                    .setValueType(Enum.STRING)
+                                    .build())
+                    .addFeatures(
+                            FeatureSpec.newBuilder().setName("feature_1").setValueType(Enum.STRING).build())
+                    .addFeatures(
+                            FeatureSpec.newBuilder().setName("feature_2").setValueType(Enum.INT64).build())
+                    .build();
+
+    Map<String, FeatureSetSpec> featureSetSpecs = new HashMap<>();
+    featureSetSpecs.put("myproject/feature_set", fs1);
+
+    List<FeatureRow> input = new ArrayList<>();
+    List<FeatureRow> expected = new ArrayList<>();
+
+    FeatureRow randomRow = TestUtil.createRandomFeatureRow(fs1);
+    expected.add(randomRow);
+    randomRow = randomRow.toBuilder().setFeatureSet("feature_set").build();
+    input.add(randomRow);
+
+    PCollectionTuple output =
+            p.apply(Create.of(input))
+                    .setCoder(ProtoCoder.of(FeatureRow.class))
+                    .apply(
+                            ProcessAndValidateFeatureRows.newBuilder()
+                                    .setDefaultProject("myproject")
+                                    .setFailureTag(FAILURE_TAG)
+                                    .setSuccessTag(SUCCESS_TAG)
+                                    .setFeatureSetSpecs(featureSetSpecs)
+                                    .build());
 
     PAssert.that(output.get(SUCCESS_TAG)).containsInAnyOrder(expected);
 
@@ -212,6 +263,7 @@ public class ProcessAndValidateFeatureRowsTest {
             .setCoder(ProtoCoder.of(FeatureRow.class))
             .apply(
                 ProcessAndValidateFeatureRows.newBuilder()
+                        .setDefaultProject("myproject")
                     .setFailureTag(FAILURE_TAG)
                     .setSuccessTag(SUCCESS_TAG)
                     .setFeatureSetSpecs(featureSets)

--- a/ingestion/src/test/java/feast/ingestion/transform/ProcessAndValidateFeatureRowsTest.java
+++ b/ingestion/src/test/java/feast/ingestion/transform/ProcessAndValidateFeatureRowsTest.java
@@ -159,7 +159,7 @@ public class ProcessAndValidateFeatureRowsTest {
             .setCoder(ProtoCoder.of(FeatureRow.class))
             .apply(
                 ProcessAndValidateFeatureRows.newBuilder()
-                        .setDefaultProject("myproject")
+                    .setDefaultProject("myproject")
                     .setFailureTag(FAILURE_TAG)
                     .setSuccessTag(SUCCESS_TAG)
                     .setFeatureSetSpecs(featureSetSpecs)
@@ -173,24 +173,24 @@ public class ProcessAndValidateFeatureRowsTest {
   @Test
   public void shouldApplyDefaultProject() {
     FeatureSetSpec fs1 =
-            FeatureSetSpec.newBuilder()
-                    .setName("feature_set")
-                    .setProject("myproject")
-                    .addEntities(
-                            EntitySpec.newBuilder()
-                                    .setName("entity_id_primary")
-                                    .setValueType(Enum.INT32)
-                                    .build())
-                    .addEntities(
-                            EntitySpec.newBuilder()
-                                    .setName("entity_id_secondary")
-                                    .setValueType(Enum.STRING)
-                                    .build())
-                    .addFeatures(
-                            FeatureSpec.newBuilder().setName("feature_1").setValueType(Enum.STRING).build())
-                    .addFeatures(
-                            FeatureSpec.newBuilder().setName("feature_2").setValueType(Enum.INT64).build())
-                    .build();
+        FeatureSetSpec.newBuilder()
+            .setName("feature_set")
+            .setProject("myproject")
+            .addEntities(
+                EntitySpec.newBuilder()
+                    .setName("entity_id_primary")
+                    .setValueType(Enum.INT32)
+                    .build())
+            .addEntities(
+                EntitySpec.newBuilder()
+                    .setName("entity_id_secondary")
+                    .setValueType(Enum.STRING)
+                    .build())
+            .addFeatures(
+                FeatureSpec.newBuilder().setName("feature_1").setValueType(Enum.STRING).build())
+            .addFeatures(
+                FeatureSpec.newBuilder().setName("feature_2").setValueType(Enum.INT64).build())
+            .build();
 
     Map<String, FeatureSetSpec> featureSetSpecs = new HashMap<>();
     featureSetSpecs.put("myproject/feature_set", fs1);
@@ -204,15 +204,15 @@ public class ProcessAndValidateFeatureRowsTest {
     input.add(randomRow);
 
     PCollectionTuple output =
-            p.apply(Create.of(input))
-                    .setCoder(ProtoCoder.of(FeatureRow.class))
-                    .apply(
-                            ProcessAndValidateFeatureRows.newBuilder()
-                                    .setDefaultProject("myproject")
-                                    .setFailureTag(FAILURE_TAG)
-                                    .setSuccessTag(SUCCESS_TAG)
-                                    .setFeatureSetSpecs(featureSetSpecs)
-                                    .build());
+        p.apply(Create.of(input))
+            .setCoder(ProtoCoder.of(FeatureRow.class))
+            .apply(
+                ProcessAndValidateFeatureRows.newBuilder()
+                    .setDefaultProject("myproject")
+                    .setFailureTag(FAILURE_TAG)
+                    .setSuccessTag(SUCCESS_TAG)
+                    .setFeatureSetSpecs(featureSetSpecs)
+                    .build());
 
     PAssert.that(output.get(SUCCESS_TAG)).containsInAnyOrder(expected);
 
@@ -263,7 +263,7 @@ public class ProcessAndValidateFeatureRowsTest {
             .setCoder(ProtoCoder.of(FeatureRow.class))
             .apply(
                 ProcessAndValidateFeatureRows.newBuilder()
-                        .setDefaultProject("myproject")
+                    .setDefaultProject("myproject")
                     .setFailureTag(FAILURE_TAG)
                     .setSuccessTag(SUCCESS_TAG)
                     .setFeatureSetSpecs(featureSets)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/gojek/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/gojek/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Extension to #693. Feast Core deploys Feast ingestion jobs with a parameter that sets its default project. This default project is just a string (using “default” for now).

When a FeatureRow is read from Kafka with with a complete feature set reference (`project/feature_set`) then it is processed as normal. However, when a FeatureRow is read in with a feature set reference missing project (just `featureset`), then Feast Ingestion prepends the default project string to this reference.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Feature rows can be ingested with just the feature set name. Feast core will apply the default project to those feature rows.
```
