### PR TITLE
Fix grpc security variables name and missing exec qualifier in docker.dev

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -113,8 +113,8 @@ grpc:
     port: 6565
     security:
       enabled: false
-      certificateChainPath: server.crt
-      privateKeyPath: server.key
+      certificateChain: server.crt
+      privateKey: server.key
       
 spring:
   jpa:

--- a/infra/docker/core/Dockerfile.dev
+++ b/infra/docker/core/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM openjdk:11-jre
 ARG REVISION=dev
-ADD $PWD/core/target/feast-core-$REVISION.jar /opt/feast/feast-core.jar
+ADD $PWD/core/target/feast-core-$REVISION-exec.jar /opt/feast/feast-core.jar
 CMD ["java",\
      "-Xms2048m",\
      "-Xmx2048m",\

--- a/infra/docker/serving/Dockerfile.dev
+++ b/infra/docker/serving/Dockerfile.dev
@@ -7,7 +7,7 @@ ARG REVISION=dev
 RUN wget -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.1/grpc_health_probe-linux-amd64 \
          -O /usr/bin/grpc-health-probe && \
     chmod +x /usr/bin/grpc-health-probe
-ADD $PWD/serving/target/feast-serving-$REVISION.jar /opt/feast/feast-serving.jar
+ADD $PWD/serving/target/feast-serving-$REVISION-exec.jar /opt/feast/feast-serving.jar
 CMD ["java",\
      "-Xms1024m",\
      "-Xmx1024m",\

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -114,8 +114,8 @@ grpc:
     port: ${GRPC_PORT:6566}
     security:
       enabled: false
-      certificateChainPath: server.crt
-      privateKeyPath: server.key
+      certificateChain: server.crt
+      privateKey: server.key
 
 server:
   # The port number on which the Tomcat webserver that serves REST API endpoints should listen


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Grpc security variable names in application.yml are incorrect. Also exec qualifiers are missing from DockerFile.dev
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related #823 

**Does this PR introduce a user-facing change?**:No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
previous behavior : enabling grpc security and setting valid server.crt and server.key, throws an error. 
Also docker images build using DockerFile.dev will not boot.

With this PR, enabling security shouldn't throw any error if valid server.crt and server.key are set.
Images build using DockerFile.dev will boot without any errors.
```
