### PR TITLE
Added kustomization templates

### DIFF
--- a/infra/kustomization/README.md
+++ b/infra/kustomization/README.md
@@ -1,0 +1,52 @@
+feast-kustomization contains open source feast-core kustomization and will contain feast-serving kustomization
+
+├── README.md
+├── base
+│   ├── feast-core
+│   │   ├── application.yml
+│   │   ├── deployment.yaml
+│   │   ├── kustomization.yaml
+│   │   └── service.yaml
+│   ├── kafka
+│   │   └── kustomization.yaml
+│   ├── kafka-rest-proxy
+│   │   ├── 10-schema-registry-deployment.yaml
+│   │   ├── 11-schema-registry-service.yaml
+│   │   ├── 20-rest-proxy.yaml
+│   │   ├── 21-rest-service.yaml
+│   │   └── kustomization.yaml
+│   ├── postgres
+│   │   ├── kustomization.yaml
+│   │   ├── postgres.yaml
+│   │   ├── secret.yaml
+│   │   └── service.yaml
+│   └── redis
+│       ├── kustomization.yaml
+│       ├── redis.yaml
+│       └── service.yaml
+└── sample
+    ├── feast-core
+    │   ├── application-test.yml
+    │   ├── deployment.yaml
+    │   ├── ksa.yaml
+    │   └── kustomization.yaml
+    ├── kafka
+    │   ├── kafka-scale1.json
+    │   ├── kafka.yaml
+    │   ├── kustomization.yaml
+    │   ├── outsider-0.yaml
+    │   └── zookeeper.yaml
+    ├── kafka-rest-proxy
+    │   ├── kustomization.yaml
+    │   └── rest-proxy-service.yaml
+    └── postgres
+        ├── kustomization.yaml
+        ├── pd.yaml
+        └── volume-claims.yaml
+
+Resource Config
+
+|         | Deployed to cluster            | Purpose            |  
+|---------|--------------------------------|--------------------|------------------
+|base     | No                             | Shared config      |
+|sample   | Yes - Manually or Continuously | Deployable config  | feast-core: feast-core deployable config 

--- a/infra/kustomization/base/feast-core/application.yaml
+++ b/infra/kustomization/base/feast-core/application.yaml
@@ -1,0 +1,26 @@
+grpc:
+  port: 6565
+  enable-reflection: true
+
+spring:
+  jpa:
+    hibernate.ddl-auto: update
+    hibernate.naming.physical-strategy=org.hibernate.boot.model.naming: PhysicalNamingStrategyStandardImpl
+    properties.hibernate.event.merge.entity_copy_observer: allow
+    properties.hibernate.format_sql: true
+
+  datasource:
+    driverClassName: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT:5432}/${DB_DATABASE:postgres}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:password}
+
+management:
+  metrics:
+    export:
+      simple:
+        enabled: false
+      statsd:
+        enabled: false
+        host: localhost
+        port: 8125

--- a/infra/kustomization/base/feast-core/deployment.yaml
+++ b/infra/kustomization/base/feast-core/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feast-core
+  labels:
+    app: feast-core
+spec:
+  # `replicas` omitted to allow `apply` of manifest while scaled by
+  # HPA and avoid dropping replica count back to 1
+  #replicas: 1
+  selector:
+    matchLabels:
+      app: feast-core
+  template:
+    metadata:
+      labels:
+        app: feast-core
+    spec:
+      volumes:
+      - name: feast-core-config
+        configMap:
+          name: feast-core
+      serviceAccountName: feast-core
+      containers:
+      - name: feast-core
+        image: gcr.io/kf-feast/feast-core:develop
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: feast-core-config
+          mountPath: "/etc/feast/feast-core"
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: grpc
+          containerPort: 6565
+        args:
+        - --spring.config.location=file:/etc/feast/feast-core/application.yaml
+        resources:
+          limits:
+            memory: 3Gi
+            cpu: 3000m
+          requests:
+            cpu: 1000m
+            memory: 3Gi
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+          failureThreshold: 5

