### PR TITLE
Gitlab build for AWS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,72 @@
+services:
+  - docker:18.09.7-dind
+
+default:
+  image: docker:stable
+  tags:
+    - dsp
+
+.test: &test
+  stage: build
+  image: maven:3.6-jdk-11
+  script:
+    - infra/scripts/test-end-to-end.sh
+  except:
+    - ^v0\.(3|4)-branch$
+
+variables:
+  DOCKER_HOST: tcp://localhost:2375
+  # This is the region of AWS, used by the deployer ecs-deploy
+  REGION: "eu-west-1"
+  ACCOUNT: "674300753731"
+  SERVICE_NAME: "feast"
+  # Image name
+  IMAGE_NAME: "feast"
+  # Elastic Container Registry URL of the package.
+  ECR_URL: "674300753731.dkr.ecr.eu-west-1.amazonaws.com/dsp/feast"
+  IMAGE_TAG: "0.6.${CI_PIPELINE_IID}"
+
+before_script:
+  - | # ${variable//-/} is a bash replacement that strips the hyphens from the contents of the variable. Needed for API Gateway.
+    echo "===== Account => ${ACCOUNT}, Region => ${REGION} ====="
+    apk add --no-cache curl jq python3 py-pip
+    pip3 install awscli
+    echo $(python3 --version)
+    echo $(pip3 --version)
+
+stages:
+  - build
+  - publish
+  - deploy
+
+test:
+  <<: *test
+
+build:
+  stage: build
+  except:
+    - master
+  script:
+    - |
+      echo "===== Building image ====="
+      export IMAGE="${ECR_URL}:${IMAGE_TAG}"
+      echo IMAGE_TAG $IMAGE_TAG IMAGE $IMAGE
+      $(aws ecr get-login --no-include-email --region ${REGION}  --registry-ids ${ACCOUNT})
+      docker build -t $IMAGE_NAME . --build-arg CT_ARTIFACTORY_USERNAME=$CT_ARTIFACTORY_USERNAME \
+        --build-arg CT_ARTIFACTORY_API_KEY=$CT_ARTIFACTORY_API_KEY --build-arg LICENSE_KEY=$NEWRELIC_LICENSE_KEY
+
+"build & publish":
+  stage: publish
+  only:
+    - master
+  script:
+    - |
+      echo "===== Building and pushing image ====="
+      export IMAGE="${ECR_URL}:${IMAGE_TAG}"
+      echo IMAGE_TAG $IMAGE_TAG IMAGE $IMAGE
+      $(aws ecr get-login --no-include-email --region ${REGION}  --registry-ids ${ACCOUNT})
+      docker build -t $IMAGE_NAME . --build-arg CT_ARTIFACTORY_USERNAME=$CT_ARTIFACTORY_USERNAME \
+        --build-arg CT_ARTIFACTORY_API_KEY=$CT_ARTIFACTORY_API_KEY --build-arg LICENSE_KEY=$NEWRELIC_LICENSE_KEY
+      docker tag $IMAGE_NAME $IMAGE
+      docker tag $IMAGE_NAME $IMAGE_NAME:latest
+      docker push $IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,50 +23,40 @@ variables:
   # Image name
   IMAGE_NAME: "feast"
   # Elastic Container Registry URL of the package.
-  ECR_URL: "674300753731.dkr.ecr.eu-west-1.amazonaws.com/dsp/feast"
+  ECR_URL: "674300753731.dkr.ecr.eu-west-1.amazonaws.com/feast"
   IMAGE_TAG: "0.6.${CI_PIPELINE_IID}"
 
-# before_script:
-#   - | # ${variable//-/} is a bash replacement that strips the hyphens from the contents of the variable. Needed for API Gateway.
-#     echo "===== Account => ${ACCOUNT}, Region => ${REGION} ====="
-#     yum install curl jq python3 py-pip
-#     pip3 install awscli
-#     echo $(python3 --version)
-#     echo $(pip3 --version)
+before_script:
+  - | # ${variable//-/} is a bash replacement that strips the hyphens from the contents of the variable. Needed for API Gateway.
+    echo "===== Account => ${ACCOUNT}, Region => ${REGION} ====="
+    apt-get install curl jq python3 py-pip
+    pip3 install awscli
+    echo $(python3 --version)
+    echo $(pip3 --version)
+    $(aws ecr get-login --no-include-email --region ${REGION}  --registry-ids ${ACCOUNT})
 
 stages:
-  - build
+  # - build
   - publish
-  - deploy
 
 test:
   <<: *test
 
-build:
-  stage: build
-  except:
-    - master
-  script:
-    - |
-      echo "===== Building image ====="
-      export IMAGE="${ECR_URL}:${IMAGE_TAG}"
-      echo IMAGE_TAG $IMAGE_TAG IMAGE $IMAGE
-      $(aws ecr get-login --no-include-email --region ${REGION}  --registry-ids ${ACCOUNT})
-      docker build -t $IMAGE_NAME . --build-arg CT_ARTIFACTORY_USERNAME=$CT_ARTIFACTORY_USERNAME \
-        --build-arg CT_ARTIFACTORY_API_KEY=$CT_ARTIFACTORY_API_KEY --build-arg LICENSE_KEY=$NEWRELIC_LICENSE_KEY
-
 "build & publish":
   stage: publish
