### PR TITLE
CLI command to start/stop/list streaming ingestion job on emr

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -371,5 +371,58 @@ def sync_offline_to_online(feature_table: str, start_time: str, end_time: str):
     feast.pyspark.aws.jobs.sync_offline_to_online(client, table, start_time, end_time)
 
 
+@cli.command()
+@click.option(
+    "--feature-table",
+    "-t",
+    help="Feature table name to ingest data into",
+    required=True,
+)
+@click.option(
+    "--jar", "-j", help="Feature table name to ingest data into", default="",
+)
+def start_stream_to_online(feature_table: str, jar: str):
+    """
+    Start stream to online sync job.
+    """
+    import feast.pyspark.aws.jobs
+
+    client = Client()
+    table = client.get_feature_table(feature_table)
+    feast.pyspark.aws.jobs.start_stream_to_online(client, table, [jar] if jar else [])
+
+
+@cli.command()
+@click.option(
+    "--feature-table",
+    "-t",
+    help="Feature table name to ingest data into",
+    required=True,
+)
+def stop_stream_to_online(feature_table: str):
+    """
+    Start stream to online sync job.
+    """
+    import feast.pyspark.aws.jobs
+
+    feast.pyspark.aws.jobs.stop_stream_to_online(feature_table)
+
+
+@cli.command()
+def list_emr_jobs():
+    """
+    List jobs.
+    """
+    from tabulate import tabulate
+
+    import feast.pyspark.aws.jobs
+
+    jobs = feast.pyspark.aws.jobs.list_jobs(None, None)
+
+    print(
+        tabulate(jobs, headers=feast.pyspark.aws.jobs.JobInfo._fields, tablefmt="plain")
+    )
+
+
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Add SDK glue code and the corresponding CLI command to kick off the streaming ingestion on EMR, check if it is already running, stop it and list running jobs.

```release-note
Added CLI commands `start-stream-to-online` and `stop-stream-to-online` to kick off stream ingestion jobs 
```