--- a/infra/kustomization/base/feast-core/hpa.yaml
+++ b/infra/kustomization/base/feast-core/hpa.yaml
@@ -1,0 +1,12 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: feast-core
+spec:
+  maxReplicas: 5
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: feast-core
+  targetCPUUtilizationPercentage: 50

--- a/infra/kustomization/base/feast-core/kustomization.yaml
+++ b/infra/kustomization/base/feast-core/kustomization.yaml
@@ -1,0 +1,19 @@
+
+resources:
+- deployment.yaml
+- service.yaml
+- serviceAccount.yaml
+- hpa.yaml
+
+commonLabels:
+  app: feast-core
+  component: core
+  release: feast-core
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: feast-core
+    files:
+    - application.yaml

--- a/infra/kustomization/base/feast-core/service.yaml
+++ b/infra/kustomization/base/feast-core/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: feast-core
+  labels:
+    app: feast-core
+spec:
+  selector:
+    app: feast-core
+    
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: grpc
+    port: 6565
+    targetPort: 6565

--- a/infra/kustomization/base/feast-core/serviceAccount.yaml
+++ b/infra/kustomization/base/feast-core/serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: feast-core
+  namespace: feast

--- a/infra/kustomization/base/kafka-rest-proxy/10-schema-registry-deployment.yaml
+++ b/infra/kustomization/base/kafka-rest-proxy/10-schema-registry-deployment.yaml
@@ -1,0 +1,39 @@
+# confluent/schema-registry
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: schema-registry
+  labels:
+    app: schema-registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: schema-registry
+  template:
+    metadata:
+      labels:
+        app: schema-registry
+    spec:
+      containers:
+        - name: schema-registry
+          image: confluentinc/cp-schema-registry:5.4.0
+          imagePullPolicy: Always
+          ports:
+            - name: schema-registry
+              containerPort: 8081
+              protocol: TCP
+
+          env:
+          - name: SCHEMA_REGISTRY_HOST_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: SCHEMA_REGISTRY_LISTENERS
+            value: http://0.0.0.0:8081
+          - name: SCHEMA_REGISTRY_KAFKASTORE_GROUP_ID
+            value: schema-registry-540
+          - name: SCHEMA_REGISTRY_MASTER_ELIGIBILITY
+            value: "true"
+          - name: SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS
+            value: PLAINTEXT://$(KAFKA_BROKER):9092            

--- a/infra/kustomization/base/kafka-rest-proxy/11-schema-registry-service.yaml
+++ b/infra/kustomization/base/kafka-rest-proxy/11-schema-registry-service.yaml
@@ -1,0 +1,10 @@
+# confluent/schema-registry
+apiVersion: v1
+kind: Service
+metadata:
+  name: schema-registry
+spec:
+  ports:
+  - port: 8081
+  selector:
+    app: schema-registry

--- a/infra/kustomization/base/kafka-rest-proxy/20-rest-proxy.yaml
+++ b/infra/kustomization/base/kafka-rest-proxy/20-rest-proxy.yaml
@@ -1,0 +1,37 @@
+# confluent/kafka-rest
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rest-proxy
+  labels:
+    app: rest-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rest-proxy
+  template:
+    metadata:
+      labels:
+        app: rest-proxy
+    spec:
+      containers:
+        - name: rest-proxy-server
+          image: confluentinc/cp-kafka-rest:5.3.0
+          imagePullPolicy: Always
+          ports:
+            - name: rest-proxy
+              containerPort: 8082
+              protocol: TCP
+
+          env:
+          - name: KAFKA_REST_HOST_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: KAFKA_REST_LISTENERS
+            value: http://0.0.0.0:8082            
+          - name: KAFKA_REST_SCHEMA_REGISTRY_URL
+            value: http://$(schema-registry-svc):8081
+          - name: KAFKA_REST_BOOTSTRAP_SERVERS
+            value: $(KAFKA_BROKER):9092 

