### PR TITLE
Forward port Lint Version script fixes

### DIFF
--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -41,6 +41,7 @@ jobs:
         run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
       - name: Push versioned Docker image
         run: |
+          source infra/scripts/setup-common-functions.sh
           # Build and push semver tagged commits
           # Regular expression should match MAJOR.MINOR.PATCH[-PRERELEASE[.IDENTIFIER]]
           # eg. v0.7.1 v0.7.2-alpha v0.7.2-rc.1
@@ -52,10 +53,10 @@ jobs:
             docker push gcr.io/kf-feast/feast-${{ matrix.component }}:${VERSION_WITHOUT_PREFIX}
 
             # Also update "latest" image if tagged commit is pushed to stable branch
-            HIGHEST_SEMVER_TAG=$(git tag -l --sort -version:refname | head -n 1)
+            HIGHEST_SEMVER_TAG=$(get_tag_release -m)
             echo "Only push to latest tag if tag is the highest semver version $HIGHEST_SEMVER_TAG"
 
-            if [ "${VERSION_WITHOUT_PREFIX}" == "${HIGHEST_SEMVER_TAG:1}" ]
+            if [ "${VERSION_WITHOUT_PREFIX}" = "${HIGHEST_SEMVER_TAG:1}" ]
             then
               docker tag gcr.io/kf-feast/feast-${{ matrix.component }}:${GITHUB_SHA} gcr.io/kf-feast/feast-${{ matrix.component }}:latest
               docker push gcr.io/kf-feast/feast-${{ matrix.component }}:latest

--- a/infra/scripts/setup-common-functions.sh
+++ b/infra/scripts/setup-common-functions.sh
@@ -174,3 +174,45 @@ wait_for_docker_image(){
 
   set -$oldopt
 }
+
+# Usage: TAG=$(get_tag_release [-ms])
+# Parses the last release from git tags.
+# Options:
+# -m - Use only tags that are tagged on the current branch
+# -s - Use only stable version tags. (ie no prerelease tags).
+get_tag_release() {
+  local GIT_TAG_CMD="git tag -l"
+  # Match only Semver tags
+  # Regular expression should match MAJOR.MINOR.PATCH[-PRERELEASE[.IDENTIFIER]]
+  # eg. v0.7.1 v0.7.2-alpha v0.7.2-rc.1
+  local TAG_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+  local OPTIND opt
+  while getopts "ms" opt; do
+    case "${opt}" in
+      m)
+        GIT_TAG_CMD="$GIT_TAG_CMD --merged"
+        ;;
+      s)
+        # Match only stable version tags.
+        TAG_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+$"
+        ;;
+      *)
+        echo "get_tag_release(): Error: Bad arguments: $@"
+        return 1
+        ;;
+    esac
+  done
+  shift $((OPTIND-1))
+
+  # Retrieve tags from git and filter as per regex.
+  local FILTERED_TAGS=$(bash -c "$GIT_TAG_CMD" | grep -P "$TAG_REGEX")
+
+  # Sort version tags in highest semver version first.
+  # To make sure that prerelease versions (ie versions vMAJOR.MINOR.PATCH-PRERELEASE suffix)
+  # are sorted after stable versions (ie vMAJOR.MINOR.PATCH), we append '_' after 
+  # eachustable version as '_' is after '-' found in prerelease version
+  # alphanumerically and remove after sorting.
+  local SEMVER_SORTED_TAGS=$(echo "$FILTERED_TAGS" | sed -e '/-/!{s/$/_/}' | sort -rV \
+    | sed -e 's/_$//')
+  echo $(echo "$SEMVER_SORTED_TAGS" | head -n 1)
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Forward ports lint version script fixes:
- Fixes issue where lint-version sorts prerelease versions higher than stable versions. (ie `v0.7.0-rc.3` was higher sorted than `v0.7.0`)
- Refactor out version parsing from tags into `get_tag_release()` common function.
- Use `get_tag_release` in master docker push workflow to determine highest merged versioned tag.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
