### PR TITLE
Add configurable prefix to Consumer Group in IngestionJob's Kafka reader

### DIFF
--- a/job-controller/src/main/java/feast/jobcontroller/config/FeastProperties.java
+++ b/job-controller/src/main/java/feast/jobcontroller/config/FeastProperties.java
@@ -176,6 +176,10 @@ public class FeastProperties {
     /* Population job metric properties */
     private MetricsProperties metrics;
 
+    @NotNull
+    /* Prefix for JobId to separate consumer groups for independent jobs running in parallel */
+    private String jobIdPrefix;
+
     /* Timeout in seconds for each attempt to update or submit a new job to the runner */
     @Positive private long jobUpdateTimeoutSeconds;
 

--- a/job-controller/src/main/java/feast/jobcontroller/config/JobControllerConfig.java
+++ b/job-controller/src/main/java/feast/jobcontroller/config/JobControllerConfig.java
@@ -87,9 +87,9 @@ public class JobControllerConfig {
     Boolean shouldConsolidateJobs =
         feastProperties.getJobs().getController().getConsolidateJobsPerSource();
     if (shouldConsolidateJobs) {
-      return new ConsolidatedJobStrategy(jobRepository);
+      return new ConsolidatedJobStrategy(jobRepository, feastProperties.getJobs());
     } else {
-      return new JobPerStoreStrategy(jobRepository);
+      return new JobPerStoreStrategy(jobRepository, feastProperties.getJobs());
     }
   }
 

--- a/job-controller/src/main/java/feast/jobcontroller/config/JobControllerConfig.java
+++ b/job-controller/src/main/java/feast/jobcontroller/config/JobControllerConfig.java
@@ -86,10 +86,11 @@ public class JobControllerConfig {
       FeastProperties feastProperties, JobRepository jobRepository) {
     Boolean shouldConsolidateJobs =
         feastProperties.getJobs().getController().getConsolidateJobsPerSource();
+    FeastProperties.JobProperties jobProperties = feastProperties.getJobs();
     if (shouldConsolidateJobs) {
-      return new ConsolidatedJobStrategy(jobRepository, feastProperties.getJobs());
+      return new ConsolidatedJobStrategy(jobRepository, jobProperties);
     } else {
-      return new JobPerStoreStrategy(jobRepository, feastProperties.getJobs());
+      return new JobPerStoreStrategy(jobRepository, jobProperties);
     }
   }
 

--- a/job-controller/src/main/java/feast/jobcontroller/runner/ConsolidatedJobStrategy.java
+++ b/job-controller/src/main/java/feast/jobcontroller/runner/ConsolidatedJobStrategy.java
@@ -74,7 +74,8 @@ public class ConsolidatedJobStrategy implements JobGroupingStrategy {
                 source.getKafkaSourceConfig().getBootstrapServers(),
                 source.getKafkaSourceConfig().getTopic()),
             dateSuffix);
-    if (!this.jobProperties.getJobIdPrefix().isEmpty()) {
+    if (this.jobProperties.getJobIdPrefix() != null
+        && !this.jobProperties.getJobIdPrefix().isEmpty()) {
       jobId = this.jobProperties.getJobIdPrefix() + "-" + jobId;
     }
     return jobId.replaceAll("_store", "-").toLowerCase();

--- a/job-controller/src/main/java/feast/jobcontroller/runner/ConsolidatedJobStrategy.java
+++ b/job-controller/src/main/java/feast/jobcontroller/runner/ConsolidatedJobStrategy.java
@@ -16,6 +16,7 @@
  */
 package feast.jobcontroller.runner;
 
+import feast.jobcontroller.config.FeastProperties.JobProperties;
 import feast.jobcontroller.dao.JobRepository;
 import feast.jobcontroller.model.Job;
 import feast.jobcontroller.model.JobStatus;
@@ -38,9 +39,11 @@ import org.apache.commons.lang3.tuple.Pair;
  */
 public class ConsolidatedJobStrategy implements JobGroupingStrategy {
   private final JobRepository jobRepository;
+  private final JobProperties jobProperties;
 
-  public ConsolidatedJobStrategy(JobRepository jobRepository) {
+  public ConsolidatedJobStrategy(JobRepository jobRepository, JobProperties jobProperties) {
     this.jobRepository = jobRepository;
+    this.jobProperties = jobProperties;
   }
 
   @Override
@@ -71,6 +74,9 @@ public class ConsolidatedJobStrategy implements JobGroupingStrategy {
                 source.getKafkaSourceConfig().getBootstrapServers(),
                 source.getKafkaSourceConfig().getTopic()),
             dateSuffix);
+    if (!this.jobProperties.getJobIdPrefix().isEmpty()) {
+      jobId = this.jobProperties.getJobIdPrefix() + "-" + jobId;
+    }
     return jobId.replaceAll("_store", "-").toLowerCase();
   }
 

--- a/job-controller/src/main/java/feast/jobcontroller/runner/JobPerStoreStrategy.java
+++ b/job-controller/src/main/java/feast/jobcontroller/runner/JobPerStoreStrategy.java
@@ -17,6 +17,7 @@
 package feast.jobcontroller.runner;
 
 import com.google.common.collect.Lists;
+import feast.jobcontroller.config.FeastProperties.JobProperties;
 import feast.jobcontroller.dao.JobRepository;
 import feast.jobcontroller.model.Job;
 import feast.jobcontroller.model.JobStatus;
@@ -38,9 +39,11 @@ import org.apache.commons.lang3.tuple.Pair;
  */
 public class JobPerStoreStrategy implements JobGroupingStrategy {
   private final JobRepository jobRepository;
+  private final JobProperties jobProperties;
 
-  public JobPerStoreStrategy(JobRepository jobRepository) {
+  public JobPerStoreStrategy(JobRepository jobRepository, JobProperties jobProperties) {
     this.jobRepository = jobRepository;
+    this.jobProperties = jobProperties;
   }
 
   @Override
@@ -78,6 +81,9 @@ public class JobPerStoreStrategy implements JobGroupingStrategy {
                 source.getKafkaSourceConfig().getTopic()),
             Lists.newArrayList(stores).get(0).getName(),
             dateSuffix);
+    if (!this.jobProperties.getJobIdPrefix().isEmpty()) {
+      jobId = this.jobProperties.getJobIdPrefix() + "-" + jobId;
+    }
     return jobId.replaceAll("_store", "-").toLowerCase();
   }
 

--- a/job-controller/src/main/java/feast/jobcontroller/runner/JobPerStoreStrategy.java
+++ b/job-controller/src/main/java/feast/jobcontroller/runner/JobPerStoreStrategy.java
@@ -81,7 +81,8 @@ public class JobPerStoreStrategy implements JobGroupingStrategy {
                 source.getKafkaSourceConfig().getTopic()),
             Lists.newArrayList(stores).get(0).getName(),
             dateSuffix);