--- a/infra/kustomization/base/kafka-rest-proxy/21-rest-service.yaml
+++ b/infra/kustomization/base/kafka-rest-proxy/21-rest-service.yaml
@@ -1,0 +1,14 @@
+# confluent/kafka-rest
+apiVersion: v1
+kind: Service
+metadata:
+  name: rest-proxy
+  labels:
+    app: rest-proxy
+spec:
+  ports:
+    - name: rest-proxy
+      port: 80
+      targetPort: 8082
+  selector:
+    app: rest-proxy

--- a/infra/kustomization/base/kafka-rest-proxy/kustomization.yaml
+++ b/infra/kustomization/base/kafka-rest-proxy/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+  - 10-schema-registry-deployment.yaml
+  - 11-schema-registry-service.yaml
+  - 20-rest-proxy.yaml
+  - 21-rest-service.yaml
+
+namePrefix: kafka-
+
+vars:
+  - name: schema-registry-svc
+    objref:
+      kind: Service
+      name: schema-registry
+      apiVersion: v1
+    fieldref:
+      fieldpath: metadata.name      

--- a/infra/kustomization/base/kafka/kustomization.yaml
+++ b/infra/kustomization/base/kafka/kustomization.yaml
@@ -1,0 +1,7 @@
+# https://github.com/Yolean/kubernetes-kafka
+
+bases:
+  - github.com/Yolean/kubernetes-kafka/rbac-namespace-default/?ref=60d01b5
+  - github.com/Yolean/kubernetes-kafka/kafka/?ref=60d01b5
+  - github.com/Yolean/kubernetes-kafka/zookeeper/?ref=60d01b5
+

--- a/infra/kustomization/base/postgres/kustomization.yaml
+++ b/infra/kustomization/base/postgres/kustomization.yaml
@@ -1,0 +1,8 @@
+
+
+resources:
+  - postgres.yaml
+  - service.yaml
+  - secret.yaml
+
+

--- a/infra/kustomization/base/postgres/postgres.yaml
+++ b/infra/kustomization/base/postgres/postgres.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  selector:
+    matchLabels:
+      app: postgres
+      role: master
+  serviceName: postgres-headless
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: postgres
+        role: master
+    spec:
+      securityContext:
+        fsGroup: 1001
+      initContainers:
+        - name: init-chmod-data
+          image: docker.io/bitnami/minideb:stretch
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /bitnami/postgresql/data
+              chmod 700 /bitnami/postgresql/data
+              find /bitnami/postgresql -mindepth 0 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
+                xargs chown -R 1001:1001
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: postgredb
+              mountPath: /bitnami/postgresql
+              subPath:
+      containers:
+        - name: postgres
+          image: docker.io/bitnami/postgresql:11.5.0-debian-9-r60
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          securityContext:
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER       
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_DB
+          ports:
+            - name: tcp-postgres
+              containerPort: 5432             
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "postgres" -d "feast" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  pg_isready -U "postgres" -d "feast" -h 127.0.0.1 -p 5432
+                  [ -f /opt/bitnami/postgresql/tmp/.initialized ]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 6
+          volumeMounts:
+            - name: postgredb
+              mountPath: /bitnami/postgresql
+              subPath:
+  volumeClaimTemplates:
+    - metadata:
+        name: postgredb
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi

--- a/infra/kustomization/base/postgres/secret.yaml
+++ b/infra/kustomization/base/postgres/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+type: Opaque
+data:
+  POSTGRES_PASSWORD: 
+stringData:
+  POSTGRES_USER: postgres
+  POSTGRES_DB: feast

--- a/infra/kustomization/base/postgres/service.yaml
+++ b/infra/kustomization/base/postgres/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  ports:
+   - port: 5432
+  selector:
+   app: postgres
+   role: master

--- a/infra/kustomization/base/redis/kustomization.yaml
+++ b/infra/kustomization/base/redis/kustomization.yaml
@@ -1,0 +1,4 @@
+
+resources:
+- redis.yaml
+- service.yaml

