### PR TITLE
Rework test-runner for e2e on dataflow w/ reusing existing infrastructure (installed kafka, redis, etc)

### DIFF
--- a/.prow/config.yaml
+++ b/.prow/config.yaml
@@ -254,8 +254,11 @@ presubmits:
       - name: service-account-df
         secret:
           secretName: feast-e2e-service-account
+      - name: docker-socket
+          hostPath:
+            path: /var/run/docker.sock
       containers:
-      - image: maven:3.6-jdk-11
+      - image: google/cloud-sdk:273.0.0
         command: ["infra/scripts/test-end-to-end-batch-dataflow.sh"]
         resources:
           requests:
@@ -264,28 +267,11 @@ presubmits:
         volumeMounts:
         - name: service-account-df
           mountPath: "/etc/service-account-df"
+        - name: docker-socket
+          mountPath: /var/run/docker.sock
+        securityContext:
+          privileged: true
     skip_branches:
-    - ^v0\.(3|4)-branch$
-
-  - name: test-end-to-end-batch-dataflow-java-8
-    decorate: true
-    always_run: false
-    spec:
-      volumes:
-        - name: service-account-df
-          secret:
-            secretName: feast-e2e-service-account
-      containers:
-        - image: maven:3.6-jdk-8
-          command: ["infra/scripts/test-end-to-end-batch-dataflow.sh"]
-          resources:
-            requests:
-              cpu: "6"
-              memory: "6144Mi"
-          volumeMounts:
-            - name: service-account-df
-              mountPath: "/etc/service-account-df"
-    branches:
     - ^v0\.(3|4)-branch$
 
   - name: publish-docker-images

--- a/infra/scripts/test-end-to-end-batch-dataflow.sh
+++ b/infra/scripts/test-end-to-end-batch-dataflow.sh
@@ -26,7 +26,7 @@ This script will run end-to-end tests for Feast Core and Batch Serving using Dat
 1. Setup K8s cluster (optional, if it was not created before)
 2. Reuse existing IP addresses or generate new ones for stateful services
 3. Install stateful services (kafka, redis, postgres, etc) (optional)
-4. Build core & serving docker images
+4. Build core & serving docker images (optional)
 5. Create temporary BQ table for Feast Serving.
 6. Rollout target images to cluster via helm in dedicated namespace (pr-{number})
 7. Install Python 3.7.4, Feast Python SDK and run end-to-end tests from
@@ -199,7 +199,7 @@ if [[ -z $existing_deps ]]; then
 fi
 
 # 4.
-buildTarget "$@"
+# buildTarget "$@"
 
 # 5.
 echo "
@@ -229,10 +229,11 @@ export GCLOUD_NETWORK=$GCLOUD_NETWORK
 export GCLOUD_SUBNET=$GCLOUD_SUBNET
 export GCLOUD_REGION=$GCLOUD_REGION
 export HELM_COMMON_NAME=$HELM_COMMON_NAME
+export IMAGE_TAG=${PULL_PULL_SHA:1}
 
 cd $ORIGINAL_DIR/infra/scripts/test-templates
 envsubst $'$TEMP_BUCKET $DATASET_NAME $GCLOUD_PROJECT $GCLOUD_NETWORK \
-  $GCLOUD_SUBNET $GCLOUD_REGION $PULL_NUMBER $HELM_COMMON_NAME $feast_kafka_1_ip
+  $GCLOUD_SUBNET $GCLOUD_REGION $IMAGE_TAG $HELM_COMMON_NAME $feast_kafka_1_ip
   $feast_kafka_2_ip $feast_kafka_3_ip $feast_redis_ip $feast_statsd_ip' < values-end-to-end-batch-dataflow.yaml > $ORIGINAL_DIR/infra/charts/feast/values-end-to-end-batch-dataflow-updated.yaml
 
 

--- a/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
+++ b/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
@@ -6,7 +6,7 @@ feast-core:
   postgresql:
     existingSecret: feast-postgresql
   image:
-    tag: $PULL_NUMBER
+    tag: $IMAGE_TAG
   application-override.yaml:
     spring:
       datasource:
@@ -42,7 +42,7 @@ feast-online-serving:
   # feast-online-serving.enabled -- Flag to install Feast Online Serving
   enabled: true
   image:
-    tag: $PULL_NUMBER
+    tag: $IMAGE_TAG
   application-override.yaml:
     feast:
       active_store: online
@@ -63,7 +63,7 @@ feast-batch-serving:
   # feast-batch-serving.enabled -- Flag to install Feast Batch Serving
   enabled: true
   image:
-    tag: $PULL_NUMBER
+    tag: $IMAGE_TAG
   gcpServiceAccount:
     enabled: true
   application-override.yaml:

--- a/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
+++ b/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
@@ -5,8 +5,6 @@ feast-core:
     enabled: true
   postgresql:
     existingSecret: feast-postgresql
-  service:
-    type: LoadBalancer
   image:
     tag: $IMAGE_TAG
   application-override.yaml:
