### PR TITLE
Add caching to authorization

### DIFF
--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -28,10 +28,10 @@
             <artifactId>feast-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-		<dependency>
-		    <groupId>org.springframework</groupId>
-		    <artifactId>spring-context-support</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+        </dependency>
         <dependency>
             <groupId>net.devh</groupId>
             <artifactId>grpc-server-spring-boot-starter</artifactId>
@@ -96,16 +96,16 @@
             <version>3.0.2</version>
         </dependency>
         <dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>${mockito.version}</version>
-			<scope>test</scope>
-		</dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -28,6 +28,10 @@
             <artifactId>feast-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+		<dependency>
+		    <groupId>org.springframework</groupId>
+		    <artifactId>spring-context-support</artifactId>
+		</dependency>
         <dependency>
             <groupId>net.devh</groupId>
             <artifactId>grpc-server-spring-boot-starter</artifactId>
@@ -91,6 +95,17 @@
             <artifactId>jsr305</artifactId>
             <version>3.0.2</version>
         </dependency>
+        <dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>${mockito.version}</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
     <build>
         <plugins>
@@ -130,6 +145,10 @@
                 <configuration>
                     <excludePackageNames>feast.auth.generated.client.api</excludePackageNames>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/auth/src/main/java/feast/auth/authorization/HttpAuthorizationProvider.java