--- a/infra/kustomization/base/redis/redis.yaml
+++ b/infra/kustomization/base/redis/redis.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: master
+        image: bitnami/redis:5.0
+        resources:
+          requests:
+            cpu: 100m
+            memory: 150Mi
+          limits:
+            cpu: 300m
+            memory: 150Mi
+        ports:
+        - containerPort: 6379
+        env:
+        - name: ALLOW_EMPTY_PASSWORD
+          value: "yes"
+        args:
+        - /opt/bitnami/scripts/redis/run.sh
+        - --maxmemory 
+        - 100mb

--- a/infra/kustomization/base/redis/service.yaml
+++ b/infra/kustomization/base/redis/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis

--- a/infra/kustomization/base/serving-batch/application.yaml
+++ b/infra/kustomization/base/serving-batch/application.yaml
@@ -1,0 +1,23 @@
+feast:
+  core-grpc-port: 6565
+  core-host: feast-core
+  jobs:
+    staging-location: GCS_PATH
+    store-options:
+      host: localhost
+      port: 6379
+    store-type: REDIS
+  store:
+    config-path: /etc/feast/feast-serving/store.yaml
+    redis-pool-max-idle: 64
+    redis-pool-max-size: 128
+  tracing:
+    enabled: false
+    service-name: feast-serving
+    tracer-name: jaeger
+  version: 0.3
+grpc:
+  enable-reflection: true
+  port: 6566
+server:
+  port: 8080

--- a/infra/kustomization/base/serving-batch/deployment.yaml
+++ b/infra/kustomization/base/serving-batch/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feast-serving-batch
+  namespace: feast
+  labels:
+    app: feast-serving-batch
+    component: serving
+    release: feast
+spec:
+  # `replicas` omitted to allow `apply` of manifest while scaled by
+  # HPA and avoid dropping replica count back to 1
+  #replicas: 1
+  selector:
+    matchLabels:
+      app: feast-serving-batch
+      component: serving
+      release: feast
+  template:
+    metadata:
+      annotations:
+
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      labels:
+        app: feast-serving-batch
+        component: serving
+        release: feast
+    spec:
+      # This disables injection of ENV vars for service discovery
+      # injecting the ENV vars creates clashes with the way that Spring Boot
+      # discovers configuration
+      enableServiceLinks: false
+      volumes:
+      - name: feast-serving-batch-config
+        configMap:
+          name: feast-serving-batch
+      serviceAccountName: feast-serving-batch
+      containers:
+      - name: feast-serving-batch
+        image: gcr.io/kf-feast/feast-serving:develop
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: feast-serving-batch-config
+          mountPath: "/etc/feast/feast-serving"
+        args:
+        - "--spring.config.location=file:/etc/feast/feast-serving/application.yaml"
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: grpc
+          containerPort: 6566
+        resources:
+          limits:
+            cpu: 2
+            memory: 1024Mi
+          requests:
+            cpu: 500m
+            memory: 1024Mi
+        readinessProbe:
+          exec:
+            command: ["grpc-health-probe", "-addr=:6566"]
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+          failureThreshold: 5

--- a/infra/kustomization/base/serving-batch/hpa.yaml
+++ b/infra/kustomization/base/serving-batch/hpa.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: feast-serving-batch
+  namespace: feast
+spec:
+  maxReplicas: 5
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: feast-serving-batch
+  targetCPUUtilizationPercentage: 50

--- a/infra/kustomization/base/serving-batch/kustomization.yaml
+++ b/infra/kustomization/base/serving-batch/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- service.yaml
+- hpa.yaml
+- serviceAccount.yaml
+
+namespace: feast
+
+generatorOptions:
+  labels:
+    app: feast-serving-batch
+    component: serving
+    release: feast
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: feast-serving-batch
+    files:
+      - application.yaml
+      - store.yaml

--- a/infra/kustomization/base/serving-batch/service.yaml
+++ b/infra/kustomization/base/serving-batch/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: feast-serving-batch
+  namespace: feast
+  labels:
+    app: feast-serving-batch
+    component: serving
+    release: feast
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: grpc
+    port: 6566
+    targetPort: 6566
+  selector:
+    app: feast-serving-batch
+    component: serving
+    release: feast

