### PR TITLE
Fix docker image building for PR commits

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -8,12 +8,20 @@ jobs:
     strategy:
       matrix:
         component: [core, serving]
+    env:
+      GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha }}
+      REGISTRY: gcr.io/kf-feast
     steps:
       - uses: actions/checkout@v2
       - name: build image
-        run: make build-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
+        run: make build-${{ matrix.component }}-docker REGISTRY=${REGISTRY} VERSION=${GITHUB_SHA}
       - name: push image
-        run: make push-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
+        run: |
+          docker push ${REGISTRY}/feast-${{ matrix.component }}:${GITHUB_SHA}
+          if [ -n "${GITHUB_PR_SHA}" ]; then
+            docker tag ${REGISTRY}/feast-${{ matrix.component }}:${GITHUB_SHA} gcr.io/kf-feast/feast-${{ matrix.component }}:${GITHUB_PR_SHA}
+            docker push ${REGISTRY}/feast-${{ matrix.component }}:${GITHUB_PR_SHA}
+          fi
 
   lint-java:
     container: gcr.io/kf-feast/feast-ci:latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

GitHub Actions won't build and push images based on the PR commit SHA because it creates its own merged commit. This causes dataflow tests to fail because Prow uses the commit SHA from the PR. This PR allows GA to tag and push those images.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
