### PR TITLE
Fix Helm chart requirements lock and version linting

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: install dependencies
+      - name: Lint versions throughout repo
         run: make lint-versions
 
   unit-test-java:

--- a/infra/charts/feast/README.md
+++ b/infra/charts/feast/README.md
@@ -281,7 +281,6 @@ feast-batch-serving:
           staging_location: gs://<bucket_name>/feast-staging-location
           initial_retry_delay_seconds: 3
           total_timeout_seconds: 21600
-          write_triggering_frequency_seconds: 600
         subscriptions:
         - name: "*"
           project: "*"

--- a/infra/charts/feast/charts/feast-core/README.md
+++ b/infra/charts/feast/charts/feast-core/README.md
@@ -23,7 +23,7 @@ Current chart version is `0.7-SNAPSHOT`
 | gcpServiceAccount.existingSecret.name | string | `"feast-gcp-service-account"` | Name of the existing secret containing the service account |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"gcr.io/kf-feast/feast-core"` | Docker image repository |
-| image.tag | string | `"latest"` | Image tag |
+| image.tag | string | `"0.6.2"` | Image tag |
 | ingress.grpc.annotations | object | `{}` | Extra annotations for the ingress |
 | ingress.grpc.auth.enabled | bool | `false` | Flag to enable auth |
 | ingress.grpc.class | string | `"nginx"` | Which ingress controller to use |

--- a/infra/charts/feast/charts/feast-core/values.yaml
+++ b/infra/charts/feast/charts/feast-core/values.yaml
@@ -5,7 +5,7 @@ image:
   # image.repository -- Docker image repository
   repository: gcr.io/kf-feast/feast-core
   # image.tag -- Image tag
-  tag: latest
+  tag: 0.6.2
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/infra/charts/feast/charts/feast-jupyter/README.md
+++ b/infra/charts/feast/charts/feast-jupyter/README.md
@@ -17,5 +17,5 @@ Current chart version is `0.7-SNAPSHOT`
 | gcpServiceAccount.existingSecret.name | string | `"feast-gcp-service-account"` | Name of the existing secret containing the service account |
 | image.pullPolicy | string | `"Always"` | Image pull policy |
 | image.repository | string | `"gcr.io/kf-feast/feast-jupyter"` | Docker image repository |
-| image.tag | string | `"latest"` | Image tag |
+| image.tag | string | `"0.6.2"` | Image tag |
 | replicaCount | int | `1` | Number of pods that will be created |

--- a/infra/charts/feast/charts/feast-jupyter/values.yaml
+++ b/infra/charts/feast/charts/feast-jupyter/values.yaml
@@ -5,7 +5,7 @@ image:
   # image.repository -- Docker image repository
   repository: gcr.io/kf-feast/feast-jupyter
   # image.tag -- Image tag
-  tag: latest
+  tag: 0.6.2
   # image.pullPolicy -- Image pull policy
   pullPolicy: Always
 

--- a/infra/charts/feast/charts/feast-serving/README.md
+++ b/infra/charts/feast/charts/feast-serving/README.md
@@ -23,7 +23,7 @@ Current chart version is `0.7-SNAPSHOT`
 | gcpServiceAccount.existingSecret.name | string | `"feast-gcp-service-account"` | Name of the existing secret containing the service account |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"gcr.io/kf-feast/feast-serving"` | Docker image repository |
-| image.tag | string | `"latest"` | Image tag |
+| image.tag | string | `"0.6.2"` | Image tag |
 | ingress.grpc.annotations | object | `{}` | Extra annotations for the ingress |
 | ingress.grpc.auth.enabled | bool | `false` | Flag to enable auth |
 | ingress.grpc.class | string | `"nginx"` | Which ingress controller to use |

--- a/infra/charts/feast/charts/feast-serving/values.yaml
+++ b/infra/charts/feast/charts/feast-serving/values.yaml
@@ -5,7 +5,7 @@ image:
   # image.repository -- Docker image repository
   repository: gcr.io/kf-feast/feast-serving
   # image.tag -- Image tag
-  tag: latest
+  tag: 0.6.2
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/infra/charts/feast/requirements.lock
+++ b/infra/charts/feast/requirements.lock
@@ -1,16 +1,16 @@
 dependencies:
 - name: feast-core
   repository: ""
-  version: 0.5.1
+  version: 0.6.2
 - name: feast-serving
   repository: ""
-  version: 0.5.1
+  version: 0.6.2
 - name: feast-serving
   repository: ""
-  version: 0.5.1
+  version: 0.6.2
 - name: feast-jupyter
   repository: ""
-  version: 0.5.1
+  version: 0.6.2
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 8.6.1

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -13,6 +13,7 @@ export FEAST_MASTER_VERSION=$(mvn help:evaluate -Dexpression=project.version -q 
 }
 
 # Determine the highest released version from Git history
