### PR TITLE
Use grpc interceptor for open tracing and ensure that trace id is propagated

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/feast-dev/feast/sdk/go/protos/feast/serving"
 	"google.golang.org/grpc"
 
+	"github.com/opentracing-contrib/go-grpc"
 	"go.opencensus.io/plugin/ocgrpc"
 )
 
@@ -24,12 +25,35 @@ type GrpcClient struct {
 	conn *grpc.ClientConn
 }
 
-// NewGrpcClient constructs a client that can interact via grpc with the feast serving instance at the given host:port.
-func NewGrpcClient(host string, port int) (*GrpcClient, error) {
-	feastCli := &GrpcClient{}
+// GrpcClientBuilder is used to construct the client with more advanced options.
+type GrpcClientBuilder struct {
+	host   string
+	port   int
+	tracer opentracing.Tracer
+}
 
-	adr := fmt.Sprintf("%s:%d", host, port)
-	conn, err := grpc.Dial(adr, grpc.WithStatsHandler(&ocgrpc.ClientHandler{}), grpc.WithInsecure())
+// WithTracer supplies an existing tracer instance to Feast client, so that the gRPC calls
+// to Feast Online Serving can be traced. If no tracer is supplied, a no ops tracer will
+// be used instead.
+func (builder *GrpcClientBuilder) WithTracer(tracer opentracing.Tracer) *GrpcClientBuilder {
+	builder.tracer = tracer
+	return builder
+}
+
+// Build build the client.
+func (builder *GrpcClientBuilder) Build() (*GrpcClient, error) {
+
+	feastCli := &GrpcClient{}
+	if builder.tracer == nil {
+		builder.tracer = opentracing.NoopTracer{}
+	}
+
+	adr := fmt.Sprintf("%s:%d", builder.host, builder.port)
+	conn, err := grpc.Dial(adr, grpc.WithStatsHandler(&ocgrpc.ClientHandler{}), grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(
+			otgrpc.OpenTracingClientInterceptor(builder.tracer)),
+		grpc.WithStreamInterceptor(
+			otgrpc.OpenTracingStreamClientInterceptor(builder.tracer)))
 	if err != nil {
 		return nil, err
 	}
@@ -38,11 +62,22 @@ func NewGrpcClient(host string, port int) (*GrpcClient, error) {
 	return feastCli, nil
 }
 
+// NewGrpcClientBuilder instantiate new GrpcClientBuilder.
+func NewGrpcClientBuilder(host string, port int) *GrpcClientBuilder {
+	return &GrpcClientBuilder{
+		host: host,
+		port: port,
+	}
+}
+
+// NewGrpcClient constructs a client that can interact via grpc with the feast serving instance at the given host:port.
+func NewGrpcClient(host string, port int) (*GrpcClient, error) {
+	return NewGrpcClientBuilder(host, port).Build()
+}
+
 // GetOnlineFeatures gets the latest values of the request features from the Feast serving instance provided.
 func (fc *GrpcClient) GetOnlineFeatures(ctx context.Context, req *OnlineFeaturesRequest) (
 	*OnlineFeaturesResponse, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "get_online_features")
-	defer span.Finish()
 
 	featuresRequest, err := req.buildRequest()
 	if err != nil {
@@ -63,8 +98,6 @@ func (fc *GrpcClient) GetOnlineFeatures(ctx context.Context, req *OnlineFeatures
 // GetFeastServingInfo gets information about the feast serving instance this client is connected to.
 func (fc *GrpcClient) GetFeastServingInfo(ctx context.Context, in *serving.GetFeastServingInfoRequest) (
 	*serving.GetFeastServingInfoResponse, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "get_info")
-	defer span.Finish()
 
 	return fc.cli.GetFeastServingInfo(ctx, in)
 }

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/feast-dev/feast/sdk/go/protos/feast/types"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
-	"github.com/opentracing/opentracing-go"
 )
 
 func TestGetOnlineFeatures(t *testing.T) {
@@ -62,10 +61,9 @@ func TestGetOnlineFeatures(t *testing.T) {
 			defer ctrl.Finish()
 			cli := mock_serving.NewMockServingServiceClient(ctrl)
 			ctx := context.Background()
-			_, traceCtx := opentracing.StartSpanFromContext(ctx, "get_online_features")
 			rawRequest, _ := tc.req.buildRequest()
 			resp := tc.want.RawResponse
-			cli.EXPECT().GetOnlineFeatures(traceCtx, rawRequest).Return(resp, nil).Times(1)
+			cli.EXPECT().GetOnlineFeatures(ctx, rawRequest).Return(resp, nil).Times(1)
 
 			client := &GrpcClient{
 				cli: cli,

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/golang/mock v1.4.3
 	github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0
 	github.com/google/go-cmp v0.4.0
+	github.com/opentracing-contrib/go-grpc v0.0.0-20200813121455-4a6760c71486
 	github.com/opentracing/opentracing-go v1.1.0
-	github.com/stretchr/testify v1.4.0 // indirect
 	go.opencensus.io v0.22.1
 	google.golang.org/grpc v1.28.0
 	google.golang.org/protobuf v1.21.0

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -35,6 +35,10 @@ github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 h1:MJG/KsmcqMwFAkh8mTnAwhyKoB+sTAnY4CACC110tbU=
+github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
+github.com/opentracing-contrib/go-grpc v0.0.0-20200813121455-4a6760c71486 h1:K35HCWaOTJIPW6cDHK4yj3QfRY/NhE0pBbfoc0M2NMQ=
+github.com/opentracing-contrib/go-grpc v0.0.0-20200813121455-4a6760c71486/go.mod h1:DYR5Eij8rJl8h7gblRrOZ8g0kW1umSpKqYIBTgeDtLo=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -57,6 +61,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJV
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190921015927-1a5e07d1ff72 h1:PdU68SuVQNpTFEyGl0zoQOMysY+E0innv/QbAqV853w=
+golang.org/x/net v0.0.0-20190921015927-1a5e07d1ff72/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -91,6 +97,7 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.28.0 h1:bO/TA4OxCOummhSf10siHuG7vJOiwh7SpRpFZDkOgl4=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -19,6 +19,7 @@
     <!-- TODO: Standardize other modules on JUnit 5 and move this to parent -->
     <junit.version>5.5.2</junit.version>
     <mockito.version>2.28.2</mockito.version>
+    <opentracing.version>0.33.0</opentracing.version>
   </properties>
 
   <dependencies>
@@ -32,6 +33,23 @@
       <groupId>dev.feast</groupId>
       <artifactId>feast-common</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <!-- Tracing -->
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-grpc</artifactId>
+      <version>0.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <version>${opentracing.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-noop</artifactId>
+      <version>${opentracing.version}</version>
     </dependency>
 
     <!-- GRPC and Protobuf -->

--- a/sdk/java/src/test/java/com/gojek/feast/FeastClientTest.java
+++ b/sdk/java/src/test/java/com/gojek/feast/FeastClientTest.java
@@ -35,6 +35,7 @@ import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
+import io.opentracing.noop.NoopTracerFactory;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -81,7 +82,7 @@ public class FeastClientTest {
     ManagedChannel channel =
         this.grpcRule.register(
             InProcessChannelBuilder.forName(serverName).directExecutor().build());
-    this.client = new FeastClient(channel);
+    this.client = new FeastClient(channel, NoopTracerFactory.create());
   }
 
   @Test

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -38,3 +38,4 @@ flake8
 black
 boto3
 moto
+grpcio-opentracing

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -46,6 +46,8 @@ REQUIRED = [
     "numpy",
     "google",
     "confluent_kafka",
+    "grpcio-opentracing",
+    "opentracing"
 ]
 
 # README file from Feast repo root directory

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -159,6 +159,13 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-grpc</artifactId>
+      <version>0.2.3</version>
+    </dependency>
+
     <!--compile "com.google.protobuf:protobuf-java-util:${protobuf.version}"-->
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -175,21 +182,21 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>
-    <!--compile 'io.jaegertracing:jaeger-client:0.31.0'-->
+    <!--compile 'io.jaegertracing:jaeger-client:1.3.2'-->
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-client</artifactId>
-      <version>0.31.0</version>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
-      <version>0.31.0</version>
+      <version>0.33.0</version>
     </dependency>
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-noop</artifactId>
-      <version>0.31.0</version>
+      <version>0.33.0</version>
     </dependency>
 
     <!-- The client -->

--- a/serving/src/main/java/feast/serving/config/InstrumentationConfig.java
+++ b/serving/src/main/java/feast/serving/config/InstrumentationConfig.java
@@ -17,6 +17,7 @@
 package feast.serving.config;
 
 import io.opentracing.Tracer;
+import io.opentracing.contrib.grpc.TracingServerInterceptor;
 import io.opentracing.noop.NoopTracerFactory;
 import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
@@ -53,5 +54,10 @@ public class InstrumentationConfig {
 
     return io.jaegertracing.Configuration.fromEnv(feastProperties.getTracing().getServiceName())
         .getTracer();
+  }
+
+  @Bean
+  public TracingServerInterceptor tracingInterceptor(Tracer tracer) {
+    return TracingServerInterceptor.newBuilder().withTracer(tracer).build();
   }
 }

--- a/serving/src/main/java/feast/serving/service/OnlineServingService.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingService.java
@@ -16,24 +16,21 @@
  */
 package feast.serving.service;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 import com.google.protobuf.Duration;
 import feast.common.models.Feature;
-import feast.common.models.FeatureSet;
 import feast.proto.serving.ServingAPIProto.*;
 import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesRequest.EntityRow;
 import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesResponse.FieldStatus;
 import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesResponse.FieldValues;
 import feast.proto.types.FeatureRowProto.FeatureRow;
-import feast.proto.types.FieldProto.Field;
 import feast.proto.types.ValueProto.Value;
 import feast.serving.specs.CachedSpecService;
 import feast.serving.util.Metrics;
 import feast.storage.api.retriever.FeatureSetRequest;
 import feast.storage.api.retriever.OnlineRetriever;
 import io.grpc.Status;
-import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.Tracer;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -66,86 +63,90 @@ public class OnlineServingService implements ServingService {
   /** {@inheritDoc} */
   @Override
   public GetOnlineFeaturesResponse getOnlineFeatures(GetOnlineFeaturesRequest request) {
-    try (Scope scope = tracer.buildSpan("getOnlineFeatures").startActive(true)) {
-      List<EntityRow> entityRows = request.getEntityRowsList();
-      // Collect the feature/entity value for each entity row in entityValueMap
-      Map<EntityRow, Map<String, Value>> entityValuesMap =
-          entityRows.stream().collect(Collectors.toMap(row -> row, row -> new HashMap<>()));
-      // Collect the feature/entity status metadata for each entity row in entityValueMap
-      Map<EntityRow, Map<String, FieldStatus>> entityStatusesMap =
-          entityRows.stream().collect(Collectors.toMap(row -> row, row -> new HashMap<>()));
-      // Collect featureRows retrieved for logging/tracing
-      List<List<Optional<FeatureRow>>> logFeatureRows = new LinkedList<>();
+    List<EntityRow> entityRows = request.getEntityRowsList();
+    // Collect the feature/entity value for each entity row in entityValueMap
+    Map<EntityRow, Map<String, Value>> entityValuesMap =
+        entityRows.stream().collect(Collectors.toMap(row -> row, row -> new HashMap<>()));
+    // Collect the feature/entity status metadata for each entity row in entityValueMap
+    Map<EntityRow, Map<String, FieldStatus>> entityStatusesMap =
+        entityRows.stream().collect(Collectors.toMap(row -> row, row -> new HashMap<>()));
 
-      if (!request.getOmitEntitiesInResponse()) {
-        // Add entity row's fields as response fields
-        entityRows.forEach(
-            entityRow -> {
-              Map<String, Value> valueMap = entityRow.getFieldsMap();
-              entityValuesMap.get(entityRow).putAll(valueMap);
-              entityStatusesMap.get(entityRow).putAll(getMetadataMap(valueMap, false, false));
-            });
-      }
-
-      List<FeatureSetRequest> featureSetRequests =
-          specService.getFeatureSets(request.getFeaturesList(), request.getProject());
-      for (FeatureSetRequest featureSetRequest : featureSetRequests) {
-        // Pull feature rows for given entity rows from the feature/featureset specified in feature
-        // set request.
-        // from the configured online
-        List<Optional<FeatureRow>> featureRows =
-            retriever.getOnlineFeatures(entityRows, featureSetRequest);
-        // Check that feature row returned corresponds to a given entity row.
-        if (featureRows.size() != entityRows.size()) {
-          throw Status.INTERNAL
-              .withDescription(
-                  "The no. of FeatureRow obtained from OnlineRetriever"
-                      + "does not match no. of entityRow passed.")
-              .asRuntimeException();
-        }
-
-        Streams.zip(entityRows.stream(), featureRows.stream(), Pair::of)
-            .forEach(
-                entityFeaturePair -> {
-                  EntityRow entityRow = entityFeaturePair.getLeft();
-                  Optional<FeatureRow> featureRow = entityFeaturePair.getRight();
-                  // Unpack feature field values and merge into entityValueMap
-                  boolean isOutsideMaxAge =
-                      checkOutsideMaxAge(featureSetRequest, entityRow, featureRow);
-                  Map<String, Value> valueMap =
-                      unpackValueMap(featureRow, featureSetRequest, isOutsideMaxAge);
-                  entityValuesMap.get(entityRow).putAll(valueMap);
-
-                  // Generate metadata for feature values and merge into entityFieldsMap
-                  boolean isNotFound = featureRow.isEmpty();
-                  Map<String, FieldStatus> statusMap =
-                      getMetadataMap(valueMap, isNotFound, isOutsideMaxAge);
-                  entityStatusesMap.get(entityRow).putAll(statusMap);
-
-                  // Populate metrics/log request
-                  populateCountMetrics(statusMap, featureSetRequest);
-                });
-        populateRequestCountMetrics(featureSetRequest);
-        logFeatureRows.add(featureRows);
-      }
-      if (scope != null) {
-        logFeatureRowsTrace(scope, logFeatureRows, featureSetRequests);
-      }
-
-      // Build response field values from entityValuesMap and entityStatusesMap
-      // Reponse field values should be in the same order as the entityRows provided by the user.
-      List<FieldValues> fieldValuesList =
-          entityRows.stream()
-              .map(
-                  entityRow -> {
-                    return FieldValues.newBuilder()
-                        .putAllFields(entityValuesMap.get(entityRow))
-                        .putAllStatuses(entityStatusesMap.get(entityRow))
-                        .build();
-                  })
-              .collect(Collectors.toList());
-      return GetOnlineFeaturesResponse.newBuilder().addAllFieldValues(fieldValuesList).build();
+    if (!request.getOmitEntitiesInResponse()) {
+      // Add entity row's fields as response fields
+      entityRows.forEach(
+          entityRow -> {
+            Map<String, Value> valueMap = entityRow.getFieldsMap();
+            entityValuesMap.get(entityRow).putAll(valueMap);
+            entityStatusesMap.get(entityRow).putAll(getMetadataMap(valueMap, false, false));
+          });
     }
+
+    Span specServiceSpan = tracer.buildSpan("getFeatureSets").start();
+    List<FeatureSetRequest> featureSetRequests =
+        specService.getFeatureSets(request.getFeaturesList(), request.getProject());
+    if (specServiceSpan != null) {
+      specServiceSpan.finish();
+    }
+    Span onlineRetrievalSpan = tracer.buildSpan("onlineRetrieval").start();
+    if (onlineRetrievalSpan != null) {
+      onlineRetrievalSpan.setTag("entities", entityRows.size());
+      onlineRetrievalSpan.setTag("feature sets", featureSetRequests.size());
+    }
+    for (FeatureSetRequest featureSetRequest : featureSetRequests) {
+      // Pull feature rows for given entity rows from the feature/featureset specified in feature
+      // set request.
+      // from the configured online
+      List<Optional<FeatureRow>> featureRows =
+          retriever.getOnlineFeatures(entityRows, featureSetRequest);
+      // Check that feature row returned corresponds to a given entity row.
+      if (featureRows.size() != entityRows.size()) {
+        throw Status.INTERNAL
+            .withDescription(
+                "The no. of FeatureRow obtained from OnlineRetriever"
+                    + "does not match no. of entityRow passed.")
+            .asRuntimeException();
+      }
+
+      Streams.zip(entityRows.stream(), featureRows.stream(), Pair::of)
+          .forEach(
+              entityFeaturePair -> {
+                EntityRow entityRow = entityFeaturePair.getLeft();
+                Optional<FeatureRow> featureRow = entityFeaturePair.getRight();
+                // Unpack feature field values and merge into entityValueMap
+                boolean isOutsideMaxAge =
+                    checkOutsideMaxAge(featureSetRequest, entityRow, featureRow);
+                Map<String, Value> valueMap =
+                    unpackValueMap(featureRow, featureSetRequest, isOutsideMaxAge);
+                entityValuesMap.get(entityRow).putAll(valueMap);
+
+                // Generate metadata for feature values and merge into entityFieldsMap
+                boolean isNotFound = featureRow.isEmpty();
+                Map<String, FieldStatus> statusMap =
+                    getMetadataMap(valueMap, isNotFound, isOutsideMaxAge);
+                entityStatusesMap.get(entityRow).putAll(statusMap);
+
+                // Populate metrics/log request
+                populateCountMetrics(statusMap, featureSetRequest);
+              });
+      populateRequestCountMetrics(featureSetRequest);
+    }
+    if (onlineRetrievalSpan != null) {
+      onlineRetrievalSpan.finish();
+    }
+
+    // Build response field values from entityValuesMap and entityStatusesMap
+    // Reponse field values should be in the same order as the entityRows provided by the user.
+    List<FieldValues> fieldValuesList =
+        entityRows.stream()
+            .map(
+                entityRow -> {
+                  return FieldValues.newBuilder()
+                      .putAllFields(entityValuesMap.get(entityRow))
+                      .putAllStatuses(entityStatusesMap.get(entityRow))
+                      .build();
+                })
+            .collect(Collectors.toList());
+    return GetOnlineFeaturesResponse.newBuilder().addAllFieldValues(fieldValuesList).build();
   }
 
   /**
@@ -252,40 +253,6 @@ public class OnlineServingService implements ServingService {
     }
     long timeDifference = givenTimestamp - featureRow.get().getEventTimestamp().getSeconds();
     return timeDifference > maxAge.getSeconds();
-  }
-
-  private void logFeatureRowsTrace(
-      Scope scope,
-      List<List<Optional<FeatureRow>>> logFeatureRows,
-      List<FeatureSetRequest> featureSetRequests) {
-    List<List<FeatureRow>> loggableFeatureRows =
-        Streams.zip(
-                logFeatureRows.stream(),
-                featureSetRequests.stream(),
-                (featureRows, featureSetRequest) -> {
-                  FeatureRow.Builder nullFeatureRowBuilder =
-                      FeatureRow.newBuilder()
-                          .setFeatureSet(
-                              FeatureSet.getFeatureSetStringRef(featureSetRequest.getSpec()));
-                  for (FeatureReference featureReference :
-                      featureSetRequest.getFeatureReferences()) {
-                    nullFeatureRowBuilder.addFields(
-                        Field.newBuilder().setName(featureReference.getName()));
-                  }
-
-                  // log null feature row when feature row is empty
-                  return featureRows.stream()
-                      .map(
-                          featureRow -> {
-                            return (featureRow.isEmpty())
-                                ? nullFeatureRowBuilder.build()
-                                : featureRow.get();
-                          })
-                      .collect(Collectors.toList());
-                })
-            .collect(Collectors.toList());
-
-    scope.span().log(ImmutableMap.of("event", "featureRows", "value", loggableFeatureRows));
   }
 
   private void populateCountMetrics(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Feast Serving and Feast Golang SDK uses Jaeger tracing. However, the spans are collected in such a way that the propagation context are ignored. As a result, the trace from client and server side exists as separated, independent spans.

In addition, the tracer instance is not initialized properly in the Feast Golang SDK. The SDK users should have been allowed to pass an existing tracer instance to the client, so that the Feast spans can be connected with the existing traces from the client side.

This PR use third party interceptor libraries to capture the trace for both client and server, which takes care of the trace id propagation.

Tracing support has also been added to Java and Python SDK.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Tracing support has been added to Feast SDK. Users are now able to pass existing instance of Open Tracing Tracer to Feast clients.

The span operation name will be different, as the interceptor library use a different naming convention than the name that was hard coded previously.
```