--- a/infra/kustomization/base/serving-batch/serviceAccount.yaml
+++ b/infra/kustomization/base/serving-batch/serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: feast-serving-batch
+  namespace: feast

--- a/infra/kustomization/base/serving-batch/store.yaml
+++ b/infra/kustomization/base/serving-batch/store.yaml
@@ -1,0 +1,9 @@
+bigquery_config:
+  dataset_id: DATASET
+  project_id: PROJECT
+name: bigquery
+subscriptions:
+- name: '*'
+  project: '*'
+  version: '*'
+type: BIGQUERY

--- a/infra/kustomization/base/serving-online/application.yaml
+++ b/infra/kustomization/base/serving-online/application.yaml
@@ -1,0 +1,21 @@
+feast:
+  core-grpc-port: 6565
+  core-host: feast-core
+  jobs:
+    staging-location: ""
+    store-options: {}
+    store-type: ""
+  store:
+    config-path: /etc/feast/feast-serving/store.yaml
+    redis-pool-max-idle: 64
+    redis-pool-max-size: 128
+  tracing:
+    enabled: false
+    service-name: feast-serving
+    tracer-name: jaeger
+  version: 0.3
+grpc:
+  enable-reflection: true
+  port: 6566
+server:
+  port: 8080

--- a/infra/kustomization/base/serving-online/deployment.yaml
+++ b/infra/kustomization/base/serving-online/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feast-serving-online
+  namespace: feast
+  labels:
+    app: feast-serving-online
+    component: serving
+    release: feast
+spec:
+  # `replicas` omitted to allow `apply` of manifest while scaled by
+  # HPA and avoid dropping replica count back to 1
+  #replicas: 1
+  selector:
+    matchLabels:
+      app: feast-serving-online
+      component: serving
+      release: feast
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 25%
+  template:
+    metadata:
+      annotations:
+
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+      labels:
+        app: feast-serving-online
+        component: serving
+        release: feast
+    spec:
+      # This disables injection of ENV vars for service discovery
+      # injecting the ENV vars creates clashes with the way that Spring Boot
+      # discovers configuration
+      enableServiceLinks: false
+      volumes:
+      - name: feast-serving-online-config
+        configMap:
+          name: feast-serving-online
+
+      containers:
+      - name: feast-serving-online
+        image: gcr.io/kf-feast/feast-serving:develop
+        imagePullPolicy: IfNotPresent
+
+        volumeMounts:
+        - name: feast-serving-online-config
+          mountPath: "/etc/feast/feast-serving"
+
+        args:
+        - "--spring.config.location=file:/etc/feast/feast-serving/application.yaml"
+
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: grpc
+          containerPort: 6566
+
+        resources:
+          limits:
+            cpu: 2
+            memory: 2048Mi
+          requests:
+            cpu: 1
+            memory: 2048Mi
+        readinessProbe:
+          exec:
+            command: ["grpc-health-probe", "-addr=:6566"]
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+          failureThreshold: 5

--- a/infra/kustomization/base/serving-online/hpa.yaml
+++ b/infra/kustomization/base/serving-online/hpa.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: feast-serving-online
+  namespace: feast
+spec:
+  maxReplicas: 5
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: feast-serving-online
+  targetCPUUtilizationPercentage: 50

--- a/infra/kustomization/base/serving-online/kustomization.yaml
+++ b/infra/kustomization/base/serving-online/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- service.yaml
+- hpa.yaml
+
+namespace: feast
+
+generatorOptions:
+  labels:
+    app: feast-serving-online
+    component: serving
+    release: feast
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: feast-serving-online
+    files:
+      - application.yaml
+      - store.yaml

--- a/infra/kustomization/base/serving-online/service.yaml
+++ b/infra/kustomization/base/serving-online/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: feast-serving-online
+  namespace: feast
+  labels:
+    app: feast-serving-online
+    release: feast
+    component: serving
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: grpc
+    port: 6566
+    targetPort: 6566
+  selector:
+    app: feast-serving-online
+    component: serving
+    release: feast

