### PR TITLE
Add community SDK section to API docs [Backporting v0.7-branch]

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -8,3 +8,9 @@ The following API docs are available
 * [Go Client SDK](https://godoc.org/github.com/feast-dev/feast/sdk/go): This SDK is used for the retrieval of online features from Feast.
 * [Python SDK](https://api.docs.feast.dev/python/): This is the complete reference to the Feast Python SDK. The SDK is used to manage feature sets, features, jobs, projects, and entities. It can also be used to retrieve training datasets or online features from Feast Serving.
 
+### Community Contributions
+
+The following community provided SDKs are available
+
+* [Node.js SDK](https://github.com/MichaelHirn/feast-client/): A Node.js SDK written in TypeScript. The SDK is used to manage feature sets, features, jobs, projects, and entities.
+

--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -9,3 +9,8 @@ The following API docs are available
 * [Java Client SDK](https://javadoc.io/doc/dev.feast/feast-sdk): The Java library used for the retrieval of online features from Feast.
 * [Python SDK](https://api.docs.feast.dev/python/): This is the complete reference to the Feast Python SDK. The SDK is used to manage feature sets, features, jobs, projects, and entities. It can also be used to retrieve training datasets or online features from Feast Serving.
 
+### Community Contributions
+
+The following community provided SDKs are available
+
+* [Node.js SDK](https://github.com/MichaelHirn/feast-client/): A Node.js SDK written in TypeScript. The SDK is used to manage feature sets, features, jobs, projects, and entities.


### PR DESCRIPTION
including reference to community-provided Node.js SDK

**What this PR does / why we need it**:

"Backports" the original PR #992 into the v0.7-branch so changes get published in the docs.

cc @woop 

**Which issue(s) this PR fixes**:

Does not fix an issue

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