-    if (!this.jobProperties.getJobIdPrefix().isEmpty()) {
+    if (this.jobProperties.getJobIdPrefix() != null
+        && !this.jobProperties.getJobIdPrefix().isEmpty()) {
       jobId = this.jobProperties.getJobIdPrefix() + "-" + jobId;
     }
     return jobId.replaceAll("_store", "-").toLowerCase();

--- a/job-controller/src/main/resources/application.yml
+++ b/job-controller/src/main/resources/application.yml
@@ -23,6 +23,9 @@ feast:
     # Enabling JobManagement
     enabled: true
 
+    # Prefix for JobId
+    job_id_prefix: ""
+
     # Job update polling interval in milliseconds: how often Feast checks if new jobs should be sent to the runner.
     polling_interval_milliseconds: 60000
 

--- a/job-controller/src/main/resources/application.yml
+++ b/job-controller/src/main/resources/application.yml
@@ -23,7 +23,7 @@ feast:
     # Enabling JobManagement
     enabled: true
 
-    # Prefix for JobId
+    # Configurable Prefix for JobId to allow jobs working in parallel to separate their Kafka consumer groups
     job_id_prefix: ""
 
     # Job update polling interval in milliseconds: how often Feast checks if new jobs should be sent to the runner.

--- a/job-controller/src/test/java/feast/jobcontroller/service/JobControllerIT.java
+++ b/job-controller/src/test/java/feast/jobcontroller/service/JobControllerIT.java
@@ -65,6 +65,7 @@ import org.springframework.util.SocketUtils;
 @SpringBootTest(
     properties = {
       "feast.jobs.enabled=true",
+      "feast.jobs.job_id_prefix=test-prefix",
       "feast.jobs.polling_interval_milliseconds=1000",
       "feast.stream.specsOptions.notifyIntervalMilliseconds=1000",
       "feast.jobs.controller.consolidate-jobs-per-source=true",
@@ -166,6 +167,9 @@ public class JobControllerIT extends BaseIT {
 
     assertThat(
         jobManager.getAllJobs(), containsInAnyOrder(hasProperty("id", equalTo(job.getId()))));
+    assertThat(
+        jobManager.getAllJobs(),
+        containsInAnyOrder(hasProperty("id", containsString("test-prefix"))));
   }
 
   @Test

--- a/job-controller/src/test/java/feast/jobcontroller/service/JobControllerServiceTest.java
+++ b/job-controller/src/test/java/feast/jobcontroller/service/JobControllerServiceTest.java
@@ -76,6 +76,7 @@ public class JobControllerServiceTest {
     feastProperties = new FeastProperties();
     JobProperties jobProperties = new JobProperties();
     jobProperties.setJobUpdateTimeoutSeconds(5);
+    jobProperties.setJobIdPrefix("test-prefix");
 
     FeastProperties.JobProperties.ControllerProperties.FeatureSetSelector selector =
         new FeastProperties.JobProperties.ControllerProperties.FeatureSetSelector();
@@ -104,7 +105,7 @@ public class JobControllerServiceTest {
             specService,
             jobManager,
             feastProperties,
-            new ConsolidatedJobStrategy(jobRepository),
+            new ConsolidatedJobStrategy(jobRepository, feastProperties.getJobs()),
             mock(KafkaTemplate.class));
 
     controllerWithJobPerStore =
@@ -113,7 +114,7 @@ public class JobControllerServiceTest {
             specService,
             jobManager,
             feastProperties,
-            new JobPerStoreStrategy(jobRepository),
+            new JobPerStoreStrategy(jobRepository, feastProperties.getJobs()),
             mock(KafkaTemplate.class));
   }
 
@@ -286,6 +287,7 @@ public class JobControllerServiceTest {
         controllerWithConsolidation.makeJobUpdateTasks(
             ImmutableList.of(Pair.of(source, ImmutableSet.of(store))));
 
+    assertThat(tasks.get(0).getJob().getId(), containsString("test-prefix"));
     assertThat("CreateTask is expected", tasks.get(0) instanceof CreateJobTask);
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
To allow multiple deployments with jobs running in parallel, we should separate their Kafka consumer groups which is based on the JobId. This would prevent overwriting each other's offsets.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
