### PR TITLE
Cleanup e2e and docker-compose tests

### DIFF
--- a/core/src/main/java/feast/core/validators/Matchers.java
+++ b/core/src/main/java/feast/core/validators/Matchers.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 public class Matchers {
 
   private static Pattern BIGQUERY_TABLE_REF_REGEX =
-      Pattern.compile("[a-zA-Z0-9-]+[:]+[a-zA-Z0-9]+[.]+[a-zA-Z0-9_]*");
+      Pattern.compile("[a-zA-Z0-9-]+[:]+[a-zA-Z0-9_]+[.]+[a-zA-Z0-9_]*");
   private static Pattern UPPER_SNAKE_CASE_REGEX = Pattern.compile("^[A-Z0-9]+(_[A-Z0-9]+)*$");
   private static Pattern LOWER_SNAKE_CASE_REGEX = Pattern.compile("^[a-z0-9]+(_[a-z0-9]+)*$");
   private static Pattern VALID_CHARACTERS_REGEX = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");

--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -63,4 +63,4 @@ export FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS=$(docker inspect -f '{{range .N
 ${PROJECT_ROOT_DIR}/infra/scripts/wait-for-it.sh ${FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS}:6566 --timeout=120
 
 # Run e2e tests for Redis
-docker exec feast_jupyter_1 bash -c 'cd /feast/tests/e2e && pytest *.py --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'
+docker exec feast_jupyter_1 bash -c 'cd /feast/tests/e2e && pytest *.py -m "not bq" --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'

--- a/sdk/python/feast/feature.py
+++ b/sdk/python/feast/feature.py
@@ -46,6 +46,9 @@ class Feature:
             return False
         return True
 
+    def __lt__(self, other):
+        return self.name < other.name
+
     @property
     def name(self):
         """

--- a/sdk/python/feast/feature_table.py
+++ b/sdk/python/feast/feature_table.py
@@ -80,9 +80,9 @@ class FeatureTable:
         ):
             return False
 
-        if self.entities != other.entities:
+        if sorted(self.entities) != sorted(other.entities):
             return False
-        if self.features != other.features:
+        if sorted(self.features) != sorted(other.features):
             return False
         if self.batch_source != other.batch_source:
             return False


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Fixes the following:
1. docker-compose test are currently failing due to missing GCP credentials
2. Usage of polling instead of sleep for e2e tests
3. Using BQ source should allow dataset to contain underscore
4. Flaky e2e test due to ordering of entities and features (which are returned as a set)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
