### PR TITLE
Add support to Python SDK for staging files on Amazon S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.6.0](https://github.com/feast-dev/feast/tree/v0.6.0) (2020-MM-DD)
+
+[Full Changelog](https://github.com/feast-dev/feast/compare/v0.5.1...v0.6.0)
+
+**Implemented enhancements:**
+- Add support for staging files on S3 [\#706](https://github.com/feast-dev/feast/pull/769) ([jmelinav](https://github.com/jmelinav))
+
 ## [0.5.1](https://github.com/feast-dev/feast/tree/0.5.1) (2020-06-06)
 
 [Full Changelog](https://github.com/feast-dev/feast/compare/v0.5.0...v0.5.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [v0.6.0](https://github.com/feast-dev/feast/tree/v0.6.0) (2020-MM-DD)
-
-[Full Changelog](https://github.com/feast-dev/feast/compare/v0.5.1...v0.6.0)
-
-**Implemented enhancements:**
-- Add support for staging files on S3 [\#706](https://github.com/feast-dev/feast/pull/769) ([jmelinav](https://github.com/jmelinav))
-
 ## [0.5.1](https://github.com/feast-dev/feast/tree/0.5.1) (2020-06-06)
 
 [Full Changelog](https://github.com/feast-dev/feast/compare/v0.5.0...v0.5.1)

--- a/sdk/python/feast/job.py
+++ b/sdk/python/feast/job.py
@@ -21,7 +21,7 @@ from feast.serving.ServingService_pb2 import (
 from feast.serving.ServingService_pb2 import Job as JobProto
 from feast.serving.ServingService_pb2_grpc import ServingServiceStub
 from feast.source import Source
-from feast.staging.storage_client import StorageClient
+from feast.staging.storage_client import get_staging_client
 from feast.wait import wait_retry_backoff
 from tensorflow_metadata.proto.v0 import statistics_pb2
 
@@ -48,7 +48,6 @@ class RetrievalJob:
         """
         self.job_proto = job_proto
         self.serving_stub = serving_stub
-        self.storage_client = StorageClient()
 
     @property
     def id(self):
@@ -122,7 +121,7 @@ class RetrievalJob:
         """
         uris = self.get_avro_files(timeout_sec)
         for file_uri in uris:
-            file_obj = self.storage_client.execute_file_download(file_uri)
+            file_obj = get_staging_client(file_uri.scheme).download_file(file_uri)
             file_obj.seek(0)
             avro_reader = fastavro.reader(file_obj)
 

--- a/sdk/python/feast/job.py
+++ b/sdk/python/feast/job.py
@@ -24,8 +24,8 @@ from feast.source import Source
 from feast.wait import wait_retry_backoff
 from tensorflow_metadata.proto.v0 import statistics_pb2
 
-from feast.staging.staging_strategy import StagingStrategy
 
+from feast.staging.storage_client import StorageClient
 # Maximum no of seconds to wait until the retrieval jobs status is DONE in Feast
 # Currently set to the maximum query execution time limit in BigQuery
 DEFAULT_TIMEOUT_SEC: int = 21600
@@ -49,7 +49,7 @@ class RetrievalJob:
         """
         self.job_proto = job_proto
         self.serving_stub = serving_stub
-        self.staging_strategy = StagingStrategy()
+        self.storage_client = StorageClient()
 
     @property
     def id(self):
@@ -123,7 +123,7 @@ class RetrievalJob:
         """
         uris = self.get_avro_files(timeout_sec)
         for file_uri in uris:
-            file_obj = self.staging_strategy.execute_file_download(file_uri)
+            file_obj = self.storage_client.execute_file_download(file_uri)
             file_obj.seek(0)
             avro_reader = fastavro.reader(file_obj)
 

--- a/sdk/python/feast/job.py
+++ b/sdk/python/feast/job.py
@@ -21,11 +21,10 @@ from feast.serving.ServingService_pb2 import (
 from feast.serving.ServingService_pb2 import Job as JobProto
 from feast.serving.ServingService_pb2_grpc import ServingServiceStub
 from feast.source import Source
+from feast.staging.storage_client import StorageClient
 from feast.wait import wait_retry_backoff
 from tensorflow_metadata.proto.v0 import statistics_pb2
 
-
-from feast.staging.storage_client import StorageClient
 # Maximum no of seconds to wait until the retrieval jobs status is DONE in Feast
 # Currently set to the maximum query execution time limit in BigQuery
 DEFAULT_TIMEOUT_SEC: int = 21600

--- a/sdk/python/feast/job.py
+++ b/sdk/python/feast/job.py
@@ -1,10 +1,8 @@
-import tempfile
 from typing import List
 from urllib.parse import urlparse
 
 import fastavro
 import pandas as pd
-from google.cloud import storage
 from google.protobuf.json_format import MessageToJson
 
 from feast.constants import CONFIG_TIMEOUT_KEY
@@ -26,6 +24,15 @@ from feast.source import Source
 from feast.wait import wait_retry_backoff
 from tensorflow_metadata.proto.v0 import statistics_pb2
 
+from feast.staging.staging_strategy import StagingStrategy
+
+# Maximum no of seconds to wait until the retrieval jobs status is DONE in Feast
+# Currently set to the maximum query execution time limit in BigQuery
+DEFAULT_TIMEOUT_SEC: int = 21600
+
+# Maximum no of seconds to wait before reloading the job status in Feast
+MAX_WAIT_INTERVAL_SEC: int = 60
+
 
 class RetrievalJob:
     """
@@ -42,8 +49,7 @@ class RetrievalJob:
         """
         self.job_proto = job_proto
         self.serving_stub = serving_stub
-        # TODO: abstract away GCP depedency
-        self.gcs_client = storage.Client(project=None)
+        self.staging_strategy = StagingStrategy()
 
     @property
     def id(self):
@@ -117,16 +123,7 @@ class RetrievalJob:
         """
         uris = self.get_avro_files(timeout_sec)
         for file_uri in uris:
-            if file_uri.scheme == "gs":
-                file_obj = tempfile.TemporaryFile()
-                self.gcs_client.download_blob_to_file(file_uri.geturl(), file_obj)
-            elif file_uri.scheme == "file":
-                file_obj = open(file_uri.path, "rb")
-            else:
-                raise Exception(
-                    f"Could not identify file URI {file_uri}. Only gs:// and file:// supported"
-                )
-
+            file_obj = self.staging_strategy.execute_file_download(file_uri)
             file_obj.seek(0)
             avro_reader = fastavro.reader(file_obj)
 

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -76,7 +76,7 @@ def export_source_to_staging_location(
         source_uri = urlparse(source)
         if source_uri.scheme in ["", "file"]:
             # Local file provided as a source
-            dir_path = None
+            dir_path = ""
             file_name = os.path.basename(source)
             source_path = os.path.abspath(
                 os.path.join(source_uri.netloc, source_uri.path)
@@ -98,7 +98,7 @@ def export_source_to_staging_location(
     )
 
     # Clean up, remove local staging file
-    if isinstance(source, pd.DataFrame) and len(str(dir_path)) > 4:
+    if dir_path and isinstance(source, pd.DataFrame) and len(dir_path) > 4:
         shutil.rmtree(dir_path)
 
     return [staging_location_uri.rstrip("/") + "/" + file_name]

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 import os
-import re
 import shutil
 import tempfile
 import uuid
 from datetime import datetime
 from typing import List, Optional, Tuple, Union
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import urlparse
 
 import pandas as pd
-from google.cloud import storage
 from pandavro import to_avro
+
+from feast.staging.staging_strategy import StagingStrategy
 
 
 def export_source_to_staging_location(
@@ -58,6 +58,7 @@ def export_source_to_staging_location(
             remote staging location.
     """
 
+    staging_strategy = StagingStrategy()
     uri = urlparse(staging_location_uri)
 
     # Prepare Avro file to be exported to staging location
@@ -66,28 +67,21 @@ def export_source_to_staging_location(
         uri_path = None  # type: Optional[str]
         if uri.scheme == "file":
             uri_path = uri.path
-
         # Remote gs staging location provided by serving
         dir_path, file_name, source_path = export_dataframe_to_local(
             df=source, dir_path=uri_path
         )
-    elif urlparse(source).scheme in ["", "file"]:
-        # Local file provided as a source
-        dir_path = ""
-        file_name = os.path.basename(source)
-        source_path = os.path.abspath(
-            os.path.join(urlparse(source).netloc, urlparse(source).path)
-        )
-    elif urlparse(source).scheme == "gs":
-        # Google Cloud Storage path provided
-        input_source_uri = urlparse(source)
-        if "*" in source:
-            # Wildcard path
-            return _get_files(
-                bucket=str(input_source_uri.hostname), uri=input_source_uri
+    elif isinstance(source, str):
+        if urlparse(source).scheme in ["", "file"]:
+            # Local file provided as a source
+            dir_path = None
+            file_name = os.path.basename(source)
+            source_path = os.path.abspath(
+                os.path.join(urlparse(source).netloc, urlparse(source).path)
             )
         else:
-            return [source]
+            # gs, s3 file provided as a source.
+            return staging_strategy.execute_get_source_files(source)
     else:
         raise Exception(
             f"Only string and DataFrame types are allowed as a "
@@ -95,20 +89,12 @@ def export_source_to_staging_location(
         )
 
     # Push data to required staging location
-    if uri.scheme == "gs":
-        # Staging location is a Google Cloud Storage path
-        upload_file_to_gcs(
-            source_path, str(uri.hostname), str(uri.path).strip("/") + "/" + file_name
-        )
-    elif uri.scheme == "file":
-        # Staging location is a file path
-        # Used for end-to-end test
-        pass
-    else:
-        raise Exception(
-            f"Staging location {staging_location_uri} does not have a "
-            f"valid URI. Only gs:// and file:// uri scheme are supported."
-        )
+    staging_strategy.execute_file_upload(
+        uri.scheme,
+        source_path,
+        uri.hostname,
+        str(uri.path).strip("/") + "/" + file_name,
+    )
 
     # Clean up, remove local staging file
     if isinstance(source, pd.DataFrame) and len(str(dir_path)) > 4:
@@ -160,70 +146,6 @@ def export_dataframe_to_local(
         ]
 
     return dir_path, file_name, dest_path
-
-
-def upload_file_to_gcs(local_path: str, bucket: str, remote_path: str) -> None:
-    """
-    Upload a file from the local file system to Google Cloud Storage (GCS).
-
-    Args:
-        local_path (str):
-            Local filesystem path of file to upload.
-
-        bucket (str):
-            GCS bucket destination to upload to.
-
-        remote_path (str):
-            Path within GCS bucket to upload file to, includes file name.
-
-    Returns:
-        None:
-            None
-    """
-
-    storage_client = storage.Client(project=None)
-    bucket_storage = storage_client.get_bucket(bucket)
-    blob = bucket_storage.blob(remote_path)
-    blob.upload_from_filename(local_path)
-
-
-def _get_files(bucket: str, uri: ParseResult) -> List[str]:
-    """
-    List all available files within a Google storage bucket that matches a wild
-    card path.
-
-    Args:
-        bucket (str):
-            Google Storage bucket to reference.
-
-        uri (urllib.parse.ParseResult):
-            Wild card uri path containing the "*" character.
-            Example:
-                * gs://feast/staging_location/*
-                * gs://feast/staging_location/file_*.avro
-
-    Returns:
-        List[str]:
-            List of all available files matching the wildcard path.
-    """
-
-    storage_client = storage.Client(project=None)
-    bucket_storage = storage_client.get_bucket(bucket)
-    path = uri.path
-
-    if "*" in path:
-        regex = re.compile(path.replace("*", ".*?").strip("/"))
-        blob_list = bucket_storage.list_blobs(
-            prefix=path.strip("/").split("*")[0], delimiter="/"
-        )
-        # File path should not be in path (file path must be longer than path)
-        return [
-            f"{uri.scheme}://{uri.hostname}/{file}"
-            for file in [x.name for x in blob_list]
-            if re.match(regex, file) and file not in path
-        ]
-    else:
-        raise Exception(f"{path} is not a wildcard path")
 
 
 def _get_file_name() -> str:

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 import pandas as pd
 from pandavro import to_avro
 
-from feast.staging.staging_strategy import StagingStrategy
+from feast.staging.storage_client import StorageClient
 
 
 def export_source_to_staging_location(
@@ -60,7 +60,7 @@ def export_source_to_staging_location(
             remote staging location.
     """
 
-    staging_strategy = StagingStrategy()
+    storage_client = StorageClient()
     uri = urlparse(staging_location_uri)
 
     # Prepare Avro file to be exported to staging location
@@ -83,7 +83,7 @@ def export_source_to_staging_location(
             )
         else:
             # gs, s3 file provided as a source.
-            return staging_strategy.execute_get_source_files(source)
+            return storage_client.execute_get_source_files(source)
     else:
         raise Exception(
             f"Only string and DataFrame types are allowed as a "
@@ -91,7 +91,7 @@ def export_source_to_staging_location(
         )
 
     # Push data to required staging location
-    staging_strategy.execute_file_upload(
+    storage_client.execute_file_upload(
         uri.scheme,
         source_path,
         uri.hostname,

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -44,12 +44,14 @@ def export_source_to_staging_location(
                 * Pandas DataFrame
                 * Local Avro file
                 * GCS Avro file
+                * S3 Avro file
 
 
         staging_location_uri (str):
             Remote staging location where DataFrame should be written.
             Examples:
                 * gs://bucket/path/
+                * s3://bucket/path/
                 * file:///data/subfolder/
 
     Returns:

--- a/sdk/python/feast/staging/staging_strategy.py
+++ b/sdk/python/feast/staging/staging_strategy.py
@@ -1,0 +1,162 @@
+import re
+from abc import ABC, ABCMeta, abstractmethod
+from enum import Enum
+from tempfile import TemporaryFile
+from typing import List
+from urllib.parse import ParseResult, urlparse
+
+import boto3
+from google.cloud import storage
+
+
+class PROTOCOL(Enum):
+    GS = "gs"
+    S3 = "s3"
+    LOCAL_FILE = "file"
+
+
+class StagingStrategy:
+    def __init__(self):
+        self._protocol_dict = dict()
+
+    def execute_file_download(self, file_uri: ParseResult) -> TemporaryFile:
+        protocol = self._get_staging_protocol(file_uri.scheme)
+        return protocol.download_file(file_uri)
+
+    def execute_get_source_files(self, source: str) -> List[str]:
+        uri = urlparse(source)
+        if "*" in uri.path:
+            protocol = self._get_staging_protocol(uri.scheme)
+            return protocol.list_files(bucket=uri.hostname, uri=uri)
+        elif PROTOCOL(uri.scheme) in [PROTOCOL.S3, PROTOCOL.GS]:
+            return [source]
+        else:
+            raise Exception(
+                f"Could not identify file protocol {uri.scheme}. Only gs:// and file:// and s3:// supported"
+            )
+
+    def execute_file_upload(
+        self, scheme: str, local_path: str, bucket: str, remote_path: str
+    ):
+        protocol = self._get_staging_protocol(scheme)
+        return protocol.upload_file(local_path, bucket, remote_path)
+
+    def _get_staging_protocol(self, protocol):
+        if protocol in self._protocol_dict:
+            return self._protocol_dict[protocol]
+        else:
+            if PROTOCOL(protocol) == PROTOCOL.GS:
+                self._protocol_dict[protocol] = GCSProtocol()
+            elif PROTOCOL(protocol) == PROTOCOL.S3:
+                self._protocol_dict[protocol] = S3Protocol()
+            elif PROTOCOL(protocol) == PROTOCOL.LOCAL_FILE:
+                self._protocol_dict[protocol] = LocalFSProtocol()
+            else:
+                raise Exception(
+                    f"Could not identify file protocol {protocol}. Only gs:// and file:// and s3:// supported"
+                )
+            return self._protocol_dict[protocol]
+
+
+class AbstractStagingProtocol(ABC):
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def download_file(self, uri: ParseResult) -> TemporaryFile:
+        pass
+
+    @abstractmethod
+    def list_files(self, bucket: str, uri: ParseResult) -> List[str]:
+        pass
+
+    @abstractmethod
+    def upload_file(self, local_path: str, bucket: str, remote_path: str):
+        pass
+
+
+class GCSProtocol(AbstractStagingProtocol):
+    def __init__(self):
+        self.gcs_client = storage.Client(project=None)
+
+    def download_file(self, uri: ParseResult) -> TemporaryFile:
+        url = uri.geturl()
+        file_obj = TemporaryFile()
+        self.gcs_client.download_blob_to_file(url, file_obj)
+        return file_obj
+
+    def list_files(self, bucket: str, uri: ParseResult) -> List[str]:
+        bucket = self.gcs_client.get_bucket(bucket)
+        path = uri.path
+
+        if "*" in path:
+            regex = re.compile(path.replace("*", ".*?").strip("/"))
+            blob_list = bucket.list_blobs(
+                prefix=path.strip("/").split("*")[0], delimiter="/"
+            )
+            # File path should not be in path (file path must be longer than path)
+            return [
+                f"{uri.scheme}://{uri.hostname}/{file}"
+                for file in [x.name for x in blob_list]
+                if re.match(regex, file) and file not in path
+            ]
+        else:
+            raise Exception(f"{path} is not a wildcard path")
+
+    def upload_file(self, local_path: str, bucket: str, remote_path: str):
+        bucket = self.gcs_client.get_bucket(bucket)
+        blob = bucket.blob(remote_path)
+        blob.upload_from_filename(local_path)
+
+
+class S3Protocol(AbstractStagingProtocol):
+    def __init__(self):
+        self.s3_client = boto3.client("s3")
+
+    def download_file(self, uri: ParseResult) -> TemporaryFile:
+        url = uri.path[1:]  # removing leading / from the path
+        bucket = uri.hostname
+        file_obj = TemporaryFile()
+        self.s3_client.download_fileobj(bucket, url, file_obj)
+        return file_obj
+
+    def list_files(self, bucket: str, uri: ParseResult) -> List[str]:
+        path = uri.path
+
+        if "*" in path:
+            regex = re.compile(path.replace("*", ".*?").strip("/"))
+            blob_list = self.s3_client.list_objects(
+                Bucket=bucket, Prefix=path.strip("/").split("*")[0], Delimiter="/"
+            )
+            # File path should not be in path (file path must be longer than path)
+            return [
+                f"{uri.scheme}://{uri.hostname}/{file}"
+                for file in [x["Key"] for x in blob_list["Contents"]]
+                if re.match(regex, file) and file not in path
+            ]
+        else:
+            raise Exception(f"{path} is not a wildcard path")
+
+    def upload_file(self, local_path: str, bucket: str, remote_path: str):
+        with open(local_path, "rb") as file:
+            self.s3_client.upload_fileobj(file, bucket, remote_path)
+
+
+class LocalFSProtocol(AbstractStagingProtocol):
+    def __init__(self):
+        pass
+
+    def download_file(self, file_uri: ParseResult) -> TemporaryFile:
+        url = file_uri.path
+        file_obj = open(url, "rb")
+        return file_obj
+
+    def list_files(self, bucket: str, uri: ParseResult) -> List[str]:
+        raise NotImplementedError("list file not implemented for Local file")
+
+    def upload_file(self, local_path: str, bucket: str, remote_path: str):
+        pass  # For test cases

--- a/sdk/python/feast/staging/staging_strategy.py
+++ b/sdk/python/feast/staging/staging_strategy.py
@@ -10,20 +10,42 @@ from google.cloud import storage
 
 
 class PROTOCOL(Enum):
+    """
+    Currently supported protocols enum class.
+    """
+
     GS = "gs"
     S3 = "s3"
     LOCAL_FILE = "file"
 
 
 class StagingStrategy:
+    """
+    Class for handling different staging protocols currently s3, gs and local file are supported.
+    """
+
     def __init__(self):
         self._protocol_dict = dict()
 
     def execute_file_download(self, file_uri: ParseResult) -> TemporaryFile:
+        """
+        Downloads a file from the uri location and returns a TemporaryFile object
+
+        :param file_uri: Parsed uri of the file ex: urlparse("gs://bucket/file.avro")
+        :return: TemporaryFile object
+        """
         protocol = self._get_staging_protocol(file_uri.scheme)
         return protocol.download_file(file_uri)
 
     def execute_get_source_files(self, source: str) -> List[str]:
+        """
+        Lists all the files under a directory if path has wildcard(*) character.
+
+        :param source: File path with the protocol ex: gs://bucket/* or gs://bucket/file.avro
+        :return: List[str]
+                    Returns a list containing the full path to the file(s) in the
+                    remote staging location.
+        """
         uri = urlparse(source)
         if "*" in uri.path:
             protocol = self._get_staging_protocol(uri.scheme)
@@ -38,10 +60,26 @@ class StagingStrategy:
     def execute_file_upload(
         self, scheme: str, local_path: str, bucket: str, remote_path: str
     ):
+        """
+        Uploads file to a cloud storage, currently s3 and gs are supported
+
+        :param scheme: uri scheme: s3 or gs
+        :param local_path: Path to the local file that needs to be uploaded/staged
+        :param bucket: s3 or gs Bucket name
+        :param remote_path: relative path to the folder to which the files need to be uploaded
+        :return: None
+        """
         protocol = self._get_staging_protocol(scheme)
         return protocol.upload_file(local_path, bucket, remote_path)
 
     def _get_staging_protocol(self, protocol):
+        """
+        Lazy initialization of a specific protocol object(GCSProtocol, S3Protocol etc.) w
+        hen the 1st instance is encountered.
+
+        :param protocol: uri scheme: s3, gs or file
+        :return: returns a concrete implementation of AbstractStagingProtocol
+        """
         if protocol in self._protocol_dict:
             return self._protocol_dict[protocol]
         else:
@@ -59,6 +97,9 @@ class StagingStrategy:
 
 
 class AbstractStagingProtocol(ABC):
+    """
+    Abstract class for staging protocol, any new protocol should implement this class.
+    """
 
     __metaclass__ = ABCMeta
 
@@ -80,16 +121,36 @@ class AbstractStagingProtocol(ABC):
 
 
 class GCSProtocol(AbstractStagingProtocol):
+    """
+    Implementation of AbstractStagingProtocol for google cloud storage
+    """
+
     def __init__(self):
         self.gcs_client = storage.Client(project=None)
 
     def download_file(self, uri: ParseResult) -> TemporaryFile:
+        """
+        Downloads a file from google cloud storage and returns a TemporaryFile object
+
+        :param uri: Parsed uri of the file ex: urlparse("gs://bucket/file.avro")
+        :return: TemporaryFile object
+        """
         url = uri.geturl()
         file_obj = TemporaryFile()
         self.gcs_client.download_blob_to_file(url, file_obj)
         return file_obj
 
     def list_files(self, bucket: str, uri: ParseResult) -> List[str]:
+        """
+        Lists all the files under a directory in google cloud storage if path has wildcard(*) character.
+
+        :param bucket: google cloud storage bucket name
+        :param uri: parsed uri of location in google cloud storage. ex: urlparse("gs://bucket/file.avro")
+        :return: List[str]
+                    Returns a list containing the full path to the file(s) in the
+                    remote staging location.
+        """
+
         bucket = self.gcs_client.get_bucket(bucket)
         path = uri.path
 
@@ -108,16 +169,34 @@ class GCSProtocol(AbstractStagingProtocol):
             raise Exception(f"{path} is not a wildcard path")
 
     def upload_file(self, local_path: str, bucket: str, remote_path: str):
+        """
+        Uploads file to google cloud storage.
+
+        :param local_path: Path to the local file that needs to be uploaded/staged
+        :param bucket: s3 gs Bucket name
+        :param remote_path: relative path to the folder to which the files need to be uploaded
+        :return: None
+        """
         bucket = self.gcs_client.get_bucket(bucket)
         blob = bucket.blob(remote_path)
         blob.upload_from_filename(local_path)
 
 
 class S3Protocol(AbstractStagingProtocol):
+    """
+       Implementation of AbstractStagingProtocol for Aws S3 storage
+    """
+
     def __init__(self):
         self.s3_client = boto3.client("s3")
 
     def download_file(self, uri: ParseResult) -> TemporaryFile:
+        """
+        Downloads a file from AWS s3 storage and returns a TemporaryFile object
+
+        :param uri: Parsed uri of the file ex: urlparse("s3://bucket/file.avro")
+        :return: TemporaryFile object
+        """
         url = uri.path[1:]  # removing leading / from the path
         bucket = uri.hostname
         file_obj = TemporaryFile()
@@ -125,6 +204,15 @@ class S3Protocol(AbstractStagingProtocol):
         return file_obj
 
     def list_files(self, bucket: str, uri: ParseResult) -> List[str]:
+        """
+        Lists all the files under a directory in s3 if path has wildcard(*) character.
+
+        :param bucket: s3 bucket name
+        :param uri: parsed uri of location in s3. ex: urlparse("s3://bucket/file.avro")
+        :return: List[str]
+                    Returns a list containing the full path to the file(s) in the
+                    remote staging location.
+        """
         path = uri.path
 
         if "*" in path:
@@ -142,21 +230,40 @@ class S3Protocol(AbstractStagingProtocol):
             raise Exception(f"{path} is not a wildcard path")
 
     def upload_file(self, local_path: str, bucket: str, remote_path: str):
+        """
+        Uploads file to s3.
+
+        :param local_path: Path to the local file that needs to be uploaded/staged
+        :param bucket: s3 Bucket name
+        :param remote_path: relative path to the folder to which the files need to be uploaded
+        :return: None
+        """
         with open(local_path, "rb") as file:
             self.s3_client.upload_fileobj(file, bucket, remote_path)
 
 
 class LocalFSProtocol(AbstractStagingProtocol):
+    """
+       Implementation of AbstractStagingProtocol for local file
+       Note: The is used for E2E tests.
+    """
+
     def __init__(self):
         pass
 
-    def download_file(self, file_uri: ParseResult) -> TemporaryFile:
-        url = file_uri.path
+    def download_file(self, uri: ParseResult) -> TemporaryFile:
+        """
+        Reads a local file from the disk
+
+        :param uri: Parsed uri of the file ex: urlparse("file://folder/file.avro")
+        :return: TemporaryFile object
+        """
+        url = uri.path
         file_obj = open(url, "rb")
         return file_obj
 
     def list_files(self, bucket: str, uri: ParseResult) -> List[str]:
-        raise NotImplementedError("list file not implemented for Local file")
+        raise NotImplementedError("list files not implemented for Local file")
 
     def upload_file(self, local_path: str, bucket: str, remote_path: str):
         pass  # For test cases

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -18,6 +18,7 @@ import re
 from abc import ABC, ABCMeta, abstractmethod
 from tempfile import TemporaryFile
 from typing import List
+from typing.io import IO
 from urllib.parse import ParseResult
 
 GS = "gs"
@@ -37,7 +38,7 @@ class AbstractStagingClient(ABC):
         pass
 
     @abstractmethod
-    def download_file(self, uri: ParseResult) -> TemporaryFile:
+    def download_file(self, uri: ParseResult) -> IO[bytes]:
         pass
 
     @abstractmethod
@@ -64,9 +65,9 @@ class GCSClient(AbstractStagingClient):
             )
         self.gcs_client = storage.Client(project=None)
 
-    def download_file(self, uri: ParseResult) -> TemporaryFile:
+    def download_file(self, uri: ParseResult) -> IO[bytes]:
         """
-        Downloads a file from google cloud storage and returns a TemporaryFile object
+        Downloads a file from google cloud storageF and returns a TemporaryFile object
 
         Args:
             uri (urllib.parse.ParseResult): Parsed uri of the file ex: urlparse("gs://bucket/file.avro")
@@ -117,8 +118,8 @@ class GCSClient(AbstractStagingClient):
             bucket (str): gs Bucket name
             remote_path (str): relative path to the folder to which the files need to be uploaded
         """
-        bucket = self.gcs_client.get_bucket(bucket)
-        blob = bucket.blob(remote_path)
+        gs_bucket = self.gcs_client.get_bucket(bucket)
+        blob = gs_bucket.blob(remote_path)
         blob.upload_from_filename(local_path)
 
 
@@ -137,7 +138,7 @@ class S3Client(AbstractStagingClient):
             )
         self.s3_client = boto3.client("s3")
 
-    def download_file(self, uri: ParseResult) -> TemporaryFile:
+    def download_file(self, uri: ParseResult) -> IO[bytes]:
         """
         Downloads a file from AWS s3 storage and returns a TemporaryFile object
 
@@ -201,7 +202,7 @@ class LocalFSClient(AbstractStagingClient):
     def __init__(self):
         pass
 
-    def download_file(self, uri: ParseResult) -> TemporaryFile:
+    def download_file(self, uri: ParseResult) -> IO[bytes]:
         """
         Reads a local file from the disk
 

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Cimpress
+# Copyright 2020 The Feast Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -28,7 +28,7 @@ LOCAL_FILE = "file"
 
 class AbstractStagingClient(ABC):
     """
-    Abstract class for staging client, any new client should implement this class.
+    Client used to stage files in order to upload or download datasets into a historical store.
     """
 
     __metaclass__ = ABCMeta
@@ -39,14 +39,23 @@ class AbstractStagingClient(ABC):
 
     @abstractmethod
     def download_file(self, uri: ParseResult) -> IO[bytes]:
+        """
+        Downloads a file from an object store and returns a TemporaryFile object
+        """
         pass
 
     @abstractmethod
     def list_files(self, bucket: str, path: str) -> List[str]:
+        """
+        Lists all the files under a directory in an object store.
+        """
         pass
 
     @abstractmethod
     def upload_file(self, local_path: str, bucket: str, remote_path: str):
+        """
+        Uploads a file to an object store.
+        """
         pass
 
 
@@ -67,7 +76,7 @@ class GCSClient(AbstractStagingClient):
 
     def download_file(self, uri: ParseResult) -> IO[bytes]:
         """
-        Downloads a file from google cloud storageF and returns a TemporaryFile object
+        Downloads a file from google cloud storage and returns a TemporaryFile object
 
         Args:
             uri (urllib.parse.ParseResult): Parsed uri of the file ex: urlparse("gs://bucket/file.avro")

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -92,11 +92,11 @@ class GCSClient(AbstractStagingClient):
                     remote staging location.
         """
 
-        bucket = self.gcs_client.get_bucket(bucket)
+        gs_bucket = self.gcs_client.get_bucket(bucket)
 
         if "*" in path:
             regex = re.compile(path.replace("*", ".*?").strip("/"))
-            blob_list = bucket.list_blobs(
+            blob_list = gs_bucket.list_blobs(
                 prefix=path.strip("/").split("*")[0], delimiter="/"
             )
             # File path should not be in path (file path must be longer than path)

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -16,107 +16,18 @@
 
 import re
 from abc import ABC, ABCMeta, abstractmethod
-from enum import Enum
 from tempfile import TemporaryFile
 from typing import List
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult
+
+GS = "gs"
+S3 = "s3"
+LOCAL_FILE = "file"
 
 
-class PROTOCOL(Enum):
+class AbstractStagingClient(ABC):
     """
-    Currently supported protocols enum class.
-    """
-
-    GS = "gs"
-    S3 = "s3"
-    LOCAL_FILE = "file"
-
-
-class StorageClient:
-    """
-    Class for handling different staging protocols currently s3, gs and local file are supported.
-    """
-
-    def __init__(self):
-        self._protocol_dict = dict()
-
-    def execute_file_download(self, file_uri: ParseResult) -> TemporaryFile:
-        """
-        Downloads a file from the uri location and returns a TemporaryFile object
-
-        Args:
-            file_uri (urllib.parse.ParseResult): Parsed uri of the file ex: urlparse("gs://bucket/file.avro")
-        Returns:
-            TemporaryFile object
-        """
-        protocol = self._get_staging_protocol(file_uri.scheme)
-        return protocol.download_file(file_uri)
-
-    def execute_get_source_files(self, source: str) -> List[str]:
-        """
-        Lists all the files under a directory if path has wildcard(*) character.
-
-        Args:
-            source (str): File path with the protocol ex: gs://bucket/* or gs://bucket/file.avro
-        Returns:
-            List[str]: A list containing the full path to the file(s) in the remote staging location.
-        """
-        uri = urlparse(source)
-        if "*" in uri.path:
-            protocol = self._get_staging_protocol(uri.scheme)
-            return protocol.list_files(bucket=uri.hostname, uri=uri)
-        elif PROTOCOL(uri.scheme) in [PROTOCOL.S3, PROTOCOL.GS]:
-            return [source]
-        else:
-            raise Exception(
-                f"Could not identify file protocol {uri.scheme}. Only gs:// and file:// and s3:// supported"
-            )
-
-    def execute_file_upload(
-        self, scheme: str, local_path: str, bucket: str, remote_path: str
-    ):
-        """
-        Uploads file to a cloud storage, currently s3 and gs are supported
-
-        Args:
-            scheme (str): uri scheme: s3 or gs
-            local_path (str): Path to the local file that needs to be uploaded/staged
-            bucket (str): s3 or gs Bucket name
-            remote_path (str): relative path to the folder to which the files need to be uploaded
-        """
-        protocol = self._get_staging_protocol(scheme)
-        return protocol.upload_file(local_path, bucket, remote_path)
-
-    def _get_staging_protocol(self, protocol):
-        """
-        Lazy initialization of a specific protocol object(GCSProtocol, S3Protocol etc.) w
-        hen the 1st instance is encountered.
-
-        Args:
-            protocol (str): uri scheme: s3, gs or file
-
-        Returns:
-            An object of concrete implementation of AbstractStagingProtocol
-        """
-        if protocol in self._protocol_dict:
-            return self._protocol_dict[protocol]
-        else:
-            if PROTOCOL(protocol) == PROTOCOL.GS:
-                self._protocol_dict[protocol] = GCSProtocol()
-            elif PROTOCOL(protocol) == PROTOCOL.S3:
-                self._protocol_dict[protocol] = S3Protocol()
-            elif PROTOCOL(protocol) == PROTOCOL.LOCAL_FILE:
-                self._protocol_dict[protocol] = LocalFSProtocol()
-            else:
-                raise Exception(
-                    f"Could not identify file protocol {protocol}. Only gs:// and file:// and s3:// supported"
-                )
-            return self._protocol_dict[protocol]
-
-
-class AbstractStagingProtocol(ABC):
-    """
-    Abstract class for staging protocol, any new protocol should implement this class.
+    Abstract class for staging client, any new client should implement this class.
     """
 
     __metaclass__ = ABCMeta
@@ -130,7 +41,7 @@ class AbstractStagingProtocol(ABC):
         pass
 
     @abstractmethod
-    def list_files(self, bucket: str, uri: ParseResult) -> List[str]:
+    def list_files(self, bucket: str, path: str) -> List[str]:
         pass
 
     @abstractmethod
@@ -138,9 +49,9 @@ class AbstractStagingProtocol(ABC):
         pass
 
 
-class GCSProtocol(AbstractStagingProtocol):
+class GCSClient(AbstractStagingClient):
     """
-    Implementation of AbstractStagingProtocol for google cloud storage
+    Implementation of AbstractStagingClient for google cloud storage
     """
 
     def __init__(self):
@@ -168,13 +79,13 @@ class GCSProtocol(AbstractStagingProtocol):
         self.gcs_client.download_blob_to_file(url, file_obj)
         return file_obj
 
-    def list_files(self, bucket: str, uri: ParseResult) -> List[str]:
+    def list_files(self, bucket: str, path: str) -> List[str]:
         """
         Lists all the files under a directory in google cloud storage if path has wildcard(*) character.
 
         Args:
             bucket (str): google cloud storage bucket name
-            uri (urllib.parse.ParseResult): parsed uri of location in google cloud storage. ex: urlparse("gs://bucket/file.avro")
+            path (str): object location in google cloud storage.
 
         Returns:
             List[str]: A list containing the full path to the file(s) in the
@@ -182,7 +93,6 @@ class GCSProtocol(AbstractStagingProtocol):
         """
 
         bucket = self.gcs_client.get_bucket(bucket)
-        path = uri.path
 
         if "*" in path:
             regex = re.compile(path.replace("*", ".*?").strip("/"))
@@ -191,12 +101,12 @@ class GCSProtocol(AbstractStagingProtocol):
             )
             # File path should not be in path (file path must be longer than path)
             return [
-                f"{uri.scheme}://{uri.hostname}/{file}"
+                f"{GS}://{bucket}/{file}"
                 for file in [x.name for x in blob_list]
                 if re.match(regex, file) and file not in path
             ]
         else:
-            raise Exception(f"{path} is not a wildcard path")
+            return [f"{S3}://{bucket}/{path.lstrip('/')}"]
 
     def upload_file(self, local_path: str, bucket: str, remote_path: str):
         """
@@ -212,9 +122,9 @@ class GCSProtocol(AbstractStagingProtocol):
         blob.upload_from_filename(local_path)
 
 
-class S3Protocol(AbstractStagingProtocol):
+class S3Client(AbstractStagingClient):
     """
-       Implementation of AbstractStagingProtocol for Aws S3 storage
+       Implementation of AbstractStagingClient for Aws S3 storage
     """
 
     def __init__(self):
@@ -242,19 +152,18 @@ class S3Protocol(AbstractStagingProtocol):
         self.s3_client.download_fileobj(bucket, url, file_obj)
         return file_obj
 
-    def list_files(self, bucket: str, uri: ParseResult) -> List[str]:
+    def list_files(self, bucket: str, path: str) -> List[str]:
         """
         Lists all the files under a directory in s3 if path has wildcard(*) character.
 
         Args:
-            bucket (str): s3 bucket name
-            uri (urllib.parse.ParseResult): parsed uri of location in s3. ex: urlparse("s3://bucket/file.avro")
+            bucket (str): s3 bucket name.
+            path (str): Object location in s3.
 
         Returns:
             List[str]: A list containing the full path to the file(s) in the
                     remote staging location.
         """
-        path = uri.path
 
         if "*" in path:
             regex = re.compile(path.replace("*", ".*?").strip("/"))
@@ -263,12 +172,12 @@ class S3Protocol(AbstractStagingProtocol):
             )
             # File path should not be in path (file path must be longer than path)
             return [
-                f"{uri.scheme}://{uri.hostname}/{file}"
+                f"{S3}://{bucket}/{file}"
                 for file in [x["Key"] for x in blob_list["Contents"]]
                 if re.match(regex, file) and file not in path
             ]
         else:
-            raise Exception(f"{path} is not a wildcard path")
+            return [f"{S3}://{bucket}/{path.lstrip('/')}"]
 
     def upload_file(self, local_path: str, bucket: str, remote_path: str):
         """
@@ -283,9 +192,9 @@ class S3Protocol(AbstractStagingProtocol):
             self.s3_client.upload_fileobj(file, bucket, remote_path)
 
 
-class LocalFSProtocol(AbstractStagingProtocol):
+class LocalFSClient(AbstractStagingClient):
     """
-       Implementation of AbstractStagingProtocol for local file
+       Implementation of AbstractStagingClient for local file
        Note: The is used for E2E tests.
     """
 
@@ -305,8 +214,29 @@ class LocalFSProtocol(AbstractStagingProtocol):
         file_obj = open(url, "rb")
         return file_obj
 
-    def list_files(self, bucket: str, uri: ParseResult) -> List[str]:
+    def list_files(self, bucket: str, path: str) -> List[str]:
         raise NotImplementedError("list files not implemented for Local file")
 
     def upload_file(self, local_path: str, bucket: str, remote_path: str):
         pass  # For test cases
+
+
+storage_clients = {GS: GCSClient, S3: S3Client, LOCAL_FILE: LocalFSClient}
+
+
+def get_staging_client(scheme):
+    """
+    Initialization of a specific client object(GCSClient, S3Client etc.)
+
+    Args:
+        scheme (str): uri scheme: s3, gs or file
+
+    Returns:
+        An object of concrete implementation of AbstractStagingClient
+    """
+    try:
+        return storage_clients[scheme]()
+    except ValueError:
+        raise Exception(
+            f"Could not identify file scheme {scheme}. Only gs://, file:// and s3:// are supported"
+        )

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2020 Cimpress
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import re
 from abc import ABC, ABCMeta, abstractmethod
 from enum import Enum

--- a/sdk/python/requirements-ci.txt
+++ b/sdk/python/requirements-ci.txt
@@ -11,5 +11,6 @@ pytest-ordering==0.6.*
 pandas==0.*
 mock==2.0.0
 pandavro==1.5.*
+moto
 mypy
 mypy-protobuf

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -36,3 +36,5 @@ mypy-protobuf
 pre-commit
 flake8
 black
+boto3
+moto

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -46,6 +46,7 @@ REQUIRED = [
     "numpy",
     "google",
     "confluent_kafka",
+    'boto3'
 ]
 
 # README file from Feast repo root directory

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -46,7 +46,6 @@ REQUIRED = [
     "numpy",
     "google",
     "confluent_kafka",
-    'boto3'
 ]
 
 # README file from Feast repo root directory

--- a/sdk/python/tests/loaders/test_file.py
+++ b/sdk/python/tests/loaders/test_file.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2020 Cimpress
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import tempfile
 from unittest.mock import patch
 from urllib.parse import urlparse

--- a/sdk/python/tests/loaders/test_file.py
+++ b/sdk/python/tests/loaders/test_file.py
@@ -1,0 +1,77 @@
+import tempfile
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import boto3
+import fastavro
+import pandas as pd
+import pandavro
+from moto import mock_s3
+from pandas.testing import assert_frame_equal
+from pytest import fixture
+
+from feast.loaders.file import export_source_to_staging_location
+
+BUCKET = "test_bucket"
+FOLDER_NAME = "test_folder"
+FILE_NAME = "test.avro"
+
+LOCAL_FILE = "file://tmp/tmp"
+S3_LOCATION = f"s3://{BUCKET}/{FOLDER_NAME}"
+
+TEST_DATA_FRAME = pd.DataFrame(
+    {
+        "driver": [1001, 1002, 1003],
+        "transaction": [1001, 1002, 1003],
+        "driver_id": [1001, 1002, 1003],
+    }
+)
+
+
+@fixture
+def avro_data_path():
+    final_results = tempfile.mktemp()
+    pandavro.to_avro(file_path_or_buffer=final_results, df=TEST_DATA_FRAME)
+    return final_results
+
+
+@patch("feast.loaders.file._get_file_name", return_value=FILE_NAME)
+def test_export_source_to_staging_location_local_file_should_pass(get_file_name):
+    source = export_source_to_staging_location(TEST_DATA_FRAME, LOCAL_FILE)
+    assert source == [f"{LOCAL_FILE}/{FILE_NAME}"]
+    assert get_file_name.call_count == 1
+
+
+@mock_s3
+@patch("feast.loaders.file._get_file_name", return_value=FILE_NAME)
+def test_export_source_to_staging_location_dataframe_to_s3_should_pass(get_file_name):
+    s3_client = boto3.client("s3")
+    s3_client.create_bucket(Bucket=BUCKET)
+    source = export_source_to_staging_location(TEST_DATA_FRAME, S3_LOCATION)
+    file_obj = tempfile.TemporaryFile()
+    uri = urlparse(source[0])
+    s3_client.download_fileobj(uri.hostname, uri.path[1:], file_obj)
+    file_obj.seek(0)
+    avro_reader = fastavro.reader(file_obj)
+    retrived_df = pd.DataFrame.from_records([r for r in avro_reader])
+    assert_frame_equal(retrived_df, TEST_DATA_FRAME)
+    assert get_file_name.call_count == 1
+
+
+def test_export_source_to_staging_location_s3_file_as_source_should_pass():
+    source = export_source_to_staging_location(S3_LOCATION, None)
+    assert source == [S3_LOCATION]
+
+
+@mock_s3
+def test_export_source_to_staging_location_s3_wildcard_as_source_should_pass(
+    avro_data_path,
+):
+    s3_client = boto3.client("s3")
+    s3_client.create_bucket(Bucket=BUCKET)
+    with open(avro_data_path, "rb") as data:
+        s3_client.upload_fileobj(data, BUCKET, f"{FOLDER_NAME}/file1.avro")
+    with open(avro_data_path, "rb") as data:
+        s3_client.upload_fileobj(data, BUCKET, f"{FOLDER_NAME}/file2.avro")
+    sources = export_source_to_staging_location(f"{S3_LOCATION}/*", None)
+    assert sources == [f"{S3_LOCATION}/file1.avro", f"{S3_LOCATION}/file2.avro"]

--- a/sdk/python/tests/loaders/test_file.py
+++ b/sdk/python/tests/loaders/test_file.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Cimpress
+# Copyright 2020 The Feast Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sdk/python/tests/loaders/test_file.py
+++ b/sdk/python/tests/loaders/test_file.py
@@ -54,7 +54,7 @@ def test_export_source_to_staging_location_dataframe_to_s3_should_pass(get_file_
     file_obj.seek(0)
     avro_reader = fastavro.reader(file_obj)
     retrived_df = pd.DataFrame.from_records([r for r in avro_reader])
-    assert_frame_equal(retrived_df, TEST_DATA_FRAME)
+    assert_frame_equal(retrived_df, TEST_DATA_FRAME, check_like=True)
     assert get_file_name.call_count == 1
 
 

--- a/sdk/python/tests/test_job.py
+++ b/sdk/python/tests/test_job.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Cimpress
+# Copyright 2020 The Feast Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sdk/python/tests/test_job.py
+++ b/sdk/python/tests/test_job.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2020 Cimpress
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import tempfile
 
 import boto3

--- a/sdk/python/tests/test_job.py
+++ b/sdk/python/tests/test_job.py
@@ -61,7 +61,7 @@ class TestRetrievalJob:
             ),
         )
         retrived_df = retrieve_job.to_dataframe()
-        assert_frame_equal(TEST_DATA_FRAME, retrived_df)
+        assert_frame_equal(TEST_DATA_FRAME, retrived_df, check_like=True)
 
     @mock_s3
     def test_to_dataframe_s3_file_staging_should_pass(
@@ -87,7 +87,7 @@ class TestRetrievalJob:
             ),
         )
         retrived_df = retrieve_job.to_dataframe()
-        assert_frame_equal(TEST_DATA_FRAME, retrived_df)
+        assert_frame_equal(TEST_DATA_FRAME, retrived_df, check_like=True)
 
     @pytest.mark.parametrize(
         "job_proto,exception",

--- a/sdk/python/tests/test_job.py
+++ b/sdk/python/tests/test_job.py
@@ -10,7 +10,7 @@ from pandas.testing import assert_frame_equal
 from pytest import fixture, raises
 
 import feast.serving.ServingService_pb2_grpc as Serving
-from feast.job import RetrievalJob, JobProto
+from feast.job import JobProto, RetrievalJob
 from feast.serving.ServingService_pb2 import DataFormat, GetJobResponse
 from feast.serving.ServingService_pb2 import Job as BatchRetrievalJob
 from feast.serving.ServingService_pb2 import JobStatus, JobType

--- a/sdk/python/tests/test_job.py
+++ b/sdk/python/tests/test_job.py
@@ -1,0 +1,128 @@
+import tempfile
+
+import boto3
+import grpc
+import pandas as pd
+import pandavro
+import pytest
+from moto import mock_s3
+from pandas.testing import assert_frame_equal
+from pytest import fixture, raises
+
+import feast.serving.ServingService_pb2_grpc as Serving
+from feast.job import RetrievalJob, JobProto
+from feast.serving.ServingService_pb2 import DataFormat, GetJobResponse
+from feast.serving.ServingService_pb2 import Job as BatchRetrievalJob
+from feast.serving.ServingService_pb2 import JobStatus, JobType
+
+BUCKET = "test_bucket"
+
+TEST_DATA_FRAME = pd.DataFrame(
+    {
+        "driver": [1001, 1002, 1003],
+        "transaction": [1001, 1002, 1003],
+        "driver_id": [1001, 1002, 1003],
+    }
+)
+
+
+class TestRetrievalJob:
+    @fixture
+    def retrieve_job(self):
+
+        serving_service_stub = Serving.ServingServiceStub(grpc.insecure_channel(""))
+        job_proto = JobProto(
+            id="123",
+            type=JobType.JOB_TYPE_DOWNLOAD,
+            status=JobStatus.JOB_STATUS_RUNNING,
+        )
+        return RetrievalJob(job_proto, serving_service_stub)
+
+    @fixture
+    def avro_data_path(self):
+        final_results = tempfile.mktemp()
+        pandavro.to_avro(file_path_or_buffer=final_results, df=TEST_DATA_FRAME)
+        return final_results
+
+    def test_to_dataframe_local_file_staging_should_pass(
+        self, retrieve_job, avro_data_path, mocker
+    ):
+        mocker.patch.object(
+            retrieve_job.serving_stub,
+            "GetJob",
+            return_value=GetJobResponse(
+                job=BatchRetrievalJob(
+                    id="123",
+                    type=JobType.JOB_TYPE_DOWNLOAD,
+                    status=JobStatus.JOB_STATUS_DONE,
+                    file_uris=[f"file://{avro_data_path}"],
+                    data_format=DataFormat.DATA_FORMAT_AVRO,
+                )
+            ),
+        )
+        retrived_df = retrieve_job.to_dataframe()
+        assert_frame_equal(TEST_DATA_FRAME, retrived_df)
+
+    @mock_s3
+    def test_to_dataframe_s3_file_staging_should_pass(
+        self, retrieve_job, avro_data_path, mocker
+    ):
+        s3_client = boto3.client("s3")
+        target = "test_proj/test_features.avro"
+        s3_client.create_bucket(Bucket=BUCKET)
+        with open(avro_data_path, "rb") as data:
+            s3_client.upload_fileobj(data, BUCKET, target)
+
+        mocker.patch.object(
+            retrieve_job.serving_stub,
+            "GetJob",
+            return_value=GetJobResponse(
+                job=BatchRetrievalJob(
+                    id="123",
+                    type=JobType.JOB_TYPE_DOWNLOAD,
+                    status=JobStatus.JOB_STATUS_DONE,
+                    file_uris=[f"s3://{BUCKET}/{target}"],
+                    data_format=DataFormat.DATA_FORMAT_AVRO,
+                )
+            ),
+        )
+        retrived_df = retrieve_job.to_dataframe()
+        assert_frame_equal(TEST_DATA_FRAME, retrived_df)
+
+    @pytest.mark.parametrize(
+        "job_proto,exception",
+        [
+            (
+                GetJobResponse(
+                    job=BatchRetrievalJob(
+                        id="123",
+                        type=JobType.JOB_TYPE_DOWNLOAD,
+                        status=JobStatus.JOB_STATUS_DONE,
+                        data_format=DataFormat.DATA_FORMAT_AVRO,
+                        error="Testing job failure",
+                    )
+                ),
+                Exception,
+            ),
+            (
+                GetJobResponse(
+                    job=BatchRetrievalJob(
+                        id="123",
+                        type=JobType.JOB_TYPE_DOWNLOAD,
+                        status=JobStatus.JOB_STATUS_DONE,
+                        data_format=DataFormat.DATA_FORMAT_INVALID,
+                    )
+                ),
+                Exception,
+            ),
+        ],
+        ids=["when_retrieve_job_fails", "when_data_format_is_not_avro"],
+    )
+    def test_to_dataframe_s3_file_staging_should_raise(
+        self, retrieve_job, mocker, job_proto, exception
+    ):
+        mocker.patch.object(
+            retrieve_job.serving_stub, "GetJob", return_value=job_proto,
+        )
+        with raises(exception):
+            retrieve_job.to_dataframe()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently Feast client cannot stage data anywhere except GCP storage. The PR adds S3 staging support on client.
**Which issue(s) this PR fixes**: Client can stage files on s3. 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Python Client changes for #706.
Edit: Fixes #562 

**Does this PR introduce a user-facing change?**: No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support to Python SDK for staging files on Amazon S3
```
