### PR TITLE
Publish helm chart script should not modify the chart content

### DIFF
--- a/.prow/config.yaml
+++ b/.prow/config.yaml
@@ -493,15 +493,6 @@ postsubmits:
           mv /tmp/linux-amd64/helm /usr/bin/helm
           helm init --client-only
 
-          sed -i "/version: /c\version: ${PULL_BASE_REF:1}" infra/charts/feast/Chart.yaml
-          sed -i "/  version: /c\  version: ${PULL_BASE_REF:1}" infra/charts/feast/requirements.yaml
-
-          sed -i "/version: /c\version: ${PULL_BASE_REF:1}" infra/charts/feast/charts/feast-core/Chart.yaml
-          sed -i "/  tag: /c\  tag: ${PULL_BASE_REF:1}" infra/charts/feast/charts/feast-core/values.yaml
-
-          sed -i "/version: /c\version: ${PULL_BASE_REF:1}" infra/charts/feast/charts/feast-serving/Chart.yaml
-          sed -i "/  tag: /c\  tag: ${PULL_BASE_REF:1}" infra/charts/feast/charts/feast-serving/values.yaml
-
           infra/scripts/sync-helm-charts.sh
         volumeMounts:
         - name: service-account


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
The current publish helm chart script modifies the existing charts in the repository before publishing the chart. The original intention is that, should a developer forgot to update the version, the script will automatically correct the mistake.

However, this preprocessing is currently modifying the versions of the non-feast dependencies. As a result the helm chart publication job will fail due to dependency not being met (eg. Prometheus).

This PR remove the preprocessing step. Instead the developer should explicitly update the image/tag version in the release branch.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
