### PR TITLE
"Start Offline-to-online ingestion" method in Python SDK

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -819,10 +819,9 @@ class Client:
             CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_LOCATION
         )
         output_format = self._config.get(CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_FORMAT)
-        job_id = f"historical-feature-{str(uuid.uuid4())}"
 
         return start_historical_feature_retrieval_job(
-            self, entity_source, feature_tables, output_format, output_location, job_id
+            self, entity_source, feature_tables, output_format, output_location
         )
 
     def get_historical_features_df(

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -14,7 +14,6 @@
 import logging
 import multiprocessing
 import shutil
-import uuid
 from datetime import datetime
 from itertools import groupby
 from typing import Any, Dict, List, Optional, Union

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -17,6 +17,7 @@ import shutil
 import uuid
 from itertools import groupby
 from typing import Any, Dict, List, Optional, Union
+from datetime import datetime
 
 import grpc
 import pandas as pd
@@ -78,11 +79,13 @@ from feast.pyspark.abc import RetrievalJob
 from feast.pyspark.launcher import (
     start_historical_feature_retrieval_job,
     start_historical_feature_retrieval_spark_session,
+    start_offline_to_online_ingestion,
 )
 from feast.serving.ServingService_pb2 import (
     GetFeastServingInfoRequest,
     GetOnlineFeaturesRequestV2,
 )
+from feast.pyspark.abc import SparkJob
 from feast.serving.ServingService_pb2_grpc import ServingServiceStub
 
 _logger = logging.getLogger(__name__)
@@ -883,3 +886,11 @@ class Client:
             ]
             feature_tables.append(feature_table)
         return feature_tables
+
+    def start_offline_to_online_ingestion(
+        self,
+        feature_table: Union[FeatureTable, str],
+        start: Union[datetime, str],
+        end: Union[datetime, str],
+    ) -> SparkJob:
+        return start_offline_to_online_ingestion(feature_table, start, end, self)

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -15,9 +15,9 @@ import logging
 import multiprocessing
 import shutil
 import uuid
+from datetime import datetime
 from itertools import groupby
 from typing import Any, Dict, List, Optional, Union
-from datetime import datetime
 
 import grpc
 import pandas as pd
@@ -75,7 +75,7 @@ from feast.loaders.ingest import (
     _write_partitioned_table_from_source,
 )
 from feast.online_response import OnlineResponse, _infer_online_entity_rows
-from feast.pyspark.abc import RetrievalJob
+from feast.pyspark.abc import RetrievalJob, SparkJob
 from feast.pyspark.launcher import (
     start_historical_feature_retrieval_job,
     start_historical_feature_retrieval_spark_session,
@@ -85,7 +85,6 @@ from feast.serving.ServingService_pb2 import (
     GetFeastServingInfoRequest,
     GetOnlineFeaturesRequestV2,
 )
-from feast.pyspark.abc import SparkJob
 from feast.serving.ServingService_pb2_grpc import ServingServiceStub
 
 _logger = logging.getLogger(__name__)
@@ -893,4 +892,4 @@ class Client:
         start: Union[datetime, str],
         end: Union[datetime, str],
     ) -> SparkJob:
-        return start_offline_to_online_ingestion(feature_table, start, end, self)
+        return start_offline_to_online_ingestion(feature_table, start, end, self)  # type: ignore

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -67,7 +67,10 @@ CONFIG_MAX_WAIT_INTERVAL_KEY = "max_wait_interval"
 # Spark Job Config
 CONFIG_SPARK_LAUNCHER = "spark_launcher"  # standalone, dataproc, emr
 
+CONFIG_SPARK_INGESTION_JOB_JAR = "spark_ingestion_jar"
+
 CONFIG_SPARK_STANDALONE_MASTER = "spark_standalone_master"
+CONFIG_SPARK_HOME = "spark_home"
 
 CONFIG_SPARK_DATAPROC_CLUSTER_NAME = "dataproc_cluster_name"
 CONFIG_SPARK_DATAPROC_PROJECT = "dataproc_project"
@@ -109,4 +112,6 @@ FEAST_DEFAULT_OPTIONS = {
     CONFIG_MAX_WAIT_INTERVAL_KEY: "60",
     # Authentication Provider - Google OpenID/OAuth
     CONFIG_AUTH_PROVIDER: "google",
+    CONFIG_SPARK_LAUNCHER: "dataproc",
+    CONFIG_SPARK_INGESTION_JOB_JAR: "gs://feast-jobs/feast-ingestion-spark-0.8-SNAPSHOT.jar",
 }

