### PR TITLE
Deallocate featureSet from job when source changed

### DIFF
--- a/core/src/main/java/feast/core/dao/FeatureSetJobStatusRepository.java
+++ b/core/src/main/java/feast/core/dao/FeatureSetJobStatusRepository.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.core.dao;
+
+import feast.core.model.FeatureSetJobStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeatureSetJobStatusRepository
+    extends JpaRepository<FeatureSetJobStatus, FeatureSetJobStatus.FeatureSetJobStatusKey> {
+  long count();
+}

--- a/core/src/main/java/feast/core/model/FeatureSetJobStatus.java
+++ b/core/src/main/java/feast/core/model/FeatureSetJobStatus.java
@@ -79,6 +79,6 @@ public class FeatureSetJobStatus {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(job, featureSet, deliveryStatus, version);
+    return Objects.hashCode(job, featureSet);
   }
 }

--- a/core/src/main/java/feast/core/model/Job.java
+++ b/core/src/main/java/feast/core/model/Job.java
@@ -175,15 +175,16 @@ public class Job extends AbstractTimestampEntity {
   }
 
   public Job clone() {
-    Job job = Job.builder()
-        .setStores(getStores())
-        .setStoreName(getStoreName())
-        .setSourceConfig(getSourceConfig())
-        .setSourceType(getSourceType())
-        .setFeatureSetJobStatuses(new HashSet<>())
-        .setRunner(getRunner())
-        .setStatus(JobStatus.UNKNOWN)
-        .build();
+    Job job =
+        Job.builder()
+            .setStores(getStores())
+            .setStoreName(getStoreName())
+            .setSourceConfig(getSourceConfig())
+            .setSourceType(getSourceType())
+            .setFeatureSetJobStatuses(new HashSet<>())
+            .setRunner(getRunner())
+            .setStatus(JobStatus.UNKNOWN)
+            .build();
     job.addAllFeatureSets(getFeatureSets());
     return job;
   }

--- a/core/src/main/resources/db/migration/V2.3__Fix_Primary_Keys.sql
+++ b/core/src/main/resources/db/migration/V2.3__Fix_Primary_Keys.sql
@@ -1,0 +1,3 @@
+ALTER TABLE jobs_feature_sets ADD CONSTRAINT jobs_feature_sets_pkey PRIMARY KEY (job_id, feature_sets_id);
+
+ALTER TABLE jobs_stores ADD CONSTRAINT jobs_stores_pkey PRIMARY KEY (job_id, store_name);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
After FeatureSet updated with new Source it should be deallocated from its current job and allocated to new one. Deallocation (deletion of FeatureSetJobStatus) doesn't happen which leads to inconsistent state when FeatureSet remains PENDING.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
