### PR TITLE
Fetch Job's Created Datetime from Dataflow

### DIFF
--- a/job-controller/src/main/java/feast/jobcontroller/model/Job.java
+++ b/job-controller/src/main/java/feast/jobcontroller/model/Job.java
@@ -88,10 +88,10 @@ public abstract class Job {
   }
 
   public void preSave() {
-    if (created == null) {
-      created = new Date();
+    if (this.created == null) {
+      this.created = new Date();
     }
-    lastUpdated = new Date();
+    this.lastUpdated = new Date();
   }
 
   public void setExtId(String extId) {
@@ -100,6 +100,11 @@ public abstract class Job {
 
   public void setStatus(JobStatus status) {
     this.status = status;
+  }
+
+  public void setCreated(Date created) {
+    this.created = created;
+    this.lastUpdated = created;
   }
 
   public boolean hasTerminated() {

--- a/job-controller/src/main/java/feast/jobcontroller/runner/dataflow/DataflowJobManager.java
+++ b/job-controller/src/main/java/feast/jobcontroller/runner/dataflow/DataflowJobManager.java
@@ -51,6 +51,7 @@ import org.apache.beam.runners.dataflow.DataflowPipelineJob;
 import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.joda.time.DateTime;
 
 @Slf4j
 public class DataflowJobManager implements JobManager {
@@ -307,6 +308,9 @@ public class DataflowJobManager implements JobManager {
 
               job.setExtId(dfJob.getId());
               job.setStatus(JobStatus.RUNNING);
+              if (dfJob.getCreateTime() != null) {
+                job.setCreated(DateTime.parse(dfJob.getCreateTime()).toDate());
+              }
 
               return job;
             })

--- a/job-controller/src/main/resources/application.yml
+++ b/job-controller/src/main/resources/application.yml
@@ -57,8 +57,8 @@ feast:
           workerMachineType: n1-standard-1
           deadLetterTableSpec: project_id:dataset_id.table_id
           kafkaConsumerProperties:
-            "max.poll.records": "50000"
-            "receive.buffer.bytes": "33554432"
+            "[max.poll.records]": "50000"
+            "[receive.buffer.bytes]": "33554432"
 
     # Configuration options for metric collection for all ingestion jobs
     metrics:

--- a/job-controller/src/test/java/feast/jobcontroller/runner/dataflow/DataflowJobManagerTest.java
+++ b/job-controller/src/test/java/feast/jobcontroller/runner/dataflow/DataflowJobManagerTest.java
@@ -51,6 +51,8 @@ import org.apache.beam.runners.dataflow.DataflowPipelineJob;
 import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -237,6 +239,8 @@ public class DataflowJobManagerTest {
 
     Printer jsonPrinter = JsonFormat.printer();
 
+    LocalDateTime created = DateTime.now().toLocalDateTime();
+
     when(dataflow
             .projects()
             .locations()
@@ -248,6 +252,7 @@ public class DataflowJobManagerTest {
             new com.google.api.services.dataflow.model.Job()
                 .setLabels(ImmutableMap.of("application", "feast"))
                 .setId("job-2")
+                .setCreateTime(created.toString())
                 .setEnvironment(
                     new Environment()
                         .setSdkPipelineOptions(
@@ -268,7 +273,9 @@ public class DataflowJobManagerTest {
                 hasProperty("id", equalTo("kafka-to-redis")),
                 hasProperty("source", equalTo(source)),
                 hasProperty("stores", hasValue(store)),
-                hasProperty("extId", equalTo("job-2")))));
+                hasProperty("extId", equalTo("job-2")),
+                hasProperty("created", equalTo(created.toDate())),
+                hasProperty("lastUpdated", equalTo(created.toDate())))));
   }
 
   @Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

When JobController starts - it pulls existing jobs from dataflow. However, created datetime was missing. This PR fix that.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
