### PR TITLE
Increase Docker Compose test timeout

### DIFF
--- a/tests/e2e/basic-ingest-redis-serving.py
+++ b/tests/e2e/basic-ingest-redis-serving.py
@@ -114,7 +114,7 @@ def test_basic_ingest_success(client, basic_dataframe):
     time.sleep(5)
 
 
-@pytest.mark.timeout(45)
+@pytest.mark.timeout(60)
 @pytest.mark.run(order=12)
 def test_basic_retrieve_online_success(client, basic_dataframe):
     # Poll serving for feature values until the correct values are returned


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
The Docker Compose tests have been failing sparingly but in a non-deterministic manner, due to timeout errors, [here](https://github.com/feast-dev/feast/runs/684970318?check_suite_focus=true#step:3:469) is an example of the latest of such failure.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
NA

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