+++ b/auth/src/main/java/feast/auth/authorization/HttpAuthorizationProvider.java
@@ -71,7 +71,7 @@ public class HttpAuthorizationProvider implements AuthorizationProvider {
    * @param authentication Spring Security Authentication object
    * @return AuthorizationResult result of authorization query
    */
-  @Cacheable(value = CacheConfiguration.AUTHORIZATION_CACHE)
+  @Cacheable(value = CacheConfiguration.AUTHORIZATION_CACHE, keyGenerator = "authKeyGenerator")
   public AuthorizationResult checkAccessToProject(String projectId, Authentication authentication) {
 
     CheckAccessRequest checkAccessRequest = new CheckAccessRequest();

--- a/auth/src/main/java/feast/auth/authorization/HttpAuthorizationProvider.java
+++ b/auth/src/main/java/feast/auth/authorization/HttpAuthorizationProvider.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 /**
  * HTTPAuthorizationProvider uses an external HTTP service for authorizing requests. Please see

--- a/auth/src/main/java/feast/auth/authorization/HttpAuthorizationProvider.java
+++ b/auth/src/main/java/feast/auth/authorization/HttpAuthorizationProvider.java
@@ -16,16 +16,17 @@
  */
 package feast.auth.authorization;
 
+import feast.auth.config.CacheConfiguration;
 import feast.auth.generated.client.api.DefaultApi;
 import feast.auth.generated.client.invoker.ApiClient;
 import feast.auth.generated.client.invoker.ApiException;
 import feast.auth.generated.client.model.CheckAccessRequest;
+import feast.auth.utils.AuthUtils;
 import java.util.Map;
-import org.hibernate.validator.internal.constraintvalidators.bv.EmailValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.jwt.Jwt;
 
 /**
  * HTTPAuthorizationProvider uses an external HTTP service for authorizing requests. Please see
@@ -41,7 +42,7 @@ public class HttpAuthorizationProvider implements AuthorizationProvider {
    * The default subject claim is the key within the Authentication object where the user's identity
    * can be found
    */
-  private final String DEFAULT_SUBJECT_CLAIM = "email";
+  private final String subjectClaim;
 
   /**
    * Initializes the HTTPAuthorizationProvider
@@ -58,26 +59,29 @@ public class HttpAuthorizationProvider implements AuthorizationProvider {
     ApiClient apiClient = new ApiClient();
     apiClient.setBasePath(options.get("authorizationUrl"));
     this.defaultApiClient = new DefaultApi(apiClient);
+    subjectClaim = options.get("subjectClaim");
   }
 
   /**
-   * Validates whether a user has access to a project
+   * Validates whether a user has access to a project. @Cacheable is using {@link
+   * CacheConfiguration} settings to cache output of the method {@link AuthorizationResult} for a
+   * specified duration set in cache settings.
    *
    * @param projectId Name of the Feast project
    * @param authentication Spring Security Authentication object
    * @return AuthorizationResult result of authorization query
    */
+  @Cacheable(value = CacheConfiguration.AUTHORIZATION_CACHE)
   public AuthorizationResult checkAccessToProject(String projectId, Authentication authentication) {
 
     CheckAccessRequest checkAccessRequest = new CheckAccessRequest();
     Object context = getContext(authentication);
-    String subject = getSubjectFromAuth(authentication, DEFAULT_SUBJECT_CLAIM);
+    String subject = AuthUtils.getSubjectFromAuth(authentication, subjectClaim);
     String resource = "projects:" + projectId;
     checkAccessRequest.setAction("ALL");
     checkAccessRequest.setContext(context);
     checkAccessRequest.setResource(resource);
     checkAccessRequest.setSubject(subject);
-
     try {
       Jwt credentials = ((Jwt) authentication.getCredentials());
       // Make authorization request to external service
@@ -113,32 +117,5 @@ public class HttpAuthorizationProvider implements AuthorizationProvider {
   private Object getContext(Authentication authentication) {
     // Not implemented yet, left empty
     return new Object();
-  }
-
-  /**
-   * Get user email from their authentication object.
-   *
-   * @param authentication Spring Security Authentication object, used to extract user details
-   * @param subjectClaim Indicates the claim where the subject can be found
-   * @return String user email
-   */
-  private String getSubjectFromAuth(Authentication authentication, String subjectClaim) {
-    Jwt principle = ((Jwt) authentication.getPrincipal());
-    Map<String, Object> claims = principle.getClaims();
-    String subjectValue = (String) claims.get(subjectClaim);
-
-    if (subjectValue.isEmpty()) {
-      throw new IllegalStateException(
-          String.format("JWT does not have a valid claim %s.", subjectClaim));
-    }
-
-    if (subjectClaim.equals("email")) {
-      boolean validEmail = (new EmailValidator()).isValid(subjectValue, null);
-      if (!validEmail) {
-        throw new IllegalStateException("JWT contains an invalid email address");
-      }
-    }
-
-    return subjectValue;
   }
 }

--- a/auth/src/main/java/feast/auth/config/CacheConfiguration.java
+++ b/auth/src/main/java/feast/auth/config/CacheConfiguration.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.auth.config;
+
+import com.google.common.cache.CacheBuilder;
+import feast.auth.utils.AuthUtils;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.cache.interceptor.CacheResolver;
+import org.springframework.cache.interceptor.KeyGenerator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
+
+/** CacheConfiguration class defines Cache settings for HttpAuthorizationProvider class. */
+@Configuration
+@EnableCaching
+@Setter
+@Getter
+public class CacheConfiguration implements CachingConfigurer {
+
+  private static final int CACHE_SIZE = 10000;
+
+  public static int TTL = 60;
+
+  public static final String AUTHORIZATION_CACHE = "authorization";
+
+  @Autowired SecurityProperties secutiryProps;
+
+  @Bean
+  public CacheManager cacheManager() {
+    ConcurrentMapCacheManager cacheManager =
+        new ConcurrentMapCacheManager(AUTHORIZATION_CACHE) {
+
+          @Override
+          protected Cache createConcurrentMapCache(final String name) {
+            return new ConcurrentMapCache(
+                name,
+                CacheBuilder.newBuilder()
+                    .expireAfterWrite(TTL, TimeUnit.SECONDS)
+                    .maximumSize(CACHE_SIZE)
+                    .build()
+                    .asMap(),
+                false);
+          }
+        };
+
+    return cacheManager;
+  }
+
+  @Override
+  public CacheResolver cacheResolver() {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  /*
+   * KeyGenerator for HttpAuthorizationProvider.checkAccessToProject() Method.
+   * Key format : checkAccessToProject-<projectId>-<subjectClaim>
+   */
+  @Override
+  public KeyGenerator keyGenerator() {
+    return (Object target, Method method, Object... params) -> {
+      String projectId = (String) params[0];
+      Authentication authentication = (Authentication) params[1];
+      String subject =
+          AuthUtils.getSubjectFromAuth(
+              authentication, secutiryProps.getAuthorization().getOptions().get("subjectClaim"));
+      return String.format("%s-%s-%s", method.getName(), projectId, subject);
+    };
+  }
+
+  @Override
+  public CacheErrorHandler errorHandler() {
+    // TODO Auto-generated method stub
+    return null;
+  }
+}

--- a/auth/src/main/java/feast/auth/config/CacheConfiguration.java
+++ b/auth/src/main/java/feast/auth/config/CacheConfiguration.java
@@ -72,18 +72,12 @@ public class CacheConfiguration implements CachingConfigurer {
     return cacheManager;
   }
 
-  @Override
-  public CacheResolver cacheResolver() {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
   /*
-   * KeyGenerator for HttpAuthorizationProvider.checkAccessToProject() Method.
+   * KeyGenerator used by {@link Cacheable} for caching authorization requests.
    * Key format : checkAccessToProject-<projectId>-<subjectClaim>
    */
-  @Override
-  public KeyGenerator keyGenerator() {
+  @Bean
+  public KeyGenerator authKeyGenerator() {
     return (Object target, Method method, Object... params) -> {
       String projectId = (String) params[0];
       Authentication authentication = (Authentication) params[1];
@@ -92,6 +86,17 @@ public class CacheConfiguration implements CachingConfigurer {
               authentication, secutiryProps.getAuthorization().getOptions().get("subjectClaim"));
       return String.format("%s-%s-%s", method.getName(), projectId, subject);
     };
+  }
+
+  @Override
+  public CacheResolver cacheResolver() {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public KeyGenerator keyGenerator() {
+    return null;
   }
 
   @Override

--- a/auth/src/main/java/feast/auth/utils/AuthUtils.java
+++ b/auth/src/main/java/feast/auth/utils/AuthUtils.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.auth.utils;
+
+import java.util.Map;
+import org.hibernate.validator.internal.constraintvalidators.bv.EmailValidator;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class AuthUtils {
+
+  // Suppresses default constructor, ensuring non-instantiability.
+  private AuthUtils() {}
+
+  /**
+   * Get user email from their authentication object.
+   *
+   * @param authentication Spring Security Authentication object, used to extract user details
+   * @param subjectClaim Indicates the claim where the subject can be found
+   * @return String user email
+   */
+  public static String getSubjectFromAuth(Authentication authentication, String subjectClaim) {
+    Jwt principle = ((Jwt) authentication.getPrincipal());
+    Map<String, Object> claims = principle.getClaims();
+    String subjectValue = (String) claims.getOrDefault(subjectClaim, "");
+
+    if (subjectValue.isEmpty()) {
+      throw new IllegalStateException(
+          String.format("JWT does not have a valid claim %s.", subjectClaim));
+    }
+
+    if (subjectClaim.equals("email")) {
+      boolean validEmail = (new EmailValidator()).isValid(subjectValue, null);
+      if (!validEmail) {
+        throw new IllegalStateException("JWT contains an invalid email address");
+      }
+    }
+    return subjectValue;
+  }
+}

--- a/auth/src/test/java/feast/auth/authorization/HttpAuthorizationProviderCachingTest.java
+++ b/auth/src/test/java/feast/auth/authorization/HttpAuthorizationProviderCachingTest.java
@@ -90,26 +90,30 @@ public class HttpAuthorizationProviderCachingTest {
     Jwt jwt = Mockito.mock(Jwt.class);
     Map<String, Object> claims = new HashMap<>();
     claims.put("email", "test@test.com");
+    doReturn(jwt).when(auth).getCredentials();
     doReturn(jwt).when(auth).getPrincipal();
     doReturn(claims).when(jwt).getClaims();
+    doReturn("test_token").when(jwt).getTokenValue();
     AuthorizationResult authResult = new AuthorizationResult();
     authResult.setAllowed(true);
-    doReturn(authResult).when(api).checkAccessPost(any(CheckAccessRequest.class));
+    doReturn(authResult)
+        .when(api)
+        .checkAccessPost(any(CheckAccessRequest.class), any(String.class));
 
     // Should save the result in cache
     provider.checkAccessToProject("test", auth);
     // Should read from cache
     provider.checkAccessToProject("test", auth);
-    verify(api, times(1)).checkAccessPost(any(CheckAccessRequest.class));
+    verify(api, times(1)).checkAccessPost(any(CheckAccessRequest.class), any(String.class));
 
     // cache ttl is set to 1 second for testing.
     Thread.sleep(1100);
 
     // Should make an invocation to external service
     provider.checkAccessToProject("test", auth);
-    verify(api, times(2)).checkAccessPost(any(CheckAccessRequest.class));
+    verify(api, times(2)).checkAccessPost(any(CheckAccessRequest.class), any(String.class));
     // Should read from cache
     provider.checkAccessToProject("test", auth);
-    verify(api, times(2)).checkAccessPost(any(CheckAccessRequest.class));
+    verify(api, times(2)).checkAccessPost(any(CheckAccessRequest.class), any(String.class));
   }
 }

--- a/auth/src/test/java/feast/auth/authorization/HttpAuthorizationProviderCachingTest.java
+++ b/auth/src/test/java/feast/auth/authorization/HttpAuthorizationProviderCachingTest.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.auth.authorization;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import feast.auth.config.CacheConfiguration;
+import feast.auth.config.SecurityProperties;
+import feast.auth.config.SecurityProperties.AuthenticationProperties;
+import feast.auth.config.SecurityProperties.AuthorizationProperties;
+import feast.auth.generated.client.api.DefaultApi;
+import feast.auth.generated.client.model.AuthorizationResult;
+import feast.auth.generated.client.model.CheckAccessRequest;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.FieldSetter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(
+    classes = {CacheConfiguration.class, HttpAuthorizationProviderCachingTest.Config.class})
+public class HttpAuthorizationProviderCachingTest {
+
+  // static since field needs to updated in provider() bean
+  private static DefaultApi api = Mockito.mock(DefaultApi.class);
+
+  @Autowired AuthorizationProvider provider;
+
+  @Configuration
+  static class Config {
+    @Bean
+    SecurityProperties securityProps() {
+      // setting TTL static variable in SecurityProperties bean, since CacheConfiguration bean is
+      // dependent on SecurityProperties.
+      CacheConfiguration.TTL = 1;
+      AuthenticationProperties authentication = Mockito.mock(AuthenticationProperties.class);
+      AuthorizationProperties authorization = new AuthorizationProperties();
+      authorization.setEnabled(true);
+      authorization.setProvider("http");
+      Map<String, String> options = new HashMap<>();
+      options.put("authorizationUrl", "localhost");
+      options.put("subjectClaim", "email");
+      authorization.setOptions(options);
+      SecurityProperties sp = new SecurityProperties();
+      sp.setAuthentication(authentication);
+      sp.setAuthorization(authorization);
+      return sp;
+    }
+
+    @Bean
+    AuthorizationProvider provider() throws NoSuchFieldException, SecurityException {
+      Map<String, String> options = new HashMap<>();
+      options.put("authorizationUrl", "localhost");
+      options.put("subjectClaim", "email");
+      HttpAuthorizationProvider provider = new HttpAuthorizationProvider(options);
+      FieldSetter.setField(provider, provider.getClass().getDeclaredField("defaultApiClient"), api);
+      return provider;
+    }
+  }
+
+  @Test
+  public void testCheckAccessToProjectShouldReadFromCacheWhenAvailable() throws Exception {
+    Authentication auth = Mockito.mock(Authentication.class);
+    Jwt jwt = Mockito.mock(Jwt.class);
+    Map<String, Object> claims = new HashMap<>();
+    claims.put("email", "test@test.com");
+    doReturn(jwt).when(auth).getPrincipal();
+    doReturn(claims).when(jwt).getClaims();
+    AuthorizationResult authResult = new AuthorizationResult();
+    authResult.setAllowed(true);
+    doReturn(authResult).when(api).checkAccessPost(any(CheckAccessRequest.class));
+
+    // Should save the result in cache
+    provider.checkAccessToProject("test", auth);
+    // Should read from cache
+    provider.checkAccessToProject("test", auth);
+    verify(api, times(1)).checkAccessPost(any(CheckAccessRequest.class));
+
+    // cache ttl is set to 1 second for testing.
+    Thread.sleep(1100);
+
+    // Should make an invocation to external service
+    provider.checkAccessToProject("test", auth);
+    verify(api, times(2)).checkAccessPost(any(CheckAccessRequest.class));
+    // Should read from cache
+    provider.checkAccessToProject("test", auth);
+    verify(api, times(2)).checkAccessPost(any(CheckAccessRequest.class));
+  }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -94,6 +94,7 @@ feast:
       provider: http
       options:
         authorizationUrl: http://localhost:8082
+        subjectClaim: email
 
 grpc:
   server:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently all requests are authorized against an external server, as this can cause latency issues in serving, Caching the authorization for a short span of time will avoid external call on subsequent requests. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
related to #823 

**Does this PR introduce a user-facing change?**:No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Project level authorization access requests are now cached.
```
