### PR TITLE
Fix project argument for feature set describe in CLI

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -156,12 +156,20 @@ def feature_set_create(filename):
 
 @feature_set.command("describe")
 @click.argument("name", type=click.STRING)
-def feature_set_describe(name: str):
+@click.option(
+    "--project",
+    "-p",
+    help="Project that feature set belongs to",
+    type=click.STRING,
+    default="default",
+)
+def feature_set_describe(name: str, project: str):
     """
     Describe a feature set
     """
     feast_client = Client()  # type: Client
-    fs = feast_client.get_feature_set(name=name)
+    fs = feast_client.get_feature_set(name=name, project=project)
+
     if not fs:
         print(f'Feature set with name "{name}" could not be found')
         return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
`feast feature-sets describe <name>` cannot be used because it doesn't allow the user to set a project, nor does it default to any value.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #727 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now pass in --project parameter to retrieve information about a feature set using cli.
```
