### PR TITLE
BQ sink produces sample of successful inserts

### DIFF
--- a/core/src/main/resources/db/migration/V2.5__Fix_Subscription_MIgration.sql
+++ b/core/src/main/resources/db/migration/V2.5__Fix_Subscription_MIgration.sql
@@ -1,0 +1,14 @@
+WITH updates as (
+    select name,
+           array_to_string(array_agg(b.array_to_string), ',') as subscriptions
+    from (
+             select name, array_to_string(string_to_array(subscriptions, ':') || '{false}', ':')
+             from (
+                      select name, unnest(string_to_array(subscriptions, ',')) as subscriptions from stores) a
+             WHERE array_length(string_to_array(subscriptions, ':'), 1) = 2) b
+    group by name
+)
+UPDATE stores
+SET subscriptions = updates.subscriptions
+FROM updates
+WHERE stores.name = updates.name

--- a/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
+++ b/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
@@ -21,6 +21,7 @@ import static feast.storage.common.testing.TestUtil.field;
 import static feast.storage.connectors.bigquery.writer.FeatureSetSpecToTableSchema.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -493,6 +494,30 @@ public class BigQuerySinkTest {
     p.run();
   }
 
+  @Test
+  public void featureRowBatchShouldSampleOnRestore() {
+    List<FeatureRow> stream =
+        IntStream.range(0, 1000)
+            .mapToObj(i -> generateRow("project/fs"))
+            .collect(Collectors.toList());
+
+    PCollection<Long> result =
+        p.apply(Create.of(stream))
+            .apply("KV", ParDo.of(new ExtractKV()))
+            .apply(new CompactFeatureRows(1000))
+            .apply(ParDo.of(new FlatMapWithSample(100)))
+            .apply(Count.globally());
+
+    PAssert.that(result)
+        .satisfies(
+            r -> {
+              // sample size is within bound of required size
+              assertThat(Math.abs(r.iterator().next() - 100), lessThan(5L));
+              return null;
+            });
+    p.run();
+  }
+
   private List<FeatureRow> dropNullFeature(List<FeatureRow> input) {
     return input.stream()
         .map(
@@ -538,6 +563,19 @@ public class BigQuerySinkTest {
     @Override
     public Table answer(InvocationOnMock invocationOnMock) throws Throwable {
       return FakeTable.create(mock(BigQuery.class), tableId, tableDefinition);
+    }
+  }
+
+  private static class FlatMapWithSample extends DoFn<KV<String, FeatureRowsBatch>, FeatureRow> {
+    private int sampleSize;
+
+    FlatMapWithSample(int sampleSize) {
+      this.sampleSize = sampleSize;
+    }
+
+    @ProcessElement
+    public void process(ProcessContext c) {
+      c.element().getValue().getFeatureRowsSample(sampleSize).forEachRemaining(c::output);
     }
   }
 }

--- a/tests/e2e/redis/basic-ingest-redis-serving.py
+++ b/tests/e2e/redis/basic-ingest-redis-serving.py
@@ -558,32 +558,6 @@ def test_basic_retrieve_online_entity_listform(client, list_entity_dataframe):
     )
 
 
-@pytest.mark.timeout(300)
-@pytest.mark.run(order=19)
-def test_basic_ingest_jobs(client):
-    # list ingestion jobs given featureset
-    cust_trans_fs = client.get_feature_set(name="customer_transactions")
-    ingest_jobs = client.list_ingest_jobs(
-        feature_set_ref=FeatureSetRef.from_feature_set(cust_trans_fs)
-    )
-    # filter ingestion jobs to only those that are running
-    ingest_jobs = [
-        job for job in ingest_jobs if job.status == IngestionJobStatus.RUNNING
-    ]
-    assert len(ingest_jobs) >= 1
-
-    for ingest_job in ingest_jobs:
-        # restart ingestion ingest_job
-        client.restart_ingest_job(ingest_job)
-        ingest_job.wait(IngestionJobStatus.RUNNING)
-        assert ingest_job.status == IngestionJobStatus.RUNNING
-
-        # stop ingestion ingest_job
-        client.stop_ingest_job(ingest_job)
-        ingest_job.wait(IngestionJobStatus.ABORTED)
-        assert ingest_job.status == IngestionJobStatus.ABORTED
-
-
 @pytest.fixture(scope="module")
 def all_types_dataframe():
     return pd.DataFrame(
@@ -762,16 +736,33 @@ def test_all_types_ingest_jobs(client, all_types_dataframe):
     ]
     assert len(ingest_jobs) >= 1
 
-    for ingest_job in ingest_jobs:
-        # restart ingestion ingest_job
-        client.restart_ingest_job(ingest_job)
-        ingest_job.wait(IngestionJobStatus.RUNNING)
-        assert ingest_job.status == IngestionJobStatus.RUNNING
+    ingest_job = ingest_jobs[0]
+    # restart ingestion ingest_job
+    # restart means stop current job
+    # (replacement will be automatically spawned)
+    client.restart_ingest_job(ingest_job)
+    # wait for replacement to be created
+    time.sleep(15)  # should be more than polling_interval
 
-        # stop ingestion ingest_job
-        client.stop_ingest_job(ingest_job)
-        ingest_job.wait(IngestionJobStatus.ABORTED)
-        assert ingest_job.status == IngestionJobStatus.ABORTED
+    # id without timestamp part
+    # that remains the same between jobs
+    shared_id = "-".join(ingest_job.id.split("-")[:-1])
+    replacement_jobs = [
+        job
+        for job in ingest_jobs
+        if job.status == IngestionJobStatus.RUNNING and job.id.startswith(shared_id)
+    ]
+
+    assert len(replacement_jobs) >= 1
+    replacement_job = replacement_jobs[0]
+
+    replacement_job.wait(IngestionJobStatus.RUNNING)
+    assert replacement_job.status == IngestionJobStatus.RUNNING
+
+    # stop ingestion ingest_job
+    client.stop_ingest_job(replacement_job)
+    replacement_job.wait(IngestionJobStatus.ABORTED)
+    assert replacement_job.status == IngestionJobStatus.ABORTED
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Output of BQ batch insert is now sample from all inserted rows.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Currently BQ's `successful inserts` produces all rows that were in batch. In some use-cases like batch ingestion it could produce up to 30k / sec rows (or ~5 M rows in batch for the default flush frequency (3m)). This output is used in metrics where whole batch (with 5M rows) is grouped into single list, which requires it to fit into memory of one machine. This can lead to memory issues.

I suspect that this is overkill since metrics can be easily calculated from sample of inserted data instead of whole batch. This PR changes BQ successful inserts to output only sample of inserted data.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
