### PR TITLE
JobCoordinator can be configured to use only subset of FeatureSets or Stores

### DIFF
--- a/core/src/main/java/feast/core/config/FeastProperties.java
+++ b/core/src/main/java/feast/core/config/FeastProperties.java
@@ -22,6 +22,7 @@ import feast.auth.config.SecurityProperties.AuthorizationProperties;
 import feast.common.logging.config.LoggingProperties;
 import feast.common.validators.OneOfStrings;
 import feast.core.config.FeastProperties.StreamProperties.FeatureStreamOptions;
+import feast.proto.core.StoreProto;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -114,6 +115,30 @@ public class FeastProperties {
 
       /* Labels to identify jobs managed by this job coordinator */
       private Map<String, String> jobSelector = new HashMap<>();
+
+      /* Selectors to define featureSets that are responsibility of current JobManager */
+      private List<Selector> featureSetSelector = new ArrayList<>();
+
+      /* Specify names of stores that must not be used by current JobManager */
+      private List<String> blacklistedStores = new ArrayList<>();
+
+      /**
+       * Similarly to Store's subscription this selector defines set of FeatureSets. All FeatureSets
+       * that match both project and name will be selected. Project and name may use *
+       */
+      @Getter
+      @Setter
+      public static class Selector {
+        private String project;
+        private String name;
+
+        public StoreProto.Store.Subscription toSubscription() {
+          return StoreProto.Store.Subscription.newBuilder()
+              .setName(this.name)
+              .setProject(this.project)
+              .build();
+        }
+      }
     }
 
     /** List of configured job runners. */

