### PR TITLE
Return all tables if project unspecified

### DIFF
--- a/core/src/main/java/feast/core/dao/FeatureTableRepository.java
+++ b/core/src/main/java/feast/core/dao/FeatureTableRepository.java
@@ -28,4 +28,7 @@ public interface FeatureTableRepository extends JpaRepository<FeatureTable, Long
 
   // Find FeatureTables by project
   List<FeatureTable> findAllByProject_Name(String projectName);
+
+  // Find all FeatureTables
+  List<FeatureTable> findAllByProject_NameLikeOrderByNameAsc(String projectName);
 }

--- a/core/src/main/java/feast/core/service/SpecService.java
+++ b/core/src/main/java/feast/core/service/SpecService.java
@@ -682,19 +682,28 @@ public class SpecService {
 
   /**
    * List the FeatureTables matching the filter in the given filter. Scopes down listing to project
-   * if specified, the default project otherwise.
+   * if specified, otherwise all FeatureTables will be returned.
    *
    * @param filter Filter containing the desired project and labels
    * @return ListFeatureTablesResponse with list of FeatureTables found matching the filter
    */
   @Transactional
   public ListFeatureTablesResponse listFeatureTables(ListFeatureTablesRequest.Filter filter) {
-    String projectName = resolveProjectName(filter.getProject());
+    String projectName = filter.getProject();
     Map<String, String> labelsFilter = filter.getLabelsMap();
 
-    checkValidCharacters(projectName, "project");
+    if (projectName.isEmpty()) {
+      projectName = "*";
+    }
 
-    List<FeatureTable> matchingTables = tableRepository.findAllByProject_Name(projectName);
+    List<FeatureTable> matchingTables;
+    if (projectName.equals("*")) {
+      matchingTables =
+          tableRepository.findAllByProject_NameLikeOrderByNameAsc(projectName.replace('*', '%'));
+    } else {
+      checkValidCharacters(projectName, "project");
+      matchingTables = tableRepository.findAllByProject_Name(projectName);
+    }
 
     ListFeatureTablesResponse.Builder response = ListFeatureTablesResponse.newBuilder();
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, in Serving, [when caching Feature sets](https://github.com/feast-dev/feast/blob/master/serving/src/main/java/feast/serving/specs/CachedSpecService.java#L239), we allow wildcard match to return all Feature sets spec in one go. Likewise, as we update Serving to handle Feature tables, we'll require an easy way to retrieve all Feature tables. 

When project is not specified in list Feature tables call, all Feature tables will be returned.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
