### PR TITLE
Authentication and Authorization into feast-auth module.

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>dev.feast</groupId>
+		<artifactId>feast-parent</artifactId>
+		<version>${revision}</version>
+	</parent>
+	<artifactId>feast-auth</artifactId>
+
+	<name>Feast Authenication and Authorization</name>
+
+	<dependencies>
+		<dependency>
+            <groupId>dev.feast</groupId>
+            <artifactId>feast-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+		<dependency>
+			<groupId>net.devh</groupId>
+			<artifactId>grpc-server-spring-boot-starter</artifactId>
+			<version>2.4.0.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-oauth2-resource-server</artifactId>
+			<version>5.3.0.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-oauth2-jose</artifactId>
+			<version>5.3.0.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>sh.ory.keto</groupId>
+			<artifactId>keto-client</artifactId>
+			<version>0.4.4-alpha.1</version>
+		</dependency>
+		<dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>6.1.2.Final</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -1,51 +1,51 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>dev.feast</groupId>
-		<artifactId>feast-parent</artifactId>
-		<version>${revision}</version>
-	</parent>
-	<artifactId>feast-auth</artifactId>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>dev.feast</groupId>
+        <artifactId>feast-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>feast-auth</artifactId>
 
-	<name>Feast Authentication and Authorization</name>
+    <name>Feast Authentication and Authorization</name>
 
-	<dependencies>
-		<dependency>
+    <dependencies>
+        <dependency>
             <groupId>dev.feast</groupId>
             <artifactId>feast-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-		<dependency>
-			<groupId>net.devh</groupId>
-			<artifactId>grpc-server-spring-boot-starter</artifactId>
-			<version>2.4.0.RELEASE</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-oauth2-resource-server</artifactId>
-			<version>5.3.0.RELEASE</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-oauth2-jose</artifactId>
-			<version>5.3.0.RELEASE</version>
-		</dependency>
-		<dependency>
-			<groupId>sh.ory.keto</groupId>
-			<artifactId>keto-client</artifactId>
-			<version>0.4.4-alpha.1</version>
-		</dependency>
-		<dependency>
+        <dependency>
+            <groupId>net.devh</groupId>
+            <artifactId>grpc-server-spring-boot-starter</artifactId>
+            <version>2.4.0.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
+            <version>5.3.0.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+            <version>5.3.0.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>sh.ory.keto</groupId>
+            <artifactId>keto-client</artifactId>
+            <version>0.4.4-alpha.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
         <dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<version>6.1.2.Final</version>
-		</dependency>
-	</dependencies>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>6.1.2.Final</version>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<artifactId>feast-auth</artifactId>
 
-	<name>Feast Authenication and Authorization</name>
+	<name>Feast Authentication and Authorization</name>
 
 	<dependencies>
 		<dependency>

--- a/auth/src/main/java/feast/auth/authentication/DefaultJwtAuthenticationProvider.java
+++ b/auth/src/main/java/feast/auth/authentication/DefaultJwtAuthenticationProvider.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feast.core.auth.authentication;
+package feast.auth.authentication;
 
 import java.util.Map;
 import org.springframework.security.authentication.AuthenticationProvider;

--- a/auth/src/main/java/feast/auth/authorization/AuthorizationProvider.java
+++ b/auth/src/main/java/feast/auth/authorization/AuthorizationProvider.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feast.core.auth.authorization;
+package feast.auth.authorization;
 
 import org.springframework.security.core.Authentication;
 

--- a/auth/src/main/java/feast/auth/authorization/AuthorizationResult.java
+++ b/auth/src/main/java/feast/auth/authorization/AuthorizationResult.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feast.core.auth.authorization;
+package feast.auth.authorization;
 
 import java.util.Optional;
 import javax.annotation.Nullable;

--- a/auth/src/main/java/feast/auth/authorization/Keto/KetoAuthorizationProvider.java
+++ b/auth/src/main/java/feast/auth/authorization/Keto/KetoAuthorizationProvider.java
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feast.core.auth.authorization.Keto;
+package feast.auth.authorization.Keto;
 
