### PR TITLE
Keep StoreProto inside JobStore to decouple JobCoordination from SpecService internals

### DIFF
--- a/core/src/main/java/feast/core/dao/JobRepository.java
+++ b/core/src/main/java/feast/core/dao/JobRepository.java
@@ -41,5 +41,5 @@ public interface JobRepository extends JpaRepository<Job, String> {
   List<Job> findByFeatureSetJobStatusesIn(List<FeatureSetJobStatus> featureSetsJobStatuses);
 
   // find jobs by feast store name
-  List<Job> findByStoresName(String storeName);
+  List<Job> findByJobStoresIdStoreName(String storeName);
 }

--- a/core/src/main/java/feast/core/dao/JobRepository.java
+++ b/core/src/main/java/feast/core/dao/JobRepository.java
@@ -40,6 +40,6 @@ public interface JobRepository extends JpaRepository<Job, String> {
 
   List<Job> findByFeatureSetJobStatusesIn(List<FeatureSetJobStatus> featureSetsJobStatuses);
 
-  // find jobs by feast store name
+  // find jobs that have at least one store with given name
   List<Job> findByJobStoresIdStoreName(String storeName);
 }

--- a/core/src/main/java/feast/core/job/ConsolidatedJobStrategy.java
+++ b/core/src/main/java/feast/core/job/ConsolidatedJobStrategy.java
@@ -50,12 +50,12 @@ public class ConsolidatedJobStrategy implements JobGroupingStrategy {
         .findFirstBySourceTypeAndSourceConfigAndStoreNameAndStatusNotInOrderByLastUpdatedDesc(
             source.getType(), source.getConfig(), null, JobStatus.getTerminalStates())
         .orElseGet(
-            () ->
-                Job.builder()
-                    .setSource(source)
-                    .setStores(stores)
-                    .setFeatureSetJobStatuses(new HashSet<>())
-                    .build());
+            () -> {
+              Job job =
+                  Job.builder().setSource(source).setFeatureSetJobStatuses(new HashSet<>()).build();
+              job.setStores(stores);
+              return job;
+            });
   }
 
   @Override

--- a/core/src/main/java/feast/core/job/JobPerStoreStrategy.java
+++ b/core/src/main/java/feast/core/job/JobPerStoreStrategy.java
@@ -55,13 +55,16 @@ public class JobPerStoreStrategy implements JobGroupingStrategy {
         .findFirstBySourceTypeAndSourceConfigAndStoreNameAndStatusNotInOrderByLastUpdatedDesc(
             source.getType(), source.getConfig(), store.getName(), JobStatus.getTerminalStates())
         .orElseGet(
-            () ->
-                Job.builder()
-                    .setSource(source)
-                    .setStoreName(store.getName())
-                    .setStores(stores)
-                    .setFeatureSetJobStatuses(new HashSet<>())
-                    .build());
+            () -> {
+              Job job =
+                  Job.builder()
+                      .setSource(source)
+                      .setStoreName(store.getName())
+                      .setFeatureSetJobStatuses(new HashSet<>())
+                      .build();
+              job.setStores(stores);
+              return job;
+            });
   }
 
   @Override

--- a/core/src/main/java/feast/core/model/Job.java
+++ b/core/src/main/java/feast/core/model/Job.java
@@ -136,6 +136,11 @@ public class Job extends AbstractTimestampEntity {
     }
   }
 