+git fetch --prune --unshallow --tags || true
 FEAST_RELEASE_VERSION_WITH_V=$(git tag -l --sort -version:refname | head -n 1)
 echo $FEAST_RELEASE_VERSION_WITH_V
 

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -28,8 +28,14 @@ export FEAST_RELEASE_VERSION=${FEAST_RELEASE_VERSION_WITH_V:1}
 declare -a files_to_validate_version=(
   "infra/charts/feast/Chart.yaml,1,${FEAST_MASTER_VERSION}"
   "infra/charts/feast/charts/feast-core/Chart.yaml,1,${FEAST_MASTER_VERSION}"
+  "infra/charts/feast/charts/feast-core/values.yaml,1,${FEAST_RELEASE_VERSION}"
+  "infra/charts/feast/charts/feast-core/README.md,1,${FEAST_RELEASE_VERSION}"
   "infra/charts/feast/charts/feast-serving/Chart.yaml,1,${FEAST_MASTER_VERSION}"
+  "infra/charts/feast/charts/feast-jupyter/values.yaml,1,${FEAST_RELEASE_VERSION}"
+  "infra/charts/feast/charts/feast-jupyter/README.md,1,${FEAST_RELEASE_VERSION}"
   "infra/charts/feast/charts/feast-jupyter/Chart.yaml,1,${FEAST_MASTER_VERSION}"
+  "infra/charts/feast/charts/feast-serving/values.yaml,1,${FEAST_RELEASE_VERSION}"
+  "infra/charts/feast/charts/feast-serving/README.md,1,${FEAST_RELEASE_VERSION}"
   "infra/charts/feast/requirements.yaml,4,${FEAST_MASTER_VERSION}"
   "infra/charts/feast/requirements.lock,4,${FEAST_RELEASE_VERSION}"
   "infra/docker-compose/.env.sample,1,${FEAST_RELEASE_VERSION}"
@@ -62,5 +68,5 @@ for i in "${files_to_validate_version[@]}"; do
     echo "Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, but found $ACTUAL_OCCURRENCES"
     exit 1
   fi
-    echo "========================================================="
+  echo "========================================================="
 done

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -14,9 +14,13 @@ export FEAST_MASTER_VERSION=$(mvn help:evaluate -Dexpression=project.version -q 
 
 # Determine the highest released version from Git history
 FEAST_RELEASE_VERSION_WITH_V=$(git tag -l --sort -version:refname | head -n 1)
-export FEAST_RELEASE_VERSION=${FEAST_RELEASE_VERSION_WITH_V:1}
+echo $FEAST_RELEASE_VERSION_WITH_V
+
+export FEAST_RELEASE_VERSION=${FEAST_RELEASE_VERSION_WITH_V#"v"}
+echo $FEAST_RELEASE_VERSION
+
 [[ -z "$FEAST_RELEASE_VERSION" ]] && {
-  echo "$FEAST_RELEASE_VERSION is missing"
+  echo "FEAST_RELEASE_VERSION is missing"
   exit 1
 }
 

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -30,7 +30,8 @@ declare -a files_to_validate_version=(
   "infra/charts/feast/charts/feast-core/Chart.yaml,1,${FEAST_MASTER_VERSION}"
   "infra/charts/feast/charts/feast-serving/Chart.yaml,1,${FEAST_MASTER_VERSION}"
   "infra/charts/feast/charts/feast-jupyter/Chart.yaml,1,${FEAST_MASTER_VERSION}"
-  "infra/charts/feast/requirements.yaml,4,${FEAST_MASTER_VERSION}" # We are only testing for the version once
+  "infra/charts/feast/requirements.yaml,4,${FEAST_MASTER_VERSION}"
+  "infra/charts/feast/requirements.lock,4,${FEAST_RELEASE_VERSION}"
   "infra/docker-compose/.env.sample,1,${FEAST_RELEASE_VERSION}"
 )
 
@@ -47,14 +48,17 @@ for i in "${files_to_validate_version[@]}"; do
   echo "File contents:"
   echo "========================================================="
   cat "$FILE_PATH"
+  echo
   echo "========================================================="
   ACTUAL_OCCURRENCES=$(grep -c "$VERSION" "$FILE_PATH" || true)
 
   if [ "${ACTUAL_OCCURRENCES}" -eq "${EXPECTED_OCCURRENCES}" ]; then
     echo "SUCCESS"
+    echo
     echo "Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, and found $ACTUAL_OCCURRENCES"
   else
     echo "FAILURE"
+    echo
     echo "Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, but found $ACTUAL_OCCURRENCES"
     exit 1
   fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Allows for linting of versions based on latest stable tag, bump the requirements lock for our helm charts, and allows for specifying the amount of versions to find in a file.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #924

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
