### PR TITLE
Prevent field duplications on schema merge in BigQuery sink

### DIFF
--- a/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
+++ b/storage/connectors/bigquery/src/test/java/feast/storage/connectors/bigquery/writer/BigQuerySinkTest.java
@@ -315,7 +315,9 @@ public class BigQuerySinkTest {
                 TableId.of("test-project", "test_dataset", "myproject_fs_2"),
                 StandardTableDefinition.of(
                     Schema.of(
-                        Field.of("old_feature_1", LegacySQLTypeName.FLOAT),
+                        Field.newBuilder("old_feature_1", LegacySQLTypeName.FLOAT)
+                            .setDescription("Some old description")
+                            .build(),
                         Field.of("old_feature_2", LegacySQLTypeName.INTEGER)))));
 
     FeatureSetSpec spec_fs_2 =
@@ -331,6 +333,11 @@ public class BigQuerySinkTest {
                 FeatureSpec.newBuilder()
                     .setName("feature")
                     .setValueType(ValueProto.ValueType.Enum.STRING)
+                    .build())
+            .addFeatures(
+                FeatureSpec.newBuilder()
+                    .setName("old_feature_1")
+                    .setValueType(ValueProto.ValueType.Enum.FLOAT)
                     .build())
             .build();
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

After BQ table was edited outside of ingestion job we might fail on generating schema from `FeatureSetSpec`:
```
org.apache.beam.sdk.util.UserCodeException: java.lang.IllegalArgumentException: Multiple entries with same key: s2id_13=6 and s2id_13=0
```
since we expect TableFields to be completely equal (including description).

This PR fix that with overwriting existing fields by using Map (that keeps inserting order) instead of merging two Lists.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