-import feast.core.auth.authorization.AuthorizationProvider;
-import feast.core.auth.authorization.AuthorizationResult;
+import feast.auth.authorization.AuthorizationProvider;
+import feast.auth.authorization.AuthorizationResult;
 import java.util.List;
 import java.util.Map;
 import org.hibernate.validator.internal.constraintvalidators.bv.EmailValidator;

--- a/auth/src/main/java/feast/auth/config/SecurityConfig.java
+++ b/auth/src/main/java/feast/auth/config/SecurityConfig.java
@@ -14,21 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feast.core.config;
+package feast.auth.config;
 
-import feast.core.auth.authentication.DefaultJwtAuthenticationProvider;
-import feast.core.auth.authorization.AuthorizationProvider;
-import feast.core.auth.authorization.Keto.KetoAuthorizationProvider;
-import feast.core.config.FeastProperties.SecurityProperties;
-import feast.proto.core.CoreServiceGrpc;
+import feast.auth.authentication.DefaultJwtAuthenticationProvider;
+import feast.auth.authorization.AuthorizationProvider;
+import feast.auth.authorization.Keto.KetoAuthorizationProvider;
 import java.util.ArrayList;
 import java.util.List;
 import net.devh.boot.grpc.server.security.authentication.BearerAuthenticationReader;
 import net.devh.boot.grpc.server.security.authentication.GrpcAuthenticationReader;
-import net.devh.boot.grpc.server.security.check.AccessPredicate;
 import net.devh.boot.grpc.server.security.check.AccessPredicateVoter;
