### PR TITLE
OSX doesn't always have sched_getaffinity

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -93,7 +93,10 @@ from feast.types.Value_pb2 import Value as Value
 
 _logger = logging.getLogger(__name__)
 
-CPU_COUNT: int = len(os.sched_getaffinity(0))
+try:
+    CPU_COUNT: int = len(os.sched_getaffinity(0))
+except AttributeError as e:
+    CPU_COUNT: int = 2
 
 warnings.simplefilter("once", DeprecationWarning)
 


### PR DESCRIPTION
1. The python client breaks when calling
 CPU_COUNT: int = len(os.sched_getaffinity(0))

**What this PR does / why we need it**:
When importing the python client I encounter an error
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'os' has no attribute 'sched_getaffinity'
```
We should fallback or use another trick to compute this value, it seems to be a known issue
https://stackoverflow.com/questions/42538153/python-3-6-0-os-module-does-not-have-sched-getaffinity-method

