### PR TITLE
Bugfix: Re-applying of featuresets does not update label changes

### DIFF
--- a/core/src/main/java/feast/core/model/Feature.java
+++ b/core/src/main/java/feast/core/model/Feature.java
@@ -240,7 +240,6 @@ public class Feature {
    * @param featureSpec {@link FeatureSpec} containing schema changes.
    */
   public void updateFromProto(FeatureSpec featureSpec) {
-    this.setLabels(TypeConversion.convertMapToJsonString(featureSpec.getLabelsMap()));
     if (isArchived()) {
       throw new IllegalArgumentException(
           String.format(
@@ -253,6 +252,7 @@ public class Feature {
               "You are attempting to change the type of feature %s from %s to %s. This isn't allowed. Please create a new feature.",
               featureSpec.getName(), type, featureSpec.getValueType()));
     }
+    this.setLabels(TypeConversion.convertMapToJsonString(featureSpec.getLabelsMap()));
     updateSchema(featureSpec);
   }
 

--- a/core/src/main/java/feast/core/model/Feature.java
+++ b/core/src/main/java/feast/core/model/Feature.java
@@ -235,11 +235,12 @@ public class Feature {
   }
 
   /**
-   * Update the feature object with a valid feature spec. Only schema changes are allowed.
+   * Update the feature object with a valid feature spec.
    *
    * @param featureSpec {@link FeatureSpec} containing schema changes.
    */
   public void updateFromProto(FeatureSpec featureSpec) {
+    this.setLabels(TypeConversion.convertMapToJsonString(featureSpec.getLabelsMap()));
     if (isArchived()) {
       throw new IllegalArgumentException(
           String.format(

--- a/core/src/main/java/feast/core/model/FeatureSet.java
+++ b/core/src/main/java/feast/core/model/FeatureSet.java
@@ -314,9 +314,9 @@ public class FeatureSet extends AbstractTimestampEntity {
               spec.getEntitiesList(), existingEntities));
     }
 
-    // 4. Update max age, source and labels.
-    maxAgeSeconds = spec.getMaxAge().getSeconds();
-    source = Source.fromProto(spec.getSource());
+    // 2. Update max age, source and labels.
+    this.maxAgeSeconds = spec.getMaxAge().getSeconds();
+    this.source = Source.fromProto(spec.getSource());
     this.setLabels(TypeConversion.convertMapToJsonString(spec.getLabelsMap()));
 
     Map<String, FeatureSpec> updatedFeatures =

--- a/core/src/main/java/feast/core/model/FeatureSet.java
+++ b/core/src/main/java/feast/core/model/FeatureSet.java
@@ -314,9 +314,10 @@ public class FeatureSet extends AbstractTimestampEntity {
               spec.getEntitiesList(), existingEntities));
     }
 
-    // 4. Update max age and source.
+    // 4. Update max age, source and labels.
     maxAgeSeconds = spec.getMaxAge().getSeconds();
     source = Source.fromProto(spec.getSource());
+    this.setLabels(TypeConversion.convertMapToJsonString(spec.getLabelsMap()));
 
     Map<String, FeatureSpec> updatedFeatures =
         spec.getFeaturesList().stream().collect(Collectors.toMap(FeatureSpec::getName, fs -> fs));

--- a/core/src/test/java/feast/core/service/SpecServiceTest.java
+++ b/core/src/test/java/feast/core/service/SpecServiceTest.java
@@ -701,6 +701,42 @@ public class SpecServiceTest {
   }
 
   @Test
+  public void applyFeatureSetShouldUpdateLabels() throws InvalidProtocolBufferException {
+    FeatureSpec updatedFeature =
+        FeatureSpec.newBuilder().setName("feature").setValueType(Enum.STRING).build();
+
+    FeatureSet featureSet = featureSets.get(0);
+    FeatureSetSpec featureSetSpec = featureSet.toProto().getSpec().toBuilder().build();
+    Map<String, String> featureSetLabels =
+        new HashMap<>() {
+          {
+            put("fsLabel1", "fsValue1");
+          }
+        };
+
+    FeatureSetProto.FeatureSet incomingFeatureSet =
+        FeatureSetProto.FeatureSet.newBuilder()
+            .setSpec(
+                featureSetSpec
+                    .toBuilder()
+                    .setFeatures(0, updatedFeature)
+                    .putAllLabels(featureSetLabels)
+                    .build())
+            .build();
+
+    ApplyFeatureSetResponse applyFeatureSetResponse =
+        specService.applyFeatureSet(incomingFeatureSet);
+    FeatureSetProto.FeatureSet updatedFs = applyFeatureSetResponse.getFeatureSet();
+    Map<String, String> updatedFsLabels = updatedFs.getSpec().getLabelsMap();
+
+    Map<String, String> updatedFeatureLabels = updatedFs.getSpec().getFeatures(0).getLabelsMap();
+    Map<String, String> emptyFeatureLabels = new HashMap<>();
+
+    assertEquals(featureSetLabels, updatedFsLabels);
+    assertEquals(emptyFeatureLabels, updatedFeatureLabels);
+  }
+
+  @Test
   public void applyFeatureSetShouldAcceptFeatureSetLabels() throws InvalidProtocolBufferException {
     Map<String, String> featureSetLabels =
         new HashMap<>() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, when we reapply featuresets to add/remove labels from featureset or features, the changes made to labels are not propagated.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
