### PR TITLE
Fix Optional#get() and string comparison bugs in JobService

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ format-java:
 	mvn spotless:apply
 
 lint-java:
-	mvn spotless:check
+	mvn --no-transfer-progress spotless:check
 
 test-java:
-	mvn test
+	mvn --no-transfer-progress test
 
 test-java-with-coverage:
-	mvn test jacoco:report-aggregate
+	mvn --no-transfer-progress test jacoco:report-aggregate
 
 build-java:
 	mvn clean verify

--- a/core/src/main/java/feast/core/service/JobService.java
+++ b/core/src/main/java/feast/core/service/JobService.java
@@ -71,7 +71,8 @@ public class JobService {
     }
   }
 
-  /* Job Service API */
+  // region Job Service API
+
   /**
    * List Ingestion Jobs in Feast matching the given request. See CoreService protobuf documentation
    * for more detailed documentation.
@@ -88,16 +89,16 @@ public class JobService {
 
     // check that filter specified and not empty
     if (request.hasFilter()
-        && !(request.getFilter().getId() == ""
-            && request.getFilter().getStoreName() == ""
-            && request.getFilter().hasFeatureSetReference() == false)) {
+        && !(request.getFilter().getId().isEmpty()
+            && request.getFilter().getStoreName().isEmpty()
+            && !request.getFilter().hasFeatureSetReference())) {
       // filter jobs based on request filter
       ListIngestionJobsRequest.Filter filter = request.getFilter();
 
       // for proto3, default value for missing values:
       // - numeric values (ie int) is zero
       // - strings is empty string
-      if (filter.getId() != "") {
+      if (!filter.getId().isEmpty()) {
         // get by id: no more filters required: found job
         Optional<Job> job = this.jobRepository.findById(filter.getId());
         if (job.isPresent()) {
@@ -105,7 +106,7 @@ public class JobService {
         }
       } else {
         // multiple filters can apply together in an 'and' operation
-        if (filter.getStoreName() != "") {
+        if (!filter.getStoreName().isEmpty()) {
           // find jobs by name
           List<Job> jobs = this.jobRepository.findByStoreName(filter.getStoreName());
           Set<String> jobIds = jobs.stream().map(Job::getId).collect(Collectors.toSet());
@@ -140,7 +141,7 @@ public class JobService {
     // convert matching job models to ingestion job protos
     List<IngestionJobProto.IngestionJob> ingestJobs = new ArrayList<>();
     for (String jobId : matchingJobIds) {
-      Job job = this.jobRepository.findById(jobId).get();
+      Job job = this.jobRepository.findById(jobId).orElseThrow();
       // job that failed on start won't be converted toProto successfully
       // and they're irrelevant here
       if (job.getStatus() == JobStatus.ERROR) {
@@ -160,21 +161,20 @@ public class JobService {
    * @param request restart ingestion job request specifying which job to stop
    * @throws NoSuchElementException when restart job request requests to restart a nonexistent job.
    * @throws UnsupportedOperationException when job to be restarted is in an unsupported status
-   * @throws InvalidProtocolBufferException on error when constructing response protobuf
    */
   @Transactional