--- a/infra/kustomization/base/serving-online/store.yaml
+++ b/infra/kustomization/base/serving-online/store.yaml
@@ -1,0 +1,9 @@
+name: redis
+redis_config:
+  host: feast-redis-master.feast.svc
+  port: 6379
+subscriptions:
+- name: '*'
+  project: '*'
+  version: '*'
+type: REDIS

--- a/infra/kustomization/sample/feast-core/application-test.yml
+++ b/infra/kustomization/sample/feast-core/application-test.yml
@@ -1,0 +1,19 @@
+feast:
+  jobs:
+    metrics:
+      enabled: false
+      host: localhost
+      port: 9125
+      type: statsd
+    runner: DataflowRunner
+    options:
+      project: #GCP_PROJECT_ID#
+      region:  #GCP_PROJECT_REGION#
+    updates:
+      timeoutSeconds: 240
+  stream:
+    options:
+      partitions: 1
+      replicationFactor: 1
+      topic: sample
+    type: kafka

--- a/infra/kustomization/sample/feast-core/deployment.yaml
+++ b/infra/kustomization/sample/feast-core/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: feast-core
+
+spec:
+  replicas: 1
+  template:
+    spec:
+      serviceAccountName: feast-ksa
+      containers:
+      - name: feast-core          
+
+        command:
+          - java
+          - -jar
+          - /opt/feast/feast-core.jar
+          - "--spring.config.location=file:/etc/feast/feast-core/"
+          - "--feast.stream.options.bootstrapServers=$(KAFKA_BROKER):9092"
+
+        env:            
+          - name: DB_HOST
+            value: $(DB_HOST)
+            
+          - name: DB_DATABASE
+            valueFrom: 
+              secretKeyRef:
+                name: postgres-secret
+                key: POSTGRES_DB
+
+          - name: SPRING_DATASOURCE_USERNAME
+            valueFrom: 
+              secretKeyRef:
+                name: postgres-secret
+                key: POSTGRES_USER
+
+          - name: SPRING_DATASOURCE_PASSWORD
+            valueFrom: 
+              secretKeyRef:
+                name: postgres-secret
+                key: POSTGRES_PASSWORD         
+
+          - name: spring.profiles.active
+            value: test

--- a/infra/kustomization/sample/feast-core/ksa.yaml
+++ b/infra/kustomization/sample/feast-core/ksa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: feast-ksa
+  annotations:
+    iam.gke.io/gcp-service-account: #GCP_SERVICE_ACCOUNT# 

--- a/infra/kustomization/sample/feast-core/kustomization.yaml
+++ b/infra/kustomization/sample/feast-core/kustomization.yaml
@@ -1,0 +1,41 @@
+resources:
+- ../kafka
+- ../postgres
+- ksa.yaml
+- ../../base/feast-core
+- ../../base/redis
+- ../kafka-rest-proxy
+
+commonLabels:
+  env: sample
+
+namespace: feast
+
+images:
+  - name: feast-core
+    newTag: 0.4.5
+
+vars:
+  - name: KAFKA_BROKER
+    objref:
+      kind: Service
+      name: bootstrap
+      apiVersion: v1
+    fieldref:
+      fieldpath: metadata.name
+  - name: DB_HOST
+    objref:
+      kind: Service
+      name: postgres
+      apiVersion: v1
+    fieldref:
+      fieldpath: metadata.name
+
+configMapGenerator:
+  - name: feast-core-configmap-application
+    behavior: merge
+    files:
+    - application-test.yml
+
+patchesStrategicMerge:
+  - deployment.yaml

--- a/infra/kustomization/sample/kafka-rest-proxy/kustomization.yaml
+++ b/infra/kustomization/sample/kafka-rest-proxy/kustomization.yaml
@@ -1,0 +1,6 @@
+
+resources:
+- ../../base/kafka-rest-proxy
+      
+patchesStrategicMerge:
+  - rest-proxy-service.yaml

