### PR TITLE
Add feature set status JOB_STARTING to denote feature sets waiting for job to get to RUNNING state

### DIFF
--- a/core/src/main/java/feast/core/job/JobUpdateTask.java
+++ b/core/src/main/java/feast/core/job/JobUpdateTask.java
@@ -25,6 +25,7 @@ import feast.core.model.Job;
 import feast.core.model.JobStatus;
 import feast.core.model.Source;
 import feast.core.model.Store;
+import feast.proto.core.FeatureSetProto.FeatureSetStatus;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -102,7 +103,16 @@ public class JobUpdateTask implements Callable<Job> {
 
   boolean requiresUpdate(Job job) {
     // If set of feature sets has changed
-    return !Sets.newHashSet(featureSets).equals(Sets.newHashSet(job.getFeatureSets()));
+    if (!Sets.newHashSet(featureSets).equals(Sets.newHashSet(job.getFeatureSets()))) {
+      return true;
+    }
+    // If any of the incoming feature sets were updated
+    for (FeatureSet featureSet : featureSets) {
+      if (featureSet.getStatus() == FeatureSetStatus.STATUS_PENDING) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private Job createJob() {

--- a/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
+++ b/core/src/main/java/feast/core/job/dataflow/DataflowJobManager.java
@@ -162,6 +162,7 @@ public class DataflowJobManager implements JobManager {
               true);
 
       job.setExtId(extId);
+      job.setStatus(JobStatus.PENDING);
       return job;
     } catch (InvalidProtocolBufferException e) {
       log.error(e.getMessage());

--- a/core/src/test/java/feast/core/service/JobCoordinatorServiceTest.java
+++ b/core/src/test/java/feast/core/service/JobCoordinatorServiceTest.java
@@ -51,6 +51,7 @@ import feast.proto.core.StoreProto.Store.RedisConfig;
 import feast.proto.core.StoreProto.Store.StoreType;
 import feast.proto.core.StoreProto.Store.Subscription;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
@@ -149,7 +150,7 @@ public class JobCoordinatorServiceTest {
             .build();
     FeatureSet featureSet2 = FeatureSet.fromProto(featureSetProto2);
     String extId = "ext";
-    ArgumentCaptor<Job> jobArgCaptor = ArgumentCaptor.forClass(Job.class);
+    ArgumentCaptor<List<Job>> jobArgCaptor = ArgumentCaptor.forClass(List.class);
 
     Job expectedInput =
         new Job(
@@ -183,9 +184,9 @@ public class JobCoordinatorServiceTest {
         new JobCoordinatorService(
             jobRepository, featureSetRepository, specService, jobManager, feastProperties);
     jcs.Poll();
-    verify(jobRepository, times(1)).saveAndFlush(jobArgCaptor.capture());
-    Job actual = jobArgCaptor.getValue();
-    assertThat(actual, equalTo(expected));
+    verify(jobRepository, times(1)).saveAll(jobArgCaptor.capture());
+    List<Job> actual = jobArgCaptor.getValue();
+    assertThat(actual, equalTo(Collections.singletonList(expected)));
   }
 
   @Test
@@ -277,7 +278,7 @@ public class JobCoordinatorServiceTest {
             feast.core.model.Store.fromProto(store),
             Arrays.asList(featureSet2),
             JobStatus.RUNNING);
-    ArgumentCaptor<Job> jobArgCaptor = ArgumentCaptor.forClass(Job.class);
+    ArgumentCaptor<List<Job>> jobArgCaptor = ArgumentCaptor.forClass(List.class);
 
     when(featureSetRepository.findAllByNameLikeAndProject_NameLikeOrderByNameAsc("%", "project1"))
         .thenReturn(Lists.newArrayList(featureSet1, featureSet2));
@@ -294,8 +295,8 @@ public class JobCoordinatorServiceTest {
             jobRepository, featureSetRepository, specService, jobManager, feastProperties);
     jcs.Poll();
 
-    verify(jobRepository, times(2)).saveAndFlush(jobArgCaptor.capture());
-    List<Job> actual = jobArgCaptor.getAllValues();
+    verify(jobRepository, times(1)).saveAll(jobArgCaptor.capture());
+    List<Job> actual = jobArgCaptor.getValue();
 
     assertThat(actual.get(0), equalTo(expected1));
     assertThat(actual.get(1), equalTo(expected2));

--- a/protos/feast/core/FeatureSet.proto
+++ b/protos/feast/core/FeatureSet.proto
@@ -147,5 +147,6 @@ message FeatureSetMeta {
 enum FeatureSetStatus {
     STATUS_INVALID = 0;
     STATUS_PENDING = 1;
+    STATUS_JOB_STARTING = 3;
     STATUS_READY = 2;
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Removal of PENDING status check in #708 causes jobs to be unable to track feature set updates.

This PR adds a new status STATUS_JOB_STARTING to denote that a feature set was updated, but a job has already been initialised, preventing the JobCoordinator from spinning up new jobs in its place.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
