### PR TITLE
Use stable Kafka consumer group ID for job

### DIFF
--- a/ingestion/src/main/java/feast/ingestion/ImportJob.java
+++ b/ingestion/src/main/java/feast/ingestion/ImportJob.java
@@ -120,6 +120,8 @@ public class ImportJob {
               "ReadFeatureRowFromSource",
               ReadFromSource.newBuilder()
                   .setSource(source)
+                  .setConsumerGroupId(
+                      ReadFromSource.generateConsumerGroupId(source.getType(), store.getName()))
                   .setSuccessTag(FEATURE_ROW_OUT)
                   .setFailureTag(DEADLETTER_OUT)
                   .build());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #646 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

### Design
This PR will have the functionality to have same consumer group for same job even after restart. Currently you can set consumer group from the ImportJob and it is optional.

But from issue discussion,

> For a FeatureSet with a high throughput Source, it is likely that during the period the job is stopped, the lag becomes incredibly high that if the job is to continue from the last offset it may not be able to keep up. Also, this very old data may have less value than the most recent one. But because the job cannot catch up, it cannot ingest fresh data as a result. That's why when a job is stopped, it is assigned a new consumer group id when started again so it will read from the latest offset in the Source.

the current PR will not be that useful.

### Solutions
1. Use labels to  point out that one feature set will use different consumer groups at all time or same consumer groups. User can add label like `high_throughput: true` and based on it we will set the consumer group from ImportJob.
 ```  
 labels {
    key: "high_throughput"
    value: "true"
  }
 ```
2. We can add consumer group value to Kafka config while registering a feature set. We make this consumer group as optional so if not provided we always use the new consumer group as it is now. The Kafka config will look like
  ```
  kafka_source_config {
      bootstrap_servers: "localhost:9092"
      topic: "feast-features"
      consumer_group: "some_group_name"
    }
 ```



