### PR TITLE
Fix Github Actions versioned image push

### DIFF
--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Push versioned release
         run: |
           # Build and push semver tagged commits
-          rx='^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))$ '
+          # Regular expression should match MAJOR.MINOR.PATCH[-PRERELEASE[.IDENTIFIER]]
+          # eg. v0.7.1 v0.7.2-alpha v0.7.2-rc.1
+          rx='^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))$ '
           if [[ "${RELEASE_VERSION}" =~ $rx ]]; then
             VERSION_WITHOUT_PREFIX=${RELEASE_VERSION:1}
 

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -45,7 +45,7 @@ jobs:
           # Regular expression should match MAJOR.MINOR.PATCH[-PRERELEASE[.IDENTIFIER]]
           # eg. v0.7.1 v0.7.2-alpha v0.7.2-rc.1
           rx='^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))$ '
-          if [[ "${RELEASE_VERSION}" =~ $rx ]]; then
+          if echo "${RELEASE_VERSION}" | grep -P "$rx" &>/dev/null ; then
             VERSION_WITHOUT_PREFIX=${RELEASE_VERSION:1}
 
             docker tag gcr.io/kf-feast/feast-${{ matrix.component }}:${GITHUB_SHA} gcr.io/kf-feast/feast-${{ matrix.component }}:${VERSION_WITHOUT_PREFIX}

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Push versioned release
         run: |
           # Build and push semver tagged commits
-          rx='^v[0-9]+?\.[0-9]+?\.[0-9]+?$'
+          rx='^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))$ '
           if [[ "${RELEASE_VERSION}" =~ $rx ]]; then
             VERSION_WITHOUT_PREFIX=${RELEASE_VERSION:1}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
- Fix master only workflow regex for semver to allow for prerelease suffix ie `v0.7.0-rc.1`, `v0.7.0-alpha`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
