### PR TITLE
Bugfix: Python SDK listing of ingestion job fails for featureset reference filter

### DIFF
--- a/core/src/main/java/feast/core/dao/JobRepository.java
+++ b/core/src/main/java/feast/core/dao/JobRepository.java
@@ -40,6 +40,9 @@ public interface JobRepository extends JpaRepository<Job, String> {
 
   List<Job> findByFeatureSetJobStatusesIn(List<FeatureSetJobStatus> featureSetsJobStatuses);
 
+  List<Job> findByFeatureSetJobStatusesFeatureSetNameAndFeatureSetJobStatusesFeatureSetProjectName(
+      String featureSetName, String featureSetProject);
+
   // find jobs that have at least one store with given name
   List<Job> findByJobStoresIdStoreName(String storeName);
 }

--- a/core/src/main/java/feast/core/service/JobService.java
+++ b/core/src/main/java/feast/core/service/JobService.java
@@ -23,11 +23,9 @@ import feast.core.job.Runner;
 import feast.core.log.Action;
 import feast.core.log.AuditLogger;
 import feast.core.log.Resource;
-import feast.core.model.FeatureSet;
 import feast.core.model.Job;
 import feast.core.model.JobStatus;
 import feast.proto.core.CoreServiceProto.ListFeatureSetsRequest;
-import feast.proto.core.CoreServiceProto.ListFeatureSetsResponse;
 import feast.proto.core.CoreServiceProto.ListIngestionJobsRequest;
 import feast.proto.core.CoreServiceProto.ListIngestionJobsResponse;
 import feast.proto.core.CoreServiceProto.RestartIngestionJobRequest;
@@ -115,19 +113,12 @@ public class JobService {
         if (filter.hasFeatureSetReference()) {
           // find a matching featuresets for reference
           FeatureSetReference fsReference = filter.getFeatureSetReference();
-          ListFeatureSetsResponse response =
-              this.specService.listFeatureSets(this.toListFeatureSetFilter(fsReference));
-          List<FeatureSet> featureSets =
-              response.getFeatureSetsList().stream()
-                  .map(FeatureSet::fromProto)
-                  .collect(Collectors.toList());
 
           // find jobs for the matching featuresets
           Collection<Job> matchingJobs =
-              this.jobRepository.findByFeatureSetJobStatusesIn(
-                  featureSets.stream()
-                      .flatMap(fs -> fs.getJobStatuses().stream())
-                      .collect(Collectors.toList()));
+              this.jobRepository
+                  .findByFeatureSetJobStatusesFeatureSetNameAndFeatureSetJobStatusesFeatureSetProjectName(
+                      fsReference.getName(), fsReference.getProject());
           List<String> jobIds = matchingJobs.stream().map(Job::getId).collect(Collectors.toList());
           matchingJobIds = this.mergeResults(matchingJobIds, jobIds);
         }

--- a/core/src/main/java/feast/core/service/JobService.java
+++ b/core/src/main/java/feast/core/service/JobService.java
@@ -119,7 +119,11 @@ public class JobService {
               this.jobRepository
                   .findByFeatureSetJobStatusesFeatureSetNameAndFeatureSetJobStatusesFeatureSetProjectName(
                       fsReference.getName(), fsReference.getProject());
-          List<String> jobIds = matchingJobs.stream().map(Job::getId).collect(Collectors.toList());
+          List<String> jobIds =
+              matchingJobs.stream()
+                  .filter(job -> job.getStatus().equals(JobStatus.RUNNING))
+                  .map(Job::getId)
+                  .collect(Collectors.toList());
           matchingJobIds = this.mergeResults(matchingJobIds, jobIds);
         }
       }

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -66,7 +66,6 @@ from feast.core.CoreService_pb2 import (
 )
 from feast.core.CoreService_pb2_grpc import CoreServiceStub
 from feast.core.FeatureSet_pb2 import FeatureSetStatus
-from feast.core.IngestionJob_pb2 import IngestionJobStatus
 from feast.feature import Feature, FeatureRef
 from feast.feature_set import Entity, FeatureSet, FeatureSetRef
 from feast.grpc import auth as feast_auth
@@ -763,9 +762,6 @@ class Client:
         response = self._core_service.ListIngestionJobs(request)  # type: ignore
         ingest_jobs = [
             IngestJob(proto, self._core_service) for proto in response.jobs  # type: ignore
-        ]
-        ingest_jobs = [
-            job for job in ingest_jobs if job.status == IngestionJobStatus.RUNNING
         ]
 
         return ingest_jobs

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -754,7 +754,9 @@ class Client:
         if feature_set_ref:
             feature_set_ref_proto = feature_set_ref.to_proto()
         list_filter = ListIngestionJobsRequest.Filter(
-            id=job_id, feature_set_reference=feature_set_ref_proto, store_name=store_name,
+            id=job_id,
+            feature_set_reference=feature_set_ref_proto,
+            store_name=store_name,
         )
         request = ListIngestionJobsRequest(filter=list_filter)
         # make list request & unpack response
@@ -762,7 +764,9 @@ class Client:
         ingest_jobs = [
             IngestJob(proto, self._core_service) for proto in response.jobs  # type: ignore
         ]
-        ingest_jobs = [job for job in ingest_jobs if job.status == IngestionJobStatus.RUNNING]
+        ingest_jobs = [
+            job for job in ingest_jobs if job.status == IngestionJobStatus.RUNNING
+        ]
 
         return ingest_jobs
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Python SDK's `list_ingest_jobs()` is currently broken when passing feature_set_ref as the grpc method expects a proto form feature_set_ref. Also, FeatureSet's `getJobStatuses()` does not work as intended.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
