### PR TITLE
Allow use of Kubernetes for Github Actions

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -1,10 +1,10 @@
-name: complete workflow
+name: complete
 
 on: [push, pull_request]
 
 jobs:
   build-push-docker-images:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     strategy:
       matrix:
         component: [core, serving]
@@ -16,13 +16,11 @@ jobs:
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           version: '290.0.1'
-          service_account_key: ${{ secrets.GCR_SERVICE_ACCOUNT }}
-          project_id: kf-feast
           export_default_credentials: true
-      - run: gcloud auth configure-docker --quiet
-      - name: build image
+      - run: gcloud auth configure-docker
+      - name: Build image
         run: make build-${{ matrix.component }}-docker REGISTRY=${REGISTRY} VERSION=${GITHUB_SHA}
-      - name: push image
+      - name: Push image
         run: |
           docker push ${REGISTRY}/feast-${{ matrix.component }}:${GITHUB_SHA}
           if [ -n "${GITHUB_PR_SHA}" ]; then
@@ -35,7 +33,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: lint java
+      - name: Lint java
         run: make lint-java
 
   lint-python:
@@ -43,11 +41,11 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: install dependencies
+      - name: Install dependencies
         run: make install-python-ci-dependencies
-      - name: compile protos
+      - name: Compile protos
         run: make compile-protos-python
-      - name: lint python
+      - name: Lint python
         run: make lint-python
 
   lint-go:
@@ -55,9 +53,9 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: install dependencies
+      - name: Install dependencies
         run: make install-go-ci-dependencies
-      - name: lint go
+      - name: Lint go
         run: make lint-go
 
   lint-versions:
@@ -66,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: install dependencies
-        run: make lint-versions
+        run: Make lint-versions
 
   unit-test-java:
     runs-on: ubuntu-latest
@@ -79,7 +77,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: test java
+      - name: Test java
         run: make test-java-with-coverage
       - uses: actions/upload-artifact@v2
         with:
@@ -91,9 +89,9 @@ jobs:
     container: gcr.io/kf-feast/feast-ci:latest
     steps:
       - uses: actions/checkout@v2
-      - name: install python
+      - name: Install python
         run: make install-python
-      - name: test python
+      - name: Test python
         run: make test-python
 
   unit-test-go:
@@ -101,9 +99,9 @@ jobs:
     container: gcr.io/kf-feast/feast-ci:latest
     steps:
       - uses: actions/checkout@v2
-      - name: install dependencies
+      - name: Install dependencies
         run: make compile-protos-go
-      - name: test go
+      - name: Test go
         run: make test-go
 
   integration-test:

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           version: '290.0.1'
           export_default_credentials: true
-      - run: gcloud auth configure-docker
+      - run: gcloud auth configure-docker --quiet
       - name: Build image
         run: make build-${{ matrix.component }}-docker REGISTRY=${REGISTRY} VERSION=${GITHUB_SHA}
       - name: Push image

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           version: '290.0.1'
           export_default_credentials: true
-        - run: gcloud auth configure-docker
+      - run: gcloud auth configure-docker --quiet
       - name: Build image
         run: make build-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
       - name: Push image

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -8,26 +8,31 @@ on:
 
 jobs:
   build-docker-images:
-    runs-on: [self-hosted, builder]
+    runs-on: [self-hosted]
     strategy:
       matrix:
         component: [core, serving, jupyter, ci]
     steps:
       - uses: actions/checkout@v2
-      - name: build image
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          export_default_credentials: true
+        - run: gcloud auth configure-docker
+      - name: Build image
         run: make build-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
-      - name: push image
+      - name: Push image
         run: make push-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
-      - name: push feast dev
+      - name: Push image to feast dev
         run: |
           if [ ${GITHUB_REF#refs/*/} == "master" ]; then
             docker tag gcr.io/kf-feast/feast-${{ matrix.component }}:${GITHUB_SHA} gcr.io/kf-feast/feast-${{ matrix.component }}:dev
             docker push gcr.io/kf-feast/feast-${{ matrix.component }}:dev
           fi
-      - name: get version
+      - name: Get version
         id: get_version
         run: echo ::set-output name=VERSION::${${GITHUB_REF/refs\/tags\//}:1}
-      - name: push versioned release
+      - name: Push versioned release
         run: |
 
           # Build and push semver tagged commits
@@ -52,5 +57,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: test docker compose
+      - name: Test docker compose
         run: ./infra/scripts/test-docker-compose.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Currently builds cannot push images to Google GCR because secrets cannot be used on forks. This PR allows self-hosted Kubernetes pods to be used for Github Actions.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
