### PR TITLE
Fix lint version not pulling tags.

### DIFF
--- a/infra/scripts/validate-version-consistency.sh
+++ b/infra/scripts/validate-version-consistency.sh
@@ -9,7 +9,10 @@
 #   versions against the given merge branch.
 set -e
 
+# Fetch tags and current branch
+git fetch --prune --unshallow --tags || true
 BRANCH_NAME=${TARGET_MERGE_BRANCH-$(git rev-parse --abbrev-ref HEAD)}
+
 # Matches (ie vMAJOR.MINOR-branch) release branch names
 RELEASE_BRANCH_REGEX="^v[0-9]+\.[0-9]+-branch$"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Fixes lint-version not pulling tags before linting versions.
- Required as Github Actions uses a [no tag fetch](https://github.com/feast-dev/feast/runs/1100675375#step:3:31) running in github actions.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
