### PR TITLE
Release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v0.3.8](https://github.com/feast-dev/feast/tree/v0.3.8) (2020-06-10)
+
+[Full Changelog](https://github.com/feast-dev/feast/compare/v0.3.7...v0.3.8)
+
+**Implemented enhancements:**
+
+- v0.3 backport: Add feature and feature set labels [\#737](https://github.com/feast-dev/feast/pull/737) ([ches](https://github.com/ches))
+
+**Merged pull requests:**
+
+- v0.3 backport: Add Java coverage reporting [\#734](https://github.com/feast-dev/feast/pull/734) ([ches](https://github.com/ches))
+
 ## [v0.3.7](https://github.com/gojek/feast/tree/v0.3.7) (2020-05-01)
 
 [Full Changelog](https://github.com/gojek/feast/compare/v0.3.6...v0.3.7)

--- a/infra/charts/feast/Chart.yaml
+++ b/infra/charts/feast/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart to install Feast on kubernetes
 name: feast
-version: 0.3.2
+version: 0.3.8

--- a/infra/charts/feast/README.md
+++ b/infra/charts/feast/README.md
@@ -39,7 +39,7 @@ helm repo update
 Install Feast release with minimal features, without batch serving and persistency:
 ```bash
 RELEASE_NAME=demo
-helm install feast-charts/feast --name $RELEASE_NAME --version 0.3.2 -f values-demo.yaml
+helm install feast-charts/feast --name $RELEASE_NAME --version 0.3.8 -f values-demo.yaml
 ```
 
 Install Feast release for typical use cases, with batch and online serving:
@@ -60,7 +60,7 @@ PROJECT_ID=google-cloud-project-id
 DATASET_ID=bigquery-dataset-id
 
 # Install the Helm release using default values.yaml
-helm install feast-charts/feast --name feast --version 0.3.2 \
+helm install feast-charts/feast --name feast --version 0.3.8 \
   --set feast-serving-batch."application\.yaml".feast.jobs.staging-location=$STAGING_LOCATION \
   --set feast-serving-batch."store\.yaml".bigquery_config.project_id=$PROJECT_ID \
   --set feast-serving-batch."store\.yaml".bigquery_config.dataset_id=$DATASET_ID
@@ -83,7 +83,7 @@ The following table lists the configurable parameters of the Feast chart and the
 | `feast-core.kafka.topics[0].partitions` |  No of partitions for the topic | `1`
 | `feast-core.replicaCount` | No of pods to create | `1`
 | `feast-core.image.repository` | Repository for Feast Core Docker image | `gcr.io/kf-feast/feast-core`
-| `feast-core.image.tag` | Tag for Feast Core Docker image | `0.3.2`
+| `feast-core.image.tag` | Tag for Feast Core Docker image | `0.3.8`
 | `feast-core.image.pullPolicy` | Image pull policy for Feast Core Docker image | `IfNotPresent`
 | `feast-core.application.yaml` | Configuration for Feast Core application | Refer to this [link](charts/feast-core/values.yaml) 
 | `feast-core.springConfigMountPath` | Directory to mount application.yaml | `/etc/feast/feast-core`
@@ -116,7 +116,7 @@ The following table lists the configurable parameters of the Feast chart and the
 | `feast-serving-online.core.enabled` | Flag for Feast Serving to use Feast Core in the same Helm release | `true`
 | `feast-serving-online.replicaCount` | No of pods to create  | `1`
 | `feast-serving-online.image.repository` | Repository for Feast Serving Docker image | `gcr.io/kf-feast/feast-serving`
-| `feast-serving-online.image.tag` | Tag for Feast Serving Docker image | `0.3.2`
+| `feast-serving-online.image.tag` | Tag for Feast Serving Docker image | `0.3.8`
 | `feast-serving-online.image.pullPolicy` | Image pull policy for Feast Serving Docker image | `IfNotPresent`
 | `feast-serving-online.application.yaml` | Application configuration for Feast Serving | Refer to this [link](charts/feast-serving/values.yaml) 
 | `feast-serving-online.store.yaml` | Store configuration for Feast Serving | Refer to this [link](charts/feast-serving/values.yaml) 
@@ -150,7 +150,7 @@ The following table lists the configurable parameters of the Feast chart and the
 | `feast-serving-batch.core.enabled` | Flag for Feast Serving to use Feast Core in the same Helm release | `true`
 | `feast-serving-batch.replicaCount` | No of pods to create  | `1`
 | `feast-serving-batch.image.repository` | Repository for Feast Serving Docker image | `gcr.io/kf-feast/feast-serving`
-| `feast-serving-batch.image.tag` | Tag for Feast Serving Docker image | `0.3.2`
+| `feast-serving-batch.image.tag` | Tag for Feast Serving Docker image | `0.3.8`
 | `feast-serving-batch.image.pullPolicy` | Image pull policy for Feast Serving Docker image | `IfNotPresent`
 | `feast-serving-batch.application.yaml` | Application configuration for Feast Serving | Refer to this [link](charts/feast-serving/values.yaml) 
 | `feast-serving-batch.store.yaml` | Store configuration for Feast Serving | Refer to this [link](charts/feast-serving/values.yaml) 

--- a/infra/charts/feast/charts/feast-core/Chart.yaml
+++ b/infra/charts/feast/charts/feast-core/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for core component of Feast
 name: feast-core
-version: 0.3.2
+version: 0.3.8

--- a/infra/charts/feast/charts/feast-serving/Chart.yaml
+++ b/infra/charts/feast/charts/feast-serving/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for serving component of Feast
 name: feast-serving
-version: 0.3.2
+version: 0.3.8

--- a/infra/charts/feast/requirements.lock
+++ b/infra/charts/feast/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: feast-core
   repository: ""
-  version: 0.3.2
+  version: 0.3.8
 - name: feast-serving
   repository: ""
-  version: 0.3.2
+  version: 0.3.8
 - name: feast-serving
   repository: ""
-  version: 0.3.2
+  version: 0.3.8
 digest: sha256:7ee4cd271cbd4ace44817dd12ba65f490a8e3529adf199604a2c2bdad9c2fac3
 generated: "2019-11-27T13:35:41.334054+08:00"

--- a/infra/charts/feast/requirements.yaml
+++ b/infra/charts/feast/requirements.yaml
@@ -1,12 +1,12 @@
 dependencies:
 - name: feast-core
-  version: 0.3.2
+  version: 0.3.8
   condition: feast-core.enabled
 - name: feast-serving
   alias: feast-serving-batch
-  version: 0.3.2
+  version: 0.3.8
   condition: feast-serving-batch.enabled
 - name: feast-serving
   alias: feast-serving-online
-  version: 0.3.2
+  version: 0.3.8
   condition: feast-serving-online.enabled

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </modules>
 
     <properties>
-        <revision>0.3.8-SNAPSHOT</revision>
+        <revision>0.3.8</revision>
         <github.url>https://github.com/gojek/feast</github.url>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
I wanted to get the switch to using Java 11 for Core and Serving backported as well, to hopefully be able to drop Prow configuration for Java 8 except perhaps one to guard regressions for Ingestion, but there are some issues with Cassandra in Java 11 that we'll have to look into later.

This release is to get the labels support in v0.3 out in published protos.