### PR TITLE
Use RedisKeyV2 as key serializer and java murmur implementation in Redis Sink

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -149,3 +149,15 @@ jobs:
       - uses: actions/checkout@v2
       - name: Test docker compose
         run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}
+
+  publish-ingestion-jar:
+    runs-on: [ self-hosted ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          export_default_credentials: true
+      - make build-java-no-tests REVISION=${GITHUB_SHA}
+      - gsutil cp ./spark/ingestion/target/feast-ingestion-spark-${GITHUB_SHA}.jar gs://feast-jobs/
+

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -146,7 +146,7 @@ jobs:
     needs:
     - build-push-docker-images
     - publish-ingestion-jar
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     env:
       GCP_SERVICE_ACCOUNT: /etc/gcloud/key.json
     steps:

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -161,6 +161,8 @@ jobs:
           export_default_credentials: true
       - name: build-jar
         run: make build-java-no-tests REVISION=${GITHUB_SHA}
+      - name: ls
+        run: ls -l ./spark/ingestion/target/
       - name: copy to gs
         run: gsutil cp ./spark/ingestion/target/feast-ingestion-spark-${GITHUB_SHA}.jar gs://feast-jobs/
 

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -151,6 +151,11 @@ jobs:
       GCP_SERVICE_ACCOUNT: /etc/gcloud/key.json
     steps:
       - uses: actions/checkout@v2
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          export_default_credentials: true
+      - run: gcloud auth configure-docker --quiet
       - name: Test docker compose
         run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}
 

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -151,13 +151,15 @@ jobs:
         run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}
 
   publish-ingestion-jar:
-    runs-on:  [self-hosted]
+    runs-on: ubuntu-latest
     container: gcr.io/kf-feast/feast-ci:latest
     steps:
       - uses: actions/checkout@v2
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           version: '290.0.1'
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
       - name: build-jar
         run: make build-java-no-tests REVISION=${GITHUB_SHA}

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -161,6 +161,9 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '1.8'
+      - uses: stCarolas/setup-maven@v3
+        with:
+            maven-version: 3.6.3
       - name: build-jar
         run: make build-java-no-tests REVISION=${GITHUB_SHA}
       - name: ls

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -160,7 +160,7 @@ jobs:
           export_default_credentials: true
       - uses: actions/setup-java@v1
         with:
-          - java-version: '1.8'
+          java-version: '1.8'
       - name: build-jar
         run: make build-java-no-tests REVISION=${GITHUB_SHA}
       - name: ls

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -151,8 +151,8 @@ jobs:
         run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}
 
   publish-ingestion-jar:
-    runs-on: [ self-hosted ]
-    container: maven:3.6.3-jdk-11
+    runs-on: ubuntu-latest
+    container: gcr.io/kf-feast/feast-ci:latest
     steps:
       - uses: actions/checkout@v2
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -151,16 +151,16 @@ jobs:
         run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}
 
   publish-ingestion-jar:
-    runs-on: ubuntu-latest
-    container: gcr.io/kf-feast/feast-ci:latest
+    runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v2
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:
           version: '290.0.1'
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
+      - uses: actions/setup-java@v1
+        with:
+          - java-version: '1.8'
       - name: build-jar
         run: make build-java-no-tests REVISION=${GITHUB_SHA}
       - name: ls

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -158,6 +158,8 @@ jobs:
         with:
           version: '290.0.1'
           export_default_credentials: true
-      - make build-java-no-tests REVISION=${GITHUB_SHA}
-      - gsutil cp ./spark/ingestion/target/feast-ingestion-spark-${GITHUB_SHA}.jar gs://feast-jobs/
+      - name: build-jar
+        run: make build-java-no-tests REVISION=${GITHUB_SHA}
+      - name: copy to gs
+        run: gsutil cp ./spark/ingestion/target/feast-ingestion-spark-${GITHUB_SHA}.jar gs://feast-jobs/
 

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -152,6 +152,7 @@ jobs:
 
   publish-ingestion-jar:
     runs-on: [ self-hosted ]
