### PR TITLE
Add Branch and RC Awareness to Version Lint & Fix Semver Regex

### DIFF
--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -31,15 +31,15 @@ jobs:
         run: make build-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
       - name: Push image
         run: make push-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
-      - name: Push image to feast dev
+      - name: Push development Docker image
         run: |
           if [ ${GITHUB_REF#refs/*/} == "master" ]; then
-            docker tag gcr.io/kf-feast/feast-${{ matrix.component }}:${GITHUB_SHA} gcr.io/kf-feast/feast-${{ matrix.component }}:dev
-            docker push gcr.io/kf-feast/feast-${{ matrix.component }}:dev
+            docker tag gcr.io/kf-feast/feast-${{ matrix.component }}:${GITHUB_SHA} gcr.io/kf-feast/feast-${{ matrix.component }}:develop
+            docker push gcr.io/kf-feast/feast-${{ matrix.component }}:develop
           fi
       - name: Get version
         run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
-      - name: Push versioned release
+      - name: Push versioned Docker image
         run: |
           # Build and push semver tagged commits
           # Regular expression should match MAJOR.MINOR.PATCH[-PRERELEASE[.IDENTIFIER]]

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -44,8 +44,8 @@ jobs:
           # Build and push semver tagged commits
           # Regular expression should match MAJOR.MINOR.PATCH[-PRERELEASE[.IDENTIFIER]]
           # eg. v0.7.1 v0.7.2-alpha v0.7.2-rc.1
-          rx='^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))$ '
-          if echo "${RELEASE_VERSION}" | grep -P "$rx" &>/dev/null ; then
+          SEMVER_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+          if echo "${RELEASE_VERSION}" | grep -P "$SEMVER_REGEX" &>/dev/null ; then
             VERSION_WITHOUT_PREFIX=${RELEASE_VERSION:1}
 
             docker tag gcr.io/kf-feast/feast-${{ matrix.component }}:${GITHUB_SHA} gcr.io/kf-feast/feast-${{ matrix.component }}:${VERSION_WITHOUT_PREFIX}

--- a/datatypes/java/README.md
+++ b/datatypes/java/README.md
@@ -16,7 +16,7 @@ Dependency Coordinates
 <dependency>
   <groupId>dev.feast</groupId>
   <artifactId>datatypes-java</artifactId>
-  <version>0.4.0-SNAPSHOT</version>
+  <version>0.7-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/docs/contributing/development-guide.md
+++ b/docs/contributing/development-guide.md
@@ -210,7 +210,7 @@ grpc_cli call localhost:6566 GetFeastServingInfo ''
 
 ```text
 connecting to localhost:6566
-version: "0.6.2-SNAPSHOT"
+version: "0.7-SNAPSHOT"
 type: FEAST_SERVING_TYPE_ONLINE
 
 Rpc succeeded with OK status

--- a/infra/charts/feast/charts/feast-core/README.md
+++ b/infra/charts/feast/charts/feast-core/README.md
@@ -23,7 +23,7 @@ Current chart version is `0.7-SNAPSHOT`
 | gcpServiceAccount.existingSecret.name | string | `"feast-gcp-service-account"` | Name of the existing secret containing the service account |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"gcr.io/kf-feast/feast-core"` | Docker image repository |
-| image.tag | string | `"0.6.2"` | Image tag |
+| image.tag | string | `"develop"` | Image tag |
 | ingress.grpc.annotations | object | `{}` | Extra annotations for the ingress |
 | ingress.grpc.auth.enabled | bool | `false` | Flag to enable auth |
 | ingress.grpc.class | string | `"nginx"` | Which ingress controller to use |

--- a/infra/charts/feast/charts/feast-core/values.yaml
+++ b/infra/charts/feast/charts/feast-core/values.yaml
@@ -5,7 +5,7 @@ image:
   # image.repository -- Docker image repository
   repository: gcr.io/kf-feast/feast-core
   # image.tag -- Image tag
-  tag: 0.6.2
+  tag: develop
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/infra/charts/feast/charts/feast-jobcontroller/README.md
+++ b/infra/charts/feast/charts/feast-jobcontroller/README.md
@@ -23,7 +23,7 @@ Current chart version is `0.7-SNAPSHOT`
 | gcpServiceAccount.existingSecret.name | string | `"feast-gcp-service-account"` | Name of the existing secret containing the service account |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"gcr.io/kf-feast/feast-jobcontroller"` | Docker image repository |
-| image.tag | string | `"0.6.2"` | Image tag |
+| image.tag | string | `"develop"` | Image tag |
 | ingress.grpc.annotations | object | `{}` | Extra annotations for the ingress |
 | ingress.grpc.auth.enabled | bool | `false` | Flag to enable auth |
 | ingress.grpc.class | string | `"nginx"` | Which ingress controller to use |

--- a/infra/charts/feast/charts/feast-jobcontroller/values.yaml
+++ b/infra/charts/feast/charts/feast-jobcontroller/values.yaml
@@ -5,7 +5,7 @@ image:
   # image.repository -- Docker image repository
   repository: gcr.io/kf-feast/feast-jobcontroller
   # image.tag -- Image tag
-  tag: 0.6.2
+  tag: develop
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/infra/charts/feast/charts/feast-jupyter/README.md
+++ b/infra/charts/feast/charts/feast-jupyter/README.md
@@ -17,5 +17,5 @@ Current chart version is `0.7-SNAPSHOT`
 | gcpServiceAccount.existingSecret.name | string | `"feast-gcp-service-account"` | Name of the existing secret containing the service account |
 | image.pullPolicy | string | `"Always"` | Image pull policy |
 | image.repository | string | `"gcr.io/kf-feast/feast-jupyter"` | Docker image repository |
-| image.tag | string | `"0.6.2"` | Image tag |
+| image.tag | string | `"develop"` | Image tag |
 | replicaCount | int | `1` | Number of pods that will be created |

--- a/infra/charts/feast/charts/feast-jupyter/values.yaml
+++ b/infra/charts/feast/charts/feast-jupyter/values.yaml
@@ -5,7 +5,7 @@ image:
   # image.repository -- Docker image repository
   repository: gcr.io/kf-feast/feast-jupyter
   # image.tag -- Image tag
-  tag: 0.6.2
+  tag: develop
   # image.pullPolicy -- Image pull policy
   pullPolicy: Always
 

--- a/infra/charts/feast/charts/feast-serving/README.md
+++ b/infra/charts/feast/charts/feast-serving/README.md
@@ -23,7 +23,7 @@ Current chart version is `0.7-SNAPSHOT`
 | gcpServiceAccount.existingSecret.name | string | `"feast-gcp-service-account"` | Name of the existing secret containing the service account |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"gcr.io/kf-feast/feast-serving"` | Docker image repository |
-| image.tag | string | `"0.6.2"` | Image tag |
+| image.tag | string | `"develop"` | Image tag |
 | ingress.grpc.annotations | object | `{}` | Extra annotations for the ingress |
 | ingress.grpc.auth.enabled | bool | `false` | Flag to enable auth |
 | ingress.grpc.class | string | `"nginx"` | Which ingress controller to use |

--- a/infra/charts/feast/charts/feast-serving/values.yaml
+++ b/infra/charts/feast/charts/feast-serving/values.yaml
@@ -5,7 +5,7 @@ image:
   # image.repository -- Docker image repository
   repository: gcr.io/kf-feast/feast-serving
   # image.tag -- Image tag
-  tag: 0.6.2
+  tag: develop
   # image.pullPolicy -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/infra/charts/feast/requirements.lock
+++ b/infra/charts/feast/requirements.lock
@@ -1,16 +1,16 @@
 dependencies:
 - name: feast-core
   repository: ""
-  version: 0.6.2
+  version: 0.7-SNAPSHOT
 - name: feast-serving
   repository: ""
-  version: 0.6.2
+  version: 0.7-SNAPSHOT
 - name: feast-serving
   repository: ""
-  version: 0.6.2
+  version: 0.7-SNAPSHOT
 - name: feast-jupyter
   repository: ""
-  version: 0.6.2
+  version: 0.7-SNAPSHOT
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 8.6.1

--- a/infra/docker-compose/.env.sample
+++ b/infra/docker-compose/.env.sample
@@ -1,5 +1,5 @@
 COMPOSE_PROJECT_NAME=feast
-FEAST_VERSION=0.6.2
+FEAST_VERSION=develop
 GCP_SERVICE_ACCOUNT=./gcp-service-accounts/key.json
 FEAST_CORE_CONFIG=./core/core.yml
 FEAST_JOB_CONTROLLER_CONFIG=./jobcontroller/jobcontroller.yml

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -106,17 +106,12 @@ for i in "${files_to_validate_version[@]}"; do
   
   echo "========================================================="
   echo "Testing whether versions are correctly set within file: $FILE_PATH"
-  echo
   ACTUAL_OCCURRENCES=$(grep -c -P "\bv?$VERSION\b" "$FILE_PATH" || true)
 
   if [ "${ACTUAL_OCCURRENCES}" -eq "${EXPECTED_OCCURRENCES}" ]; then
-    echo "SUCCESS"
-    echo
-    echo "Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, and found $ACTUAL_OCCURRENCES"
+    echo "OK: Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, and found $ACTUAL_OCCURRENCES"
   else
-    echo "FAILURE"
-    echo
-    echo "Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, but found $ACTUAL_OCCURRENCES"
+    echo "FAIL: Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, but found $ACTUAL_OCCURRENCES"
     IS_LINT_SUCCESS=false
   fi
 done

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -75,18 +75,22 @@ declare -a files_to_validate_version=(
   "infra/charts/feast/Chart.yaml,1,${FEAST_MAVEN_VERSION}"
   "infra/charts/feast/charts/feast-core/Chart.yaml,1,${FEAST_MAVEN_VERSION}"
   "infra/charts/feast/charts/feast-core/values.yaml,1,${FEAST_DOCKER_VERSION}"
+  "infra/charts/feast/charts/feast-core/README.md,1,${FEAST_MAVEN_VERSION}"
   "infra/charts/feast/charts/feast-core/README.md,1,${FEAST_DOCKER_VERSION}"
   "infra/charts/feast/charts/feast-serving/Chart.yaml,1,${FEAST_MAVEN_VERSION}"
   "infra/charts/feast/charts/feast-jupyter/values.yaml,1,${FEAST_DOCKER_VERSION}"
   "infra/charts/feast/charts/feast-jupyter/README.md,1,${FEAST_DOCKER_VERSION}"
+  "infra/charts/feast/charts/feast-jupyter/README.md,1,${FEAST_MAVEN_VERSION}"
   "infra/charts/feast/charts/feast-jupyter/Chart.yaml,1,${FEAST_MAVEN_VERSION}"
   "infra/charts/feast/charts/feast-serving/values.yaml,1,${FEAST_DOCKER_VERSION}"
   "infra/charts/feast/charts/feast-serving/README.md,1,${FEAST_DOCKER_VERSION}"
+  "infra/charts/feast/charts/feast-serving/README.md,1,${FEAST_MAVEN_VERSION}"
   "infra/charts/feast/charts/feast-jobcontroller/Chart.yaml,1,${FEAST_MAVEN_VERSION}"
   "infra/charts/feast/charts/feast-jobcontroller/values.yaml,1,${FEAST_DOCKER_VERSION}"
+  "infra/charts/feast/charts/feast-jobcontroller/README.md,1,${FEAST_MAVEN_VERSION}"
   "infra/charts/feast/charts/feast-jobcontroller/README.md,1,${FEAST_DOCKER_VERSION}"
   "infra/charts/feast/requirements.yaml,4,${FEAST_MAVEN_VERSION}"
-  "infra/charts/feast/requirements.lock,4,${FEAST_DOCKER_VERSION}"
+  "infra/charts/feast/requirements.lock,4,${FEAST_MAVEN_VERSION}"
   "infra/docker-compose/.env.sample,1,${FEAST_DOCKER_VERSION}"
 )
 
@@ -109,9 +113,9 @@ for i in "${files_to_validate_version[@]}"; do
   ACTUAL_OCCURRENCES=$(grep -c -P "\bv?$VERSION\b" "$FILE_PATH" || true)
 
   if [ "${ACTUAL_OCCURRENCES}" -eq "${EXPECTED_OCCURRENCES}" ]; then
-    echo "OK: Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, and found $ACTUAL_OCCURRENCES"
+    echo "OK: Expecting $EXPECTED_OCCURRENCES occurrences of '$VERSION' in $FILE_PATH, and found $ACTUAL_OCCURRENCES"
   else
-    echo "FAIL: Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, but found $ACTUAL_OCCURRENCES"
+    echo "FAIL: Expecting $EXPECTED_OCCURRENCES occurrences of '$VERSION' in $FILE_PATH, but found $ACTUAL_OCCURRENCES"
     IS_LINT_SUCCESS=false
   fi
 done

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -1,52 +1,89 @@
 #!/usr/bin/env bash
 
 # This script will scan through a list of files to validate that all versions are consistent with
-# - Master version (could be snapshot)
-# - Highest stable commit (latest tag)
+# - fix-version-cross-branch-ref version:  (could be snapshot)
+# - Docker images version: 'dev' on fix-version-cross-branch-ref, Highest tag on release branches 
+# - Release version: Highest stable commit. Latest tag repo wide, release candidates not included
 set -e
 
+# Matches (ie vMAJOR.MINOR-branch) release branch names
+RELEASE_BRANCH_REGEX="v[0-9]+\.[0-9]+-branch"
+
 # Determine the current Feast version from Maven (pom.xml)
-export FEAST_MASTER_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-[[ -z "$FEAST_MASTER_VERSION" ]] && {
-  echo "$FEAST_MASTER_VERSION is missing, please check pom.xml and maven"
+export FEAST_MAVEN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+[[ -z "$FEAST_MAVEN_VERSION" ]] && {
+  echo "$FEAST_MAVEN_VERSION is missing, please check pom.xml and maven"
   exit 1
 }
+echo "Linting Maven version: $FEAST_MAVEN_VERSION"
 
-# Determine the highest released version from Git history
-git fetch --prune --unshallow --tags || true
-FEAST_RELEASE_VERSION_WITH_V=$(git tag -l --sort -version:refname | head -n 1)
-echo $FEAST_RELEASE_VERSION_WITH_V
-
-export FEAST_RELEASE_VERSION=${FEAST_RELEASE_VERSION_WITH_V#"v"}
-echo $FEAST_RELEASE_VERSION
-
-[[ -z "$FEAST_RELEASE_VERSION" ]] && {
-  echo "FEAST_RELEASE_VERSION is missing"
+# Determine Docker image version tag relative to current branch
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+if [ $BRANCH_NAME = "fix-version-cross-branch-ref" ]
+then
+    # Use development version
+    FEAST_DOCKER_VERSION="dev"
+elif echo "$BRANCH_NAME" | grep -P $RELEASE_BRANCH_REGEX &>/dev/null
+then
+    # Use last release tag tagged on the release branch
+    LAST_MERGED_TAG=$(git tag -l --sort -version:refname --merged | head -n 1)
+    FEAST_DOCKER_VERSION=${LAST_MERGED_TAG:"v"}
+else
+    # Do not enforce version linting as we don't know if the target merge branch
+    FEAST_DOCKER_VERSION="_ANY"
+fi
+[[ -z "$FEAST_DOCKER_VERSION" ]] && {
+  echo "FEAST_DOCKER_VERSION is missing"
   exit 1
 }
+export FEAST_DOCKER_VERSION
+echo "Linting docker image version: $FEAST_DOCKER_VERSION"
 
-# List of files to validate with master version (from pom.xml)
+# Determine highest stable version relative to current branch
+# Regular expression for matching stable tags in the format vMAJOR.MINOR.PATCH
+STABLE_TAG_REGEX="v[0-9]+\.[0-9]+\.[0-9]+"
+if [ $BRANCH_NAME = "fix-version-cross-branch-ref" ]
+then
+    # Use last stable tag repo wide
+    LAST_STABLE_TAG=$(git tag --sort -version:refname | grep -P "$STABLE_TAG_REGEX" | head -n 1)
+    FEAST_STABLE_VERSION=${LAST_STABLE_TAG#"v"}
+elif echo "$BRANCH_NAME" | grep -P $RELEASE_BRANCH_REGEX &>/dev/null
+then
+    # Use last stable tag tagged on the release branch
+    LAST_STABLE_MERGE_TAG=$(git tag --sort -version:refname --merged | grep -P "$STABLE_TAG_REGEX" | head -n 1)
+    FEAST_STABLE_VERSION=${LAST_STABLE_MERGE_TAG#"v"}
+else
+    # Do not enforce version linting as we don't know if the target merge branch
+    FEAST_STABLE_VERSION="_ANY"
+fi
+[[ -z "$FEAST_STABLE_VERSION" ]] && {
+  echo "FEAST_STABLE_VERSION is missing"
+  exit 1
+}
+export FEAST_STABLE_VERSION
+echo "Linting stable version: $FEAST_STABLE_VERSION"
+
+# List of files to validate with fix-version-cross-branch-ref version (from pom.xml)
 # Structure is a comma separated list of structure
 # <File to validate>, <Amount of occurrences of specific version to look for>, <version to look for>
-#
 
 declare -a files_to_validate_version=(
-  "infra/charts/feast/Chart.yaml,1,${FEAST_MASTER_VERSION}"
-  "infra/charts/feast/charts/feast-core/Chart.yaml,1,${FEAST_MASTER_VERSION}"
-  "infra/charts/feast/charts/feast-core/values.yaml,1,${FEAST_RELEASE_VERSION}"
-  "infra/charts/feast/charts/feast-core/README.md,1,${FEAST_RELEASE_VERSION}"
-  "infra/charts/feast/charts/feast-serving/Chart.yaml,1,${FEAST_MASTER_VERSION}"
-  "infra/charts/feast/charts/feast-jupyter/values.yaml,1,${FEAST_RELEASE_VERSION}"
-  "infra/charts/feast/charts/feast-jupyter/README.md,1,${FEAST_RELEASE_VERSION}"
-  "infra/charts/feast/charts/feast-jupyter/Chart.yaml,1,${FEAST_MASTER_VERSION}"
-  "infra/charts/feast/charts/feast-serving/values.yaml,1,${FEAST_RELEASE_VERSION}"
-  "infra/charts/feast/charts/feast-serving/README.md,1,${FEAST_RELEASE_VERSION}"
-  "infra/charts/feast/charts/feast-jobcontroller/Chart.yaml,1,${FEAST_MASTER_VERSION}"
-  "infra/charts/feast/charts/feast-jobcontroller/values.yaml,1,${FEAST_RELEASE_VERSION}"
-  "infra/charts/feast/charts/feast-jobcontroller/README.md,1,${FEAST_RELEASE_VERSION}"
-  "infra/charts/feast/requirements.yaml,4,${FEAST_MASTER_VERSION}"
-  "infra/charts/feast/requirements.lock,4,${FEAST_RELEASE_VERSION}"
-  "infra/docker-compose/.env.sample,1,${FEAST_RELEASE_VERSION}"
+  "infra/charts/feast/Chart.yaml,1,${FEAST_MAVEN_VERSION}"
+  "infra/charts/feast/charts/feast-core/Chart.yaml,1,${FEAST_MAVEN_VERSION}"
+  "infra/charts/feast/charts/feast-core/values.yaml,1,${FEAST_STABLE_VERSION}"
+  "infra/charts/feast/charts/feast-core/README.md,1,${FEAST_STABLE_VERSION}"
+  "infra/charts/feast/charts/feast-serving/Chart.yaml,1,${FEAST_MAVEN_VERSION}"
+  "infra/charts/feast/charts/feast-jupyter/values.yaml,1,${FEAST_STABLE_VERSION}"
+  "infra/charts/feast/charts/feast-jupyter/README.md,1,${FEAST_STABLE_VERSION}"
+  "infra/charts/feast/charts/feast-jupyter/Chart.yaml,1,${FEAST_MAVEN_VERSION}"
+  "infra/charts/feast/charts/feast-serving/values.yaml,1,${FEAST_STABLE_VERSION}"
+  "infra/charts/feast/charts/feast-serving/README.md,1,${FEAST_STABLE_VERSION}"
+  "infra/charts/feast/charts/feast-jobcontroller/Chart.yaml,1,${FEAST_MAVEN_VERSION}"
+  "infra/charts/feast/charts/feast-jobcontroller/values.yaml,1,${FEAST_STABLE_VERSION}"
+  "infra/charts/feast/charts/feast-jobcontroller/README.md,1,${FEAST_STABLE_VERSION}"
+  "infra/charts/feast/requirements.yaml,4,${FEAST_MAVEN_VERSION}"
+  "infra/charts/feast/requirements.lock,4,${FEAST_STABLE_VERSION}"
+  "infra/docker-compose/.env.sample,1,${FEAST_STABLE_VERSION}"
 )
 
 echo
@@ -55,6 +92,12 @@ echo
 
 for i in "${files_to_validate_version[@]}"; do
   IFS=',' read -r FILE_PATH EXPECTED_OCCURRENCES VERSION <<<"${i}"
+  # Disable version lint if '_ANY' specified as version.
+  if [ "$VERSION" = "_ANY" ]
+  then
+      continue
+  fi
+  
   echo
   echo
   echo "Testing whether versions are correctly set within file: $FILE_PATH"

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -24,7 +24,7 @@ echo "Linting Maven version: $FEAST_MAVEN_VERSION"
 if [ $BRANCH_NAME = "master" ]
 then
     # Use development version
-    FEAST_DOCKER_VERSION="dev"
+    FEAST_DOCKER_VERSION="develop"
 elif echo "$BRANCH_NAME" | grep -P $RELEASE_BRANCH_REGEX &>/dev/null
 then
     # Use last release tag tagged on the release branch

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -5,7 +5,8 @@
 # - Docker images version: 'dev' on master, Highest tag on release branches 
 # - Release version: Highest stable commit. Latest tag repo wide, release candidates not included
 # Usage: ./validate-version-consistency.sh 
-# Optionaly set TARGET_MERGE_BRANCH var to the target merge branch to lint against the given merge branch.
+# Optionaly set TARGET_MERGE_BRANCH var to the target merge branch to lint 
+#   versions against the given merge branch.
 set -e
 
 BRANCH_NAME=${TARGET_MERGE_BRANCH-$(git rev-parse --abbrev-ref HEAD)}
@@ -92,6 +93,7 @@ declare -a files_to_validate_version=(
   "infra/charts/feast/requirements.yaml,4,${FEAST_MAVEN_VERSION}"
   "infra/charts/feast/requirements.lock,4,${FEAST_MAVEN_VERSION}"
   "infra/docker-compose/.env.sample,1,${FEAST_DOCKER_VERSION}"
+  "datatypes/java/README.md,1,${FEAST_MAVEN_VERSION}"
 )
 
 echo

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -19,7 +19,7 @@ export FEAST_MASTER_VERSION=$(mvn help:evaluate -Dexpression=project.version -q 
   echo "$FEAST_MASTER_VERSION is missing, please check pom.xml and maven"
   exit 1
 }
-echo "Linting master version: $FEAST_MASTER_VERSION"
+echo "Linting Master Version: $FEAST_MASTER_VERSION"
 
 # Determine Last release tag relative to current branch
 if [ $BRANCH_NAME = "master" ]
@@ -33,6 +33,7 @@ then
     FEAST_MASTER_VERSION=${LAST_MERGED_TAG#"v"}
 else
     # Do not enforce version linting as we don't know if the target merge branch FEAST_RELEASE_VERSION="_ANY"
+    FEAST_RELEASE_VERSION="_ANY"
     echo "WARNING: Skipping docker version lint"
 fi
 [[ -z "$FEAST_RELEASE_VERSION" ]] && {
@@ -40,7 +41,7 @@ fi
   exit 1
 }
 export FEAST_RELEASE_VERSION
-echo "Linting docker image version: $FEAST_RELEASE_VERSION"
+echo "Linting Release Version: $FEAST_RELEASE_VERSION"
 
 # Determine highest stable version (no release candidates) relative to current branch.
 # Regular expression for matching stable tags in the format vMAJOR.MINOR.PATCH
@@ -65,7 +66,7 @@ fi
   exit 1
 }
 export FEAST_STABLE_VERSION
-echo "Linting stable version: $FEAST_STABLE_VERSION"
+echo "Linting Stable Version: $FEAST_STABLE_VERSION"
 
 # List of files to validate with master version (from pom.xml)
 # Structure is a comma separated list of structure

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -116,11 +116,6 @@ for i in "${files_to_validate_version[@]}"; do
   else
     echo "FAILURE"
     echo
-    echo "File contents:"
-    echo "========================================================="
-    cat "$FILE_PATH"
-    echo "========================================================="
-    echo 
     echo "Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, but found $ACTUAL_OCCURRENCES"
     IS_LINT_SUCCESS=false
   fi

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -99,6 +99,7 @@ declare -a files_to_validate_version=(
   "docs/getting-started/deploying-feast/docker-compose.md,1,${FEAST_STABLE_VERSION}"
   "docs/getting-started/deploying-feast/kubernetes.md,1,${FEAST_STABLE_VERSION}"
   "README.md,1,${FEAST_STABLE_VERSION}"
+  "CHANGELOG.md,2,${FEAST_STABLE_VERSION}"
 )
 
 echo

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -94,6 +94,11 @@ declare -a files_to_validate_version=(
   "infra/charts/feast/requirements.lock,4,${FEAST_MAVEN_VERSION}"
   "infra/docker-compose/.env.sample,1,${FEAST_DOCKER_VERSION}"
   "datatypes/java/README.md,1,${FEAST_MAVEN_VERSION}"
+  "docs/contributing/development-guide.md,4,${FEAST_MAVEN_VERSION}"
+  "docs/administration/audit-logging.md,1,${FEAST_STABLE_VERSION}"
+  "docs/getting-started/deploying-feast/docker-compose.md,1,${FEAST_STABLE_VERSION}"
+  "docs/getting-started/deploying-feast/kubernetes.md,1,${FEAST_STABLE_VERSION}"
+  "README.md,1,${FEAST_STABLE_VERSION}"
 )
 
 echo

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -102,15 +102,9 @@ for i in "${files_to_validate_version[@]}"; do
       continue
   fi
   
-  echo
-  echo
+  echo "========================================================="
   echo "Testing whether versions are correctly set within file: $FILE_PATH"
   echo
-  echo "File contents:"
-  echo "========================================================="
-  cat "$FILE_PATH"
-  echo
-  echo "========================================================="
   ACTUAL_OCCURRENCES=$(grep -c -P "\bv?$VERSION\b" "$FILE_PATH" || true)
 
   if [ "${ACTUAL_OCCURRENCES}" -eq "${EXPECTED_OCCURRENCES}" ]; then
@@ -120,8 +114,12 @@ for i in "${files_to_validate_version[@]}"; do
   else
     echo "FAILURE"
     echo
+    echo "File contents:"
+    echo "========================================================="
+    cat "$FILE_PATH"
+    echo "========================================================="
+    echo 
     echo "Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, but found $ACTUAL_OCCURRENCES"
     exit 1
   fi
-  echo "========================================================="
 done

--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -94,6 +94,8 @@ echo
 echo "Testing list of files to ensure they have the correct version"
 echo
 
+
+IS_LINT_SUCCESS=true
 for i in "${files_to_validate_version[@]}"; do
   IFS=',' read -r FILE_PATH EXPECTED_OCCURRENCES VERSION <<<"${i}"
   # Disable version lint if '_ANY' specified as version.
@@ -120,6 +122,8 @@ for i in "${files_to_validate_version[@]}"; do
     echo "========================================================="
     echo 
     echo "Expecting $EXPECTED_OCCURRENCES occurrences of $VERSION in $FILE_PATH, but found $ACTUAL_OCCURRENCES"
-    exit 1
+    IS_LINT_SUCCESS=false
   fi
 done
+
+if $IS_LINT_SUCCESS; then exit 0; else exit 1; fi

--- a/serving/README.md
+++ b/serving/README.md
@@ -11,8 +11,8 @@ From the Feast project root directory, run the following Maven command to start 
 ```bash
 # Assumptions: 
 # - Local Feast Core is running on localhost:6565
+# Uses configuration from serving/src/main/resources/application.yml
 mvn -pl serving spring-boot:run -Dspring-boot.run.arguments=\
---feast.store.config-path=./sample_redis_config.yml,\
 --feast.core-host=localhost,\
 --feast.core-port=6565
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->
**Why we need it**:
Currently the Feast deployments (helm, docker-compose) reference runs the last release version in the current master's infra.
- This can break if infra and release version are not completely compatible #957  

Currently version lint will fail on master when a new release candidate in tagged in a vX.Y-branch release branch


**What this PR does**:
Updates version lint script to become  branch aware:
- Version lint script now lints for 3 kinds of versions:
    - Maven version:  Feast version set in maven.
    - Docker version: Docker image version tag to use in deployments.
         - uses `develop` on master, versioned tag on vX.Y-branch release branches.
    - Release version: Stable release version without release candidates.
         - uses repo wide latest stable version on master.
         - uses last stable version tag on release branch.

Changes docker images used in master branch to `develop`
- Previously images used latest version.
- Rename `dev` docker image tag to `develop` to make it possible to lint (as implementation relies on counting references.)

Improve version lint coverage to some docs with version:
- Update outdated info in docs.

Fixed bad regex introduced in #994 where it did not match version tag without prerelease suffix:
- fixes issue where regex matches `v0.7.1-rc.1` properly but not `v0.7.1`




**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Feast k8s/docker-compose deployments on master now run the `develop` Feast image instead of latest release version.
```
