### PR TITLE
IngestionJob is being gracefully replaced to minimize downtime

### DIFF
--- a/core/src/main/java/feast/core/model/Job.java
+++ b/core/src/main/java/feast/core/model/Job.java
@@ -158,6 +158,18 @@ public class Job extends AbstractTimestampEntity {
     return ingestJob;
   }
 
+  public Job clone() {
+    return Job.builder()
+        .setStores(getStores())
+        .setStoreName(getStoreName())
+        .setSourceConfig(getSourceConfig())
+        .setSourceType(getSourceType())
+        .setFeatureSetJobStatuses(new HashSet<>())
+        .setRunner(getRunner())
+        .setStatus(JobStatus.UNKNOWN)
+        .build();
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(getSource(), this.stores, this.runner);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Previously, when job required upgrade (currently happens when store config changed) - we stopped current running job and then spawn new one sequentially. That may bring downtime in Ingestion, which is unwanted, especially for online storing.

In this PR we spawn clone of the job first. The old one being garbage collected (terminated) on the next run of JobCoordintatorService.Poll when we are sure that replacement is up & running.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
