### PR TITLE
Fix kubectl installation on dataflow e2e test

### DIFF
--- a/infra/scripts/test-end-to-end-batch-dataflow.sh
+++ b/infra/scripts/test-end-to-end-batch-dataflow.sh
@@ -4,7 +4,7 @@ echo "Preparing environment variables..."
 set -e
 set -o pipefail
 
-test -z ${GOOGLE_APPLICATION_CREDENTIALS} && GOOGLE_APPLICATION_CREDENTIALS="/etc/service-account/service-account-df.json"
+test -z ${GOOGLE_APPLICATION_CREDENTIALS} && GOOGLE_APPLICATION_CREDENTIALS="/etc/service-account-df/service-account-df.json"
 test -z ${GCLOUD_PROJECT} && GCLOUD_PROJECT="kf-feast"
 test -z ${GCLOUD_REGION} && GCLOUD_REGION="us-central1"
 test -z ${GCLOUD_NETWORK} && GCLOUD_NETWORK="default"
@@ -38,10 +38,15 @@ Installing gcloud SDK and required packages
 ============================================================
 "
 apt-get -qq update
-apt-get -y install wget netcat kafkacat build-essential gettext-base curl kubectl
+apt-get -y install wget netcat kafkacat build-essential gettext-base curl apt-transport-https gnupg2
+
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 chmod 700 $ORIGINAL_DIR/get_helm.sh
 $ORIGINAL_DIR/get_helm.sh
+
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+chmod +x ./kubectl
+mv ./kubectl /usr/local/bin/kubectl
 
 if [[ ! $(command -v gsutil) ]]; then
   CURRENT_DIR=$(dirname "$BASH_SOURCE")


### PR DESCRIPTION
**What this PR does / why we need it**:
The current dataflow e2e test attempts to install kubectl via apt, but it will fail because the package is not available. This PR uses alternative way to install kubectl.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
