### PR TITLE
Move communication with IngestionJob to JobCoordinator

### DIFF
--- a/core/src/main/java/feast/core/config/FeastProperties.java
+++ b/core/src/main/java/feast/core/config/FeastProperties.java
@@ -172,6 +172,10 @@ public class FeastProperties {
 
       /* Kafka topic to receive acknowledgment from ingestion job on successful processing of new specs */
       @NotBlank private String specsAckTopic = "feast-feature-set-specs-ack";
+
+      /* Notify jobs interval in millisecond.
+      How frequently Feast will check on Pending FeatureSets and publish them to kafka. */
+      @Positive private long notifyIntervalMilliseconds;
     }
   }
 

--- a/core/src/main/java/feast/core/dao/FeatureSetRepository.java
+++ b/core/src/main/java/feast/core/dao/FeatureSetRepository.java
@@ -17,6 +17,7 @@
 package feast.core.dao;
 
 import feast.core.model.FeatureSet;
+import feast.proto.core.FeatureSetProto;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -37,4 +38,7 @@ public interface FeatureSetRepository extends JpaRepository<FeatureSet, String> 
   // find all feature sets matching the given name pattern and project pattern
   List<FeatureSet> findAllByNameLikeAndProject_NameLikeOrderByNameAsc(
       String name, String project_name);
+
+  // find all feature sets matching given status
+  List<FeatureSet> findAllByStatus(FeatureSetProto.FeatureSetStatus status);
 }

--- a/core/src/main/java/feast/core/model/FeatureSetJobStatus.java
+++ b/core/src/main/java/feast/core/model/FeatureSetJobStatus.java
@@ -16,6 +16,7 @@
  */
 package feast.core.model;
 
+import com.google.common.base.Objects;
 import feast.proto.core.FeatureSetProto.FeatureSetJobDeliveryStatus;
 import java.io.Serializable;
 import javax.persistence.*;
@@ -61,4 +62,23 @@ public class FeatureSetJobStatus {
   @Enumerated(EnumType.STRING)
   @Column(name = "delivery_status")
   private FeatureSetJobDeliveryStatus deliveryStatus;
+
+  @Column(name = "version", columnDefinition = "integer default 0")
+  private int version;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FeatureSetJobStatus that = (FeatureSetJobStatus) o;
+    return version == that.version
+        && Objects.equal(job.getId(), that.job.getId())
+        && Objects.equal(featureSet.getReference(), that.featureSet.getReference())
+        && deliveryStatus == that.deliveryStatus;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(job, featureSet, deliveryStatus, version);
+  }
 }

--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -16,6 +16,8 @@
  */
 package feast.core.service;
 
+import static feast.core.model.FeatureSet.parseReference;
+
 import com.google.protobuf.InvalidProtocolBufferException;
 import feast.core.config.FeastProperties;
 import feast.core.config.FeastProperties.JobProperties;
@@ -26,6 +28,8 @@ import feast.core.job.JobUpdateTask;
 import feast.core.model.*;
 import feast.proto.core.CoreServiceProto.ListStoresRequest.Filter;
 import feast.proto.core.CoreServiceProto.ListStoresResponse;
+import feast.proto.core.FeatureSetProto;
+import feast.proto.core.IngestionJobProto;
 import feast.proto.core.StoreProto;
 import feast.proto.core.StoreProto.Store.Subscription;
 import java.util.ArrayList;
