### PR TITLE
Allow entities and features to be updated

### DIFF
--- a/core/src/main/java/feast/core/model/FeatureV2.java
+++ b/core/src/main/java/feast/core/model/FeatureV2.java
@@ -23,11 +23,14 @@ import java.util.Map;
 import java.util.Objects;
 import javax.persistence.*;
 import javax.persistence.Entity;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 
 /** Defines a single Feature defined in a {@link FeatureTable} */
 @Getter
 @Entity
+@Setter(AccessLevel.PRIVATE)
 @Table(
     name = "features_v2",
     uniqueConstraints = @UniqueConstraint(columnNames = {"name", "feature_table_id"}))
@@ -96,12 +99,8 @@ public class FeatureV2 {
               "Updating the name of a registered Feature is not allowed: %s to %s",
               getName(), spec.getName()));
     }
-    if (!getType().equals(spec.getValueType())) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Updating the value type of a registered Feature is not allowed: %s to %s",
-              getType(), spec.getValueType()));
-    }
+    // Update feature type
+    this.setType(spec.getValueType());
 
     // Update Feature based on spec
     this.labelsJSON = TypeConversion.convertMapToJsonString(spec.getLabelsMap());

--- a/core/src/main/java/feast/core/service/SpecService.java
+++ b/core/src/main/java/feast/core/service/SpecService.java
@@ -671,7 +671,7 @@ public class SpecService {
       return ApplyFeatureTableResponse.newBuilder().setTable(existingTable.get().toProto()).build();
     }
     if (existingTable.isPresent()) {
-      existingTable.get().updateFromProto(applySpec);
+      existingTable.get().updateFromProto(projectName, applySpec, entityRepository);
       table = existingTable.get();
     }
 


### PR DESCRIPTION
Signed-off-by: Terence <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
As we're moving towards supporting deletion of feature tables, this is a step towards it by allowing changes to:
- the entities in a feature table
- the features and their types in a feature table

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now update their entities and features in a feature table.
```
