### PR TITLE
Fetch Job's labels from dataflow

### DIFF
--- a/job-controller/src/main/java/feast/jobcontroller/runner/dataflow/DataflowJobManager.java
+++ b/job-controller/src/main/java/feast/jobcontroller/runner/dataflow/DataflowJobManager.java
@@ -304,6 +304,10 @@ public class DataflowJobManager implements JobManager {
                       .setStores(
                           stores.stream()
                               .collect(Collectors.toMap(StoreProto.Store::getName, s -> s)))
+                      .setLabels(
+                          dfJob.getLabels() == null
+                              ? new HashMap<>()
+                              : new HashMap<>(dfJob.getLabels()))
                       .build();
 
               job.setExtId(dfJob.getId());

--- a/job-controller/src/test/java/feast/jobcontroller/runner/dataflow/DataflowJobManagerTest.java
+++ b/job-controller/src/test/java/feast/jobcontroller/runner/dataflow/DataflowJobManagerTest.java
@@ -275,7 +275,8 @@ public class DataflowJobManagerTest {
                 hasProperty("stores", hasValue(store)),
                 hasProperty("extId", equalTo("job-2")),
                 hasProperty("created", equalTo(created.toDate())),
-                hasProperty("lastUpdated", equalTo(created.toDate())))));
+                hasProperty("lastUpdated", equalTo(created.toDate())),
+                hasProperty("labels", hasEntry("application", "feast")))));
   }
 
   @Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Job's labels are missing in JobRepository after JobController restarted.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
