### PR TITLE
Add validation when feature type is changed

### DIFF
--- a/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -107,16 +107,16 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
                 specService.getFeatureSpec(feature.get().getFeatureReference());
             ValueProto.ValueType.Enum valueTypeEnum = tempFeatureSpecV2.getValueType();
             ValueProto.Value.ValCase valueCase = feature.get().getFeatureValue().getValCase();
-            boolean isSameFeatureType = checkSameType(valueTypeEnum, valueCase);
+            boolean isMatchingFeatureSpec = checkSameFeatureSpec(valueTypeEnum, valueCase);
 
             boolean isOutsideMaxAge = checkOutsideMaxAge(featureTableSpec, entityRow, feature);
             Map<String, ValueProto.Value> valueMap =
-                unpackValueMap(feature, isOutsideMaxAge, isSameFeatureType);
+                unpackValueMap(feature, isOutsideMaxAge, isMatchingFeatureSpec);
             allValueMaps.putAll(valueMap);
 
             // Generate metadata for feature values and merge into entityFieldsMap
             Map<String, GetOnlineFeaturesResponse.FieldStatus> statusMap =
-                getMetadataMap(valueMap, !isSameFeatureType, isOutsideMaxAge);
+                getMetadataMap(valueMap, !isMatchingFeatureSpec, isOutsideMaxAge);
             allStatusMaps.putAll(statusMap);
 
             // Populate metrics/log request
@@ -160,7 +160,7 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
     }
   }
 
