### PR TITLE
Replace IngestionJob when store was updated

### DIFF
--- a/core/src/main/java/feast/core/model/Store.java
+++ b/core/src/main/java/feast/core/model/Store.java
@@ -47,7 +47,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Entity
 @Table(name = "stores")
-public class Store {
+public class Store extends AbstractTimestampEntity {
 
   // Name of the store. Must be unique
   @Id

--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -223,6 +223,10 @@ public class JobCoordinatorService {
       return true;
     }
 
+    if (stores.stream().anyMatch(s -> s.getLastUpdated().after(job.getCreated()))) {
+      return true;
+    }
+
     return false;
   }
 

--- a/core/src/main/resources/db/migration/V2.4__Store_Timestamps.sql
+++ b/core/src/main/resources/db/migration/V2.4__Store_Timestamps.sql
@@ -1,0 +1,2 @@
+ALTER TABLE stores ADD COLUMN created timestamp default now();
+ALTER TABLE stores ADD COLUMN last_updated timestamp default now();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

TestCase that fails:
1. There's existing consolidated job with state RUNNING
2. Job has attached Store with subscription project_1:*
3. We update Store config (on serving layer) by adding new subscription project_2:*
4. After serving layer sent Store to Core - Job should be replaced with new one that has both subscriptions

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
