### PR TITLE
Labels unit tests improvement

### DIFF
--- a/core/src/test/java/feast/core/service/SpecServiceTest.java
+++ b/core/src/test/java/feast/core/service/SpecServiceTest.java
@@ -543,8 +543,6 @@ public class SpecServiceTest {
 
   @Test
   public void applyFeatureSetShouldAcceptFeatureLabels() throws InvalidProtocolBufferException {
-    List<EntitySpec> entitySpecs = new ArrayList<>();
-    entitySpecs.add(EntitySpec.newBuilder().setName("entity1").setValueType(Enum.INT64).build());
 
     Map<String, String> featureLabels0 =
         new HashMap<>() {
@@ -583,7 +581,6 @@ public class SpecServiceTest {
         FeatureSetSpec.newBuilder()
             .setProject("project1")
             .setName("featureSetWithConstraints")
-            .addAllEntities(entitySpecs)
             .addAllFeatures(featureSpecs)
             .build();
     FeatureSetProto.FeatureSet featureSet =
@@ -592,22 +589,15 @@ public class SpecServiceTest {
     ApplyFeatureSetResponse applyFeatureSetResponse = specService.applyFeatureSet(featureSet);
     FeatureSetSpec appliedFeatureSetSpec = applyFeatureSetResponse.getFeatureSet().getSpec();
 
-    // appliedEntitySpecs needs to be sorted because the list returned by specService may not
-    // follow the order in the request
-    List<EntitySpec> appliedEntitySpecs = new ArrayList<>(appliedFeatureSetSpec.getEntitiesList());
-    appliedEntitySpecs.sort(Comparator.comparing(EntitySpec::getName));
-
     // appliedFeatureSpecs needs to be sorted because the list returned by specService may not
     // follow the order in the request
     List<FeatureSpec> appliedFeatureSpecs =
         new ArrayList<>(appliedFeatureSetSpec.getFeaturesList());
     appliedFeatureSpecs.sort(Comparator.comparing(FeatureSpec::getName));
 
-    var featureSpecsLabels =
-        featureSpecs.stream().map(e -> e.getLabelsMap()).collect(Collectors.toList());
-    assertEquals(appliedEntitySpecs, entitySpecs);
-    assertEquals(appliedFeatureSpecs, featureSpecs);
-    assertEquals(featureSpecsLabels, featureLabels);
+    var appliedFeatureSpecsLabels =
+        appliedFeatureSpecs.stream().map(e -> e.getLabelsMap()).collect(Collectors.toList());
+    assertEquals(appliedFeatureSpecsLabels, featureLabels);
   }
 
   @Test


### PR DESCRIPTION
**What this PR does / why we need it**:
The last assertion was only asserting against the object constructed in the test code and not the object created by production code. This PR fixes it. 
Also removed entities as I don't think they're relevant to this test.

**Which issue(s) this PR fixes**:
NONE

**Does this PR introduce a user-facing change?**:
no 

```release-note
NONE
```