--- a/core/src/main/java/feast/core/config/FeastProperties.java
+++ b/core/src/main/java/feast/core/config/FeastProperties.java
@@ -117,10 +117,10 @@ public class FeastProperties {
       private Map<String, String> jobSelector = new HashMap<>();
 
       /* Selectors to define featureSets that are responsibility of current JobManager */
-      private List<Selector> featureSetSelector = new ArrayList<>();
+      private List<FeatureSetSelector> featureSetSelector = new ArrayList<>();
 
-      /* Specify names of stores that must not be used by current JobManager */
-      private List<String> blacklistedStores = new ArrayList<>();
+      /* Specify names of stores that must be used by current JobManager */
+      private List<String> whitelistedStores = new ArrayList<>();
 
       /**
        * Similarly to Store's subscription this selector defines set of FeatureSets. All FeatureSets
@@ -128,7 +128,7 @@ public class FeastProperties {
        */
       @Getter
       @Setter
-      public static class Selector {
+      public static class FeatureSetSelector {
         private String project;
         private String name;
 

--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -67,7 +67,7 @@ public class JobCoordinatorService {
   private final JobGroupingStrategy groupingStrategy;
   private final KafkaTemplate<String, FeatureSetSpec> specPublisher;
   private final List<Store.Subscription> featureSetSubscriptions;
-  private final List<String> blacklistedStores;
+  private final List<String> whitelistedStores;
 
   @Autowired
   public JobCoordinatorService(
@@ -85,9 +85,9 @@ public class JobCoordinatorService {
     this.groupingStrategy = groupingStrategy;
     this.featureSetSubscriptions =
         feastProperties.getJobs().getCoordinator().getFeatureSetSelector().stream()
-            .map(JobProperties.CoordinatorProperties.Selector::toSubscription)
+            .map(JobProperties.CoordinatorProperties.FeatureSetSelector::toSubscription)
             .collect(Collectors.toList());
-    this.blacklistedStores = feastProperties.getJobs().getCoordinator().getBlacklistedStores();
+    this.whitelistedStores = feastProperties.getJobs().getCoordinator().getWhitelistedStores();
   }
 
   /**
@@ -298,7 +298,7 @@ public class JobCoordinatorService {
   private List<Store> getAllStores() {
     ListStoresResponse listStoresResponse = specService.listStores(Filter.newBuilder().build());
     return listStoresResponse.getStoreList().stream()
-        .filter(s -> !this.blacklistedStores.contains(s.getName()))
+        .filter(s -> this.whitelistedStores.contains(s.getName()))
         .collect(Collectors.toList());
   }
 

--- a/core/src/main/java/feast/core/service/JobCoordinatorService.java
+++ b/core/src/main/java/feast/core/service/JobCoordinatorService.java
@@ -66,6 +66,8 @@ public class JobCoordinatorService {
   private final JobProperties jobProperties;
   private final JobGroupingStrategy groupingStrategy;
   private final KafkaTemplate<String, FeatureSetSpec> specPublisher;
+  private final List<Store.Subscription> featureSetSubscriptions;
+  private final List<String> blacklistedStores;
 
   @Autowired
   public JobCoordinatorService(
@@ -81,6 +83,11 @@ public class JobCoordinatorService {
     this.jobProperties = feastProperties.getJobs();
     this.specPublisher = specPublisher;
     this.groupingStrategy = groupingStrategy;
+    this.featureSetSubscriptions =
+        feastProperties.getJobs().getCoordinator().getFeatureSetSelector().stream()
+            .map(JobProperties.CoordinatorProperties.Selector::toSubscription)
+            .collect(Collectors.toList());
+    this.blacklistedStores = feastProperties.getJobs().getCoordinator().getBlacklistedStores();
   }
 
   /**
@@ -290,7 +297,9 @@ public class JobCoordinatorService {
 
   private List<Store> getAllStores() {
     ListStoresResponse listStoresResponse = specService.listStores(Filter.newBuilder().build());
-    return listStoresResponse.getStoreList();
+    return listStoresResponse.getStoreList().stream()
+        .filter(s -> !this.blacklistedStores.contains(s.getName()))
+        .collect(Collectors.toList());
   }
 
   /**
@@ -319,7 +328,7 @@ public class JobCoordinatorService {
    * @param store to get subscribed FeatureSets for
    * @return list of FeatureSets that the store subscribes to.
    */
-  private List<FeatureSet> getFeatureSetsForStore(Store store) {
+  List<FeatureSet> getFeatureSetsForStore(Store store) {
     return store.getSubscriptionsList().stream()
         .flatMap(
             subscription -> {
@@ -330,7 +339,14 @@ public class JobCoordinatorService {
                             .setProject(subscription.getProject())
                             .setFeatureSetName(subscription.getName())
                             .build())
-                    .getFeatureSetsList().stream();
+                    .getFeatureSetsList().stream()
+                    .filter(
+                        f ->
+                            this.featureSetSubscriptions.isEmpty()
+                                || isSubscribedToFeatureSet(
+                                    this.featureSetSubscriptions,
+                                    f.getSpec().getProject(),
+                                    f.getSpec().getName()));
               } catch (InvalidProtocolBufferException e) {
                 throw new RuntimeException(
                     String.format(

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -80,8 +80,11 @@ feast:
       featureSetSelector:
         - project: "*"
           name: "*"
-      # Stores names that won't be used by current instance of JobManager
-      blacklisted-stores: []
+      # Stores names that are enabled on current instance of JobManager
+      whitelisted-stores:
+        - online
+        - online_cluster
+        - historical
 
   stream:
     # Feature stream type. Only kafka is supported.

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -78,8 +78,8 @@ feast:
 
       # Specify feature sets that should be handled by current instance of JobManager
       featureSetSelector:
-        - project: *
-          name: *
+        - project: "*"
+          name: "*"
       # Stores names that won't be used by current instance of JobManager
       blacklisted-stores: []
 

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -76,6 +76,13 @@ feast:
       jobSelector:
         application: feast
 
+      # Specify feature sets that should be handled by current instance of JobManager
+      featureSetSelector:
+        - project: *
+          name: *
+      # Stores names that won't be used by current instance of JobManager
+      blacklisted-stores: []
+
   stream:
     # Feature stream type. Only kafka is supported.
     type: kafka

--- a/core/src/test/java/feast/core/service/JobCoordinatorIT.java
+++ b/core/src/test/java/feast/core/service/JobCoordinatorIT.java
@@ -55,7 +55,9 @@ import org.springframework.kafka.core.KafkaTemplate;
       "feast.jobs.enabled=true",
       "feast.jobs.polling_interval_milliseconds=1000",
       "feast.stream.specsOptions.notifyIntervalMilliseconds=100",
-      "feast.jobs.coordinator.consolidate-jobs-per-source=true"
+      "feast.jobs.coordinator.consolidate-jobs-per-source=true",
+      "feast.jobs.coordinator.feature-set-selector[0].name=test",
+      "feast.jobs.coordinator.feature-set-selector[0].project=default"
     })
 public class JobCoordinatorIT extends BaseIT {
   @Autowired private FakeJobManager jobManager;
@@ -127,7 +129,7 @@ public class JobCoordinatorIT extends BaseIT {
   @Test
   public void shouldUpgradeJobWhenStoreChanged() {
     apiClient.simpleApplyFeatureSet(
-        DataGenerator.createFeatureSet(DataGenerator.getDefaultSource(), "project", "test"));
+        DataGenerator.createFeatureSet(DataGenerator.getDefaultSource(), "default", "test"));
 
     await().until(jobManager::getAllJobs, hasSize(1));
 
@@ -151,7 +153,7 @@ public class JobCoordinatorIT extends BaseIT {
   @Test
   public void shouldRestoreJobThatStopped() {
     apiClient.simpleApplyFeatureSet(
-        DataGenerator.createFeatureSet(DataGenerator.getDefaultSource(), "project", "test"));
+        DataGenerator.createFeatureSet(DataGenerator.getDefaultSource(), "default", "test"));
 
     await().until(jobManager::getAllJobs, hasSize(1));
     Job job = jobRepository.findByStatus(JobStatus.RUNNING).get(0);
@@ -173,10 +175,27 @@ public class JobCoordinatorIT extends BaseIT {
                     hasProperty("id", not(ingestionJobs.get(0).getId())))));
   }
 
+  @Test
+  @SneakyThrows
+  public void shouldNotCreateJobForUnwantedFeatureSet() {
+    apiClient.simpleApplyFeatureSet(
+        DataGenerator.createFeatureSet(DataGenerator.getDefaultSource(), "default", "other"));
+
+    Thread.sleep(2000);
+
+    assertThat(jobManager.getAllJobs(), hasSize(0));
+  }
+
   @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
   @Nested
   class SpecNotificationFlow extends SequentialFlow {
     Job job;
+
+    @AfterAll
+    public void tearDown() {
+      jobManager.cleanAll();
+      jobRepository.deleteAll();
+    }
 
     @Test
     @Order(1)

--- a/core/src/test/java/feast/core/service/JobCoordinatorIT.java
+++ b/core/src/test/java/feast/core/service/JobCoordinatorIT.java
@@ -57,7 +57,9 @@ import org.springframework.kafka.core.KafkaTemplate;
       "feast.stream.specsOptions.notifyIntervalMilliseconds=100",
       "feast.jobs.coordinator.consolidate-jobs-per-source=true",
       "feast.jobs.coordinator.feature-set-selector[0].name=test",
-      "feast.jobs.coordinator.feature-set-selector[0].project=default"
+      "feast.jobs.coordinator.feature-set-selector[0].project=default",
+      "feast.jobs.coordinator.whitelisted-stores[0]=test-store",
+      "feast.jobs.coordinator.whitelisted-stores[1]=new-store",
     })
 public class JobCoordinatorIT extends BaseIT {
   @Autowired private FakeJobManager jobManager;

--- a/core/src/test/java/feast/core/service/JobCoordinatorServiceTest.java
+++ b/core/src/test/java/feast/core/service/JobCoordinatorServiceTest.java
@@ -75,15 +75,16 @@ public class JobCoordinatorServiceTest {
     JobProperties jobProperties = new JobProperties();
     jobProperties.setJobUpdateTimeoutSeconds(5);
 
-    JobProperties.CoordinatorProperties.Selector selector =
-        new JobProperties.CoordinatorProperties.Selector();
+    JobProperties.CoordinatorProperties.FeatureSetSelector selector =
+        new JobProperties.CoordinatorProperties.FeatureSetSelector();
     selector.setName("fs*");
     selector.setProject("*");
 
     JobProperties.CoordinatorProperties coordinatorProperties =
         new JobProperties.CoordinatorProperties();
     coordinatorProperties.setFeatureSetSelector(ImmutableList.of(selector));
-    coordinatorProperties.setBlacklistedStores(ImmutableList.of("blacklisted-store"));
+    coordinatorProperties.setWhitelistedStores(
+        ImmutableList.of("test-store", "test", "test-1", "test-2", "normal-store"));
 
     jobProperties.setCoordinator(coordinatorProperties);
     feastProperties.setJobs(jobProperties);

--- a/core/src/test/java/feast/core/service/JobCoordinatorServiceTest.java
+++ b/core/src/test/java/feast/core/service/JobCoordinatorServiceTest.java
@@ -17,6 +17,7 @@
 package feast.core.service;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
 import static org.hamcrest.core.Is.isA;
@@ -73,7 +74,20 @@ public class JobCoordinatorServiceTest {
     feastProperties = new FeastProperties();
     JobProperties jobProperties = new JobProperties();
     jobProperties.setJobUpdateTimeoutSeconds(5);
+
+    JobProperties.CoordinatorProperties.Selector selector =
+        new JobProperties.CoordinatorProperties.Selector();
+    selector.setName("fs*");
+    selector.setProject("*");
+
+    JobProperties.CoordinatorProperties coordinatorProperties =
+        new JobProperties.CoordinatorProperties();
+    coordinatorProperties.setFeatureSetSelector(ImmutableList.of(selector));
+    coordinatorProperties.setBlacklistedStores(ImmutableList.of("blacklisted-store"));
+
+    jobProperties.setCoordinator(coordinatorProperties);
     feastProperties.setJobs(jobProperties);
+
     TestUtil.setupAuditLogger();
 
     JobManager jobManager = mock(JobManager.class);
@@ -136,8 +150,8 @@ public class JobCoordinatorServiceTest {
     Source source1 = DataGenerator.createSource("servers:9092", "topic");
     Source source2 = DataGenerator.createSource("others.servers:9092", "topic");
 
-    FeatureSet featureSet1 = DataGenerator.createFeatureSet(source1, "project1", "features1");
-    FeatureSet featureSet2 = DataGenerator.createFeatureSet(source2, "project1", "features2");
+    FeatureSet featureSet1 = DataGenerator.createFeatureSet(source1, "project1", "fs1");
+    FeatureSet featureSet2 = DataGenerator.createFeatureSet(source2, "project1", "fs2");
 
     when(specService.listFeatureSets(
             Filter.newBuilder().setFeatureSetName("*").setProject("project1").build()))
@@ -170,8 +184,8 @@ public class JobCoordinatorServiceTest {
     Source source1 = DataGenerator.createSource("servers:9092", "topic");
     Source source2 = DataGenerator.createSource("other.servers:9092", "topic");
 
-    FeatureSet featureSet1 = DataGenerator.createFeatureSet(source1, "default", "feature1");
-    FeatureSet featureSet2 = DataGenerator.createFeatureSet(source2, "default", "feature2");
+    FeatureSet featureSet1 = DataGenerator.createFeatureSet(source1, "default", "fs1");
+    FeatureSet featureSet2 = DataGenerator.createFeatureSet(source2, "default", "fs2");
 
     when(specService.listFeatureSets(
             Filter.newBuilder().setFeatureSetName("features1").setProject("*").build()))
@@ -268,7 +282,7 @@ public class JobCoordinatorServiceTest {
 
     Source source = DataGenerator.createSource("servers:9092", "topic");
 
-    FeatureSet featureSet = DataGenerator.createFeatureSet(source, "default", "features1");
+    FeatureSet featureSet = DataGenerator.createFeatureSet(source, "default", "fs1");
 
     when(specService.listFeatureSets(
             Filter.newBuilder().setFeatureSetName("*").setProject("*").build()))
@@ -310,7 +324,6 @@ public class JobCoordinatorServiceTest {
     Store store2 =
         DataGenerator.createStore(
             "test-2", Store.StoreType.REDIS, ImmutableList.of(Triple.of("*", "*", false)));
-    ;
 
     Source source = DataGenerator.createSource("servers:9092", "topic");
 
@@ -332,5 +345,63 @@ public class JobCoordinatorServiceTest {
 
     assertThat(jobTasks, hasSize(1));
     assertThat(jobTasks, hasItem(isA(CreateJobTask.class)));
+  }
+
+  @Test
+  @SneakyThrows
+  public void shouldSelectOnlyFeatureSetsThatJobManagerSubscribedTo() {
+    Store store = DataGenerator.getDefaultStore();
+    Source source = DataGenerator.getDefaultSource();
+
+    FeatureSet featureSet1 = DataGenerator.createFeatureSet(source, "default", "fs1");
+    FeatureSet featureSet2 = DataGenerator.createFeatureSet(source, "project", "fs3");
+    FeatureSet featureSet3 = DataGenerator.createFeatureSet(source, "default", "not-fs");
+
+    when(specService.listFeatureSets(
+            Filter.newBuilder().setFeatureSetName("*").setProject("*").build()))
+        .thenReturn(
+            ListFeatureSetsResponse.newBuilder()
+                .addAllFeatureSets(Lists.newArrayList(featureSet1, featureSet2, featureSet3))
+                .build());
+
+    List<FeatureSet> featureSetsForStore = jcsWithConsolidation.getFeatureSetsForStore(store);
+    assertThat(featureSetsForStore, containsInAnyOrder(featureSet1, featureSet2));
+  }
+
+  @Test
+  @SneakyThrows
+  public void shouldSelectOnlyStoresThatNotBlacklisted() {
+    Store store1 =
+        DataGenerator.createStore(
+            "normal-store",
+            Store.StoreType.REDIS,
+            ImmutableList.of(Triple.of("project1", "*", false)));
+    Store store2 =
+        DataGenerator.createStore(
+            "blacklisted-store",
+            Store.StoreType.REDIS,
+            ImmutableList.of(Triple.of("project2", "*", false)));
+
+    Source source1 = DataGenerator.createSource("source-1", "topic");
+    Source source2 = DataGenerator.createSource("source-2", "topic");
+
+    FeatureSet featureSet1 = DataGenerator.createFeatureSet(source1, "default", "fs1");
+    FeatureSet featureSet2 = DataGenerator.createFeatureSet(source2, "project", "fs3");
+
+    when(specService.listStores(any()))
+        .thenReturn(ListStoresResponse.newBuilder().addStore(store1).addStore(store2).build());
+
+    when(specService.listFeatureSets(
+            Filter.newBuilder().setProject("project1").setFeatureSetName("*").build()))
+        .thenReturn(ListFeatureSetsResponse.newBuilder().addFeatureSets(featureSet1).build());
+
+    when(specService.listFeatureSets(
+            Filter.newBuilder().setProject("project2").setFeatureSetName("*").build()))
+        .thenReturn(ListFeatureSetsResponse.newBuilder().addFeatureSets(featureSet2).build());
+
+    ArrayList<Pair<Source, Set<Store>>> pairs =
+        Lists.newArrayList(jcsWithConsolidation.getSourceToStoreMappings());
+
+    assertThat(pairs, containsInAnyOrder(Pair.of(source1, ImmutableSet.of(store1))));
   }
 }

--- a/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
+++ b/infra/scripts/test-templates/values-end-to-end-batch-dataflow.yaml
@@ -25,6 +25,12 @@ feast-core:
           jobSelector:
             application: feast
             tag: $IMAGE_TAG
+          featureSetSelector:
+            - project: "*"
+              name: "*"
+          whitelisted-stores:
+            - online
+            - historical
         runners:
         - name: dataflow
           type: DataflowRunner


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR adds ability to configure via application properties which FeatureSets and Stores will be available in (and managed by) current instance of JobManager.

This should be useful when you have several deployments of JobManager and each will be responsible for only subset of FeatureSets.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
# application.yaml
feast:
  jobs:
    coordinator:
      # Specify feature sets that should be handled by current instance of JobManager
      featureSetSelector:
        - project: "*"
          name: "*"
      # Stores names that won't be used by current instance of JobManager
      whitelisted-stores: [online, online_cluster, historical]
```
