### PR TITLE
Add created_timestamp_column to DataSource. Rename timestamp_column -> event_timestamp_column

### DIFF
--- a/common-test/src/main/java/feast/common/it/DataGenerator.java
+++ b/common-test/src/main/java/feast/common/it/DataGenerator.java
@@ -243,7 +243,7 @@ public class DataGenerator {
         .setType(DataSource.SourceType.BATCH_FILE)
         .setFileOptions(
             FileOptions.newBuilder().setFileFormat(fileFormat).setFileUrl(fileURL).build())
-        .setTimestampColumn(timestampColumn)
+        .setEventTimestampColumn(timestampColumn)
         .setDatePartitionColumn(datePartitionColumn)
         .build();
   }
@@ -253,7 +253,7 @@ public class DataGenerator {
     return DataSource.newBuilder()
         .setType(DataSource.SourceType.BATCH_BIGQUERY)
         .setBigqueryOptions(BigQueryOptions.newBuilder().setTableRef(bigQueryTableRef).build())
-        .setTimestampColumn(timestampColumn)
+        .setEventTimestampColumn(timestampColumn)
         .setDatePartitionColumn(datePartitionColumn)
         .build();
   }
@@ -268,7 +268,7 @@ public class DataGenerator {
                 .setBootstrapServers(servers)
                 .setClassPath(classPath)
                 .build())
-        .setTimestampColumn(timestampColumn)
+        .setEventTimestampColumn(timestampColumn)
         .build();
   }
 }

