### PR TITLE
Add YAML export to Python SDK

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -54,7 +54,7 @@ func (fc *GrpcClient) GetOnlineFeatures(ctx context.Context, req *OnlineFeatures
 	// collect unqiue entity refs from entity rows
 	entityRefs := make(map[string]struct{})
 	for _, entityRows := range req.Entities {
-		for ref, _ := range entityRows {
+		for ref := range entityRows {
 			entityRefs[ref] = struct{}{}
 		}
 	}

--- a/sdk/python/feast/feature_set.py
+++ b/sdk/python/feast/feature_set.py
@@ -80,6 +80,9 @@ class FeatureSet:
             if key not in other.fields.keys() or self.fields[key] != other.fields[key]:
                 return False
 
+            if self.fields[key] != other.fields[key]:
+                return False
+
         if (
             self.name != other.name
             or self.project != other.project
@@ -787,13 +790,17 @@ class FeatureSet:
             entities=[
                 Entity.from_proto(entity) for entity in feature_set_proto.spec.entities
             ],
-            max_age=feature_set_proto.spec.max_age,
+            max_age=(
+                None
+                if feature_set_proto.spec.max_age.seconds == 0 and feature_set_proto.spec.max_age.nanos == 0
+                else feature_set_proto.spec.max_age
+            ),
             source=(
                 None
                 if feature_set_proto.spec.source.type == 0
                 else Source.from_proto(feature_set_proto.spec.source)
             ),
-            project=feature_set_proto.spec.project
+            project=None
             if len(feature_set_proto.spec.project) == 0
             else feature_set_proto.spec.project,
         )
@@ -840,21 +847,14 @@ class FeatureSet:
         """
         return MessageToDict(self.to_proto())
 
-    def to_yaml(self, path: str = None):
+    def to_yaml(self):
         """
-        Converts a feature set to a YAML file. If a file path is provided the YAML will be written to disk, otherwise it
-        will be returned as a string.
+        Converts a feature set to a YAML string.
 
-        :param path: Optional file path to export feature set to
-        :return: Feature set string returned in YAML format if no file path provided
+        :return: Feature set string returned in YAML format
         """
         feature_set_dict = self.to_dict()
-        if path:
-            # Export to YAML file
-            yaml.dump(feature_set_dict, path)
-        else:
-            # Return YAML as string
-            return yaml.dump(feature_set_dict, allow_unicode=True)
+        return yaml.dump(feature_set_dict, allow_unicode=True)
 
 
 class FeatureSetRef:

--- a/sdk/python/feast/feature_set.py
+++ b/sdk/python/feast/feature_set.py
@@ -847,7 +847,11 @@ class FeatureSet:
         :return: Dictionary object representation of feature set
         """
         feature_set_dict = MessageToDict(self.to_proto())
-        del feature_set_dict["meta"]
+
+        # Remove meta when empty for more readable exports
+        if feature_set_dict["meta"] == {}:
+            del feature_set_dict["meta"]
+
         return feature_set_dict
 
     def to_yaml(self):

--- a/sdk/python/feast/feature_set.py
+++ b/sdk/python/feast/feature_set.py
@@ -17,9 +17,10 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 import pyarrow as pa
+import yaml
 from google.protobuf import json_format
 from google.protobuf.duration_pb2 import Duration
-from google.protobuf.json_format import MessageToJson
+from google.protobuf.json_format import MessageToDict, MessageToJson
 from google.protobuf.message import Message
 from pandas.api.types import is_datetime64_ns_dtype
 from pyarrow.lib import TimestampType
@@ -84,6 +85,9 @@ class FeatureSet:
             or self.project != other.project
             or self.max_age != other.max_age
         ):
+            return False
+
+        if self.source != other.source:
             return False
         return True
 
@@ -827,6 +831,30 @@ class FeatureSet:
         )
 
         return FeatureSetProto(spec=spec, meta=meta)
