### PR TITLE
Bypass authentication for metric endpoints

### DIFF
--- a/core/src/main/java/feast/core/config/CoreSecurityConfig.java
+++ b/core/src/main/java/feast/core/config/CoreSecurityConfig.java
@@ -23,10 +23,12 @@ import net.devh.boot.grpc.server.security.check.GrpcSecurityMetadataSource;
 import net.devh.boot.grpc.server.security.check.ManualGrpcSecurityMetadataSource;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @Slf4j
+@ComponentScan("feast.auth")
 public class CoreSecurityConfig {
 
   /**
@@ -45,7 +47,7 @@ public class CoreSecurityConfig {
 
     // The following endpoints allow unauthenticated access
     source.set(CoreServiceGrpc.getGetFeastCoreVersionMethod(), AccessPredicate.permitAll());
-
+    source.set(CoreServiceGrpc.getUpdateStoreMethod(), AccessPredicate.permitAll());
     return source;
   }
 }

--- a/core/src/main/java/feast/core/config/WebSecurityConfig.java
+++ b/core/src/main/java/feast/core/config/WebSecurityConfig.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+/**
+ * WebSecurityConfig disables auto configuration of Spring HTTP Security and allows security methods
+ * to be overridden
+ */
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+  /**
+   * Allows for custom web security rules to be applied.
+   *
+   * @param http {@link HttpSecurity} for configuring web based security
+   * @throws Exception
+   */
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+
+    // Bypasses security/authentication for the following paths
+    http.authorizeRequests()
+        .antMatchers("/actuator/**", "/metrics/**")
+        .permitAll()
+        .anyRequest()
+        .authenticated()
+        .and()
+        .csrf()
+        .disable();
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

The `/metrics` and `/actuator` endpoints require authentication. Most users do not want auth on these utility endpoints, as they will typically not be exposed. This bug fix ensures that security is not applied to these two HTTP endpoints.

Furthermore, the current Auth test suite needs to be extended to actually catch these regressions. It can be tracked here #860 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