--- a/core/src/main/java/feast/core/model/DataSource.java
+++ b/core/src/main/java/feast/core/model/DataSource.java
@@ -63,7 +63,10 @@ public class DataSource {
   private String fieldMapJSON;
 
   @Column(name = "timestamp_column")
-  private String timestampColumn;
+  private String eventTimestampColumn;
+
+  @Column(name = "created_timestamp_column")
+  private String createdTimestampColumn;
 
   @Column(name = "date_partition_column")
   private String datePartitionColumn;
@@ -115,7 +118,8 @@ public class DataSource {
     source.setFieldMapJSON(TypeConversion.convertMapToJsonString(spec.getFieldMappingMap()));
 
     // Set timestamp mapping columns
-    source.setTimestampColumn(spec.getTimestampColumn());
+    source.setEventTimestampColumn(spec.getEventTimestampColumn());
+    source.setCreatedTimestampColumn(spec.getCreatedTimestampColumn());
     source.setDatePartitionColumn(spec.getDatePartitionColumn());
 
     return source;
@@ -163,7 +167,8 @@ public class DataSource {
     // Parse field mapping and options from JSON
     spec.putAllFieldMapping(TypeConversion.convertJsonStringToMap(getFieldMapJSON()));
 
-    spec.setTimestampColumn(getTimestampColumn());
+    spec.setEventTimestampColumn(getEventTimestampColumn());
+    spec.setCreatedTimestampColumn(getCreatedTimestampColumn());
     spec.setDatePartitionColumn(getDatePartitionColumn());
 
     return spec.build();

--- a/core/src/main/resources/db/migration/V2.9__Data_Source_Created_Timestamp_Column.sql
+++ b/core/src/main/resources/db/migration/V2.9__Data_Source_Created_Timestamp_Column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE data_sources ADD COLUMN created_timestamp_column character varying(255);

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 // indirect
-	golang.org/x/tools v0.0.0-20201001230009-b5b87423c93b // indirect
+	golang.org/x/tools v0.0.0-20201013053347-2db1cd791039 // indirect
 	google.golang.org/grpc v1.29.1
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/russross/blackfriday.v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -490,6 +490,8 @@ golang.org/x/tools v0.0.0-20200929223013-bf155c11ec6f h1:7+Nz9MyPqt2qMCTvNiRy1G0
 golang.org/x/tools v0.0.0-20200929223013-bf155c11ec6f/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201001230009-b5b87423c93b h1:07IVqnnzaip3TGyl/cy32V5YP3FguWG4BybYDTBNpm0=
 golang.org/x/tools v0.0.0-20201001230009-b5b87423c93b/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201013053347-2db1cd791039 h1:kLBxO4OPBgPwjg8Vvu+/0DCHIfDwYIGNFcD66NU9kpo=
+golang.org/x/tools v0.0.0-20201013053347-2db1cd791039/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/protos/feast/core/DataSource.proto
+++ b/protos/feast/core/DataSource.proto
@@ -38,12 +38,15 @@ message DataSource {
   // and fields in parent FeatureTable.
   map<string, string> field_mapping = 2;
 
-  // Must specify timestamp column name
-  string timestamp_column = 3;
+  // Must specify event timestamp column name
+  string event_timestamp_column = 3;
 
   // (Optional) Specify partition column
   // useful for file sources
   string date_partition_column = 4;
+
+  // Must specify creation timestamp column name
+  string created_timestamp_column = 5;
 
   // Defines options for DataSource that sources features from a file
   message FileOptions {

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -656,7 +656,7 @@ class Client:
         _check_field_mappings(
             column_names,
             name,
-            feature_table.batch_source.timestamp_column,
+            feature_table.batch_source.event_timestamp_column,
             feature_table.batch_source.field_mapping,
         )
 
@@ -671,7 +671,7 @@ class Client:
                 column_names,
                 pyarrow_table,
                 feature_table.batch_source.date_partition_column,
-                feature_table.batch_source.timestamp_column,
+                feature_table.batch_source.event_timestamp_column,
             )
         else:
             dir_path, dest_path = _write_non_partitioned_table_from_source(
@@ -680,12 +680,12 @@ class Client:
 
         try:
             if issubclass(type(feature_table.batch_source), FileSource):
-                file_url = feature_table.batch_source.file_options.file_url[:-1]
+                file_url = feature_table.batch_source.file_options.file_url.rstrip("*")
                 _upload_to_file_source(file_url, with_partitions, dest_path)
             if issubclass(type(feature_table.batch_source), BigQuerySource):
                 bq_table_ref = feature_table.batch_source.bigquery_options.table_ref
                 feature_table_timestamp_column = (
-                    feature_table.batch_source.timestamp_column
+                    feature_table.batch_source.event_timestamp_column
                 )
 
                 _upload_to_bq_source(

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -64,13 +64,9 @@ def export_source_to_staging_location(
 
     # Prepare Avro file to be exported to staging location
     if isinstance(source, pd.DataFrame):
-        # DataFrame provided as a source
-        uri_path = None  # type: Optional[str]
-        if uri.scheme == "file":
-            uri_path = uri.path
         # Remote gs staging location provided by serving
         dir_path, file_name, source_path = export_dataframe_to_local(
-            df=source, dir_path=uri_path
+            df=source
         )
     elif isinstance(source, str):
         source_uri = urlparse(source)

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -65,9 +65,7 @@ def export_source_to_staging_location(
     # Prepare Avro file to be exported to staging location
     if isinstance(source, pd.DataFrame):
         # Remote gs staging location provided by serving
-        dir_path, file_name, source_path = export_dataframe_to_local(
-            df=source
-        )
+        dir_path, file_name, source_path = export_dataframe_to_local(df=source)
     elif isinstance(source, str):
         source_uri = urlparse(source)
         if source_uri.scheme in ["", "file"]:

--- a/sdk/python/feast/pyspark/aws/jobs.py
+++ b/sdk/python/feast/pyspark/aws/jobs.py
@@ -134,8 +134,10 @@ def _batch_source_to_json(batch_source):
     return {
         "file": {
             "path": batch_source.file_options.file_url,
-            "mapping": dict(batch_source.field_mapping),
-            "timestampColumn": batch_source.timestamp_column,
+            "field_mapping": dict(batch_source.field_mapping),
+            "event_timestamp_column": batch_source.event_timestamp_column,
+            "created_timestamp_column": batch_source.created_timestamp_column,
+            "date_partition_column": batch_source.date_partition_column,
         }
     }
 

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -229,8 +229,8 @@ class LocalFSClient(AbstractStagingClient):
     def list_files(self, bucket: str, path: str) -> List[str]:
         raise NotImplementedError("list files not implemented for Local file")
 
-    def upload_file(self, local_path: str, folder: str, remote_path: str):
-        dest_fpath = os.path.join(folder + "/" + remote_path)
+    def upload_file(self, local_path: str, bucket: str, remote_path: str):
+        dest_fpath = "/" + remote_path
         os.makedirs(os.path.dirname(dest_fpath), exist_ok=True)
         shutil.copy(local_path, dest_fpath)
 

--- a/sdk/python/tests/test_feature_table.py
+++ b/sdk/python/tests/test_feature_table.py
@@ -61,7 +61,8 @@ class TestFeatureTable:
             },
             file_format="parquet",
             file_url="file://feast/*",
-            timestamp_column="ts_col",
+            event_timestamp_column="ts_col",
+            created_timestamp_column="timestamp",
             date_partition_column="date_partition_col",
         )
 
@@ -73,7 +74,8 @@ class TestFeatureTable:
             bootstrap_servers="localhost:9094",
             class_path="random/path/to/class",
             topic="test_topic",
-            timestamp_column="ts_col",
+            event_timestamp_column="ts_col",
+            created_timestamp_column="timestamp",
         )
 
         test_feature_table = FeatureTable(

--- a/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
@@ -79,13 +79,13 @@ trait BasePipeline {
       entities: Seq[Field]
   ): Array[Column] = {
     val featureColumns = features
-      .filter(f => !source.mapping.contains(f.name))
-      .map(f => (f.name, f.name)) ++ source.mapping
+      .filter(f => !source.fieldMapping.contains(f.name))
+      .map(f => (f.name, f.name)) ++ source.fieldMapping
 
-    val timestampColumn = Seq((source.timestampColumn, source.timestampColumn))
+    val timestampColumn = Seq((source.eventTimestampColumn, source.eventTimestampColumn))
     val entitiesColumns =
       entities
-        .filter(e => !source.mapping.contains(e.name))
+        .filter(e => !source.fieldMapping.contains(e.name))
         .map(e => (e.name, e.name))
 
     (featureColumns ++ entitiesColumns ++ timestampColumn).map { case (alias, source) =>

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -35,7 +35,7 @@ object BatchPipeline extends BasePipeline {
     val featureTable = config.featureTable
     val projection =
       inputProjection(config.source, featureTable.features, featureTable.entities)
-    val validator = new RowValidator(featureTable, config.source.timestampColumn)
+    val validator = new RowValidator(featureTable, config.source.eventTimestampColumn)
 
     val input = config.source match {
       case source: BQSource =>
@@ -70,7 +70,7 @@ object BatchPipeline extends BasePipeline {
       .option("entity_columns", featureTable.entities.map(_.name).mkString(","))
       .option("namespace", featureTable.name)
       .option("project_name", featureTable.project)
-      .option("timestamp_column", config.source.timestampColumn)
+      .option("timestamp_column", config.source.eventTimestampColumn)
       .save()
 
     config.deadLetterPath match {

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -39,7 +39,7 @@ object IngestionJob {
 
     opt[String](name = "source")
       .action((x, c) =>
-        parseJSON(x).extract[Sources] match {
+        parseJSON(x).camelizeKeys.extract[Sources] match {
           case Sources(file: Some[FileSource], _, _)   => c.copy(source = file.get)
           case Sources(_, bq: Some[BQSource], _)       => c.copy(source = bq.get)
           case Sources(_, _, kafka: Some[KafkaSource]) => c.copy(source = kafka.get)
@@ -49,7 +49,7 @@ object IngestionJob {
       .text("JSON-encoded source object (e.g. {\"kafka\":{\"bootstrapServers\":...}}")
 
     opt[String](name = "feature-table")
-      .action((x, c) => c.copy(featureTable = parseJSON(x).extract[FeatureTable]))
+      .action((x, c) => c.copy(featureTable = parseJSON(x).camelizeKeys.extract[FeatureTable]))
       .required()
       .text("JSON-encoded FeatureTableSpec object")
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -33,9 +33,11 @@ abstract class MetricConfig
 case class StatsDConfig(host: String, port: Int) extends MetricConfig
 
 abstract class Source {
-  def mapping: Map[String, String]
+  def fieldMapping: Map[String, String]
 
-  def timestampColumn: String
+  def eventTimestampColumn: String
+  def createdTimestampColumn: Option[String]
+  def datePartitionColumn: Option[String]
 }
 
 abstract class BatchSource extends Source
@@ -46,24 +48,30 @@ abstract class StreamingSource extends Source {
 
 case class FileSource(
     path: String,
-    override val mapping: Map[String, String],
-    override val timestampColumn: String
+    override val fieldMapping: Map[String, String],
+    override val eventTimestampColumn: String,
+    override val createdTimestampColumn: Option[String] = None,
+    override val datePartitionColumn: Option[String] = None
 ) extends BatchSource
 
 case class BQSource(
     project: String,
     dataset: String,
     table: String,
-    override val mapping: Map[String, String],
-    override val timestampColumn: String
+    override val fieldMapping: Map[String, String],
+    override val eventTimestampColumn: String,
+    override val createdTimestampColumn: Option[String] = None,
+    override val datePartitionColumn: Option[String] = None
 ) extends BatchSource
 
 case class KafkaSource(
     bootstrapServers: String,
     topic: String,
     override val classpath: String,
-    override val mapping: Map[String, String],
-    override val timestampColumn: String
+    override val fieldMapping: Map[String, String],
+    override val eventTimestampColumn: String,
+    override val createdTimestampColumn: Option[String] = None,
+    override val datePartitionColumn: Option[String] = None
 ) extends StreamingSource
 
 case class Sources(

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -42,7 +42,7 @@ object StreamingPipeline extends BasePipeline with Serializable {
     val featureTable = config.featureTable
     val projection =
       inputProjection(config.source, featureTable.features, featureTable.entities)
-    val validator = new RowValidator(featureTable, config.source.timestampColumn)
+    val validator = new RowValidator(featureTable, config.source.eventTimestampColumn)
 
     val messageParser =
       protoParser(sparkSession, config.source.asInstanceOf[StreamingSource].classpath)
@@ -79,7 +79,7 @@ object StreamingPipeline extends BasePipeline with Serializable {
           .option("entity_columns", featureTable.entities.map(_.name).mkString(","))
           .option("namespace", featureTable.name)
           .option("project_name", featureTable.project)
-          .option("timestamp_column", config.source.timestampColumn)
+          .option("timestamp_column", config.source.eventTimestampColumn)
           .save()
 
         config.deadLetterPath match {

--- a/spark/ingestion/src/main/scala/feast/ingestion/sources/bq/BigQueryReader.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/sources/bq/BigQueryReader.scala
@@ -33,7 +33,7 @@ object BigQueryReader {
     sqlContext.read
       .format("bigquery")
       .load(s"${source.project}.${source.dataset}.${source.table}")
-      .filter(col(source.timestampColumn) >= new Timestamp(start.getMillis))
-      .filter(col(source.timestampColumn) < new Timestamp(end.getMillis))
+      .filter(col(source.eventTimestampColumn) >= new Timestamp(start.getMillis))
+      .filter(col(source.eventTimestampColumn) < new Timestamp(end.getMillis))
   }
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/sources/file/FileReader.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/sources/file/FileReader.scala
@@ -32,7 +32,7 @@ object FileReader {
   ): DataFrame = {
     sqlContext.read
       .parquet(source.path)
-      .filter(col(source.timestampColumn) >= new Timestamp(start.getMillis))
-      .filter(col(source.timestampColumn) < new Timestamp(end.getMillis))
+      .filter(col(source.eventTimestampColumn) >= new Timestamp(start.getMillis))
+      .filter(col(source.eventTimestampColumn) < new Timestamp(end.getMillis))
   }
 }

--- a/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
@@ -105,8 +105,8 @@ class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
       bootstrapServers = kafkaContainer.bootstrapServers,
       topic = "topic",
       classpath = "com.example.protos.TestMessage",
-      mapping = Map.empty,
-      timestampColumn = "event_timestamp"
+      fieldMapping = Map.empty,
+      eventTimestampColumn = "event_timestamp"
     )
     val featureKeyEncoder: String => String = encodeFeatureKey(config.featureTable)
   }
@@ -160,7 +160,7 @@ class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
     val configWithKafka = config.copy(
       source = kafkaSource.copy(
         classpath = "com.example.protos.AllTypesMessage",
-        mapping = Map(
+        fieldMapping = Map(
           "map_value"     -> "map.key",
           "inner_double"  -> "inner.double",
           "inner_float"   -> "inner.float",

--- a/tests/e2e/test-register.py
+++ b/tests/e2e/test-register.py
@@ -69,7 +69,8 @@ def basic_featuretable():
         },
         file_format="PARQUET",
         file_url="gs://example/feast/*",
-        timestamp_column="datetime_col",
+        event_timestamp_column="datetime_col",
+        created_timestamp_column="timestamp",
         date_partition_column="datetime",
     )
     stream_source = KafkaSource(
@@ -81,7 +82,8 @@ def basic_featuretable():
         bootstrap_servers="localhost:9094",
         class_path="random/path/to/class",
         topic="test_topic",
-        timestamp_column="datetime_col",
+        event_timestamp_column="datetime_col",
+        created_timestamp_column="timestamp",
     )
     return FeatureTable(
         name="basic_featuretable",
@@ -112,7 +114,11 @@ def bq_dataset():
 
 @pytest.fixture
 def bq_featuretable(bq_table_id):
-    batch_source = BigQuerySource(table_ref=bq_table_id, timestamp_column="datetime",)
+    batch_source = BigQuerySource(
+        table_ref=bq_table_id,
+        event_timestamp_column="datetime",
+        created_timestamp_column="timestamp",
+    )
     return FeatureTable(
         name="basic_featuretable",
         entities=["driver_id", "customer_id"],
@@ -140,7 +146,8 @@ def alltypes_featuretable():
     batch_source = FileSource(
         file_format="parquet",
         file_url="file://feast/*",
-        timestamp_column="ts_col",
+        event_timestamp_column="ts_col",
+        created_timestamp_column="timestamp",
         date_partition_column="date_partition_col",
     )
     return FeatureTable(


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
`created_timestamp_column` in DataSource will help with deduplicating values for the same entity on historical retrieval.
`timestamp_column` renames to `event_timestamp_column` to avoid confusion


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
