### PR TITLE
Fix listing of Ingestion Jobs with Error Status

### DIFF
--- a/job-controller/src/main/java/feast/jobcontroller/service/JobService.java
+++ b/job-controller/src/main/java/feast/jobcontroller/service/JobService.java
@@ -112,11 +112,6 @@ public class JobService {
     List<IngestionJobProto.IngestionJob> ingestJobs = new ArrayList<>();
     for (String jobId : matchingJobIds) {
       Job job = this.jobRepository.findById(jobId).orElseThrow();
-      // job that failed on start won't be converted toProto successfully
-      // and they're irrelevant here
-      if (job.getStatus() == JobStatus.ERROR) {
-        continue;
-      }
       ingestJobs.add(job.toProto());
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Listing of ingestion jobs skip over the ones with `ERROR` job status.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #895 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
