### PR TITLE
Configurable kafka consumer in IngestionJob

### DIFF
--- a/ingestion/src/main/java/feast/ingestion/ImportJob.java
+++ b/ingestion/src/main/java/feast/ingestion/ImportJob.java
@@ -120,6 +120,7 @@ public class ImportJob {
                 .setSource(source)
                 .setSuccessTag(FEATURE_ROW_OUT)
                 .setFailureTag(DEADLETTER_OUT)
+                .setKafkaConsumerProperties(options.getKafkaConsumerProperties())
                 .build());
 
     // Step 3. Process and validate incoming FeatureRows
@@ -172,14 +173,6 @@ public class ImportJob {
         DeadletterSink deadletterSink =
             new BigQueryDeadletterSink(options.getDeadLetterTableSpec());
 
-        convertedFeatureRows
-            .get(DEADLETTER_OUT)
-            .apply("WriteFailedElements_ReadFromSource", deadletterSink.write());
-
-        validatedRows
-            .get(DEADLETTER_OUT)
-            .apply("WriteFailedElements_ValidateRows", deadletterSink.write());
-
         writeFeatureRows
             .getFailedInserts()
             .apply("WriteFailedElements_WriteFeatureRowToStore", deadletterSink.write());
@@ -193,6 +186,18 @@ public class ImportJob {
       writeFeatureRows
           .getFailedInserts()
           .apply("WriteFailureMetrics", WriteFailureMetricsTransform.create(store.getName()));
+    }
+
+    if (options.getDeadLetterTableSpec() != null) {
+      DeadletterSink deadletterSink = new BigQueryDeadletterSink(options.getDeadLetterTableSpec());
+
+      convertedFeatureRows
+          .get(DEADLETTER_OUT)
+          .apply("WriteFailedElements_ReadFromSource", deadletterSink.write());
+
+      validatedRows
+          .get(DEADLETTER_OUT)
+          .apply("WriteFailedElements_ValidateRows", deadletterSink.write());
     }
 
     sinkReadiness

--- a/ingestion/src/main/java/feast/ingestion/ImportJob.java
+++ b/ingestion/src/main/java/feast/ingestion/ImportJob.java
@@ -41,6 +41,7 @@ import feast.storage.api.writer.FeatureSink;
 import feast.storage.api.writer.WriteResult;
 import feast.storage.connectors.bigquery.writer.BigQueryDeadletterSink;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -120,7 +121,10 @@ public class ImportJob {
                 .setSource(source)
                 .setSuccessTag(FEATURE_ROW_OUT)
                 .setFailureTag(DEADLETTER_OUT)
-                .setKafkaConsumerProperties(options.getKafkaConsumerProperties())
+                .setKafkaConsumerProperties(
+                    options.getKafkaConsumerProperties() == null
+                        ? new HashMap<>()
+                        : options.getKafkaConsumerProperties())
                 .build());
 
     // Step 3. Process and validate incoming FeatureRows

--- a/ingestion/src/main/java/feast/ingestion/options/ImportOptions.java
+++ b/ingestion/src/main/java/feast/ingestion/options/ImportOptions.java
@@ -18,7 +18,6 @@ package feast.ingestion.options;
 
 import java.util.List;
 import java.util.Map;
-
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.direct.DirectOptions;
 import org.apache.beam.sdk.options.Default;
@@ -75,9 +74,7 @@ public interface ImportOptions extends PipelineOptions, DataflowPipelineOptions,
 
   void setStoresJson(List<String> storeJson);
 
-  @Required
-  @Description(
-      "Properties Map for Kafka Consumer used to pull FeatureRows")
+  @Description("Properties Map for Kafka Consumer used to pull FeatureRows")
   Map<String, String> getKafkaConsumerProperties();
 
   void setKafkaConsumerProperties(Map<String, String> kafkaConsumerProperties);

--- a/ingestion/src/main/java/feast/ingestion/options/ImportOptions.java
+++ b/ingestion/src/main/java/feast/ingestion/options/ImportOptions.java
@@ -17,6 +17,8 @@
 package feast.ingestion.options;
 
 import java.util.List;
+import java.util.Map;
+
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.direct.DirectOptions;
 import org.apache.beam.sdk.options.Default;
@@ -72,6 +74,13 @@ public interface ImportOptions extends PipelineOptions, DataflowPipelineOptions,
   List<String> getStoresJson();
 
   void setStoresJson(List<String> storeJson);
+
+  @Required
+  @Description(
+      "Properties Map for Kafka Consumer used to pull FeatureRows")
+  Map<String, String> getKafkaConsumerProperties();
+
+  void setKafkaConsumerProperties(Map<String, String> kafkaConsumerProperties);
 
   @Description(
       "(Optional) Deadletter elements will be written to this BigQuery table."

--- a/ingestion/src/main/java/feast/ingestion/transform/ReadFromSource.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/ReadFromSource.java
@@ -24,6 +24,8 @@ import feast.proto.core.SourceProto.SourceType;
 import feast.proto.types.FeatureRowProto.FeatureRow;
 import feast.storage.api.writer.FailedElement;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.io.kafka.KafkaIO;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -33,6 +35,7 @@ import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 @AutoValue
 public abstract class ReadFromSource extends PTransform<PBegin, PCollectionTuple> {
@@ -42,6 +45,8 @@ public abstract class ReadFromSource extends PTransform<PBegin, PCollectionTuple
   public abstract TupleTag<FeatureRow> getSuccessTag();
 
   public abstract TupleTag<FailedElement> getFailureTag();
+
+  public abstract Map<String, String> getKafkaConsumerProperties();
 
   public static Builder newBuilder() {
     return new AutoValue_ReadFromSource.Builder();
@@ -55,6 +60,8 @@ public abstract class ReadFromSource extends PTransform<PBegin, PCollectionTuple
     public abstract Builder setSuccessTag(TupleTag<FeatureRow> successTag);
 
     public abstract Builder setFailureTag(TupleTag<FailedElement> failureTag);
+
+    public abstract Builder setKafkaConsumerProperties(Map<String, String> kafkaConsumerProperties);
 
     abstract ReadFromSource autobuild();
 
@@ -75,6 +82,10 @@ public abstract class ReadFromSource extends PTransform<PBegin, PCollectionTuple
 
   @Override
   public PCollectionTuple expand(PBegin input) {
+    Map<String, Object> consumerProperties = new HashMap<>(getKafkaConsumerProperties());
+    consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG,
+        generateConsumerGroupId(input.getPipeline().getOptions().getJobName()));
+
     return input
         .getPipeline()
         .apply(
@@ -82,10 +93,7 @@ public abstract class ReadFromSource extends PTransform<PBegin, PCollectionTuple
             KafkaIO.readBytes()
                 .withBootstrapServers(getSource().getKafkaSourceConfig().getBootstrapServers())
                 .withTopic(getSource().getKafkaSourceConfig().getTopic())
-                .withConsumerConfigUpdates(
-                    ImmutableMap.of(
-                        "group.id",
-                        generateConsumerGroupId(input.getPipeline().getOptions().getJobName())))
+                .withConsumerConfigUpdates(consumerProperties)
                 .withReadCommitted()
                 .commitOffsetsInFinalize())
         .apply(

--- a/ingestion/src/main/java/feast/ingestion/transform/ReadFromSource.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/ReadFromSource.java
@@ -34,7 +34,6 @@ import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 @AutoValue
@@ -83,7 +82,8 @@ public abstract class ReadFromSource extends PTransform<PBegin, PCollectionTuple
   @Override
   public PCollectionTuple expand(PBegin input) {
     Map<String, Object> consumerProperties = new HashMap<>(getKafkaConsumerProperties());
-    consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG,
+    consumerProperties.put(
+        ConsumerConfig.GROUP_ID_CONFIG,
         generateConsumerGroupId(input.getPipeline().getOptions().getJobName()));
 
     return input

--- a/job-controller/src/main/java/feast/jobcontroller/runner/dataflow/DataflowRunnerConfig.java
+++ b/job-controller/src/main/java/feast/jobcontroller/runner/dataflow/DataflowRunnerConfig.java
@@ -47,6 +47,7 @@ public class DataflowRunnerConfig extends RunnerConfig {
     this.labels = runnerConfigOptions.getLabelsMap();
     this.enableStreamingEngine = runnerConfigOptions.getEnableStreamingEngine();
     this.workerDiskType = runnerConfigOptions.getWorkerDiskType();
+    this.kafkaConsumerProperties = runnerConfigOptions.getKafkaConsumerPropertiesMap();
     validate();
   }
 
@@ -99,6 +100,9 @@ public class DataflowRunnerConfig extends RunnerConfig {
 
   /* Type of persistent disk to be used by workers */
   public String workerDiskType;
+
+  /* Kafka Consumer Config Properties used in FeatureRow Consumer */
+  public Map<String, String> kafkaConsumerProperties;
 
   /** Validates Dataflow runner configuration options */
   public void validate() {

--- a/job-controller/src/main/resources/application.yml
+++ b/job-controller/src/main/resources/application.yml
@@ -56,6 +56,9 @@ feast:
           usePublicIps: false
           workerMachineType: n1-standard-1
           deadLetterTableSpec: project_id:dataset_id.table_id
+          kafkaConsumerProperties:
+            "max.poll.records": "50000"
+            "receive.buffer.bytes": "33554432"
 
     # Configuration options for metric collection for all ingestion jobs
     metrics:

--- a/protos/feast/core/Runner.proto
+++ b/protos/feast/core/Runner.proto
@@ -86,4 +86,7 @@ message DataflowRunnerConfigOptions {
 
     /* Type of persistent disk to be used by workers */
     string workerDiskType = 16;
+
+    /* Kafka consumer configuration properties */
+    map<string, string> kafkaConsumerProperties = 17;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Kafka consumer that pulls FeatureRows from source should be configurable (via `jobcontroller` application properties) to be able to tune it for better performance.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
application.yml in jobcontroller

feast:
  jobs:
    runners:
    - name: dataflow
      options:
        kafkaConsumerProperties:
          "max.poll.records": "50000"
          "receive.buffer.bytes": "33554432"
```
