### PR TITLE
Fix Python native types multiple entities online retrieval

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -993,6 +993,7 @@ def _infer_online_entity_rows(
     entity_type_map = dict()
 
     for entity in entity_rows_dicts:
+        fields = {}
         for key, value in entity.items():
             # Allow for feast.types.Value
             if isinstance(value, Value):
@@ -1009,9 +1010,8 @@ def _infer_online_entity_rows(
                             f"Input entity {key} has mixed types, {current_dtype} and {entity_type_map[key]}. That is not allowed. "
                         )
                 proto_value = _python_value_to_proto_value(current_dtype, value)
-            entity_row_list.append(
-                GetOnlineFeaturesRequest.EntityRow(fields={key: proto_value})
-            )
+            fields[key] = proto_value
+        entity_row_list.append(GetOnlineFeaturesRequest.EntityRow(fields=fields))
     return entity_row_list
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Online retrieval with python native types was introduced in 0.6 and a bug was introduced. Specifically, retrieving features with more than 1 entity would fail since only 1 entity is converted during the online retrieval call.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
