### PR TITLE
Don't send unrecognized featureSets to deadletter in IngestionJob

### DIFF
--- a/ingestion/src/main/java/feast/ingestion/transform/fn/ValidateFeatureRowDoFn.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/fn/ValidateFeatureRowDoFn.java
@@ -31,9 +31,12 @@ import java.util.Map;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @AutoValue
 public abstract class ValidateFeatureRowDoFn extends DoFn<FeatureRow, FeatureRow> {
+  private static final Logger log = LoggerFactory.getLogger(ValidateFeatureRowDoFn.class);
 
   public abstract PCollectionView<Map<String, Iterable<FeatureSetProto.FeatureSetSpec>>>
       getFeatureSets();
@@ -65,40 +68,41 @@ public abstract class ValidateFeatureRowDoFn extends DoFn<FeatureRow, FeatureRow
     FeatureRow featureRow = context.element();
     Iterable<FeatureSetProto.FeatureSetSpec> featureSetSpecs =
         context.sideInput(getFeatureSets()).get(featureRow.getFeatureSet());
-
-    List<FieldProto.Field> fields = new ArrayList<>();
-    if (featureSetSpecs != null) {
-      FeatureSetProto.FeatureSetSpec latestSpec = Iterators.getLast(featureSetSpecs.iterator());
-      FeatureSet featureSet = new FeatureSet(latestSpec);
-
-      for (FieldProto.Field field : featureRow.getFieldsList()) {
-        Field fieldSpec = featureSet.getField(field.getName());
-        if (fieldSpec == null) {
-          // skip
-          continue;
-        }
-        // If value is set in the FeatureRow, make sure the value type matches
-        // that defined in FeatureSetSpec
-        if (!field.getValue().getValCase().equals(ValCase.VAL_NOT_SET)) {
-          int expectedTypeFieldNumber = fieldSpec.getType().getNumber();
-          int actualTypeFieldNumber = field.getValue().getValCase().getNumber();
-          if (expectedTypeFieldNumber != actualTypeFieldNumber) {
-            error =
-                String.format(
-                    "FeatureRow contains field '%s' with invalid type '%s'. Feast expects the field type to match that in FeatureSet '%s'. Please check the FeatureRow data.",
-                    field.getName(), field.getValue().getValCase(), fieldSpec.getType());
-            break;
-          }
-        }
-        if (!fields.contains(field)) {
-          fields.add(field);
-        }
-      }
-    } else {
-      error =
+    if (featureSetSpecs == null) {
+      log.warn(
           String.format(
               "FeatureRow contains invalid feature set id %s. Please check that the feature rows are being published to the correct topic on the feature stream.",
-              featureRow.getFeatureSet());
+              featureRow.getFeatureSet()));
+      return;
+    }
+
+    List<FieldProto.Field> fields = new ArrayList<>();
+
+    FeatureSetProto.FeatureSetSpec latestSpec = Iterators.getLast(featureSetSpecs.iterator());
+    FeatureSet featureSet = new FeatureSet(latestSpec);
+
+    for (FieldProto.Field field : featureRow.getFieldsList()) {
+      Field fieldSpec = featureSet.getField(field.getName());
+      if (fieldSpec == null) {
+        // skip
+        continue;
+      }
+      // If value is set in the FeatureRow, make sure the value type matches
+      // that defined in FeatureSetSpec
+      if (!field.getValue().getValCase().equals(ValCase.VAL_NOT_SET)) {
+        int expectedTypeFieldNumber = fieldSpec.getType().getNumber();
+        int actualTypeFieldNumber = field.getValue().getValCase().getNumber();
+        if (expectedTypeFieldNumber != actualTypeFieldNumber) {
+          error =
+              String.format(
+                  "FeatureRow contains field '%s' with invalid type '%s'. Feast expects the field type to match that in FeatureSet '%s'. Please check the FeatureRow data.",
+                  field.getName(), field.getValue().getValCase(), fieldSpec.getType());
+          break;
+        }
+      }
+      if (!fields.contains(field)) {
+        fields.add(field);
+      }
     }
 
     if (error != null) {

--- a/ingestion/src/main/java/feast/ingestion/transform/fn/ValidateFeatureRowDoFn.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/fn/ValidateFeatureRowDoFn.java
@@ -71,7 +71,9 @@ public abstract class ValidateFeatureRowDoFn extends DoFn<FeatureRow, FeatureRow
     if (featureSetSpecs == null) {
       log.warn(
           String.format(
-              "FeatureRow contains invalid feature set id %s. Please check that the feature rows are being published to the correct topic on the feature stream.",
+              "FeatureRow contains invalid featureSetReference %s."
+                  + " Please check that the feature rows are being published"
+                  + " to the correct topic on the feature stream.",
               featureRow.getFeatureSet()));
       return;
     }

--- a/ingestion/src/test/java/feast/ingestion/transform/ProcessAndValidateFeatureRowsTest.java
+++ b/ingestion/src/test/java/feast/ingestion/transform/ProcessAndValidateFeatureRowsTest.java
@@ -16,6 +16,8 @@
  */
 package feast.ingestion.transform;
 
+import static feast.common.models.FeatureSet.getFeatureSetStringRef;
+
 import feast.proto.core.FeatureSetProto.EntitySpec;
 import feast.proto.core.FeatureSetProto.FeatureSetSpec;
 import feast.proto.core.FeatureSetProto.FeatureSpec;
@@ -104,7 +106,17 @@ public class ProcessAndValidateFeatureRowsTest {
       expected.add(randomRow);
     }
 
-    input.add(FeatureRow.newBuilder().setFeatureSet("invalid").build());
+    FeatureRow invalidRow =
+        FeatureRow.newBuilder()
+            .setFeatureSet(getFeatureSetStringRef(fs1))
+            .addFields(
+                Field.newBuilder()
+                    .setName("feature_1")
+                    .setValue(Value.newBuilder().setBoolVal(false).build())
+                    .build())
+            .build();
+
+    input.add(invalidRow);
 
     PCollectionView<Map<String, Iterable<FeatureSetSpec>>> specsView =
         p.apply("StaticSpecs", Create.of(featureSetSpecs)).apply(View.asMultimap());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Currently we overpopulating deadletter sink (in bq) by sending all FeatureRows that coming in with unknown FeatureSetReference. That could create billions of rows within hours and create long queue in IngestionJob, which disrupt normal processing (OOM, eg). We should just write smth to log instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
