### PR TITLE
  Bypass authentication for metric endpoints on Serving.

### DIFF
--- a/core/src/test/java/feast/core/metrics/CoreMetricsIT.java
+++ b/core/src/test/java/feast/core/metrics/CoreMetricsIT.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.core.metrics;
+
+import static org.junit.Assert.assertTrue;
+
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import feast.core.it.BaseIT;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = {
+      "feast.security.authentication.enabled=true",
+    })
+public class CoreMetricsIT extends BaseIT {
+  private static final String METRIC_ENDPOINT = "/metrics";
+  private static OkHttpClient httpClient;
+  @LocalServerPort private int metricsPort;
+
+  @BeforeAll
+  public static void globalSetUp() {
+    httpClient = new OkHttpClient();
+  }
+
+  /** Test that Feast Core metrics endpoint can be accessed with authentication enabled */
+  @Test
+  public void shouldAllowUnauthenticatedAccessToMetricsEndpoint() throws IOException {
+    Request request =
+        new Request.Builder()
+            .url(String.format("http://localhost:%d%s", metricsPort, METRIC_ENDPOINT))
+            .get()
+            .build();
+    Response response = httpClient.newCall(request).execute();
+    assertTrue(response.isSuccessful());
+    assertTrue(!response.body().string().isEmpty());
+  }
+}

--- a/serving/src/main/java/feast/serving/config/WebSecurityConfig.java
+++ b/serving/src/main/java/feast/serving/config/WebSecurityConfig.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.serving.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+/**
+ * WebSecurityConfig disables auto configuration of Spring HTTP Security and allows security methods
+ * to be overridden
+ */
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+  /**
+   * Allows for custom web security rules to be applied.
+   *
+   * @param http {@link HttpSecurity} for configuring web based security
+   * @throws Exception
+   */
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+
+    // Bypasses security/authentication for the following paths
+    http.authorizeRequests()
+        .antMatchers("/actuator/**", "/metrics/**")
+        .permitAll()
+        .anyRequest()
+        .authenticated()
+        .and()
+        .csrf()
+        .disable();
+  }
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Follow up of #862 to extend Authentication Bypass for metrics access to Serving for the `/metrics` and `/actuator` endpoints.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
