### PR TITLE
Fix Docker Compose Batch Serving

### DIFF
--- a/infra/docker-compose/.env.sample
+++ b/infra/docker-compose/.env.sample
@@ -13,7 +13,6 @@ FEAST_SERVING_IMAGE=gcr.io/kf-feast/feast-serving
 # Feast Serving - Batch (BigQuery)
 FEAST_BATCH_SERVING_CONFIG=batch-serving.yml
 FEAST_BATCH_SERVING_GCP_SERVICE_ACCOUNT_KEY=placeholder.json
-FEAST_BATCH_JOB_STAGING_LOCATION=gs://your-gcs-bucket/staging
 # Feast Serving - Online (Redis)
 FEAST_ONLINE_SERVING_CONFIG=online-serving.yml
 

--- a/infra/docker-compose/core/core.yml
+++ b/infra/docker-compose/core/core.yml
@@ -11,4 +11,4 @@ feast:
     type: kafka
     options:
       topic: feast-features
-      bootstrapServers: kafka:9092
+      bootstrapServers: "kafka:9092,localhost:9094"

--- a/infra/docker-compose/serving/batch-serving.yml
+++ b/infra/docker-compose/serving/batch-serving.yml
@@ -9,7 +9,7 @@ feast:
       config:
         project_id: project
         dataset_id: dataset
-        staging_location: gs:///gcs_bucket/prefix
+        staging_location: gs://gcs_bucket/prefix
         initial_retry_delay_seconds: 1
         total_timeout_seconds: 21600
       subscriptions:

--- a/infra/docker-compose/serving/batch-serving.yml
+++ b/infra/docker-compose/serving/batch-serving.yml
@@ -1,15 +1,15 @@
 feast:
   core-host: core
-  active-store: batch
+  active-store: historical
   stores:
     - name: historical
       type: BIGQUERY
       # Changes required for batch serving to work
       # Please see https://api.docs.feast.dev/grpc/feast.core.pb.html#Store for configuration options
       config:
-        project_id: my_project
-        dataset_id: my_dataset
-        staging_location: gs://mybucket/myprefix
+        project_id: project
+        dataset_id: dataset
+        staging_location: gs:///gcs_bucket/prefix
         initial_retry_delay_seconds: 1
         total_timeout_seconds: 21600
       subscriptions:
@@ -18,3 +18,6 @@ feast:
   job_store:
     redis_host: redis
     redis_port: 6379
+  
+grpc:
+  port: 6567


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Fix Docker Compose Batch Serving setup:
- Fixed Batch Serving gRPC listening on wrong port (6566 instead of 6567)
- Fixed `active-store` typo in `batch-serving.yml` config: should be `historical` instead of `batch`.
- Fixed issue where external Feast Clients (ie not inside docker network) could not access Kafka