--- a/sdk/python/feast/pyspark/abc.py
+++ b/sdk/python/feast/pyspark/abc.py
@@ -95,7 +95,7 @@ class RetrievalJobParameters(SparkJobParameters):
 
     def get_name(self) -> str:
         all_feature_tables_names = [ft["name"] for ft in self._feature_tables]
-        return f"HistoryRetrieval-{all_feature_tables_names}"
+        return f"HistoryRetrieval-{'-'.join(all_feature_tables_names)}"
 
     def get_main_file_path(self) -> str:
         return os.path.join(

--- a/sdk/python/feast/pyspark/abc.py
+++ b/sdk/python/feast/pyspark/abc.py
@@ -331,4 +331,7 @@ class JobLauncher(abc.ABC):
         start: datetime,
         end: datetime,
     ) -> IngestionJob:
+        """
+        Submits a batch ingestion job to a Spark cluster.
+        """
         raise NotImplementedError

--- a/sdk/python/feast/pyspark/abc.py
+++ b/sdk/python/feast/pyspark/abc.py
@@ -214,7 +214,6 @@ class JobLauncher(abc.ABC):
             feature_tables_conf (List[Dict]): List of feature table specification.
                 The order of the feature table must correspond to that of feature_tables_sources.
             destination_conf (Dict): Retrieval job output destination.
-            job_id (str): A job id that is unique for each job submission.
 
         Raises:
             SparkJobFailure: The spark job submission failed, encountered error

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -1,17 +1,25 @@
-from typing import TYPE_CHECKING, List, Union
-
-from datetime import datetime
-from urllib.parse import urlparse
-import tempfile
 import shutil
+import tempfile
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Union
+from urllib.parse import urlparse
 
 from feast.config import Config
-from feast.constants import *
+from feast.constants import (
+    CONFIG_SPARK_DATAPROC_CLUSTER_NAME,
+    CONFIG_SPARK_DATAPROC_PROJECT,
+    CONFIG_SPARK_DATAPROC_REGION,
+    CONFIG_SPARK_DATAPROC_STAGING_LOCATION,
+    CONFIG_SPARK_HOME,
+    CONFIG_SPARK_INGESTION_JOB_JAR,
+    CONFIG_SPARK_LAUNCHER,
+    CONFIG_SPARK_STANDALONE_MASTER,
+)
 from feast.data_source import BigQuerySource, DataSource, FileSource
 from feast.feature_table import FeatureTable
-from feast.pyspark.abc import JobLauncher, RetrievalJob, IngestionJob
-from feast.value_type import ValueType
+from feast.pyspark.abc import IngestionJob, JobLauncher, RetrievalJob
 from feast.staging.storage_client import get_staging_client
