### PR TITLE
support redis ssl in feast-serving

### DIFF
--- a/infra/terraform/aws/helm.tf
+++ b/infra/terraform/aws/helm.tf
@@ -62,6 +62,7 @@ locals {
               config = {
                 host = module.redis.endpoint
                 port = 6379
+                ssl  = true
               }
               subscriptions = [
                 {

--- a/protos/feast/core/Store.proto
+++ b/protos/feast/core/Store.proto
@@ -110,6 +110,8 @@ message Store {
     int32 max_retries = 4;
     // Optional. How often flush data to redis
     int32 flush_frequency_seconds = 5;
+    // Optional. Connect over SSL.
+    bool ssl = 6;
   }
 
   message BigQueryConfig {

--- a/sdk/python/requirements-ci.txt
+++ b/sdk/python/requirements-ci.txt
@@ -19,3 +19,4 @@ mypy-protobuf
 avro==1.10.0
 confluent_kafka
 gcsfs
+urllib3>=1.25.4

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClient.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClient.java
@@ -47,10 +47,14 @@ public class RedisClient implements RedisClientAdapter {
   }
 
   public static RedisClientAdapter create(Map<String, String> config) {
+
+    RedisURI uri = RedisURI.create(config.get("host"), Integer.parseInt(config.get("port")));
+
+    if (Boolean.parseBoolean(config.get("ssl"))) {
+      uri.setSsl(true);
+    }
     StatefulRedisConnection<byte[], byte[]> connection =
-        io.lettuce.core.RedisClient.create(
-                RedisURI.create(config.get("host"), Integer.parseInt(config.get("port"))))
-            .connect(new ByteArrayCodec());
+        io.lettuce.core.RedisClient.create(uri).connect(new ByteArrayCodec());
 
     return new RedisClient(connection);
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Support connecting to redis with ssl in feast-serving

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
