### PR TITLE
Add support for labels on feature sets

### DIFF
--- a/sdk/python/feast/feature.py
+++ b/sdk/python/feast/feature.py
@@ -28,6 +28,7 @@ class Feature(Field):
         return FeatureProto(
             name=self.name,
             value_type=value_type,
+            labels=self.labels,
             presence=self.presence,
             group_presence=self.group_presence,
             shape=self.shape,
@@ -57,7 +58,7 @@ class Feature(Field):
             Feature object
         """
         feature = cls(
-            name=feature_proto.name, dtype=ValueType(feature_proto.value_type),
+            name=feature_proto.name, dtype=ValueType(feature_proto.value_type), labels=feature_proto.labels
         )
         feature.update_presence_constraints(feature_proto)
         feature.update_shape_type(feature_proto)

--- a/sdk/python/feast/feature.py
+++ b/sdk/python/feast/feature.py
@@ -58,7 +58,9 @@ class Feature(Field):
             Feature object
         """
         feature = cls(
-            name=feature_proto.name, dtype=ValueType(feature_proto.value_type), labels=feature_proto.labels
+            name=feature_proto.name,
+            dtype=ValueType(feature_proto.value_type),
+            labels=feature_proto.labels,
         )
         feature.update_presence_constraints(feature_proto)
         feature.update_shape_type(feature_proto)

--- a/sdk/python/feast/feature_set.py
+++ b/sdk/python/feast/feature_set.py
@@ -86,7 +86,8 @@ class FeatureSet:
                 return False
 
         if (
-            self.name != other.name
+            self.labels != other.labels
+            or self.name != other.name
             or self.project != other.project
             or self.max_age != other.max_age
         ):

--- a/sdk/python/feast/feature_set.py
+++ b/sdk/python/feast/feature_set.py
@@ -69,8 +69,11 @@ class FeatureSet:
             self._source = None
         else:
             self._source = source
+        if labels is None:
+            self._labels = OrderedDict()
+        else:
+            self._labels = labels
         self._max_age = max_age
-        self._labels = labels
         self._status = None
         self._created_timestamp = None
 
@@ -267,19 +270,13 @@ class FeatureSet:
         """
         Sets the label value for a given key
         """
-        if not self.labels:
-            self.labels = {key: value}
-        else:
-            self.labels[key] = value
+        self.labels[key] = value
 
     def remove_label(self, key: str):
         """
         Removes a label based on key
         """
-        if not self.labels or key not in self.labels.keys():
-            raise ValueError("Could not find label key " + key + ", no action taken")
-        elif key in self.labels.keys():
-            del self.labels[key]
+        del self.labels[key]
 
     def add(self, resource):
         """

--- a/sdk/python/feast/feature_set.py
+++ b/sdk/python/feast/feature_set.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import warnings
 from collections import OrderedDict
-from typing import Dict, List, Optional, MutableMapping
+from typing import Dict, List, MutableMapping, Optional
 
 import pandas as pd
 from google.protobuf import json_format
@@ -56,7 +56,7 @@ class FeatureSet:
         entities: List[Entity] = None,
         source: Source = None,
         max_age: Optional[Duration] = None,
-        labels: Optional[MutableMapping[str, str]] = None
+        labels: Optional[MutableMapping[str, str]] = None,
     ):
         self._name = name
         self._project = project

--- a/sdk/python/feast/feature_set.py
+++ b/sdk/python/feast/feature_set.py
@@ -312,11 +312,7 @@ class FeatureSet:
         Args:
             name: Name of Feature or Entity to be removed
         """
-        if name not in self._fields:
-            raise ValueError("Could not find field " + name + ", no action taken")
-        if name in self._fields:
-            del self._fields[name]
-            return
+        del self._fields[name]
 
     def _add_fields(self, fields: List[Field]):
         """

--- a/sdk/python/feast/field.py
+++ b/sdk/python/feast/field.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Union
+from typing import Union, MutableMapping, Optional
 
 from feast.core.FeatureSet_pb2 import EntitySpec, FeatureSpec
 from feast.value_type import ValueType
@@ -24,11 +24,12 @@ class Field:
     features.
     """
 
-    def __init__(self, name: str, dtype: ValueType):
+    def __init__(self, name: str, dtype: ValueType, labels: Optional[MutableMapping[str, str]] = None):
         self._name = name
         if not isinstance(dtype, ValueType):
             raise ValueError("dtype is not a valid ValueType")
         self._dtype = dtype
+        self._labels = labels
         self._presence = None
         self._group_presence = None
         self._shape = None
@@ -64,6 +65,13 @@ class Field:
         Getter for data type of this field
         """
         return self._dtype
+
+    @property
+    def labels(self) -> MutableMapping[str, str]:
+        """
+        Getter for labels of this field
+        """
+        return self._presence
 
     @property
     def presence(self) -> schema_pb2.FeaturePresence:

--- a/sdk/python/feast/field.py
+++ b/sdk/python/feast/field.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections import OrderedDict
 from typing import MutableMapping, Optional, Union
 
 from feast.core.FeatureSet_pb2 import EntitySpec, FeatureSpec
@@ -34,7 +35,10 @@ class Field:
         if not isinstance(dtype, ValueType):
             raise ValueError("dtype is not a valid ValueType")
         self._dtype = dtype
-        self._labels = labels
+        if labels is None:
+            self._labels = OrderedDict()
+        else:
+            self._labels = labels
         self._presence = None
         self._group_presence = None
         self._shape = None
@@ -53,7 +57,11 @@ class Field:
         self._time_of_day_domain = None
 
     def __eq__(self, other):
-        if self.name != other.name or self.dtype != other.dtype:
+        if (
+            self.name != other.name
+            or self.dtype != other.dtype
+            or self.labels != other.labels
+        ):
             return False
         return True
 
@@ -76,7 +84,7 @@ class Field:
         """
         Getter for labels of this field
         """
-        return self._presence
+        return self._labels
 
     @property
     def presence(self) -> schema_pb2.FeaturePresence:

--- a/sdk/python/feast/field.py
+++ b/sdk/python/feast/field.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Union, MutableMapping, Optional
+from typing import MutableMapping, Optional, Union
 
 from feast.core.FeatureSet_pb2 import EntitySpec, FeatureSpec
 from feast.value_type import ValueType
@@ -24,7 +24,12 @@ class Field:
     features.
     """
 
-    def __init__(self, name: str, dtype: ValueType, labels: Optional[MutableMapping[str, str]] = None):
+    def __init__(
+        self,
+        name: str,
+        dtype: ValueType,
+        labels: Optional[MutableMapping[str, str]] = None,
+    ):
         self._name = name
         if not isinstance(dtype, ValueType):
             raise ValueError("dtype is not a valid ValueType")

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -276,6 +276,7 @@ class TestClient:
                     spec=FeatureSetSpecProto(
                         name="my_feature_set",
                         max_age=Duration(seconds=3600),
+                        labels={'key1': 'val1', 'key2': 'val2'},
                         features=[
                             FeatureSpecProto(
                                 name="my_feature_1",
@@ -308,6 +309,10 @@ class TestClient:
 
         assert (
             feature_set.name == "my_feature_set"
+            and 'key1' in feature_set.labels
+            and feature_set.labels['key1'] == 'val1'
+            and 'key2' in feature_set.labels
+            and feature_set.labels['key2'] == 'val2'
             and feature_set.fields["my_feature_1"].name == "my_feature_1"
             and feature_set.fields["my_feature_1"].dtype == ValueType.FLOAT
             and feature_set.fields["my_entity_1"].name == "my_entity_1"

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -276,7 +276,7 @@ class TestClient:
                     spec=FeatureSetSpecProto(
                         name="my_feature_set",
                         max_age=Duration(seconds=3600),
-                        labels={'key1': 'val1', 'key2': 'val2'},
+                        labels={"key1": "val1", "key2": "val2"},
                         features=[
                             FeatureSpecProto(
                                 name="my_feature_1",
@@ -309,10 +309,10 @@ class TestClient:
 
         assert (
             feature_set.name == "my_feature_set"
-            and 'key1' in feature_set.labels
-            and feature_set.labels['key1'] == 'val1'
-            and 'key2' in feature_set.labels
-            and feature_set.labels['key2'] == 'val2'
+            and "key1" in feature_set.labels
+            and feature_set.labels["key1"] == "val1"
+            and "key2" in feature_set.labels
+            and feature_set.labels["key2"] == "val2"
             and feature_set.fields["my_feature_1"].name == "my_feature_1"
             and feature_set.fields["my_feature_1"].dtype == ValueType.FLOAT
             and feature_set.fields["my_entity_1"].name == "my_entity_1"

--- a/sdk/python/tests/test_feature_set.py
+++ b/sdk/python/tests/test_feature_set.py
@@ -287,6 +287,54 @@ def make_tfx_schema_domain_info_inline(schema):
                 feature.int_domain.MergeFrom(domain_ref_to_int_domain[domain_ref])
 
 
+def test_feature_set_class_contains_labels():
+    fs = FeatureSet("my-feature-set", labels={'key1': 'val1', 'key2': 'val2'})
+    assert 'key1' in fs.labels.keys() and fs.labels['key1'] == 'val1'
+    assert 'key2' in fs.labels.keys() and fs.labels['key2'] == 'val2'
+
+
+def test_feature_set_without_labels():
+    fs = FeatureSet("my-feature-set")
+    assert fs.labels is None
+
+
+def test_set_labels_adds_to_class():
+    fs = FeatureSet("my-feature-set")
+    fs.set_label('k1', 'v1')
+    assert fs.labels['k1'] == 'v1'
+
+
+def test_set_labels_overwrites_existing():
+    fs = FeatureSet("my-feature-set")
+    fs.set_label('k1', 'v1')
+    fs.set_label('k1', 'v2')
+    assert fs.labels['k1'] == 'v2'
+
+
+def test_remove_labels_empty_failure():
+    fs = FeatureSet("my-feature-set")
+    with pytest.raises(ValueError):
+        fs.remove_label('key1')
+
+
+def test_remove_labels_invalid_key_failure():
+    fs = FeatureSet("my-feature-set")
+    fs.set_label('k1', 'v1')
+    with pytest.raises(ValueError):
+        fs.remove_label('key1')
+
+
+def test_feature_set_unequal_based_on_labels():
+    fs1 = FeatureSet("my-feature-set")
+    fs2 = FeatureSet("my-feature-set")
+    assert fs1 == fs2
+    fs1.set_label('k1', 'v1')
+    fs2.set_label('k1', 'v1')
+    assert fs1 == fs2
+    fs2.set_label('k1', 'unequal')
+    assert not fs1 == fs2
+
+
 class TestFeatureSetRef:
     def test_from_feature_set(self):
         feature_set = FeatureSet("test", "test")

--- a/sdk/python/tests/test_feature_set.py
+++ b/sdk/python/tests/test_feature_set.py
@@ -335,6 +335,14 @@ def test_feature_set_unequal_based_on_labels():
     assert not fs1 == fs2
 
 
+def test_feature_set_unequal_other_has_no_labels():
+    fs1 = FeatureSet("my-feature-set")
+    fs2 = FeatureSet("my-feature-set")
+    assert fs1 == fs2
+    fs1.set_label("k1", "v1")
+    assert not fs1 == fs2
+
+
 class TestFeatureSetRef:
     def test_from_feature_set(self):
         feature_set = FeatureSet("test", "test")

--- a/sdk/python/tests/test_feature_set.py
+++ b/sdk/python/tests/test_feature_set.py
@@ -63,7 +63,7 @@ class TestFeatureSet:
         assert len(fs.features) == 1 and fs.features[0].name == "my-feature-2"
 
     def test_remove_feature_failure(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(KeyError):
             fs = FeatureSet("my-feature-set")
             fs.drop(name="my-feature-1")
 

--- a/sdk/python/tests/test_feature_set.py
+++ b/sdk/python/tests/test_feature_set.py
@@ -288,9 +288,9 @@ def make_tfx_schema_domain_info_inline(schema):
 
 
 def test_feature_set_class_contains_labels():
-    fs = FeatureSet("my-feature-set", labels={'key1': 'val1', 'key2': 'val2'})
-    assert 'key1' in fs.labels.keys() and fs.labels['key1'] == 'val1'
-    assert 'key2' in fs.labels.keys() and fs.labels['key2'] == 'val2'
+    fs = FeatureSet("my-feature-set", labels={"key1": "val1", "key2": "val2"})
+    assert "key1" in fs.labels.keys() and fs.labels["key1"] == "val1"
+    assert "key2" in fs.labels.keys() and fs.labels["key2"] == "val2"
 
 
 def test_feature_set_without_labels():
@@ -300,38 +300,38 @@ def test_feature_set_without_labels():
 
 def test_set_labels_adds_to_class():
     fs = FeatureSet("my-feature-set")
-    fs.set_label('k1', 'v1')
-    assert fs.labels['k1'] == 'v1'
+    fs.set_label("k1", "v1")
+    assert fs.labels["k1"] == "v1"
 
 
 def test_set_labels_overwrites_existing():
     fs = FeatureSet("my-feature-set")
-    fs.set_label('k1', 'v1')
-    fs.set_label('k1', 'v2')
-    assert fs.labels['k1'] == 'v2'
+    fs.set_label("k1", "v1")
+    fs.set_label("k1", "v2")
+    assert fs.labels["k1"] == "v2"
 
 
 def test_remove_labels_empty_failure():
     fs = FeatureSet("my-feature-set")
     with pytest.raises(ValueError):
-        fs.remove_label('key1')
+        fs.remove_label("key1")
 
 
 def test_remove_labels_invalid_key_failure():
     fs = FeatureSet("my-feature-set")
-    fs.set_label('k1', 'v1')
+    fs.set_label("k1", "v1")
     with pytest.raises(ValueError):
-        fs.remove_label('key1')
+        fs.remove_label("key1")
 
 
 def test_feature_set_unequal_based_on_labels():
     fs1 = FeatureSet("my-feature-set")
     fs2 = FeatureSet("my-feature-set")
     assert fs1 == fs2
-    fs1.set_label('k1', 'v1')
-    fs2.set_label('k1', 'v1')
+    fs1.set_label("k1", "v1")
+    fs2.set_label("k1", "v1")
     assert fs1 == fs2
-    fs2.set_label('k1', 'unequal')
+    fs2.set_label("k1", "unequal")
     assert not fs1 == fs2
 
 

--- a/tests/e2e/redis/basic-ingest-redis-serving.py
+++ b/tests/e2e/redis/basic-ingest-redis-serving.py
@@ -688,11 +688,16 @@ class TestsBasedOnGrpc:
     @pytest.mark.run(order=51)
     def test_register_feature_set_with_labels(self, core_service_stub):
         feature_set_name = "test_feature_set_labels"
-        feature_set_proto = FeatureSet(feature_set_name, PROJECT_NAME).to_proto()
-        feature_set_proto.spec.labels[self.LABEL_KEY] = self.LABEL_VALUE
+        feature_set_proto = FeatureSet(
+            name=feature_set_name,
+            project=PROJECT_NAME,
+            labels={self.LABEL_KEY: self.LABEL_VALUE},
+        ).to_proto()
         self.apply_feature_set(core_service_stub, feature_set_proto)
 
-        retrieved_feature_set = self.get_feature_set(core_service_stub, feature_set_name, PROJECT_NAME)
+        retrieved_feature_set = self.get_feature_set(
+            core_service_stub, feature_set_name, PROJECT_NAME
+        )
 
         assert self.LABEL_KEY in retrieved_feature_set.spec.labels
         assert retrieved_feature_set.spec.labels[self.LABEL_KEY] == self.LABEL_VALUE
@@ -701,12 +706,22 @@ class TestsBasedOnGrpc:
     @pytest.mark.run(order=52)
     def test_register_feature_with_labels(self, core_service_stub):
         feature_set_name = "test_feature_labels"
-        feature_set_proto = FeatureSet(feature_set_name, PROJECT_NAME, features=[Feature("rating", ValueType.INT64)]) \
-            .to_proto()
-        feature_set_proto.spec.features[0].labels[self.LABEL_KEY] = self.LABEL_VALUE
+        feature_set_proto = FeatureSet(
+            name=feature_set_name,
+            project=PROJECT_NAME,
+            features=[
+                Feature(
+                    name="rating",
+                    dtype=ValueType.INT64,
+                    labels={self.LABEL_KEY: self.LABEL_VALUE},
+                )
+            ],
+        ).to_proto()
         self.apply_feature_set(core_service_stub, feature_set_proto)
 
-        retrieved_feature_set = self.get_feature_set(core_service_stub, feature_set_name, PROJECT_NAME)
+        retrieved_feature_set = self.get_feature_set(
+            core_service_stub, feature_set_name, PROJECT_NAME
+        )
         retrieved_feature = retrieved_feature_set.spec.features[0]
 
         assert self.LABEL_KEY in retrieved_feature.labels


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding labels to Python sdk with relevant FeatureSet class functions:
```python
set_label(key: str, value: str)
remove_label(key: str)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #663 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can use the Python SDK to add metadata to feature sets in the form of labels.
```