-  private boolean checkSameType(
+  private boolean checkSameFeatureSpec(
       ValueProto.ValueType.Enum valueTypeEnum, ValueProto.Value.ValCase valueCase) {
     HashMap<ValueProto.ValueType.Enum, ValueProto.Value.ValCase> typingMap =
         new HashMap<>() {
@@ -231,11 +231,11 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
   }
 
   private static Map<String, ValueProto.Value> unpackValueMap(
-      Optional<Feature> feature, boolean isOutsideMaxAge, boolean isSameFeatureType) {
+      Optional<Feature> feature, boolean isOutsideMaxAge, boolean isMatchingFeatureSpec) {
     Map<String, ValueProto.Value> valueMap = new HashMap<>();
 
     if (feature.isPresent()) {
-      if (!isOutsideMaxAge && isSameFeatureType) {
+      if (!isOutsideMaxAge && isMatchingFeatureSpec) {
         valueMap.put(
             FeatureV2.getFeatureStringRef(feature.get().getFeatureReference()),
             feature.get().getFeatureValue());

--- a/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -103,9 +103,9 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
 
             FeatureTableSpec featureTableSpec =
                 specService.getFeatureTableSpec(projectName, feature.get().getFeatureReference());
-            FeatureProto.FeatureSpecV2 tempFeatureSpecV2 =
-                specService.getFeatureSpec(feature.get().getFeatureReference());
-            ValueProto.ValueType.Enum valueTypeEnum = tempFeatureSpecV2.getValueType();
+            FeatureProto.FeatureSpecV2 featureSpec =
+                specService.getFeatureSpec(projectName, feature.get().getFeatureReference());
+            ValueProto.ValueType.Enum valueTypeEnum = featureSpec.getValueType();
             ValueProto.Value.ValCase valueCase = feature.get().getFeatureValue().getValCase();
             boolean isMatchingFeatureSpec = checkSameFeatureSpec(valueTypeEnum, valueCase);
 

--- a/serving/src/main/java/feast/serving/specs/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/specs/CachedSpecService.java
@@ -29,6 +29,7 @@ import feast.proto.core.CoreServiceProto.ListFeatureSetsResponse;
 import feast.proto.core.CoreServiceProto.ListFeatureTablesRequest;
 import feast.proto.core.CoreServiceProto.ListFeatureTablesResponse;
 import feast.proto.core.CoreServiceProto.ListProjectsRequest;
+import feast.proto.core.FeatureProto;
 import feast.proto.core.FeatureSetProto.FeatureSet;
 import feast.proto.core.FeatureSetProto.FeatureSetSpec;
 import feast.proto.core.FeatureSetProto.FeatureSpec;
@@ -51,6 +52,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 
@@ -92,6 +94,9 @@ public class CachedSpecService {
           .help("number of feature sets served by this instance")
           .register();
 
+  private final LoadingCache<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2>
+      featureCache;
+
   public CachedSpecService(CoreSpecService coreService, StoreProto.Store store) {
     this.coreService = coreService;
     this.store = coreService.registerStore(store);
@@ -104,12 +109,19 @@ public class CachedSpecService {
         CacheBuilder.newBuilder().maximumSize(MAX_SPEC_COUNT).build(featureSetCacheLoader);
     featureSetCache.putAll(featureSets);
 
-    Map<String, FeatureTableSpec> featureTables = getFeatureTableMap();
+    Map<String, FeatureTableSpec> featureTables = getFeatureTableMap().getLeft();
     CacheLoader<String, FeatureTableSpec> featureTableCacheLoader =
         CacheLoader.from(featureTables::get);
     featureTableCache =
         CacheBuilder.newBuilder().maximumSize(MAX_SPEC_COUNT).build(featureTableCacheLoader);
     featureTableCache.putAll(featureTables);
+
+    Map<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2> features =
+        getFeatureTableMap().getRight();
+    CacheLoader<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2> featureCacheLoader =
+        CacheLoader.from(features::get);
+    featureCache = CacheBuilder.newBuilder().build(featureCacheLoader);
+    featureCache.putAll(features);
   }
 
   /**
@@ -241,12 +253,18 @@ public class CachedSpecService {
 
     featureSetsCount.set(featureSetCache.size());
 
-    Map<String, FeatureTableSpec> featureTableMap = getFeatureTableMap();
+    Map<String, FeatureTableSpec> featureTableMap = getFeatureTableMap().getLeft();
 
     featureTableCache.invalidateAll();
     featureTableCache.putAll(featureTableMap);
 
     featureTablesCount.set(featureTableCache.size());
+
+    Map<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2> featureMap =
+        getFeatureTableMap().getRight();
+    featureCache.invalidateAll();
+    featureCache.putAll(featureMap);
+
     cacheLastUpdated.set(System.currentTimeMillis());
   }
 
@@ -369,8 +387,13 @@ public class CachedSpecService {
    *
    * @return Map in the format of <project/featuretable_name: FeatureTableSpec>
    */
-  private Map<String, FeatureTableSpec> getFeatureTableMap() {
+  private ImmutablePair<
+          Map<String, FeatureTableSpec>,
+          Map<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2>>
+      getFeatureTableMap() {
     HashMap<String, FeatureTableSpec> featureTables = new HashMap<>();
+    HashMap<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2> features =
+        new HashMap<>();
 
     List<String> projects =
         coreService.listProjects(ListProjectsRequest.newBuilder().build()).getProjectsList();
@@ -386,13 +409,24 @@ public class CachedSpecService {
           FeatureTableSpec spec = featureTable.getSpec();
           // Key of Map is in the form of <project/featuretable_name>
           featureTables.put(getFeatureTableStringRef(project, spec), spec);
+
+          String featureTableName = spec.getName();
+          List<FeatureProto.FeatureSpecV2> featureSpecs = spec.getFeaturesList();
+          for (FeatureProto.FeatureSpecV2 featureSpec : featureSpecs) {
+            ServingAPIProto.FeatureReferenceV2 featureReference =
+                ServingAPIProto.FeatureReferenceV2.newBuilder()
+                    .setFeatureTable(featureTableName)
+                    .setName(featureSpec.getName())
+                    .build();
+            features.put(featureReference, featureSpec);
+          }
         }
       } catch (StatusRuntimeException e) {
         throw new RuntimeException(
             String.format("Unable to retrieve specs matching project %s", project), e);
       }
     }
-    return featureTables;
+    return ImmutablePair.of(featureTables, features);
   }
 
   public FeatureTableSpec getFeatureTableSpec(
@@ -407,5 +441,18 @@ public class CachedSpecService {
     }
 
     return featureTableSpec;
+  }
+
+  public FeatureProto.FeatureSpecV2 getFeatureSpec(
+      ServingAPIProto.FeatureReferenceV2 featureReference) {
+    FeatureProto.FeatureSpecV2 featureSpec;
+    try {
+      featureSpec = featureCache.get(featureReference);
+    } catch (ExecutionException e) {
+      throw new SpecRetrievalException(
+          String.format("Unable to find Feature with name: %s", featureReference.getName()), e);
+    }
+
+    return featureSpec;
   }
 }


### PR DESCRIPTION
Signed-off-by: Terence <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
In the past, we didn't allow changes to feature types so this validation was not necessary. As we think about implementing deletion of feature tables, we'll need to consider how old values stored in redis will be retrieved. This PR is the first step to handling older values that are based of older types.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
