### PR TITLE
Add IngestionId & EventTimestamp to FeatureRowBatch to calculate lag metric correctly

### DIFF
--- a/core/src/main/resources/db/migration/V2.5__Fix_Subscription_MIgration.sql
+++ b/core/src/main/resources/db/migration/V2.5__Fix_Subscription_MIgration.sql
@@ -1,0 +1,14 @@
+WITH updates as (
+    select name,
+           array_to_string(array_agg(b.array_to_string), ',') as subscriptions
+    from (
+             select name, array_to_string(string_to_array(subscriptions, ':') || '{false}', ':')
+             from (
+                      select name, unnest(string_to_array(subscriptions, ',')) as subscriptions from stores) a
+             WHERE array_length(string_to_array(subscriptions, ':'), 1) = 2) b
+    group by name
+)
+UPDATE stores
+SET subscriptions = updates.subscriptions
+FROM updates
+WHERE stores.name = updates.name

--- a/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
+++ b/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
@@ -124,6 +124,11 @@ public class BigQuerySinkTest {
     FeatureRow.Builder row =
         FeatureRow.newBuilder()
             .setFeatureSet(featureSet)
+            .setEventTimestamp(
+                com.google.protobuf.Timestamp.newBuilder()
+                    .setSeconds(System.currentTimeMillis() / 1000)
+                    .build())
+            .setIngestionId("ingestion-id")
             .addFields(field("entity", rd.nextInt(), ValueProto.ValueType.Enum.INT64))
             .addFields(FieldProto.Field.newBuilder().setName("null_value").build());
 
@@ -499,6 +504,8 @@ public class BigQuerySinkTest {
             r ->
                 FeatureRow.newBuilder()
                     .setFeatureSet(r.getFeatureSet())
+                    .setIngestionId(r.getIngestionId())
+                    .setEventTimestamp(r.getEventTimestamp())
                     .addAllFields(copyFieldsWithout(r, "null_value"))
                     .build())
         .collect(Collectors.toList());
@@ -520,6 +527,8 @@ public class BigQuerySinkTest {
 
               return FeatureRow.newBuilder()
                   .setFeatureSet(row.getFeatureSet())
+                  .setEventTimestamp(row.getEventTimestamp())
+                  .setIngestionId(row.getIngestionId())
                   .addAllFields(fieldsList)
                   .build();
             })

--- a/tests/e2e/redis/basic-ingest-redis-serving.py
+++ b/tests/e2e/redis/basic-ingest-redis-serving.py
@@ -558,32 +558,6 @@ def test_basic_retrieve_online_entity_listform(client, list_entity_dataframe):
     )
 
 
-@pytest.mark.timeout(300)
-@pytest.mark.run(order=19)
-def test_basic_ingest_jobs(client):
-    # list ingestion jobs given featureset
-    cust_trans_fs = client.get_feature_set(name="customer_transactions")
-    ingest_jobs = client.list_ingest_jobs(
-        feature_set_ref=FeatureSetRef.from_feature_set(cust_trans_fs)
-    )
-    # filter ingestion jobs to only those that are running
-    ingest_jobs = [
-        job for job in ingest_jobs if job.status == IngestionJobStatus.RUNNING
-    ]
-    assert len(ingest_jobs) >= 1
-
-    for ingest_job in ingest_jobs:
-        # restart ingestion ingest_job
-        client.restart_ingest_job(ingest_job)
-        ingest_job.wait(IngestionJobStatus.RUNNING)
-        assert ingest_job.status == IngestionJobStatus.RUNNING
-
-        # stop ingestion ingest_job
-        client.stop_ingest_job(ingest_job)
-        ingest_job.wait(IngestionJobStatus.ABORTED)
-        assert ingest_job.status == IngestionJobStatus.ABORTED
-
-
 @pytest.fixture(scope="module")
 def all_types_dataframe():
     return pd.DataFrame(
@@ -762,16 +736,33 @@ def test_all_types_ingest_jobs(client, all_types_dataframe):
     ]
     assert len(ingest_jobs) >= 1
 
-    for ingest_job in ingest_jobs:
-        # restart ingestion ingest_job
-        client.restart_ingest_job(ingest_job)
-        ingest_job.wait(IngestionJobStatus.RUNNING)
-        assert ingest_job.status == IngestionJobStatus.RUNNING
+    ingest_job = ingest_jobs[0]
+    # restart ingestion ingest_job
+    # restart means stop current job
+    # (replacement will be automatically spawned)
+    client.restart_ingest_job(ingest_job)
+    # wait for replacement to be created
+    time.sleep(15)  # should be more than polling_interval
 
-        # stop ingestion ingest_job
-        client.stop_ingest_job(ingest_job)
-        ingest_job.wait(IngestionJobStatus.ABORTED)
-        assert ingest_job.status == IngestionJobStatus.ABORTED
+    # id without timestamp part
+    # that remains the same between jobs
+    shared_id = "-".join(ingest_job.id.split("-")[:-1])
+    replacement_jobs = [
+        job
+        for job in ingest_jobs
+        if job.status == IngestionJobStatus.RUNNING and job.id.startswith(shared_id)
+    ]
+
+    assert len(replacement_jobs) >= 1
+    replacement_job = replacement_jobs[0]
+
+    replacement_job.wait(IngestionJobStatus.RUNNING)
+    assert replacement_job.status == IngestionJobStatus.RUNNING
+
+    # stop ingestion ingest_job
+    client.stop_ingest_job(replacement_job)
+    replacement_job.wait(IngestionJobStatus.ABORTED)
+    assert replacement_job.status == IngestionJobStatus.ABORTED
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**Which issue(s) this PR fixes**:

Currently row based metrics (like lag) are calculated incorrectly due to absence of correct timestamp in FeatureRow.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
