### PR TITLE
Redis host fix

### DIFF
--- a/infra/docker-compose/docker-compose.online.yml
+++ b/infra/docker-compose/docker-compose.online.yml
@@ -5,6 +5,7 @@ services:
     image: ${FEAST_SERVING_IMAGE}:${FEAST_VERSION}
     volumes:
       - ./serving/${FEAST_ONLINE_SERVING_CONFIG}:/etc/feast/application.yml
+      - ./serving/sample_redis_config.yml:/etc/feast/sample_redis_config.yml
     depends_on:
       - redis
     ports:
@@ -15,6 +16,7 @@ services:
       - -jar
       - /opt/feast/feast-serving.jar
       - --spring.config.location=classpath:/application.yml,file:/etc/feast/application.yml
+      - --feast.store.config-path=/etc/feast/sample_redis_config.yml
 
   redis:
     image: redis:5-alpine

--- a/infra/docker-compose/serving/sample_redis_config.yml
+++ b/infra/docker-compose/serving/sample_redis_config.yml
@@ -1,0 +1,9 @@
+name: serving
+type: REDIS
+redis_config:
+  host: redis
+  port: 6379
+subscriptions:
+  - name: "*"
+    project: "*"
+    version: "*"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**Why we need it**: 
1. The online-serving.yml file does not effectively set the host to redis (although it has the correct value in the config) but instead tries to connect to localhost and errors out. 
2. The sample_redis_config.yml file specified in the development guide does not exist and a default config seems to point to it because of which it errors.

**What this PR does**:
1.  Creates a sample_redis_config.yml from the one mentioned in the development guide. Changes the host from "localhost" to "redis".
2. Mounts the yml file to the host filesystem.
3. Sets the config path to point to it.

**Which issue(s) this PR fixes**: Redis connection 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Does this PR introduce a user-facing change?**: NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
