### PR TITLE
BQ sink produces sample of successful inserts

### DIFF
--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
@@ -215,12 +215,9 @@ public class FeatureRowsBatch implements Serializable {
         .setFeatureSet(getFeatureSetReference())
         .setEventTimestamp(
             Timestamp.newBuilder()
-                .setSeconds(
-                    (long)
-                        (((List<Object>) values.get(timestampColumnIdx)).get(rowIdx)))
+                .setSeconds((long) (((List<Object>) values.get(timestampColumnIdx)).get(rowIdx)))
                 .build())
-        .setIngestionId(
-            (String) (((List<Object>) values.get(ingestionIdColumnIdx)).get(rowIdx)))
+        .setIngestionId((String) (((List<Object>) values.get(ingestionIdColumnIdx)).get(rowIdx)))
         .addAllFields(
             schema.getFieldNames().stream()
                 .map(
@@ -250,10 +247,7 @@ public class FeatureRowsBatch implements Serializable {
   public Iterator<FeatureRowProto.FeatureRow> getFeatureRows() {
     int featureCount = ((List<Object>) values.get(0)).size();
 
-    return IntStream.range(0, featureCount)
-        .parallel()
-        .mapToObj(this::restoreFeatureRow)
-        .iterator();
+    return IntStream.range(0, featureCount).parallel().mapToObj(this::restoreFeatureRow).iterator();
   }
 
   public Iterator<FeatureRowProto.FeatureRow> getFeatureRowsSample(int maxCount) {

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/compression/FeatureRowsBatch.java
@@ -207,48 +207,64 @@ public class FeatureRowsBatch implements Serializable {
     return new FeatureRowsBatch(row.getSchema(), row.getValues());
   }
 
-  public Iterator<FeatureRowProto.FeatureRow> getFeatureRows() {
+  private FeatureRowProto.FeatureRow restoreFeatureRow(int rowIdx) {
     int timestampColumnIdx = schema.indexOf("eventTimestamp");
     int ingestionIdColumnIdx = schema.indexOf("ingestionId");
 
-    return IntStream.range(0, ((List<Object>) values.get(0)).size())
-        .parallel()
-        .mapToObj(
-            rowIdx ->
-                FeatureRowProto.FeatureRow.newBuilder()
-                    .setFeatureSet(getFeatureSetReference())
-                    .setEventTimestamp(
-                        Timestamp.newBuilder()
-                            .setSeconds(
-                                (long)
-                                    (((List<Object>) values.get(timestampColumnIdx)).get(rowIdx)))
-                            .build())
-                    .setIngestionId(
-                        (String) (((List<Object>) values.get(ingestionIdColumnIdx)).get(rowIdx)))
-                    .addAllFields(
-                        schema.getFieldNames().stream()
-                            .map(
-                                fieldName -> {
-                                  if (SERVICE_FIELDS.contains(fieldName)) {
-                                    return null;
-                                  }
-                                  int fieldIdx = schema.indexOf(fieldName);
+    return FeatureRowProto.FeatureRow.newBuilder()
+        .setFeatureSet(getFeatureSetReference())
+        .setEventTimestamp(
+            Timestamp.newBuilder()
+                .setSeconds(
+                    (long)
+                        (((List<Object>) values.get(timestampColumnIdx)).get(rowIdx)))
+                .build())
+        .setIngestionId(
+            (String) (((List<Object>) values.get(ingestionIdColumnIdx)).get(rowIdx)))
+        .addAllFields(
+            schema.getFieldNames().stream()
+                .map(
+                    fieldName -> {
+                      if (SERVICE_FIELDS.contains(fieldName)) {
+                        return null;
+                      }
+                      int fieldIdx = schema.indexOf(fieldName);
 
-                                  return FieldProto.Field.newBuilder()
-                                      .setName(schema.getField(fieldIdx).getName())
-                                      .setValue(
-                                          objectToProtoValue(
-                                              ((List<Object>) values.get(fieldIdx)).get(rowIdx),
-                                              schemaToProtoTypes.get(
-                                                  schema
-                                                      .getField(fieldIdx)
-                                                      .getType()
-                                                      .getCollectionElementType())))
-                                      .build();
-                                })
-                            .filter(Objects::nonNull)
-                            .collect(Collectors.toList()))
-                    .build())
+                      return FieldProto.Field.newBuilder()
+                          .setName(schema.getField(fieldIdx).getName())
+                          .setValue(
+                              objectToProtoValue(
+                                  ((List<Object>) values.get(fieldIdx)).get(rowIdx),
+                                  schemaToProtoTypes.get(
+                                      schema
+                                          .getField(fieldIdx)
+                                          .getType()
+                                          .getCollectionElementType())))
+                          .build();
+                    })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList()))
+        .build();
+  }
+
+  public Iterator<FeatureRowProto.FeatureRow> getFeatureRows() {
+    int featureCount = ((List<Object>) values.get(0)).size();
+
+    return IntStream.range(0, featureCount)
+        .parallel()
+        .mapToObj(this::restoreFeatureRow)
+        .iterator();
+  }
+
+  public Iterator<FeatureRowProto.FeatureRow> getFeatureRowsSample(int maxCount) {
+    int featureCount = ((List<Object>) values.get(0)).size();
+    Random rd = new Random(42);
+
+    return IntStream.range(0, featureCount)
+        .filter(idx -> rd.nextInt(featureCount) < maxCount)
+        .parallel()
+        .mapToObj(this::restoreFeatureRow)
+        .limit(maxCount)
         .iterator();
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Output of BQ batch insert is now sample from all inserted rows.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Currently BQ's `successful inserts` produces all rows that were in batch. In some use-cases like batch ingestion it could produce up to 30k / sec rows (or ~5 M rows in batch for the default flush frequency (3m)). This output is used in metrics where whole batch (with 5M rows) is grouped into single list, which requires it to fit into memory of one machine. This can lead to memory issues.

I suspect that this is overkill since metrics can be easily calculated from sample of inserted data instead of whole batch. This PR changes BQ successful inserts to output only sample of inserted data.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
