### PR TITLE
v0.5 backport: Restore SDK and Ingestion compatibility with Java 8 runtimes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,6 +33,14 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>

--- a/datatypes/java/pom.xml
+++ b/datatypes/java/pom.xml
@@ -39,15 +39,6 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <!-- To ensure Ingestion remains compatible for Java 8-only Beam runners -->
-            <release>8</release>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <configuration>
             <!-- Required for generated code to compile; annotations are common false positive -->

--- a/ingestion/pom.xml
+++ b/ingestion/pom.xml
@@ -33,15 +33,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <!-- To ensure Ingestion remains compatible for Java 8-only Beam runners -->
-          <release>8</release>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.1</version>
         <executions>
@@ -79,6 +70,31 @@
                   <shadedPattern>com.google.cloud.bigquery.vendor</shadedPattern>
                 </relocation>
               </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <!--
+            We want to keep Ingestion compatible with Java 8 runtime for Beam runners, #518.
+            Unfortunately this doesn't seem to work on Reactor modules, though:
+            https://github.com/mojohaus/mojo-parent/issues/85
+            -->
+          <execution>
+            <id>enforce-bytecode-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.8</maxJdkVersion>
+                </enforceBytecodeVersion>
+              </rules>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -411,7 +411,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>11</release>
+                    <!-- Our leaf applications target 11, except Ingestion and its deps remain on 8 for Beam -->
+                    <release>8</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/sdk/java/src/test/java/com/gojek/feast/RequestUtilTest.java
+++ b/sdk/java/src/test/java/com/gojek/feast/RequestUtilTest.java
@@ -19,6 +19,7 @@ package com.gojek.feast;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.TextFormat;
 import feast.proto.serving.ServingAPIProto.FeatureReference;
 import java.util.Arrays;