-import net.devh.boot.grpc.server.security.check.GrpcSecurityMetadataSource;
-import net.devh.boot.grpc.server.security.check.ManualGrpcSecurityMetadataSource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -43,10 +38,10 @@ import org.springframework.security.oauth2.server.resource.BearerTokenAuthentica
 @Configuration
 public class SecurityConfig {
 
-  private final SecurityProperties securityProperties;
+  private SecurityProperties securityProperties;
 
-  public SecurityConfig(FeastProperties feastProperties) {
-    this.securityProperties = feastProperties.getSecurity();
+  public SecurityConfig(SecurityProperties securityProperties) {
+    this.securityProperties = securityProperties;
   }
 
   /**
@@ -84,26 +79,6 @@ public class SecurityConfig {
   @ConditionalOnProperty(prefix = "feast.security.authentication", name = "enabled")
   GrpcAuthenticationReader authenticationReader() {
     return new BearerAuthenticationReader(BearerTokenAuthenticationToken::new);
-  }
-
-  /**
-   * Creates a SecurityMetadataSource when authentication is enabled. This allows for the
-   * configuration of endpoint level security rules.
-   *
-   * @return GrpcSecurityMetadataSource
-   */
-  @Bean
-  @ConditionalOnProperty(prefix = "feast.security.authentication", name = "enabled")
-  GrpcSecurityMetadataSource grpcSecurityMetadataSource() {
-    final ManualGrpcSecurityMetadataSource source = new ManualGrpcSecurityMetadataSource();
-
-    // Authentication is enabled for all gRPC endpoints
-    source.setDefault(AccessPredicate.authenticated());
-
-    // The following endpoints allow unauthenticated access
-    source.set(CoreServiceGrpc.getGetFeastCoreVersionMethod(), AccessPredicate.permitAll());
-
-    return source;
   }
 
   /**

--- a/auth/src/main/java/feast/auth/config/SecurityConfig.java
+++ b/auth/src/main/java/feast/auth/config/SecurityConfig.java
@@ -38,7 +38,7 @@ import org.springframework.security.oauth2.server.resource.BearerTokenAuthentica
 @Configuration
 public class SecurityConfig {
 
-  private SecurityProperties securityProperties;
+  private final SecurityProperties securityProperties;
 
   public SecurityConfig(SecurityProperties securityProperties) {
     this.securityProperties = securityProperties;

--- a/auth/src/main/java/feast/auth/config/SecurityProperties.java
+++ b/auth/src/main/java/feast/auth/config/SecurityProperties.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.auth.config;
+
+import feast.common.validators.OneOfStrings;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SecurityProperties {
+  private AuthenticationProperties authentication;
+  private AuthorizationProperties authorization;
+
+  @Getter
+  @Setter
+  public static class AuthenticationProperties {
+
+    // Enable authentication
+    private boolean enabled;
+
+    // Named authentication provider to use
+    @OneOfStrings({"jwt"})
+    private String provider;
+
+    // K/V options to initialize the provider with
+    private Map<String, String> options;
+  }
+
+  @Getter
+  @Setter
+  public static class AuthorizationProperties {
+
+    // Enable authorization. Authentication must be enabled if authorization is enabled.
+    private boolean enabled;
+
+    // Named authorization provider to use.
+    @OneOfStrings({"none", "keto"})
+    private String provider;
+
+    // K/V options to initialize the provider with
+    private Map<String, String> options;
+  }
+}

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>lombok</artifactId>
         </dependency>
         <dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+			<version>2.0.0.Final</version>
+		</dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/common/src/main/java/feast/common/validators/OneOfStringValidator.java
+++ b/common/src/main/java/feast/common/validators/OneOfStringValidator.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feast.core.validators;
+package feast.common.validators;
 
 import java.util.Arrays;
 import javax.validation.ConstraintValidator;

--- a/common/src/main/java/feast/common/validators/OneOfStrings.java
+++ b/common/src/main/java/feast/common/validators/OneOfStrings.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feast.core.validators;
+package feast.common.validators;
 
 import java.lang.annotation.*;
 import javax.validation.Constraint;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -81,6 +81,11 @@
             <artifactId>feast-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>dev.feast</groupId>
+            <artifactId>feast-auth</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- Hot reloading for Spring Boot. spring-boot-maven-plugin removes
              this automatically when packaging. -->
@@ -136,14 +141,9 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-oauth2-resource-server</artifactId>
-			<version>5.3.0.RELEASE</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-jose</artifactId>
 			<version>5.3.0.RELEASE</version>
-		</dependency>
+		</dependency> 
 		<dependency>
 			<groupId>net.devh</groupId>
 			<artifactId>grpc-server-spring-boot-starter</artifactId>
@@ -266,11 +266,6 @@
 			<version>3.10.0</version>
 		</dependency>
 
-		<dependency>
-			<groupId>sh.ory.keto</groupId>
-			<artifactId>keto-client</artifactId>
-			<version>0.4.4-alpha.1</version>
-		</dependency>
         <!--testCompile 'com.jayway.jsonpath:json-path-assert:2.2.0'-->
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
@@ -300,16 +295,6 @@
             <artifactId>flyway-core</artifactId>
             <version>${flyway.version}</version>
         </dependency>
-		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
-			<version>2.0.0.Final</version>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<version>6.1.2.Final</version>
-		</dependency>
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator-annotation-processor</artifactId>

--- a/core/src/main/java/feast/core/config/CoreSecurityConfig.java
+++ b/core/src/main/java/feast/core/config/CoreSecurityConfig.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.core.config;
+
+import feast.proto.core.CoreServiceGrpc;
+import lombok.extern.slf4j.Slf4j;
+import net.devh.boot.grpc.server.security.check.AccessPredicate;
+import net.devh.boot.grpc.server.security.check.GrpcSecurityMetadataSource;
+import net.devh.boot.grpc.server.security.check.ManualGrpcSecurityMetadataSource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Slf4j
+public class CoreSecurityConfig {
+
+  /**
+   * Creates a SecurityMetadataSource when authentication is enabled. This allows for the
+   * configuration of endpoint level security rules.
+   *
+   * @return GrpcSecurityMetadataSource
+   */
+  @Bean
+  @ConditionalOnProperty(prefix = "feast.security.authentication", name = "enabled")
+  GrpcSecurityMetadataSource grpcSecurityMetadataSource() {
+    final ManualGrpcSecurityMetadataSource source = new ManualGrpcSecurityMetadataSource();
+
+    // Authentication is enabled for all gRPC endpoints
+    source.setDefault(AccessPredicate.authenticated());
+
+    // The following endpoints allow unauthenticated access
+    source.set(CoreServiceGrpc.getGetFeastCoreVersionMethod(), AccessPredicate.permitAll());
+
+    return source;
+  }
+}

--- a/core/src/main/java/feast/core/config/FeastProperties.java
+++ b/core/src/main/java/feast/core/config/FeastProperties.java
@@ -76,7 +76,7 @@ public class FeastProperties {
 
   @Bean
   SecurityProperties securityProperties() {
-    return this.security;
+    return this.getSecurity();
   }
 
   /** Feast job properties. These properties are used for ingestion jobs. */

--- a/core/src/main/java/feast/core/config/FeastProperties.java
+++ b/core/src/main/java/feast/core/config/FeastProperties.java
@@ -16,8 +16,9 @@
  */
 package feast.core.config;
 
+import feast.auth.config.SecurityProperties;
+import feast.common.validators.OneOfStrings;
 import feast.core.config.FeastProperties.StreamProperties.FeatureStreamOptions;
-import feast.core.validators.OneOfStrings;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -39,11 +40,12 @@ import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.info.BuildProperties;
-import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Getter
 @Setter
-@Component
+@Configuration
 @ConfigurationProperties(prefix = "feast", ignoreInvalidFields = true)
 public class FeastProperties {
 
@@ -71,6 +73,11 @@ public class FeastProperties {
   private StreamProperties stream;
 
   private SecurityProperties security;
+
+  @Bean
+  SecurityProperties securityProperties() {
+    return this.security;
+  }
 
   /** Feast job properties. These properties are used for ingestion jobs. */
   @Getter
@@ -270,44 +277,6 @@ public class FeastProperties {
                 + ". Make sure it is a valid IP address or DNS hostname e.g. localhost or 10.128.10.40. Error detail: "
                 + e.getMessage());
       }
-    }
-  }
-
-  @Getter
-  @Setter
-  public static class SecurityProperties {
-
-    private AuthenticationProperties authentication;
-    private AuthorizationProperties authorization;
-
-    @Getter
-    @Setter
-    public static class AuthenticationProperties {
-
-      // Enable authentication
-      private boolean enabled;
-
-      // Named authentication provider to use
-      @OneOfStrings({"jwt"})
-      private String provider;
-
-      // K/V options to initialize the provider with
-      private Map<String, String> options;
-    }
-
-    @Getter
-    @Setter
-    public static class AuthorizationProperties {
-
-      // Enable authorization. Authentication must be enabled if authorization is enabled.
-      private boolean enabled;
-
-      // Named authorization provider to use.
-      @OneOfStrings({"none", "keto"})
-      private String provider;
-
-      // K/V options to initialize the provider with
-      private Map<String, String> options;
     }
   }
 }

