### PR TITLE
Streaming Ingestion Pipeline with Spark

### DIFF
--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -313,6 +313,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -36,7 +36,6 @@
         <spark.version>2.4.7</spark.version>
         <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-        <project.version>0.7-SNAPSHOT</project.version>
     </properties>
 
     <dependencies>

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -36,6 +36,7 @@
         <spark.version>2.4.7</spark.version>
         <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+        <protobuf.version>3.12.2</protobuf.version>
     </properties>
 
     <dependencies>
@@ -54,7 +55,13 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.12.2</version>
+            <version>${protobuf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.gojek</groupId>
+            <artifactId>stencil</artifactId>
+            <version>4.2.0</version>
         </dependency>
 
         <dependency>
@@ -100,7 +107,12 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql-kafka-0-10_${scala.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>2.5.1</version>
         </dependency>
 
         <dependency>
@@ -171,13 +183,6 @@
             <groupId>com.dimafeng</groupId>
             <artifactId>testcontainers-scala-kafka_${scala.version}</artifactId>
             <version>0.38.3</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>2.5.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -302,8 +307,8 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <protocArtifact>com.google.protobuf:protoc:3.12.2</protocArtifact>
-                            <protocVersion>3.12.2</protocVersion>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+                            <protocVersion>${protobuf.version}</protocVersion>
                             <inputDirectories>
                                 <include>src/test/proto</include>
                             </inputDirectories>

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -185,12 +185,24 @@
             <version>0.38.3</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.27.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 
     <build>
         <sourceDirectory>src/main/scala</sourceDirectory>
         <testSourceDirectory>src/test/scala</testSourceDirectory>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
@@ -313,7 +325,18 @@
                                 <include>src/test/proto</include>
                             </inputDirectories>
                             <includeStdTypes>true</includeStdTypes>
-                            <outputDirectory>src/test/scala</outputDirectory>
+                            <outputTargets>
+                                <outputTarget>
+                                    <type>java</type>
+                                    <addSources>none</addSources>
+                                    <outputDirectory>src/test/scala</outputDirectory>
+                                </outputTarget>
+                                <outputTarget>
+                                    <type>descriptor</type>
+                                    <addSources>none</addSources>
+                                    <outputDirectory>src/test/resources/stencil/__files</outputDirectory>
+                                </outputTarget>
+                            </outputTargets>
                         </configuration>
                     </execution>
                 </executions>

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -39,7 +39,6 @@
         <project.version>0.7-SNAPSHOT</project.version>
     </properties>
 
-
     <dependencies>
         <dependency>
             <groupId>dev.feast</groupId>
@@ -169,6 +168,19 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.dimafeng</groupId>
+            <artifactId>testcontainers-scala-kafka_${scala.version}</artifactId>
+            <version>0.38.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>2.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 
@@ -276,6 +288,28 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <version>3.11.4</version>
+                <executions>
+                    <execution>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <protocArtifact>com.google.protobuf:protoc:3.12.2</protocArtifact>
+                            <protocVersion>3.12.2</protocVersion>
+                            <inputDirectories>
+                                <include>src/test/proto</include>
+                            </inputDirectories>
+                            <includeStdTypes>true</includeStdTypes>
+                            <outputDirectory>src/test/scala</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
@@ -17,7 +17,8 @@
 package feast.ingestion
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{Column, SparkSession}
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.streaming.StreamingQuery
 
 trait BasePipeline {
@@ -67,4 +68,27 @@ trait BasePipeline {
   }
 
   def createPipeline(sparkSession: SparkSession, config: IngestionJobConfig): Option[StreamingQuery]
+
+  /**
+    * Build column projection using custom mapping with fallback to feature|entity names.
+    */
+  def inputProjection(
+      source: Source,
+      features: Seq[Field],
+      entities: Seq[Field]
+  ): Array[Column] = {
+    val featureColumns = features
+      .filter(f => !source.mapping.contains(f.name))
+      .map(f => (f.name, f.name)) ++ source.mapping
+
+    val timestampColumn = Seq((source.timestampColumn, source.timestampColumn))
+    val entitiesColumns =
+      entities
+        .filter(e => !source.mapping.contains(e.name))
+        .map(e => (e.name, e.name))
+
+    (featureColumns ++ entitiesColumns ++ timestampColumn).map { case (alias, source) =>
+      col(source).alias(alias)
+    }.toArray
+  }
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
@@ -18,6 +18,7 @@ package feast.ingestion
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.streaming.StreamingQuery
 
 trait BasePipeline {
   def createSparkSession(jobConfig: IngestionJobConfig): SparkSession = {
@@ -65,5 +66,5 @@ trait BasePipeline {
       .getOrCreate()
   }
 
-  def createPipeline(sparkSession: SparkSession, config: IngestionJobConfig): Unit
+  def createPipeline(sparkSession: SparkSession, config: IngestionJobConfig): Option[StreamingQuery]
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -57,7 +57,7 @@ object BatchPipeline extends BasePipeline {
     val projected = input.select(projection: _*).cache()
 
     TypeCheck.allTypesMatch(projected.schema, featureTable) match {
-      case Left(error) =>
+      case Some(error) =>
         throw new RuntimeException(s"Dataframe columns don't match expected feature types: $error")
       case _ => ()
     }

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.functions.col
   * 5. Store invalid rows in parquet format at `deadletter` destination
   */
 object BatchPipeline extends BasePipeline {
-  override def createPipeline(sparkSession: SparkSession, config: IngestionJobConfig): Unit = {
+  override def createPipeline(sparkSession: SparkSession, config: IngestionJobConfig) = {
     val featureTable = config.featureTable
     val projection =
       inputProjection(config.source, featureTable.features, featureTable.entities)
@@ -77,6 +77,7 @@ object BatchPipeline extends BasePipeline {
       case _ => None
     }
 
+    None
   }
 
   /**

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -58,7 +58,7 @@ object BatchPipeline extends BasePipeline {
 
     TypeCheck.allTypesMatch(projected.schema, featureTable) match {
       case Left(error) =>
-        throw new RuntimeException(s"Dataframes columns don't match expected feature types: $error")
+        throw new RuntimeException(s"Dataframe columns don't match expected feature types: $error")
       case _ => ()
     }
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -79,27 +79,4 @@ object BatchPipeline extends BasePipeline {
 
     None
   }
-
-  /**
-    * Build column projection using custom mapping with fallback to feature|entity names.
-    */
-  private def inputProjection(
-      source: Source,
-      features: Seq[Field],
-      entities: Seq[Field]
-  ): Array[Column] = {
-    val featureColumns = features
-      .filter(f => !source.mapping.contains(f.name))
-      .map(f => (f.name, f.name)) ++ source.mapping
-
-    val timestampColumn = Seq((source.timestampColumn, source.timestampColumn))
-    val entitiesColumns =
-      entities
-        .filter(e => !source.mapping.contains(e.name))
-        .map(e => (e.name, e.name))
-
-    (featureColumns ++ entitiesColumns ++ timestampColumn).map { case (alias, source) =>
-      col(source).alias(alias)
-    }.toArray
-  }
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -35,7 +35,7 @@ object BatchPipeline extends BasePipeline {
     val featureTable = config.featureTable
     val projection =
       inputProjection(config.source, featureTable.features, featureTable.entities)
-    val validator = new RowValidator(featureTable)
+    val validator = new RowValidator(featureTable, config.source.timestampColumn)
 
     val input = config.source match {
       case source: BQSource =>

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -81,7 +81,7 @@ object IngestionJob {
             BatchPipeline.createPipeline(sparkSession, config)
           case Modes.Online =>
             val sparkSession = BatchPipeline.createSparkSession(config)
-            StreamingPipeline.createPipeline(sparkSession, config)
+            StreamingPipeline.createPipeline(sparkSession, config).get.awaitTermination
         }
       case None =>
         println("Parameters can't be parsed")

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -79,6 +79,9 @@ object IngestionJob {
           case Modes.Offline =>
             val sparkSession = BatchPipeline.createSparkSession(config)
             BatchPipeline.createPipeline(sparkSession, config)
+          case Modes.Online =>
+            val sparkSession = BatchPipeline.createSparkSession(config)
+            StreamingPipeline.createPipeline(sparkSession, config)
         }
       case None =>
         println("Parameters can't be parsed")

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -40,7 +40,9 @@ abstract class Source {
 
 abstract class BatchSource extends Source
 
-abstract class StreamingSource extends Source
+abstract class StreamingSource extends Source {
+  def classpath: String
+}
 
 case class FileSource(
     path: String,
@@ -59,6 +61,7 @@ case class BQSource(
 case class KafkaSource(
     bootstrapServers: String,
     topic: String,
+    override val classpath: String,
     override val mapping: Map[String, String],
     override val timestampColumn: String
 ) extends StreamingSource

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -63,7 +63,7 @@ object StreamingPipeline extends BasePipeline with Serializable {
 
     TypeCheck.allTypesMatch(projected.schema, featureTable) match {
       case Left(error) =>
-        throw new RuntimeException(s"Dataframes columns don't match expected feature types: $error")
+        throw new RuntimeException(s"Dataframe columns don't match expected feature types: $error")
       case _ => ()
     }
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -62,7 +62,7 @@ object StreamingPipeline extends BasePipeline with Serializable {
       .select(projection: _*)
 
     TypeCheck.allTypesMatch(projected.schema, featureTable) match {
-      case Left(error) =>
+      case Some(error) =>
         throw new RuntimeException(s"Dataframe columns don't match expected feature types: $error")
       case _ => ()
     }

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion
+
+import java.sql
+
+import com.google.protobuf.Descriptors.{Descriptor, EnumValueDescriptor, FieldDescriptor}
+import com.google.protobuf.{AbstractMessage, ByteString, GeneratedMessageV3, Parser, Timestamp}
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.types._
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType._
+import org.apache.spark.sql.streaming.StreamingQuery
+
+import scala.collection.convert.ImplicitConversions._
+import collection.JavaConverters._
+
+object StreamingPipeline extends BasePipeline with Serializable {
+  override def createPipeline(
+      sparkSession: SparkSession,
+      config: IngestionJobConfig
+  ): Option[StreamingQuery] = {
+    import sparkSession.implicits._
+
+    val featureTable = config.featureTable
+
+    val input = config.source match {
+      case source: KafkaSource =>
+        sparkSession.readStream
+          .format("kafka")
+          .option("kafka.bootstrap.servers", source.bootstrapServers)
+          .option("subscribe", source.topic)
+          .option("startingOffsets", "earliest")
+          .load()
+    }
+
+    val klass = loadClass(config.source.asInstanceOf[StreamingSource].classpath)
+      .asInstanceOf[Class[GeneratedMessageV3]]
+
+    val defaultInstance =
+      klass.getMethod("getDefaultInstance").invoke(null).asInstanceOf[GeneratedMessageV3]
+
+    val schema = StructType(defaultInstance.getDescriptorForType.getFields.flatMap(structFieldFor))
+    print(schema)
+
+    val u = udf(createMessageParser(defaultInstance), schema)
+    val o = input.withColumn("content", u($"value")).select("content.*")
+
+    val query = o.writeStream
+      .format("feast.ingestion.stores.redis")
+      .option("entity_columns", featureTable.entities.map(_.name).mkString(","))
+      .option("namespace", featureTable.name)
+      .option("project_name", featureTable.project)
+      .option("timestamp_column", config.source.timestampColumn)
+      .start()
+
+    Some(query)
+  }
+
+  private def loadClass(className: String) =
+    Class.forName(className, true, getClass.getClassLoader)
+
+  def structFieldFor(fd: FieldDescriptor): Option[StructField] = {
+    val dataType = fd.getJavaType match {
+      case INT         => Some(IntegerType)
+      case LONG        => Some(LongType)
+      case FLOAT       => Some(FloatType)
+      case DOUBLE      => Some(DoubleType)
+      case BOOLEAN     => Some(BooleanType)
+      case STRING      => Some(StringType)
+      case BYTE_STRING => Some(BinaryType)
+      case ENUM        => Some(StringType)
+      case MESSAGE =>
+        fd.getMessageType.getFullName match {
+          case "google.protobuf.Timestamp" => Some(TimestampType)
+          case _ =>
+            Option(fd.getMessageType.getFields.flatMap(structFieldFor))
+              .filter(_.nonEmpty)
+              .map(StructType.apply)
+        }
+    }
+
+    dataType.map(dt =>
+      StructField(
+        fd.getName,
+        if (fd.isRepeated) ArrayType(dt, containsNull = false) else dt,
+        nullable = !fd.isRequired && !fd.isRepeated
+      )
+    )
+  }
+
+  /**
+    * @param defaultInstance except protobuf message instance because it's serializable
+    *                        and both parser & fields descriptor can be extracted from it
+    */
+  def createMessageParser(defaultInstance: GeneratedMessageV3): Array[Byte] => Row = {
+    def toRowData(fd: FieldDescriptor, obj: AnyRef): AnyRef = {
+      fd.getJavaType match {
+        case BYTE_STRING => obj.asInstanceOf[ByteString].toByteArray
+        case ENUM        => obj.asInstanceOf[EnumValueDescriptor].getName
+        case MESSAGE =>
+          fd.getMessageType.getFullName match {
+            case "google.protobuf.Timestamp" =>
+              new sql.Timestamp(obj.asInstanceOf[Timestamp].getSeconds * 1000)
+            case _ => messageToRow(obj.asInstanceOf[AbstractMessage])
+          }
+
+        case _ => obj
+      }
+    }
+
+    def messageToRow(message: AbstractMessage) = {
+      val fields = message.getAllFields
+
+      Row(defaultInstance.getDescriptorForType.getFields.map { fd =>
+        if (fields.containsKey(fd)) {
+          val obj = fields.get(fd)
+          if (fd.isRepeated) {
+            obj.asInstanceOf[java.util.List[Object]].map(toRowData(fd, _))
+          } else {
+            toRowData(fd, obj)
+          }
+        } else if (fd.isRepeated) {
+          Seq()
+        } else null
+      }: _*)
+    }
+
+    bytes: Array[Byte] =>
+      messageToRow(defaultInstance.getParserForType.parseFrom(bytes).asInstanceOf[AbstractMessage])
+  }
+
+}

--- a/spark/ingestion/src/main/scala/feast/ingestion/registry/proto/LocalProtoRegistry.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/registry/proto/LocalProtoRegistry.scala
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.registry.proto
+import java.io.{IOException, ObjectInputStream}
+
+import com.google.protobuf.Descriptors.Descriptor
+
+import collection.mutable
+import scala.util.control.NonFatal
+
+class LocalProtoRegistry extends ProtoRegistry {
+  @transient
+  private var cache: mutable.Map[String, Descriptor] = mutable.Map.empty
+
+  @throws(classOf[IOException])
+  private def readObject(ois: ObjectInputStream): Unit = {
+    try {
+      ois.defaultReadObject()
+      cache = mutable.Map.empty
+    } catch {
+      case NonFatal(e) =>
+        throw new IOException(e)
+    }
+  }
+
+  override def getProtoDescriptor(className: String): Descriptor = {
+    if (!cache.contains(className)) {
+      cache(className) = Class
+        .forName(className, true, getClass.getClassLoader)
+        .getMethod("getDescriptor")
+        .invoke(null)
+        .asInstanceOf[Descriptor]
+    }
+
+    cache(className)
+  }
+}

--- a/spark/ingestion/src/main/scala/feast/ingestion/registry/proto/ProtoRegistry.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/registry/proto/ProtoRegistry.scala
@@ -14,22 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feast.ingestion.validation
+package feast.ingestion.registry.proto
 
-import feast.ingestion.FeatureTable
-import org.apache.spark.sql.Column
-import org.apache.spark.sql.functions.col
+import com.google.protobuf.Descriptors.Descriptor
 
-class RowValidator(featureTable: FeatureTable, timestampColumn: String) extends Serializable {
-  def allEntitiesPresent: Column =
-    featureTable.entities.map(e => col(e.name).isNotNull).reduce(_.&&(_))
-
-  def atLeastOneFeatureNotNull: Column =
-    featureTable.features.map(f => col(f.name).isNotNull).reduce(_.||(_))
-
-  def timestampPresent: Column =
-    col(timestampColumn).isNotNull
-
-  def checkAll: Column =
-    allEntitiesPresent && atLeastOneFeatureNotNull && timestampPresent
+trait ProtoRegistry extends Serializable {
+  def getProtoDescriptor(className: String): Descriptor
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/registry/proto/ProtoRegistryFactory.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/registry/proto/ProtoRegistryFactory.scala
@@ -19,8 +19,8 @@ package feast.ingestion.registry.proto
 import org.apache.spark.sql.SparkSession
 
 object ProtoRegistryFactory {
-  val CONFIG_PREFIX       = "feast.ingestion.registry.proto"
-  val PROTO_REGISTRY_KIND = s"$CONFIG_PREFIX.kind"
+  val CONFIG_PREFIX       = "feast.ingestion.registry.proto."
+  val PROTO_REGISTRY_KIND = s"${CONFIG_PREFIX}kind"
   val DEFAULT_KIND        = "local"
 
   def resolveProtoRegistry(sparkSession: SparkSession): ProtoRegistry = {

--- a/spark/ingestion/src/main/scala/feast/ingestion/registry/proto/ProtoRegistryFactory.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/registry/proto/ProtoRegistryFactory.scala
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.registry.proto
+
+import org.apache.spark.sql.SparkSession
+
+object ProtoRegistryFactory {
+  val CONFIG_PREFIX       = "feast.ingestion.registry.proto"
+  val PROTO_REGISTRY_KIND = s"$CONFIG_PREFIX.kind"
+  val DEFAULT_KIND        = "local"
+
+  def resolveProtoRegistry(sparkSession: SparkSession): ProtoRegistry = {
+    val config     = sparkSession.sparkContext.getConf
+    val kind       = config.get(PROTO_REGISTRY_KIND, DEFAULT_KIND)
+    val properties = config.getAllWithPrefix(CONFIG_PREFIX).toMap
+    protoRegistry(kind, properties)
+  }
+
+  private def protoRegistry(name: String, properties: Map[String, String]): ProtoRegistry =
+    name match {
+      case "local"   => new LocalProtoRegistry
+      case "stencil" => new StencilProtoRegistry(properties("url"))
+    }
+}

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/DefaultSource.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/DefaultSource.scala
@@ -16,16 +16,14 @@
  */
 package feast.ingestion.stores.redis
 
-import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
-import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, StreamSinkProvider}
-import org.apache.spark.sql.streaming.OutputMode
+import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider}
 
 /**
   * Entrypoint to Redis Storage. Implements only `CreatableRelationProvider` since it's only possible write to Redis.
   * Here we parse configuration from spark parameters & provide SparkRedisConfig to `RedisSinkRelation`
   */
-class RedisRelationProvider extends CreatableRelationProvider with StreamSinkProvider {
+class RedisRelationProvider extends CreatableRelationProvider {
   override def createRelation(
       sqlContext: SQLContext,
       mode: SaveMode,
@@ -39,13 +37,6 @@ class RedisRelationProvider extends CreatableRelationProvider with StreamSinkPro
 
     relation
   }
-
-  override def createSink(
-      sqlContext: SQLContext,
-      parameters: Map[String, String],
-      partitionColumns: Seq[String],
-      outputMode: OutputMode
-  ): Sink = {}
 }
 
 class DefaultSource extends RedisRelationProvider

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/DefaultSource.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/DefaultSource.scala
@@ -16,14 +16,16 @@
  */
 package feast.ingestion.stores.redis
 
+import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
-import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, RelationProvider}
+import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, StreamSinkProvider}
+import org.apache.spark.sql.streaming.OutputMode
 
 /**
   * Entrypoint to Redis Storage. Implements only `CreatableRelationProvider` since it's only possible write to Redis.
   * Here we parse configuration from spark parameters & provide SparkRedisConfig to `RedisSinkRelation`
   */
-class RedisRelationProvider extends CreatableRelationProvider {
+class RedisRelationProvider extends CreatableRelationProvider with StreamSinkProvider {
   override def createRelation(
       sqlContext: SQLContext,
       mode: SaveMode,
@@ -37,6 +39,13 @@ class RedisRelationProvider extends CreatableRelationProvider {
 
     relation
   }
+
+  override def createSink(
+      sqlContext: SQLContext,
+      parameters: Map[String, String],
+      partitionColumns: Seq[String],
+      outputMode: OutputMode
+  ): Sink = {}
 }
 
 class DefaultSource extends RedisRelationProvider

--- a/spark/ingestion/src/main/scala/feast/ingestion/utils/ProtoReflection.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/utils/ProtoReflection.scala
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.utils
+
+import java.sql
+
+import com.google.protobuf.Descriptors.{EnumValueDescriptor, FieldDescriptor}
+import com.google.protobuf.Descriptors.FieldDescriptor.JavaType._
+import com.google.protobuf.{AbstractMessage, ByteString, GeneratedMessageV3, Timestamp}
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+
+import collection.convert.ImplicitConversions._
+
+object ProtoReflection {
+  def structFieldFor(fd: FieldDescriptor): Option[StructField] = {
+    val dataType = fd.getJavaType match {
+      case INT         => Some(IntegerType)
+      case LONG        => Some(LongType)
+      case FLOAT       => Some(FloatType)
+      case DOUBLE      => Some(DoubleType)
+      case BOOLEAN     => Some(BooleanType)
+      case STRING      => Some(StringType)
+      case BYTE_STRING => Some(BinaryType)
+      case ENUM        => Some(StringType)
+      case MESSAGE =>
+        fd.getMessageType.getFullName match {
+          case "google.protobuf.Timestamp" => Some(TimestampType)
+          case _ =>
+            Option(fd.getMessageType.getFields.flatMap(structFieldFor))
+              .filter(_.nonEmpty)
+              .map(StructType.apply)
+        }
+    }
+
+    dataType.map(dt =>
+      StructField(
+        fd.getName,
+        if (fd.isRepeated) ArrayType(dt, containsNull = false) else dt,
+        nullable = !fd.isRequired && !fd.isRepeated
+      )
+    )
+  }
+
+  /**
+    * @param defaultInstance except protobuf message instance because it's serializable
+    *                        and both parser & fields descriptor can be extracted from it
+    */
+  def createMessageParser(defaultInstance: GeneratedMessageV3): Array[Byte] => Row = {
+    def toRowData(fd: FieldDescriptor, obj: AnyRef): AnyRef = {
+      fd.getJavaType match {
+        case BYTE_STRING => obj.asInstanceOf[ByteString].toByteArray
+        case ENUM        => obj.asInstanceOf[EnumValueDescriptor].getName
+        case MESSAGE =>
+          fd.getMessageType.getFullName match {
+            case "google.protobuf.Timestamp" =>
+              new sql.Timestamp(obj.asInstanceOf[Timestamp].getSeconds * 1000)
+            case _ => messageToRow(obj.asInstanceOf[AbstractMessage])
+          }
+
+        case _ => obj
+      }
+    }
+
+    def defaultValue(fd: FieldDescriptor): AnyRef = {
+      fd.getJavaType match {
+        case ENUM    => null
+        case MESSAGE => null
+        case _       => fd.getDefaultValue
+      }
+    }
+
+    def messageToRow(message: AbstractMessage) = {
+      val fields = message.getAllFields
+
+      Row(defaultInstance.getDescriptorForType.getFields.map { fd =>
+        if (fields.containsKey(fd)) {
+          val obj = fields.get(fd)
+          if (fd.isRepeated) {
+            obj.asInstanceOf[java.util.List[Object]].map(toRowData(fd, _))
+          } else {
+            toRowData(fd, obj)
+          }
+        } else if (fd.isRepeated) {
+          Seq()
+        } else defaultValue(fd)
+      }: _*)
+    }
+
+    bytes: Array[Byte] =>
+      messageToRow(defaultInstance.getParserForType.parseFrom(bytes).asInstanceOf[AbstractMessage])
+  }
+}

--- a/spark/ingestion/src/main/scala/feast/ingestion/utils/TypeConversion.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/utils/TypeConversion.scala
@@ -23,6 +23,7 @@ import feast.proto.types.ValueProto
 import org.apache.spark.sql.types._
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 object TypeConversion {
   def sqlTypeToProtoValue(value: Any, `type`: DataType): Message = {
@@ -33,26 +34,36 @@ object TypeConversion {
       case DoubleType  => ValueProto.Value.newBuilder().setDoubleVal(value.asInstanceOf[Double])
       case FloatType   => ValueProto.Value.newBuilder().setFloatVal(value.asInstanceOf[Float])
       case StringType  => ValueProto.Value.newBuilder().setStringVal(value.asInstanceOf[String])
+      case BooleanType => ValueProto.Value.newBuilder().setBoolVal(value.asInstanceOf[Boolean])
+      case BinaryType =>
+        ValueProto.Value
+          .newBuilder()
+          .setBytesVal(ByteString.copyFrom(value.asInstanceOf[Array[Byte]]))
       case ArrayType(t: IntegerType, _) =>
         ValueProto.Value
           .newBuilder()
           .setInt32ListVal(
             ValueProto.Int32List.newBuilder
-              .addAllVal(value.asInstanceOf[Array[Integer]].toSeq.asJava)
+              .addAllVal(value.asInstanceOf[mutable.WrappedArray[Integer]].asJava)
           )
       case ArrayType(t: LongType, _) =>
         ValueProto.Value
           .newBuilder()
           .setInt64ListVal(
             ValueProto.Int64List.newBuilder
-              .addAllVal(value.asInstanceOf[Array[Long]].toSeq.map(java.lang.Long.valueOf).asJava)
+              .addAllVal(
+                value.asInstanceOf[mutable.WrappedArray[Long]].map(java.lang.Long.valueOf).asJava
+              )
           )
       case ArrayType(t: BooleanType, _) =>
         ValueProto.Value
           .newBuilder()
           .setBoolListVal(
             ValueProto.BoolList.newBuilder.addAllVal(
-              value.asInstanceOf[Array[Boolean]].toSeq.map(java.lang.Boolean.valueOf).asJava
+              value
+                .asInstanceOf[mutable.WrappedArray[Boolean]]
+                .map(java.lang.Boolean.valueOf)
+                .asJava
             )
           )
       case ArrayType(t: FloatType, _) =>
@@ -60,26 +71,24 @@ object TypeConversion {
           .newBuilder()
           .setFloatListVal(
             ValueProto.FloatList.newBuilder
-              .addAllVal(value.asInstanceOf[Array[Float]].toSeq.map(java.lang.Float.valueOf).asJava)
+              .addAllVal(
+                value.asInstanceOf[mutable.WrappedArray[Float]].map(java.lang.Float.valueOf).asJava
+              )
           )
       case ArrayType(t: DoubleType, _) =>
         ValueProto.Value
           .newBuilder()
           .setDoubleListVal(
             ValueProto.DoubleList.newBuilder.addAllVal(
-              value.asInstanceOf[Array[Double]].toSeq.map(java.lang.Double.valueOf).asJava
+              value.asInstanceOf[mutable.WrappedArray[Double]].map(java.lang.Double.valueOf).asJava
             )
           )
-      case ArrayType(t: ByteType, _) =>
-        ValueProto.Value
-          .newBuilder()
-          .setBytesVal(ByteString.copyFrom(value.asInstanceOf[Array[Byte]]))
       case ArrayType(t: StringType, _) =>
         ValueProto.Value
           .newBuilder()
           .setStringListVal(
             ValueProto.StringList.newBuilder
-              .addAllVal(value.asInstanceOf[Array[String]].toSeq.asJava)
+              .addAllVal(value.asInstanceOf[mutable.WrappedArray[String]].asJava)
           )
       case TimestampType =>
         Timestamp
@@ -94,20 +103,27 @@ object TypeConversion {
 
   implicit def protoValueAsScala(v: ValueProto.Value): AsScala[Any] = new AsScala[Any](
     v.getValCase match {
-      case ValueProto.Value.ValCase.INT32_VAL       => v.getInt32Val
-      case ValueProto.Value.ValCase.INT64_VAL       => v.getInt64Val
-      case ValueProto.Value.ValCase.FLOAT_VAL       => v.getFloatVal
-      case ValueProto.Value.ValCase.BOOL_VAL        => v.getBoolVal
-      case ValueProto.Value.ValCase.DOUBLE_VAL      => v.getDoubleVal
-      case ValueProto.Value.ValCase.STRING_VAL      => v.getStringVal
-      case ValueProto.Value.ValCase.BYTES_VAL       => v.getBytesVal
-      case ValueProto.Value.ValCase.INT32_LIST_VAL  => v.getInt32ListVal.getValList
-      case ValueProto.Value.ValCase.INT64_LIST_VAL  => v.getInt64ListVal.getValList
-      case ValueProto.Value.ValCase.FLOAT_LIST_VAL  => v.getFloatListVal.getValList
-      case ValueProto.Value.ValCase.DOUBLE_LIST_VAL => v.getDoubleListVal.getValList
-      case ValueProto.Value.ValCase.BOOL_LIST_VAL   => v.getBoolListVal.getValList
-      case ValueProto.Value.ValCase.STRING_LIST_VAL => v.getStringListVal.getValList
-      case ValueProto.Value.ValCase.BYTES_LIST_VAL  => v.getBytesListVal.getValList
+      case ValueProto.Value.ValCase.INT32_VAL  => v.getInt32Val
+      case ValueProto.Value.ValCase.INT64_VAL  => v.getInt64Val
+      case ValueProto.Value.ValCase.FLOAT_VAL  => v.getFloatVal
+      case ValueProto.Value.ValCase.BOOL_VAL   => v.getBoolVal
+      case ValueProto.Value.ValCase.DOUBLE_VAL => v.getDoubleVal
+      case ValueProto.Value.ValCase.STRING_VAL => v.getStringVal
+      case ValueProto.Value.ValCase.BYTES_VAL  => v.getBytesVal
+      case ValueProto.Value.ValCase.INT32_LIST_VAL =>
+        v.getInt32ListVal.getValList.iterator().asScala.toList
+      case ValueProto.Value.ValCase.INT64_LIST_VAL =>
+        v.getInt64ListVal.getValList.iterator().asScala.toList
+      case ValueProto.Value.ValCase.FLOAT_LIST_VAL =>
+        v.getFloatListVal.getValList.iterator().asScala.toList
+      case ValueProto.Value.ValCase.DOUBLE_LIST_VAL =>
+        v.getDoubleListVal.getValList.iterator().asScala.toList
+      case ValueProto.Value.ValCase.BOOL_LIST_VAL =>
+        v.getBoolListVal.getValList.iterator().asScala.toList
+      case ValueProto.Value.ValCase.STRING_LIST_VAL =>
+        v.getStringListVal.getValList.iterator().asScala.toList
+      case ValueProto.Value.ValCase.BYTES_LIST_VAL =>
+        v.getBytesListVal.getValList.iterator().asScala.toList
       case ValueProto.Value.ValCase.VAL_NOT_SET =>
         throw new RuntimeException(s"$v not a ValueProto")
     }

--- a/spark/ingestion/src/main/scala/feast/ingestion/validation/TypeCheck.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/validation/TypeCheck.scala
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.validation
+
+import feast.ingestion.FeatureTable
+import feast.proto.types.ValueProto.ValueType
+import org.apache.spark.sql.types._
+
+object TypeCheck {
+  def typesMatch(defType: ValueType.Enum, columnType: DataType): Boolean =
+    (defType, columnType) match {
+      case (ValueType.Enum.BOOL, BooleanType)                        => true
+      case (ValueType.Enum.INT32, IntegerType)                       => true
+      case (ValueType.Enum.INT64, LongType)                          => true
+      case (ValueType.Enum.FLOAT, FloatType)                         => true
+      case (ValueType.Enum.DOUBLE, DoubleType)                       => true
+      case (ValueType.Enum.STRING, StringType)                       => true
+      case (ValueType.Enum.BYTES, BinaryType)                        => true
+      case (ValueType.Enum.BOOL_LIST, ArrayType(_: BooleanType, _))  => true
+      case (ValueType.Enum.INT32_LIST, ArrayType(_: IntegerType, _)) => true
+      case (ValueType.Enum.INT64_LIST, ArrayType(_: LongType, _))    => true
+      case (ValueType.Enum.FLOAT_LIST, ArrayType(_: FloatType, _))   => true
+      case (ValueType.Enum.DOUBLE_LIST, ArrayType(_: DoubleType, _)) => true
+      case (ValueType.Enum.STRING_LIST, ArrayType(_: StringType, _)) => true
+      case (ValueType.Enum.BYTES_LIST, ArrayType(_: BinaryType, _))  => true
+      case _                                                         => false
+    }
+
+  /**
+    * Verify whether types declared in FeatureTable match correspondent columns
+    * @param schema Spark's dataframe columns
+    * @param featureTable definition of expected schema
+    * @return true if all match
+    */
+  def allTypesMatch(schema: StructType, featureTable: FeatureTable): Either[String, Boolean] = {
+    val typeByField =
+      (featureTable.entities ++ featureTable.features).map(f => f.name -> f.`type`).toMap
+
+    schema.fields
+      .map(f =>
+        if (typeByField.contains(f.name) && !typesMatch(typeByField(f.name), f.dataType)) {
+          Left(
+            s"Feature ${f.name} has different type ${f.dataType} instead of expected ${typeByField(f.name)}"
+          )
+        } else Right(true)
+      )
+      .foldLeft[Either[String, Boolean]](Right(true)) {
+        case (Left(error), _)        => Left(error)
+        case (Right(_), Left(error)) => Left(error)
+        case _                       => Right(true)
+      }
+  }
+}

--- a/spark/ingestion/src/test/proto/com/example/source.proto
+++ b/spark/ingestion/src/test/proto/com/example/source.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package com.example;
+
+option java_multiple_files = true;
+option java_package = "com.example.protos";
+
+import "google/protobuf/timestamp.proto";
+
+message TestMessage {
+  int64 s2_id = 1;
+  VehicleType.Enum vehicle_type = 2;
+  int64 unique_drivers = 3;
+  google.protobuf.Timestamp event_timestamp = 4;
+}
+
+message VehicleType {
+  enum Enum {
+    UNKNOWN = 0;
+    CAR = 1;
+    BIKE = 2;
+  }
+}

--- a/spark/ingestion/src/test/proto/com/example/source.proto
+++ b/spark/ingestion/src/test/proto/com/example/source.proto
@@ -21,3 +21,37 @@ message VehicleType {
     BIKE = 2;
   }
 }
+
+message InnerMessage {
+  repeated double double = 1;
+  repeated float float = 2;
+  repeated int32 integer = 3;
+  repeated int64 long = 4;
+  enum Enum {
+    zero = 0;
+    one = 1;
+  }
+  Enum enum = 5;
+}
+
+message AllTypesMessage {
+  double double = 1;
+  float float = 2;
+  int32 integer = 3;
+  int64 long = 4;
+  uint32 uinteger = 5;
+  uint64 ulong = 6;
+  sint32 sinteger = 7;
+  sint64 slong = 8;
+  fixed32 finteger = 9;
+  fixed64 flong = 10;
+  sfixed32 sfinteger = 11;
+  sfixed64 sflong = 13;
+  bool bool = 14;
+  string string = 15;
+  bytes bytes = 16;
+  map<string, string> map = 17;
+  InnerMessage inner = 18;
+
+  google.protobuf.Timestamp event_timestamp = 19;
+}

--- a/spark/ingestion/src/test/scala/feast/ingestion/SparkSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/SparkSpec.scala
@@ -16,26 +16,27 @@
  */
 package feast.ingestion
 
-import java.nio.file.{Files, Paths}
-
-import com.google.protobuf.Timestamp
-import feast.proto.types.ValueProto
-
-import org.scalacheck.Gen
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest._
-import matchers._
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.functions.to_date
+import org.scalatest.BeforeAndAfter
 
-import scala.reflect.runtime.universe.TypeTag
-import scala.util.hashing.MurmurHash3
+class SparkSpec extends UnitSpec with BeforeAndAfter {
+  var sparkSession: SparkSession                         = null
+  def withSparkConfOverrides(conf: SparkConf): SparkConf = conf
 
-abstract class UnitSpec
-    extends AnyFlatSpec
-    with should.Matchers
-    with OptionValues
-    with Inside
-    with Inspectors
+  before {
+    val sparkConf = new SparkConf()
+      .setMaster("local[4]")
+      .setAppName("Testing")
+      .set("spark.default.parallelism", "8")
+
+    sparkSession = SparkSession
+      .builder()
+      .config(withSparkConfOverrides(sparkConf))
+      .getOrCreate()
+  }
+
+  after {
+    sparkSession.stop()
+  }
+}

--- a/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
@@ -26,31 +26,27 @@ import com.dimafeng.testcontainers.{
 }
 import feast.proto.types.ValueProto.ValueType
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
 import org.joda.time.DateTime
 import org.apache.kafka.clients.producer._
 import com.example.protos.{TestMessage, VehicleType}
 import com.google.protobuf.Timestamp
+import org.scalacheck.Gen
+import redis.clients.jedis.Jedis
 
-class StreamingPipelineIT extends UnitSpec with ForAllTestContainer {
+import collection.JavaConverters._
+
+import feast.ingestion.helpers.RedisStorageHelper._
+import feast.ingestion.helpers.DataHelper._
+
+class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
   val redisContainer = GenericContainer("redis:6.0.8", exposedPorts = Seq(6379))
   val kafkaContainer = KafkaContainer()
 
   override val container = MultipleContainers(redisContainer, kafkaContainer)
-
-  trait SparkContext {
-    val sparkConf = new SparkConf()
-      .setMaster("local[4]")
-      .setAppName("Testing")
-      .set("spark.redis.host", redisContainer.host)
-      .set("spark.default.parallelism", "8")
-      .set("spark.redis.port", redisContainer.mappedPort(6379).toString)
-
-    val sparkSession = SparkSession
-      .builder()
-      .config(sparkConf)
-      .getOrCreate()
-  }
+  override def withSparkConfOverrides(conf: SparkConf): SparkConf = conf
+    .set("spark.redis.host", redisContainer.host)
+    .set("spark.redis.port", redisContainer.mappedPort(6379).toString)
+    .set("spark.sql.streaming.checkpointLocation", generateTempPath("checkpoint"))
 
   trait KafkaPublisher {
     val props = new Properties()
@@ -65,23 +61,47 @@ class StreamingPipelineIT extends UnitSpec with ForAllTestContainer {
     }
   }
 
-  trait Scope extends SparkContext with KafkaPublisher {
+  trait Scope extends KafkaPublisher {
+    val jedis = new Jedis("localhost", redisContainer.mappedPort(6379))
+    jedis.flushAll()
+
     val config = IngestionJobConfig(
       featureTable = FeatureTable(
-        name = "test-fs",
+        name = "driver-fs",
         project = "default",
-        entities = Seq(Field("customer", ValueType.Enum.STRING)),
+        entities = Seq(
+          Field("s2_id", ValueType.Enum.INT32),
+          Field("vehicle_type", ValueType.Enum.STRING)
+        ),
         features = Seq(
-          Field("feature1", ValueType.Enum.INT32),
-          Field("feature2", ValueType.Enum.FLOAT)
+          Field("unique_drivers", ValueType.Enum.INT64)
         )
-      ),
-      startTime = DateTime.parse("2020-08-01"),
-      endTime = DateTime.parse("2020-09-01")
+      )
     )
-  }
 
-  "Streaming pipeline" should "stream" in new Scope {
+    def encodeEntityKey(row: TestMessage, featureTable: FeatureTable): Array[Byte] = {
+      val entityPrefix = featureTable.entities.map(_.name).sorted.mkString("_")
+      s"${featureTable.project}_${entityPrefix}:${row.getS2Id}:${row.getVehicleType}".getBytes
+    }
+
+    def groupByEntity(row: TestMessage) =
+      new String(encodeEntityKey(row, config.featureTable))
+
+    def rowGenerator =
+      for {
+        s2_id        <- Gen.chooseNum(0, 1000000)
+        vehicle_type <- Gen.oneOf(VehicleType.Enum.BIKE, VehicleType.Enum.CAR)
+        drivers      <- Gen.chooseNum(0, 1000)
+        eventTimestamp <- Gen
+          .choose(0, 300)
+          .map(DateTime.now.withMillisOfSecond(0).minusSeconds)
+      } yield TestMessage.newBuilder
+        .setS2Id(s2_id)
+        .setVehicleType(vehicle_type)
+        .setUniqueDrivers(drivers)
+        .setEventTimestamp(Timestamp.newBuilder.setSeconds(eventTimestamp.getMillis / 1000))
+        .build
+
     val kafkaSource = KafkaSource(
       bootstrapServers = kafkaContainer.bootstrapServers,
       topic = "topic",
@@ -89,21 +109,51 @@ class StreamingPipelineIT extends UnitSpec with ForAllTestContainer {
       mapping = Map.empty,
       timestampColumn = "event_timestamp"
     )
+    val featureKeyEncoder: String => String = encodeFeatureKey(config.featureTable)
+  }
 
+  "Streaming pipeline" should "store valid proto messages from kafka to redis" in new Scope {
     val configWithKafka = config.copy(source = kafkaSource)
+    val query           = StreamingPipeline.createPipeline(sparkSession, configWithKafka).get
+    query.processAllAvailable() // to init kafka consumer
 
-    val m = TestMessage
-      .newBuilder()
-      .setS2Id(1)
-      .setUniqueDrivers(100)
-      .setVehicleType(VehicleType.Enum.BIKE)
-      .setEventTimestamp(Timestamp.newBuilder().setSeconds(DateTime.now().getMillis / 1000).build())
-      .build
-
-    val query = StreamingPipeline.createPipeline(sparkSession, configWithKafka).get
-
-    sendToKafka(kafkaSource.topic, m)
+    val rows = generateDistinctRows(rowGenerator, 1000, groupByEntity)
+    rows.foreach(sendToKafka(kafkaSource.topic, _))
 
     query.processAllAvailable()
+
+    rows.foreach { r =>
+      val storedValues = jedis.hgetAll(encodeEntityKey(r, config.featureTable)).asScala.toMap
+      storedValues should beStoredRow(
+        Map(
+          featureKeyEncoder("unique_drivers") -> r.getUniqueDrivers,
+          "_ts:driver-fs"                     -> new java.sql.Timestamp(r.getEventTimestamp.getSeconds * 1000)
+        )
+      )
+    }
+  }
+
+  "Streaming pipeline" should "store invalid proto messages to deadletter path" in new Scope {
+    val configWithDeadletter = config.copy(
+      source = kafkaSource,
+      deadLetterPath = Some(generateTempPath("deadletters"))
+    )
+    val query = StreamingPipeline.createPipeline(sparkSession, configWithDeadletter).get
+    query.processAllAvailable() // to init kafka consumer
+
+    val rows = generateDistinctRows(rowGenerator, 1000, groupByEntity).map(
+      _.toBuilder.clearVehicleType().build()
+    )
+
+    rows.foreach(sendToKafka(kafkaSource.topic, _))
+    query.processAllAvailable()
+
+    // ingest twice to check that rows are appended to deadletter path
+    rows.foreach(sendToKafka(kafkaSource.topic, _))
+    query.processAllAvailable()
+
+    sparkSession.read
+      .parquet(configWithDeadletter.deadLetterPath.get)
+      .count() should be(2 * rows.length)
   }
 }

--- a/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
@@ -69,7 +69,7 @@ class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
         name = "driver-fs",
         project = "default",
         entities = Seq(
-          Field("s2_id", ValueType.Enum.INT32),
+          Field("s2_id", ValueType.Enum.INT64),
           Field("vehicle_type", ValueType.Enum.STRING)
         ),
         features = Seq(
@@ -255,5 +255,26 @@ class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
         allTypesKeyEncoder("inner_long")    -> List(1L)
       )
     )
+  }
+
+  "Expected feature types" should "match source types" in new Scope {
+    val configWithKafka = config.copy(
+      source = kafkaSource,
+      featureTable = FeatureTable(
+        name = "driver-fs",
+        project = "default",
+        entities = Seq(
+          Field("s2_id", ValueType.Enum.STRING),
+          Field("vehicle_type", ValueType.Enum.INT32)
+        ),
+        features = Seq(
+          Field("unique_drivers", ValueType.Enum.FLOAT)
+        )
+      )
+    )
+
+    assertThrows[RuntimeException] {
+      StreamingPipeline.createPipeline(sparkSession, configWithKafka).get
+    }
   }
 }

--- a/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion
+
+import java.util.Properties
+
+import com.dimafeng.testcontainers.{
+  ForAllTestContainer,
+  GenericContainer,
+  KafkaContainer,
+  MultipleContainers
+}
+import feast.proto.types.ValueProto.ValueType
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.joda.time.DateTime
+import org.apache.kafka.clients.producer._
+import com.example.protos.{TestMessage, VehicleType}
+import com.google.protobuf.Timestamp
+
+class StreamingPipelineIT extends UnitSpec with ForAllTestContainer {
+  val redisContainer = GenericContainer("redis:6.0.8", exposedPorts = Seq(6379))
+  val kafkaContainer = KafkaContainer()
+
+  override val container = MultipleContainers(redisContainer, kafkaContainer)
+
+  trait SparkContext {
+    val sparkConf = new SparkConf()
+      .setMaster("local[4]")
+      .setAppName("Testing")
+      .set("spark.redis.host", redisContainer.host)
+      .set("spark.default.parallelism", "8")
+      .set("spark.redis.port", redisContainer.mappedPort(6379).toString)
+
+    val sparkSession = SparkSession
+      .builder()
+      .config(sparkConf)
+      .getOrCreate()
+  }
+
+  trait KafkaPublisher {
+    val props = new Properties()
+    props.put("bootstrap.servers", kafkaContainer.bootstrapServers)
+    props.put("key.serializer", "org.apache.kafka.common.serialization.VoidSerializer");
+    props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+
+    val producer = new KafkaProducer[Void, Array[Byte]](props)
+
+    def sendToKafka(topic: String, m: TestMessage): Unit = {
+      producer.send(new ProducerRecord[Void, Array[Byte]](topic, null, m.toByteArray))
+    }
+  }
+
+  trait Scope extends SparkContext with KafkaPublisher {
+    val config = IngestionJobConfig(
+      featureTable = FeatureTable(
+        name = "test-fs",
+        project = "default",
+        entities = Seq(Field("customer", ValueType.Enum.STRING)),
+        features = Seq(
+          Field("feature1", ValueType.Enum.INT32),
+          Field("feature2", ValueType.Enum.FLOAT)
+        )
+      ),
+      startTime = DateTime.parse("2020-08-01"),
+      endTime = DateTime.parse("2020-09-01")
+    )
+  }
+
+  "Streaming pipeline" should "stream" in new Scope {
+    val kafkaSource = KafkaSource(
+      bootstrapServers = kafkaContainer.bootstrapServers,
+      topic = "topic",
+      classpath = "com.example.protos.TestMessage",
+      mapping = Map.empty,
+      timestampColumn = "event_timestamp"
+    )
+
+    val configWithKafka = config.copy(source = kafkaSource)
+
+    val m = TestMessage
+      .newBuilder()
+      .setS2Id(1)
+      .setUniqueDrivers(100)
+      .setVehicleType(VehicleType.Enum.BIKE)
+      .setEventTimestamp(Timestamp.newBuilder().setSeconds(DateTime.now().getMillis / 1000).build())
+      .build
+
+    val query = StreamingPipeline.createPipeline(sparkSession, configWithKafka).get
+
+    sendToKafka(kafkaSource.topic, m)
+
+    query.processAllAvailable()
+  }
+}

--- a/spark/ingestion/src/test/scala/feast/ingestion/UnitSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/UnitSpec.scala
@@ -16,22 +16,9 @@
  */
 package feast.ingestion
 
-import java.nio.file.{Files, Paths}
-
-import com.google.protobuf.Timestamp
-import feast.proto.types.ValueProto
-
-import org.scalacheck.Gen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest._
 import matchers._
-
-import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.functions.to_date
-
-import scala.reflect.runtime.universe.TypeTag
-import scala.util.hashing.MurmurHash3
 
 abstract class UnitSpec
     extends AnyFlatSpec

--- a/spark/ingestion/src/test/scala/feast/ingestion/helpers/RedisStorageHelper.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/helpers/RedisStorageHelper.scala
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.helpers
+
+import com.google.protobuf.Timestamp
+import feast.ingestion.FeatureTable
+import feast.proto.types.ValueProto
+import feast.ingestion.utils.TypeConversion._
+import org.scalatest.matchers.Matcher
+import org.scalatest.matchers.must.Matchers.contain
+
+import scala.util.hashing.MurmurHash3
+
+object RedisStorageHelper {
+  def encodeFeatureKey(featureTable: FeatureTable)(feature: String): String = {
+    val fullReference = s"${featureTable.name}:$feature"
+    MurmurHash3.stringHash(fullReference).toHexString
+  }
+
+  def beStoredRow(mappedRow: Map[String, Any]): Matcher[Map[Array[Byte], Array[Byte]]] = {
+    val m: Matcher[Map[String, Any]] = contain.allElementsOf(mappedRow).matcher
+
+    m compose {
+      (_: Map[Array[Byte], Array[Byte]])
+        .map { case (k, v) =>
+          (
+            new String(k),
+            if (new String(k).startsWith("_ts"))
+              Timestamp.parseFrom(v).asScala
+            else
+              ValueProto.Value.parseFrom(v).asScala
+          )
+        }
+    }
+  }
+}

--- a/spark/ingestion/src/test/scala/feast/ingestion/registry/StencilSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/registry/StencilSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.registry
+
+import com.example.protos.TestMessage
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import feast.ingestion.helpers.DataHelper.generateTempPath
+import feast.ingestion.registry.proto.ProtoRegistryFactory
+import feast.ingestion.utils.ProtoReflection
+import feast.ingestion.SparkSpec
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType, TimestampType}
+import org.scalatest.BeforeAndAfterAll
+
+case class BinaryRecord(bytes: Array[Byte])
+
+class StencilSpec extends SparkSpec with BeforeAndAfterAll {
+  override def withSparkConfOverrides(conf: SparkConf): SparkConf = conf
+    .set("spark.sql.streaming.checkpointLocation", generateTempPath("checkpoint"))
+    .set("feast.ingestion.registry.proto.kind", "stencil")
+    .set(
+      "feast.ingestion.registry.proto.url",
+      s"http://localhost:${wireMockConfig.portNumber()}/source.desc"
+    )
+
+  val wireMockConfig = (new WireMockConfiguration)
+    .withRootDirectory(getClass.getResource("/stencil").getPath)
+    .port(8082)
+  val wireMockServer = new WireMockServer(wireMockConfig)
+
+  override def beforeAll(): Unit =
+    wireMockServer.start()
+
+  override def afterAll(): Unit =
+    wireMockServer.stop()
+
+  trait Scope {
+    implicit val encoder: ExpressionEncoder[BinaryRecord] = ExpressionEncoder[BinaryRecord]
+  }
+
+  "Streaming pipeline" should "be able to fetch proto classes from external repos" in new Scope {
+    val testMessage = TestMessage
+      .newBuilder()
+      .setS2Id(1)
+      .setUniqueDrivers(100)
+      .build()
+
+    val protoRegistry = ProtoRegistryFactory.resolveProtoRegistry(sparkSession)
+    val className     = "com.example.protos.TestMessage"
+
+    val parser: Array[Byte] => Row = ProtoReflection.createMessageParser(protoRegistry, className)
+    val parseUDF =
+      udf(parser, ProtoReflection.inferSchema(protoRegistry.getProtoDescriptor(className)))
+
+    val parsed = sparkSession
+      .createDataset(Seq(BinaryRecord(testMessage.toByteArray)))
+      .withColumn("parsed", parseUDF(col("bytes")))
+      .select("parsed.*")
+
+    parsed.schema should be(
+      StructType(
+        StructField("s2_id", LongType, true) ::
+          StructField("vehicle_type", StringType, true) ::
+          StructField("unique_drivers", LongType, true) ::
+          StructField("event_timestamp", TimestampType, true) :: Nil
+      )
+    )
+
+    parsed.collect() should contain(
+      Row(
+        1L,
+        null,
+        100,
+        null
+      )
+    )
+  }
+}

--- a/spark/ingestion/src/test/scala/feast/ingestion/registry/StencilSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/registry/StencilSpec.scala
@@ -56,7 +56,7 @@ class StencilSpec extends SparkSpec with BeforeAndAfterAll {
     implicit val encoder: ExpressionEncoder[BinaryRecord] = ExpressionEncoder[BinaryRecord]
   }
 
-  "Streaming pipeline" should "be able to fetch proto classes from external repos" in new Scope {
+  "Proto parser" should "be able to retrieve proto descriptors from external repos" in new Scope {
     val testMessage = TestMessage
       .newBuilder()
       .setS2Id(1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR replaces current (beam) Ingestion Job with spark version. However, several changes are introduced:
1. Input to streaming pipeline is arbitrary* protobuf. Message class must be provided through `FeatureTable` configuration.
2. Ingestion job stores only to redis and writes deadletters as parquet files.

Currently there are two ways to make protobuf class available for job in runtime:
1. Compile proto & pack it into jar and add jar to list of files on Spark-submit.
This option has a limitation that compiled class must be linked to shadowed protobuf library `com.google.protobuf.vendor`
since in our job we had to shadow protobuf due to conflicts with spark dependencies.
2. Use proto registry (external service) as source of proto descriptors. As starter we gonna support https://github.com/gojekfarm/stencil But we would need to support more common implementation of proto registry.

*Arbitrary protobuf has some limitations. `oneof`, `google.protobuf.Any` are not supported. Thus `FeatureRow` can't be input to new streaming pipeline.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Streaming ingestion job expects arbitrary protobuf as input with some limitations to not supporting `oneof` since spark's dataframe doesn't support it
```
