### PR TITLE
Fix docker-compose test

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -142,3 +142,11 @@ jobs:
         with:
           name: load-test-results
           path: load-test-output/
+
+  tests-docker-compose:
+    needs: build-push-docker-images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test docker compose
+        run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -64,4 +64,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Test docker compose
-        run: ./infra/scripts/test-docker-compose.sh
+        run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -58,10 +58,3 @@ jobs:
               docker push gcr.io/kf-feast/feast-${{ matrix.component }}:latest
             fi
           fi
-
-  tests-docker-compose:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Test docker compose
-        run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}

--- a/infra/docker-compose/jobcontroller/jobcontroller.yml
+++ b/infra/docker-compose/jobcontroller/jobcontroller.yml
@@ -1,7 +1,7 @@
 feast:
   core-host: core
   jobs:
-    polling_interval_milliseconds: 20000
+    polling_interval_milliseconds: 10000
     job_update_timeout_seconds: 240
     active_runner: direct
     runners:

--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -63,4 +63,4 @@ export FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS=$(docker inspect -f '{{range .N
 ${PROJECT_ROOT_DIR}/infra/scripts/wait-for-it.sh ${FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS}:6566 --timeout=120
 
 # Run e2e tests for Redis
-docker exec feast_jupyter_1 bash -c 'cd /feast/tests/e2e/redis && pytest --verbose -rs basic-ingest-redis-serving.py --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'
+docker exec feast_jupyter_1 bash -c 'cd /feast/tests/e2e/redis && pytest --verbose -rs basic-ingest-redis-serving.py --core_url core:6565 --serving_url=online_serving:6566 --jobcontroller_url=jobcontroller:6570 --kafka_brokers=kafka:9092'

--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -26,6 +26,11 @@ export COMPOSE_INTERACTIVE_NO_CLI=1
 cd ${PROJECT_ROOT_DIR}/infra/docker-compose/
 cp .env.sample .env
 
+# Replace FEAST_VERSION with latest github image SHA
+tmpfile=$(mktemp /tmp/docker-compose.XXXXXX)
+FEAST_VERSION=$(grep FEAST_VERSION .env | cut -d '=' -f 2-)
+sed "s|$FEAST_VERSION|$LATEST_GH_COMMIT_SHA|g" < .env > $tmpfile && mv $tmpfile .env
+
 # Start Docker Compose containers
 docker-compose up -d
 

--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -50,6 +50,12 @@ export FEAST_CORE_CONTAINER_IP_ADDRESS=$(docker inspect -f '{{range .NetworkSett
 # Wait for Feast Core to be ready
 ${PROJECT_ROOT_DIR}/infra/scripts/wait-for-it.sh ${FEAST_CORE_CONTAINER_IP_ADDRESS}:6565 --timeout=120
 
+# Get Feast Job Controller container IP address
+export FEAST_JOB_CONTROLLER_CONTAINER_IP_ADDRESS=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' feast_jobcontroller_1)
+
+# Wait for Feast Job Controller to be ready
+"${PROJECT_ROOT_DIR}"/infra/scripts/wait-for-it.sh ${FEAST_JOB_CONTROLLER_CONTAINER_IP_ADDRESS}:6570 --timeout=120
+
 # Get Feast Online Serving container IP address
 export FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' feast_online_serving_1)
 

--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -7,6 +7,7 @@ echo "
 Running Docker Compose tests with pytest at 'tests/e2e'
 ============================================================
 "
+LATEST_GH_COMMIT_SHA=$1
 
 clean_up () {
     ARG=$?
@@ -27,9 +28,8 @@ cd ${PROJECT_ROOT_DIR}/infra/docker-compose/
 cp .env.sample .env
 
 # Replace FEAST_VERSION with latest github image SHA
-tmpfile=$(mktemp /tmp/docker-compose.XXXXXX)
-FEAST_VERSION=$(grep FEAST_VERSION .env | cut -d '=' -f 2-)
-sed "s|$FEAST_VERSION|$LATEST_GH_COMMIT_SHA|g" < .env > $tmpfile && mv $tmpfile .env
+export FEAST_VERSION=$LATEST_GH_COMMIT_SHA
+echo "Testing docker-compose setup with version SHA, $FEAST_VERSION."
 
 # Start Docker Compose containers
 docker-compose up -d


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
`tests-docker-compose` test that triggers when PRs are merged to master branch currently runs tests on a specific version (eg. 0.6.2) image. This causes test failures since Dockerfiles may have changed since a specific version tag.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #956 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
