### PR TITLE
Add redis key prefix as an option to Redis cluster

### DIFF
--- a/protos/feast/core/Store.proto
+++ b/protos/feast/core/Store.proto
@@ -134,6 +134,14 @@ message Store {
     int32 max_retries = 3;
     // Optional. How often flush data to redis
     int32 flush_frequency_seconds = 4;
+    // Optional. Append a prefix to the Redis Key
+    string key_prefix = 5;
+    // Optional. Enable fallback to another key prefix if the original key is not present.
+    // Useful for migrating key prefix without re-ingestion. Disabled by default.
+    bool enable_fallback = 6;
+    // Optional. This would be the fallback prefix to use if enable_fallback is true.
+    string fallback_prefix = 7;
+
   }
 
   message Subscription {

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/serializer/RedisKeyPrefixSerializer.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/serializer/RedisKeyPrefixSerializer.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.connectors.redis.serializer;
+
+import feast.proto.storage.RedisProto.RedisKey;
+
+public class RedisKeyPrefixSerializer implements RedisKeySerializer {
+
+  private final byte[] prefixBytes;
+
+  public RedisKeyPrefixSerializer(String prefix) {
+    this.prefixBytes = prefix.getBytes();
+  }
+
+  public byte[] serialize(RedisKey redisKey) {
+    byte[] key = redisKey.toByteArray();
+
+    if (prefixBytes.length == 0) {
+      return key;
+    }
+
+    byte[] keyWithPrefix = new byte[prefixBytes.length + key.length];
+    System.arraycopy(prefixBytes, 0, keyWithPrefix, 0, prefixBytes.length);
+    System.arraycopy(key, 0, keyWithPrefix, prefixBytes.length, key.length);
+    return keyWithPrefix;
+  }
+}

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/serializer/RedisKeyProtoSerializer.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/serializer/RedisKeyProtoSerializer.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.connectors.redis.serializer;
+
+import feast.proto.storage.RedisProto.RedisKey;
+
+public class RedisKeyProtoSerializer implements RedisKeySerializer {
+
+  public byte[] serialize(RedisKey redisKey) {
+    return redisKey.toByteArray();
+  }
+}

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/serializer/RedisKeySerializer.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/serializer/RedisKeySerializer.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.connectors.redis.serializer;
+
+import feast.proto.storage.RedisProto.RedisKey;
+import java.io.Serializable;
+
+public interface RedisKeySerializer extends Serializable {
+
+  byte[] serialize(RedisKey key);
+}

--- a/storage/connectors/redis/src/test/java/feast/storage/connectors/redis/serializer/RedisKeyPrefixSerializerTest.java
+++ b/storage/connectors/redis/src/test/java/feast/storage/connectors/redis/serializer/RedisKeyPrefixSerializerTest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.storage.connectors.redis.serializer;
+
+import static org.junit.Assert.*;
+
+import com.google.common.collect.Lists;
+import feast.proto.storage.RedisProto.RedisKey;
+import feast.proto.types.FieldProto;
+import feast.proto.types.ValueProto;
+import org.junit.Test;
+
+public class RedisKeyPrefixSerializerTest {
+
+  private RedisKey key =
+      RedisKey.newBuilder()
+          .setFeatureSet("project/featureSet")
+          .addAllEntities(
+              Lists.newArrayList(
+                  FieldProto.Field.newBuilder()
+                      .setName("entity1")
+                      .setValue(ValueProto.Value.newBuilder().setInt64Val(1))
+                      .build()))
+          .build();
+
+  @Test
+  public void shouldPrependKey() {
+    RedisKeyPrefixSerializer serializer = new RedisKeyPrefixSerializer("namespace:");
+    String keyWithPrefix = new String(serializer.serialize(key));
+    assertEquals(String.format("namespace:%s", new String(key.toByteArray())), keyWithPrefix);
+  }
+
+  @Test
+  public void shouldNotPrependKeyIfEmptyString() {
+    RedisKeyPrefixSerializer serializer = new RedisKeyPrefixSerializer("");
+    assertArrayEquals(key.toByteArray(), serializer.serialize(key));
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
There are scenarios where multiple Feast deployment are sharing the same Redis cluster, but key collision between the different deployment should be avoided. Since Redis cluster doesn't support database, attaching prefix to keys is a good workaround to achive namespacing.

To facilitate migration of redis keys from one prefix to another, fallback mechanism has also been introduced. If enabled, when a key is not found in the database, a fallback prefix can be used instead. However, this will results in more calls to Redis, and additional latency.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Additional optional configuration for Redis cluster, where user can specified a prefix to be prepended to the Redis keys written / retrieved.
```
