### PR TITLE
Create table in BigQuery if doesn't exists when new FeatureSetSpec arrived to IngestionJob

### DIFF
--- a/core/src/main/java/feast/core/job/JobUpdateTask.java
+++ b/core/src/main/java/feast/core/job/JobUpdateTask.java
@@ -238,7 +238,7 @@ public class JobUpdateTask implements Callable<Job> {
         String.format(
             "%s-%d-to-%s-%s",
             source.getTypeString(), Objects.hashCode(source.getConfig()), storeName, dateSuffix);
-    return jobId.replaceAll("_store", "-");
+    return jobId.replaceAll("_store", "-").toLowerCase();
   }
 
   private void logAudit(Action action, Job job, String detail, Object... args) {

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/FeatureSetSpecToTableSchema.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/FeatureSetSpecToTableSchema.java
@@ -43,8 +43,8 @@ import org.apache.beam.sdk.values.KV;
 import org.slf4j.Logger;
 
 /**
- * Converts {@link feast.proto.core.FeatureSetProto.FeatureSetSpec} into BigQuery schema Serializes
- * it into json-like format {@link TableSchema} Fetches existing schema to merge existing fields
+ * Converts {@link feast.proto.core.FeatureSetProto.FeatureSetSpec} into BigQuery schema. Serializes
+ * it into json-like format {@link TableSchema}. Fetches existing schema to merge existing fields
  * with new ones.
  *
  * <p>As a side effect this Operation may create bq table (if it doesn't exist) to make

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/FeatureSetSpecToTableSchema.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/FeatureSetSpecToTableSchema.java
@@ -59,6 +59,12 @@ public class FeatureSetSpecToTableSchema
   private static final Logger log =
       org.slf4j.LoggerFactory.getLogger(FeatureSetSpecToTableSchema.class);
 
+  // Reserved columns
+  public static final String EVENT_TIMESTAMP_COLUMN = "event_timestamp";
+  public static final String CREATED_TIMESTAMP_COLUMN = "created_timestamp";
+  public static final String INGESTION_ID_COLUMN = "ingestion_id";
+  public static final String JOB_ID_COLUMN = "job_id";
+
   // Column description for reserved fields
   public static final String BIGQUERY_EVENT_TIMESTAMP_FIELD_DESCRIPTION =
       "Event time for the FeatureRow";
@@ -109,7 +115,9 @@ public class FeatureSetSpecToTableSchema
 
   private void createTable(String specKey, Schema schema) {
     TimePartitioning timePartitioning =
-        TimePartitioning.newBuilder(TimePartitioning.Type.DAY).setField("event_timestamp").build();
+        TimePartitioning.newBuilder(TimePartitioning.Type.DAY)
+            .setField(EVENT_TIMESTAMP_COLUMN)
+            .build();
 
     StandardTableDefinition tableDefinition =
         StandardTableDefinition.newBuilder()
@@ -166,14 +174,14 @@ public class FeatureSetSpecToTableSchema
     Map<String, Pair<StandardSQLTypeName, String>>
         reservedFieldNameToPairOfStandardSQLTypeAndDescription =
             ImmutableMap.of(
-                "event_timestamp",
+                EVENT_TIMESTAMP_COLUMN,
                 Pair.of(StandardSQLTypeName.TIMESTAMP, BIGQUERY_EVENT_TIMESTAMP_FIELD_DESCRIPTION),
-                "created_timestamp",
+                CREATED_TIMESTAMP_COLUMN,
                 Pair.of(
                     StandardSQLTypeName.TIMESTAMP, BIGQUERY_CREATED_TIMESTAMP_FIELD_DESCRIPTION),
-                "ingestion_id",
+                INGESTION_ID_COLUMN,
                 Pair.of(StandardSQLTypeName.STRING, BIGQUERY_INGESTION_ID_FIELD_DESCRIPTION),
-                "job_id",
+                JOB_ID_COLUMN,
                 Pair.of(StandardSQLTypeName.STRING, BIGQUERY_JOB_ID_FIELD_DESCRIPTION));
     for (Map.Entry<String, Pair<StandardSQLTypeName, String>> entry :
         reservedFieldNameToPairOfStandardSQLTypeAndDescription.entrySet()) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Currently we create table in BQ only with first batch insert, when first data is arrived.
To speed up e2e tests this PR changes it, so table would be created inside IngestionJob when new FeatureSetSpec is received.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
