### PR TITLE
Add IngestionId & EventTimestamp to FeatureRowBatch to calculate lag metric correctly

### DIFF
--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
@@ -166,7 +166,6 @@ public class FeatureRowsBatch implements Serializable {
                     if (SERVICE_FIELDS.contains(fieldName)) {
                       return;
                     }
-
                     Schema.Field field = schema.getField(fieldName);
                     int idx = schema.indexOf(fieldName);
 

--- a/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
+++ b/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
@@ -124,6 +124,11 @@ public class BigQuerySinkTest {
     FeatureRow.Builder row =
         FeatureRow.newBuilder()
             .setFeatureSet(featureSet)
+            .setEventTimestamp(
+                com.google.protobuf.Timestamp.newBuilder()
+                    .setSeconds(System.currentTimeMillis() / 1000)
+                    .build())
+            .setIngestionId("ingestion-id")
             .addFields(field("entity", rd.nextInt(), ValueProto.ValueType.Enum.INT64))
             .addFields(FieldProto.Field.newBuilder().setName("null_value").build());
 
@@ -499,6 +504,8 @@ public class BigQuerySinkTest {
             r ->
                 FeatureRow.newBuilder()
                     .setFeatureSet(r.getFeatureSet())
+                    .setIngestionId(r.getIngestionId())
+                    .setEventTimestamp(r.getEventTimestamp())
                     .addAllFields(copyFieldsWithout(r, "null_value"))
                     .build())
         .collect(Collectors.toList());
@@ -520,6 +527,8 @@ public class BigQuerySinkTest {
 
               return FeatureRow.newBuilder()
                   .setFeatureSet(row.getFeatureSet())
+                  .setEventTimestamp(row.getEventTimestamp())
+                  .setIngestionId(row.getIngestionId())
                   .addAllFields(fieldsList)
                   .build();
             })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Currently row based metrics (like lag) are calculated incorrectly due to absence of correct timestamp in FeatureRow.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
