### PR TITLE
Refactor common module's feature string reference method

### DIFF
--- a/common/src/main/java/feast/common/models/Feature.java
+++ b/common/src/main/java/feast/common/models/Feature.java
@@ -22,19 +22,32 @@ public class Feature {
 
   /**
    * Accepts FeatureReference object and returns its reference in String
-   * "project/featureset_name:feature_name".
+   * "featureset_name:feature_name".
    *
    * @param featureReference {@link FeatureReference}
-   * @param ignoreProject Flag whether to return FeatureReference with project name
    * @return String format of FeatureReference
    */
-  public static String getFeatureStringRef(
-      FeatureReference featureReference, boolean ignoreProject) {
+  public static String getFeatureStringRef(FeatureReference featureReference) {
     String ref = featureReference.getName();
     if (!featureReference.getFeatureSet().isEmpty()) {
       ref = featureReference.getFeatureSet() + ":" + ref;
     }
-    if (!featureReference.getProject().isEmpty() && !ignoreProject) {
+    return ref;
+  }
+
+  /**
+   * Accepts FeatureReference object and returns its reference with project included in String, eg.
+   * "project/featureset_name:feature_name".
+   *
+   * @param featureReference {@link FeatureReference}
+   * @return String format of FeatureReference
+   */
+  public static String getFeatureStringWithProjectRef(FeatureReference featureReference) {
+    String ref = featureReference.getName();
+    if (!featureReference.getFeatureSet().isEmpty()) {
+      ref = featureReference.getFeatureSet() + ":" + ref;
+    }
+    if (!featureReference.getProject().isEmpty()) {
       ref = featureReference.getProject() + "/" + ref;
     }
     return ref;

--- a/common/src/test/java/feast/common/models/FeaturesTest.java
+++ b/common/src/test/java/feast/common/models/FeaturesTest.java
@@ -88,9 +88,8 @@ public class FeaturesTest {
             .setName(featureSetSpec.getFeatures(0).getName())
             .build();
 
-    String actualFeatureStringRef = Feature.getFeatureStringRef(featureReference, false);
-    String actualFeatureIgnoreProjectStringRef =
-        Feature.getFeatureStringRef(featureReference, true);
+    String actualFeatureStringRef = Feature.getFeatureStringWithProjectRef(featureReference);
+    String actualFeatureIgnoreProjectStringRef = Feature.getFeatureStringRef(featureReference);
     String expectedFeatureStringRef = "project1/featureSetWithConstraints:feature1";
     String expectedFeatureIgnoreProjectStringRef = "featureSetWithConstraints:feature1";
 

--- a/sdk/java/src/main/java/com/gojek/feast/FeastClient.java
+++ b/sdk/java/src/main/java/com/gojek/feast/FeastClient.java
@@ -151,7 +151,7 @@ public class FeastClient implements AutoCloseable {
                   // Strip project from string Feature References from returned from serving
                   FeatureReference featureRef =
                       RequestUtil.parseFeatureRef(fieldName, true).build();
-                  stripFieldName = Feature.getFeatureStringRef(featureRef, true);
+                  stripFieldName = Feature.getFeatureStringRef(featureRef);
                   row.set(
                       stripFieldName,
                       fieldValues.getFieldsMap().get(fieldName),

--- a/sdk/java/src/test/java/com/gojek/feast/RequestUtilTest.java
+++ b/sdk/java/src/test/java/com/gojek/feast/RequestUtilTest.java
@@ -76,9 +76,7 @@ class RequestUtilTest {
             .map(ref -> ref.toBuilder().clearProject().build())
             .collect(Collectors.toList());
     List<String> actual =
-        input.stream()
-            .map(ref -> Feature.getFeatureStringRef(ref, true))
-            .collect(Collectors.toList());
+        input.stream().map(ref -> Feature.getFeatureStringRef(ref)).collect(Collectors.toList());
     assertEquals(expected.size(), actual.size());
     for (int i = 0; i < expected.size(); i++) {
       assertEquals(expected.get(i), actual.get(i));

--- a/serving/src/main/java/feast/serving/service/OnlineServingService.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingService.java
@@ -175,7 +175,7 @@ public class OnlineServingService implements ServingService {
                   Collectors.toMap(
                       featureRowField -> {
                         FeatureReference featureRef = nameRefMap.get(featureRowField.getName());
-                        return Feature.getFeatureStringRef(featureRef, false);
+                        return Feature.getFeatureStringWithProjectRef(featureRef);
                       },
                       featureRowField -> {
                         // drop feature values with an age outside feature set's max age.
@@ -188,7 +188,7 @@ public class OnlineServingService implements ServingService {
     // create empty values for features specified in request but not present in feature row.
     Set<String> missingFeatures =
         nameRefMap.values().stream()
-            .map(ref -> Feature.getFeatureStringRef(ref, false))
+            .map(ref -> Feature.getFeatureStringWithProjectRef(ref))
             .collect(Collectors.toSet());
     missingFeatures.removeAll(valueMap.keySet());
     missingFeatures.forEach(refString -> valueMap.put(refString, Value.newBuilder().build()));

--- a/serving/src/main/java/feast/serving/specs/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/specs/CachedSpecService.java
@@ -16,7 +16,7 @@
  */
 package feast.serving.specs;
 
-import static feast.common.models.Feature.getFeatureStringRef;
+import static feast.common.models.Feature.getFeatureStringWithProjectRef;
 import static feast.common.models.FeatureSet.getFeatureSetStringRef;
 import static java.util.stream.Collectors.groupingBy;
 
@@ -117,18 +117,18 @@ public class CachedSpecService {
             featureReference -> {
               // map feature reference to coresponding feature set name
               String fsName =
-                  featureToFeatureSetMapping.get(getFeatureStringRef(featureReference, false));
+                  featureToFeatureSetMapping.get(getFeatureStringWithProjectRef(featureReference));
               if (fsName == null) {
                 throw new SpecRetrievalException(
                     String.format(
                         "Unable to find Feature Set for the given Feature Reference: %s",
-                        getFeatureStringRef(featureReference, false)));
+                        getFeatureStringWithProjectRef(featureReference)));
               } else if (fsName == FEATURE_SET_CONFLICT_FLAG) {
                 throw new SpecRetrievalException(
                     String.format(
                         "Given Feature Reference is amibigous as it matches multiple Feature Sets: %s."
                             + "Please specify a more specific Feature Reference (ie specify the project or feature set)",
-                        getFeatureStringRef(featureReference, false)));
+                        getFeatureStringWithProjectRef(featureReference)));
               }
               return Pair.of(fsName, featureReference);
             })
@@ -291,6 +291,6 @@ public class CachedSpecService {
       featureRef = featureRef.clearFeatureSet();
     }
     return Pair.of(
-        getFeatureStringRef(featureRef.build(), false), getFeatureSetStringRef(featureSetSpec));
+        getFeatureStringWithProjectRef(featureRef.build()), getFeatureSetStringRef(featureSetSpec));
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Refactor common module's getFeatureStringRef method to not use flag.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
