### PR TITLE
Add request response logging via fluentd

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -158,6 +158,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.fluentd</groupId>
+            <artifactId>fluent-logger</artifactId>
+            <version>0.3.1</version>
+        </dependency>
 
         <!-- Bean Validation API support -->
         <dependency>

--- a/common/src/main/java/feast/common/logging/AuditLogger.java
+++ b/common/src/main/java/feast/common/logging/AuditLogger.java
@@ -26,7 +26,6 @@ import feast.common.logging.entry.LogResource;
 import feast.common.logging.entry.LogResource.ResourceType;
 import feast.common.logging.entry.MessageAuditLogEntry;
 import feast.common.logging.entry.TransitionAuditLogEntry;
-import io.grpc.Status;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -151,11 +150,9 @@ public class AuditLogger {
         fluentdLogs.put("request", JsonFormat.printer().print(messageAuditLogEntry.getRequest()));
         fluentdLogs.put("response", JsonFormat.printer().print(messageAuditLogEntry.getResponse()));
       } catch (InvalidProtocolBufferException e) {
-        throw Status.INTERNAL
-            .withDescription(
-                "Request/Response log conversion to JSON failed. Unable to forward logs to logging service.")
-            .withCause(e)
-            .asRuntimeException();
+        log.error(
+            "Request/Response log conversion to JSON failed. Unable to forward logs to logging service.",
+            e);
       }
       fluentLogger.log("fluentd", fluentdLogs);
     } else {

--- a/common/src/main/java/feast/common/logging/AuditLogger.java
+++ b/common/src/main/java/feast/common/logging/AuditLogger.java
@@ -128,11 +128,6 @@ public class AuditLogger {
     if (!properties.isEnabled()) {
       return;
     }
-    if (entry.getKind().equals(AuditLogEntryKind.MESSAGE)
-        && properties.getMessageLogging() != null
-        && !properties.getMessageLogging().isEnabled()) {
-      return;
-    }
 
     // Either forward log to logging layer or log to console
     if (properties.getMessageLogging().getDestination().equals(FLUENTD_DESTINATION)) {

--- a/common/src/main/java/feast/common/logging/AuditLogger.java
+++ b/common/src/main/java/feast/common/logging/AuditLogger.java
@@ -42,7 +42,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class AuditLogger {
-  private static final String DESTINATION = "fluentd";
+  private static final String FLUENTD_DESTINATION = "fluentd";
   private static final String DEFAULT_RELEASE_NAME = "feast-0-0";
   private static final Marker AUDIT_MARKER = MarkerFactory.getMarker("AUDIT_MARK");
   private static FluentLogger fluentLogger;
@@ -136,7 +136,7 @@ public class AuditLogger {
     }
 
     // Either forward log to logging layer or log to console
-    if (properties.getMessageLogging().getDestination().equals(DESTINATION)) {
+    if (properties.getMessageLogging().getDestination().equals(FLUENTD_DESTINATION)) {
       Map<String, Object> fluentdLogs = new HashMap<>();
       String releaseName =
           StringUtils.defaultIfEmpty(System.getenv("RELEASE_NAME"), DEFAULT_RELEASE_NAME);

--- a/common/src/main/java/feast/common/logging/AuditLogger.java
+++ b/common/src/main/java/feast/common/logging/AuditLogger.java
@@ -52,12 +52,12 @@ public class AuditLogger {
     // This allows us to use the dependencies in the AuditLogger's static methods
     AuditLogger.properties = loggingProperties.getAudit();
     AuditLogger.buildProperties = buildProperties;
-    if (AuditLogger.properties.getLogForwarderProperties().isEnabled()) {
+    if (AuditLogger.properties.getMessageLogging().isEnabled()) {
       AuditLogger.fluentLogger =
           FluentLogger.getLogger(
               "feast",
-              AuditLogger.properties.getLogForwarderProperties().getFluentdHost(),
-              AuditLogger.properties.getLogForwarderProperties().getFluentdPort());
+              AuditLogger.properties.getMessageLogging().getFluentdHost(),
+              AuditLogger.properties.getMessageLogging().getFluentdPort());
     }
   }
 
@@ -124,10 +124,14 @@ public class AuditLogger {
     if (!properties.isEnabled()) {
       return;
     }
+    if (entry.getKind().equals(AuditLogEntryKind.MESSAGE)
+        && !properties.getMessageLogging().isEnabled()) {
+      return;
+    }
 
     // Either forward log to logging layer or log to console
     Map<String, Object> fluentdLogs = new HashMap<>();
-    if (properties.getLogForwarderProperties().isEnabled()) {
+    if (properties.getMessageLogging().getDestination().equals("fluentd")) {
       MessageAuditLogEntry messageAuditLogEntry = (MessageAuditLogEntry) entry;
       try {
         fluentdLogs.put("id", messageAuditLogEntry.getId());

--- a/common/src/main/java/feast/common/logging/config/LoggingProperties.java
+++ b/common/src/main/java/feast/common/logging/config/LoggingProperties.java
@@ -24,20 +24,6 @@ import lombok.Setter;
 @Setter
 public class LoggingProperties {
   @NotNull private AuditLogProperties audit;
-  @NotNull private LogForwarderProperties logForwarderProperties;
-
-  @Getter
-  @Setter
-  public static class LogForwarderProperties {
-    // Whether to enable/disable (request/response) log forwarding entirely.
-    private boolean enabled;
-
-    // fluentD service host for external (request/response) logging.
-    private String fluentdHost;
-
-    // fluentD service port for external (request/response) logging.
-    private Integer fluentdPort;
-  }
 
   @Getter
   @Setter
@@ -47,5 +33,20 @@ public class LoggingProperties {
 
     // Whether to enable/disable message level (ie request/response) audit logging.
     private boolean messageLoggingEnabled;
+
+    private LogForwarderProperties logForwarderProperties;
+
+    @Getter
+    @Setter
+    public static class LogForwarderProperties {
+      // Whether to enable/disable (request/response) log forwarding entirely.
+      private boolean enabled;
+
+      // fluentD service host for external (request/response) logging.
+      private String fluentdHost;
+
+      // fluentD service port for external (request/response) logging.
+      private Integer fluentdPort;
+    }
   }
 }

--- a/common/src/main/java/feast/common/logging/config/LoggingProperties.java
+++ b/common/src/main/java/feast/common/logging/config/LoggingProperties.java
@@ -24,6 +24,20 @@ import lombok.Setter;
 @Setter
 public class LoggingProperties {
   @NotNull private AuditLogProperties audit;
+  @NotNull private LogForwarderProperties forwarder;
+
+  @Getter
+  @Setter
+  public static class LogForwarderProperties {
+    // Whether to enable/disable (request/response) log forwarding entirely.
+    private boolean enabled;
+
+    // fluentD service host for external (request/response) logging.
+    private String fluentdHost;
+
+    // fluentD service port for external (request/response) logging.
+    private Integer fluentdPort;
+  }
 
   @Getter
   @Setter

--- a/common/src/main/java/feast/common/logging/config/LoggingProperties.java
+++ b/common/src/main/java/feast/common/logging/config/LoggingProperties.java
@@ -24,7 +24,7 @@ import lombok.Setter;
 @Setter
 public class LoggingProperties {
   @NotNull private AuditLogProperties audit;
-  @NotNull private LogForwarderProperties forwarder;
+  @NotNull private LogForwarderProperties logForwarderProperties;
 
   @Getter
   @Setter

--- a/common/src/main/java/feast/common/logging/config/LoggingProperties.java
+++ b/common/src/main/java/feast/common/logging/config/LoggingProperties.java
@@ -31,16 +31,16 @@ public class LoggingProperties {
     // Whether to enable/disable audit logging entirely.
     private boolean enabled;
 
-    // Whether to enable/disable message level (ie request/response) audit logging.
-    private boolean messageLoggingEnabled;
-
-    private LogForwarderProperties logForwarderProperties;
+    private MessageLogging messageLogging;
 
     @Getter
     @Setter
-    public static class LogForwarderProperties {
-      // Whether to enable/disable (request/response) log forwarding entirely.
+    public static class MessageLogging {
+      // Whether to enable/disable message level (ie request/response) audit logging.
       private boolean enabled;
+
+      // Whether to log to console or fluentd
+      private String destination;
 
       // fluentD service host for external (request/response) logging.
       private String fluentdHost;

--- a/common/src/main/java/feast/common/logging/config/LoggingProperties.java
+++ b/common/src/main/java/feast/common/logging/config/LoggingProperties.java
@@ -16,6 +16,7 @@
  */
 package feast.common.logging.config;
 
+import feast.common.validators.OneOfStrings;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
@@ -40,6 +41,7 @@ public class LoggingProperties {
       private boolean enabled;
 
       // Whether to log to console or fluentd
+      @OneOfStrings({"console", "fluentd"})
       private String destination;
 
       // fluentD service host for external (request/response) logging.

--- a/common/src/main/java/feast/common/logging/interceptors/GrpcMessageInterceptor.java
+++ b/common/src/main/java/feast/common/logging/interceptors/GrpcMessageInterceptor.java
@@ -33,7 +33,6 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import java.util.Map;
-import lombok.SneakyThrows;
 import org.slf4j.event.Level;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
@@ -105,7 +104,6 @@ public class GrpcMessageInterceptor implements ServerInterceptor {
             entryBuilder.setResponse((Message) message);
           }
 
-          @SneakyThrows
           @Override
           public void close(Status status, Metadata trailers) {
             super.close(status, trailers);

--- a/common/src/main/java/feast/common/logging/interceptors/GrpcMessageInterceptor.java
+++ b/common/src/main/java/feast/common/logging/interceptors/GrpcMessageInterceptor.java
@@ -33,6 +33,7 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import java.util.Map;
+import lombok.SneakyThrows;
 import org.slf4j.event.Level;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
@@ -104,6 +105,7 @@ public class GrpcMessageInterceptor implements ServerInterceptor {
             entryBuilder.setResponse((Message) message);
           }
 
+          @SneakyThrows
           @Override
           public void close(Status status, Metadata trailers) {
             super.close(status, trailers);

--- a/common/src/main/java/feast/common/logging/interceptors/GrpcMessageInterceptor.java
+++ b/common/src/main/java/feast/common/logging/interceptors/GrpcMessageInterceptor.java
@@ -69,7 +69,7 @@ public class GrpcMessageInterceptor implements ServerInterceptor {
   public <ReqT, RespT> Listener<ReqT> interceptCall(
       ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
     // Disable the message logging interceptor entirely if message logging is disabled.
-    if (!loggingProperties.getAudit().isMessageLoggingEnabled()) {
+    if (!loggingProperties.getAudit().getMessageLogging().isEnabled()) {
       return next.startCall(call, headers);
     }
 

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -53,7 +53,7 @@ feast:
   logging:
     # Logging forwarder currently provides a machine readable structured JSON log to an
     # external fluentd service that can give better insight into what is happening in Feast.
-    forwarder:
+    logForwarderProperties:
       enabled: false
       fluentdHost: localhost
       fluentdPort: 24224

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -51,12 +51,6 @@ feast:
     disableRestControllerAuth: false
 
   logging:
-    # Logging forwarder currently provides a machine readable structured JSON log to an
-    # external fluentd service that can give better insight into what is happening in Feast.
-    logForwarderProperties:
-      enabled: false
-      fluentdHost: localhost
-      fluentdPort: 24224
     # Audit logging provides a machine readable structured JSON log that can give better 
     # insight into what is happening in Feast.
     audit:
@@ -64,6 +58,12 @@ feast:
       enabled: true
       # Whether to enable message level (ie request/response) audit logging
       messageLoggingEnabled: false
+      # Logging forwarder currently provides a machine readable structured JSON log to an
+      # external fluentd service that can give better insight into what is happening in Feast.
+      logForwarderProperties:
+        enabled: false
+        fluentdHost: localhost
+        fluentdPort: 24224
 
 grpc:
   server:

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -57,11 +57,12 @@ feast:
       # Whether audit logging is enabled. 
       enabled: true
       # Whether to enable message level (ie request/response) audit logging
-      messageLoggingEnabled: false
-      # Logging forwarder currently provides a machine readable structured JSON log to an
-      # external fluentd service that can give better insight into what is happening in Feast.
-      logForwarderProperties:
+      messageLogging:
         enabled: false
+        # Logging forwarder currently provides a machine readable structured JSON log to an
+        # external fluentd service that can give better insight into what is happening in Feast.
+        # Accepts console / fluentd as destination
+        destination: console
         fluentdHost: localhost
         fluentdPort: 24224
 

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -51,6 +51,12 @@ feast:
     disableRestControllerAuth: false
 
   logging:
+    # Logging forwarder currently provides a machine readable structured JSON log to an
+    # external fluentd service that can give better insight into what is happening in Feast.
+    forwarder:
+      enabled: false
+      fluentdHost: localhost
+      fluentdPort: 24224
     # Audit logging provides a machine readable structured JSON log that can give better 
     # insight into what is happening in Feast.
     audit:

--- a/core/src/test/java/feast/core/logging/CoreLoggingIT.java
+++ b/core/src/test/java/feast/core/logging/CoreLoggingIT.java
@@ -59,7 +59,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(
     properties = {
       "feast.logging.audit.enabled=true",
-      "feast.logging.audit.messageLoggingEnabled=true",
+      "feast.logging.audit.messageLogging.enabled=true",
+      "feast.logging.audit.messageLogging.destination=console"
     })
 public class CoreLoggingIT extends BaseIT {
   private static TestLogAppender testAuditLogAppender;

--- a/job-controller/src/main/resources/application.yml
+++ b/job-controller/src/main/resources/application.yml
@@ -111,6 +111,12 @@ feast:
       notifyIntervalMilliseconds: 1000
         
   logging:
+    # Logging forwarder currently provides a machine readable structured JSON log to an
+    # external fluentd service that can give better insight into what is happening in Feast.
+    logForwarderProperties:
+      enabled: false
+      fluentdHost: localhost
+      fluentdPort: 24224
     # Audit logging provides a machine readable structured JSON log that can give better 
     # insight into what is happening in Feast.
     audit:

--- a/job-controller/src/main/resources/application.yml
+++ b/job-controller/src/main/resources/application.yml
@@ -117,11 +117,12 @@ feast:
       # Whether audit logging is enabled. 
       enabled: true
       # Whether to enable message level (ie request/response) audit logging
-      messageLoggingEnabled: false
-      # Logging forwarder currently provides a machine readable structured JSON log to an
-      # external fluentd service that can give better insight into what is happening in Feast.
-      logForwarderProperties:
+      messageLogging:
         enabled: false
+        # Logging forwarder currently provides a machine readable structured JSON log to an
+        # external fluentd service that can give better insight into what is happening in Feast.
+        # Accepts console / fluentd as destination
+        destination: console
         fluentdHost: localhost
         fluentdPort: 24224
 

--- a/job-controller/src/main/resources/application.yml
+++ b/job-controller/src/main/resources/application.yml
@@ -111,12 +111,6 @@ feast:
       notifyIntervalMilliseconds: 1000
         
   logging:
-    # Logging forwarder currently provides a machine readable structured JSON log to an
-    # external fluentd service that can give better insight into what is happening in Feast.
-    logForwarderProperties:
-      enabled: false
-      fluentdHost: localhost
-      fluentdPort: 24224
     # Audit logging provides a machine readable structured JSON log that can give better 
     # insight into what is happening in Feast.
     audit:
@@ -124,6 +118,12 @@ feast:
       enabled: true
       # Whether to enable message level (ie request/response) audit logging
       messageLoggingEnabled: false
+      # Logging forwarder currently provides a machine readable structured JSON log to an
+      # external fluentd service that can give better insight into what is happening in Feast.
+      logForwarderProperties:
+        enabled: false
+        fluentdHost: localhost
+        fluentdPort: 24224
 
 grpc:
   server:

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -100,12 +100,6 @@ feast:
     redis_port: 6379
 
   logging:
-    # Logging forwarder currently provides a machine readable structured JSON log to an
-    # external fluentd service that can give better insight into what is happening in Feast.
-    logForwarderProperties:
-      enabled: false
-      fluentdHost: localhost
-      fluentdPort: 24224
     # Audit logging provides a machine readable structured JSON log that can give better 
     # insight into what is happening in Feast.
     audit:
@@ -113,6 +107,12 @@ feast:
       enabled: true
       # Whether to enable message level (ie request/response) audit logging
       messageLoggingEnabled: false
+      # Logging forwarder currently provides a machine readable structured JSON log to an
+      # external fluentd service that can give better insight into what is happening in Feast.
+      logForwarderProperties:
+        enabled: false
+        fluentdHost: localhost
+        fluentdPort: 24224
 
 grpc:
   server:

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -100,6 +100,12 @@ feast:
     redis_port: 6379
 
   logging:
+    # Logging forwarder currently provides a machine readable structured JSON log to an
+    # external fluentd service that can give better insight into what is happening in Feast.
+    logForwarderProperties:
+      enabled: false
+      fluentdHost: localhost
+      fluentdPort: 24224
     # Audit logging provides a machine readable structured JSON log that can give better 
     # insight into what is happening in Feast.
     audit:

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -106,11 +106,12 @@ feast:
       # Whether audit logging is enabled. 
       enabled: true
       # Whether to enable message level (ie request/response) audit logging
-      messageLoggingEnabled: false
-      # Logging forwarder currently provides a machine readable structured JSON log to an
-      # external fluentd service that can give better insight into what is happening in Feast.
-      logForwarderProperties:
+      messageLogging:
         enabled: false
+        # Logging forwarder currently provides a machine readable structured JSON log to an
+        # external fluentd service that can give better insight into what is happening in Feast.
+        # Accepts console / fluentd as destination
+        destination: console
         fluentdHost: localhost
         fluentdPort: 24224
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR introduces the option to enable request/response logging to an external fluentd service. This is an addition to the existing Audit logging capabilities which logs to the console.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now enable forwarding of logs to an external fluentd service that's been setup.
```
