### PR TITLE
Reduce polling interval for docker-compose test and fix flaky e2e test

### DIFF
--- a/infra/docker-compose/jobcontroller/jobcontroller.yml
+++ b/infra/docker-compose/jobcontroller/jobcontroller.yml
@@ -1,7 +1,7 @@
 feast:
   core-host: core
   jobs:
-    polling_interval_milliseconds: 10000
+    polling_interval_milliseconds: 5000
     job_update_timeout_seconds: 240
     active_runner: direct
     runners:

--- a/tests/e2e/redis/basic-ingest-redis-serving.py
+++ b/tests/e2e/redis/basic-ingest-redis-serving.py
@@ -734,6 +734,7 @@ def test_basic_ingest_retrieval_multi_entities(client):
         }
     )
     client.ingest("merchant_fs", merchant_df, timeout=600)
+    time.sleep(15)
 
     online_request_entity = [
         {"driver_id": 0, "merchant_id": 0},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Polling interval is too high for configuration that's used to run docker-compose-tests, resulting in redis pytest failures. Failure also stems for e2e tests when featureset update is not yet propagated.

Example failures:
1. https://github.com/feast-dev/feast/pull/975/checks?check_run_id=1065997200
2. http://prow.feast.ai/view/gcs/feast-templocation-kf-feast/pr-logs/pull/feast-dev_feast/980/test-end-to-end/1301743039177297923 
3. http://prow.feast.ai/view/gcs/feast-templocation-kf-feast/pr-logs/pull/feast-dev_feast/980/test-end-to-end-auth/1301743039177297921

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
