### PR TITLE
Implement list job and get job methods for Dataproc launcher

### DIFF
--- a/infra/scripts/test-integration.sh
+++ b/infra/scripts/test-integration.sh
@@ -4,4 +4,4 @@ python -m pip install --upgrade pip setuptools wheel
 make install-python
 python -m pip install -qr tests/requirements.txt
 
-pytest tests/integration --dataproc-cluster-name feast-e2e --dataproc-project kf-feast --dataproc-region us-central1  --staging-location gs://feast-templocation-kf-feast
+pytest tests/integration --dataproc-cluster-name feast-e2e --dataproc-project kf-feast --dataproc-region us-central1  --dataproc-staging-location gs://feast-templocation-kf-feast

--- a/infra/scripts/test-integration.sh
+++ b/infra/scripts/test-integration.sh
@@ -4,4 +4,4 @@ python -m pip install --upgrade pip setuptools wheel
 make install-python
 python -m pip install -qr tests/requirements.txt
 
-pytest tests/integration/
+pytest tests/integration --dataproc-cluster-name feast-e2e --dataproc-project kf-feast --dataproc-region us-central1  --staging-location gs://feast-templocation-kf-feast

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -150,7 +150,7 @@ class DataprocRetrievalJob(DataprocJobMixin, RetrievalJob):
         status = self.block_polling(timeout_sec=timeout_sec)
         if status == SparkJobStatus.COMPLETED:
             return self._output_file_uri
-        raise SparkJobFailure(self.get_error_message)
+        raise SparkJobFailure(self.get_error_message())
 
 
 class DataprocBatchIngestionJob(DataprocJobMixin, BatchIngestionJob):

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -59,7 +59,12 @@ class DataprocJobMixin:
         """
         self._job = self._refresh_fn()
         status = self._job.status
-        if status.state == JobStatus.State.ERROR:
+        if status.state in (
+            JobStatus.State.ERROR,
+            JobStatus.State.CANCEL_PENDING,
+            JobStatus.State.CANCEL_STARTED,
+            JobStatus.State.CANCELLED,
+        ):
             return SparkJobStatus.FAILED
         elif status.state == JobStatus.State.RUNNING:
             return SparkJobStatus.IN_PROGRESS
@@ -89,6 +94,12 @@ class DataprocJobMixin:
         status = self._job.status
         if status.state == JobStatus.State.ERROR:
             return status.details
+        elif status.state in (
+            JobStatus.State.CANCEL_PENDING,
+            JobStatus.State.CANCEL_STARTED,
+            JobStatus.State.CANCELLED,
+        ):
+            return "Job was cancelled."
         return None
 
     def block_polling(self, interval_sec=30, timeout_sec=3600) -> SparkJobStatus:

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -142,7 +142,6 @@ class DataprocRetrievalJob(DataprocJobMixin, RetrievalJob):
         super().__init__(job, refresh_fn, cancel_fn)
         self._output_file_uri = output_file_uri
 
-
     def get_output_file_uri(self, timeout_sec=None, block=True):
         if not block:
             return self._output_file_uri

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -1,12 +1,12 @@
+import json
 import os
+import time
 import uuid
 from functools import partial
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
-from google.api_core.operation import Operation
-from google.cloud import dataproc_v1
-from google.cloud.dataproc_v1 import JobStatus
+from google.cloud.dataproc_v1 import Job, JobControllerClient, JobStatus
 
 from feast.pyspark.abc import (
     BatchIngestionJob,
@@ -18,6 +18,7 @@ from feast.pyspark.abc import (
     SparkJobFailure,
     SparkJobParameters,
     SparkJobStatus,
+    SparkJobType,
     StreamIngestionJob,
     StreamIngestionJobParameters,
 )
@@ -25,21 +26,39 @@ from feast.staging.storage_client import get_staging_client
 
 
 class DataprocJobMixin:
-    def __init__(self, operation: Operation, cancel_fn: Callable[[], None]):
+    def __init__(
+        self, job: Job, refresh_fn: Callable[[], Job], cancel_fn: Callable[[], None]
+    ):
         """
