### PR TITLE
Improve ingestion speed of Feast Python SDK

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -806,6 +806,8 @@ class Client:
                 break
             time.sleep(3)
 
+        print("Starting ingestion...")
+
         if timeout is not None:
             timeout = timeout - int(time.time() - current_time)
 
@@ -834,11 +836,10 @@ class Client:
                     for serialized_row in chunk:
                         produce(topic=topic, value=serialized_row)
 
-                    # Force a flush after each chunk
-                    flush(timeout=timeout)
-
                     # Remove chunk from memory
                     del chunk
+
+                flush(timeout=timeout)
 
             else:
                 raise Exception(

--- a/sdk/python/feast/loaders/abstract_producer.py
+++ b/sdk/python/feast/loaders/abstract_producer.py
@@ -60,7 +60,6 @@ class AbstractProducer:
         print("Ingestion complete!")
 
         print(f"\nIngestion statistics:" f"\nSuccess: {self.pbar.n}/{self.row_count}")
-        return None
 
 
 class ConfluentProducer(AbstractProducer):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Moves the flush() method of the Python Kafka client outside of the data processing loop to improve ingestion speed.

**Does this PR introduce a user-facing change?**:
```release-note
None
```
