### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.5.1](https://github.com/feast-dev/feast/tree/0.5.1) (2020-06-06)
+
+[Full Changelog](https://github.com/feast-dev/feast/compare/v0.5.0...v0.5.1)
+
+**Implemented enhancements:**
+- Add support for version method in Feast SDK and Core [\#759](https://github.com/feast-dev/feast/pull/759) ([woop](https://github.com/woop))
+- Refactor runner configuration, add labels to dataflow options [\#718](https://github.com/feast-dev/feast/pull/718) ([zhilingc](https://github.com/zhilingc))
+
+**Fixed bugs:**
+- Fix pipeline options toArgs\(\) returning empty list [\#765](https://github.com/feast-dev/feast/pull/765) ([zhilingc](https://github.com/zhilingc))
+- Fix project argument for feature set describe in CLI [\#731](https://github.com/feast-dev/feast/pull/731) ([terryyylim](https://github.com/terryyylim))
+- Fix Go and Java SDK Regressions [\#729](https://github.com/feast-dev/feast/pull/729) ([mrzzy](https://github.com/mrzzy))
+- Remove usage of parallel stream for feature value map generation [\#751](https://github.com/feast-dev/feast/pull/751) ([khorshuheng](https://github.com/khorshuheng))
+- Restore Feast Java SDK and Ingestion compatibility with Java 8 runtimes [\#722](https://github.com/feast-dev/feast/pull/722) ([ches](https://github.com/ches))
+- Python sdk bug fixes [\#723](https://github.com/feast-dev/feast/pull/723) ([zhilingc](https://github.com/zhilingc))
+
+**Merged pull requests:**
+- Increase Jaeger Tracing coverage [\#719](https://github.com/feast-dev/feast/pull/719) ([terryyylim](https://github.com/terryyylim))
+- Recompile golang protos to include new FeatureSetStatus [\#755](https://github.com/feast-dev/feast/pull/755) ([zhilingc](https://github.com/zhilingc))
+- Merge Redis cluster connector with Redis connector [\#752](https://github.com/feast-dev/feast/pull/752) ([pyalex](https://github.com/pyalex))
+- Remove unused Hibernate dep from Serving [\#721](https://github.com/feast-dev/feast/pull/721) ([ches](https://github.com/ches))
+
 ## [v0.5.0](https://github.com/feast-dev/feast/tree/v0.5.0) (2020-05-19)
 
 [Full Changelog](https://github.com/feast-dev/feast/compare/v0.4.7...v0.5.0)

--- a/infra/charts/feast/Chart.yaml
+++ b/infra/charts/feast/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Feature store for machine learning.
 name: feast
-version: 0.5.0-alpha.1
+version: 0.5.1

--- a/infra/charts/feast/README.md
+++ b/infra/charts/feast/README.md
@@ -1,7 +1,7 @@
 feast
 ===== 
 
-Feature store for machine learning. Current chart version is `0.5.0-alpha.1`
+Feature store for machine learning. Current chart version is `0.5.1`
 
 ## TL;DR;
 
@@ -32,9 +32,9 @@ This chart install Feast deployment on a Kubernetes cluster using the [Helm](htt
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | feast-core | 0.5.0-alpha.1 |
-|  | feast-serving | 0.5.0-alpha.1 |
-|  | feast-serving | 0.5.0-alpha.1 |
+|  | feast-core | 0.5.1 |
+|  | feast-serving | 0.5.1 |
+|  | feast-serving | 0.5.1 |
 |  | prometheus-statsd-exporter | 0.1.2 |
 | https://kubernetes-charts-incubator.storage.googleapis.com/ | kafka | 0.20.8 |
 | https://kubernetes-charts.storage.googleapis.com/ | grafana | 5.0.5 |

--- a/infra/charts/feast/charts/feast-core/Chart.yaml
+++ b/infra/charts/feast/charts/feast-core/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Feast Core registers feature specifications and manage ingestion jobs.
 name: feast-core
-version: 0.5.0-alpha.1
+version: 0.5.1

--- a/infra/charts/feast/charts/feast-core/README.md
+++ b/infra/charts/feast/charts/feast-core/README.md
@@ -2,7 +2,7 @@ feast-core
 ==========
 Feast Core registers feature specifications and manage ingestion jobs.
 
-Current chart version is `0.5.0-alpha.1`
+Current chart version is `0.5.1`
 
 
 

--- a/infra/charts/feast/charts/feast-serving/Chart.yaml
+++ b/infra/charts/feast/charts/feast-serving/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Feast Serving serves low-latency latest features and historical batch features.
 name: feast-serving
-version: 0.5.0-alpha.1
+version: 0.5.1

--- a/infra/charts/feast/charts/feast-serving/README.md
+++ b/infra/charts/feast/charts/feast-serving/README.md
@@ -2,7 +2,7 @@ feast-serving
 =============
 Feast Serving serves low-latency latest features and historical batch features.
 
-Current chart version is `0.5.0-alpha.1`
+Current chart version is `0.5.1`
 
 
 

--- a/infra/charts/feast/requirements.lock
+++ b/infra/charts/feast/requirements.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: feast-core
   repository: ""
-  version: 0.5.0-alpha.1
+  version: 0.5.1
 - name: feast-serving
   repository: ""
-  version: 0.5.0-alpha.1
+  version: 0.5.1
 - name: feast-serving
   repository: ""
-  version: 0.5.0-alpha.1
+  version: 0.5.1
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 8.6.1

--- a/infra/charts/feast/requirements.yaml
+++ b/infra/charts/feast/requirements.yaml
@@ -1,14 +1,14 @@
 dependencies:
 - name: feast-core
-  version: 0.5.0-alpha.1
+  version: 0.5.1
   condition: feast-core.enabled
 - name: feast-serving
   alias: feast-online-serving
-  version: 0.5.0-alpha.1
+  version: 0.5.1
   condition: feast-online-serving.enabled
 - name: feast-serving
   alias: feast-batch-serving
-  version: 0.5.0-alpha.1
+  version: 0.5.1
   condition: feast-batch-serving.enabled
 - name: postgresql
   version: 8.6.1

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     </modules>
 
     <properties>
-        <revision>0.5</revision>
+        <revision>0.5.1</revision>
         <github.url>https://github.com/feast-dev/feast</github.url>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
**What this PR does / why we need it**:
The following has been updated in preparation for release 0.5.1:
1. Helm chart version and default image tag
2. Changelog

The changelog will be backported back to master.
