### PR TITLE
Add missing key count metric

### DIFF
--- a/serving/src/main/java/feast/serving/service/OnlineServingService.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingService.java
@@ -297,7 +297,7 @@ public class OnlineServingService implements ServingService {
               String featureRefString = es.getKey();
               FieldStatus status = es.getValue();
               if (status == FieldStatus.NOT_FOUND) {
-                Metrics.missingKeyCount.labels(project, featureRefString).inc();
+                Metrics.notFoundKeyCount.labels(project, featureRefString).inc();
               }
               if (status == FieldStatus.OUTSIDE_MAX_AGE) {
                 Metrics.staleKeyCount.labels(project, featureRefString).inc();

--- a/serving/src/main/java/feast/serving/service/OnlineServingService.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingService.java
@@ -123,8 +123,7 @@ public class OnlineServingService implements ServingService {
                   entityStatusesMap.get(entityRow).putAll(statusMap);
 
                   // Populate metrics/log request
-                  populateMissingKeyCountMetrics(statusMap, featureSetRequest);
-                  populateStaleKeyCountMetrics(statusMap, featureSetRequest);
+                  populateCountMetrics(statusMap, featureSetRequest);
                 });
         populateRequestCountMetrics(featureSetRequest);
         logFeatureRows.add(featureRows);
@@ -288,7 +287,7 @@ public class OnlineServingService implements ServingService {
     scope.span().log(ImmutableMap.of("event", "featureRows", "value", loggableFeatureRows));
   }
 
-  private void populateMissingKeyCountMetrics(
+  private void populateCountMetrics(
       Map<String, FieldStatus> statusMap, FeatureSetRequest featureSetRequest) {
     String project = featureSetRequest.getSpec().getProject();
     statusMap
@@ -300,18 +299,6 @@ public class OnlineServingService implements ServingService {
               if (status == FieldStatus.NOT_FOUND) {
                 Metrics.missingKeyCount.labels(project, featureRefString).inc();
               }
-            });
-  }
-
-  private void populateStaleKeyCountMetrics(
-      Map<String, FieldStatus> statusMap, FeatureSetRequest featureSetRequest) {
-    String project = featureSetRequest.getSpec().getProject();
-    statusMap
-        .entrySet()
-        .forEach(
-            es -> {
-              String featureRefString = es.getKey();
-              FieldStatus status = es.getValue();
               if (status == FieldStatus.OUTSIDE_MAX_AGE) {
                 Metrics.staleKeyCount.labels(project, featureRefString).inc();
               }

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -46,14 +46,6 @@ public class Metrics {
           .labelNames("project", "feature_name")
           .register();
 
-  public static final Counter invalidEncodingCount =
-      Counter.build()
-          .name("invalid_encoding_feature_count")
-          .subsystem("feast_serving")
-          .help("number requested feature rows that were stored with the wrong encoding")
-          .labelNames("project", "feature_name")
-          .register();
-
   public static final Counter staleKeyCount =
       Counter.build()
           .name("stale_feature_count")

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -40,7 +40,7 @@ public class Metrics {
 
   public static final Counter missingKeyCount =
       Counter.build()
-          .name("missing_feature_count")
+          .name("not_found_feature_count")
           .subsystem("feast_serving")
           .help("number requested feature rows that were not found")
           .labelNames("project", "feature_name")

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -38,7 +38,7 @@ public class Metrics {
           .labelNames("project", "feature_name")
           .register();
 
-  public static final Counter missingKeyCount =
+  public static final Counter notFoundKeyCount =
       Counter.build()
           .name("not_found_feature_count")
           .subsystem("feast_serving")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
[missingKeyCount](https://github.com/feast-dev/feast/blob/master/serving/src/main/java/feast/serving/util/Metrics.java#L41 ) metric used to be available in Prometheus but was removed during refactor to OnlineServingService and RedisOnlineRetriever, from [RedisServingService](https://github.com/feast-dev/feast/blob/cc884b4480c50555d8a9f28e0629d138d0d9bd36/serving/src/main/java/feast/serving/service/RedisServingService.java#L220).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
