### PR TITLE
Remove unused Hibernate dep from Serving

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -149,11 +149,9 @@
             <version>v1b3-rev266-1.25.0</version>
         </dependency>
 
-        <!--compile 'org.hibernate:hibernate-core:5.3.6.Final'-->
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>5.3.6.Final</version>
         </dependency>
 
         <!--compile 'org.postgresql:postgresql:42.2.5'-->

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <io.prometheus.version>0.8.0</io.prometheus.version>
         <byte-buddy.version>1.9.10</byte-buddy.version>
         <hamcrest.version>1.3</hamcrest.version>
+        <hibernate.version>5.3.6.Final</hibernate.version>
         <kafka.version>2.3.0</kafka.version>
         <mockito.version>2.28.2</mockito.version>
         <!-- OpenCensus is used in grpc and Google's HTTP client libs in Cloud SDKs -->
@@ -248,6 +249,11 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-core</artifactId>
+                <version>${hibernate.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -259,13 +259,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Hibernate for formatting SQL string -->
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-core</artifactId>
-      <version>5.4.5.Final</version>
-    </dependency>
-
     <!-- Utilities -->
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes an unused dependency. Just a little housekeeping noticed in the context of something related. Core and Serving were using different versions of Hibernate, which I first wanted to align, then thought to myself, "wait, how does Serving use Hibernate?"

Maybe someone knows the background of what "Hibernate for formatting SQL string" meant, but grepping/`mvn dependency:analyze`/building suggests it is indeed unused.

**Which issue(s) this PR fixes**:

No issue

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
