### PR TITLE
Add validation for dataflow region

### DIFF
--- a/job-controller/src/main/java/feast/jobcontroller/runner/dataflow/DataflowRunnerConfig.java
+++ b/job-controller/src/main/java/feast/jobcontroller/runner/dataflow/DataflowRunnerConfig.java
@@ -16,6 +16,7 @@
  */
 package feast.jobcontroller.runner.dataflow;
 
+import feast.common.validators.OneOfStrings;
 import feast.jobcontroller.runner.option.RunnerConfig;
 import feast.proto.core.RunnerProto.DataflowRunnerConfigOptions;
 import java.util.Map;
@@ -55,7 +56,23 @@ public class DataflowRunnerConfig extends RunnerConfig {
   @NotBlank public String project;
 
   /* The Google Compute Engine region for creating Dataflow jobs. */
-  @NotBlank public String region;
+  @OneOfStrings({
+    "us-west1",
+    "us-central1",
+    "us-east1",
+    "us-east4",
+    "northamerica-northeast1",
+    "europe-west1",
+    "europe-west2",
+    "europe-west3",
+    "europe-west4",
+    "asia-southeast1",
+    "asia-east1",
+    "asia-northeast1",
+    "australia-southeast1"
+  })
+  @NotBlank
+  public String region;
 
   /* GCP availability zone for operations. */
   @NotBlank public String workerZone;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
When selecting a region that Dataflow is not supported in, user is not receiving a descriptive exception.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #812 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
