### PR TITLE
Allow maps in environment variables in helm charts

### DIFF
--- a/infra/charts/feast/charts/feast-core/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-core/templates/deployment.yaml
@@ -100,7 +100,12 @@ spec:
 
         {{- range $key, $value := .Values.envOverrides }}
         - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
+          {{- if eq (kindOf $value) "map" }}
+          valueFrom:
+            {{- toYaml $value | nindent 12}}
+          {{- else }}
           value: {{ $value | quote }}
+          {{- end}}
         {{- end }}
 
         command:

--- a/infra/charts/feast/charts/feast-jobcontroller/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-jobcontroller/templates/deployment.yaml
@@ -100,7 +100,12 @@ spec:
 
         {{- range $key, $value := .Values.envOverrides }}
         - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
+          {{ - if eq (kindOf $value) "map" }}
+          valueFrom:
+            {{ - toYaml $value | nindent 12 }}
+          {{ - else }}
           value: {{ $value | quote }}
+          {{ - end }}
         {{- end }}
 
         command:

--- a/infra/charts/feast/charts/feast-jobcontroller/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-jobcontroller/templates/deployment.yaml
@@ -100,12 +100,12 @@ spec:
 
         {{- range $key, $value := .Values.envOverrides }}
         - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
-          {{ - if eq (kindOf $value) "map" }}
+          {{- if eq (kindOf $value) "map" }}
           valueFrom:
-            {{ - toYaml $value | nindent 12 }}
-          {{ - else }}
+            {{- toYaml $value | nindent 12 }}
+          {{- else }}
           value: {{ $value | quote }}
-          {{ - end }}
+          {{- end }}
         {{- end }}
 
         command:

--- a/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
@@ -92,12 +92,12 @@ spec:
 
         {{- range $key, $value := .Values.envOverrides }}
         - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
-          {{ - if eq (kindOf $value) "map" }}
+          {{- if eq (kindOf $value) "map" }}
           valueFrom:
-            {{ - toYaml $value | nindent 12 }}
-          {{ - else }}
+            {{- toYaml $value | nindent 12 }}
+          {{- else }}
           value: {{ $value | quote }}
-          {{ - end }}
+          {{- end }}
         {{- end }}
 
         command:

--- a/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
@@ -92,7 +92,12 @@ spec:
 
         {{- range $key, $value := .Values.envOverrides }}
         - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
+          {{ - if eq (kindOf $value) "map" }}
+          valueFrom:
+            {{ - toYaml $value | nindent 12 }}
+          {{ - else }}
           value: {{ $value | quote }}
+          {{ - end }}
         {{- end }}
 
         command:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently it's not possible to use more complicated expressions (than string or int) as environment variable in kubernetes `Deployment` object via helm charts. `Map` structure could be useful to provide kube metadata as parameter to feast services.
```
env:
- name: MY_POD_NAMESPACE
  valueFrom:
    fieldRef:
      fieldPath: metadata.namespace
```

Now this can be achieved with
`--set envOverrides.MY_POD_NAMESPACE.fieldRef.fieldPath=metadata.namespace`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