+  /**
+   * Materialize stores from protos stored in {@link JobStore}
+   *
+   * @return set of {@link Store}
+   */
   public Set<Store> getStores() {
     return getJobStores().stream()
         .map(JobStore::getStoreProto)
@@ -143,6 +148,11 @@ public class Job extends AbstractTimestampEntity {
         .collect(Collectors.toSet());
   }
 
+  /**
+   * Copy stores as protos to JobStores {@link JobStore} to keep job's version of allocated stores.
+   *
+   * @param stores allocated set of {@link Store}
+   */
   public void setStores(Set<Store> stores) {
     jobStores = new HashSet<>();
     for (Store store : stores) {

--- a/core/src/main/java/feast/core/model/Job.java
+++ b/core/src/main/java/feast/core/model/Job.java
@@ -76,16 +76,8 @@ public class Job extends AbstractTimestampEntity {
   private String sourceConfig;
 
   // Sinks
-  @ManyToMany
-  @JoinTable(
-      name = "jobs_stores",
-      joinColumns = @JoinColumn(name = "job_id"),
-      inverseJoinColumns = @JoinColumn(name = "store_name"),
-      indexes = {
-        @Index(name = "idx_jobs_stores_job_id", columnList = "job_id"),
-        @Index(name = "idx_jobs_stores_store_name", columnList = "store_name")
-      })
-  private Set<Store> stores;
+  @OneToMany(mappedBy = "job", cascade = CascadeType.ALL)
+  private Set<JobStore> jobStores = new HashSet<>();
 
   @Deprecated
   @Column(name = "store_name")
@@ -144,6 +136,20 @@ public class Job extends AbstractTimestampEntity {
     }
   }
 
+  public Set<Store> getStores() {
+    return getJobStores().stream()
+        .map(JobStore::getStoreProto)
+        .map(Store::fromProto)
+        .collect(Collectors.toSet());
+  }
+
+  public void setStores(Set<Store> stores) {
+    jobStores = new HashSet<>();
+    for (Store store : stores) {
+      jobStores.add(new JobStore(this, store));
+    }
+  }
+
   /**
    * Convert a job model to ingestion job proto
    *
@@ -177,7 +183,6 @@ public class Job extends AbstractTimestampEntity {
   public Job clone() {
     Job job =
         Job.builder()
-            .setStores(getStores())
             .setStoreName(getStoreName())
             .setSourceConfig(getSourceConfig())
             .setSourceType(getSourceType())
@@ -185,13 +190,14 @@ public class Job extends AbstractTimestampEntity {
             .setRunner(getRunner())
             .setStatus(JobStatus.UNKNOWN)
             .build();
+    job.setStores(getStores());
     job.addAllFeatureSets(getFeatureSets());
     return job;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getSource(), this.stores, this.runner);
+    return Objects.hash(getSource(), getStores(), this.runner);
   }
 
   @Override
@@ -204,7 +210,7 @@ public class Job extends AbstractTimestampEntity {
       return false;
     } else if (!getSource().equals(other.getSource())) {
       return false;
-    } else if (!stores.equals(other.stores)) {
+    } else if (!getStores().equals(other.getStores())) {
       return false;
     }
     return true;

--- a/core/src/main/java/feast/core/model/JobStore.java
+++ b/core/src/main/java/feast/core/model/JobStore.java
@@ -77,7 +77,7 @@ public class JobStore {
 
   public StoreProto.Store getStoreProto() {
     try {
-      return StoreProto.Store.parseFrom(storeProto);
+      return StoreProto.Store.parseFrom(this.storeProto);
     } catch (InvalidProtocolBufferException e) {
       return StoreProto.Store.newBuilder().build();
     }
@@ -100,11 +100,12 @@ public class JobStore {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     JobStore jobStore = (JobStore) o;
-    return Objects.equal(id, jobStore.id) && Objects.equal(storeProto, jobStore.storeProto);
+    return Objects.equal(this.id, jobStore.id)
+        && Objects.equal(this.storeProto, jobStore.storeProto);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(id, storeProto);
+    return Objects.hashCode(this.id, this.storeProto);
   }
 }

--- a/core/src/main/java/feast/core/model/JobStore.java
+++ b/core/src/main/java/feast/core/model/JobStore.java
@@ -29,6 +29,10 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Represents {@link Store}s attached to one {@link Job}. Keeps copy of Store's proto to detect
+ * changes in original Store.
+ */
 @Entity
 @Table(
     name = "jobs_stores",

--- a/core/src/main/java/feast/core/model/JobStore.java
+++ b/core/src/main/java/feast/core/model/JobStore.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.core.model;
+
+import com.google.common.base.Objects;
+import com.google.protobuf.InvalidProtocolBufferException;
+import feast.proto.core.StoreProto;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import javax.persistence.*;
+import javax.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(
+    name = "jobs_stores",
+    indexes = {
+      @Index(name = "idx_jobs_stores_job_id", columnList = "job_id"),
+      @Index(name = "idx_jobs_stores_store_name", columnList = "store_name")
+    })
+@Getter
+@Setter
+public class JobStore {
+  @Embeddable
+  @EqualsAndHashCode
+  @AllArgsConstructor
+  public static class JobStoreKey implements Serializable {
+    public JobStoreKey() {}
+
+    @Column(name = "job_id")
+    String jobId;
+
+    @Column(name = "store_name")
+    String storeName;
+  }
+
+  @EmbeddedId private JobStoreKey id = new JobStoreKey();
+
+  @ManyToOne
+  @MapsId("jobId")
+  @JoinColumn(name = "job_id")
+  private Job job;
+
+  @Column(name = "store_proto", nullable = false)
+  @Lob
+  private byte[] storeProto;
+
+  public JobStore() {}
+
+  public JobStore(Job job, Store store) {
+    this.job = job;
+    this.id.storeName = store.getName();
+    try {
+      setStoreProto(store.toProto());
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException("Couldn't convert Store to proto. Reason: %s", e.getCause());
+    }
+  }
+
+  public StoreProto.Store getStoreProto() {
+    try {
+      return StoreProto.Store.parseFrom(storeProto);
+    } catch (InvalidProtocolBufferException e) {
+      return StoreProto.Store.newBuilder().build();
+    }
+  }
+
+  public void setStoreProto(StoreProto.Store storeProto) {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try {
+      storeProto.writeTo(output);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          String.format("Couldn't write StoreProto to byteArray: %s", e.getCause()));
+    }
+
+    this.storeProto = output.toByteArray();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    JobStore jobStore = (JobStore) o;
+    return Objects.equal(id, jobStore.id) && Objects.equal(storeProto, jobStore.storeProto);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id, storeProto);
+  }
+}

--- a/core/src/main/java/feast/core/model/Store.java
+++ b/core/src/main/java/feast/core/model/Store.java
@@ -47,7 +47,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @Entity
 @Table(name = "stores")
-public class Store extends AbstractTimestampEntity {
+public class Store {
 
   // Name of the store. Must be unique
   @Id

--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -227,10 +227,6 @@ public class JobCoordinatorService {
       return true;
     }
 
-    if (stores.stream().anyMatch(s -> s.getLastUpdated().after(job.getCreated()))) {
-      return true;
-    }
-
     return false;
   }
 

--- a/core/src/main/java/feast/core/service/JobService.java
+++ b/core/src/main/java/feast/core/service/JobService.java
@@ -108,7 +108,7 @@ public class JobService {
         // multiple filters can apply together in an 'and' operation
         if (!filter.getStoreName().isEmpty()) {
           // find jobs by name
-          List<Job> jobs = this.jobRepository.findByStoresName(filter.getStoreName());
+          List<Job> jobs = this.jobRepository.findByJobStoresIdStoreName(filter.getStoreName());
           Set<String> jobIds = jobs.stream().map(Job::getId).collect(Collectors.toSet());
           matchingJobIds = this.mergeResults(matchingJobIds, jobIds);
         }

--- a/core/src/main/resources/db/migration/V2.4__Store_Timestamps.sql
+++ b/core/src/main/resources/db/migration/V2.4__Store_Timestamps.sql
@@ -1,2 +1,0 @@
-ALTER TABLE stores ADD COLUMN created timestamp default now();
-ALTER TABLE stores ADD COLUMN last_updated timestamp default now();

--- a/core/src/main/resources/db/migration/V2.4__Store_proto.sql
+++ b/core/src/main/resources/db/migration/V2.4__Store_proto.sql
@@ -1,0 +1,1 @@
+ALTER TABLE jobs_stores ADD COLUMN store_proto oid not null;

--- a/core/src/test/java/feast/core/job/JobTasksTest.java
+++ b/core/src/test/java/feast/core/job/JobTasksTest.java
@@ -76,15 +76,17 @@ public class JobTasksTest {
   }
 
   Job makeJob(String extId, List<FeatureSet> featureSets, JobStatus status) {
-    return Job.builder()
-        .setId("job")
-        .setExtId(extId)
-        .setRunner(RUNNER)
-        .setSource(source)
-        .setStores(ImmutableSet.of(store))
-        .setFeatureSetJobStatuses(TestUtil.makeFeatureSetJobStatus(featureSets))
-        .setStatus(status)
-        .build();
+    Job job =
+        Job.builder()
+            .setId("job")
+            .setExtId(extId)
+            .setRunner(RUNNER)
+            .setSource(source)
+            .setFeatureSetJobStatuses(TestUtil.makeFeatureSetJobStatus(featureSets))
+            .setStatus(status)
+            .build();
+    job.setStores(ImmutableSet.of(store));
+    return job;
   }
 
   CreateJobTask makeCreateTask(Job currentJob) {

--- a/core/src/test/java/feast/core/job/direct/DirectRunnerJobManagerTest.java
+++ b/core/src/test/java/feast/core/job/direct/DirectRunnerJobManagerTest.java
@@ -150,11 +150,10 @@ public class DirectRunnerJobManagerTest {
             .setExtId("")
             .setRunner(Runner.DIRECT)
             .setSource(Source.fromProto(source))
-            .setStores(ImmutableSet.of(Store.fromProto(store)))
             .setFeatureSetJobStatuses(makeFeatureSetJobStatus(FeatureSet.fromProto(featureSet)))
             .setStatus(JobStatus.PENDING)
             .build();
-
+    job.setStores(ImmutableSet.of(Store.fromProto(store)));
     Job actual = drJobManager.startJob(job);
 
     verify(drJobManager, times(1)).runPipeline(pipelineOptionsCaptor.capture());

--- a/core/src/test/java/feast/core/service/JobServiceTest.java
+++ b/core/src/test/java/feast/core/service/JobServiceTest.java
@@ -123,7 +123,7 @@ public class JobServiceTest {
 
   public void setupJobRepository() {
     when(this.jobRepository.findById(this.job.getId())).thenReturn(Optional.of(this.job));
-    when(this.jobRepository.findByStoresName(this.dataStore.getName()))
+    when(this.jobRepository.findByJobStoresIdStoreName(this.dataStore.getName()))
         .thenReturn(Arrays.asList(this.job));
     when(this.jobRepository.findByFeatureSetJobStatusesIn(
             Lists.newArrayList((this.featureSet.getJobStatuses()))))
@@ -148,15 +148,17 @@ public class JobServiceTest {
   }
 
   private Job newDummyJob(String id, String extId, JobStatus status) {
-    return job.builder()
-        .setId(id)
-        .setExtId(extId)
-        .setRunner(Runner.DATAFLOW)
-        .setSource(this.dataSource)
-        .setStores(ImmutableSet.of(this.dataStore))
-        .setFeatureSetJobStatuses(makeFeatureSetJobStatus(this.featureSet))
-        .setStatus(status)
-        .build();
+    Job job =
+        Job.builder()
+            .setId(id)
+            .setExtId(extId)
+            .setRunner(Runner.DATAFLOW)
+            .setSource(this.dataSource)
+            .setFeatureSetJobStatuses(makeFeatureSetJobStatus(this.featureSet))
+            .setStatus(status)
+            .build();
+    job.setStores(ImmutableSet.of(this.dataStore));
+    return job;
   }
 
   private List<FeatureSetReference> newDummyFeatureSetReferences() {

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -15,8 +15,8 @@
 
 import datetime
 import logging
-import os
 import multiprocessing
+import os
 import shutil
 import tempfile
 import time


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR reverts #846 to keep Job and Store more decoupled (and not use StoreRepository from JobCoordinator).
Now Job keeps full copy of related Stores (in proto) in `jobs_stores` table. It allows us to compare deployed stores with new one coming from `SpecService` and upgrade IngestionJob if needed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