+    container: maven:3.6.3-jdk-11
     steps:
       - uses: actions/checkout@v2
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -147,6 +147,8 @@ jobs:
     - build-push-docker-images
     - publish-ingestion-jar
     runs-on: ubuntu-latest
+    env:
+      GCP_SERVICE_ACCOUNT: /etc/gcloud/key.json
     steps:
       - uses: actions/checkout@v2
       - name: Test docker compose
@@ -165,7 +167,7 @@ jobs:
           java-version: '11'
       - uses: stCarolas/setup-maven@v3
         with:
-            maven-version: 3.6.3
+          maven-version: 3.6.3
       - name: build-jar
         run: make build-java-no-tests REVISION=${GITHUB_SHA}
       - name: copy to gs

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -143,7 +143,9 @@ jobs:
           path: load-test-output/
 
   tests-docker-compose:
-    needs: build-push-docker-images
+    needs:
+    - build-push-docker-images
+    - publish-ingestion-jar
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -160,14 +162,12 @@ jobs:
           export_default_credentials: true
       - uses: actions/setup-java@v1
         with:
-          java-version: '1.8'
+          java-version: '11'
       - uses: stCarolas/setup-maven@v3
         with:
             maven-version: 3.6.3
       - name: build-jar
         run: make build-java-no-tests REVISION=${GITHUB_SHA}
-      - name: ls
-        run: ls -l ./spark/ingestion/target/
       - name: copy to gs
-        run: gsutil cp ./spark/ingestion/target/feast-ingestion-spark-${GITHUB_SHA}.jar gs://feast-jobs/
+        run: gsutil cp ./spark/ingestion/target/feast-ingestion-spark-${GITHUB_SHA}.jar gs://feast-jobs/spark/ingestion/
 

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -146,16 +146,9 @@ jobs:
     needs:
     - build-push-docker-images
     - publish-ingestion-jar
-    runs-on: [self-hosted]
-    env:
-      GCP_SERVICE_ACCOUNT: /etc/gcloud/key.json
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-        with:
-          version: '290.0.1'
-          export_default_credentials: true
-      - run: gcloud auth configure-docker --quiet
       - name: Test docker compose
         run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}
 

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -151,7 +151,7 @@ jobs:
         run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}
 
   publish-ingestion-jar:
-    runs-on: ubuntu-latest
+    runs-on:  [self-hosted]
     container: gcr.io/kf-feast/feast-ci:latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -62,3 +62,28 @@ jobs:
               docker push gcr.io/kf-feast/feast-${{ matrix.component }}:latest
             fi
           fi
+
+  publish-ingestion-jar:
+    runs-on: [ self-hosted ]
+    env:
+      PUBLISH_BUCKET: feast-jobs
+    steps:
+      - uses: actions/checkout@v2
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          export_default_credentials: true
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - uses: stCarolas/setup-maven@v3
+        with:
+          maven-version: 3.6.3
+      - name: build-jar
+        run: |
+          SEMVER_REGEX='^v[0-9]+\.[0-9]+\.[0-9]+(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+          if echo "${RELEASE_VERSION}" | grep -P "$SEMVER_REGEX" &>/dev/null ; then
+            VERSION=${RELEASE_VERSION:1}
+            make build-java-no-tests REVISION=${VERSION}
+            gsutil cp ./spark/ingestion/target/feast-ingestion-spark-${VERSION}.jar gs://${PUBLISH_BUCKET}/spark/ingestion/
+          fi

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ build-java:
 	mvn clean verify
 
 build-java-no-tests:
-	mvn --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true -Drevision=$REVISION clean package
+	mvn --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true -Drevision=${REVISION} clean package
 
 # Python SDK
 

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ test-java-with-coverage:
 build-java:
 	mvn clean verify
 