@@ -33,14 +37,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.*;
 import java.util.stream.Collectors;
 import javax.validation.constraints.Positive;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Pair;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,11 +54,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class JobCoordinatorService {
 
+  private final int SPEC_PUBLISHING_TIMEOUT_SECONDS = 5;
+
   private final JobRepository jobRepository;
   private final FeatureSetRepository featureSetRepository;
   private final SpecService specService;
   private final JobManager jobManager;
   private final JobProperties jobProperties;
+  private final KafkaTemplate<String, FeatureSetProto.FeatureSetSpec> specPublisher;
 
   @Autowired
   public JobCoordinatorService(
@@ -61,12 +69,14 @@ public class JobCoordinatorService {
       FeatureSetRepository featureSetRepository,
       SpecService specService,
       JobManager jobManager,
-      FeastProperties feastProperties) {
+      FeastProperties feastProperties,
+      KafkaTemplate<String, FeatureSetProto.FeatureSetSpec> specPublisher) {
     this.jobRepository = jobRepository;
     this.featureSetRepository = featureSetRepository;
     this.specService = specService;
     this.jobManager = jobManager;
     this.jobProperties = feastProperties.getJobs();
+    this.specPublisher = specPublisher;
   }
 
   /**
@@ -152,5 +162,125 @@ public class JobCoordinatorService {
     }
     // return the latest
     return Optional.of(jobs.get(0));
+  }
+
+  @Transactional
+  @Scheduled(fixedDelayString = "${feast.stream.specsOptions.notifyIntervalMilliseconds}")
+  public void notifyJobsWhenFeatureSetUpdated() {
+    List<FeatureSet> pendingFeatureSets =
+        featureSetRepository.findAllByStatus(FeatureSetProto.FeatureSetStatus.STATUS_PENDING);
+
+    pendingFeatureSets.stream()
+        .filter(
+            fs -> {
+              List<FeatureSetJobStatus> runningJobs =
+                  fs.getJobStatuses().stream()
+                      .filter(jobStatus -> jobStatus.getJob().isRunning())
+                      .collect(Collectors.toList());
+
+              return runningJobs.size() > 0
+                  && runningJobs.stream()
+                      .allMatch(jobStatus -> jobStatus.getVersion() < fs.getVersion());
+            })
+        .forEach(
+            fs -> {
+              log.info("Sending new FeatureSet {} to Ingestion", fs.getReference());
+
+              // Sending latest version of FeatureSet to all currently running IngestionJobs
+              // (there's one topic for all sets).
+              // All related jobs would apply new FeatureSet on the fly.
+              // In case kafka doesn't respond within SPEC_PUBLISHING_TIMEOUT_SECONDS we will try
+              // again later.
+              try {
+                specPublisher
+                    .sendDefault(fs.getReference(), fs.toProto().getSpec())
+                    .get(SPEC_PUBLISHING_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+              } catch (Exception e) {
+                log.error(
+                    "Error occurred while sending FeatureSetSpec to kafka. Cause {}."
+                        + " Will retry later",
+                    e.getMessage());
+                return;
+              }
+
+              // Updating delivery status for related jobs (that are currently using this
+              // FeatureSet).
+              // We now set status to IN_PROGRESS, so listenAckFromJobs would be able to
+              // monitor delivery progress for each new version.
+              fs.getJobStatuses().stream()
+                  .filter(s -> s.getJob().isRunning())
+                  .forEach(
+                      jobStatus -> {
+                        jobStatus.setDeliveryStatus(
+                            FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS);
+                        jobStatus.setVersion(fs.getVersion());
+                      });
+              featureSetRepository.saveAndFlush(fs);
+            });
+  }
+
+  /**
+   * Listener for ACK messages coming from IngestionJob when FeatureSetSpec is installed (in
+   * pipeline).
+   *
+   * <p>Updates FeatureSetJobStatus for respected FeatureSet (selected by reference) and Job (select
+   * by Id).
+   *
+   * <p>When all related (running) to FeatureSet jobs are updated - FeatureSet receives READY status
+   *
+   * @param record ConsumerRecord with key: FeatureSet reference and value: Ack message
+   */
+  @KafkaListener(topics = {"${feast.stream.specsOptions.specsAckTopic}"})
+  @Transactional
+  public void listenAckFromJobs(
+      ConsumerRecord<String, IngestionJobProto.FeatureSetSpecAck> record) {
+    String setReference = record.key();
+    Pair<String, String> projectAndSetName = parseReference(setReference);
+    FeatureSet featureSet =
+        featureSetRepository.findFeatureSetByNameAndProject_Name(
+            projectAndSetName.getSecond(), projectAndSetName.getFirst());
+    if (featureSet == null) {
+      log.warn(
+          String.format("ACKListener received message for unknown FeatureSet %s", setReference));
+      return;
+    }
+
+    int ackVersion = record.value().getFeatureSetVersion();
+
+    if (featureSet.getVersion() != ackVersion) {
+      log.warn(
+          String.format(
+              "ACKListener received outdated ack for %s. Current %d, Received %d",
+              setReference, featureSet.getVersion(), ackVersion));
+      return;
+    }
+
+    log.info("Updating featureSet {} delivery statuses.", featureSet.getReference());
+
+    featureSet.getJobStatuses().stream()
+        .filter(
+            js ->
+                js.getJob().getId().equals(record.value().getJobName())
+                    && js.getVersion() == ackVersion)
+        .findFirst()
+        .ifPresent(
+            featureSetJobStatus ->
+                featureSetJobStatus.setDeliveryStatus(
+                    FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_DELIVERED));
+
+    boolean allDelivered =
+        featureSet.getJobStatuses().stream()
+            .filter(js -> js.getJob().isRunning())
+            .allMatch(
+                js ->
+                    js.getDeliveryStatus()
+                        .equals(FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_DELIVERED));
+
+    if (allDelivered) {
+      log.info("FeatureSet {} update is completely delivered", featureSet.getReference());
+
+      featureSet.setStatus(FeatureSetProto.FeatureSetStatus.STATUS_READY);
+      featureSetRepository.saveAndFlush(featureSet);
+    }
   }
 }

--- a/core/src/main/java/feast/core/service/SpecService.java
+++ b/core/src/main/java/feast/core/service/SpecService.java
@@ -16,7 +16,6 @@
  */
 package feast.core.service;
 
-import static feast.core.model.FeatureSet.parseReference;
 import static feast.core.validators.Matchers.checkValidCharacters;
 import static feast.core.validators.Matchers.checkValidCharactersAllowAsterisk;
 
@@ -42,21 +41,15 @@ import feast.proto.core.CoreServiceProto.UpdateStoreRequest;
 import feast.proto.core.CoreServiceProto.UpdateStoreResponse;
 import feast.proto.core.FeatureSetProto;
 import feast.proto.core.FeatureSetProto.FeatureSetStatus;
-import feast.proto.core.IngestionJobProto;
 import feast.proto.core.SourceProto;
 import feast.proto.core.StoreProto;
 import feast.proto.core.StoreProto.Store.Subscription;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.util.Pair;
-import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,26 +61,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class SpecService {
 
-  private final int SPEC_PUBLISHING_TIMEOUT_SECONDS = 5;
-
   private final FeatureSetRepository featureSetRepository;
   private final ProjectRepository projectRepository;
   private final StoreRepository storeRepository;
   private final Source defaultSource;
-  private final KafkaTemplate<String, FeatureSetProto.FeatureSetSpec> specPublisher;
 
   @Autowired
   public SpecService(
       FeatureSetRepository featureSetRepository,
       StoreRepository storeRepository,
       ProjectRepository projectRepository,
-      Source defaultSource,
-      KafkaTemplate<String, FeatureSetProto.FeatureSetSpec> specPublisher) {
+      Source defaultSource) {
     this.featureSetRepository = featureSetRepository;
     this.storeRepository = storeRepository;
     this.projectRepository = projectRepository;
     this.defaultSource = defaultSource;
-    this.specPublisher = specPublisher;
   }
 
   /**
@@ -383,37 +371,6 @@ public class SpecService {
 
     featureSet.incVersion();
 
-    // Sending latest version of FeatureSet to all currently running IngestionJobs (there's one
-    // topic for all sets).
-    // All related jobs would apply new FeatureSet on the fly.
-    // We wait for Kafka broker to ack that the message was added to topic before actually
-    // committing this FeatureSet.
-    // In case kafka doesn't respond within SPEC_PUBLISHING_TIMEOUT_SECONDS we abort current
-    // transaction and return error to client.
-    try {
-      specPublisher
-          .sendDefault(featureSet.getReference(), featureSet.toProto().getSpec())
-          .get(SPEC_PUBLISHING_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-    } catch (Exception e) {
-      throw io.grpc.Status.UNAVAILABLE
-          .withDescription(
-              String.format(
-                  "Unable to publish FeatureSet to Kafka. Cause: %s",
-                  e.getCause() != null ? e.getCause().getMessage() : "unknown"))
-          .withCause(e)
-          .asRuntimeException();
-    }
-
-    // Updating delivery status for related jobs (that are currently using this FeatureSet).
-    // We now set status to IN_PROGRESS, so listenAckFromJobs would be able to
-    // monitor delivery progress for each new version.
-    featureSet.getJobStatuses().stream()
-        .filter(s -> s.getJob().isRunning())
-        .forEach(
-            s ->
-                s.setDeliveryStatus(
-                    FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS));
-
     // Persist the FeatureSet object
     featureSet.setStatus(FeatureSetStatus.STATUS_PENDING);
     project.addFeatureSet(featureSet);
@@ -461,61 +418,5 @@ public class SpecService {
         .setStatus(UpdateStoreResponse.Status.UPDATED)
         .setStore(updateStoreRequest.getStore())
         .build();
-  }
-
-  /**
-   * Listener for ACK messages coming from IngestionJob when FeatureSetSpec is installed (in
-   * pipeline).
-   *
-   * <p>Updates FeatureSetJobStatus for respected FeatureSet (selected by reference) and Job (select
-   * by Id).
-   *
-   * <p>When all related (running) to FeatureSet jobs are updated - FeatureSet receives READY status
-   *
-   * @param record ConsumerRecord with key: FeatureSet reference and value: Ack message
-   */
-  @KafkaListener(topics = {"${feast.stream.specsOptions.specsAckTopic}"})
-  @Transactional
-  public void listenAckFromJobs(
-      ConsumerRecord<String, IngestionJobProto.FeatureSetSpecAck> record) {
-    String setReference = record.key();
-    Pair<String, String> projectAndSetName = parseReference(setReference);
-    FeatureSet featureSet =
-        featureSetRepository.findFeatureSetByNameAndProject_Name(
-            projectAndSetName.getSecond(), projectAndSetName.getFirst());
-    if (featureSet == null) {
-      log.warn(
-          String.format("ACKListener received message for unknown FeatureSet %s", setReference));
-      return;
-    }
-
-    if (featureSet.getVersion() != record.value().getFeatureSetVersion()) {
-      log.warn(
-          String.format(
-              "ACKListener received outdated ack for %s. Current %d, Received %d",
-              setReference, featureSet.getVersion(), record.value().getFeatureSetVersion()));
-      return;
-    }
-
-    featureSet.getJobStatuses().stream()
-        .filter(js -> js.getJob().getId().equals(record.value().getJobName()))
-        .findFirst()
-        .ifPresent(
-            featureSetJobStatus ->
-                featureSetJobStatus.setDeliveryStatus(
-                    FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_DELIVERED));
-
-    boolean allDelivered =
-        featureSet.getJobStatuses().stream()
-            .filter(js -> js.getJob().isRunning())
-            .allMatch(
-                js ->
-                    js.getDeliveryStatus()
-                        .equals(FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_DELIVERED));
-
-    if (allDelivered) {
-      featureSet.setStatus(FeatureSetStatus.STATUS_READY);
-      featureSetRepository.saveAndFlush(featureSet);
-    }
   }
 }

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -81,6 +81,7 @@ feast:
     specsOptions:
       specsTopic: feast-specs
       specsAckTopic: feast-specs-ack
+      notifyIntervalMilliseconds: 1000
 
 spring:
   jpa:

--- a/core/src/test/java/feast/core/service/JobCoordinatorServiceTest.java
+++ b/core/src/test/java/feast/core/service/JobCoordinatorServiceTest.java
@@ -17,14 +17,13 @@
 package feast.core.service;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.protobuf.InvalidProtocolBufferException;
 import feast.core.config.FeastProperties;
@@ -42,6 +41,7 @@ import feast.proto.core.CoreServiceProto.ListStoresResponse;
 import feast.proto.core.FeatureSetProto;
 import feast.proto.core.FeatureSetProto.FeatureSetMeta;
 import feast.proto.core.FeatureSetProto.FeatureSetSpec;
+import feast.proto.core.IngestionJobProto;
 import feast.proto.core.SourceProto.KafkaSourceConfig;
 import feast.proto.core.SourceProto.Source;
 import feast.proto.core.SourceProto.SourceType;
@@ -49,14 +49,20 @@ import feast.proto.core.StoreProto;
 import feast.proto.core.StoreProto.Store.RedisConfig;
 import feast.proto.core.StoreProto.Store.StoreType;
 import feast.proto.core.StoreProto.Store.Subscription;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CancellationException;
+import lombok.SneakyThrows;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.AsyncResult;
 
 public class JobCoordinatorServiceTest {
 
@@ -65,8 +71,10 @@ public class JobCoordinatorServiceTest {
   @Mock JobManager jobManager;
   @Mock SpecService specService;
   @Mock FeatureSetRepository featureSetRepository;
+  @Mock private KafkaTemplate<String, FeatureSetSpec> kafkaTemplate;
 
   private FeastProperties feastProperties;
+  private JobCoordinatorService jcs;
 
   @Before
   public void setUp() {
@@ -75,14 +83,23 @@ public class JobCoordinatorServiceTest {
     JobProperties jobProperties = new JobProperties();
     jobProperties.setJobUpdateTimeoutSeconds(5);
     feastProperties.setJobs(jobProperties);
+
+    jcs =
+        new JobCoordinatorService(
+            jobRepository,
+            featureSetRepository,
+            specService,
+            jobManager,
+            feastProperties,
+            kafkaTemplate);
+
+    when(kafkaTemplate.sendDefault(any(), any())).thenReturn(new AsyncResult<>(null));
   }
 
   @Test
   public void shouldDoNothingIfNoStoresFound() throws InvalidProtocolBufferException {
     when(specService.listStores(any())).thenReturn(ListStoresResponse.newBuilder().build());
-    JobCoordinatorService jcs =
-        new JobCoordinatorService(
-            jobRepository, featureSetRepository, specService, jobManager, feastProperties);
+
     jcs.Poll();
     verify(jobRepository, times(0)).saveAndFlush(any());
   }
@@ -101,9 +118,7 @@ public class JobCoordinatorServiceTest {
     when(specService.listFeatureSets(
             Filter.newBuilder().setProject("*").setFeatureSetName("*").build()))
         .thenReturn(ListFeatureSetsResponse.newBuilder().build());
-    JobCoordinatorService jcs =
-        new JobCoordinatorService(
-            jobRepository, featureSetRepository, specService, jobManager, feastProperties);
+
     jcs.Poll();
     verify(jobRepository, times(0)).saveAndFlush(any());
   }
@@ -178,9 +193,6 @@ public class JobCoordinatorServiceTest {
     when(jobManager.startJob(argThat(new JobMatcher(expectedInput)))).thenReturn(expected);
     when(jobManager.getRunnerType()).thenReturn(Runner.DATAFLOW);
 
-    JobCoordinatorService jcs =
-        new JobCoordinatorService(
-            jobRepository, featureSetRepository, specService, jobManager, feastProperties);
     jcs.Poll();
     verify(jobRepository, times(1)).saveAll(jobArgCaptor.capture());
     List<Job> actual = jobArgCaptor.getValue();
@@ -288,9 +300,6 @@ public class JobCoordinatorServiceTest {
     when(jobManager.startJob(argThat(new JobMatcher(expectedInput2)))).thenReturn(expected2);
     when(jobManager.getRunnerType()).thenReturn(Runner.DATAFLOW);
 
-    JobCoordinatorService jcs =
-        new JobCoordinatorService(
-            jobRepository, featureSetRepository, specService, jobManager, feastProperties);
     jcs.Poll();
 
     verify(jobRepository, times(1)).saveAll(jobArgCaptor.capture());
@@ -298,5 +307,178 @@ public class JobCoordinatorServiceTest {
 
     assertThat(actual.get(0), equalTo(expected1));
     assertThat(actual.get(1), equalTo(expected2));
+  }
+
+  @Test
+  public void shouldSendPendingFeatureSetToJobs() {
+    FeatureSet fs1 =
+        TestObjectFactory.CreateFeatureSet(
+            "fs_1", "project", Collections.emptyList(), Collections.emptyList());
+    fs1.setVersion(2);
+
+    FeatureSetJobStatus status1 =
+        TestObjectFactory.CreateFeatureSetJobStatusWithJob(
+            JobStatus.RUNNING, FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_DELIVERED, 1);
+    FeatureSetJobStatus status2 =
+        TestObjectFactory.CreateFeatureSetJobStatusWithJob(
+            JobStatus.RUNNING, FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_DELIVERED, 1);
+    FeatureSetJobStatus status3 =
+        TestObjectFactory.CreateFeatureSetJobStatusWithJob(
+            JobStatus.ABORTED, FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_DELIVERED, 2);
+
+    // spec needs to be send
+    fs1.getJobStatuses().addAll(ImmutableList.of(status1, status2, status3));
+
+    FeatureSet fs2 =
+        TestObjectFactory.CreateFeatureSet(
+            "fs_2", "project", Collections.emptyList(), Collections.emptyList());
+    fs2.setVersion(5);
+
+    // spec already sent to kafka
+    fs2.getJobStatuses()
+        .addAll(
+            ImmutableList.of(
+                TestObjectFactory.CreateFeatureSetJobStatusWithJob(
+                    JobStatus.RUNNING,
+                    FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS,
+                    5)));
+
+    // feature set without running jobs attached
+    FeatureSet fs3 =
+        TestObjectFactory.CreateFeatureSet(
+            "fs_3", "project", Collections.emptyList(), Collections.emptyList());
+    fs3.getJobStatuses()
+        .addAll(
+            ImmutableList.of(
+                TestObjectFactory.CreateFeatureSetJobStatusWithJob(
+                    JobStatus.ABORTED,
+                    FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS,
+                    5)));
+
+    when(featureSetRepository.findAllByStatus(FeatureSetProto.FeatureSetStatus.STATUS_PENDING))
+        .thenReturn(ImmutableList.of(fs1, fs2, fs3));
+
+    jcs.notifyJobsWhenFeatureSetUpdated();
+
+    verify(kafkaTemplate).sendDefault(eq(fs1.getReference()), any(FeatureSetSpec.class));
+    verify(kafkaTemplate, never()).sendDefault(eq(fs2.getReference()), any(FeatureSetSpec.class));
+    verify(kafkaTemplate, never()).sendDefault(eq(fs3.getReference()), any(FeatureSetSpec.class));
+
+    assertThat(status1.getVersion(), is(2));
+    assertThat(
+        status1.getDeliveryStatus(),
+        is(FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS));
+
+    assertThat(status2.getVersion(), is(2));
+    assertThat(
+        status2.getDeliveryStatus(),
+        is(FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS));
+
+    assertThat(status3.getVersion(), is(2));
+    assertThat(
+        status3.getDeliveryStatus(),
+        is(FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_DELIVERED));
+  }
+
+  @Test
+  @SneakyThrows
+  public void shouldNotUpdateJobStatusVersionWhenKafkaUnavailable() {
+    FeatureSet fsInTest =
+        TestObjectFactory.CreateFeatureSet(
+            "fs_1", "project", Collections.emptyList(), Collections.emptyList());
+    fsInTest.setVersion(2);
+
+    FeatureSetJobStatus featureSetJobStatus =
+        TestObjectFactory.CreateFeatureSetJobStatusWithJob(
+            JobStatus.RUNNING, FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_DELIVERED, 1);
+    fsInTest.getJobStatuses().add(featureSetJobStatus);
+
+    CancellationException exc = new CancellationException();
+    when(kafkaTemplate.sendDefault(eq(fsInTest.getReference()), any()).get()).thenThrow(exc);
+    when(featureSetRepository.findAllByStatus(FeatureSetProto.FeatureSetStatus.STATUS_PENDING))
+        .thenReturn(ImmutableList.of(fsInTest));
+
+    jcs.notifyJobsWhenFeatureSetUpdated();
+    assertThat(featureSetJobStatus.getVersion(), is(1));
+  }
+
+  @Test
+  public void specAckListenerShouldDoNothingWhenMessageIsOutdated() {
+    FeatureSet fsInTest =
+        TestObjectFactory.CreateFeatureSet(
+            "fs", "project", Collections.emptyList(), Collections.emptyList());
+    FeatureSetJobStatus j1 =
+        TestObjectFactory.CreateFeatureSetJobStatusWithJob(
+            JobStatus.RUNNING, FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS, 1);
+    FeatureSetJobStatus j2 =
+        TestObjectFactory.CreateFeatureSetJobStatusWithJob(
+            JobStatus.RUNNING, FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS, 1);
+
+    fsInTest.getJobStatuses().addAll(Arrays.asList(j1, j2));
+
+    when(featureSetRepository.findFeatureSetByNameAndProject_Name(
+            fsInTest.getName(), fsInTest.getProject().getName()))
+        .thenReturn(fsInTest);
+
+    jcs.listenAckFromJobs(newAckMessage("project/invalid", 0, j1.getJob().getId()));
+    jcs.listenAckFromJobs(newAckMessage(fsInTest.getReference(), 0, ""));
+    jcs.listenAckFromJobs(newAckMessage(fsInTest.getReference(), -1, j1.getJob().getId()));
+
+    assertThat(
+        j1.getDeliveryStatus(), is(FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS));
+    assertThat(
+        j2.getDeliveryStatus(), is(FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS));
+  }
+
+  @Test
+  public void specAckListenerShouldUpdateFeatureSetStatus() {
+    FeatureSet fsInTest =
+        TestObjectFactory.CreateFeatureSet(
+            "fs", "project", Collections.emptyList(), Collections.emptyList());
+    fsInTest.setStatus(FeatureSetProto.FeatureSetStatus.STATUS_PENDING);
+
+    FeatureSetJobStatus j1 =
+        TestObjectFactory.CreateFeatureSetJobStatusWithJob(
+            JobStatus.RUNNING, FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS, 1);
+    FeatureSetJobStatus j2 =
+        TestObjectFactory.CreateFeatureSetJobStatusWithJob(
+            JobStatus.RUNNING, FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS, 1);
+    FeatureSetJobStatus j3 =
+        TestObjectFactory.CreateFeatureSetJobStatusWithJob(
+            JobStatus.ABORTED, FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS, 1);
+
+    fsInTest.getJobStatuses().addAll(Arrays.asList(j1, j2, j3));
+
+    when(featureSetRepository.findFeatureSetByNameAndProject_Name(
+            fsInTest.getName(), fsInTest.getProject().getName()))
+        .thenReturn(fsInTest);
+
+    jcs.listenAckFromJobs(
+        newAckMessage(fsInTest.getReference(), fsInTest.getVersion(), j1.getJob().getId()));
+
+    assertThat(
+        j1.getDeliveryStatus(), is(FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_DELIVERED));
+    assertThat(fsInTest.getStatus(), is(FeatureSetProto.FeatureSetStatus.STATUS_PENDING));
+
+    jcs.listenAckFromJobs(
+        newAckMessage(fsInTest.getReference(), fsInTest.getVersion(), j2.getJob().getId()));
+
+    assertThat(
+        j2.getDeliveryStatus(), is(FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_DELIVERED));
+
+    assertThat(fsInTest.getStatus(), is(FeatureSetProto.FeatureSetStatus.STATUS_READY));
+  }
+
+  private ConsumerRecord<String, IngestionJobProto.FeatureSetSpecAck> newAckMessage(
+      String key, int version, String jobName) {
+    return new ConsumerRecord<>(
+        "topic",
+        0,
+        0,
+        key,
+        IngestionJobProto.FeatureSetSpecAck.newBuilder()
+            .setFeatureSetVersion(version)
+            .setJobName(jobName)
+            .build());
   }
 }

--- a/core/src/test/java/feast/core/service/TestObjectFactory.java
+++ b/core/src/test/java/feast/core/service/TestObjectFactory.java
@@ -16,16 +16,14 @@
  */
 package feast.core.service;
 
-import feast.core.model.Entity;
-import feast.core.model.Feature;
-import feast.core.model.FeatureSet;
-import feast.core.model.Source;
+import feast.core.model.*;
 import feast.proto.core.FeatureSetProto;
 import feast.proto.core.SourceProto;
 import feast.proto.types.ValueProto;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class TestObjectFactory {
 
@@ -72,5 +70,20 @@ public class TestObjectFactory {
   public static Entity CreateEntity(String name, ValueProto.ValueType.Enum valueType) {
     return Entity.fromProto(
         FeatureSetProto.EntitySpec.newBuilder().setName(name).setValueType(valueType).build());
+  }
+
+  public static FeatureSetJobStatus CreateFeatureSetJobStatusWithJob(
+      JobStatus status, FeatureSetProto.FeatureSetJobDeliveryStatus deliveryStatus, int version) {
+    Job job = new Job();
+    job.setStatus(status);
+    job.setId(UUID.randomUUID().toString());
+
+    FeatureSetJobStatus featureSetJobStatus = new FeatureSetJobStatus();
+    featureSetJobStatus.setJob(job);
+
+    featureSetJobStatus.setDeliveryStatus(deliveryStatus);
+    featureSetJobStatus.setVersion(version);
+
+    return featureSetJobStatus;
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

To resolve some concerns related to overloading responsibilities in SpecService in my previous PR https://github.com/feast-dev/feast/pull/792 I moved all communications with IngestionJob to JobCoordinatorService

Implemented flow

New FeatureSet:
1. FeatureSet being created through SpecService.applyFeatureSet with status PENDING
2. `JobCoordinator.Poll` allocates this Set to Job(s) by creating FeatureSetJobStatus (see `JobUpdateTask.updateFeatureSets`) with version=0 and deliveryStatus=in-progress
3. `JobCoordinator.notifyJobs` detects that there's pending FeatureSet with allocated job(s) and send FeatureSetSpec to kafka (topic is shared between all jobs)
4. `JobCoordinator.listenAckFromJobs` receives ack from job and update deliveryStatus in FeatureSetJobStatus
5. As soon as all allocated jobs acknowledged FeatureSet status set to READY

Existing FeatureSet:
1. FeatureSet being updated through SpecService.applyFeatureSet. Status changed to PENDING. Version incremented.
2. FeatureSet is already allocated to job(s) so `JobCoordinator.notifyJobs` picks it up and send to kafka with updating FeatureSetJobStatus to the latest version
... same flow as previous

New job spawned (bc previous canceled, eg):
1. JobUpdateTask creates FeatureSetJobStatuses for all allocated  FeatureSets with `version = <latest-version-of-feature-set>` since new Job can read whole history of FeatureSets from kafka topic. Nothing is being sent to specs topic


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
