### PR TITLE
Fix py SDK historical retrieval job to chunked dataframe conversion

### DIFF
--- a/sdk/python/feast/job.py
+++ b/sdk/python/feast/job.py
@@ -134,13 +134,9 @@ class RetrievalJob:
     ) -> pd.DataFrame:
         """
         Wait until a job is done to get an iterable rows of result. This method
-        will split the response into chunked DataFrame of a specified size to
-        to be yielded to the instance calling it.
+        will return the response as a DataFrame.
 
         Args:
-            max_chunk_size (int):
-                Maximum number of rows that the DataFrame should contain.
-
             timeout_sec (int):
                 Max no of seconds to wait until job is done. If "timeout_sec"
                 is exceeded, an exception will be raised.
@@ -180,14 +176,14 @@ class RetrievalJob:
 
         # Max chunk size defined by user
         for result in self.result(timeout_sec=timeout_sec):
-            result.append(records)
+            records.append(result)
             if len(records) == max_chunk_size:
                 df = pd.DataFrame.from_records(records)
                 records.clear()  # Empty records array
                 yield df
 
         # Handle for last chunk that is < max_chunk_size
-        if not records:
+        if records:
             yield pd.DataFrame.from_records(records)
 
     def __iter__(self):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Current implementation attempts to append to a Dict instead of List, which throws `AttributeError`. Also, last chunk of data which is less than max_chunk_size is not returned.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #944, #948 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
