### PR TITLE
Fix Java & Go SDK TLS support

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -63,7 +63,7 @@ func NewSecureGrpcClient(host string, port int, security SecurityConfig) (*GrpcC
 			return nil, err
 		}
 		options = append(options, grpc.WithTransportCredentials(tlsCreds))
-	} else if security.EnableTLS {
+	} else {
 		// Use system TLS certificate pool.
 		certPool, err := x509.SystemCertPool()
 		if err != nil {

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -27,7 +27,7 @@ type GrpcClient struct {
 type SecurityConfig struct {
 	// Whether to enable TLS SSL trasnport security if true.
 	EnableTLS bool
-	// Optional: Provides path to TLS certificate use the verify Service identity.
+	// Optional: Provides path to TLS certificate used the verify Service identity.
 	TLSCertPath string
 	// Optional: Credential used for authentication.
 	// Disables authentication if unspecified.
@@ -36,17 +36,17 @@ type SecurityConfig struct {
 
 // NewGrpcClient constructs a client that can interact via grpc with the feast serving instance at the given host:port.
 func NewGrpcClient(host string, port int) (*GrpcClient, error) {
-	return NewAuthGrpcClient(host, port, SecurityConfig{
+	return NewSecureGrpcClient(host, port, SecurityConfig{
 		EnableTLS:  false,
 		Credential: nil,
 	})
 }
 
-// NewAuthGrpcClient constructs a client that can connect with feast serving instances with authentication enabled.
+// NewAuthGrpcClient constructs a secure client that uses security features (ie authentication).
 // host - hostname of the serving host/instance to connect to.
 // port - post of the host to service host/instancf to connect to.
 // securityConfig - security config configures client security.
-func NewAuthGrpcClient(host string, port int, security SecurityConfig) (*GrpcClient, error) {
+func NewSecureGrpcClient(host string, port int, security SecurityConfig) (*GrpcClient, error) {
 	feastCli := &GrpcClient{}
 	adr := fmt.Sprintf("%s:%d", host, port)
 

--- a/sdk/java/src/main/java/com/gojek/feast/FeastClient.java
+++ b/sdk/java/src/main/java/com/gojek/feast/FeastClient.java
@@ -85,7 +85,8 @@ public class FeastClient implements AutoCloseable {
                   .sslContext(GrpcSslContexts.forClient().trustManager(certificateFile).build())
                   .build();
         } catch (SSLException e) {
-          throw new IllegalArgumentException(String.format("Invalid Certificate provided at path: %s", certificatePath), e);
+          throw new IllegalArgumentException(
+              String.format("Invalid Certificate provided at path: %s", certificatePath), e);
         }
       } else {
         // Use system certificates for TLS

--- a/sdk/java/src/main/java/com/gojek/feast/SecurityConfig.java
+++ b/sdk/java/src/main/java/com/gojek/feast/SecurityConfig.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2019 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gojek.feast;
+
+import com.google.auto.value.AutoValue;
+import io.grpc.CallCredentials;
+import java.util.Optional;
+
+/** SecurityConfig captures the security related configuration for FeastClient */
+@AutoValue
+public abstract class SecurityConfig {
+  /**
+   * Enables authentication If specified, the call credentials used to provide credentials to
+   * authenticate with Feast.
+   */
+  public abstract Optional<CallCredentials> getCredentials();
+
+  /** Whether to use TLS transport security is use when connecting to Feast. */
+  public abstract boolean isTLSEnabled();
+
+  /**
+   * If specified and TLS is enabled, provides path to TLS certificate use the verify Service
+   * identity.
+   */
+  public abstract Optional<String> getCertificatePath();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setCredentials(Optional<CallCredentials> credentials);
+
+    public abstract Builder setTLSEnabled(boolean isTLSEnabled);
+
+    public abstract Builder setCertificatePath(Optional<String> certificatePath);
+
+    public abstract SecurityConfig build();
+  }
+
+  public static SecurityConfig.Builder newBuilder() {
+    return new AutoValue_SecurityConfig.Builder()
+        .setCredentials(Optional.empty())
+        .setTLSEnabled(false)
+        .setCertificatePath(Optional.empty());
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Follow up of #971:
- implements missing TLS support for Java SDK.
- Fixes Go SDK issue where it does not use system certificates if TLS enabled but no certificate path is specified.
- Rename Go and Java SDK secure client creation methods to include "secure" instead of "authenticated"
     - Go SDK: `NewAuthGrpcClient()` -> `NewSecureGrpcClient()`  
     - Java SDK: `createdAuthenticated()` -> `createSecure()`

Continuation of #504

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
implements TLS support for Java SDK.
 Rename Go and Java SDK secure client creation methods to include "secure" instead of "authenticated"
     - Go SDK: `NewAuthGrpcClient()` -> `NewSecureGrpcClient()`  
     - Java SDK: `createdAuthenticated()` -> `createSecure()`
```
