### PR TITLE
Fix empty array when retrieving stats data

### DIFF
--- a/core/src/main/java/feast/core/service/StatsService.java
+++ b/core/src/main/java/feast/core/service/StatsService.java
@@ -129,6 +129,9 @@ public class StatsService {
         List<FeatureNameStatistics> featureNameStatistics =
             getFeatureNameStatisticsByDate(
                 statisticsRetriever, featureSet, features, timestamp, request.getForceRefresh());
+        if (featureNameStatistics.size() != 0) {
+          featureNameStatisticsList.add(featureNameStatistics);
+        }
         featureNameStatisticsList.add(featureNameStatistics);
         timestamp += 86400; // advance by a day
       }
@@ -147,13 +150,15 @@ public class StatsService {
         List<FeatureNameStatistics> featureNameStatistics =
             getFeatureNameStatisticsByDataset(
                 statisticsRetriever, featureSet, features, datasetId, request.getForceRefresh());
-        featureNameStatisticsList.add(featureNameStatistics);
-        if (featureNameStatisticsList.size() == 0) {
-          throw new RetrievalException(
-              String.format(
-                  "Unable to find any data over provided data sets %s",
-                  request.getIngestionIdsList()));
+        if (featureNameStatistics.size() != 0) {
+          featureNameStatisticsList.add(featureNameStatistics);
         }
+      }
+      if (featureNameStatisticsList.size() == 0) {
+        throw new RetrievalException(
+            String.format(
+                "Unable to find any data over provided data sets %s",
+                request.getIngestionIdsList()));
       }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
These 2 methods, [this](https://github.com/feast-dev/feast/blob/master/core/src/main/java/feast/core/service/StatsService.java#L254) and [that](https://github.com/feast-dev/feast/blob/master/core/src/main/java/feast/core/service/StatsService.java#L185) will always be returning at least an empty arraylist. So essentially, when being called in [getFeatureStatistics](https://github.com/feast-dev/feast/blob/master/core/src/main/java/feast/core/service/StatsService.java#L92), these conditions, [this](https://github.com/feast-dev/feast/blob/master/core/src/main/java/feast/core/service/StatsService.java#L135) and [that](https://github.com/feast-dev/feast/blob/master/core/src/main/java/feast/core/service/StatsService.java#L151) will never be triggered, since length of arraylist will always at least be 1.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
N/A
```
