### PR TITLE
In redis retrieval call fallback only when there's missing keys

### DIFF
--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterOnlineRetriever.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterOnlineRetriever.java
@@ -228,6 +228,10 @@ public class RedisClusterOnlineRetriever implements OnlineRetriever {
                 .boxed()
                 .collect(Collectors.toList());
 
+        if (indexMissingValue.isEmpty()) {
+          return redisValues;
+        }
+
         byte[][] fallbackBinaryKeys =
             indexMissingValue.stream()
                 .map(i -> fallbackSerializer.serialize(keys.get(i)))

--- a/storage/connectors/redis/src/test/java/feast/storage/connectors/redis/retriever/RedisClusterOnlineRetrieverTest.java
+++ b/storage/connectors/redis/src/test/java/feast/storage/connectors/redis/retriever/RedisClusterOnlineRetrieverTest.java
@@ -18,7 +18,7 @@ package feast.storage.connectors.redis.retriever;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.google.common.collect.ImmutableList;
@@ -147,7 +147,9 @@ public class RedisClusterOnlineRetrieverTest {
     List<KeyValue<byte[], byte[]>> featureRowBytes = Lists.newArrayList(keyValue1, keyValue2);
 
     OnlineRetriever redisClusterOnlineRetriever =
-        new RedisClusterOnlineRetriever.Builder(connection, serializer).build();
+        new RedisClusterOnlineRetriever.Builder(connection, serializer)
+            .withFallbackSerializer(fallbackSerializer)
+            .build();
     when(syncCommands.mget(serializedKey1, serializedKey2)).thenReturn(featureRowBytes);
 
     List<Optional<FeatureRow>> expected =
@@ -174,6 +176,9 @@ public class RedisClusterOnlineRetrieverTest {
     List<Optional<FeatureRow>> actual =
         redisClusterOnlineRetriever.getOnlineFeatures(entityRows, featureSetRequest);
     assertThat(actual, equalTo(expected));
+
+    // check that fallback is used only when there's something to fallback
+    verify(syncCommands, never()).mget();
   }
 
   @Test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Currently there's no check if `indexMissingValue` is empty before making second (fallback) request to redis. That cause exception
```
io.lettuce.core.RedisCommandExecutionException: ERR wrong number of arguments for 'mget' command
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
