### PR TITLE
Fix: JobCoordinator tries to create duplicate FeatureSetJobStatuses

### DIFF
--- a/core/src/main/java/feast/core/model/FeatureSetJobStatus.java
+++ b/core/src/main/java/feast/core/model/FeatureSetJobStatus.java
@@ -21,6 +21,8 @@ import feast.proto.core.FeatureSetProto.FeatureSetJobDeliveryStatus;
 import java.io.Serializable;
 import javax.persistence.*;
 import javax.persistence.Entity;
+
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -37,6 +39,7 @@ import lombok.Setter;
 public class FeatureSetJobStatus {
   @Embeddable
   @EqualsAndHashCode
+  @AllArgsConstructor
   public static class FeatureSetJobStatusKey implements Serializable {
     public FeatureSetJobStatusKey() {}
 

--- a/core/src/main/java/feast/core/model/FeatureSetJobStatus.java
+++ b/core/src/main/java/feast/core/model/FeatureSetJobStatus.java
@@ -21,7 +21,6 @@ import feast.proto.core.FeatureSetProto.FeatureSetJobDeliveryStatus;
 import java.io.Serializable;
 import javax.persistence.*;
 import javax.persistence.Entity;
-
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -267,7 +267,7 @@ public class JobCoordinatorService {
       status.setJob(job);
       status.setDeliveryStatus(FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS);
 
-      current.put(status.getId(), status);
+      current.put(new FeatureSetJobStatus.FeatureSetJobStatusKey(job.getId(), featureSet.getId()), status);
     }
 
     Set<FeatureSetJobStatus.FeatureSetJobStatusKey> toDelete =

--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -267,7 +267,8 @@ public class JobCoordinatorService {
       status.setJob(job);
       status.setDeliveryStatus(FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS);
 
-      current.put(new FeatureSetJobStatus.FeatureSetJobStatusKey(job.getId(), featureSet.getId()), status);
+      current.put(
+          new FeatureSetJobStatus.FeatureSetJobStatusKey(job.getId(), featureSet.getId()), status);
     }
 
     Set<FeatureSetJobStatus.FeatureSetJobStatusKey> toDelete =

--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -378,7 +378,8 @@ public class JobCoordinatorService {
               // FeatureSet).
               // We now set status to IN_PROGRESS, so listenAckFromJobs would be able to
               // monitor delivery progress for each new version.
-              fs.getJobStatuses().stream()
+              Set<FeatureSetJobStatus> jobStatuses = fs.getJobStatuses();
+              jobStatuses.stream()
                   .filter(s -> s.getJob().isRunning())
                   .forEach(
                       jobStatus -> {
@@ -386,7 +387,8 @@ public class JobCoordinatorService {
                             FeatureSetProto.FeatureSetJobDeliveryStatus.STATUS_IN_PROGRESS);
                         jobStatus.setVersion(fs.getVersion());
                       });
-              featureSetRepository.saveAndFlush(fs);
+              jobStatusRepository.saveAll(jobStatuses);
+              jobStatusRepository.flush();
             });
   }
 

--- a/core/src/test/java/feast/core/util/TestUtil.java
+++ b/core/src/test/java/feast/core/util/TestUtil.java
@@ -141,6 +141,7 @@ public class TestUtil {
 
     featureSetJobStatus.setDeliveryStatus(deliveryStatus);
     featureSetJobStatus.setVersion(version);
+    featureSetJobStatus.setId(new FeatureSetJobStatus.FeatureSetJobStatusKey(job.getId(), 0));
 
     return featureSetJobStatus;
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Prevent from creating FeatureSetJobStatuses that would violate unique primary key constraint.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
