### PR TITLE
Throw more informative exception when write_triggering_frequency_seconds is missing

### DIFF
--- a/infra/charts/feast/README.md
+++ b/infra/charts/feast/README.md
@@ -164,6 +164,7 @@ feast-batch-serving:
           staging_location: gs://<bucket_name>/feast-staging-location
           initial_retry_delay_seconds: 3
           total_timeout_seconds: 21600
+          write_triggering_frequency_seconds: 600
         subscriptions:
         - name: "*"
           project: "*"
@@ -280,6 +281,7 @@ feast-batch-serving:
           staging_location: gs://<bucket_name>/feast-staging-location
           initial_retry_delay_seconds: 3
           total_timeout_seconds: 21600
+          write_triggering_frequency_seconds: 600
         subscriptions:
         - name: "*"
           project: "*"

--- a/infra/charts/feast/README.md.gotmpl
+++ b/infra/charts/feast/README.md.gotmpl
@@ -137,6 +137,7 @@ feast-batch-serving:
           staging_location: gs://<bucket_name>/feast-staging-location
           initial_retry_delay_seconds: 3
           total_timeout_seconds: 21600
+          write_triggering_frequency_seconds: 600
         subscriptions:
         - name: "*"
           project: "*"

--- a/infra/charts/feast/values-batch-serving.yaml
+++ b/infra/charts/feast/values-batch-serving.yaml
@@ -20,6 +20,7 @@ feast-batch-serving:
           staging_location: gs://<bucket_name>/feast-staging-location
           initial_retry_delay_seconds: 3
           total_timeout_seconds: 21600
+          write_triggering_frequency_seconds: 600
         subscriptions:
         - name: "*"
           project: "*"

--- a/infra/docker-compose/serving/batch-serving.yml
+++ b/infra/docker-compose/serving/batch-serving.yml
@@ -12,6 +12,7 @@ feast:
         staging_location: gs://gcs_bucket/prefix
         initial_retry_delay_seconds: 1
         total_timeout_seconds: 21600
+        write_triggering_frequency_seconds: 600
       subscriptions:
         - name: "*"
           project: "*"

--- a/protos/feast/core/Store.proto
+++ b/protos/feast/core/Store.proto
@@ -108,7 +108,7 @@ message Store {
     int32 initial_backoff_ms = 3;
     // Optional. Maximum total number of retries for connecting to Redis. Default to zero retries.
     int32 max_retries = 4;
-    // Optional. how often flush data to redis
+    // Optional. How often flush data to redis
     int32 flush_frequency_seconds = 5;
   }
 
@@ -118,6 +118,7 @@ message Store {
     string staging_location = 3;
     int32 initial_retry_delay_seconds = 4;
     int32 total_timeout_seconds = 5;
+    // Required. Frequency of running BQ load job and flushing all collected rows to BQ table
     int32 write_triggering_frequency_seconds = 6;
   }
 
@@ -131,7 +132,7 @@ message Store {
     string connection_string = 1;
     int32 initial_backoff_ms = 2;
     int32 max_retries = 3;
-    // Optional. how often flush data to redis
+    // Optional. How often flush data to redis
     int32 flush_frequency_seconds = 4;
   }
 

--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/BigQueryFeatureSink.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/writer/BigQueryFeatureSink.java
@@ -16,6 +16,8 @@
  */
 package feast.storage.connectors.bigquery.writer;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.bigquery.*;
@@ -62,6 +64,12 @@ public abstract class BigQueryFeatureSink implements FeatureSink {
    * @return {@link BigQueryFeatureSink.Builder}
    */
   public static FeatureSink fromConfig(BigQueryConfig config) {
+    checkArgument(
+        config.getWriteTriggeringFrequencySeconds() > 0,
+        "Invalid configuration: "
+            + "write_triggering_frequency_seconds in BigQueryConfig must be positive integer. "
+            + "Please fix that in your serving configuration.");
+
     return BigQueryFeatureSink.builder()
         .setDatasetId(config.getDatasetId())
         .setProjectId(config.getProjectId())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

When `write_triggering_frequency_seconds` is not specified in `BigQueryConfig` not very useful exceptions is being thrown
on IngestionJob start.
```
java.lang.IllegalArgumentException: FixedWindows WindowingStrategies must have 0 <= offset < size
```
Instead this PR adds check and throw more informative exception. And also adds default value to helm & docker compose.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
More informative exception when `BigQueryConfig` is not properly filled.
```
