### PR TITLE
Prevent reserved fields from being registered

### DIFF
--- a/core/src/main/java/feast/core/validators/FeatureSetValidator.java
+++ b/core/src/main/java/feast/core/validators/FeatureSetValidator.java
@@ -30,6 +30,9 @@ import org.apache.commons.lang3.StringUtils;
 
 public class FeatureSetValidator {
 
+  private static List<String> reservedNames =
+      Arrays.asList("created_timestamp", "event_timestamp", "ingestion_id", "job_id");
+
   public static void validateSpec(FeatureSet featureSet) {
     if (featureSet.getSpec().getProject().isEmpty()) {
       throw new IllegalArgumentException("Project name must be provided");
@@ -69,15 +72,14 @@ public class FeatureSetValidator {
   }
 
   private static void checkReservedColumns(List<FeatureSpec> featureSpecs) {
-    List<String> reservedNames =
-        Arrays.asList("created_timestamp", "event_timestamp", "ingestion_id", "job_id");
     String reservedNamesString = StringUtils.join(reservedNames, ", ");
     for (FeatureSpec featureSpec : featureSpecs) {
       if (reservedNames.contains(featureSpec.getName())) {
         throw new IllegalArgumentException(
             String.format(
-                "Reserved feature names have been used, which are not allowed. These names include %s.",
-                reservedNamesString));
+                "Reserved feature names have been used, which are not allowed. These names include %s."
+                    + "You've just used an invalid name, %s.",
+                reservedNamesString, featureSpec.getName()));
       }
     }
   }

--- a/core/src/main/java/feast/core/validators/FeatureSetValidator.java
+++ b/core/src/main/java/feast/core/validators/FeatureSetValidator.java
@@ -22,9 +22,11 @@ import com.google.common.collect.Sets;
 import feast.proto.core.FeatureSetProto.EntitySpec;
 import feast.proto.core.FeatureSetProto.FeatureSet;
 import feast.proto.core.FeatureSetProto.FeatureSpec;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 public class FeatureSetValidator {
 
@@ -43,6 +45,7 @@ public class FeatureSetValidator {
     checkValidCharacters(featureSet.getSpec().getName(), "name");
     checkUniqueColumns(
         featureSet.getSpec().getEntitiesList(), featureSet.getSpec().getFeaturesList());
+    checkReservedColumns(featureSet.getSpec().getFeaturesList());
     for (EntitySpec entitySpec : featureSet.getSpec().getEntitiesList()) {
       checkValidCharacters(entitySpec.getName(), "entities::name");
     }
@@ -62,6 +65,20 @@ public class FeatureSetValidator {
     if (nameSet.size() != names.size()) {
       throw new IllegalArgumentException(
           String.format("fields within a featureset must be unique."));
+    }
+  }
+
+  private static void checkReservedColumns(List<FeatureSpec> featureSpecs) {
+    List<String> reservedNames =
+        Arrays.asList("created_timestamp", "event_timestamp", "ingestion_id", "job_id");
+    String reservedNamesString = StringUtils.join(reservedNames, ", ");
+    for (FeatureSpec featureSpec : featureSpecs) {
+      if (reservedNames.contains(featureSpec.getName())) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Reserved feature names have been used, which are not allowed. These names include %s.",
+                reservedNamesString));
+      }
     }
   }
 }

--- a/core/src/test/java/feast/core/service/SpecServiceTest.java
+++ b/core/src/test/java/feast/core/service/SpecServiceTest.java
@@ -56,6 +56,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -91,6 +92,7 @@ public class SpecServiceTest {
 
   private SpecService specService;
   private List<FeatureSet> featureSets;
+  private List<FeatureSet> invalidFeatureSets;
   private List<Feature> features;
   private List<Store> stores;
   private Source defaultSource;
@@ -214,6 +216,12 @@ public class SpecServiceTest {
 
     specService =
         new SpecService(featureSetRepository, storeRepository, projectRepository, defaultSource);
+
+    Feature invalidFeature1 = TestUtil.CreateFeature("created_timestamp", Enum.INT64);
+    FeatureSet invalidFeatureSet1 =
+        TestUtil.CreateFeatureSet(
+            "f1", "invalid", Arrays.asList(f3e1), Arrays.asList(invalidFeature1));
+    invalidFeatureSets = Arrays.asList(invalidFeatureSet1);
   }
 
   @Test
@@ -275,6 +283,21 @@ public class SpecServiceTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("No feature set name provided");
     specService.getFeatureSet(GetFeatureSetRequest.newBuilder().build());
+  }
+
+  @Test
+  public void shouldThrowExceptionGivenReservedFeatureName() throws InvalidProtocolBufferException {
+    List<String> reservedNames =
+        Arrays.asList("created_timestamp", "event_timestamp", "ingestion_id", "job_id");
+    String reservedNamesString = StringUtils.join(reservedNames, ", ");
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage(
+        String.format(
+            "Reserved feature names have been used, which are not allowed. These names include %s.",
+            reservedNamesString));
+    FeatureSet invalidFeatureSet = invalidFeatureSets.get(0);
+
+    specService.applyFeatureSet(invalidFeatureSet.toProto());
   }
 
   @Test

--- a/core/src/test/java/feast/core/service/SpecServiceTest.java
+++ b/core/src/test/java/feast/core/service/SpecServiceTest.java
@@ -293,8 +293,9 @@ public class SpecServiceTest {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage(
         String.format(
-            "Reserved feature names have been used, which are not allowed. These names include %s.",
-            reservedNamesString));
+            "Reserved feature names have been used, which are not allowed. These names include %s."
+                + "You've just used an invalid name, %s.",
+            reservedNamesString, "created_timestamp"));
     FeatureSet invalidFeatureSet = invalidFeatureSets.get(0);
 
     specService.applyFeatureSet(invalidFeatureSet.toProto());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR prevents applying of Featuresets with Feature names that are reserved.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #818

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
