### PR TITLE
Prevent historical retrieval from failing on dash in project / featureSet name

### DIFF
--- a/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/retriever/FeatureSetQueryInfo.java
+++ b/storage/connectors/bigquery/src/main/java/feast/storage/connectors/bigquery/retriever/FeatureSetQueryInfo.java
@@ -54,11 +54,11 @@ public class FeatureSetQueryInfo {
   }
 
   public String getProject() {
-    return project;
+    return project.replace("-", "_");
   }
 
   public String getName() {
-    return name;
+    return name.replace("-", "_");
   }
 
   public long getMaxAge() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
When project name or feature-set name contains "-" invalid query will be built on historical retrieval.
```
{
 "code" : 400,
 "errors" : [ {
    "domain" : "global",
    "location" : "q",
    "locationType" : "parameter",
    "message" : "Syntax error: Expected \")\" but got \"-\" at [16:13]",
    "reason" : "invalidQuery"
 } ],
 "message" : "Syntax error: Expected \")\" but got \"-\" at [16:13]",
 "status" : "INVALID_ARGUMENT"
}
```
And since there's no mechanism to propagate this error to the user
```
client.get_historical_features(...).to_dataframe()
```
will hang.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
