### PR TITLE
Get job controller deployment for docker compose back

### DIFF
--- a/infra/docker-compose/.env.sample
+++ b/infra/docker-compose/.env.sample
@@ -2,6 +2,7 @@ COMPOSE_PROJECT_NAME=feast
 FEAST_VERSION=0.6.2
 GCP_SERVICE_ACCOUNT=./gcp-service-accounts/key.json
 FEAST_CORE_CONFIG=./core/core.yml
+FEAST_JOB_CONTROLLER_CONFIG=./jobcontroller/jobcontroller.yml
 FEAST_HISTORICAL_SERVING_CONFIG=./serving/historical-serving.yml
 FEAST_HISTORICAL_SERVING_ENABLED=false
 FEAST_ONLINE_SERVING_CONFIG=./serving/online-serving.yml

--- a/infra/docker-compose/core/core.yml
+++ b/infra/docker-compose/core/core.yml
@@ -1,13 +1,4 @@
 feast:
-  jobs:
-    polling_interval_milliseconds: 20000
-    job_update_timeout_seconds: 240
-    active_runner: direct
-    runners:
-      - name: direct
-        type: DirectRunner
-        options:
-          tempLocation: gs://bucket/tempLocation
   stream:
     type: kafka
     options:

--- a/infra/docker-compose/docker-compose.yml
+++ b/infra/docker-compose/docker-compose.yml
@@ -21,6 +21,23 @@ services:
       - /opt/feast/feast-core.jar
       - --spring.config.location=classpath:/application.yml,file:/etc/feast/application.yml
 
+  jobcontroller:
+    image: gcr.io/kf-feast/feast-jobcontroller:${FEAST_VERSION}
+    volumes:
+      - ${FEAST_JOB_CONTROLLER_CONFIG}:/etc/feast/application.yml
+      - ${GCP_SERVICE_ACCOUNT}:/etc/gcloud/service-accounts/key.json
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: /etc/gcloud/service-accounts/key.json
+    depends_on:
+      - kafka
+    ports:
+      - 6570:6570
+    command:
+      - java
+      - -jar
+      - /opt/feast/feast-job-controller.jar
+      - --spring.config.location=classpath:/application.yml,file:/etc/feast/application.yml
+
   jupyter:
     image: gcr.io/kf-feast/feast-jupyter:${FEAST_VERSION}
     volumes:

--- a/infra/docker-compose/jobcontroller/jobcontroller.yml
+++ b/infra/docker-compose/jobcontroller/jobcontroller.yml
@@ -1,0 +1,16 @@
+feast:
+  core-host: core
+  jobs:
+    polling_interval_milliseconds: 20000
+    job_update_timeout_seconds: 240
+    active_runner: direct
+    runners:
+      - name: direct
+        type: DirectRunner
+        options:
+          tempLocation: gs://bucket/tempLocation
+  stream:
+    type: kafka
+    options:
+      topic: feast-features
+      bootstrapServers: "kafka:9092,localhost:9094"


### PR DESCRIPTION
This reverts commit 5b72335ca08dad361895fc928918615cd63b2158.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

To fix load tests we need to have docker compose config sync with master (latest dev) structure.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
