### PR TITLE
Fix IngestionJob upgrade on Store change (part 2)

### DIFF
--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -25,6 +25,7 @@ import feast.core.config.FeastProperties.JobProperties;
 import feast.core.dao.FeatureSetJobStatusRepository;
 import feast.core.dao.FeatureSetRepository;
 import feast.core.dao.JobRepository;
+import feast.core.dao.StoreRepository;
 import feast.core.job.*;
 import feast.core.model.*;
 import feast.core.model.FeatureSet;
@@ -32,8 +33,6 @@ import feast.core.model.Job;
 import feast.core.model.JobStatus;
 import feast.core.model.Source;
 import feast.core.model.Store;
-import feast.proto.core.CoreServiceProto.ListStoresRequest.Filter;
-import feast.proto.core.CoreServiceProto.ListStoresResponse;
 import feast.proto.core.FeatureSetProto;
 import feast.proto.core.IngestionJobProto;
 import java.util.*;
@@ -61,7 +60,7 @@ public class JobCoordinatorService {
   private final JobRepository jobRepository;
   private final FeatureSetRepository featureSetRepository;
   private final FeatureSetJobStatusRepository jobStatusRepository;
-  private final SpecService specService;
+  private final StoreRepository storeRepository;
   private final JobManager jobManager;
   private final JobProperties jobProperties;
   private final JobGroupingStrategy groupingStrategy;
@@ -72,7 +71,7 @@ public class JobCoordinatorService {
       JobRepository jobRepository,
       FeatureSetRepository featureSetRepository,
       FeatureSetJobStatusRepository jobStatusRepository,
-      SpecService specService,
+      StoreRepository storeRepository,
       JobManager jobManager,
       FeastProperties feastProperties,
       JobGroupingStrategy groupingStrategy,
@@ -80,7 +79,7 @@ public class JobCoordinatorService {
     this.jobRepository = jobRepository;
     this.featureSetRepository = featureSetRepository;
     this.jobStatusRepository = jobStatusRepository;
-    this.specService = specService;
+    this.storeRepository = storeRepository;
     this.jobManager = jobManager;
     this.jobProperties = feastProperties.getJobs();
     this.specPublisher = specPublisher;
@@ -297,10 +296,7 @@ public class JobCoordinatorService {
   }
 
   private List<Store> getAllStores() {
-    ListStoresResponse listStoresResponse = specService.listStores(Filter.newBuilder().build());
-    return listStoresResponse.getStoreList().stream()
-        .map(Store::fromProto)
-        .collect(Collectors.toList());
+    return storeRepository.findAll();
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
We need to use StoreRepository directly (not SpecService) to access lastUpdated property of Store.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
