### PR TITLE
Fix CI Building Images as latest instead of Github SHA and Change versions to v0.6.3-SNAPSHOT

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: install dependencies
+      - name: Lint versions throughout repo
         run: make lint-versions
 
   unit-test-java:

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ build-push-docker:
 	@$(MAKE) build-docker registry=$(REGISTRY) version=$(VERSION)
 	@$(MAKE) push-core-docker registry=$(REGISTRY) version=$(VERSION)
 	@$(MAKE) push-serving-docker registry=$(REGISTRY) version=$(VERSION)
-	@$(MAKE) push-ci-docker registry=$(REGISTRY)
+	@$(MAKE) push-ci-docker registry=$(REGISTRY) version=$(VERSION)
 
 build-docker: build-core-docker build-serving-docker build-ci-docker
 
@@ -124,7 +124,7 @@ push-serving-docker:
 	docker push $(REGISTRY)/feast-serving:$(VERSION)
 
 push-ci-docker:
-	docker push $(REGISTRY)/feast-ci:latest
+	docker push $(REGISTRY)/feast-ci:$(VERSION)
 
 push-jupyter-docker:
 	docker push $(REGISTRY)/feast-jupyter:$(VERSION)
@@ -136,7 +136,7 @@ build-serving-docker:
 	docker build -t $(REGISTRY)/feast-serving:$(VERSION) -f infra/docker/serving/Dockerfile .
 
 build-ci-docker:
-	docker build -t $(REGISTRY)/feast-ci:latest -f infra/docker/ci/Dockerfile .
+	docker build -t $(REGISTRY)/feast-ci:$(VERSION) -f infra/docker/ci/Dockerfile .
 
 build-jupyter-docker:
 	docker build -t $(REGISTRY)/feast-jupyter:$(VERSION) -f infra/docker/jupyter/Dockerfile .

--- a/datatypes/java/README.md
+++ b/datatypes/java/README.md
@@ -16,7 +16,7 @@ Dependency Coordinates
 <dependency>
   <groupId>dev.feast</groupId>
   <artifactId>datatypes-java</artifactId>
-  <version>0.6.2</version>
+  <version>0.6.3-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -181,7 +181,7 @@ grpc_cli call localhost:6566 GetFeastServingInfo ''
 
 ```text
 connecting to localhost:6566
-version: "0.6.2"
+version: "0.6.3-SNAPSHOT"
 type: FEAST_SERVING_TYPE_ONLINE
 
 Rpc succeeded with OK status

--- a/infra/charts/feast/Chart.yaml
+++ b/infra/charts/feast/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Feature store for machine learning.
 name: feast
-version: 0.6.2
+version: 0.6.3-SNAPSHOT

--- a/infra/charts/feast/README.md
+++ b/infra/charts/feast/README.md
@@ -1,7 +1,7 @@
 feast
 ===== 
 
-Feature store for machine learning. Current chart version is `0.6.2`
+Feature store for machine learning. Current chart version is `0.6.3-SNAPSHOT`
 
 ## TL;DR;
 
@@ -32,10 +32,10 @@ This chart install Feast deployment on a Kubernetes cluster using the [Helm](htt
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | feast-core | 0.6.2 |
-|  | feast-jupyter | 0.6.2 |
-|  | feast-serving | 0.6.2 |
-|  | feast-serving | 0.6.2 |
+|  | feast-core | 0.6.3-SNAPSHOT |
+|  | feast-jupyter | 0.6.3-SNAPSHOT |
+|  | feast-serving | 0.6.3-SNAPSHOT |
+|  | feast-serving | 0.6.3-SNAPSHOT |
 |  | prometheus-statsd-exporter | 0.1.2 |
 | https://kubernetes-charts-incubator.storage.googleapis.com/ | kafka | 0.20.8 |
 | https://kubernetes-charts.storage.googleapis.com/ | grafana | 5.0.5 |

--- a/infra/charts/feast/charts/feast-core/Chart.yaml
+++ b/infra/charts/feast/charts/feast-core/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Feast Core registers feature specifications and manage ingestion jobs.
 name: feast-core
-version: 0.6.2
+version: 0.6.3-SNAPSHOT

--- a/infra/charts/feast/charts/feast-core/README.md
+++ b/infra/charts/feast/charts/feast-core/README.md
@@ -2,7 +2,7 @@ feast-core
 ==========
 Feast Core registers feature specifications and manage ingestion jobs.
 
-Current chart version is `0.6.2`
+Current chart version is `0.6.3-SNAPSHOT`
 
 
 

--- a/infra/charts/feast/charts/feast-jupyter/Chart.yaml
+++ b/infra/charts/feast/charts/feast-jupyter/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Feast Jupyter provides a Jupyter server with pre-installed Feast SDK
 name: feast-jupyter
-version: 0.6.2
+version: 0.6.3-SNAPSHOT

--- a/infra/charts/feast/charts/feast-jupyter/README.md
+++ b/infra/charts/feast/charts/feast-jupyter/README.md
@@ -2,7 +2,7 @@ feast-jupyter
 =============
 Feast Jupyter provides a Jupyter server with pre-installed Feast SDK
 
-Current chart version is `0.6.2`
+Current chart version is `0.6.3-SNAPSHOT`
 
 
 

--- a/infra/charts/feast/charts/feast-serving/Chart.yaml
+++ b/infra/charts/feast/charts/feast-serving/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Feast Serving serves low-latency latest features and historical batch features.
 name: feast-serving
-version: 0.6.2
+version: 0.6.3-SNAPSHOT

--- a/infra/charts/feast/charts/feast-serving/README.md
+++ b/infra/charts/feast/charts/feast-serving/README.md
@@ -2,7 +2,7 @@ feast-serving
 =============
 Feast Serving serves low-latency latest features and historical batch features.
 
-Current chart version is `0.6.2`
+Current chart version is `0.6.3-SNAPSHOT`
 
 
 

--- a/infra/charts/feast/requirements.yaml
+++ b/infra/charts/feast/requirements.yaml
@@ -1,17 +1,17 @@
 dependencies:
 - name: feast-core
-  version: 0.6.2
+  version: 0.6.3-SNAPSHOT
   condition: feast-core.enabled
 - name: feast-serving
   alias: feast-online-serving
-  version: 0.6.2
+  version: 0.6.3-SNAPSHOT
   condition: feast-online-serving.enabled
 - name: feast-serving
   alias: feast-batch-serving
-  version: 0.6.2
+  version: 0.6.3-SNAPSHOT
   condition: feast-batch-serving.enabled
 - name: feast-jupyter
-  version: 0.6.2
+  version: 0.6.3-SNAPSHOT
   condition: feast-jupyter.enabled
 - name: postgresql
   version: 8.6.1

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </modules>
 
     <properties>
-        <revision>0.6.2 </revision>
+        <revision>0.6.3-SNAPSHOT</revision>
         <github.url>https://github.com/feast-dev/feast</github.url>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Fixes docker image building in `v0.6-branch` pushing to `latest` instead of expected Git commit SHA.
- fixes [this](https://github.com/feast-dev/feast/runs/952897101?check_suite_focus=true#step:10:1) failure of `master only` build and push docker images step
- fixes by backporting `master` Makefile.

Changes Versions to `0.6.3-SNAPSHOT` post release `0.6.2`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
