### PR TITLE
Add v0.3.8 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,18 @@ See [Feast 0.5 Release Issue](https://github.com/feast-dev/feast/issues/527) for
 - Add readiness checks for Feast services in end to end test [\#337](https://github.com/feast-dev/feast/pull/337) ([davidheryanto](https://github.com/davidheryanto))
 - Create CHANGELOG.md [\#321](https://github.com/feast-dev/feast/pull/321) ([woop](https://github.com/woop))
 
+## [v0.3.8](https://github.com/feast-dev/feast/tree/v0.3.8) (2020-06-10)
+
+[Full Changelog](https://github.com/feast-dev/feast/compare/v0.3.7...v0.3.8)
+
+**Implemented enhancements:**
+
+- v0.3 backport: Add feature and feature set labels [\#737](https://github.com/feast-dev/feast/pull/737) ([ches](https://github.com/ches))
+
+**Merged pull requests:**
+
+- v0.3 backport: Add Java coverage reporting [\#734](https://github.com/feast-dev/feast/pull/734) ([ches](https://github.com/ches))
+
 ## [v0.3.7](https://github.com/feast-dev/feast/tree/v0.3.7) (2020-05-01)
 
 [Full Changelog](https://github.com/feast-dev/feast/compare/v0.3.6...v0.3.7)


### PR DESCRIPTION
Brings v0.3.8 changelog to master.

The release process was pretty smooth! 🎉 

~~One thing: Prow publish jobs don't seem to have run for [the release commit](https://github.com/feast-dev/feast/commit/64852e26fd3d4cf342eb8c69b22724ea106cbabe), @davidheryanto maybe you can answer if it needs some extra kick? I've pushed the tag on that commit.~~