### PR TITLE
Improve parallelization in Redis Sink

### DIFF
--- a/infra/scripts/setup-common-functions.sh
+++ b/infra/scripts/setup-common-functions.sh
@@ -98,7 +98,7 @@ start_feast_serving() {
 
   if [ -n "$1" ]; then
     echo "Custom Spring application.yml location provided: $1"
-    export CONFIG_ARG="--spring.config.location=file://$1"
+    export CONFIG_ARG="--spring.config.location=classpath:/application.yml,file://$1"
   fi
 
   nohup java -jar serving/target/feast-serving-$FEAST_BUILD_VERSION.jar $CONFIG_ARG &>/var/log/feast-serving-online.log &

--- a/infra/scripts/test-end-to-end-redis-cluster.sh
+++ b/infra/scripts/test-end-to-end-redis-cluster.sh
@@ -56,6 +56,7 @@ feast:
       config: 
         # Connection string specifies the IP and ports of Redis instances in Redis cluster
         connection_string: "localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005"
+        flush_frequency_seconds: 1
       # Subscriptions indicate which feature sets needs to be retrieved and used to populate this store
       subscriptions:
         # Wildcards match all options. No filtering is done.

--- a/infra/scripts/test-end-to-end.sh
+++ b/infra/scripts/test-end-to-end.sh
@@ -74,7 +74,21 @@ if [[ ${ENABLE_AUTH} = "True" ]];
     start_feast_core
 fi
 
-start_feast_serving
+cat <<EOF > /tmp/serving.warehouse.application.yml
+feast:
+  stores:
+    - name: online
+      type: REDIS
+      config:
+        host: localhost
+        port: 6379
+        flush_frequency_seconds: 1
+      subscriptions:
+        - name: "*"
+          project: "*"
+EOF
+
+start_feast_serving /tmp/serving.warehouse.application.yml
 install_python_with_miniconda_and_feast_sdk
 
 print_banner "Running end-to-end tests with pytest at 'tests/e2e'"

--- a/protos/feast/core/Store.proto
+++ b/protos/feast/core/Store.proto
@@ -108,6 +108,8 @@ message Store {
     int32 initial_backoff_ms = 3;
     // Optional. Maximum total number of retries for connecting to Redis. Default to zero retries.
     int32 max_retries = 4;
+    // Optional. how often flush data to redis
+    int32 flush_frequency_seconds = 5;
   }
 
   message BigQueryConfig {
@@ -129,6 +131,8 @@ message Store {
     string connection_string = 1;
     int32 initial_backoff_ms = 2;
     int32 max_retries = 3;
+    // Optional. how often flush data to redis
+    int32 flush_frequency_seconds = 4;
   }
 
   message Subscription {

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/writer/RedisCustomIO.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/writer/RedisCustomIO.java
@@ -46,9 +46,6 @@ import org.slf4j.LoggerFactory;
 
 public class RedisCustomIO {
 
-  private static final int DEFAULT_BATCH_SIZE = 10000;
-  private static final int DEFAULT_FREQUENCY_SECONDS = 30;
-
   private static TupleTag<FeatureRow> successfulInsertsTag =
       new TupleTag<FeatureRow>("successfulInserts") {};
   private static TupleTag<FailedElement> failedInsertsTupleTag =
@@ -69,8 +66,8 @@ public class RedisCustomIO {
 
     private PCollectionView<Map<String, Iterable<FeatureSetSpec>>> featureSetSpecs;
     private RedisIngestionClient redisIngestionClient;
-    private int batchSize = DEFAULT_BATCH_SIZE;
-    private Duration flushFrequency = Duration.standardSeconds(DEFAULT_FREQUENCY_SECONDS);
+    private int batchSize;
+    private Duration flushFrequency;
 
     public Write(
         RedisIngestionClient redisIngestionClient,

--- a/storage/connectors/redis/src/test/java/feast/storage/connectors/redis/writer/RedisClusterFeatureSinkTest.java
+++ b/storage/connectors/redis/src/test/java/feast/storage/connectors/redis/writer/RedisClusterFeatureSinkTest.java
@@ -33,7 +33,6 @@ import feast.proto.types.FeatureRowProto.FeatureRow;
 import feast.proto.types.FieldProto.Field;
 import feast.proto.types.ValueProto.Value;
 import feast.proto.types.ValueProto.ValueType.Enum;
-import feast.storage.api.writer.FailedElement;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
@@ -221,7 +220,6 @@ public class RedisClusterFeatureSinkTest {
         p.apply(Create.of(featureRows))
             .apply(redisClusterFeatureSink.writer())
             .getFailedInserts()
-            .apply(Window.<FailedElement>into(new GlobalWindows()).triggering(Never.ever()))
             .apply(Count.globally());
 
     redisCluster.stop();
@@ -283,7 +281,6 @@ public class RedisClusterFeatureSinkTest {
         p.apply(Create.of(featureRows))
             .apply("modifiedSink", redisClusterFeatureSink.writer())
             .getFailedInserts()
-            .apply(Window.<FailedElement>into(new GlobalWindows()).triggering(Never.ever()))
             .apply(Count.globally());
 
     PAssert.that(failedElementCount).containsInAnyOrder(1L);

--- a/storage/connectors/redis/src/test/java/feast/storage/connectors/redis/writer/RedisFeatureSinkTest.java
+++ b/storage/connectors/redis/src/test/java/feast/storage/connectors/redis/writer/RedisFeatureSinkTest.java
@@ -34,7 +34,6 @@ import feast.proto.types.FeatureRowProto.FeatureRow;
 import feast.proto.types.FieldProto.Field;
 import feast.proto.types.ValueProto.Value;
 import feast.proto.types.ValueProto.ValueType.Enum;
-import feast.storage.api.writer.FailedElement;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -49,9 +48,6 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
-import org.apache.beam.sdk.transforms.windowing.Never;
-import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.PCollection;
 import org.junit.After;
 import org.junit.Before;
@@ -212,7 +208,6 @@ public class RedisFeatureSinkTest {
         p.apply(Create.of(featureRows))
             .apply(redisFeatureSink.writer())
             .getFailedInserts()
-            .apply(Window.<FailedElement>into(new GlobalWindows()).triggering(Never.ever()))
             .apply(Count.globally());
 
     redis.stop();
@@ -271,7 +266,6 @@ public class RedisFeatureSinkTest {
         p.apply(Create.of(featureRows))
             .apply(redisFeatureSink.writer())
             .getFailedInserts()
-            .apply(Window.<FailedElement>into(new GlobalWindows()).triggering(Never.ever()))
             .apply(Count.globally());
 
     redis.stop();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

In redis sink we pack rows into batches before actually flush them to redis. Current implementation use GroupBy null (all rows into one group) which cause a lot of shuffling. It could lead to significant throughput degradation. This PR replaces GroupBy with GroupIntoBatches with FeatureReference used as key. This should improve parallelization of Redis Sink

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now configure the flush frequency to write to a Redis store.
```