+
+    def to_dict(self) -> Dict:
+        """
+        Converts feature set to dict
+
+        :return: Dictionary object representation of feature set
+        """
+        return MessageToDict(self.to_proto())
+
+    def to_yaml(self, path: str = None):
+        """
+        Converts a feature set to a YAML file. If a file path is provided the YAML will be written to disk, otherwise it
+        will be returned as a string.
+
+        :param path: Optional file path to export feature set to
+        :return: Feature set string returned in YAML format if no file path provided
+        """
+        feature_set_dict = self.to_dict()
+        if path:
+            # Export to YAML file
+            yaml.dump(feature_set_dict, path)
+        else:
+            # Return YAML as string
+            return yaml.dump(feature_set_dict, allow_unicode=True)
 
 
 class FeatureSetRef:

--- a/sdk/python/feast/feature_set.py
+++ b/sdk/python/feast/feature_set.py
@@ -792,7 +792,8 @@ class FeatureSet:
             ],
             max_age=(
                 None
-                if feature_set_proto.spec.max_age.seconds == 0 and feature_set_proto.spec.max_age.nanos == 0
+                if feature_set_proto.spec.max_age.seconds == 0
+                and feature_set_proto.spec.max_age.nanos == 0
                 else feature_set_proto.spec.max_age
             ),
             source=(
@@ -845,7 +846,9 @@ class FeatureSet:
 
         :return: Dictionary object representation of feature set
         """
-        return MessageToDict(self.to_proto())
+        feature_set_dict = MessageToDict(self.to_proto())
+        del feature_set_dict["meta"]
+        return feature_set_dict
 
     def to_yaml(self):
         """
@@ -854,7 +857,7 @@ class FeatureSet:
         :return: Feature set string returned in YAML format
         """
         feature_set_dict = self.to_dict()
-        return yaml.dump(feature_set_dict, allow_unicode=True)
+        return yaml.dump(feature_set_dict, allow_unicode=True, sort_keys=False)
 
 
 class FeatureSetRef:

--- a/sdk/python/tests/test_feature_set.py
+++ b/sdk/python/tests/test_feature_set.py
@@ -257,10 +257,14 @@ class TestFeatureSet:
             ],
         )
 
+        # Create a string YAML representation of the feature set
         string_yaml = test_feature_set.to_yaml()
-        print(string_yaml)
-        actual_feature_set = FeatureSet.from_yaml(string_yaml)
-        assert test_feature_set == actual_feature_set
+
+        # Create a new feature set object from the YAML string
+        actual_feature_set_from_string = FeatureSet.from_yaml(string_yaml)
+
+        # Ensure equality is upheld to original feature set
+        assert test_feature_set == actual_feature_set_from_string
 
 
 def make_tfx_schema_domain_info_inline(schema):

--- a/sdk/python/tests/test_feature_set.py
+++ b/sdk/python/tests/test_feature_set.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import pathlib
 from concurrent import futures
 from datetime import datetime
@@ -243,6 +244,23 @@ class TestFeatureSet:
         assert len(actual_schema.feature) == len(expected_schema.feature)
         for actual, expected in zip(actual_schema.feature, expected_schema.feature):
             assert actual.SerializeToString() == expected.SerializeToString()
+
+    def test_feature_set_import_export_yaml(self):
+
+        test_feature_set = FeatureSet(
+            name="bikeshare",
+            entities=[Entity(name="station_id", dtype=ValueType.INT64)],
+            features=[
+                Feature(name="name", dtype=ValueType.STRING),
+                Feature(name="longitude", dtype=ValueType.FLOAT),
+                Feature(name="location", dtype=ValueType.STRING),
+            ],
+        )
+
+        string_yaml = test_feature_set.to_yaml()
+        print(string_yaml)
+        actual_feature_set = FeatureSet.from_yaml(string_yaml)
+        assert test_feature_set == actual_feature_set
 
 
 def make_tfx_schema_domain_info_inline(schema):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR allows users to export feature sets to YAML strings. Usage is as follows

```
fs = FeatureSet("my_feature_set")
print(fs.to_yaml())
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds the ability to export a feature set to YAML.
```
