### PR TITLE
[v0.7-branch] Provide stable jobName in RowMetrics labels (#1028)

### DIFF
--- a/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteFeatureValueMetricsDoFn.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteFeatureValueMetricsDoFn.java
@@ -24,12 +24,9 @@ import com.timgroup.statsd.StatsDClient;
 import feast.proto.types.FeatureRowProto.FeatureRow;
 import feast.proto.types.FieldProto.Field;
 import feast.proto.types.ValueProto.Value;
-import java.util.ArrayList;
-import java.util.DoubleSummaryStatistics;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.KV;
 import org.apache.commons.math3.stat.descriptive.rank.Percentile;
@@ -149,6 +146,10 @@ public abstract class WriteFeatureValueMetricsDoFn
       }
     }
 
+    String[] split = context.getPipelineOptions().getJobName().split("-");
+    String jobNameWithoutTimestamp =
+        Arrays.stream(split).limit(split.length - 1).collect(Collectors.joining("-"));
+
     for (Entry<String, DoubleSummaryStatistics> entry : featureNameToStats.entrySet()) {
       String featureName = entry.getKey();
       DoubleSummaryStatistics stats = entry.getValue();
@@ -157,7 +158,7 @@ public abstract class WriteFeatureValueMetricsDoFn
         FEATURE_SET_PROJECT_TAG_KEY + ":" + projectName,
         FEATURE_SET_NAME_TAG_KEY + ":" + featureSetName,
         FEATURE_TAG_KEY + ":" + featureName,
-        INGESTION_JOB_NAME_KEY + ":" + context.getPipelineOptions().getJobName(),
+        INGESTION_JOB_NAME_KEY + ":" + jobNameWithoutTimestamp,
         METRICS_NAMESPACE_KEY + ":" + getMetricsNamespace(),
       };
 

--- a/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteRowMetricsDoFn.java
+++ b/ingestion/src/main/java/feast/ingestion/transform/metrics/WriteRowMetricsDoFn.java
@@ -25,9 +25,11 @@ import feast.proto.types.FieldProto.Field;
 import feast.proto.types.ValueProto.Value;
 import feast.proto.types.ValueProto.Value.ValCase;
 import java.time.Clock;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.KV;
@@ -192,11 +194,15 @@ public abstract class WriteRowMetricsDoFn extends DoFn<KV<String, Iterable<Featu
       }
     }
 
+    String[] split = c.getPipelineOptions().getJobName().split("-");
+    String jobNameWithoutTimestamp =
+        Arrays.stream(split).limit(split.length - 1).collect(Collectors.joining("-"));
+
     String[] tags = {
       STORE_TAG_KEY + ":" + getStoreName(),
       FEATURE_SET_PROJECT_TAG_KEY + ":" + featureSetProject,
       FEATURE_SET_NAME_TAG_KEY + ":" + featureSetName,
-      INGESTION_JOB_NAME_KEY + ":" + c.getPipelineOptions().getJobName(),
+      INGESTION_JOB_NAME_KEY + ":" + jobNameWithoutTimestamp,
       METRICS_NAMESPACE_KEY + ":" + getMetricsNamespace(),
     };
 

--- a/ingestion/src/test/java/feast/ingestion/transform/metrics/WriteFeatureValueMetricsDoFnTest.java
+++ b/ingestion/src/test/java/feast/ingestion/transform/metrics/WriteFeatureValueMetricsDoFnTest.java
@@ -62,7 +62,7 @@ public class WriteFeatureValueMetricsDoFnTest {
   @Test
   public void shouldSendCorrectStatsDMetrics() throws IOException, InterruptedException {
     PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
-    pipelineOptions.setJobName("job");
+    pipelineOptions.setJobName("job-12345678");
 
     Map<String, Iterable<FeatureRow>> input =
         readTestInput("feast/ingestion/transform/WriteFeatureValueMetricsDoFnTest.input");

--- a/ingestion/src/test/java/feast/ingestion/transform/metrics/WriteRowMetricsDoFnTest.java
+++ b/ingestion/src/test/java/feast/ingestion/transform/metrics/WriteRowMetricsDoFnTest.java
@@ -45,7 +45,7 @@ public class WriteRowMetricsDoFnTest {
   @Test
   public void shouldSendCorrectStatsDMetrics() throws IOException, InterruptedException {
     PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
-    pipelineOptions.setJobName("job");
+    pipelineOptions.setJobName("job-12345678");
     Map<String, Iterable<FeatureRow>> input =
         readTestInput("feast/ingestion/transform/WriteRowMetricsDoFnTest.input");
     List<String> expectedLines =


### PR DESCRIPTION
Backporting "Stable job name in metrics" from master

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
