### PR TITLE
Fix Go and Java SDK Regressions

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -52,7 +52,7 @@ func (fc *GrpcClient) GetOnlineFeatures(ctx context.Context, req *OnlineFeatures
 	resp, err := fc.cli.GetOnlineFeatures(ctx, featuresRequest)
 
 	// collect unqiue entity refs from entity rows
-	var entityRefs map[string]struct{}
+	entityRefs := make(map[string]struct{})
 	for _, entityRows := range req.Entities {
 		for ref, _ := range entityRows {
 			entityRefs[ref] = struct{}{}
@@ -61,7 +61,7 @@ func (fc *GrpcClient) GetOnlineFeatures(ctx context.Context, req *OnlineFeatures
 
 	// strip projects from to projects
 	for _, fieldValue := range resp.GetFieldValues() {
-		var stripFields map[string]*types.Value
+		stripFields := make(map[string]*types.Value)
 		for refStr, value := range fieldValue.Fields {
 			_, isEntity := entityRefs[refStr]
 			if !isEntity { // is feature ref

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -71,6 +71,8 @@ func (fc *GrpcClient) GetOnlineFeatures(ctx context.Context, req *OnlineFeatures
 				}
 				stripRefStr := toFeatureRefStr(featureRef)
 				stripFields[stripRefStr] = value
+			} else {
+				stripFields[refStr] = value
 			}
 		}
 		fieldValue.Fields = stripFields

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -69,11 +69,9 @@ func (fc *GrpcClient) GetOnlineFeatures(ctx context.Context, req *OnlineFeatures
 				if err != nil {
 					return nil, err
 				}
-				stripRefStr := toFeatureRefStr(featureRef)
-				stripFields[stripRefStr] = value
-			} else {
-				stripFields[refStr] = value
+				refStr = toFeatureRefStr(featureRef)
 			}
+			stripFields[refStr] = value
 		}
 		fieldValue.Fields = stripFields
 	}

--- a/sdk/go/types.go
+++ b/sdk/go/types.go
@@ -21,12 +21,12 @@ func (r Row) equalTo(other Row) bool {
 	return true
 }
 
-// StrVal is a int64 type feast value
+// StrVal is a string type feast value
 func StrVal(val string) *types.Value {
 	return &types.Value{Val: &types.Value_StringVal{StringVal: val}}
 }
 
-// Int32Val is a int64 type feast value
+// Int32Val is a int32 type feast value
 func Int32Val(val int32) *types.Value {
 	return &types.Value{Val: &types.Value_Int32Val{Int32Val: val}}
 }

--- a/sdk/java/src/main/java/com/gojek/feast/FeastClient.java
+++ b/sdk/java/src/main/java/com/gojek/feast/FeastClient.java
@@ -23,6 +23,7 @@ import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesRequest;
 import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesRequest.EntityRow;
 import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesResponse;
 import feast.proto.serving.ServingServiceGrpc;
+import feast.proto.serving.ServingServiceGrpc.ServingServiceBlockingStub;
 import feast.proto.types.ValueProto.Value;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -39,8 +40,8 @@ public class FeastClient implements AutoCloseable {
 
   private static final int CHANNEL_SHUTDOWN_TIMEOUT_SEC = 5;
 
-  private final ManagedChannel channel;
-  private final ServingServiceGrpc.ServingServiceBlockingStub stub;
+  private ManagedChannel channel;
+  private ServingServiceBlockingStub stub;
 
   /**
    * Create a client to access Feast
@@ -161,9 +162,9 @@ public class FeastClient implements AutoCloseable {
         .collect(Collectors.toList());
   }
 
-  private FeastClient(ManagedChannel channel) {
+  protected FeastClient(ManagedChannel channel) {
     this.channel = channel;
-    stub = ServingServiceGrpc.newBlockingStub(channel);
+    this.stub = ServingServiceGrpc.newBlockingStub(channel);
   }
 
   public void close() throws Exception {

--- a/sdk/java/src/main/java/com/gojek/feast/FeastClient.java
+++ b/sdk/java/src/main/java/com/gojek/feast/FeastClient.java
@@ -40,8 +40,8 @@ public class FeastClient implements AutoCloseable {
 
   private static final int CHANNEL_SHUTDOWN_TIMEOUT_SEC = 5;
 
-  private ManagedChannel channel;
-  private ServingServiceBlockingStub stub;
+  private final ManagedChannel channel;
+  private final ServingServiceBlockingStub stub;
 
   /**
    * Create a client to access Feast

--- a/sdk/java/src/main/java/com/gojek/feast/Row.java
+++ b/sdk/java/src/main/java/com/gojek/feast/Row.java
@@ -76,7 +76,7 @@ public class Row {
         fields.put(
             fieldName, Value.newBuilder().setBytesVal(ByteString.copyFrom((byte[]) value)).build());
         break;
-      case "feast.types.ValueProto.Value":
+      case "feast.proto.types.ValueProto.Value":
         fields.put(fieldName, (Value) value);
         break;
       default:

--- a/sdk/python/tests/test_feature.py
+++ b/sdk/python/tests/test_feature.py
@@ -17,7 +17,7 @@ from feast.feature import FeatureRef
 
 class TestFeatureRef:
     def test_str_ref(self):
-        original_ref = FeatureRef(project="test", name="test")
+        original_ref = FeatureRef(feature_set="test", name="test")
         ref_str = repr(original_ref)
         parsed_ref = FeatureRef.from_str(ref_str)
         assert original_ref == parsed_ref


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This is a split off containing solely the bug fixes of PR #720 

Fixes SDK bugs introduced in PR #693 & #700 
- Go SDK crashes due to trying to add to a `nil` map. (PR #693 ).
- Go SDK obmitted entity values when in values returned from `GetOnlineFeatures()` (PR #693 )
- Java SDK's `Row.set()` rejects `feast.proto.types.ValueProto.Value` as its hardcoded class path to `feast.types.ValueProto.Value`.( PR #700 )



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed Go SDK error due to trying to add to a nil map.
Fixed Go SDK omitted entity values when get online features.
Fixed Java SDK's Row.set() does not accept feast Value type
```
