### PR TITLE
Cleanup CLI and Python dependencies

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -360,7 +360,7 @@ def job():
     pass
 
 
-@job.command(name="sync-offline-to-online")
+@job.command(name="start-offline-to-online")
 @click.option(
     "--feature-table",
     "-t",
@@ -374,21 +374,13 @@ def sync_offline_to_online(feature_table: str, start_time: str, end_time: str):
     """
     Sync offline store data to online store
     """
+    from datetime import datetime
 
-    spark_launcher = Config().get(CONFIG_SPARK_LAUNCHER)
-
-    if spark_launcher == "emr":
-        import feast.pyspark.aws.jobs
-
-        client = Client()
-        table = client.get_feature_table(feature_table)
-        feast.pyspark.aws.jobs.sync_offline_to_online(
-            client, table, start_time, end_time
-        )
-    else:
-        raise NotImplementedError(
-            f"Feast currently does not provide support for the specified spark launcher: {spark_launcher}"
-        )
+    client = Client()
+    table = client.get_feature_table(feature_table)
+    client.start_offline_to_online_ingestion(
+        table, datetime.fromisoformat(start_time), datetime.fromisoformat(end_time)
+    )
 
 
 @job.command(name="start-stream-to-online")
@@ -410,20 +402,9 @@ def start_stream_to_online(feature_table: str, jar: str):
     Start stream to online sync job
     """
 
-    spark_launcher = Config().get(CONFIG_SPARK_LAUNCHER)
-
-    if spark_launcher == "emr":
-        import feast.pyspark.aws.jobs
-
-        client = Client()
-        table = client.get_feature_table(feature_table)
-        feast.pyspark.aws.jobs.start_stream_to_online(
-            client, table, [jar] if jar else []
-        )
-    else:
-        raise NotImplementedError(
-            f"Feast currently does not provide support for the specified spark launcher: {spark_launcher}"
-        )
+    client = Client()
+    table = client.get_feature_table(feature_table)
+    client.start_stream_to_online_ingestion(table, [jar] if jar else [])
 
 
 @job.command(name="stop-stream-to-online")

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -23,6 +23,7 @@ import yaml
 
 from feast.client import Client
 from feast.config import Config
+from feast.constants import CONFIG_SPARK_LAUNCHER
 from feast.entity import Entity
 from feast.feature_table import FeatureTable
 from feast.loaders.yaml import yaml_loader
@@ -351,78 +352,127 @@ def project_list():
     print(tabulate(table, headers=["NAME"], tablefmt="plain"))
 
 
-@cli.command()
+@cli.group(name="jobs")
+def job():
+    """
+    Create and manage jobs
+    """
+    pass
+
+
+@job.command(name="sync-offline-to-online")
 @click.option(
     "--feature-table",
     "-t",
-    help="Feature table name to ingest data into",
+    help="Feature table name of data to be synced",
+    type=click.STRING,
     required=True,
 )
 @click.option("--start-time", "-s", help="Interval start", required=True)
 @click.option("--end-time", "-e", help="Interval end", required=True)
 def sync_offline_to_online(feature_table: str, start_time: str, end_time: str):
     """
-    Sync offline store to online.
+    Sync offline store data to online store
     """
-    from datetime import datetime
 
-    client = Client()
-    table = client.get_feature_table(feature_table)
-    client.start_offline_to_online_ingestion(
-        table, datetime.fromisoformat(start_time), datetime.fromisoformat(end_time)
-    )
+    spark_launcher = Config().get(CONFIG_SPARK_LAUNCHER)
+
+    if spark_launcher == "emr":
+        import feast.pyspark.aws.jobs
+
+        client = Client()
+        table = client.get_feature_table(feature_table)
+        feast.pyspark.aws.jobs.sync_offline_to_online(
+            client, table, start_time, end_time
+        )
+    else:
+        raise NotImplementedError(
+            f"Feast currently does not provide support for the specified spark launcher: {spark_launcher}"
+        )
 
 
-@cli.command()
+@job.command(name="start-stream-to-online")
 @click.option(
     "--feature-table",
     "-t",
-    help="Feature table name to ingest data into",
+    help="Feature table name of job to be started",
+    type=click.STRING,
     required=True,
 )
 @click.option(
-    "--jar", "-j", help="Feature table name to ingest data into", default="",
+    "--jar",
+    "-j",
+    help="The file path to the uber jar for offline to online ingestion spark job",
+    default="",
 )
 def start_stream_to_online(feature_table: str, jar: str):
     """
-    Start stream to online sync job.
+    Start stream to online sync job
     """
 
-    client = Client()
-    table = client.get_feature_table(feature_table)
-    client.start_stream_to_online_ingestion(table, [jar] if jar else [])
+    spark_launcher = Config().get(CONFIG_SPARK_LAUNCHER)
+
+    if spark_launcher == "emr":
+        import feast.pyspark.aws.jobs
+
+        client = Client()
+        table = client.get_feature_table(feature_table)
+        feast.pyspark.aws.jobs.start_stream_to_online(
+            client, table, [jar] if jar else []
+        )
+    else:
+        raise NotImplementedError(
+            f"Feast currently does not provide support for the specified spark launcher: {spark_launcher}"
+        )
 
 
-@cli.command()
+@job.command(name="stop-stream-to-online")
 @click.option(
     "--feature-table",
     "-t",
-    help="Feature table name to ingest data into",
+    help="Feature table name of job to be stopped",
+    type=click.STRING,
     required=True,
 )
 def stop_stream_to_online(feature_table: str):
     """
-    Start stream to online sync job.
+    Stop stream to online sync job
     """
-    import feast.pyspark.aws.jobs
 
-    feast.pyspark.aws.jobs.stop_stream_to_online(feature_table)
+    spark_launcher = Config().get(CONFIG_SPARK_LAUNCHER)
+
+    if spark_launcher == "emr":
+        import feast.pyspark.aws.jobs
+
+        feast.pyspark.aws.jobs.stop_stream_to_online(feature_table)
+    else:
+        raise NotImplementedError(
+            f"Feast currently does not provide support for the specified spark launcher: {spark_launcher}"
+        )
 
 
-@cli.command()
-def list_emr_jobs():
+@job.command()
+def list_jobs():
     """
-    List jobs.
+    List jobs
     """
     from tabulate import tabulate
 
-    import feast.pyspark.aws.jobs
+    spark_launcher = Config().get(CONFIG_SPARK_LAUNCHER)
 
-    jobs = feast.pyspark.aws.jobs.list_jobs(None, None)
+    if spark_launcher == "emr":
+        import feast.pyspark.aws.jobs
 
-    print(
-        tabulate(jobs, headers=feast.pyspark.aws.jobs.JobInfo._fields, tablefmt="plain")
-    )
+        jobs = feast.pyspark.aws.jobs.list_jobs(None, None)
+        print(
+            tabulate(
+                jobs, headers=feast.pyspark.aws.jobs.JobInfo._fields, tablefmt="plain"
+            )
+        )
+    else:
+        raise NotImplementedError(
+            f"Feast currently does not provide support for the specified spark launcher: {spark_launcher}"
+        )
 
 
 @cli.command()

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -39,14 +39,12 @@ REQUIRED = [
     "protobuf>=3.10",
     "PyYAML==5.1.*",
     "fastavro>=0.22.11,<0.23",
-    "kafka-python==1.*",
     "tabulate==0.8.*",
     "toml==0.10.*",
     "tqdm==4.*",
     "pyarrow<0.16.0,>=0.15.1",
     "numpy",
     "google",
-    "confluent_kafka",
 ]
 
 # README file from Feast repo root directory


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
- Puts emr-related cli commands under `jobs` group, where we'll be adding future support for dataproc as well.
- Removes kafka dependencies.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
sync_offline_to_online, start_stream_to_online, stop_stream_to_online and list_jobs commands in cli will now be found under `jobs` group
```
