### PR TITLE
Update owners for Prow / GitHub

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Each line is a file pattern followed by one or more owners.
 # https://help.github.com/en/articles/about-code-owners
 
-*           @zhilingc @pradithya @woop @davidheryanto @khorshuheng
-/core/      @zhilingc @pradithya
-/ingestion/ @zhilingc @pradithya
-/serving/   @zhilingc @pradithya
-/cli/       @zhilingc @pradithya
+*           @zhilingc @woop @davidheryanto @khorshuheng @pyalex
+/core/      @zhilingc
+/ingestion/ @zhilingc
+/serving/   @zhilingc
+/cli/       @zhilingc

--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,13 @@
 approvers:
-  - zhilingc
-  - pradithya
-  - woop
-  - thirteen37
   - davidheryanto
   - khorshuheng
+  - pyalex
+  - woop
+  - zhilingc
 reviewers:
-  - zhilingc
-  - woop
-  - thirteen37
+  - ches
   - davidheryanto
   - khorshuheng
+  - pyalex
+  - woop
+  - zhilingc


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove inactive reviewers, so contributors following what the Prow bot instructs them to do are likely to get appropriate attention.

Let me know if there is anything that should be changed. Added myself to reviewers, and ran `:sort` so pardon the diff being a little noisy.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
