### PR TITLE
Fix typo for fluentd request response map key

### DIFF
--- a/common/src/main/java/feast/common/logging/AuditLogger.java
+++ b/common/src/main/java/feast/common/logging/AuditLogger.java
@@ -146,7 +146,7 @@ public class AuditLogger {
         fluentdLogs.put("service", messageAuditLogEntry.getService());
         fluentdLogs.put("status_code", messageAuditLogEntry.getStatusCode());
         fluentdLogs.put("method", messageAuditLogEntry.getMethod());
-        fluentdLogs.put("release_tag", releaseName);
+        fluentdLogs.put("release_name", releaseName);
         try {
           fluentdLogs.put("request", JsonFormat.printer().print(messageAuditLogEntry.getRequest()));
           fluentdLogs.put(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This typo was introduced in #961 . It should've been `release_name` instead of `release_tag`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