-        :param operation: (google.api.core.operation.Operation): A Future for the spark job result,
-                returned by the dataproc client.
+        Implementation of common methods for different types of SparkJob running on Dataproc cluster.
+
+        Args:
+            job (Job): Dataproc job resource.
+            refresh_fn (Callable[[], Job]): A function that returns the latest job resource.
+            cancel_fn (Callable[[], None]): A function that cancel the current job.
         """
-        self._operation = operation
+        self._job = job
+        self._refresh_fn = refresh_fn
         self._cancel_fn = cancel_fn
 
     def get_id(self) -> str:
-        return self._operation.metadata.job_id
+        """
+        Getter for the job id.
+
+        Returns:
+            str: Dataproc job id.
+        """
+        return self._job.reference.job_id
 
     def get_status(self) -> SparkJobStatus:
-        self._operation._refresh_and_update()
+        """
+        Job Status retrieval
 
-        status = self._operation.metadata.status
+        Returns:
+            SparkJobStatus: Job status
+        """
+        self._job = self._refresh_fn()
+        status = self._job.status
         if status.state == JobStatus.State.ERROR:
             return SparkJobStatus.FAILED
         elif status.state == JobStatus.State.RUNNING:
@@ -54,7 +73,52 @@ class DataprocJobMixin:
         return SparkJobStatus.COMPLETED
 
     def cancel(self):
+        """
+        Manually terminate job
+        """
         self._cancel_fn()
+
+    def get_error_message(self) -> Optional[str]:
+        """
+        Getter for the job's error message if applicable.
+
+        Returns:
+            str: Status detail of the job. Return None if the job is successful.
+        """
+        self._job = self._refresh_fn()
+        status = self._job.status
+        if status.state == JobStatus.State.ERROR:
+            return status.details
+        return None
+
+    def block_polling(self, interval_sec=30, timeout_sec=3600) -> SparkJobStatus:
+        """
+        Blocks until the Dataproc job is completed or failed.
+
+        Args:
+            interval_sec (int): Polling interval.
+            timeout_sec (int): Timeout limit.
+
+        Returns:
+            SparkJobStatus: Latest job status
+
+        Raise:
+            SparkJobFailure: Raise error if the job neither failed nor completed within the timeout limit.
+        """
+
+        start = time.time()
+        while True:
+            elapsed_time = time.time() - start
+            if timeout_sec and elapsed_time >= timeout_sec:
+                raise SparkJobFailure(
+                    f"Job is still not completed after {timeout_sec}."
+                )
+
+            status = self.get_status()
+            if status in [SparkJobStatus.FAILED, SparkJobStatus.COMPLETED]:
+                break
+            time.sleep(interval_sec)
+        return status
 
 
 class DataprocRetrievalJob(DataprocJobMixin, RetrievalJob):
@@ -63,7 +127,11 @@ class DataprocRetrievalJob(DataprocJobMixin, RetrievalJob):
     """
 
     def __init__(
-        self, operation: Operation, cancel_fn: Callable[[], None], output_file_uri: str
+        self,
+        job: Job,
+        refresh_fn: Callable[[], Job],
+        cancel_fn: Callable[[], None],
+        output_file_uri: str,
     ):
         """
         This is the returned historical feature retrieval job result for DataprocClusterLauncher.
@@ -71,18 +139,18 @@ class DataprocRetrievalJob(DataprocJobMixin, RetrievalJob):
         Args:
             output_file_uri (str): Uri to the historical feature retrieval job output file.
         """
-        super().__init__(operation, cancel_fn)
+        super().__init__(job, refresh_fn, cancel_fn)
         self._output_file_uri = output_file_uri
+
 
     def get_output_file_uri(self, timeout_sec=None, block=True):
         if not block:
             return self._output_file_uri
 
-        try:
-            self._operation.result(timeout_sec)
-        except Exception as err:
-            raise SparkJobFailure(err)
-        return self._output_file_uri
+        status = self.block_polling(timeout_sec=timeout_sec)
+        if status == SparkJobStatus.COMPLETED:
+            return self._output_file_uri
+        raise SparkJobFailure(self.get_error_message)
 
 
 class DataprocBatchIngestionJob(DataprocJobMixin, BatchIngestionJob):