@@ -82,7 +83,7 @@ class RequestUtilTest {
   }
 
   private static Stream<Arguments> provideInvalidFeatureRefs() {
-    return Stream.of(Arguments.of(List.of("project/feature", "")));
+    return Stream.of(Arguments.of(ImmutableList.of("project/feature", "")));
   }
 
   @ParameterizedTest

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -41,6 +41,14 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/writer/RedisCustomIO.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/writer/RedisCustomIO.java
@@ -54,8 +54,10 @@ public class RedisCustomIO {
   private static final int DEFAULT_BATCH_SIZE = 1000;
   private static final int DEFAULT_TIMEOUT = 2000;
 
-  private static TupleTag<FeatureRow> successfulInsertsTag = new TupleTag<>("successfulInserts") {};
-  private static TupleTag<FailedElement> failedInsertsTupleTag = new TupleTag<>("failedInserts") {};
+  private static TupleTag<FeatureRow> successfulInsertsTag =
+      new TupleTag<FeatureRow>("successfulInserts") {};
+  private static TupleTag<FailedElement> failedInsertsTupleTag =
+      new TupleTag<FailedElement>("failedInserts") {};
 
   private static final Logger log = LoggerFactory.getLogger(RedisCustomIO.class);
 

--- a/storage/connectors/redis/src/test/java/feast/storage/connectors/redis/retriever/RedisOnlineRetrieverTest.java
+++ b/storage/connectors/redis/src/test/java/feast/storage/connectors/redis/retriever/RedisOnlineRetrieverTest.java
@@ -133,7 +133,7 @@ public class RedisOnlineRetrieverTest {
     when(syncCommands.mget(redisKeyList)).thenReturn(featureRowBytes);
 
     List<List<FeatureRow>> expected =
-        List.of(
+        ImmutableList.of(
             Lists.newArrayList(
                 FeatureRow.newBuilder()
                     .setEventTimestamp(Timestamp.newBuilder().setSeconds(100))
@@ -153,7 +153,7 @@ public class RedisOnlineRetrieverTest {
                     .build()));
 
     List<List<FeatureRow>> actual =
-        redisOnlineRetriever.getOnlineFeatures(entityRows, List.of(featureSetRequest));
+        redisOnlineRetriever.getOnlineFeatures(entityRows, ImmutableList.of(featureSetRequest));
     assertThat(actual, equalTo(expected));
   }
 
@@ -201,7 +201,7 @@ public class RedisOnlineRetrieverTest {
     when(syncCommands.mget(redisKeyList)).thenReturn(featureRowBytes);
 
     List<List<FeatureRow>> expected =
-        List.of(
+        ImmutableList.of(
             Lists.newArrayList(
                 FeatureRow.newBuilder()
                     .setEventTimestamp(Timestamp.newBuilder().setSeconds(100))
@@ -220,7 +220,7 @@ public class RedisOnlineRetrieverTest {
                     .build()));
 
     List<List<FeatureRow>> actual =
-        redisOnlineRetriever.getOnlineFeatures(entityRows, List.of(featureSetRequest));
+        redisOnlineRetriever.getOnlineFeatures(entityRows, ImmutableList.of(featureSetRequest));
     assertThat(actual, equalTo(expected));
   }
 

--- a/storage/connectors/rediscluster/src/main/java/feast/storage/connectors/rediscluster/writer/RedisClusterCustomIO.java
+++ b/storage/connectors/rediscluster/src/main/java/feast/storage/connectors/rediscluster/writer/RedisClusterCustomIO.java
@@ -54,8 +54,10 @@ public class RedisClusterCustomIO {
   private static final int DEFAULT_BATCH_SIZE = 1000;
   private static final int DEFAULT_TIMEOUT = 2000;
 
-  private static TupleTag<FeatureRow> successfulInsertsTag = new TupleTag<>("successfulInserts") {};
-  private static TupleTag<FailedElement> failedInsertsTupleTag = new TupleTag<>("failedInserts") {};
+  private static TupleTag<FeatureRow> successfulInsertsTag =
+      new TupleTag<FeatureRow>("successfulInserts") {};
+  private static TupleTag<FailedElement> failedInsertsTupleTag =
+      new TupleTag<FailedElement>("failedInserts") {};
 
   private static final Logger log = LoggerFactory.getLogger(RedisClusterCustomIO.class);
 

--- a/storage/connectors/rediscluster/src/test/java/feast/storage/connectors/rediscluster/retriever/RedisClusterOnlineRetrieverTest.java
+++ b/storage/connectors/rediscluster/src/test/java/feast/storage/connectors/rediscluster/retriever/RedisClusterOnlineRetrieverTest.java
@@ -133,7 +133,7 @@ public class RedisClusterOnlineRetrieverTest {
     when(syncCommands.mget(redisKeyList)).thenReturn(featureRowBytes);
 
     List<List<FeatureRow>> expected =
-        List.of(
+        ImmutableList.of(
             Lists.newArrayList(
                 FeatureRow.newBuilder()
                     .setEventTimestamp(Timestamp.newBuilder().setSeconds(100))
@@ -153,7 +153,8 @@ public class RedisClusterOnlineRetrieverTest {
                     .build()));
 
     List<List<FeatureRow>> actual =
-        redisClusterOnlineRetriever.getOnlineFeatures(entityRows, List.of(featureSetRequest));
+        redisClusterOnlineRetriever.getOnlineFeatures(
+            entityRows, ImmutableList.of(featureSetRequest));
     assertThat(actual, equalTo(expected));
   }
 
@@ -201,7 +202,7 @@ public class RedisClusterOnlineRetrieverTest {
     when(syncCommands.mget(redisKeyList)).thenReturn(featureRowBytes);
 
     List<List<FeatureRow>> expected =
-        List.of(
+        ImmutableList.of(
             Lists.newArrayList(
                 FeatureRow.newBuilder()
                     .setEventTimestamp(Timestamp.newBuilder().setSeconds(100))
@@ -220,7 +221,8 @@ public class RedisClusterOnlineRetrieverTest {
                     .build()));
 
     List<List<FeatureRow>> actual =
-        redisClusterOnlineRetriever.getOnlineFeatures(entityRows, List.of(featureSetRequest));
+        redisClusterOnlineRetriever.getOnlineFeatures(
+            entityRows, ImmutableList.of(featureSetRequest));
     assertThat(actual, equalTo(expected));
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports #722 to v0.5.

**Does this PR introduce a user-facing change?**:

```release-note
- Restores Feast Ingestion compatibility with Java 8 runtimes
- Restores Feast Java SDK compatibility with Java 8 runtimes
```