+build-java-no-tests:
+	mvn --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true -Drevision=$REVISION clean package
+
 # Python SDK
 
 install-python-ci-dependencies:

--- a/infra/docker/jupyter/Dockerfile
+++ b/infra/docker/jupyter/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/minimal-notebook:619e9cc2fc07
+FROM jupyter/pyspark-notebook:ae5f7e104dd5
 
 USER root
 WORKDIR /feast

--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -63,5 +63,5 @@ export FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS=$(docker inspect -f '{{range .N
 ${PROJECT_ROOT_DIR}/infra/scripts/wait-for-it.sh ${FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS}:6566 --timeout=120
 
 # Run e2e tests for Redis
-docker exec feast_jupyter_1 bash -e FEAST_VERSION=${FEAST_VERSION} \
+docker exec -e FEAST_VERSION=${FEAST_VERSION} feast_jupyter_1 bash \
 -c 'cd /feast/tests/e2e && unset GOOGLE_APPLICATION_CREDENTIALS && pytest *.py -m "not bq" --ingestion-jar gs://feast-jobs/spark/ingestion/feast-ingestion-spark-${FEAST_VERSION}.jar --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'

--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -63,4 +63,5 @@ export FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS=$(docker inspect -f '{{range .N
 ${PROJECT_ROOT_DIR}/infra/scripts/wait-for-it.sh ${FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS}:6566 --timeout=120
 
 # Run e2e tests for Redis
-docker exec feast_jupyter_1 bash -c 'cd /feast/tests/e2e && unset GOOGLE_APPLICATION_CREDENTIALS && pytest *.py -m "not bq" --ingestion-jar gs://feast-jobs/spark/ingestion/feast-ingestion-spark-${FEAST_VERSION}.jar --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'
+docker exec feast_jupyter_1 bash -e FEAST_VERSION=${FEAST_VERSION} \
+-c 'cd /feast/tests/e2e && unset GOOGLE_APPLICATION_CREDENTIALS && pytest *.py -m "not bq" --ingestion-jar gs://feast-jobs/spark/ingestion/feast-ingestion-spark-${FEAST_VERSION}.jar --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'

--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -63,4 +63,4 @@ export FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS=$(docker inspect -f '{{range .N
 ${PROJECT_ROOT_DIR}/infra/scripts/wait-for-it.sh ${FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS}:6566 --timeout=120
 
 # Run e2e tests for Redis
-docker exec feast_jupyter_1 bash -c 'cd /feast/tests/e2e && pytest *.py -m "not bq" --ingestion-jar gs://feast-jobs/spark/ingestion/feast-ingestion-spark-${FEAST_VERSION}.jar --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'
+docker exec feast_jupyter_1 bash -c 'cd /feast/tests/e2e && unset GOOGLE_APPLICATION_CREDENTIALS && pytest *.py -m "not bq" --ingestion-jar gs://feast-jobs/spark/ingestion/feast-ingestion-spark-${FEAST_VERSION}.jar --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'

--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -64,4 +64,4 @@ ${PROJECT_ROOT_DIR}/infra/scripts/wait-for-it.sh ${FEAST_ONLINE_SERVING_CONTAINE
 
 # Run e2e tests for Redis
 docker exec -e FEAST_VERSION=${FEAST_VERSION} feast_jupyter_1 bash \
--c 'cd /feast/tests/e2e && unset GOOGLE_APPLICATION_CREDENTIALS && pytest *.py -m "not bq" --ingestion-jar gs://feast-jobs/spark/ingestion/feast-ingestion-spark-${FEAST_VERSION}.jar --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'
+-c 'cd /feast/tests/e2e && unset GOOGLE_APPLICATION_CREDENTIALS && pytest *.py -m "not bq" --ingestion-jar gs://feast-jobs/spark/ingestion/feast-ingestion-spark-${FEAST_VERSION}.jar --redis-url redis:6379 --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'

--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -63,4 +63,4 @@ export FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS=$(docker inspect -f '{{range .N
 ${PROJECT_ROOT_DIR}/infra/scripts/wait-for-it.sh ${FEAST_ONLINE_SERVING_CONTAINER_IP_ADDRESS}:6566 --timeout=120
 
 # Run e2e tests for Redis
-docker exec feast_jupyter_1 bash -c 'cd /feast/tests/e2e && pytest *.py -m "not bq" --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'
+docker exec feast_jupyter_1 bash -c 'cd /feast/tests/e2e && pytest *.py -m "not bq" --ingestion-jar gs://feast-jobs/spark/ingestion/feast-ingestion-spark-${FEAST_VERSION}.jar --core_url core:6565 --serving_url=online_serving:6566 --kafka_brokers=kafka:9092'

--- a/infra/scripts/test-end-to-end-redis-cluster.sh
+++ b/infra/scripts/test-end-to-end-redis-cluster.sh
@@ -103,7 +103,8 @@ cd tests/e2e
 
 set +e
 CORE_NO=$(nproc --all)
-pytest *.py -n ${CORE_NO} --dist=loadscope --junitxml=${LOGS_ARTIFACT_PATH}/python-sdk-test-report.xml
+pytest *.py -n ${CORE_NO} --redis-url localhost:7000 \
+  --dist=loadscope --junitxml=${LOGS_ARTIFACT_PATH}/python-sdk-test-report.xml
 TEST_EXIT_CODE=$?
 
 if [[ ${TEST_EXIT_CODE} != 0 ]]; then

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -886,9 +886,18 @@ class Client:
         return feature_tables
 
     def start_offline_to_online_ingestion(
-        self, feature_table: Union[FeatureTable, str], start: datetime, end: datetime,
+        self, feature_table: FeatureTable, start: datetime, end: datetime,
     ) -> SparkJob:
-        return start_offline_to_online_ingestion(feature_table, start, end, self)  # type: ignore
+        """
+
+        Launch Ingestion Job from Batch Source to Online Store for given featureTable
+
+        :param feature_table: FeatureTable which will be ingested
+        :param start: lower datetime boundary
+        :param end: upper datetime boundary
+        :return: Spark Job Proxy object
+        """
+        return start_offline_to_online_ingestion(feature_table, start, end, self)
 
     def stage_dataframe(
         self,

--- a/sdk/python/feast/config.py
+++ b/sdk/python/feast/config.py
@@ -47,8 +47,7 @@ def _init_config(path: str):
     config_dir = os.path.dirname(path)
     config_dir = config_dir.rstrip("/") + "/"
 
-    if not os.path.exists(os.path.dirname(config_dir)):
-        os.makedirs(os.path.dirname(config_dir))
+    os.makedirs(os.path.dirname(config_dir), exist_ok=True)
 
     # Create the configuration file itself
     config = ConfigParser(defaults=DEFAULTS)

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -124,4 +124,7 @@ FEAST_DEFAULT_OPTIONS = {
     CONFIG_AUTH_PROVIDER: "google",
     CONFIG_SPARK_LAUNCHER: "dataproc",
     CONFIG_SPARK_INGESTION_JOB_JAR: "gs://feast-jobs/feast-ingestion-spark-0.8-SNAPSHOT.jar",
+    CONFIG_REDIS_HOST: "localhost",
+    CONFIG_REDIS_PORT: "6379",
+    CONFIG_REDIS_SSL: "False",
 }

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -19,10 +19,10 @@ import shutil
 from abc import ABC, ABCMeta, abstractmethod
 from tempfile import TemporaryFile
 from typing import List
-
-from google.auth.exceptions import DefaultCredentialsError
 from typing.io import IO
 from urllib.parse import ParseResult
+
+from google.auth.exceptions import DefaultCredentialsError
 
 GS = "gs"
 S3 = "s3"
@@ -79,7 +79,7 @@ class GCSClient(AbstractStagingClient):
             self.gcs_client = storage.Client(project=None)
         except DefaultCredentialsError:
             self.gcs_client = storage.Client.create_anonymous_client()
-            
+
     def download_file(self, uri: ParseResult) -> IO[bytes]:
         """
         Downloads a file from google cloud storage and returns a TemporaryFile object

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -19,6 +19,8 @@ import shutil
 from abc import ABC, ABCMeta, abstractmethod
 from tempfile import TemporaryFile
 from typing import List
+
+from google.auth.exceptions import DefaultCredentialsError
 from typing.io import IO
 from urllib.parse import ParseResult
 
@@ -73,8 +75,11 @@ class GCSClient(AbstractStagingClient):
                 "Install package google-cloud-storage==1.20.* for gcs staging support"
                 "run ```pip install google-cloud-storage==1.20.*```"
             )
-        self.gcs_client = storage.Client(project=None)
-
+        try:
+            self.gcs_client = storage.Client(project=None)
+        except DefaultCredentialsError:
+            self.gcs_client = storage.Client.create_anonymous_client()
+            
     def download_file(self, uri: ParseResult) -> IO[bytes]:
         """
         Downloads a file from google cloud storage and returns a TemporaryFile object

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/HashTypePersistence.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/HashTypePersistence.scala
@@ -76,11 +76,11 @@ class HashTypePersistence(config: SparkRedisConfig) extends Persistence with Ser
 
   def save(
       pipeline: Pipeline,
-      key: String,
+      key: Array[Byte],
       value: Map[Array[Byte], Array[Byte]],
       ttl: Int
   ): Unit = {
-    pipeline.hset(key.getBytes, value.asJava)
+    pipeline.hset(key, value.asJava)
     if (ttl > 0) {
       pipeline.expire(key, ttl)
     }
@@ -88,10 +88,10 @@ class HashTypePersistence(config: SparkRedisConfig) extends Persistence with Ser
 
   def getTimestamp(
       pipeline: Pipeline,
-      key: String,
+      key: Array[Byte],
       timestampField: String
   ): Response[Array[Byte]] = {
-    pipeline.hget(key.getBytes(), timestampField.getBytes)
+    pipeline.hget(key, timestampField.getBytes)
   }
 
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/HashTypePersistence.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/HashTypePersistence.scala
@@ -19,11 +19,13 @@ package feast.ingestion.stores.redis
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 import redis.clients.jedis.{Pipeline, Response}
+import java.nio.charset.StandardCharsets
+
+import com.google.common.hash.Hashing
 
 import scala.jdk.CollectionConverters._
 import com.google.protobuf.Timestamp
 import feast.ingestion.utils.TypeConversion
-import scala.util.hashing.MurmurHash3
 
 /**
   * Use Redis hash type as storage layout. Every feature is stored as separate entry in Hash.
@@ -71,7 +73,7 @@ class HashTypePersistence(config: SparkRedisConfig) extends Persistence with Ser
 
   def encodeKey(key: String): Array[Byte] = {
     val fullFeatureReference = s"${config.namespace}:$key"
-    MurmurHash3.stringHash(fullFeatureReference).toHexString.getBytes
+    Hashing.murmur3_32.hashString(fullFeatureReference, StandardCharsets.UTF_8).asBytes()
   }
 
   def save(

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/Persistence.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/Persistence.scala
@@ -28,14 +28,14 @@ trait Persistence {
 
   def save(
       pipeline: Pipeline,
-      key: String,
+      key: Array[Byte],
       value: Map[Array[Byte], Array[Byte]],
       ttl: Int
   ): Unit
 
   def getTimestamp(
       pipeline: Pipeline,
-      key: String,
+      key: Array[Byte],
       timestampField: String
   ): Response[Array[Byte]]
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
@@ -17,15 +17,20 @@
 package feast.ingestion.stores.redis
 
 import com.google.protobuf.Timestamp
-import com.redislabs.provider.redis.{ReadWriteConfig, RedisConfig, RedisEndpoint}
-import com.redislabs.provider.redis.rdd.Keys.groupKeysByNode
+import com.redislabs.provider.redis.{ReadWriteConfig, RedisConfig, RedisEndpoint, RedisNode}
+import redis.clients.jedis.util.JedisClusterCRC16
 import com.redislabs.provider.redis.util.PipelineUtils.{foreachWithPipeline, mapWithPipeline}
+import feast.ingestion.utils.TypeConversion
 import org.apache.spark.SparkEnv
 import org.apache.spark.metrics.source.RedisSinkMetricSource
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+
+import collection.JavaConverters._
+import feast.proto.storage.RedisProto.RedisKeyV2
+import feast.proto.types.ValueProto
 
 /**
   * High-level writer to Redis. Relies on `Persistence` implementation for actual storage layout.
@@ -65,14 +70,14 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
       // grouped iterator to only allocate memory for a portion of rows
       partition.grouped(config.iteratorGroupingSize).foreach { batch =>
         // group by key and keep only latest row per each key
-        val rowsWithKey: Map[String, Row] =
+        val rowsWithKey: Map[RedisKeyV2, Row] =
           compactRowsToLatestTimestamp(batch.map(row => dataKeyId(row) -> row)).toMap
 
         groupKeysByNode(redisConfig.hosts, rowsWithKey.keysIterator).foreach { case (node, keys) =>
           val conn = node.connect()
           // retrieve latest stored timestamp per key
           val timestamps = mapWithPipeline(conn, keys) { (pipeline, key) =>
-            persistence.getTimestamp(pipeline, key, timestampField)
+            persistence.getTimestamp(pipeline, key.toByteArray, timestampField)
           }
 
           val timestampByKey = timestamps
@@ -102,7 +107,7 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
                 }
 
                 val encodedRow = persistence.encodeRow(config.entityColumns, timestampField, row)
-                persistence.save(pipeline, key, encodedRow, ttl = 0)
+                persistence.save(pipeline, key.toByteArray, encodedRow, ttl = 0)
             }
           }
           conn.close()
@@ -111,7 +116,7 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
     }
   }
 
-  private def compactRowsToLatestTimestamp(rows: Seq[(String, Row)]) = rows
+  private def compactRowsToLatestTimestamp(rows: Seq[(RedisKeyV2, Row)]) = rows
     .groupBy(_._1)
     .values
     .map(_.maxBy(_._2.getAs[java.sql.Timestamp](config.timestampColumn).getTime))
@@ -119,11 +124,22 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
   /**
     * Key is built from entities columns values with prefix of entities columns names.
     */
-  private def dataKeyId(row: Row): String = {
-    val sortedEntities = config.entityColumns.sorted
-    val entityKey      = sortedEntities.map(row.getAs[Any]).map(_.toString).mkString(":")
-    val entityPrefix   = sortedEntities.mkString("_")
-    s"${config.projectName}_${entityPrefix}:$entityKey"
+  private def dataKeyId(row: Row): RedisKeyV2 = {
+    val types = row.schema.fields.map(f => (f.name, f.dataType)).toMap
+
+    val sortedEntities = config.entityColumns.sorted.toSeq
+    val entityValues = sortedEntities
+      .map(entity => (row.getAs[Any](entity), types(entity)))
+      .map { case (value, v_type) =>
+        TypeConversion.sqlTypeToProtoValue(value, v_type).asInstanceOf[ValueProto.Value]
+      }
+
+    RedisKeyV2
+      .newBuilder()
+      .setProject(config.projectName)
+      .addAllEntityNames(sortedEntities.asJava)
+      .addAllEntityValues(entityValues.asJava)
+      .build
   }
 
   private def timestampField: String = {
@@ -135,4 +151,22 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
       case Seq(head) => Some(head.asInstanceOf[RedisSinkMetricSource])
       case _         => None
     }
+
+  private def groupKeysByNode(
+      nodes: Array[RedisNode],
+      keys: Iterator[RedisKeyV2]
+  ): Iterator[(RedisNode, Array[RedisKeyV2])] = {
+    keys
+      .map(key => (getMasterNode(nodes, key), key))
+      .toArray
+      .groupBy(_._1)
+      .map(x => (x._1, x._2.map(_._2)))
+      .iterator
+  }
+
+  private def getMasterNode(nodes: Array[RedisNode], key: RedisKeyV2): RedisNode = {
+    val slot = JedisClusterCRC16.getSlot(key.toByteArray)
+
+    nodes.filter { node => node.startSlot <= slot && node.endSlot >= slot }.filter(_.idx == 0)(0)
+  }
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
@@ -87,7 +87,7 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
                 .map(Timestamp.parseFrom)
                 .map(t => new java.sql.Timestamp(t.getSeconds * 1000))
             )
-            .zip(rowsWithKey.keys)
+            .zip(keys)
             .map(_.swap)
             .toMap
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -18,6 +18,7 @@ def pytest_addoption(parser):
     parser.addoption("--dataproc-cluster-name", action="store")
     parser.addoption("--dataproc-region", action="store")
     parser.addoption("--dataproc-project", action="store")
+    parser.addoption("--ingestion-jar", action="store")
 
 
 def pytest_runtest_makereport(item, call):

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -19,6 +19,7 @@ def pytest_addoption(parser):
     parser.addoption("--dataproc-region", action="store")
     parser.addoption("--dataproc-project", action="store")
     parser.addoption("--ingestion-jar", action="store")
+    parser.addoption("--redis-url", action="store", default="localhost:6379")
 
 
 def pytest_runtest_makereport(item, call):

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -2,6 +2,7 @@ import os
 import time
 import uuid
 from datetime import datetime, timedelta
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -14,8 +15,8 @@ from feast.wait import wait_retry_backoff
 
 
 def generate_data():
-    df = pd.DataFrame(columns=["s2_id", "unique_drivers", "event_timestamp"])
-    df["s2id"] = np.random.randint(1000, 9999, 100)
+    df = pd.DataFrame(columns=["s2id", "unique_drivers", "event_timestamp"])
+    df["s2id"] = np.random.choice(999999, size=100, replace=False)
     df["unique_drivers"] = np.random.randint(0, 1000, 100)
     df["event_timestamp"] = pd.to_datetime(
         np.random.randint(int(time.time()), int(time.time()) + 3600, 100), unit="s"
@@ -26,14 +27,33 @@ def generate_data():
 
 
 @pytest.fixture(scope="session")
-def feast_client(pytestconfig):
+def feast_version():
+    return "0.8-SNAPSHOT"
+
+
+@pytest.fixture(scope="session")
+def ingestion_job_jar(pytestconfig, feast_version):
+    default_path = (
+        Path(__file__).parent.parent.parent
+        / "spark"
+        / "ingestion"
+        / "target"
+        / f"feast-ingestion-spark-{feast_version}.jar"
+    )
+
+    return pytestconfig.getoption("ingestion_jar") or f"file://{default_path}"
+
+
+@pytest.fixture(scope="session")
+def feast_client(pytestconfig, ingestion_job_jar):
     if pytestconfig.getoption("env") == "local":
         return Client(
-            core_url="localhost:6565",
-            serving_url="localhost:6566",
+            core_url=pytestconfig.getoption("core_url"),
+            serving_url=pytestconfig.getoption("serving_url"),
             spark_launcher="standalone",
             spark_standalone_master="local",
             spark_home=os.path.dirname(pyspark.__file__),
+            spark_ingestion_jar=ingestion_job_jar,
         )
 
     if pytestconfig.getoption("env") == "gcloud":
@@ -47,6 +67,7 @@ def feast_client(pytestconfig):
             dataproc_staging_location=os.path.join(
                 pytestconfig.getoption("staging_path"), "dataproc"
             ),
+            spark_ingestion_jar=ingestion_job_jar,
         )
 
 
@@ -59,7 +80,6 @@ def staging_path(pytestconfig, tmp_path):
     return os.path.join(staging_path, str(uuid.uuid4()))
 
 
-@pytest.mark.skip
 def test_offline_ingestion(feast_client: Client, staging_path: str):
     entity = Entity(name="s2id", description="S2id", value_type=ValueType.INT64,)
 
@@ -78,8 +98,8 @@ def test_offline_ingestion(feast_client: Client, staging_path: str):
     feast_client.apply_entity(entity)
     feast_client.apply_feature_table(feature_table)
 
-    df = generate_data()
-    feast_client.ingest(feature_table, df)  # write to batch (offline) storage
+    original = generate_data()
+    feast_client.ingest(feature_table, original)  # write to batch (offline) storage
 
     job = feast_client.start_offline_to_online_ingestion(
         feature_table, datetime.today(), datetime.today() + timedelta(days=1)
@@ -91,7 +111,15 @@ def test_offline_ingestion(feast_client: Client, staging_path: str):
 
     assert status == SparkJobStatus.COMPLETED
 
-    feast_client.get_online_features(
+    features = feast_client.get_online_features(
         ["drivers:unique_drivers"],
-        entity_rows=[{"s2id": s2_id} for s2_id in df["s2id"].tolist()],
+        entity_rows=[{"s2id": s2_id} for s2_id in original["s2id"].tolist()],
+    ).to_dict()
+
+    ingested = pd.DataFrame.from_dict(features)
+    pd.testing.assert_frame_equal(
+        ingested[["s2id", "drivers:unique_drivers"]],
+        original[["s2id", "unique_drivers"]].rename(
+            columns={"unique_drivers": "drivers:unique_drivers"}
+        ),
     )

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -46,6 +46,8 @@ def ingestion_job_jar(pytestconfig, feast_version):
 
 @pytest.fixture(scope="session")
 def feast_client(pytestconfig, ingestion_job_jar):
+    redis_host, redis_port = pytestconfig.getoption("redis_url").split(":")
+
     if pytestconfig.getoption("env") == "local":
         return Client(
             core_url=pytestconfig.getoption("core_url"),
@@ -54,6 +56,8 @@ def feast_client(pytestconfig, ingestion_job_jar):
             spark_standalone_master="local",
             spark_home=os.path.dirname(pyspark.__file__),
             spark_ingestion_jar=ingestion_job_jar,
+            redis_host=redis_host,
+            redis_port=redis_port,
         )
 
     if pytestconfig.getoption("env") == "gcloud":

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -55,7 +55,7 @@ def feast_client(pytestconfig, ingestion_job_jar):
             serving_url=pytestconfig.getoption("serving_url"),
             spark_launcher="standalone",
             spark_standalone_master="local",
-            spark_home=os.path.dirname(pyspark.__file__),
+            spark_home=os.getenv("SPARK_HOME") or os.path.dirname(pyspark.__file__),
             spark_ingestion_jar=ingestion_job_jar,
             redis_host=redis_host,
             redis_port=redis_port,

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -10,6 +10,7 @@ import pyspark
 import pytest
 
 from feast import Client, Entity, Feature, FeatureTable, FileSource, ValueType
+from feast.data_format import ParquetFormat
 from feast.pyspark.abc import SparkJobStatus
 from feast.wait import wait_retry_backoff
 
@@ -94,7 +95,7 @@ def test_offline_ingestion(feast_client: Client, staging_path: str):
         batch_source=FileSource(
             "event_timestamp",
             "event_timestamp",
-            "parquet",
+            ParquetFormat(),
             os.path.join(staging_path, "batch-storage"),
         ),
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Refactor Redis Sink in Ingestion Job to produce format readable by serving:
1. Keys are generated with RedisKeyV2 proto
2. Java (`com.google.common.hash`) implementation of MurMur hash is used, since its version is better compatible with other implementations.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
