### PR TITLE
Write metrics for store allocated rows only

### DIFF
--- a/ingestion/src/main/java/feast/ingestion/ImportJob.java
+++ b/ingestion/src/main/java/feast/ingestion/ImportJob.java
@@ -155,9 +155,8 @@ public class ImportJob {
       FeatureSink featureSink = getFeatureSink(store);
 
       sinkReadiness = sinkReadiness.and(featureSink.prepareWrite(featureSetSpecs));
-      PCollection<FeatureRow> rowsForStore = storeAllocatedRows
-              .get(storeTags.get(store))
-              .setCoder(ProtoCoder.of(FeatureRow.class));
+      PCollection<FeatureRow> rowsForStore =
+          storeAllocatedRows.get(storeTags.get(store)).setCoder(ProtoCoder.of(FeatureRow.class));
 
       // Step 5. Write metrics of successfully validated rows
       rowsForStore.apply(
@@ -165,8 +164,7 @@ public class ImportJob {
 
       // Step 6. Write FeatureRow to the corresponding Store.
       WriteResult writeFeatureRows =
-          rowsForStore
-              .apply("WriteFeatureRowToStore", featureSink.writer());
+          rowsForStore.apply("WriteFeatureRowToStore", featureSink.writer());
 
       // Step 7. Write FailedElements to a dead letter table in BigQuery.
       if (options.getDeadLetterTableSpec() != null) {

--- a/ingestion/src/main/java/feast/ingestion/ImportJob.java
+++ b/ingestion/src/main/java/feast/ingestion/ImportJob.java
@@ -155,17 +155,17 @@ public class ImportJob {
       FeatureSink featureSink = getFeatureSink(store);
 
       sinkReadiness = sinkReadiness.and(featureSink.prepareWrite(featureSetSpecs));
+      PCollection<FeatureRow> rowsForStore = storeAllocatedRows
+              .get(storeTags.get(store))
+              .setCoder(ProtoCoder.of(FeatureRow.class));
 
       // Step 5. Write metrics of successfully validated rows
-      validatedRows
-          .get(FEATURE_ROW_OUT)
-          .apply("WriteInflightMetrics", WriteInflightMetricsTransform.create(store.getName()));
+      rowsForStore.apply(
+          "WriteInflightMetrics", WriteInflightMetricsTransform.create(store.getName()));
 
       // Step 6. Write FeatureRow to the corresponding Store.
       WriteResult writeFeatureRows =
-          storeAllocatedRows
-              .get(storeTags.get(store))
-              .setCoder(ProtoCoder.of(FeatureRow.class))
+          rowsForStore
               .apply("WriteFeatureRowToStore", featureSink.writer());
 
       // Step 7. Write FailedElements to a dead letter table in BigQuery.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Fixes a mistake in #763 where metrics. are written for all validatedRows for every store, without filtering by store.
