### PR TITLE
Adding support for custom grpc dial options in Go SDK

### DIFF
--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+
 	"github.com/feast-dev/feast/sdk/go/protos/feast/serving"
 	"github.com/opentracing/opentracing-go"
 	"go.opencensus.io/plugin/ocgrpc"
@@ -43,16 +44,25 @@ func NewGrpcClient(host string, port int) (*GrpcClient, error) {
 	})
 }
 
-// NewAuthGrpcClient constructs a secure client that uses security features (ie authentication).
+// NewSecureGrpcClient constructs a secure client that uses security features (ie authentication).
 // host - hostname of the serving host/instance to connect to.
 // port - post of the host to service host/instancf to connect to.
 // securityConfig - security config configures client security.
 func NewSecureGrpcClient(host string, port int, security SecurityConfig) (*GrpcClient, error) {
+	return NewSecureGrpcClientWithDialOptions(host, port, security)
+}
+
+// NewSecureGrpcClientWithDialOptions constructs a secure client that uses security features (ie authentication) along with custom grpc dial options.
+// host - hostname of the serving host/instance to connect to.
+// port - post of the host to service host/instancf to connect to.
+// securityConfig - security config configures client security.
+// opts - grpc.DialOptions which should be used with this connection
+func NewSecureGrpcClientWithDialOptions(host string, port int, security SecurityConfig, opts ...grpc.DialOption) (*GrpcClient, error) {
 	feastCli := &GrpcClient{}
 	adr := fmt.Sprintf("%s:%d", host, port)
 
 	// Compile grpc dial options from security config.
-	options := []grpc.DialOption{grpc.WithStatsHandler(&ocgrpc.ClientHandler{})}
+	options := append(opts, grpc.WithStatsHandler(&ocgrpc.ClientHandler{}))
 	// Configure client TLS.
 	if !security.EnableTLS {
 		options = append(options, grpc.WithInsecure())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR adds support for custom grpc dial options in Go SDK. Currently there is now way for the clients to specify custom grpc.DialOption

**Which issue(s) this PR fixes**:
Fixes #1042 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adding support for custom grpc dial options in Go SDK
```