-  only:
-    - master
+  when: manual
   script:
     - |
-      echo "===== Building and pushing image ====="
-      export IMAGE="${ECR_URL}:${IMAGE_TAG}"
-      echo IMAGE_TAG $IMAGE_TAG IMAGE $IMAGE
-      $(aws ecr get-login --no-include-email --region ${REGION}  --registry-ids ${ACCOUNT})
-      docker build -t $IMAGE_NAME . --build-arg CT_ARTIFACTORY_USERNAME=$CT_ARTIFACTORY_USERNAME \
-        --build-arg CT_ARTIFACTORY_API_KEY=$CT_ARTIFACTORY_API_KEY --build-arg LICENSE_KEY=$NEWRELIC_LICENSE_KEY
-      docker tag $IMAGE_NAME $IMAGE
-      docker tag $IMAGE_NAME $IMAGE_NAME:latest
-      docker push $IMAGE
+      infra/scripts/download-maven-cache.sh \
+        --archive-uri gs://feast-templocation-kf-feast/.m2.2020-07-13.tar \
+        --output-dir $PWD/
+
+      infra/scripts/publish-docker-image.sh \
+        --repository ${ECR_URL}/feast-core \
+        --tag ${IMAGE_TAG} \
+        --file infra/docker/core/Dockerfile
+
+      infra/scripts/publish-docker-image.sh \
+        --repository ${ECR_URL}/feast-serving \
+        --tag ${IMAGE_TAG} \
+        --file infra/docker/serving/Dockerfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,11 +36,11 @@ before_script:
     $(aws ecr get-login --no-include-email --region ${REGION}  --registry-ids ${ACCOUNT})
 
 stages:
-  # - build
+  - build
   - publish
 
-test:
-  <<: *test
+# test:
+#   <<: *test
 
 "build & publish":
   stage: publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,11 @@ default:
   except:
     - ^v0\.(3|4)-branch$
 
+cache:
+  key: "$CI_JOB_NAME"
+  paths:
+    - .m2/repository
+
 variables:
   DOCKER_HOST: tcp://localhost:2375
   # This is the region of AWS, used by the deployer ecs-deploy
@@ -25,6 +30,13 @@ variables:
   # Elastic Container Registry URL of the package.
   ECR_URL: "674300753731.dkr.ecr.eu-west-1.amazonaws.com/feast"
   IMAGE_TAG: "0.6.${CI_PIPELINE_IID}"
+  # This will suppress any download for dependencies and plugins or upload messages which would clutter the console log.
+  # `showDateTime` will show the passed time in milliseconds. You need to specify `--batch-mode` to make this work.
+  MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
+  # As of Maven 3.3.0 instead of this you may define these options in `.mvn/maven.config` so the same config is used
+  # when running from the command line.
+  # `installAtEnd` and `deployAtEnd` are only effective with recent version of the corresponding plugins.
+  MAVEN_CLI_OPTS: "--batch-mode --errors --fail-at-end --show-version -DinstallAtEnd=true -DdeployAtEnd=true"
 
 before_script:
   - | # ${variable//-/} is a bash replacement that strips the hyphens from the contents of the variable. Needed for API Gateway.
@@ -37,13 +49,12 @@ before_script:
 
 stages:
   - build
-  - publish
 
-# test:
-#   <<: *test
+test:
+  <<: *test
 
 "build & publish":
-  stage: publish
+  stage: build
   when: manual
   script:
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ variables:
 before_script:
   - | # ${variable//-/} is a bash replacement that strips the hyphens from the contents of the variable. Needed for API Gateway.
     echo "===== Account => ${ACCOUNT}, Region => ${REGION} ====="
-    apt-get install curl jq python3 py-pip
+    apk add --no-cache bash curl jq python3 py-pip
     pip3 install awscli
     echo $(python3 --version)
     echo $(pip3 --version)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ default:
 
 .test: &test
   stage: build
-  image: maven:3.6-jdk-11
+  image: maven:3.6-jdk-11-alpine
   script:
     - infra/scripts/test-end-to-end.sh
   except:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,9 @@ services:
 default:
   image: docker:stable
   tags:
-    - dsp
+    - java
+    - k8s
+    - aws
 
 cache:
   key: "$CI_JOB_NAME"
@@ -14,14 +16,13 @@ cache:
 variables:
   DOCKER_HOST: tcp://localhost:2375
   # This is the region of AWS, used by the deployer ecs-deploy
-  REGION: "eu-west-1"
-  ACCOUNT: "674300753731"
-  SERVICE_NAME: "feast"
+  REGION: "SET_IN_CI"
+  ACCOUNT: "SET_IN_CI"
   # Image name
   IMAGE_NAME: "feast"