--- a/infra/kustomization/sample/kafka-rest-proxy/rest-proxy-service.yaml
+++ b/infra/kustomization/sample/kafka-rest-proxy/rest-proxy-service.yaml
@@ -1,0 +1,9 @@
+# confluent/kafka-rest
+apiVersion: v1
+kind: Service
+metadata:
+  name: rest-proxy
+  labels:
+    app: rest-proxy
+spec:
+  type: LoadBalancer

--- a/infra/kustomization/sample/kafka/kafka-scale1.json
+++ b/infra/kustomization/sample/kafka/kafka-scale1.json
@@ -1,0 +1,10 @@
+[
+    {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
+    {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "default.replication.factor=1"},
+    {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
+    {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "min.insync.replicas=1"},
+    {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
+    {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "offsets.topic.replication.factor=1"},
+    {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "--override"},
+    {"op": "add", "path": "/spec/template/spec/containers/0/command/-", "value": "offsets.topic.num.partitions=1"}
+  ]

--- a/infra/kustomization/sample/kafka/kafka.yaml
+++ b/infra/kustomization/sample/kafka/kafka.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka
+  namespace: kafka
+spec:
+  replicas: 1

--- a/infra/kustomization/sample/kafka/kustomization.yaml
+++ b/infra/kustomization/sample/kafka/kustomization.yaml
@@ -1,0 +1,19 @@
+# pick scale-1 and outsider-0 service on https://github.com/Yolean/kubernetes-kafka
+
+resources:
+- ../../base/kafka
+- outsider-0.yaml
+
+patchesStrategicMerge:
+- kafka.yaml
+- zookeeper.yaml
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: StatefulSet
+    name: kafka
+    namespace: kafka
+  path: kafka-scale1.json
+

--- a/infra/kustomization/sample/kafka/outsider-0.yaml
+++ b/infra/kustomization/sample/kafka/outsider-0.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: outside-0
+  namespace: kafka
+spec:
+  selector:
+    app: kafka
+    kafka-broker-id: "0"
+  ports:
+  - protocol: TCP
+    targetPort: 9094
+    port: 32400
+    nodePort: 32400
+  type: NodePort

--- a/infra/kustomization/sample/kafka/zookeeper.yaml
+++ b/infra/kustomization/sample/kafka/zookeeper.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pzoo
+  namespace: kafka
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pzoo
+  namespace: kafka
+spec:
+  replicas: 1
+  template:
+    spec:
+      initContainers:
+      - name: init-config
+        env:
+        - name: PZOO_REPLICAS
+          value: '1'
+        - name: ZOO_REPLICAS
+          value: '0'
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: zoo
+  namespace: kafka
+spec:
+  replicas: 0
+  template:
+    spec:
+      initContainers:
+      - name: init-config
+        env:
+        - name: PZOO_REPLICAS
+          value: '1'
+        - name: ZOO_REPLICAS
+          value: '0'
+        - name: ID_OFFSET
+          value: '2'

--- a/infra/kustomization/sample/postgres/kustomization.yaml
+++ b/infra/kustomization/sample/postgres/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- ../../base/postgres
+- pd.yaml
+
+patchesStrategicMerge:
+- volume-claims.yaml

--- a/infra/kustomization/sample/postgres/pd.yaml
+++ b/infra/kustomization/sample/postgres/pd.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: postgres-pd
+provisioner: kubernetes.io/gce-pd
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+parameters:
+  type: pd-standard

--- a/infra/kustomization/sample/postgres/volume-claims.yaml
+++ b/infra/kustomization/sample/postgres/volume-claims.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  volumeClaimTemplates:
+  - metadata:
+      name: postgredb
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: postgres-pd
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently Feast is primarily installed through Helm templates. We would also like to support installing the various Feast components with Kustomize. This update adds Kustomize templates for installing the various Feast services. We have implemented a similar solution internally.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #258. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
