### PR TITLE
Accept Pandas dataframe as input for historical feature retrieval

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -14,9 +14,12 @@
 import logging
 import multiprocessing
 import shutil
+import tempfile
+import uuid
 from datetime import datetime
 from itertools import groupby
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urlparse
 
 import grpc
 import pandas as pd
@@ -34,6 +37,7 @@ from feast.constants import (
     CONFIG_SERVING_URL_KEY,
     CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_FORMAT,
     CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_LOCATION,
+    CONFIG_SPARK_STAGING_LOCATION,
     FEAST_DEFAULT_OPTIONS,
 )
 from feast.core.CoreService_pb2 import (
@@ -88,6 +92,7 @@ from feast.serving.ServingService_pb2 import (
     GetOnlineFeaturesRequestV2,
 )
 from feast.serving.ServingService_pb2_grpc import ServingServiceStub
+from feast.staging.storage_client import get_staging_client
 
 _logger = logging.getLogger(__name__)
 
@@ -780,7 +785,7 @@ class Client:
     def get_historical_features(
         self,
         feature_refs: List[str],
-        entity_source: Union[FileSource, BigQuerySource],
+        entity_source: Union[pd.DataFrame, FileSource, BigQuerySource],
         project: str = None,
     ) -> RetrievalJob:
         """
@@ -791,9 +796,14 @@ class Client:
                 Each feature reference should have the following format:
                 "feature_table:feature" where "feature_table" & "feature" refer to
                 the feature and feature table names respectively.
-            entity_source (Union[FileSource, BigQuerySource]): Source for the entity rows.
-                The user needs to make sure that the source is accessible from the Spark cluster
-                that will be used for the retrieval job.
+            entity_source (Union[pd.DataFrame, FileSource, BigQuerySource]): Source for the entity rows.
+                If entity_source is a Panda DataFrame, the dataframe will be exported to the staging
+                location as parquet file. It is also assumed that the column event_timestamp is present
+                in the dataframe, and is of type datetime without timezone information.
+
+                The user needs to make sure that the source (or staging location, if entity_source is
+                a Panda DataFrame) is accessible from the Spark cluster that will be used for the
+                retrieval job.
             project: Specifies the project that contains the feature tables
                 which the requested features belong to.
 
@@ -820,6 +830,29 @@ class Client:
             CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_LOCATION
         )
         output_format = self._config.get(CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_FORMAT)
+
+        if isinstance(entity_source, pd.DataFrame):
+            staging_location = self._config.get(CONFIG_SPARK_STAGING_LOCATION)
+            entity_staging_uri = urlparse(
+                os.path.join(staging_location, str(uuid.uuid4()))
+            )
+            staging_client = get_staging_client(entity_staging_uri.scheme)
+            with tempfile.NamedTemporaryFile() as df_export_path:
+                entity_source.to_parquet(df_export_path.name)
+                bucket = (
+                    None
+                    if entity_staging_uri.scheme == "fs"
+                    else entity_staging_uri.netloc
+                )
+                staging_client.upload_file(
+                    df_export_path.name, bucket, entity_staging_uri.path
+                )
+                entity_source = FileSource(
+                    "event_timestamp",
+                    "created_timestamp",
+                    ParquetFormat(),
+                    entity_staging_uri.path,
+                )
 
         return start_historical_feature_retrieval_job(
             self, entity_source, feature_tables, output_format, output_location

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import multiprocessing
+import os
 import shutil
 import tempfile
 import uuid

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -67,6 +67,8 @@ CONFIG_MAX_WAIT_INTERVAL_KEY = "max_wait_interval"
 # Spark Job Config
 CONFIG_SPARK_LAUNCHER = "spark_launcher"  # standalone, dataproc, emr
 
+CONFIG_SPARK_STAGING_LOCATION = "spark_staging_location"
+
 CONFIG_SPARK_INGESTION_JOB_JAR = "spark_ingestion_jar"
 
 CONFIG_SPARK_STANDALONE_MASTER = "spark_standalone_master"
@@ -75,7 +77,6 @@ CONFIG_SPARK_HOME = "spark_home"
 CONFIG_SPARK_DATAPROC_CLUSTER_NAME = "dataproc_cluster_name"
 CONFIG_SPARK_DATAPROC_PROJECT = "dataproc_project"
 CONFIG_SPARK_DATAPROC_REGION = "dataproc_region"
-CONFIG_SPARK_DATAPROC_STAGING_LOCATION = "dataproc_staging_location"
 
 CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_FORMAT = "historical_feature_output_format"
 CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_LOCATION = "historical_feature_output_location"
@@ -87,7 +88,6 @@ CONFIG_REDIS_SSL = "redis_ssl"
 CONFIG_SPARK_EMR_REGION = "emr_region"
 CONFIG_SPARK_EMR_CLUSTER_ID = "emr_cluster_id"
 CONFIG_SPARK_EMR_CLUSTER_TEMPLATE_PATH = "emr_cluster_template_path"
-CONFIG_SPARK_EMR_STAGING_LOCATION = "emr_staging_location"
 CONFIG_SPARK_EMR_LOG_LOCATION = "emr_log_location"
 
 

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -12,15 +12,14 @@ from feast.constants import (
     CONFIG_SPARK_DATAPROC_CLUSTER_NAME,
     CONFIG_SPARK_DATAPROC_PROJECT,
     CONFIG_SPARK_DATAPROC_REGION,
-    CONFIG_SPARK_DATAPROC_STAGING_LOCATION,
     CONFIG_SPARK_EMR_CLUSTER_ID,
     CONFIG_SPARK_EMR_CLUSTER_TEMPLATE_PATH,
     CONFIG_SPARK_EMR_LOG_LOCATION,
     CONFIG_SPARK_EMR_REGION,
-    CONFIG_SPARK_EMR_STAGING_LOCATION,
     CONFIG_SPARK_HOME,
     CONFIG_SPARK_INGESTION_JOB_JAR,
     CONFIG_SPARK_LAUNCHER,
+    CONFIG_SPARK_STAGING_LOCATION,
     CONFIG_SPARK_STANDALONE_MASTER,
 )
 from feast.data_source import BigQuerySource, DataSource, FileSource, KafkaSource
@@ -54,7 +53,7 @@ def _dataproc_launcher(config: Config) -> JobLauncher:
 
     return gcloud.DataprocClusterLauncher(
         config.get(CONFIG_SPARK_DATAPROC_CLUSTER_NAME),
-        config.get(CONFIG_SPARK_DATAPROC_STAGING_LOCATION),
+        config.get(CONFIG_SPARK_STAGING_LOCATION),
         config.get(CONFIG_SPARK_DATAPROC_REGION),
         config.get(CONFIG_SPARK_DATAPROC_PROJECT),
     )
@@ -71,7 +70,7 @@ def _emr_launcher(config: Config) -> JobLauncher:
         region=config.get(CONFIG_SPARK_EMR_REGION),
         existing_cluster_id=_get_optional(CONFIG_SPARK_EMR_CLUSTER_ID),
         new_cluster_template_path=_get_optional(CONFIG_SPARK_EMR_CLUSTER_TEMPLATE_PATH),
-        staging_location=config.get(CONFIG_SPARK_EMR_STAGING_LOCATION),
+        staging_location=config.get(CONFIG_SPARK_STAGING_LOCATION),
         emr_log_location=config.get(CONFIG_SPARK_EMR_LOG_LOCATION),
     )
 


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, historical feature retrieval accepts only Datasource as input. This PR enables the user to supply a Panda dataframe instead, which will then be uploaded to a staging location.

Staging location configuration for the different spark clusters are also merged into a single key in this PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added support for supplying Pandas DataFrames when running historical retrieval
```
