### PR TITLE
Compression of FeatureRows collection in memory

### DIFF
--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/common/TypeUtil.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/common/TypeUtil.java
@@ -17,9 +17,12 @@
 package feast.storage.connectors.bigquery.common;
 
 import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.protobuf.ByteString;
 import feast.proto.types.ValueProto;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class TypeUtil {
 
@@ -62,5 +65,115 @@ public class TypeUtil {
    */
   public static StandardSQLTypeName toStandardSqlType(ValueProto.ValueType.Enum valueType) {
     return VALUE_TYPE_TO_STANDARD_SQL_TYPE.get(valueType);
+  }
+
+  public static Object protoValueToObject(
+      ValueProto.Value value, ValueProto.Value.ValCase valCase) {
+    switch (valCase) {
+      case BYTES_VAL:
+        return value.getBytesVal().toByteArray();
+      case STRING_VAL:
+        return value.getStringVal();
+      case INT32_VAL:
+        return value.getInt32Val();
+      case INT64_VAL:
+        return value.getInt64Val();
+      case DOUBLE_VAL:
+        return value.getDoubleVal();
+      case FLOAT_VAL:
+        return value.getFloatVal();
+      case BOOL_VAL:
+        return value.getBoolVal();
+      case BYTES_LIST_VAL:
+        return value.getBytesListVal().getValList().stream()
+            .map(ByteString::toByteArray)
+            .collect(Collectors.toList());
+      case STRING_LIST_VAL:
+        return value.getStringListVal().getValList();
+      case INT32_LIST_VAL:
+        return value.getInt32ListVal().getValList();
+      case INT64_LIST_VAL:
+        return value.getInt64ListVal().getValList();
+      case DOUBLE_LIST_VAL:
+        return value.getDoubleListVal().getValList();
+      case FLOAT_LIST_VAL:
+        return value.getFloatListVal().getValList();
+      case BOOL_LIST_VAL:
+        return value.getBoolListVal().getValList();
+      case VAL_NOT_SET:
+        break;
+    }
+    return null;
+  }
+
+  public static ValueProto.Value objectToProtoValue(
+      Object value, ValueProto.Value.ValCase valCase) {
+    ValueProto.Value.Builder builder = ValueProto.Value.newBuilder();
+    switch (valCase) {
+      case BYTES_VAL:
+        return builder.setBytesVal(ByteString.copyFrom((byte[]) value)).build();
+      case STRING_VAL:
+        return builder.setStringVal((String) value).build();
+      case INT32_VAL:
+        return builder.setInt32Val((Integer) value).build();
+      case INT64_VAL:
+        return builder.setInt64Val((Long) value).build();
+      case DOUBLE_VAL:
+        return builder.setDoubleVal((Double) value).build();
+      case FLOAT_VAL:
+        return builder.setFloatVal((Float) value).build();
+      case BOOL_VAL:
+        return builder.setBoolVal((Boolean) value).build();
+      case BYTES_LIST_VAL:
+        return builder
+            .setBytesListVal(
+                ValueProto.BytesList.newBuilder()
+                    .addAllVal(
+                        ((List<byte[]>) value)
+                            .stream().map(ByteString::copyFrom).collect(Collectors.toList()))
+                    .build())
+            .build();
+      case STRING_LIST_VAL:
+        return builder
+            .setStringListVal(
+                ValueProto.StringList.newBuilder().addAllVal((List<String>) value).build())
+            .build();
+      case INT32_LIST_VAL:
+        return builder
+            .setInt32ListVal(
+                ValueProto.Int32List.newBuilder().addAllVal((List<Integer>) value).build())
+            .build();
+      case INT64_LIST_VAL:
+        return builder
+            .setInt64ListVal(
+                ValueProto.Int64List.newBuilder().addAllVal((List<Long>) value).build())
+            .build();
+      case DOUBLE_LIST_VAL:
+        return builder
+            .setDoubleListVal(
+                ValueProto.DoubleList.newBuilder().addAllVal((List<Double>) value).build())
+            .build();
+      case FLOAT_LIST_VAL:
+        return builder
+            .setFloatListVal(
+                ValueProto.FloatList.newBuilder().addAllVal((List<Float>) value).build())
+            .build();
+      case BOOL_LIST_VAL:
+        return builder
+            .setBoolListVal(
+                ValueProto.BoolList.newBuilder().addAllVal((List<Boolean>) value).build())
+            .build();
+      case VAL_NOT_SET:
+        break;
+    }
+    return null;
+  }
+
+  public static Object protoValueToObject(ValueProto.Value value) {
+    return protoValueToObject(value, value.getValCase());
+  }
+
+  public static Object getDefaultProtoValue(ValueProto.Value.ValCase valCase) {
+    return protoValueToObject(ValueProto.Value.getDefaultInstance(), valCase);
   }
 }

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/CompactFeatureRows.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/CompactFeatureRows.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.connectors.bigquery.compression;
+
+import feast.proto.types.FeatureRowProto;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.SnappyCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.GroupIntoBatches;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+
+/**
+ * Collects batch of FeatureRow, converts them into columnar form:
+ *
+ * <p>List&lt;FeatureRow&gt; -&gt;
+ *
+ * <p>- Feature1 List&lt;Integer&gt; - all values from all rows in one list
+ *
+ * <p>- Feature2 List&lt;String&gt;
+ *
+ * <p>- ...
+ *
+ * <p>FeatureRowsBatch is in column form, hence it is better compressible. For compression we use
+ * Snappy, since it's already available in Beam as SnappyCoder.
+ */
+public class CompactFeatureRows
+    extends PTransform<
+        PCollection<KV<String, FeatureRowProto.FeatureRow>>,
+        PCollection<KV<String, FeatureRowsBatch>>> {
+  private final int batchSize;
+
+  public CompactFeatureRows(int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public PCollection<KV<String, FeatureRowsBatch>> expand(
+      PCollection<KV<String, FeatureRowProto.FeatureRow>> input) {
+    return input
+        .apply(GroupIntoBatches.ofSize(batchSize))
+        .apply(ParDo.of(new FeatureRowToColumnar()))
+        .setCoder(
+            KvCoder.of(
+                StringUtf8Coder.of(), SnappyCoder.of(FeatureRowsBatch.FeatureRowsCoder.of())));
+  }
+
+  public static class FeatureRowToColumnar
+      extends DoFn<KV<String, Iterable<FeatureRowProto.FeatureRow>>, KV<String, FeatureRowsBatch>> {
+    @ProcessElement
+    public void process(ProcessContext c) {
+      c.output(KV.of(c.element().getKey(), new FeatureRowsBatch(c.element().getValue())));
+    }
+  }
+}

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
@@ -1,0 +1,228 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.connectors.bigquery.compression;
+
+import static feast.proto.types.ValueProto.Value.ValCase.*;
+import static feast.storage.connectors.bigquery.common.TypeUtil.*;
+
+import feast.proto.types.FeatureRowProto;
+import feast.proto.types.FieldProto;
+import feast.proto.types.ValueProto;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.beam.sdk.coders.*;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.Row;
+
+/**
+ * Based on list of featureRows this class infers common schema (with all found features) and then
+ * transpose list of rows into list of values format (column-oriented).
+ *
+ * <p>getFeatureRows provides reverse transformation
+ */
+public class FeatureRowsBatch implements Serializable {
+  private final Schema schema;
+  private String featureSetReference;
+  private List<Object> values = new ArrayList<>();
+
+  public static Map<ValueProto.Value.ValCase, Schema.FieldType> protoToSchemaTypes =
+      new HashMap<>();
+  public static Map<Schema.FieldType, ValueProto.Value.ValCase> schemaToProtoTypes;
+  public static Map<String, Object> defaultValues = new HashMap<>();
+
+  static {
+    protoToSchemaTypes.put(BYTES_VAL, Schema.FieldType.BYTES);
+    protoToSchemaTypes.put(STRING_VAL, Schema.FieldType.STRING);
+    protoToSchemaTypes.put(INT32_VAL, Schema.FieldType.INT32);
+    protoToSchemaTypes.put(INT64_VAL, Schema.FieldType.INT64);
+    protoToSchemaTypes.put(DOUBLE_VAL, Schema.FieldType.DOUBLE);
+    protoToSchemaTypes.put(FLOAT_VAL, Schema.FieldType.FLOAT);
+    protoToSchemaTypes.put(BOOL_VAL, Schema.FieldType.BOOLEAN);
+    protoToSchemaTypes.put(BYTES_LIST_VAL, Schema.FieldType.array(Schema.FieldType.BYTES));
+    protoToSchemaTypes.put(STRING_LIST_VAL, Schema.FieldType.array(Schema.FieldType.STRING));
+    protoToSchemaTypes.put(INT32_LIST_VAL, Schema.FieldType.array(Schema.FieldType.INT32));
+    protoToSchemaTypes.put(INT64_LIST_VAL, Schema.FieldType.array(Schema.FieldType.INT64));
+    protoToSchemaTypes.put(FLOAT_LIST_VAL, Schema.FieldType.array(Schema.FieldType.FLOAT));
+    protoToSchemaTypes.put(BOOL_LIST_VAL, Schema.FieldType.array(Schema.FieldType.BOOLEAN));
+    protoToSchemaTypes.put(DOUBLE_LIST_VAL, Schema.FieldType.array(Schema.FieldType.DOUBLE));
+
+    schemaToProtoTypes =
+        protoToSchemaTypes.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+  }
+
+  public FeatureRowsBatch(Iterable<FeatureRowProto.FeatureRow> featureRows) {
+    this.schema = this.inferCommonSchema(featureRows);
+    this.initValues();
+    this.toColumnar(featureRows);
+  }
+
+  FeatureRowsBatch(Schema schema, List<Object> values) {
+    this.schema = schema;
+    this.values = values;
+  }
+
+  private Schema inferCommonSchema(Iterable<FeatureRowProto.FeatureRow> featureRows) {
+    Map<String, Schema.FieldType> types = new HashMap<>();
+    List<Schema.Field> fieldsInOrder = new ArrayList<>();
+
+    featureRows.forEach(
+        row ->
+            row.getFieldsList()
+                .forEach(
+                    f -> {
+                      Schema.FieldType fieldType =
+                          protoToSchemaTypes.get(f.getValue().getValCase());
+                      if (types.containsKey(f.getName())) {
+                        if (!types.get(f.getName()).equals(fieldType)) {
+                          throw new RuntimeException("schema cannot be inferred");
+                        }
+
+                        return;
+                      }
+
+                      if (!defaultValues.containsKey(f.getName())) {
+                        defaultValues.put(
+                            f.getName(), getDefaultProtoValue(f.getValue().getValCase()));
+                      }
+
+                      Schema.Field column =
+                          Schema.Field.of(f.getName(), Schema.FieldType.array(fieldType));
+
+                      types.put(f.getName(), fieldType);
+                      fieldsInOrder.add(column);
+
+                      if (featureSetReference == null) {
+                        featureSetReference = row.getFeatureSet();
+                      }
+                    }));
+    Schema schema = Schema.builder().addFields(fieldsInOrder).build();
+    schema.setUUID(UUID.randomUUID());
+    return schema;
+  }
+
+  private void initValues() {
+    IntStream.range(0, schema.getFieldCount())
+        .forEach(
+            idx -> {
+              values.add(new ArrayList<>());
+            });
+  }
+
+  private void toColumnar(Iterable<FeatureRowProto.FeatureRow> featureRows) {
+    featureRows.forEach(
+        row -> {
+          Map<String, ValueProto.Value> rowValues =
+              row.getFieldsList().stream()
+                  .collect(Collectors.toMap(FieldProto.Field::getName, FieldProto.Field::getValue));
+
+          IntStream.range(0, schema.getFieldCount())
+              .forEach(
+                  idx -> {
+                    Schema.Field field = schema.getField(idx);
+                    if (rowValues.containsKey(field.getName())) {
+                      ((List<Object>) values.get(idx))
+                          .add(protoValueToObject(rowValues.get(field.getName())));
+                    } else {
+                      ((List<Object>) values.get(idx)).add(defaultValues.get(field.getName()));
+                    }
+                  });
+        });
+  }
+
+  public Schema getSchema() {
+    return this.schema;
+  }
+
+  public String getFeatureSetReference() {
+    return this.featureSetReference;
+  }
+
+  public FeatureRowsBatch withFeatureSetReference(String featureSetReference) {
+    this.featureSetReference = featureSetReference;
+    return this;
+  }
+
+  public Row toRow() {
+    return Row.withSchema(schema).attachValues(values).build();
+  }
+
+  public static FeatureRowsBatch fromRow(Row row) {
+    return new FeatureRowsBatch(row.getSchema(), row.getValues());
+  }
+
+  public Iterator<FeatureRowProto.FeatureRow> getFeatureRows() {
+    return IntStream.range(0, ((List<Object>) values.get(0)).size())
+        .parallel()
+        .mapToObj(
+            rowIdx ->
+                FeatureRowProto.FeatureRow.newBuilder()
+                    .setFeatureSet(getFeatureSetReference())
+                    .addAllFields(
+                        IntStream.range(0, schema.getFieldCount())
+                            .mapToObj(
+                                fieldIdx ->
+                                    FieldProto.Field.newBuilder()
+                                        .setName(schema.getField(fieldIdx).getName())
+                                        .setValue(
+                                            objectToProtoValue(
+                                                ((List<Object>) values.get(fieldIdx)).get(rowIdx),
+                                                schemaToProtoTypes.get(
+                                                    schema
+                                                        .getField(fieldIdx)
+                                                        .getType()
+                                                        .getCollectionElementType())))
+                                        .build())
+                            .collect(Collectors.toList()))
+                    .build())
+        .iterator();
+  }
+
+  public static class FeatureRowsCoder extends CustomCoder<FeatureRowsBatch> {
+    private final Coder<Schema> schemaCoder = SerializableCoder.of(Schema.class);
+    private final Coder<String> referenceCoder = StringUtf8Coder.of();
+
+    public static FeatureRowsCoder of() {
+      return new FeatureRowsCoder();
+    }
+
+    private Coder<Row> getDelegateCoder(Schema schema) {
+      return RowCoderGenerator.generate(schema);
+    }
+
+    @Override
+    public void encode(FeatureRowsBatch value, OutputStream outStream)
+        throws CoderException, IOException {
+      schemaCoder.encode(value.getSchema(), outStream);
+      referenceCoder.encode(value.getFeatureSetReference(), outStream);
+      getDelegateCoder(value.getSchema()).encode(value.toRow(), outStream);
+    }
+
+    @Override
+    public FeatureRowsBatch decode(InputStream inStream) throws CoderException, IOException {
+      Schema schema = schemaCoder.decode(inStream);
+      String reference = referenceCoder.decode(inStream);
+      return FeatureRowsBatch.fromRow(getDelegateCoder(schema).decode(inStream))
+          .withFeatureSetReference(reference);
+    }
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Recently we changed BigQuery writes to use BatchLoad method to be able to update table schema in-flight. In order to produce "successful inserts" output for metrics calculation we keep in memory all FeatureRows until BigQuery load job succeed.
To use memory more efficient this PR proposes to compress FeatureRows that awaiting for bq job to finish by converting them from row-orientation into column-orientation and using generic compression on those columns.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
