### PR TITLE
Enable isort for Python SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,12 @@ format-python:
 
 lint-python:
 	cd ${ROOT_DIR}/sdk/python; mypy feast/ tests/
+	cd ${ROOT_DIR}/sdk/python; isort -rc feast tests --check-only
 	cd ${ROOT_DIR}/sdk/python; flake8 feast/ tests/
 	cd ${ROOT_DIR}/sdk/python; black --check feast tests
 
 	cd ${ROOT_DIR}/tests/e2e; mypy bq/ redis/
+	cd ${ROOT_DIR}/tests/e2e; isort -rc . --check-only
 	cd ${ROOT_DIR}/tests/e2e; flake8 .
 	cd ${ROOT_DIR}/tests/e2e; black --check .
 

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -29,6 +29,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 from google.protobuf.timestamp_pb2 import Timestamp
+from tensorflow_metadata.proto.v0 import statistics_pb2
 
 import feast.grpc.auth as feast_auth
 from feast.config import Config
@@ -86,7 +87,6 @@ from feast.serving.ServingService_pb2 import (
     GetOnlineFeaturesResponse,
 )
 from feast.serving.ServingService_pb2_grpc import ServingServiceStub
-from tensorflow_metadata.proto.v0 import statistics_pb2
 
 _logger = logging.getLogger(__name__)
 

--- a/sdk/python/feast/feature_set.py
+++ b/sdk/python/feast/feature_set.py
@@ -25,6 +25,7 @@ from google.protobuf.message import Message
 from google.protobuf.timestamp_pb2 import Timestamp
 from pandas.api.types import is_datetime64_ns_dtype
 from pyarrow.lib import TimestampType
+from tensorflow_metadata.proto.v0 import schema_pb2
 
 from feast.core.FeatureSet_pb2 import FeatureSet as FeatureSetProto
 from feast.core.FeatureSet_pb2 import FeatureSetMeta as FeatureSetMetaProto
@@ -41,7 +42,6 @@ from feast.type_map import (
     pa_to_feast_value_type,
     python_type_to_feast_value_type,
 )
-from tensorflow_metadata.proto.v0 import schema_pb2
 
 
 class FeatureSet:

--- a/sdk/python/feast/field.py
+++ b/sdk/python/feast/field.py
@@ -14,9 +14,10 @@
 from collections import OrderedDict
 from typing import MutableMapping, Optional, Union
 
+from tensorflow_metadata.proto.v0 import schema_pb2
+
 from feast.core.FeatureSet_pb2 import FeatureSpec
 from feast.value_type import ValueType
-from tensorflow_metadata.proto.v0 import schema_pb2
 
 
 class Field:

--- a/sdk/python/feast/job.py
+++ b/sdk/python/feast/job.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 import fastavro
 import pandas as pd
 from google.protobuf.json_format import MessageToJson
+from tensorflow_metadata.proto.v0 import statistics_pb2
 
 from feast.constants import CONFIG_TIMEOUT_KEY
 from feast.constants import FEAST_DEFAULT_OPTIONS as defaults
@@ -23,7 +24,6 @@ from feast.serving.ServingService_pb2_grpc import ServingServiceStub
 from feast.source import Source
 from feast.staging.storage_client import get_staging_client
 from feast.wait import wait_retry_backoff
-from tensorflow_metadata.proto.v0 import statistics_pb2
 
 # Maximum no of seconds to wait until the retrieval jobs status is DONE in Feast
 # Currently set to the maximum query execution time limit in BigQuery

--- a/sdk/python/setup.cfg
+++ b/sdk/python/setup.cfg
@@ -5,6 +5,8 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 skip=feast/types,feast/core,feast/serving,feast/storage
+known_first_party=feast,feast_serving_server,feast_core_server
+default_section=THIRDPARTY
 
 [flake8]
 ignore = E203, E266, E501, W503

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -19,6 +19,7 @@ from concurrent import futures
 from datetime import datetime
 from unittest import mock
 
+import dataframes
 import grpc
 import pandas as pd
 import pandavro
@@ -27,7 +28,6 @@ from google.protobuf.duration_pb2 import Duration
 from mock import MagicMock, patch
 from pytz import timezone
 
-import dataframes
 import feast.core.CoreService_pb2_grpc as Core
 import feast.serving.ServingService_pb2_grpc as Serving
 from feast.client import Client

--- a/sdk/python/tests/test_feature_set.py
+++ b/sdk/python/tests/test_feature_set.py
@@ -17,13 +17,14 @@ from collections import OrderedDict
 from concurrent import futures
 from datetime import datetime
 
+import dataframes
 import grpc
 import pandas as pd
 import pytest
 import pytz
 from google.protobuf import json_format
+from tensorflow_metadata.proto.v0 import schema_pb2
 
-import dataframes
 import feast.core.CoreService_pb2_grpc as Core
 from feast.client import Client
 from feast.entity import Entity
@@ -35,7 +36,6 @@ from feast.feature_set import (
 )
 from feast.value_type import ValueType
 from feast_core_server import CoreServicer
-from tensorflow_metadata.proto.v0 import schema_pb2
 
 CORE_URL = "core.feast.local"
 SERVING_URL = "serving.feast.local"

--- a/tests/e2e/bq/bq-batch-retrieval.py
+++ b/tests/e2e/bq/bq-batch-retrieval.py
@@ -10,13 +10,13 @@ import numpy as np
 import pandas as pd
 import pytest
 import pytz
+import tensorflow_data_validation as tfdv
+from bq.testutils import assert_stats_equal, clear_unsupported_fields
 from google.cloud import bigquery, storage
 from google.cloud.storage import Blob
 from google.protobuf.duration_pb2 import Duration
 from pandavro import to_avro
 
-import tensorflow_data_validation as tfdv
-from bq.testutils import assert_stats_equal, clear_unsupported_fields
 from feast.client import Client
 from feast.core.CoreService_pb2 import ListStoresRequest
 from feast.core.IngestionJob_pb2 import IngestionJobStatus

--- a/tests/e2e/bq/feature-stats.py
+++ b/tests/e2e/bq/feature-stats.py
@@ -6,14 +6,14 @@ from datetime import datetime, timedelta
 import pandas as pd
 import pytest
 import pytz
-from google.protobuf.duration_pb2 import Duration
-
 import tensorflow_data_validation as tfdv
 from bq.testutils import (
     assert_stats_equal,
     clear_unsupported_agg_fields,
     clear_unsupported_fields,
 )
+from google.protobuf.duration_pb2 import Duration
+
 from feast.client import Client
 from feast.entity import Entity
 from feast.feature import Feature

--- a/tests/e2e/bq/testutils.py
+++ b/tests/e2e/bq/testutils.py
@@ -1,6 +1,5 @@
-from google.protobuf.json_format import MessageToDict
-
 from deepdiff import DeepDiff
+from google.protobuf.json_format import MessageToDict
 
 
 def clear_unsupported_fields(datasets):

--- a/tests/e2e/setup.cfg
+++ b/tests/e2e/setup.cfg
@@ -4,6 +4,8 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
+known_first_party=feast,feast_serving_server,feast_core_server
+default_section=THIRDPARTY
 
 [flake8]
 ignore = E203, E266, E501, W503


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Enables [isort](https://github.com/timothycrosley/isort) checks for the Python SDK and e2e tests.

Contributors should use `make format` in order to sort their code, and `make lint` in order to validate that their Python code is correctly sorted.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
