### PR TITLE
BQ Sink is failing when Feature consists of only null values

### DIFF
--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
@@ -92,6 +92,9 @@ public class FeatureRowsBatch implements Serializable {
                     f -> {
                       Schema.FieldType fieldType =
                           protoToSchemaTypes.get(f.getValue().getValCase());
+                      if (fieldType == null) {
+                        return;
+                      }
                       if (types.containsKey(f.getName())) {
                         if (!types.get(f.getName()).equals(fieldType)) {
                           throw new RuntimeException("schema cannot be inferred");

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
@@ -143,11 +143,14 @@ public class FeatureRowsBatch implements Serializable {
                   idx -> {
                     Schema.Field field = schema.getField(idx);
                     if (rowValues.containsKey(field.getName())) {
-                      ((List<Object>) values.get(idx))
-                          .add(protoValueToObject(rowValues.get(field.getName())));
-                    } else {
-                      ((List<Object>) values.get(idx)).add(defaultValues.get(field.getName()));
+                      Object o = protoValueToObject(rowValues.get(field.getName()));
+                      if (o != null) {
+                        ((List<Object>) values.get(idx)).add(o);
+                        return;
+                      }
                     }
+
+                    ((List<Object>) values.get(idx)).add(defaultValues.get(field.getName()));
                   });
         });
   }

--- a/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
+++ b/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
@@ -32,6 +32,7 @@ import com.google.cloud.bigquery.*;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import feast.common.models.FeatureSetReference;
 import feast.proto.core.FeatureSetProto.EntitySpec;
 import feast.proto.core.FeatureSetProto.FeatureSetSpec;
@@ -450,13 +451,34 @@ public class BigQuerySinkTest {
 
     List<FeatureRow> input = Stream.concat(stream1, stream2).collect(Collectors.toList());
 
+    FeatureRow rowWithNull =
+        FeatureRow.newBuilder()
+            .setFeatureSet("project/fs")
+            .addAllFields(copyFieldsWithout(generateRow(""), "entity"))
+            .addFields(FieldProto.Field.newBuilder().setName("entity").build())
+            .build();
+
+    List<FeatureRow> inputWithNulls = Lists.newArrayList(input);
+    inputWithNulls.add(rowWithNull);
+
     PCollection<FeatureRow> result =
-        p.apply(Create.of(input))
+        p.apply(Create.of(inputWithNulls))
             .apply("KV", ParDo.of(new ExtractKV()))
             .apply(new CompactFeatureRows(1000))
             .apply("Flat", ParDo.of(new FlatMap()));
 
     List<FeatureRow> inputWithoutNulls = dropNullFeature(input);
+
+    inputWithoutNulls.add(
+        FeatureRow.newBuilder()
+            .setFeatureSet("project/fs")
+            .addFields(
+                FieldProto.Field.newBuilder()
+                    .setName("entity")
+                    .setValue(ValueProto.Value.newBuilder().setInt64Val(0L).build())
+                    .build())
+            .addAllFields(copyFieldsWithout(rowWithNull, "entity", "null_value"))
+            .build());
 
     PAssert.that(result).containsInAnyOrder(inputWithoutNulls);
     p.run();
@@ -473,6 +495,13 @@ public class BigQuerySinkTest {
                             .filter(f -> !f.getName().equals("null_value"))
                             .collect(Collectors.toList()))
                     .build())
+        .collect(Collectors.toList());
+  }
+
+  private List<FieldProto.Field> copyFieldsWithout(FeatureRow row, String... except) {
+    ArrayList<String> exclude = Lists.newArrayList(except);
+    return row.getFieldsList().stream()
+        .filter(f -> !exclude.contains(f.getName()))
         .collect(Collectors.toList());
   }
 

--- a/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
+++ b/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
@@ -29,6 +29,7 @@ import com.google.api.services.bigquery.model.JobConfigurationLoad;
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.cloud.bigquery.*;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import feast.common.models.FeatureSetReference;
@@ -121,7 +122,8 @@ public class BigQuerySinkTest {
     FeatureRow.Builder row =
         FeatureRow.newBuilder()
             .setFeatureSet(featureSet)
-            .addFields(field("entity", rd.nextInt(), ValueProto.ValueType.Enum.INT64));
+            .addFields(field("entity", rd.nextInt(), ValueProto.ValueType.Enum.INT64))
+            .addFields(FieldProto.Field.newBuilder().setName("null_value").build());
 
     for (ValueProto.ValueType.Enum type : ValueProto.ValueType.Enum.values()) {
       if (type == ValueProto.ValueType.Enum.INVALID
@@ -204,7 +206,9 @@ public class BigQuerySinkTest {
                         FeatureSetReference.of(spec.getProject(), spec.getName(), 1), spec))));
     PCollection<FeatureRow> successfulInserts =
         p.apply(featureRowTestStream).apply(sink.writer()).getSuccessfulInserts();
-    PAssert.that(successfulInserts).containsInAnyOrder(row1, row2);
+
+    List<FeatureRow> inputWithoutNulls = dropNullFeature(ImmutableList.of(row1, row2));
+    PAssert.that(successfulInserts).containsInAnyOrder(inputWithoutNulls);
     p.run();
 
     assert jobService.getAllJobs().size() == 1;
@@ -288,7 +292,7 @@ public class BigQuerySinkTest {
     PCollection<FeatureRow> inserts =
         p.apply(featureRowTestStream).apply(writer).getSuccessfulInserts();
 
-    PAssert.that(inserts).containsInAnyOrder(featureRow);
+    PAssert.that(inserts).containsInAnyOrder(dropNullFeature(ImmutableList.of(featureRow)));
 
     p.run();
   }
@@ -452,8 +456,24 @@ public class BigQuerySinkTest {
             .apply(new CompactFeatureRows(1000))
             .apply("Flat", ParDo.of(new FlatMap()));
 
-    PAssert.that(result).containsInAnyOrder(input);
+    List<FeatureRow> inputWithoutNulls = dropNullFeature(input);
+
+    PAssert.that(result).containsInAnyOrder(inputWithoutNulls);
     p.run();
+  }
+
+  private List<FeatureRow> dropNullFeature(List<FeatureRow> input) {
+    return input.stream()
+        .map(
+            r ->
+                FeatureRow.newBuilder()
+                    .setFeatureSet(r.getFeatureSet())
+                    .addAllFields(
+                        r.getFieldsList().stream()
+                            .filter(f -> !f.getName().equals("null_value"))
+                            .collect(Collectors.toList()))
+                    .build())
+        .collect(Collectors.toList());
   }
 
   public static class TableAnswer implements Answer<Table>, Serializable {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Schema can't be inferred when one of the features has only nulls in `FeatureRowBatch` that is used to compress FeatureRows while waiting for BQ job to load.
This PR fixes NPE

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