-  public RestartIngestionJobResponse restartJob(RestartIngestionJobRequest request)
-      throws InvalidProtocolBufferException {
-    // check job exists
-    Optional<Job> getJob = this.jobRepository.findById(request.getId());
-    if (getJob.isEmpty()) {
-      // FIXME: if getJob.isEmpty then constructing this error message will always throw an error...
-      throw new NoSuchElementException(
-          "Attempted to stop nonexistent job with id: " + getJob.get().getId());
-    }
+  public RestartIngestionJobResponse restartJob(RestartIngestionJobRequest request) {
+    String jobId = request.getId();
+
+    Job job =
+        this.jobRepository
+            .findById(jobId)
+            .orElseThrow(
+                () ->
+                    new NoSuchElementException(
+                        "Attempted to restart nonexistent job with id: " + jobId));
 
     // check job status is valid for restarting
-    Job job = getJob.get();
     JobStatus status = job.getStatus();
     if (status.isTransitional() || status.isTerminal() || status == JobStatus.UNKNOWN) {
       throw new UnsupportedOperationException(
@@ -202,20 +202,20 @@ public class JobService {
    * @param request stop ingestion job request specifying which job to stop
    * @throws NoSuchElementException when stop job request requests to stop a nonexistent job.
    * @throws UnsupportedOperationException when job to be stopped is in an unsupported status
-   * @throws InvalidProtocolBufferException on error when constructing response protobuf
    */
   @Transactional
-  public StopIngestionJobResponse stopJob(StopIngestionJobRequest request)
-      throws InvalidProtocolBufferException {
-    // check job exists
-    Optional<Job> getJob = this.jobRepository.findById(request.getId());
-    if (getJob.isEmpty()) {
-      throw new NoSuchElementException(
-          "Attempted to stop nonexistent job with id: " + getJob.get().getId());
-    }
+  public StopIngestionJobResponse stopJob(StopIngestionJobRequest request) {
+    String jobId = request.getId();
+
+    Job job =
+        this.jobRepository
+            .findById(jobId)
+            .orElseThrow(
+                () ->
+                    new NoSuchElementException(
+                        "Attempted to stop nonexistent job with id: " + jobId));
 
     // check job status is valid for stopping
-    Job job = getJob.get();
     JobStatus status = job.getStatus();
     if (status.isTerminal()) {
       // do nothing - job is already stopped
@@ -240,7 +240,9 @@ public class JobService {
     return StopIngestionJobResponse.newBuilder().build();
   }
 
-  /* Private Utility Methods */
+  // endregion
+  // region Private Utility Methods
+
   private <T> Set<T> mergeResults(Set<T> results, Collection<T> newResults) {
     if (results.size() <= 0) {
       // no existing results: copy over new results
@@ -252,7 +254,7 @@ public class JobService {
     return results;
   }
 
-  // converts feature set reference to a list feature set filter
+  /** converts feature set reference to a list feature set filter */
   private ListFeatureSetsRequest.Filter toListFeatureSetFilter(FeatureSetReference fsReference) {
     // match featuresets using contents of featureset reference
     String fsName = fsReference.getName();
@@ -262,16 +264,13 @@ public class JobService {
     // for proto3, default value for missing values:
     // - numeric values (ie int) is zero
     // - strings is empty string
-    ListFeatureSetsRequest.Filter filter =
-        ListFeatureSetsRequest.Filter.newBuilder()
-            .setFeatureSetName((fsName != "") ? fsName : "*")
-            .setProject((fsProject != "") ? fsProject : "*")
-            .build();
-
-    return filter;
+    return ListFeatureSetsRequest.Filter.newBuilder()
+        .setFeatureSetName(fsName.isEmpty() ? "*" : fsName)
+        .setProject(fsProject.isEmpty() ? "*" : fsProject)
+        .build();
   }
 
-  // sync job status using job manager
+  /** sync job status using job manager */
   private Job syncJobStatus(JobManager jobManager, Job job) {
     JobStatus newStatus = jobManager.getJobStatus(job);
     // log job status transition


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes some bugs in the Ingestion Job Management service.

Cleaning house a bit and I had a todo [from here][1] about the `get()` calls that will always fail. These don't actually have much impact since `get()` already throws `NoSuchElementException` which we're doing anyway, but we'd lose the message we try to set.

Actually perhaps more concerning is a bunch of `==` comparisons on strings, those might be a source of more functionally significant bugs for filtering in the list jobs API. I'm surprised that no tests trip something here—a little short on time to look more closely at the existing tests now, apologies.

These issues are all flagged by IntelliJ. The `==` and `this.` receiver for all class member references smell like the author was writing mostly Python at the time 😉 I'm sympathetic to not always liking IDEs, but if you use a lighter editor I'd recommend setting up something like the SpotBugs Maven plugin, which would be nice to do anyway IMO.

[1]: https://github.com/feast-dev/feast/pull/650#discussion_r415125907

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
