### PR TITLE
Allow unauthenticated access when Authorization is disabled and to Health Probe

### DIFF
--- a/auth/src/main/java/feast/auth/config/SecurityConfig.java
+++ b/auth/src/main/java/feast/auth/config/SecurityConfig.java
@@ -83,13 +83,13 @@ public class SecurityConfig {
   }
 
   /**
-   * Creates an AccessDecisionManager if authentication is enabled. This object determines the
-   * policy used to make authentication decisions.
+   * Creates an AccessDecisionManager if authorization is enabled. This object determines the policy
+   * used to make authorization decisions.
    *
    * @return AccessDecisionManager
    */
   @Bean
-  @ConditionalOnProperty(prefix = "feast.security.authentication", name = "enabled")
+  @ConditionalOnProperty(prefix = "feast.security.authorization", name = "enabled")
   AccessDecisionManager accessDecisionManager() {
     final List<AccessDecisionVoter<?>> voters = new ArrayList<>();
     voters.add(new AccessPredicateVoter());

--- a/core/src/main/java/feast/core/config/CoreSecurityConfig.java
+++ b/core/src/main/java/feast/core/config/CoreSecurityConfig.java
@@ -17,6 +17,7 @@
 package feast.core.config;
 
 import feast.proto.core.CoreServiceGrpc;
+import io.grpc.health.v1.HealthGrpc;
 import lombok.extern.slf4j.Slf4j;
 import net.devh.boot.grpc.server.security.check.AccessPredicate;
 import net.devh.boot.grpc.server.security.check.GrpcSecurityMetadataSource;
@@ -48,6 +49,7 @@ public class CoreSecurityConfig {
     // The following endpoints allow unauthenticated access
     source.set(CoreServiceGrpc.getGetFeastCoreVersionMethod(), AccessPredicate.permitAll());
     source.set(CoreServiceGrpc.getUpdateStoreMethod(), AccessPredicate.permitAll());
+    source.set(HealthGrpc.getCheckMethod(), AccessPredicate.permitAll());
     return source;
   }
 }

--- a/serving/src/main/java/feast/serving/config/ServingSecurityConfig.java
+++ b/serving/src/main/java/feast/serving/config/ServingSecurityConfig.java
@@ -18,7 +18,10 @@ package feast.serving.config;
 
 import feast.auth.credentials.GoogleAuthCredentials;
 import feast.auth.credentials.OAuthCredentials;
+import feast.proto.serving.ServingServiceGrpc;
 import io.grpc.CallCredentials;
+import io.grpc.health.v1.HealthGrpc;
+
 import java.io.IOException;
 import net.devh.boot.grpc.server.security.check.AccessPredicate;
 import net.devh.boot.grpc.server.security.check.GrpcSecurityMetadataSource;
@@ -67,6 +70,10 @@ public class ServingSecurityConfig {
 
     // Authentication is enabled for all gRPC endpoints
     source.setDefault(AccessPredicate.authenticated());
+
+    // The following endpoints allow unauthenticated access
+    source.set(ServingServiceGrpc.getGetFeastServingInfoMethod(), AccessPredicate.permitAll());
+    source.set(HealthGrpc.getCheckMethod(), AccessPredicate.permitAll());
     return source;
   }
 

--- a/serving/src/main/java/feast/serving/config/ServingSecurityConfig.java
+++ b/serving/src/main/java/feast/serving/config/ServingSecurityConfig.java
@@ -21,7 +21,6 @@ import feast.auth.credentials.OAuthCredentials;
 import feast.proto.serving.ServingServiceGrpc;
 import io.grpc.CallCredentials;
 import io.grpc.health.v1.HealthGrpc;
-
 import java.io.IOException;
 import net.devh.boot.grpc.server.security.check.AccessPredicate;
 import net.devh.boot.grpc.server.security.check.GrpcSecurityMetadataSource;

--- a/serving/src/test/java/feast/serving/it/ServingServiceOauthAuthenticationIT.java
+++ b/serving/src/test/java/feast/serving/it/ServingServiceOauthAuthenticationIT.java
@@ -17,7 +17,6 @@
 package feast.serving.it;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.testcontainers.containers.wait.strategy.Wait.forHttp;
 
@@ -26,7 +25,6 @@ import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesResponse;
 import feast.proto.serving.ServingServiceGrpc.ServingServiceBlockingStub;
 import feast.proto.types.ValueProto.Value;
 import io.grpc.ManagedChannel;
-import io.grpc.StatusRuntimeException;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
@@ -87,21 +85,17 @@ public class ServingServiceOauthAuthenticationIT extends BaseAuthIT {
   }
 
   @Test
-  public void shouldNotAllowUnauthenticatedGetOnlineFeatures() {
+  public void shouldAllowUnauthenticatedGetOnlineFeatures() {
     ServingServiceBlockingStub servingStub =
         AuthTestUtils.getServingServiceStub(false, FEAST_SERVING_PORT, null);
     GetOnlineFeaturesRequest onlineFeatureRequest =
         AuthTestUtils.createOnlineFeatureRequest(PROJECT_NAME, FEATURE_NAME, ENTITY_ID, 1);
-    Exception exception =
-        assertThrows(
-            StatusRuntimeException.class,
-            () -> {
-              servingStub.getOnlineFeatures(onlineFeatureRequest);
-            });
-
-    String expectedMessage = "UNAUTHENTICATED: Authentication failed";
-    String actualMessage = exception.getMessage();
-    assertEquals(actualMessage, expectedMessage);
+    GetOnlineFeaturesResponse featureResponse = servingStub.getOnlineFeatures(onlineFeatureRequest);
+    assertEquals(1, featureResponse.getFieldValuesCount());
+    Map<String, Value> fieldsMap = featureResponse.getFieldValues(0).getFieldsMap();
+    assertTrue(fieldsMap.containsKey(ENTITY_ID));
+    assertTrue(fieldsMap.containsKey(FEATURE_NAME));
+    ((ManagedChannel) servingStub.getChannel()).shutdown();
   }
 
   @Test

--- a/serving/src/test/java/feast/serving/it/ServingServiceOauthAuthenticationIT.java
+++ b/serving/src/test/java/feast/serving/it/ServingServiceOauthAuthenticationIT.java
@@ -86,6 +86,10 @@ public class ServingServiceOauthAuthenticationIT extends BaseAuthIT {
 
   @Test
   public void shouldAllowUnauthenticatedGetOnlineFeatures() {
+    // apply feature set
+    CoreSimpleAPIClient coreClient =
+        AuthTestUtils.getSecureApiClientForCore(FEAST_CORE_PORT, options);
+    AuthTestUtils.applyFeatureSet(coreClient, PROJECT_NAME, ENTITY_ID, FEATURE_NAME);
     ServingServiceBlockingStub servingStub =
         AuthTestUtils.getServingServiceStub(false, FEAST_SERVING_PORT, null);
     GetOnlineFeaturesRequest onlineFeatureRequest =


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Allow unauthenticated requests when only `authentication` is enabled:
- Allows "optional authentication" which is needed when transition users to authentication.
- Forced `authentication` is only enforced when  `authorization` is enabled.

Add exceptions for unauthenticated access to the health probe.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Authentication allows unauthenticated requests unless Authorization is also enabled.
Feast now allows unauthenticated access to its health probes.
```
