### PR TITLE
Dataflow runner options: disk type & streaming engine

### DIFF
--- a/core/src/main/java/feast/core/job/dataflow/DataflowRunnerConfig.java
+++ b/core/src/main/java/feast/core/job/dataflow/DataflowRunnerConfig.java
@@ -32,7 +32,7 @@ public class DataflowRunnerConfig extends RunnerConfig {
   public DataflowRunnerConfig(DataflowRunnerConfigOptions runnerConfigOptions) {
     this.project = runnerConfigOptions.getProject();
     this.region = runnerConfigOptions.getRegion();
-    this.zone = runnerConfigOptions.getZone();
+    this.workerZone = runnerConfigOptions.getWorkerZone();
     this.serviceAccount = runnerConfigOptions.getServiceAccount();
     this.network = runnerConfigOptions.getNetwork();
     this.subnetwork = runnerConfigOptions.getSubnetwork();
@@ -44,6 +44,8 @@ public class DataflowRunnerConfig extends RunnerConfig {
     this.deadLetterTableSpec = runnerConfigOptions.getDeadLetterTableSpec();
     this.diskSizeGb = runnerConfigOptions.getDiskSizeGb();
     this.labels = runnerConfigOptions.getLabelsMap();
+    this.enableStreamingEngine = runnerConfigOptions.getEnableStreamingEngine();
+    this.workerDiskType = runnerConfigOptions.getWorkerDiskType();
     validate();
   }
 
@@ -54,7 +56,7 @@ public class DataflowRunnerConfig extends RunnerConfig {
   @NotBlank public String region;
 
   /* GCP availability zone for operations. */
-  @NotBlank public String zone;
+  @NotBlank public String workerZone;
 
   /* Run the job as a specific service account, instead of the default GCE robot. */
   public String serviceAccount;
@@ -90,6 +92,12 @@ public class DataflowRunnerConfig extends RunnerConfig {
   public Integer diskSizeGb;
 
   public Map<String, String> labels;
+
+  /* If true job will be run on StreamingEngine instead of VMs */
+  public Boolean enableStreamingEngine;
+
+  /* Type of persistent disk to be used by workers */
+  public String workerDiskType;
 
   /** Validates Dataflow runner configuration options */
   public void validate() {

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -42,11 +42,13 @@ feast:
         options:
           project: my_gcp_project
           region: asia-east1
-          zone: asia-east1-a
+          workerZone: asia-east1-a
           tempLocation: gs://bucket/tempLocation
           network: default
           subnetwork: regions/asia-east1/subnetworks/mysubnetwork
           maxNumWorkers: 1
+          enableStreamingEngine: false
+          workerDiskType: compute.googleapis.com/projects/asia-east1-a/diskTypes/pd-ssd
           autoscalingAlgorithm: THROUGHPUT_BASED
           usePublicIps: false
           workerMachineType: n1-standard-1

--- a/core/src/test/java/feast/core/job/dataflow/DataflowJobManagerTest.java
+++ b/core/src/test/java/feast/core/job/dataflow/DataflowJobManagerTest.java
@@ -81,7 +81,7 @@ public class DataflowJobManagerTest {
     Builder optionsBuilder = DataflowRunnerConfigOptions.newBuilder();
     optionsBuilder.setProject("project");
     optionsBuilder.setRegion("region");
-    optionsBuilder.setZone("zone");
+    optionsBuilder.setWorkerZone("zone");
     optionsBuilder.setTempLocation("tempLocation");
     optionsBuilder.setNetwork("network");
     optionsBuilder.setSubnetwork("subnetwork");

--- a/core/src/test/java/feast/core/job/dataflow/DataflowRunnerConfigTest.java
+++ b/core/src/test/java/feast/core/job/dataflow/DataflowRunnerConfigTest.java
@@ -33,7 +33,9 @@ public class DataflowRunnerConfigTest {
         DataflowRunnerConfigOptions.newBuilder()
             .setProject("my-project")
             .setRegion("asia-east1")
-            .setZone("asia-east1-a")
+            .setWorkerZone("asia-east1-a")
+            .setEnableStreamingEngine(true)
+            .setWorkerDiskType("pd-ssd")
             .setTempLocation("gs://bucket/tempLocation")
             .setNetwork("default")
             .setSubnetwork("regions/asia-east1/subnetworks/mysubnetwork")
@@ -52,7 +54,7 @@ public class DataflowRunnerConfigTest {
         Arrays.asList(
                 "--project=my-project",
                 "--region=asia-east1",
-                "--zone=asia-east1-a",
+                "--workerZone=asia-east1-a",
                 "--tempLocation=gs://bucket/tempLocation",
                 "--network=default",
                 "--subnetwork=regions/asia-east1/subnetworks/mysubnetwork",
@@ -62,7 +64,9 @@ public class DataflowRunnerConfigTest {
                 "--workerMachineType=n1-standard-1",
                 "--deadLetterTableSpec=project_id:dataset_id.table_id",
                 "--diskSizeGb=100",
-                "--labels={\"key\":\"value\"}")
+                "--labels={\"key\":\"value\"}",
+                "--enableStreamingEngine=true",
+                "--workerDiskType=pd-ssd")
             .toArray(String[]::new);
     assertThat(args.size(), equalTo(expectedArgs.length));
     assertThat(args, containsInAnyOrder(expectedArgs));
@@ -74,7 +78,7 @@ public class DataflowRunnerConfigTest {
         DataflowRunnerConfigOptions.newBuilder()
             .setProject("my-project")
             .setRegion("asia-east1")
-            .setZone("asia-east1-a")
+            .setWorkerZone("asia-east1-a")
             .setTempLocation("gs://bucket/tempLocation")
             .setNetwork("default")
             .setSubnetwork("regions/asia-east1/subnetworks/mysubnetwork")
@@ -90,7 +94,7 @@ public class DataflowRunnerConfigTest {
         Arrays.asList(
                 "--project=my-project",
                 "--region=asia-east1",
-                "--zone=asia-east1-a",
+                "--workerZone=asia-east1-a",
                 "--tempLocation=gs://bucket/tempLocation",
                 "--network=default",
                 "--subnetwork=regions/asia-east1/subnetworks/mysubnetwork",
@@ -98,7 +102,8 @@ public class DataflowRunnerConfigTest {
                 "--autoscalingAlgorithm=THROUGHPUT_BASED",
                 "--usePublicIps=false",
                 "--workerMachineType=n1-standard-1",
-                "--labels={}")
+                "--labels={}",
+                "--enableStreamingEngine=false")
             .toArray(String[]::new);
     assertThat(args.size(), equalTo(expectedArgs.length));
     assertThat(args, containsInAnyOrder(expectedArgs));

--- a/infra/charts/feast/README.md
+++ b/infra/charts/feast/README.md
@@ -240,7 +240,7 @@ feast-core:
           options:
             project: <google_project_id>
             region: <dataflow_regional_endpoint e.g. asia-east1>
-            zone: <google_zone e.g. asia-east1-a>
+            workerZone: <google_zone e.g. asia-east1-a>
             tempLocation: <gcs_path_for_temp_files e.g. gs://bucket/tempLocation>
             network: <google_cloud_network_name>
             subnetwork: <google_cloud_subnetwork_path e.g. regions/asia-east1/subnetworks/mysubnetwork>

--- a/infra/charts/feast/README.md.gotmpl
+++ b/infra/charts/feast/README.md.gotmpl
@@ -213,7 +213,7 @@ feast-core:
           options:
             project: <google_project_id>
             region: <dataflow_regional_endpoint e.g. asia-east1>
-            zone: <google_zone e.g. asia-east1-a>
+            workerZone: <google_zone e.g. asia-east1-a>
             tempLocation: <gcs_path_for_temp_files e.g. gs://bucket/tempLocation>
             network: <google_cloud_network_name>
             subnetwork: <google_cloud_subnetwork_path e.g. regions/asia-east1/subnetworks/mysubnetwork>

--- a/infra/charts/feast/values-dataflow-runner.yaml
+++ b/infra/charts/feast/values-dataflow-runner.yaml
@@ -19,10 +19,12 @@ feast-core:
           options:
             project: <google_project_id>
             region: <dataflow_regional_endpoint e.g. asia-east1>
-            zone: <google_zone e.g. asia-east1-a>
+            workerZone: <google_zone e.g. asia-east1-a>
             tempLocation: <gcs_path_for_temp_files e.g. gs://bucket/tempLocation>
             network: <google_cloud_network_name>
             subnetwork: <google_cloud_subnetwork_path e.g. regions/asia-east1/subnetworks/mysubnetwork>
+            enableStreamingEngine: false
+            workerDiskType: <disk_type e.g. compute.googleapis.com/projects/asia-east1-a/diskTypes/pd-ssd>
             maxNumWorkers: 1
             autoscalingAlgorithm: THROUGHPUT_BASED
             usePublicIps: false

--- a/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
+++ b/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
@@ -27,7 +27,7 @@ feast-core:
           options:
             project: $GCLOUD_PROJECT
             region: $GCLOUD_REGION
-            zone: $GCLOUD_REGION-a
+            workerZone: $GCLOUD_REGION-a
             tempLocation: gs://$TEMP_BUCKET/tempLocation
             network: $GCLOUD_NETWORK
             subnetwork: regions/$GCLOUD_REGION/subnetworks/$GCLOUD_SUBNET

--- a/protos/feast/core/Runner.proto
+++ b/protos/feast/core/Runner.proto
@@ -45,7 +45,7 @@ message DataflowRunnerConfigOptions {
     string region = 2;
 
     /* GCP availability zone for operations. */
-    string zone = 3;
+    string workerZone = 3;
 
     /* Run the job as a specific service account, instead of the default GCE robot. */
     string serviceAccount = 4;
@@ -81,4 +81,9 @@ message DataflowRunnerConfigOptions {
     /* Disk size to use on each remote Compute Engine worker instance */
     int32 diskSizeGb = 14;
 
+    /* Run job on Dataflow Streaming Engine instead of creating worker VMs */
+    bool enableStreamingEngine = 15;
+
+    /* Type of persistent disk to be used by workers */
+    string workerDiskType = 16;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR extends execution parameteres for Dataflow Job according to [official documentation](https://cloud.google.com/dataflow/docs/guides/specifying-exec-params#setting-other-cloud-dataflow-pipeline-options).

Next parameter were added:
* workerDiskType
* enableStreamingEngine

Next parameter were updated:
* zone -> workerZone (due to deprecation)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

new options introduced in application.yaml

feast:
  jobs:
    runners:
    - name: dataflow
      options:
        enableStreamingEngine: false
        workerDiskType: compute.googleapis.com/projects/asia-east1-a/diskTypes/pd-ssd
        workerZone: asia-east1-a  # renamed "zone" due to deprecation

```
