### PR TITLE
add redis SSL support to the offline-to-online ingestion job

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
@@ -31,10 +31,11 @@ trait BasePipeline {
       .setMaster("local")
 
     jobConfig.store match {
-      case RedisConfig(host, port) =>
+      case RedisConfig(host, port, ssl) =>
         conf
           .set("spark.redis.host", host)
           .set("spark.redis.port", port.toString)
+          .set("spark.redis.ssl", ssl.toString)
     }
 
     jobConfig.metrics match {

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -26,7 +26,7 @@ object Modes extends Enumeration {
 
 abstract class StoreConfig
 
-case class RedisConfig(host: String, port: Int) extends StoreConfig
+case class RedisConfig(host: String, port: Int, ssl: Boolean) extends StoreConfig
 
 abstract class MetricConfig
 
@@ -84,7 +84,7 @@ case class IngestionJobConfig(
     source: Source = null,
     startTime: DateTime = DateTime.now(),
     endTime: DateTime = DateTime.now(),
-    store: StoreConfig = RedisConfig("localhost", 6379),
+    store: StoreConfig = RedisConfig("localhost", 6379, false),
     metrics: Option[MetricConfig] = Some(StatsDConfig("localhost", 9125)),
     deadLetterPath: Option[String] = None
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Support SSL option for redis connections (aka "encryption in-transit" in AWS ElastiCache) in the Spark job. SSL is already supported by lettuce/springboot out of the box, so this brings Spark to feature parity.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
