### PR TITLE
Fix Github Actions CI load-test job failing due inability to install Feast Python SDK.

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -124,7 +124,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run load test
         run:  make test-load GIT_SHA=${GITHUB_SHA}
-      - name: Install Python 3
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7'

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -119,7 +119,7 @@ jobs:
 
   load-test:
     needs: build-push-docker-images
-    runs-on: gc
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Run load test

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -122,11 +122,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Run load test
-        run:  make test-load GIT_SHA=${GITHUB_SHA}
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7'
+      - name: Run load test
+        run:  make test-load GIT_SHA=${GITHUB_SHA}
       - uses: actions/upload-artifact@v2
         with:
           name: load-test-results

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -119,11 +119,15 @@ jobs:
 
   load-test:
     needs: build-push-docker-images
-    runs-on: ubuntu-latest
+    runs-on: gc
     steps:
       - uses: actions/checkout@v2
       - name: Run load test
         run:  make test-load GIT_SHA=${GITHUB_SHA}
+      - name: Install Python 3
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
       - uses: actions/upload-artifact@v2
         with:
           name: load-test-results


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Github Actions CI `load-test` job currently produces the following [error](https://github.com/feast-dev/feast/pull/908/checks?check_run_id=934351850#step:3:408):
```
Collecting feast
  Could not find a version that satisfies the requirement feast (from versions: )
No matching distribution found for feast
```
As there is no `feast` python SDK built for Python 2.7

Adds `install-python` action to `load-test` job to inst


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
