### PR TITLE
Fix invalid characters for project, featureset, entity and features creation

### DIFF
--- a/core/src/main/java/feast/core/service/SpecService.java
+++ b/core/src/main/java/feast/core/service/SpecService.java
@@ -98,7 +98,7 @@ public class SpecService {
 
   private FeatureSet getFeatureSet(String projectName, String featureSetName) {
     // Validate input arguments
-    checkValidCharacters(featureSetName, "featureSetName");
+    checkValidCharacters(featureSetName, "featureset");
 
     if (featureSetName.isEmpty()) {
       throw new IllegalArgumentException("No feature set name provided");
@@ -151,8 +151,8 @@ public class SpecService {
           "Invalid listFeatureSetRequest, missing arguments. Must provide feature set name:");
     }
 
-    checkValidCharactersAllowAsterisk(name, "featureSetName");
-    checkValidCharactersAllowAsterisk(project, "projectName");
+    checkValidCharactersAllowAsterisk(name, "featureset");
+    checkValidCharactersAllowAsterisk(project, "project");
 
     // Autofill default project if project not specified
     if (project.isEmpty()) {
@@ -239,7 +239,7 @@ public class SpecService {
       List<String> entities = filter.getEntitiesList();
       Map<String, String> labels = filter.getLabelsMap();
 
-      checkValidCharactersAllowAsterisk(project, "projectName");
+      checkValidCharactersAllowAsterisk(project, "project");
 
       // Autofill default project if project not specified
       if (project.isEmpty()) {

--- a/core/src/main/java/feast/core/validators/FeatureSetValidator.java
+++ b/core/src/main/java/feast/core/validators/FeatureSetValidator.java
@@ -44,8 +44,8 @@ public class FeatureSetValidator {
       throw new IllegalArgumentException("Feature set label keys must not be empty");
     }
 
-    checkValidCharacters(featureSet.getSpec().getProject(), "project");
-    checkValidCharacters(featureSet.getSpec().getName(), "name");
+    checkValidCharacters(featureSet.getSpec().getProject(), "project::name");
+    checkValidCharacters(featureSet.getSpec().getName(), "featureset::name");
     checkUniqueColumns(
         featureSet.getSpec().getEntitiesList(), featureSet.getSpec().getFeaturesList());
     checkReservedColumns(featureSet.getSpec().getFeaturesList());

--- a/core/src/main/java/feast/core/validators/FeatureSetValidator.java
+++ b/core/src/main/java/feast/core/validators/FeatureSetValidator.java
@@ -44,16 +44,16 @@ public class FeatureSetValidator {
       throw new IllegalArgumentException("Feature set label keys must not be empty");
     }
 
-    checkValidCharacters(featureSet.getSpec().getProject(), "project::name");
-    checkValidCharacters(featureSet.getSpec().getName(), "featureset::name");
+    checkValidCharacters(featureSet.getSpec().getProject(), "project");
+    checkValidCharacters(featureSet.getSpec().getName(), "featureset");
     checkUniqueColumns(
         featureSet.getSpec().getEntitiesList(), featureSet.getSpec().getFeaturesList());
     checkReservedColumns(featureSet.getSpec().getFeaturesList());
     for (EntitySpec entitySpec : featureSet.getSpec().getEntitiesList()) {
-      checkValidCharacters(entitySpec.getName(), "entities::name");
+      checkValidCharacters(entitySpec.getName(), "entity");
     }
     for (FeatureSpec featureSpec : featureSet.getSpec().getFeaturesList()) {
-      checkValidCharacters(featureSpec.getName(), "features::name");
+      checkValidCharacters(featureSpec.getName(), "feature");
       if (featureSpec.getLabelsMap().containsKey("")) {
         throw new IllegalArgumentException("Feature label keys must not be empty");
       }

--- a/core/src/main/java/feast/core/validators/Matchers.java
+++ b/core/src/main/java/feast/core/validators/Matchers.java
@@ -26,48 +26,52 @@ public class Matchers {
   private static Pattern VALID_CHARACTERS_REGEX_WITH_ASTERISK_WILDCARD =
       Pattern.compile("^[a-zA-Z0-9\\-_*]*$");
 
-  private static String ERROR_MESSAGE_TEMPLATE = "invalid value for %s: %s";
+  private static String ERROR_MESSAGE_TEMPLATE = "invalid value for %s resource, %s: %s";
 
-  public static void checkUpperSnakeCase(String input, String fieldName)
+  public static void checkUpperSnakeCase(String input, String resource)
       throws IllegalArgumentException {
     if (!UPPER_SNAKE_CASE_REGEX.matcher(input).matches()) {
       throw new IllegalArgumentException(
           String.format(
               ERROR_MESSAGE_TEMPLATE,
-              fieldName,
+              resource,
+              input,
               "argument must be in upper snake case, and cannot include any special characters."));
     }
   }
 
-  public static void checkLowerSnakeCase(String input, String fieldName)
+  public static void checkLowerSnakeCase(String input, String resource)
       throws IllegalArgumentException {
     if (!LOWER_SNAKE_CASE_REGEX.matcher(input).matches()) {
       throw new IllegalArgumentException(
           String.format(
               ERROR_MESSAGE_TEMPLATE,
-              fieldName,
+              resource,
+              input,
               "argument must be in lower snake case, and cannot include any special characters."));
     }
   }
 
-  public static void checkValidCharacters(String input, String fieldName)
+  public static void checkValidCharacters(String input, String resource)
       throws IllegalArgumentException {
     if (!VALID_CHARACTERS_REGEX.matcher(input).matches()) {
       throw new IllegalArgumentException(
           String.format(
               ERROR_MESSAGE_TEMPLATE,
-              fieldName,
+              resource,
+              input,
               "argument must only contain alphanumeric characters and underscores."));
     }
   }
 
-  public static void checkValidCharactersAllowAsterisk(String input, String fieldName)
+  public static void checkValidCharactersAllowAsterisk(String input, String resource)
       throws IllegalArgumentException {
     if (!VALID_CHARACTERS_REGEX_WITH_ASTERISK_WILDCARD.matcher(input).matches()) {
       throw new IllegalArgumentException(
           String.format(
               ERROR_MESSAGE_TEMPLATE,
-              fieldName,
+              resource,
+              input,
               "argument must only contain alphanumeric characters, dashes, underscores, or an asterisk."));
     }
   }

--- a/core/src/main/java/feast/core/validators/Matchers.java
+++ b/core/src/main/java/feast/core/validators/Matchers.java
@@ -22,11 +22,11 @@ public class Matchers {
 
   private static Pattern UPPER_SNAKE_CASE_REGEX = Pattern.compile("^[A-Z0-9]+(_[A-Z0-9]+)*$");
   private static Pattern LOWER_SNAKE_CASE_REGEX = Pattern.compile("^[a-z0-9]+(_[a-z0-9]+)*$");
-  private static Pattern VALID_CHARACTERS_REGEX = Pattern.compile("^[a-zA-Z0-9\\-_]*$");
+  private static Pattern VALID_CHARACTERS_REGEX = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
   private static Pattern VALID_CHARACTERS_REGEX_WITH_ASTERISK_WILDCARD =
       Pattern.compile("^[a-zA-Z0-9\\-_*]*$");
 
-  private static String ERROR_MESSAGE_TEMPLATE = "invalid value for field %s: %s";
+  private static String ERROR_MESSAGE_TEMPLATE = "invalid value for %s: %s";
 
   public static void checkUpperSnakeCase(String input, String fieldName)
       throws IllegalArgumentException {
@@ -57,7 +57,7 @@ public class Matchers {
           String.format(
               ERROR_MESSAGE_TEMPLATE,
               fieldName,
-              "argument must only contain alphanumeric characters, dashes and underscores."));
+              "argument must only contain alphanumeric characters and underscores."));
     }
   }
 

--- a/core/src/test/java/feast/core/service/SpecServiceIT.java
+++ b/core/src/test/java/feast/core/service/SpecServiceIT.java
@@ -229,6 +229,29 @@ public class SpecServiceIT extends BaseIT {
     }
 
     @Test
+    public void shouldThrowExceptionGivenFeatureSetWithDash() {
+      StatusRuntimeException exc =
+          assertThrows(
+              StatusRuntimeException.class,
+              () ->
+                  apiClient.simpleApplyFeatureSet(
+                      DataGenerator.createFeatureSet(
+                          DataGenerator.getDefaultSource(),
+                          "project",
+                          "dash-name",
+                          ImmutableMap.of("entity", ValueProto.ValueType.Enum.STRING),
+                          ImmutableMap.of("test_string", ValueProto.ValueType.Enum.STRING))));
+
+      assertThat(
+          exc.getMessage(),
+          equalTo(
+              String.format(
+                  "INTERNAL: invalid value for %s: %s",
+                  "featureset::name",
+                  "argument must only contain alphanumeric characters and underscores.")));
+    }
+
+    @Test
     public void shouldReturnFeatureSetIfFeatureSetHasNotChanged() {
       FeatureSetProto.FeatureSet featureSet = apiClient.getFeatureSet("default", "fs1");
 

--- a/core/src/test/java/feast/core/service/SpecServiceIT.java
+++ b/core/src/test/java/feast/core/service/SpecServiceIT.java
@@ -246,8 +246,9 @@ public class SpecServiceIT extends BaseIT {
           exc.getMessage(),
           equalTo(
               String.format(
-                  "INTERNAL: invalid value for %s: %s",
-                  "featureset::name",
+                  "INTERNAL: invalid value for %s resource, %s: %s",
+                  "featureset",
+                  "dash-name",
                   "argument must only contain alphanumeric characters and underscores.")));
     }
 

--- a/core/src/test/java/feast/core/validators/MatchersTest.java
+++ b/core/src/test/java/feast/core/validators/MatchersTest.java
@@ -44,7 +44,7 @@ public class MatchersTest {
     exception.expect(IllegalArgumentException.class);
     exception.expectMessage(
         Strings.lenientFormat(
-            "invalid value for field %s: %s",
+            "invalid value for %s: %s",
             "someField",
             "argument must be in upper snake case, and cannot include any special characters."));
     String in = "redis";
@@ -62,7 +62,7 @@ public class MatchersTest {
     exception.expect(IllegalArgumentException.class);
     exception.expectMessage(
         Strings.lenientFormat(
-            "invalid value for field %s: %s",
+            "invalid value for %s: %s",
             "someField",
             "argument must be in lower snake case, and cannot include any special characters."));
     String in = "Invalid_feature name";

--- a/core/src/test/java/feast/core/validators/MatchersTest.java
+++ b/core/src/test/java/feast/core/validators/MatchersTest.java
@@ -30,13 +30,13 @@ public class MatchersTest {
   @Test
   public void checkUpperSnakeCaseShouldPassForLegitUpperSnakeCase() {
     String in = "REDIS_DB";
-    checkUpperSnakeCase(in, "someField");
+    checkUpperSnakeCase(in, "featureset");
   }
 
   @Test
   public void checkUpperSnakeCaseShouldPassForLegitUpperSnakeCaseWithNumbers() {
     String in = "REDIS1";
-    checkUpperSnakeCase(in, "someField");
+    checkUpperSnakeCase(in, "featureset");
   }
 
   @Test
@@ -44,17 +44,18 @@ public class MatchersTest {
     exception.expect(IllegalArgumentException.class);
     exception.expectMessage(
         Strings.lenientFormat(
-            "invalid value for %s: %s",
-            "someField",
+            "invalid value for %s resource, %s: %s",
+            "featureset",
+            "redis",
             "argument must be in upper snake case, and cannot include any special characters."));
     String in = "redis";
-    checkUpperSnakeCase(in, "someField");
+    checkUpperSnakeCase(in, "featureset");
   }
 
   @Test
   public void checkLowerSnakeCaseShouldPassForLegitLowerSnakeCase() {
     String in = "feature_name_v1";
-    checkLowerSnakeCase(in, "someField");
+    checkLowerSnakeCase(in, "feature");
   }
 
   @Test
@@ -62,10 +63,11 @@ public class MatchersTest {
     exception.expect(IllegalArgumentException.class);
     exception.expectMessage(
         Strings.lenientFormat(
-            "invalid value for %s: %s",
-            "someField",
+            "invalid value for %s resource, %s: %s",
+            "feature",
+            "Invalid_feature name",
             "argument must be in lower snake case, and cannot include any special characters."));
     String in = "Invalid_feature name";
-    checkLowerSnakeCase(in, "someField");
+    checkLowerSnakeCase(in, "feature");
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently - in names is being replaced to _. This is hacky solution that need to be implemented in many places. It also creates potential bug since project-1 and project_1 (feature-set and feature_set) will be using the same bq table.

It's better to validate this (and not allow such characters) on feature set creation. This PR addresses the above issue for project, featureset, features and entities.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users will no longer be allowed to include dashes in project, featureset, entity and feature name.
```