+from feast.value_type import ValueType
 
 if TYPE_CHECKING:
     from feast.client import Client

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -147,14 +147,14 @@ def start_historical_feature_retrieval_job(
 def _download_jar(remote_jar: str) -> str:
     remote_jar_parts = urlparse(remote_jar)
 
-    f = tempfile.NamedTemporaryFile(suffix=".jar", delete=False)
-    with f:
+    local_temp_jar = tempfile.NamedTemporaryFile(suffix=".jar", delete=False)
+    with local_temp_jar:
         shutil.copyfileobj(
             get_staging_client(remote_jar_parts.scheme).download_file(remote_jar_parts),
-            f,
+            local_temp_jar,
         )
 
-    return f.name
+    return local_temp_jar.name
 
 
 def start_offline_to_online_ingestion(

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -126,7 +126,6 @@ def start_historical_feature_retrieval_job(
     feature_tables: List[FeatureTable],
     output_format: str,
     output_path: str,
-    job_id: str,
 ) -> RetrievalJob:
     launcher = resolve_launcher(client._config)
     return launcher.historical_feature_retrieval(
@@ -140,7 +139,6 @@ def start_historical_feature_retrieval_job(
             for feature_table in feature_tables
         ],
         destination_conf={"format": output_format, "path": output_path},
-        job_id=job_id,
     )
 
 

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -158,7 +158,7 @@ def _download_jar(remote_jar: str) -> str:
 
 
 def start_offline_to_online_ingestion(
-    feature_table: FeatureTable, start: datetime, end: datetime, client: 'Client'
+    feature_table: FeatureTable, start: datetime, end: datetime, client: "Client"
 ) -> IngestionJob:
 
     launcher = resolve_launcher(client._config)

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -158,7 +158,7 @@ def _download_jar(remote_jar: str) -> str:
 
 
 def start_offline_to_online_ingestion(
-    feature_table: FeatureTable, start: datetime, end: datetime, client: Client
+    feature_table: FeatureTable, start: datetime, end: datetime, client: 'Client'
 ) -> IngestionJob:
 
     launcher = resolve_launcher(client._config)

--- a/sdk/python/feast/pyspark/launchers/standalone/local.py
+++ b/sdk/python/feast/pyspark/launchers/standalone/local.py
@@ -1,17 +1,76 @@
-import json
 import os
 import subprocess
+import uuid
+from datetime import datetime
 from typing import Dict, List
 
-from feast.pyspark.abc import JobLauncher, RetrievalJob, SparkJobFailure
+from feast.pyspark.abc import (
+    RetrievalJob,
+    SparkJobFailure,
+    JobLauncher,
+    SparkJob,
+    SparkJobStatus,
+    IngestionJob,
+)
 
 
-class StandaloneClusterRetrievalJob(RetrievalJob):
+class StandaloneClusterSparkJob(SparkJob):
+    def __init__(self, job_id: str, **kwargs):
+        super().__init__(**kwargs)
+        self._job_id = job_id
+        self._process = None
+
+    def get_id(self) -> str:
+        return self._job_id
+
+    def set_process(self, process: subprocess.Popen):
+        self._process = process
+
+    def get_status(self) -> SparkJobStatus:
+        code = self._process.poll()
+        if code is None:
+            return SparkJobStatus.IN_PROGRESS
+
+        if code != 0:
+            return SparkJobStatus.FAILED
+
+        return SparkJobStatus.COMPLETED
+
+
+class StandaloneClusterIngestionJob(IngestionJob, StandaloneClusterSparkJob):
+    def __init__(
+        self,
+        job_id: str,
+        feature_table: Dict,
+        source: Dict,
+        start: datetime,
+        end: datetime,
+        jar: str,
+    ):
+        super().__init__(
+            job_id=job_id,
+            feature_table=feature_table,
+            source=source,
+            start=start,
+            end=end,
+            jar=jar,
+        )
+
+
+class StandaloneClusterRetrievalJob(RetrievalJob, StandaloneClusterSparkJob):
     """
     Historical feature retrieval job result for a standalone spark cluster
     """
 
-    def __init__(self, job_id: str, process: subprocess.Popen, output_file_uri: str):
+    def __init__(
+        self,
+        job_id: str,
+        output_file_uri: str,
+        feature_tables: List[Dict],
+        feature_tables_sources: List[Dict],
+        entity_source: Dict,
+        destination: Dict,
+    ):
         """
         This is the returned historical feature retrieval job result for StandaloneClusterLauncher.
 
@@ -20,8 +79,13 @@ class StandaloneClusterRetrievalJob(RetrievalJob):
             process (subprocess.Popen): Pyspark driver process, spawned by the launcher.
             output_file_uri (str): Uri to the historical feature retrieval job output file.
         """
-        self.job_id = job_id
-        self._process = process
+        super().__init__(
+            job_id=job_id,
+            feature_tables=feature_tables,
+            feature_tables_sources=feature_tables_sources,
+            entity_source=entity_source,
+            destination=destination,
+        )
         self._output_file_uri = output_file_uri
 
     def get_id(self) -> str:
@@ -67,34 +131,61 @@ class StandaloneClusterLauncher(JobLauncher):
     def spark_submit_script_path(self):
         return os.path.join(self.spark_home, "bin/spark-submit")
 
-    def historical_feature_retrieval(
-        self,
-        pyspark_script: str,
-        entity_source_conf: Dict,
-        feature_tables_sources_conf: List[Dict],
-        feature_tables_conf: List[Dict],
-        destination_conf: Dict,
-        job_id: str,
-        **kwargs,
-    ) -> RetrievalJob:
-
+    def spark_submit(self, job: StandaloneClusterSparkJob) -> subprocess.Popen:
         submission_cmd = [
             self.spark_submit_script_path,
             "--master",
             self.master_url,
             "--name",
-            job_id,
-            pyspark_script,
-            "--feature-tables",
-            json.dumps(feature_tables_conf),
-            "--feature-tables-sources",
-            json.dumps(feature_tables_sources_conf),
-            "--entity-source",
-            json.dumps(entity_source_conf),
-            "--destination",
-            json.dumps(destination_conf),
+            job.get_name(),
         ]
 
-        process = subprocess.Popen(submission_cmd, shell=True)
-        output_file = destination_conf["path"]
-        return StandaloneClusterRetrievalJob(job_id, process, output_file)
+        if job.get_class_name():
+            submission_cmd.extend(["--class", job.get_class_name()])
+
+        submission_cmd.append(job.get_main_file_path())
+        submission_cmd.extend(job.get_arguments())
+
+        process = subprocess.Popen(submission_cmd)
+        job.set_process(process)
+        return process
+
+    def historical_feature_retrieval(
+        self,
+        entity_source_conf: Dict,
+        feature_tables_sources_conf: List[Dict],
+        feature_tables_conf: List[Dict],
+        destination_conf: Dict,
+        **kwargs,
+    ) -> RetrievalJob:
+        job = StandaloneClusterRetrievalJob(
+            job_id=str(uuid.uuid4()),
+            output_file_uri=destination_conf["path"],
+            feature_tables=feature_tables_conf,
+            feature_tables_sources=feature_tables_sources_conf,
+            entity_source=entity_source_conf,
+            destination=destination_conf,
+        )
+
+        self.spark_submit(job)
+        return job
+
+    def offline_to_online_ingestion(
+        self,
+        jar_path: str,
+        source_conf: Dict,
+        feature_table_conf: Dict,
+        start: datetime,
+        end: datetime,
+    ) -> IngestionJob:
+        job = StandaloneClusterIngestionJob(
+            job_id=str(uuid.uuid4()),
+            feature_table=feature_table_conf,
+            source=source_conf,
+            start=start,
+            end=end,
+            jar=jar_path,
+        )
+
+        self.spark_submit(job)
+        return job

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -89,6 +89,7 @@ class GCSClient(AbstractStagingClient):
         url = uri.geturl()
         file_obj = TemporaryFile()
         self.gcs_client.download_blob_to_file(url, file_obj)
+        file_obj.seek(0)
         return file_obj
 
     def list_files(self, bucket: str, path: str) -> List[str]:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,8 +11,10 @@ def pytest_addoption(parser):
     parser.addoption("--enable_auth", action="store", default="False")
     parser.addoption("--kafka_brokers", action="store", default="localhost:9092")
 
-    parser.addoption("--env", action="store", help='local|aws|gcloud', default='local')
-    parser.addoption("--staging-path", action="store", default="gs://feast-templocation-kf-feast/")
+    parser.addoption("--env", action="store", help="local|aws|gcloud", default="local")
+    parser.addoption(
+        "--staging-path", action="store", default="gs://feast-templocation-kf-feast/"
+    )
     parser.addoption("--dataproc-cluster-name", action="store")
     parser.addoption("--dataproc-region", action="store")
     parser.addoption("--dataproc-project", action="store")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,6 +11,12 @@ def pytest_addoption(parser):
     parser.addoption("--enable_auth", action="store", default="False")
     parser.addoption("--kafka_brokers", action="store", default="localhost:9092")
 
+    parser.addoption("--env", action="store", help='local|aws|gcloud', default='local')
+    parser.addoption("--staging-path", action="store", default="gs://feast-templocation-kf-feast/")
+    parser.addoption("--dataproc-cluster-name", action="store")
+    parser.addoption("--dataproc-region", action="store")
+    parser.addoption("--dataproc-project", action="store")
+
 
 def pytest_runtest_makereport(item, call):
     if "incremental" in item.keywords:

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -1,0 +1,102 @@
+import uuid
+
+import pyspark
+import pandas as pd
+import numpy as np
+import time
+import os
+import pytest
+from datetime import datetime, timedelta
+
+from feast.pyspark.abc import SparkJobStatus
+from feast import Client, Entity, FeatureTable, Feature, ValueType, FileSource
+from feast.wait import wait_retry_backoff
+
+
+def generate_data():
+    df = pd.DataFrame(columns=['s2_id', 'unique_drivers', 'event_timestamp'])
+    df['s2id'] = np.random.randint(1000, 9999, 100)
+    df['unique_drivers'] = np.random.randint(0, 1000, 100)
+    df['event_timestamp'] = pd.to_datetime(np.random.randint(
+        int(time.time()), int(time.time()) + 3600, 100), unit="s")
+    df['date'] = df['event_timestamp'].dt.date
+
+    return df
+
+
+@pytest.fixture(scope="session")
+def feast_client(pytestconfig):
+    if pytestconfig.getoption("env") == "local":
+        return Client(
+            core_url='localhost:6565',
+            serving_url='localhost:6566',
+            spark_launcher='standalone',
+            spark_standalone_master="local",
+            spark_home=os.path.dirname(pyspark.__file__)
+        )
+
+    if pytestconfig.getoption("env") == "gcloud":
+        return Client(
+            core_url=pytestconfig.getoption("core_url"),
+            serving_url=pytestconfig.getoption("serving_url"),
+            spark_launcher='dataproc',
+            dataproc_cluster_name=pytestconfig.getoption("dataproc_cluster_name"),
+            dataproc_project=pytestconfig.getoption("dataproc_project"),
+            dataproc_region=pytestconfig.getoption("dataproc_region"),
+            dataproc_staging_location=os.path.join(
+                pytestconfig.getoption("staging_path"), "dataproc")
+        )
+
+
+@pytest.fixture(scope="function")
+def staging_path(pytestconfig, tmp_path):
+    if pytestconfig.getoption("env") == "local":
+        return f"file://{tmp_path}"
+
+    staging_path = pytestconfig.getoption("staging_path")
+    return os.path.join(staging_path, str(uuid.uuid4()))
+
+
+def test_offline_ingestion(feast_client: Client, staging_path: str):
+    entity = Entity(
+        name="s2id",
+        description="S2id",
+        value_type=ValueType.INT64,
+    )
+
+    feature_table = FeatureTable(
+        name="drivers",
+        entities=["s2id"],
+        features=[
+            Feature("unique_drivers", ValueType.INT64)
+        ],
+        batch_source=FileSource(
+            "event_timestamp",
+            "event_timestamp",
+            "parquet",
+            os.path.join(staging_path, "batch-storage")
+        )
+    )
+
+    feast_client.apply_entity(entity)
+    feast_client.apply_feature_table(feature_table)
+
+    df = generate_data()
+    feast_client.ingest(feature_table, df)  # write to batch (offline) storage
+
+    job = feast_client.start_offline_to_online_ingestion(
+        feature_table,
+        datetime.today(),
+        datetime.today() + timedelta(days=1)
+    )
+
+    status = wait_retry_backoff(
+        lambda: (job.get_status(), job.get_status() != SparkJobStatus.IN_PROGRESS),
+        300
+    )
+
+    assert status == SparkJobStatus.COMPLETED
+
+    feast_client.get_online_features(["drivers:unique_drivers"], entity_rows=[
+        {"s2id": s2_id} for s2_id in df['s2id'].tolist()
+    ])

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -1,25 +1,26 @@
-import uuid
-
-import pyspark
-import pandas as pd
-import numpy as np
-import time
 import os
-import pytest
+import time
+import uuid
 from datetime import datetime, timedelta
 
+import numpy as np
+import pandas as pd
+import pyspark
+import pytest
+
+from feast import Client, Entity, Feature, FeatureTable, FileSource, ValueType
 from feast.pyspark.abc import SparkJobStatus
-from feast import Client, Entity, FeatureTable, Feature, ValueType, FileSource
 from feast.wait import wait_retry_backoff
 
 
 def generate_data():
-    df = pd.DataFrame(columns=['s2_id', 'unique_drivers', 'event_timestamp'])
-    df['s2id'] = np.random.randint(1000, 9999, 100)
-    df['unique_drivers'] = np.random.randint(0, 1000, 100)
-    df['event_timestamp'] = pd.to_datetime(np.random.randint(
-        int(time.time()), int(time.time()) + 3600, 100), unit="s")
-    df['date'] = df['event_timestamp'].dt.date
+    df = pd.DataFrame(columns=["s2_id", "unique_drivers", "event_timestamp"])
+    df["s2id"] = np.random.randint(1000, 9999, 100)
+    df["unique_drivers"] = np.random.randint(0, 1000, 100)
+    df["event_timestamp"] = pd.to_datetime(
+        np.random.randint(int(time.time()), int(time.time()) + 3600, 100), unit="s"
+    )
+    df["date"] = df["event_timestamp"].dt.date
 
     return df
 
@@ -28,23 +29,24 @@ def generate_data():
 def feast_client(pytestconfig):
     if pytestconfig.getoption("env") == "local":
         return Client(
-            core_url='localhost:6565',
-            serving_url='localhost:6566',
-            spark_launcher='standalone',
+            core_url="localhost:6565",
+            serving_url="localhost:6566",
+            spark_launcher="standalone",
             spark_standalone_master="local",
-            spark_home=os.path.dirname(pyspark.__file__)
+            spark_home=os.path.dirname(pyspark.__file__),
         )
 
     if pytestconfig.getoption("env") == "gcloud":
         return Client(
             core_url=pytestconfig.getoption("core_url"),
             serving_url=pytestconfig.getoption("serving_url"),
-            spark_launcher='dataproc',
+            spark_launcher="dataproc",
             dataproc_cluster_name=pytestconfig.getoption("dataproc_cluster_name"),
             dataproc_project=pytestconfig.getoption("dataproc_project"),
             dataproc_region=pytestconfig.getoption("dataproc_region"),
             dataproc_staging_location=os.path.join(
-                pytestconfig.getoption("staging_path"), "dataproc")
+                pytestconfig.getoption("staging_path"), "dataproc"
+            ),
         )
 
 
@@ -58,24 +60,18 @@ def staging_path(pytestconfig, tmp_path):
 
 
 def test_offline_ingestion(feast_client: Client, staging_path: str):
-    entity = Entity(
-        name="s2id",
-        description="S2id",
-        value_type=ValueType.INT64,
-    )
+    entity = Entity(name="s2id", description="S2id", value_type=ValueType.INT64,)
 
     feature_table = FeatureTable(
         name="drivers",
         entities=["s2id"],
-        features=[
-            Feature("unique_drivers", ValueType.INT64)
-        ],
+        features=[Feature("unique_drivers", ValueType.INT64)],
         batch_source=FileSource(
             "event_timestamp",
             "event_timestamp",
             "parquet",
-            os.path.join(staging_path, "batch-storage")
-        )
+            os.path.join(staging_path, "batch-storage"),
+        ),
     )
 
     feast_client.apply_entity(entity)