-  # Elastic Container Registry URL of the package.
-  ECR_URL: "674300753731.dkr.ecr.eu-west-1.amazonaws.com/feast"
-  IMAGE_TAG: "0.6.${CI_PIPELINE_IID}"
+  # Docker Image Repo (ie ECR)
+  IMAGE_REPO: "SET_IN_CI"
+  IMAGE_TAG: "${CI_PIPELINE_IID}"
   # This will suppress any download for dependencies and plugins or upload messages which would clutter the console log.
   # `showDateTime` will show the passed time in milliseconds. You need to specify `--batch-mode` to make this work.
   MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
@@ -54,11 +55,11 @@ test:
       $(aws ecr get-login --no-include-email --region ${REGION}  --registry-ids ${ACCOUNT})
 
       infra/scripts/publish-docker-image.sh \
-        --repository ${ECR_URL}/feast-core \
+        --repository ${IMAGE_REPO}/feast-core \
         --tag ${IMAGE_TAG} \
         --file infra/docker/core/Dockerfile
 
       infra/scripts/publish-docker-image.sh \
-        --repository ${ECR_URL}/feast-serving \
+        --repository ${IMAGE_REPO}/feast-serving \
         --tag ${IMAGE_TAG} \
         --file infra/docker/serving/Dockerfile

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,10 +47,6 @@ stages:
   when: manual
   script:
     - |
-      infra/scripts/download-maven-cache.sh \
-        --archive-uri gs://feast-templocation-kf-feast/.m2.2020-07-13.tar \
-        --output-dir $PWD/
-
       infra/scripts/publish-docker-image.sh \
         --repository ${ECR_URL}/feast-core \
         --tag ${IMAGE_TAG} \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,13 +26,13 @@ variables:
   ECR_URL: "674300753731.dkr.ecr.eu-west-1.amazonaws.com/dsp/feast"
   IMAGE_TAG: "0.6.${CI_PIPELINE_IID}"
 
-before_script:
-  - | # ${variable//-/} is a bash replacement that strips the hyphens from the contents of the variable. Needed for API Gateway.
-    echo "===== Account => ${ACCOUNT}, Region => ${REGION} ====="
-    apk add --no-cache curl jq python3 py-pip
-    pip3 install awscli
-    echo $(python3 --version)
-    echo $(pip3 --version)
+# before_script:
+#   - | # ${variable//-/} is a bash replacement that strips the hyphens from the contents of the variable. Needed for API Gateway.
+#     echo "===== Account => ${ACCOUNT}, Region => ${REGION} ====="
+#     yum install curl jq python3 py-pip
+#     pip3 install awscli
+#     echo $(python3 --version)
+#     echo $(pip3 --version)
 
 stages:
   - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,14 +6,6 @@ default:
   tags:
     - dsp
 
-.test: &test
-  stage: build
-  image: maven:3.6-jdk-11-alpine
-  script:
-    - infra/scripts/test-end-to-end.sh
-  except:
-    - ^v0\.(3|4)-branch$
-
 cache:
   key: "$CI_JOB_NAME"
   paths:
@@ -38,26 +30,29 @@ variables:
   # `installAtEnd` and `deployAtEnd` are only effective with recent version of the corresponding plugins.
   MAVEN_CLI_OPTS: "--batch-mode --errors --fail-at-end --show-version -DinstallAtEnd=true -DdeployAtEnd=true"
 
-before_script:
-  - | # ${variable//-/} is a bash replacement that strips the hyphens from the contents of the variable. Needed for API Gateway.
-    echo "===== Account => ${ACCOUNT}, Region => ${REGION} ====="
-    apk add --no-cache bash curl jq python3 py-pip
-    pip3 install awscli
-    echo $(python3 --version)
-    echo $(pip3 --version)
-    $(aws ecr get-login --no-include-email --region ${REGION}  --registry-ids ${ACCOUNT})
-
 stages:
   - build
 
 test:
-  <<: *test
+  stage: build
+  image: maven:3.6-jdk-11
+  script:
+    - infra/scripts/test-end-to-end.sh
+  except:
+    - ^v0\.(3|4)-branch$
 
 "build & publish":
   stage: build
   when: manual
   script:
     - |
+      echo "===== Account => ${ACCOUNT}, Region => ${REGION} ====="
+      apk add --no-cache bash curl jq python3 py-pip
+      pip3 install awscli
+      echo $(python3 --version)
+      echo $(pip3 --version)
+      $(aws ecr get-login --no-include-email --region ${REGION}  --registry-ids ${ACCOUNT})
+
       infra/scripts/publish-docker-image.sh \
         --repository ${ECR_URL}/feast-core \
         --tag ${IMAGE_TAG} \


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows us to mirror the repo in gitlab and publish docker images in ECR.  We could host the build in another project and sync the repo over in a git submodule or something but this is much simpler.  Open to any feedback.

**Does this PR introduce a user-facing change?**: No

```release-note
NONE
```
