### PR TITLE
Fix CPU count selection in Python SDK for non-Unix

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -16,6 +16,7 @@
 import datetime
 import logging
 import os
+import multiprocessing
 import shutil
 import tempfile
 import time
@@ -90,7 +91,7 @@ from tensorflow_metadata.proto.v0 import statistics_pb2
 
 _logger = logging.getLogger(__name__)
 
-CPU_COUNT: int = len(os.sched_getaffinity(0))
+CPU_COUNT: int = multiprocessing.cpu_count()
 
 
 class Client:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

The Python SDK doesn't work on macOs because `os.sched_getaffinity(0)` isn't supported. This PR uses `multiprocessing.cpu_count()` which is.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
