### PR TITLE
Remove usage of parallel stream for feature value map generation

### DIFF
--- a/serving/src/main/java/feast/serving/service/OnlineServingService.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingService.java
@@ -98,7 +98,6 @@ public class OnlineServingService implements ServingService {
           if (isStale(featureSetRequest, entityRow, featureRow)) {
             featureSetRequest
                 .getFeatureReferences()
-                .parallelStream()
                 .forEach(
                     ref -> {
                       populateStaleKeyCountMetrics(project, ref);


### PR DESCRIPTION
**What this PR does / why we need it**:
Feaute value map is not thread safe. Using parallel stream here can leads to racing condition, which results in incorrect feature value map being computed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix the bug where feature value map is generated incorrectly intermittently due to racing condition, when the feature is stale.
```