@@ -85,18 +81,16 @@ def test_offline_ingestion(feast_client: Client, staging_path: str):
     feast_client.ingest(feature_table, df)  # write to batch (offline) storage
 
     job = feast_client.start_offline_to_online_ingestion(
-        feature_table,
-        datetime.today(),
-        datetime.today() + timedelta(days=1)
+        feature_table, datetime.today(), datetime.today() + timedelta(days=1)
     )
 
     status = wait_retry_backoff(
-        lambda: (job.get_status(), job.get_status() != SparkJobStatus.IN_PROGRESS),
-        300
+        lambda: (job.get_status(), job.get_status() != SparkJobStatus.IN_PROGRESS), 300
     )
 
     assert status == SparkJobStatus.COMPLETED
 
-    feast_client.get_online_features(["drivers:unique_drivers"], entity_rows=[
-        {"s2id": s2_id} for s2_id in df['s2id'].tolist()
-    ])
+    feast_client.get_online_features(
+        ["drivers:unique_drivers"],
+        entity_rows=[{"s2id": s2_id} for s2_id in df["s2id"].tolist()],
+    )

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -59,6 +59,7 @@ def staging_path(pytestconfig, tmp_path):
     return os.path.join(staging_path, str(uuid.uuid4()))
 
 
+@pytest.mark.skip
 def test_offline_ingestion(feast_client: Client, staging_path: str):
     entity = Entity(name="s2id", description="S2id", value_type=ValueType.INT64,)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR aim to glue together various backend implementations of job submission and Feast SDK by introducing some cleaner structure with `SparkJob`, `SparkJobParameters` interfaces and separate `launch` modules.
Also `offline_to_online_ingestion` is added to `JobLauncher` interface. Implementations for standalone & dataproc launchers provided as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
