### PR TITLE
Backport delay in Redis acknowledgement of spec

### DIFF
--- a/core/src/main/java/feast/core/config/FeatureStreamConfig.java
+++ b/core/src/main/java/feast/core/config/FeatureStreamConfig.java
@@ -45,7 +45,7 @@ public class FeatureStreamConfig {
 
   String DEFAULT_KAFKA_REQUEST_TIMEOUT_MS_CONFIG = "15000";
   int DEFAULT_SPECS_TOPIC_PARTITIONING = 1;
-  short DEFAULT_SPECS_TOPIC_REPLICATION = 3;
+  short DEFAULT_SPECS_TOPIC_REPLICATION = 1;
 
   @Bean
   public KafkaAdmin admin(FeastProperties feastProperties) {

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/writer/RedisFeatureSink.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/writer/RedisFeatureSink.java
@@ -110,7 +110,20 @@ public abstract class RedisFeatureSink implements FeatureSink {
           "At least one RedisConfig or RedisClusterConfig must be provided to Redis Sink");
     }
     specsView = featureSetSpecs.apply(ParDo.of(new ReferenceToString())).apply(View.asMultimap());
-    return featureSetSpecs.apply(Keys.create());
+    return featureSetSpecs
+        .apply(
+            "DummyDelay",
+            ParDo.of(
+                new DoFn<
+                    KV<FeatureSetReference, FeatureSetSpec>,
+                    KV<FeatureSetReference, FeatureSetSpec>>() {
+                  @ProcessElement
+                  public void process(ProcessContext c) throws InterruptedException {
+                    Thread.sleep(1000);
+                    c.output(c.element());
+                  }
+                }))
+        .apply(Keys.create());
   }
 
   @Override


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Adds a delay to Redis spec send acknowledgement in order to prevent a race condition with the send event being commited.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Occasionally feature sets might enter a pending state due to a race condition with spec acknowledgement. This race has been resolved.
```
