### PR TITLE
Add disk size as Dataflow Job Configuration

### DIFF
--- a/core/src/main/java/feast/core/job/dataflow/DataflowRunnerConfig.java
+++ b/core/src/main/java/feast/core/job/dataflow/DataflowRunnerConfig.java
@@ -42,6 +42,7 @@ public class DataflowRunnerConfig extends RunnerConfig {
     this.tempLocation = runnerConfigOptions.getTempLocation();
     this.maxNumWorkers = runnerConfigOptions.getMaxNumWorkers();
     this.deadLetterTableSpec = runnerConfigOptions.getDeadLetterTableSpec();
+    this.diskSizeGb = runnerConfigOptions.getDiskSizeGb();
     this.labels = runnerConfigOptions.getLabelsMap();
     validate();
   }
@@ -84,6 +85,9 @@ public class DataflowRunnerConfig extends RunnerConfig {
 
   /* BigQuery table specification, e.g. PROJECT_ID:DATASET_ID.PROJECT_ID */
   public String deadLetterTableSpec;
+
+  /* Disk size to use on each remote Compute Engine worker instance */
+  public Integer diskSizeGb;
 
   public Map<String, String> labels;
 

--- a/core/src/test/java/feast/core/job/dataflow/DataflowRunnerConfigTest.java
+++ b/core/src/test/java/feast/core/job/dataflow/DataflowRunnerConfigTest.java
@@ -42,6 +42,7 @@ public class DataflowRunnerConfigTest {
             .setUsePublicIps(false)
             .setWorkerMachineType("n1-standard-1")
             .setDeadLetterTableSpec("project_id:dataset_id.table_id")
+            .setDiskSizeGb(100)
             .putLabels("key", "value")
             .build();
 
@@ -60,7 +61,44 @@ public class DataflowRunnerConfigTest {
                 "--usePublicIps=false",
                 "--workerMachineType=n1-standard-1",
                 "--deadLetterTableSpec=project_id:dataset_id.table_id",
+                "--diskSizeGb=100",
                 "--labels={\"key\":\"value\"}")
+            .toArray(String[]::new);
+    assertThat(args.size(), equalTo(expectedArgs.length));
+    assertThat(args, containsInAnyOrder(expectedArgs));
+  }
+
+  @Test
+  public void shouldIgnoreOptionalArguments() throws IllegalAccessException {
+    DataflowRunnerConfigOptions opts =
+        DataflowRunnerConfigOptions.newBuilder()
+            .setProject("my-project")
+            .setRegion("asia-east1")
+            .setZone("asia-east1-a")
+            .setTempLocation("gs://bucket/tempLocation")
+            .setNetwork("default")
+            .setSubnetwork("regions/asia-east1/subnetworks/mysubnetwork")
+            .setMaxNumWorkers(1)
+            .setAutoscalingAlgorithm("THROUGHPUT_BASED")
+            .setUsePublicIps(false)
+            .setWorkerMachineType("n1-standard-1")
+            .build();
+
+    DataflowRunnerConfig dataflowRunnerConfig = new DataflowRunnerConfig(opts);
+    List<String> args = Lists.newArrayList(dataflowRunnerConfig.toArgs());
+    String[] expectedArgs =
+        Arrays.asList(
+                "--project=my-project",
+                "--region=asia-east1",
+                "--zone=asia-east1-a",
+                "--tempLocation=gs://bucket/tempLocation",
+                "--network=default",
+                "--subnetwork=regions/asia-east1/subnetworks/mysubnetwork",
+                "--maxNumWorkers=1",
+                "--autoscalingAlgorithm=THROUGHPUT_BASED",
+                "--usePublicIps=false",
+                "--workerMachineType=n1-standard-1",
+                "--labels={}")
             .toArray(String[]::new);
     assertThat(args.size(), equalTo(expectedArgs.length));
     assertThat(args, containsInAnyOrder(expectedArgs));

--- a/protos/feast/core/Runner.proto
+++ b/protos/feast/core/Runner.proto
@@ -77,4 +77,8 @@ message DataflowRunnerConfigOptions {
 
     /* Labels to apply to the dataflow job */
     map<string, string> labels = 13;
+
+    /* Disk size to use on each remote Compute Engine worker instance */
+    int32 diskSizeGb = 14;
+
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
After #718, it's not possible to have arbitrary options set for runner configuration. Instead, it has to be one of the options supported by the protos defined in `DataflowRunnerConfigOptions` .

`diskSizeGb` is an important option which wasn't available in the proto. This PR added the configuration.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users will now be able to specify disk size for dataflow workers.
```
