### PR TITLE
Add User Identity in Fluentd Message Audit Logs

### DIFF
--- a/common/src/main/java/feast/common/logging/AuditLogger.java
+++ b/common/src/main/java/feast/common/logging/AuditLogger.java
@@ -143,6 +143,7 @@ public class AuditLogger {
         }
 
         fluentdLogs.put("id", messageAuditLogEntry.getId());
+        fluentdLogs.put("identity", messageAuditLogEntry.getIdentity());
         fluentdLogs.put("service", messageAuditLogEntry.getService());
         fluentdLogs.put("status_code", messageAuditLogEntry.getStatusCode());
         fluentdLogs.put("method", messageAuditLogEntry.getMethod());

--- a/docs/administration/audit-logging.md
+++ b/docs/administration/audit-logging.md
@@ -103,6 +103,7 @@ Feast currently only supports forwarding Request/Response \(Message Audit Log Ty
   "id": "45329ea9-0d48-46c5-b659-4604f6193711",
   "service": "CoreService"
   "status_code": "OK",
+  "identity": "105960238928959148073",
   "method": "ListProjects",
   "request": {},
   "response": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Adds `identity` field to Fluentd Message Audit Logs to output user identity.  

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fluentd Message Audit Logs now output user identity in the 'identity' field..
```