@@ -105,6 +173,7 @@ class DataprocClusterLauncher(JobLauncher):
     """
 
     EXTERNAL_JARS = ["gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar"]
+    JOB_TYPE_LABEL_KEY = "feast_job_type"
 
     def __init__(
         self, cluster_name: str, staging_location: str, region: str, project_id: str,
@@ -135,7 +204,7 @@ class DataprocClusterLauncher(JobLauncher):
             )
         self.project_id = project_id
         self.region = region
-        self.job_client = dataproc_v1.JobControllerClient(
+        self.job_client = JobControllerClient(
             client_options={"api_endpoint": f"{region}-dataproc.googleapis.com:443"}
         )
 
@@ -148,12 +217,15 @@ class DataprocClusterLauncher(JobLauncher):
 
         return f"gs://{self.staging_bucket}/{blob_path}"
 
-    def dataproc_submit(self, job_params: SparkJobParameters) -> Operation:
+    def dataproc_submit(
+        self, job_params: SparkJobParameters
+    ) -> Tuple[Job, Callable[[], Job], Callable[[], None]]:
         local_job_id = str(uuid.uuid4())
         main_file_uri = self._stage_files(job_params.get_main_file_path(), local_job_id)
         job_config: Dict[str, Any] = {
             "reference": {"job_id": local_job_id},
             "placement": {"cluster_name": self.cluster_name},
+            "labels": {self.JOB_TYPE_LABEL_KEY: job_params.get_job_type().name.lower()},
         }
         if job_params.get_class_name():
             job_config.update(
@@ -175,13 +247,24 @@ class DataprocClusterLauncher(JobLauncher):
                     }
                 }
             )
-        return self.job_client.submit_job_as_operation(
+
+        job = self.job_client.submit_job(
             request={
                 "project_id": self.project_id,
                 "region": self.region,
                 "job": job_config,
             }
         )
+
+        refresh_fn = partial(
+            self.job_client.get_job,
+            project_id=self.project_id,
+            region=self.region,
+            job_id=job.reference.job_id,
+        )
+        cancel_fn = partial(self.dataproc_cancel, job.reference.job_id)
+
+        return job, refresh_fn, cancel_fn
 
     def dataproc_cancel(self, job_id):
         self.job_client.cancel_job(
@@ -191,31 +274,62 @@ class DataprocClusterLauncher(JobLauncher):
     def historical_feature_retrieval(
         self, job_params: RetrievalJobParameters
     ) -> RetrievalJob:
-        operation = self.dataproc_submit(job_params)
-        cancel_fn = partial(self.dataproc_cancel, operation.metadata.job_id)
+        job, refresh_fn, cancel_fn = self.dataproc_submit(job_params)
         return DataprocRetrievalJob(
-            operation, cancel_fn, job_params.get_destination_path()
+            job, refresh_fn, cancel_fn, job_params.get_destination_path()
         )
 
     def offline_to_online_ingestion(
         self, ingestion_job_params: BatchIngestionJobParameters
     ) -> BatchIngestionJob:
-        operation = self.dataproc_submit(ingestion_job_params)
-        cancel_fn = partial(self.dataproc_cancel, operation.metadata.job_id)
-        return DataprocBatchIngestionJob(operation, cancel_fn)
+        job, refresh_fn, cancel_fn = self.dataproc_submit(ingestion_job_params)
+        return DataprocBatchIngestionJob(job, refresh_fn, cancel_fn)
 
     def start_stream_to_online_ingestion(
         self, ingestion_job_params: StreamIngestionJobParameters
     ) -> StreamIngestionJob:
-        operation = self.dataproc_submit(ingestion_job_params)
-        cancel_fn = partial(self.dataproc_cancel, operation.metadata.job_id)
-        return DataprocStreamingIngestionJob(operation, cancel_fn)
+        job, refresh_fn, cancel_fn = self.dataproc_submit(ingestion_job_params)
+        return DataprocStreamingIngestionJob(job, refresh_fn, cancel_fn)
 
     def stage_dataframe(self, df, event_timestamp_column: str):
         raise NotImplementedError
 
     def get_job_by_id(self, job_id: str) -> SparkJob:
-        raise NotImplementedError
+        job = self.job_client.get_job(
+            project_id=self.project_id, region=self.region, job_id=job_id
+        )
+        return self._dataproc_job_to_spark_job(job)
+
+    def _dataproc_job_to_spark_job(self, job: Job) -> SparkJob:
+        job_type = job.labels[self.JOB_TYPE_LABEL_KEY]
+        job_id = job.reference.job_id
+        refresh_fn = partial(
+            self.job_client.get_job,
+            project_id=self.project_id,
+            region=self.region,
+            job_id=job_id,
+        )
+        cancel_fn = partial(self.dataproc_cancel, job_id)
+
+        if job_type == SparkJobType.HISTORICAL_RETRIEVAL.name.lower():
+            output_path = json.loads(job.pyspark_job.args[-1])["path"]
+            return DataprocRetrievalJob(job, refresh_fn, cancel_fn, output_path)
+
+        if job_type == SparkJobType.BATCH_INGESTION.name.lower():
+            return DataprocBatchIngestionJob(job, refresh_fn, cancel_fn)
+
+        if job_type == SparkJobType.STREAM_INGESTION.name.lower():
+            return DataprocStreamingIngestionJob(job, refresh_fn, cancel_fn)
+
+        raise ValueError(f"Unrecognized job type: {job_type}")
 
     def list_jobs(self, include_terminated: bool) -> List[SparkJob]:
-        raise NotImplementedError
+        job_filter = f"labels.{self.JOB_TYPE_LABEL_KEY} = * AND clusterName = {self.cluster_name}"
+        if not include_terminated:
+            job_filter = job_filter + "AND status.state = ACTIVE"
+        return [
+            self._dataproc_job_to_spark_job(job)
+            for job in self.job_client.list_jobs(
+                project_id=self.project_id, region=self.region, filter=job_filter
+            )
+        ]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,2 +1,7 @@
 def pytest_addoption(parser):
-    pass
+    parser.addoption("--dataproc-cluster-name", action="store")
+    parser.addoption("--dataproc-region", action="store")
+    parser.addoption("--dataproc-project", action="store")
+    parser.addoption("--dataproc-staging-location", action="store")
+    parser.addoption("--redis-url", action="store")
+    parser.addoption("--redis-cluster", action="store_true")

--- a/tests/integration/fixtures/job_parameters.py
+++ b/tests/integration/fixtures/job_parameters.py
@@ -1,0 +1,115 @@
+import tempfile
+import uuid
+from datetime import datetime
+from os import path
+from urllib.parse import urlparse
+
+import numpy as np
+import pandas as pd
+import pytest
+from google.cloud import storage
+from pytz import utc
+
+from feast.pyspark.abc import RetrievalJobParameters
+
+
+@pytest.fixture(scope="module")
+def customer_entity() -> pd.DataFrame:
+    return pd.DataFrame(
+        np.array([[1001, datetime(year=2020, month=9, day=1, tzinfo=utc)]]),
+        columns=["customer_id", "event_timestamp"],
+    )
+
+
+@pytest.fixture(scope="module")
+def customer_feature() -> pd.DataFrame:
+    return pd.DataFrame(
+        np.array(
+            [
+                [
+                    1001,
+                    100.0,
+                    datetime(year=2020, month=9, day=1, tzinfo=utc),
+                    datetime(year=2020, month=9, day=1, tzinfo=utc),
+                ],
+            ]
+        ),
+        columns=[
+            "customer_id",
+            "total_transactions",
+            "event_timestamp",
+            "created_timestamp",
+        ],
+    )
+
+
+def upload_dataframe_to_gcs_as_parquet(df: pd.DataFrame, staging_location: str):
+    gcs_client = storage.Client()
+    staging_location_uri = urlparse(staging_location)
+    staging_bucket = staging_location_uri.netloc
+    remote_path = staging_location_uri.path.lstrip("/")
+    gcs_bucket = gcs_client.get_bucket(staging_bucket)
+    temp_dir = str(uuid.uuid4())
+    df_remote_path = path.join(remote_path, temp_dir)
+    blob = gcs_bucket.blob(df_remote_path)
+    with tempfile.NamedTemporaryFile() as df_local_path:
+        df.to_parquet(df_local_path.name)
+        blob.upload_from_filename(df_local_path.name)
+    return path.join(staging_location, df_remote_path)
+
+
+def new_retrieval_job_params(
+    entity_source_uri: str, feature_source_uri: str, destination_uri: str
+) -> RetrievalJobParameters:
+    entity_source = {
+        "file": {
+            "format": "parquet",
+            "path": entity_source_uri,
+            "event_timestamp_column": "event_timestamp",
+        }
+    }
+
+    feature_tables_sources = [
+        {
+            "file": {
+                "format": "parquet",
+                "path": feature_source_uri,
+                "event_timestamp_column": "event_timestamp",
+                "created_timestamp_column": "created_timestamp",
+            }
+        }
+    ]
+
+    feature_tables = [
+        {
+            "name": "customer_transactions",
+            "entities": [{"name": "customer", "type": "int32"}],
+        }
+    ]
+
+    destination = {"format": "parquet", "path": destination_uri}
+
+    return RetrievalJobParameters(
+        feature_tables=feature_tables,
+        feature_tables_sources=feature_tables_sources,
+        entity_source=entity_source,
+        destination=destination,
+    )
+
+
+@pytest.fixture(scope="module")
+def dataproc_retrieval_job_params(
+    pytestconfig, customer_entity, customer_feature
+) -> RetrievalJobParameters:
+    staging_location = pytestconfig.getoption("--dataproc-staging-location")
+    entity_source_uri = upload_dataframe_to_gcs_as_parquet(
+        customer_entity, staging_location
+    )
+    feature_source_uri = upload_dataframe_to_gcs_as_parquet(
+        customer_feature, staging_location
+    )
+    destination_uri = path.join(staging_location, str(uuid.uuid4()))
+
+    return new_retrieval_job_params(
+        entity_source_uri, feature_source_uri, destination_uri
+    )

--- a/tests/integration/fixtures/launchers.py
+++ b/tests/integration/fixtures/launchers.py
@@ -1,0 +1,17 @@
+import pytest
+
+from feast.pyspark.launchers.gcloud import DataprocClusterLauncher
+
+
+@pytest.fixture
+def dataproc_launcher(pytestconfig) -> DataprocClusterLauncher:
+    cluster_name = pytestconfig.getoption("--dataproc-cluster-name")
+    region = pytestconfig.getoption("--dataproc-region")
+    project_id = pytestconfig.getoption("--dataproc-project")
+    staging_location = pytestconfig.getoption("--dataproc-staging-location")
+    return DataprocClusterLauncher(
+        cluster_name=cluster_name,
+        staging_location=staging_location,
+        region=region,
+        project_id=project_id,
+    )

--- a/tests/integration/test_launchers.py
+++ b/tests/integration/test_launchers.py
@@ -28,12 +28,4 @@ def test_dataproc_job_api(
     ]
     assert job_id in active_job_ids
     retrieved_job.cancel()
-    sleep(10)
-    active_job_ids = [
-        job.get_id() for job in dataproc_launcher.list_jobs(include_terminated=False)
-    ]
-    assert job_id not in active_job_ids
-    all_job_ids = [
-        job.get_id() for job in dataproc_launcher.list_jobs(include_terminated=True)
-    ]
-    assert job_id in all_job_ids
+    assert retrieved_job.get_status() == SparkJobStatus.FAILED

--- a/tests/integration/test_launchers.py
+++ b/tests/integration/test_launchers.py
@@ -1,0 +1,39 @@
+from time import sleep
+
+from feast.pyspark.abc import RetrievalJobParameters, SparkJobStatus
+from feast.pyspark.launchers.gcloud import DataprocClusterLauncher
+
+from .fixtures.job_parameters import customer_entity  # noqa: F401
+from .fixtures.job_parameters import customer_feature  # noqa: F401
+from .fixtures.job_parameters import dataproc_retrieval_job_params  # noqa: F401
+from .fixtures.launchers import dataproc_launcher  # noqa: F401
+
+
+def test_dataproc_job_api(
+    dataproc_launcher: DataprocClusterLauncher,  # noqa: F811
+    dataproc_retrieval_job_params: RetrievalJobParameters,  # noqa: F811
+):
+    job = dataproc_launcher.historical_feature_retrieval(dataproc_retrieval_job_params)
+    job_id = job.get_id()
+    retrieved_job = dataproc_launcher.get_job_by_id(job_id)
+    assert retrieved_job.get_id() == job_id
+    status = retrieved_job.get_status()
+    assert status in [
+        SparkJobStatus.STARTING,
+        SparkJobStatus.IN_PROGRESS,
+        SparkJobStatus.COMPLETED,
+    ]
+    active_job_ids = [
+        job.get_id() for job in dataproc_launcher.list_jobs(include_terminated=False)
+    ]
+    assert job_id in active_job_ids
+    retrieved_job.cancel()
+    sleep(10)
+    active_job_ids = [
+        job.get_id() for job in dataproc_launcher.list_jobs(include_terminated=False)
+    ]
+    assert job_id not in active_job_ids
+    all_job_ids = [
+        job.get_id() for job in dataproc_launcher.list_jobs(include_terminated=True)
+    ]
+    assert job_id in all_job_ids

--- a/tests/integration/test_simple.py
+++ b/tests/integration/test_simple.py
@@ -1,2 +1,0 @@
-def test_success():
-    pass


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
get_by_id and list_jobs methods were added to the launcher interface on https://github.com/feast-dev/feast/pull/1095, but was not implemented for Dataproc launcher. This PR provides the implementation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
