### PR TITLE
Fixed SA Key permission denied in Jupyter Server deployed using Docker Compose

### DIFF
--- a/infra/docker/jupyter/Dockerfile
+++ b/infra/docker/jupyter/Dockerfile
@@ -19,10 +19,11 @@ COPY .git .git
 COPY README.md README.md
 RUN pip install -e sdk/python -U
 
-# Switch back to original user and workdir
+# Copy examples and set workdir
 USER $NB_UID
 WORKDIR $HOME
-
 COPY examples .
 
-CMD ["start-notebook.sh", "--NotebookApp.token=''"]
+USER root
+COPY infra/docker/jupyter/entrypoint.sh .
+CMD ["bash", "./entrypoint.sh", "--NotebookApp.token=''"]

--- a/infra/docker/jupyter/entrypoint.sh
+++ b/infra/docker/jupyter/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Feast Jupyter Server
+# Entrypoint Script
+#
+
+# Update permissions to allow notebook user access to - Google SA key 
+if [ -f ${GOOGLE_APPLICATION_CREDENTIALS} ]
+then
+    chown -R $NB_UID /etc/gcloud
+fi
+
+# Start Jupyter notebook server as notebook user
+start-notebook.sh --NotebookApp.token=''


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->
**Why we need it**:
Using the docker-compose deploy, users will encounter permission denied error when running an example notebook
when the Google SDK attempts to access credentials at `/etc/gcloud/service-accounts/key.json`

**What this PR does**
Adds an entrypoint.sh script to fix permissions for the SA key on container startup.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