--- a/core/src/main/java/feast/core/service/AccessManagementService.java
+++ b/core/src/main/java/feast/core/service/AccessManagementService.java
@@ -37,7 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AccessManagementService {
 
-  @Autowired private SecurityProperties securityProperties;
+  private SecurityProperties securityProperties;
 
   private AuthorizationProvider authorizationProvider;
   private ProjectRepository projectRepository;

--- a/core/src/main/java/feast/core/service/AccessManagementService.java
+++ b/core/src/main/java/feast/core/service/AccessManagementService.java
@@ -16,10 +16,10 @@
  */
 package feast.core.service;
 
-import feast.core.auth.authorization.AuthorizationProvider;
-import feast.core.auth.authorization.AuthorizationResult;
+import feast.auth.authorization.AuthorizationProvider;
+import feast.auth.authorization.AuthorizationResult;
+import feast.auth.config.SecurityProperties;
 import feast.core.config.FeastProperties;
-import feast.core.config.FeastProperties.SecurityProperties;
 import feast.core.dao.ProjectRepository;
 import feast.core.model.Project;
 import java.util.List;
@@ -37,7 +37,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class AccessManagementService {
 
-  private SecurityProperties securityProperties;
+  @Autowired private SecurityProperties securityProperties;
+
   private AuthorizationProvider authorizationProvider;
   private ProjectRepository projectRepository;
 

--- a/core/src/test/java/feast/core/auth/AuthConfigTest.java
+++ b/core/src/test/java/feast/core/auth/AuthConfigTest.java
@@ -18,7 +18,7 @@ package feast.core.auth;
 
 import static org.junit.Assert.assertNotNull;
 
-import feast.core.config.SecurityConfig;
+import feast.auth.config.SecurityConfig;
 import javax.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/core/src/test/java/feast/core/grpc/CoreServiceAuthTest.java
+++ b/core/src/test/java/feast/core/grpc/CoreServiceAuthTest.java
@@ -24,10 +24,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import feast.core.auth.authorization.AuthorizationProvider;
-import feast.core.auth.authorization.AuthorizationResult;
+import feast.auth.authorization.AuthorizationProvider;
+import feast.auth.authorization.AuthorizationResult;
+import feast.auth.config.SecurityProperties;
 import feast.core.config.FeastProperties;
-import feast.core.config.FeastProperties.SecurityProperties;
 import feast.core.dao.ProjectRepository;
 import feast.core.model.Entity;
 import feast.core.model.Feature;
@@ -73,10 +73,10 @@ class CoreServiceAuthTest {
 
   CoreServiceAuthTest() {
     MockitoAnnotations.initMocks(this);
-    FeastProperties.SecurityProperties.AuthorizationProperties authProp =
-        new FeastProperties.SecurityProperties.AuthorizationProperties();
+    SecurityProperties.AuthorizationProperties authProp =
+        new SecurityProperties.AuthorizationProperties();
     authProp.setEnabled(true);
-    FeastProperties.SecurityProperties sp = new SecurityProperties();
+    SecurityProperties sp = new SecurityProperties();
     sp.setAuthorization(authProp);
     FeastProperties feastProperties = new FeastProperties();
     feastProperties.setSecurity(sp);

--- a/core/src/test/java/feast/core/service/AccessManagementServiceTest.java
+++ b/core/src/test/java/feast/core/service/AccessManagementServiceTest.java
@@ -23,9 +23,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import feast.core.auth.authorization.AuthorizationProvider;
+import feast.auth.authorization.AuthorizationProvider;
+import feast.auth.config.SecurityProperties;
 import feast.core.config.FeastProperties;
-import feast.core.config.FeastProperties.SecurityProperties;
 import feast.core.dao.ProjectRepository;
 import feast.core.model.Project;
 import java.util.Arrays;
@@ -50,10 +50,10 @@ public class AccessManagementServiceTest {
   public void setUp() {
     initMocks(this);
     projectRepository = mock(ProjectRepository.class);
-    FeastProperties.SecurityProperties.AuthorizationProperties authProp =
-        new FeastProperties.SecurityProperties.AuthorizationProperties();
+    SecurityProperties.AuthorizationProperties authProp =
+        new SecurityProperties.AuthorizationProperties();
     authProp.setEnabled(false);
-    FeastProperties.SecurityProperties sp = new SecurityProperties();
+    SecurityProperties sp = new SecurityProperties();
     sp.setAuthorization(authProp);
     FeastProperties feastProperties = new FeastProperties();
     feastProperties.setSecurity(sp);

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <module>sdk/java</module>
         <module>docs/coverage/java</module>
         <module>common</module>
+        <module>auth</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Authentication and authorization code is currently part of core, To enable authentication and authorization on Serving, and in other modules on need basis, it is ideal to have it in a separate module. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
Related to #823 
**Does this PR introduce a user-facing change?**: No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
