### PR TITLE
Impute default project if empty before authorization is called

### DIFF
--- a/core/src/main/java/feast/core/grpc/CoreServiceImpl.java
+++ b/core/src/main/java/feast/core/grpc/CoreServiceImpl.java
@@ -30,6 +30,7 @@ import feast.core.service.SpecService;
 import feast.core.service.StatsService;
 import feast.proto.core.CoreServiceGrpc.CoreServiceImplBase;
 import feast.proto.core.CoreServiceProto.*;
+import feast.proto.core.FeatureSetProto.FeatureSet;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
@@ -187,9 +188,10 @@ public class CoreServiceImpl extends CoreServiceImplBase {
     String projectId = null;
 
     try {
-      projectId = request.getFeatureSet().getSpec().getProject();
+      FeatureSet featureSet = specService.imputeProjectName(request.getFeatureSet());
+      projectId = featureSet.getSpec().getProject();
       authorizationService.authorizeRequest(SecurityContextHolder.getContext(), projectId);
-      ApplyFeatureSetResponse response = specService.applyFeatureSet(request.getFeatureSet());
+      ApplyFeatureSetResponse response = specService.applyFeatureSet(featureSet);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
     } catch (org.hibernate.exception.ConstraintViolationException e) {

--- a/core/src/main/java/feast/core/service/SpecService.java
+++ b/core/src/main/java/feast/core/service/SpecService.java
@@ -312,15 +312,6 @@ public class SpecService {
   @Transactional
   public ApplyFeatureSetResponse applyFeatureSet(FeatureSetProto.FeatureSet newFeatureSet)
       throws InvalidProtocolBufferException {
-    // Autofill default project if not specified
-    if (newFeatureSet.getSpec().getProject().isEmpty()) {
-      newFeatureSet =
-          newFeatureSet
-              .toBuilder()
-              .setSpec(newFeatureSet.getSpec().toBuilder().setProject(Project.DEFAULT_NAME).build())
-              .build();
-    }
-
     // Validate incoming feature set
     FeatureSetValidator.validateSpec(newFeatureSet);
 
@@ -381,6 +372,21 @@ public class SpecService {
         .setFeatureSet(featureSet.toProto())
         .setStatus(status)
         .build();
+  }
+
+  /**
+   * sets project to 'default' if project is not specified in featureSet
+   *
+   * @param featureSet Feature set which needs to be imputed with default project.
+   */
+  public FeatureSetProto.FeatureSet imputeProjectName(FeatureSetProto.FeatureSet featureSet) {
+    if (featureSet.getSpec().getProject().isEmpty()) {
+      return featureSet
+          .toBuilder()
+          .setSpec(featureSet.getSpec().toBuilder().setProject(Project.DEFAULT_NAME).build())
+          .build();
+    }
+    return featureSet;
   }
 
   /**

--- a/core/src/main/java/feast/core/service/SpecService.java
+++ b/core/src/main/java/feast/core/service/SpecService.java
@@ -375,7 +375,7 @@ public class SpecService {
   }
 
   /**
-   * sets project to 'default' if project is not specified in featureSet
+   * Sets project to 'default' if project is not specified in feature set
    *
    * @param featureSet Feature set which needs to be imputed with default project.
    */

--- a/core/src/test/java/feast/core/auth/CoreServiceAuthTest.java
+++ b/core/src/test/java/feast/core/auth/CoreServiceAuthTest.java
@@ -102,6 +102,9 @@ public class CoreServiceAuthTest {
 
     StreamRecorder<ApplyFeatureSetResponse> responseObserver = StreamRecorder.create();
     FeatureSetProto.FeatureSet incomingFeatureSet = newDummyFeatureSet("f2", 1, project).toProto();
+    doReturn(incomingFeatureSet)
+        .when(specService)
+        .imputeProjectName(any(FeatureSetProto.FeatureSet.class));
     FeatureSetProto.FeatureSetSpec incomingFeatureSetSpec =
         incomingFeatureSet.getSpec().toBuilder().build();
     FeatureSetProto.FeatureSet spec =

--- a/core/src/test/java/feast/core/service/SpecServiceTest.java
+++ b/core/src/test/java/feast/core/service/SpecServiceTest.java
@@ -606,7 +606,7 @@ public class SpecServiceTest {
   }
 
   @Test
-  public void applyFeatureSetShouldUsedDefaultProjectIfUnspecified()
+  public void imputeProjectNameShouldSetDefaultProjectIfUnspecified()
       throws InvalidProtocolBufferException {
     Feature f3f1 = TestUtil.CreateFeature("f3f1", Enum.INT64);
     Feature f3f2 = TestUtil.CreateFeature("f3f2", Enum.INT64);
@@ -616,13 +616,9 @@ public class SpecServiceTest {
     FeatureSetProto.FeatureSet incomingFeatureSet =
         TestUtil.CreateFeatureSet("f3", "", Arrays.asList(f3e1), Arrays.asList(f3f2, f3f1))
             .toProto();
-    ApplyFeatureSetResponse applyFeatureSetResponse =
-        specService.applyFeatureSet(incomingFeatureSet);
-    assertThat(applyFeatureSetResponse.getStatus(), equalTo(Status.CREATED));
-
-    assertThat(
-        applyFeatureSetResponse.getFeatureSet().getSpec().getProject(),
-        equalTo(Project.DEFAULT_NAME));
+    FeatureSetProto.FeatureSet imputedFeatureSet =
+        specService.imputeProjectName(incomingFeatureSet);
+    assertThat(imputedFeatureSet.getSpec().getProject(), equalTo(Project.DEFAULT_NAME));
   }
 
   @Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
if `project` is not set in the `featureSet`, which is in the request for `applyFeatureSet` method, an empty project will be passed for authorization. Instead it should authorize against `default` project. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to #793 

**Does this PR introduce a user-facing change?**:no
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
In 'applyFeatureSet' api, project name imputation happens before invoking authorization service. 
Previous behavior, only 'admin' user could create feature sets in 'default' project, 
and authorization was failing for users who have access to 'default' project, 
since authorization was being invoked with empty 'projectId'. 
```
