### PR TITLE
Fix FeatureSetJobStatus removal

### DIFF
--- a/core/src/main/java/feast/core/model/FeatureSet.java
+++ b/core/src/main/java/feast/core/model/FeatureSet.java
@@ -93,7 +93,7 @@ public class FeatureSet extends AbstractTimestampEntity {
   @Column(name = "version", columnDefinition = "integer default 0")
   private int version;
 
-  @OneToMany(mappedBy = "featureSet", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "featureSet")
   private Set<FeatureSetJobStatus> jobStatuses = new HashSet<>();
 
   public FeatureSet() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Currently due to cascade relations from both Job and FeatureSet to FeatureSetJobStatus it's impossible to delete FeatureSetJobStatus. As a solution I propose to delete cascade on FeatureSet side because:
1. We manage FeatureSetJobStatus from Job side
2. Ideally when we completely decouple JobCoordination from Core there will be no foreign key (relationship in general) to FeatureSet in FeatureSetJobStatus (see my other PR #852 )
3. Currently we not planning to physically delete feature sets. Even if we will delete them - only by marking as deleted.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