@@ -32,7 +30,7 @@ feast-core:
             subnetwork: regions/$GCLOUD_REGION/subnetworks/$GCLOUD_SUBNET
             maxNumWorkers: 1
             autoscalingAlgorithm: THROUGHPUT_BASED
-            #usePublicIps: false
+            usePublicIps: false
             workerMachineType: n1-standard-1
             deadLetterTableSpec: $GCLOUD_PROJECT:$DATASET_NAME.deadletter
 
@@ -45,8 +43,6 @@ feast-online-serving:
   enabled: true
   image:
     tag: $IMAGE_TAG
-  service:
-    type: LoadBalancer
   application-override.yaml:
     feast:
       active_store: online
@@ -70,8 +66,6 @@ feast-batch-serving:
     tag: $IMAGE_TAG
   gcpServiceAccount:
     enabled: true
-  service:
-    type: LoadBalancer
   application-override.yaml:
     feast:
       active_store: historical
@@ -104,12 +98,12 @@ kafka:
   external:
     enabled: true
     type: LoadBalancer
-#    annotations:
-#      cloud.google.com/load-balancer-type: Internal
-#    loadBalancerSourceRanges:
-#    - 10.0.0.0/8
-#    - 172.16.0.0/12
-#    - 192.168.0.0/16
+    annotations:
+      cloud.google.com/load-balancer-type: Internal
+    loadBalancerSourceRanges:
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
     firstListenerPort: 31090
     loadBalancerIP:
     - $feast_kafka_1_ip

--- a/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
+++ b/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
@@ -5,6 +5,8 @@ feast-core:
     enabled: true
   postgresql:
     existingSecret: feast-postgresql
+  service:
+    type: LoadBalancer
   image:
     tag: $IMAGE_TAG
   application-override.yaml:
@@ -30,7 +32,7 @@ feast-core:
             subnetwork: regions/$GCLOUD_REGION/subnetworks/$GCLOUD_SUBNET
             maxNumWorkers: 1
             autoscalingAlgorithm: THROUGHPUT_BASED
-            usePublicIps: false
+            #usePublicIps: false
             workerMachineType: n1-standard-1
             deadLetterTableSpec: $GCLOUD_PROJECT:$DATASET_NAME.deadletter
 
@@ -43,6 +45,8 @@ feast-online-serving:
   enabled: true
   image:
     tag: $IMAGE_TAG
+  service:
+    type: LoadBalancer
   application-override.yaml:
     feast:
       active_store: online
@@ -66,6 +70,8 @@ feast-batch-serving:
     tag: $IMAGE_TAG
   gcpServiceAccount:
     enabled: true
+  service:
+    type: LoadBalancer
   application-override.yaml:
     feast:
       active_store: historical
@@ -98,12 +104,12 @@ kafka:
   external:
     enabled: true
     type: LoadBalancer
-    annotations:
-      cloud.google.com/load-balancer-type: Internal
-    loadBalancerSourceRanges:
-    - 10.0.0.0/8
-    - 172.16.0.0/12
-    - 192.168.0.0/16
+#    annotations:
+#      cloud.google.com/load-balancer-type: Internal
+#    loadBalancerSourceRanges:
+#    - 10.0.0.0/8
+#    - 172.16.0.0/12
+#    - 192.168.0.0/16
     firstListenerPort: 31090
     loadBalancerIP:
     - $feast_kafka_1_ip

--- a/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
+++ b/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
@@ -6,8 +6,11 @@ feast-core:
   postgresql:
     existingSecret: feast-postgresql
   image:
-    tag: $PULL_PULL_SHA:1
+    tag: $PULL_NUMBER
   application-override.yaml:
+    spring:
+      datasource:
+        url: jdbc:postgresql://$HELM_COMMON_NAME-postgresql:5432/postgres
     feast:
       stream:
         options:
@@ -39,7 +42,7 @@ feast-online-serving:
   # feast-online-serving.enabled -- Flag to install Feast Online Serving
   enabled: true
   image:
-    tag: $PULL_PULL_SHA:1
+    tag: $PULL_NUMBER
   application-override.yaml:
     feast:
       active_store: online
@@ -60,10 +63,9 @@ feast-batch-serving:
   # feast-batch-serving.enabled -- Flag to install Feast Batch Serving
   enabled: true
   image:
-    tag: $PULL_PULL_SHA:1
+    tag: $PULL_NUMBER
   gcpServiceAccount:
     enabled: true
-
   application-override.yaml:
     feast:
       active_store: historical
@@ -82,6 +84,8 @@ feast-batch-serving:
         - name: "*"
           project: "*"
           version: "*"
+      job_store:
+        redis_host: $HELM_COMMON_NAME-redis-master
 
 postgresql:
   # postgresql.enabled -- Flag to install Postgresql


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: 

Currently, dataflow tests are broken. They also was meant to create k8s cluster & install all dependencies (kafka, postgres, redis) for each run, which would significantly increase running time. I propose to create cluster once. I also separated rollout of dependencies' containers from feast containers.

**Which issue(s) this PR fixes**: broken tests on dataflow / long running tests
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**: No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
