### PR TITLE
Remove usage of parallel stream for feature value map generation (#751)

### DIFF
--- a/serving/src/main/java/feast/serving/service/OnlineServingService.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingService.java
@@ -98,7 +98,6 @@ public class OnlineServingService implements ServingService {
           if (isStale(featureSetRequest, entityRow, featureRow)) {
             featureSetRequest
                 .getFeatureReferences()
-                .parallelStream()
                 .forEach(
                     ref -> {
                       populateStaleKeyCountMetrics(project, ref);


### PR DESCRIPTION
This is to backport PR-751 to v0.5.