### PR TITLE
Fix Go SDK extra colon in metadata header for Authentication

### DIFF
--- a/sdk/go/auth.go
+++ b/sdk/go/auth.go
@@ -27,7 +27,7 @@ func (provider *Credential) GetRequestMetadata(ctx context.Context, uri ...strin
 		return map[string]string{}, nil
 	}
 	return map[string]string{
-		"Authorization": "Bearer: " + token.AccessToken,
+		"Authorization": "Bearer " + token.AccessToken,
 	}, nil
 }
 

--- a/sdk/go/auth_test.go
+++ b/sdk/go/auth_test.go
@@ -133,7 +133,7 @@ func TestCredentials(t *testing.T) {
 				t.Errorf("Expected authentication metadata with key: '%s'", authKey)
 			}
 
-			expectedVal := "Bearer: " + tc.want
+			expectedVal := "Bearer " + tc.want
 			if meta[authKey] != expectedVal {
 				t.Errorf("Expected authentication metadata with value: '%s' Got instead: '%s'", expectedVal, meta[authKey])
 			}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Fixes Go SDK outputting a extra `:` in `Authorization` grpc metadata header used for authentication:
- `Bearer: TOKEN` instead of `Bearer TOKEN`, the latter which is correct.
- Bug causes Go SDK authentication with Feast to fail.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
