### PR TITLE
Add historical retrieval via job service

### DIFF
--- a/protos/feast/core/JobService.proto
+++ b/protos/feast/core/JobService.proto
@@ -48,8 +48,8 @@ service JobService {
 
 enum JobType {
 	INVALID_JOB = 0;
-	BATCH_INGESTION = 1;
-	STREAM_INGESTION = 2;
+	BATCH_INGESTION_JOB = 1;
+	STREAM_INGESTION_JOB = 2;
 	RETRIEVAL_JOB = 4;
 }
 

--- a/protos/feast/core/JobService.proto
+++ b/protos/feast/core/JobService.proto
@@ -23,7 +23,7 @@ option java_package = "feast.proto.core";
 
 import "google/protobuf/timestamp.proto";
 import "feast/core/DataSource.proto";
-import "feast/serving/ServingService.proto";
+
 
 service JobService {
     // Start job to ingest data from offline store into online store
@@ -38,8 +38,8 @@ service JobService {
     // List all types of jobs
     rpc ListJobs (ListJobsRequest) returns (ListJobsResponse);
 
-    // Stop a single job
-    rpc StopJob (StopJobRequest) returns (StopJobResponse);
+    // Cancel a single job
+    rpc CancelJob (CancelJobRequest) returns (CancelJobResponse);
 
     // Get details of a single job
     rpc GetJob (GetJobRequest) returns (GetJobResponse);
@@ -48,9 +48,9 @@ service JobService {
 
 enum JobType {
 	INVALID_JOB = 0;
-	OFFLINE_TO_ONLINE_JOB = 1;
-	STREAM_TO_ONLINE_JOB = 2;
-	EXPORT_JOB = 4;
+	BATCH_INGESTION = 1;
+	STREAM_INGESTION = 2;
+	RETRIEVAL_JOB = 4;
 }
 
 enum JobStatus {
@@ -68,42 +68,26 @@ enum JobStatus {
 message Job {
   // Identifier of the Job
   string id = 1;
-  // External Identifier of the Job assigned by the Spark executor
-  string external_id = 2;
   // Type of the Job
-  JobType type = 3;
+  JobType type = 2;
   // Current job status
-  JobStatus status = 4;
-  // Timestamp on when the job was is created
-  google.protobuf.Timestamp created_timestamp = 5;
-  // Timestamp on when the job has stopped.
-  google.protobuf.Timestamp stop_timestamp = 6;
+  JobStatus status = 3;
 
-  message ExportJobMeta {
-    // Glob of the exported files that should be retrieved to reconstruct
-    // the dataframe with retrieved features.
-    repeated string file_glob = 1;
-    // The Historical Features request that triggered this export job
-    GetHistoricalFeaturesRequest request = 2;
+  message RetrievalJobMeta {
+    string output_location = 4;
   }
 
   message OfflineToOnlineMeta {
-    // Reference to the Feature Table being populated by this job
-    string project = 1;
-    string table_name = 2;
   }
 
   message StreamToOnlineMeta {
-    // Reference to the Feature Table being populated by this job
-    string project = 1;
-    string table_name = 2;
   }
 
   // JobType specific metadata on the job
   oneof meta {
-    ExportJobMeta export = 7;
-    OfflineToOnlineMeta offline_to_online = 8;
-    StreamToOnlineMeta stream_to_online = 9;
+    RetrievalJobMeta retrieval = 5;
+    OfflineToOnlineMeta batch_ingestion = 6;
+    StreamToOnlineMeta stream_ingestion = 7;
   }
 }
 
@@ -127,13 +111,13 @@ message StartOfflineToOnlineIngestionJobResponse {
 
 message GetHistoricalFeaturesRequest {
   // List of features that are being retrieved
-  repeated feast.serving.FeatureReferenceV2 features = 1;
+  repeated string feature_refs = 1;
 
   // Batch DataSource that can be used to obtain entity values for historical retrieval.
   // For each entity value, a feature value will be retrieved for that value/timestamp
   // Only 'BATCH_*' source types are supported.
   // Currently only BATCH_FILE source type is supported.
-  DataSource entities_source = 2;
+  DataSource entity_source = 2;
 
   // Optional field to specify project name override. If specified, uses the
   // given project for retrieval. Overrides the projects specified in
@@ -143,12 +127,13 @@ message GetHistoricalFeaturesRequest {
   // Specifies the path in a bucket to write the exported feature data files
   // Export to AWS S3 - s3://path/to/features
   // Export to GCP GCS -  gs://path/to/features
-  string destination_path = 4;
+  string output_location = 4;
 }
 
 message GetHistoricalFeaturesResponse {
     // Export Job with ID assigned by Feast
     string id = 1;
+    string output_file_uri = 2;
 }
 
 message StartStreamToOnlineIngestionJobRequest {
@@ -163,13 +148,7 @@ message StartStreamToOnlineIngestionJobResponse {
 }
 
 message ListJobsRequest {
-  Filter filter = 1;
-  message Filter {
-    // Filter jobs by job type
-    JobType type = 1;
-    // Filter jobs by current job status
-    JobStatus status = 2;
-  }
+  bool include_terminated = 1;
 }
 
 message ListJobsResponse {
@@ -184,14 +163,8 @@ message GetJobResponse {
   Job job = 1;
 }
 
-message RestartJobRequest {
+message CancelJobRequest{
   string job_id = 1;
 }
 
-message RestartJobResponse {}
-
-message StopJobRequest{
-  string job_id = 1;
-}
-
-message StopJobResponse {}
+message CancelJobResponse {}

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -471,8 +471,16 @@ def list_jobs():
     help="Path to entity df in CSV format. It is assumed to have event_timestamp column and a header.",
     required=True,
 )
+@click.option(
+    "--entity-df-dtype",
+    "-d",
+    help="Dtypes for entity df, in JSON format",
+    required=False,
+)
 @click.option("--destination", "-d", help="Destination", default="")
-def get_historical_features(features: str, entity_df_path: str, destination: str):
+def get_historical_features(
+    features: str, entity_df_path: str, entity_df_dtype: str, destination: str
+):
     """
     Get historical features
     """
@@ -481,7 +489,14 @@ def get_historical_features(features: str, entity_df_path: str, destination: str
     client = Client()
 
     # TODO: clean this up
-    entity_df = pandas.read_csv(entity_df_path, sep=None, engine="python",)
+
+    if entity_df_dtype:
+        dtype = json.loads(entity_df_dtype)
+        entity_df = pandas.read_csv(
+            entity_df_path, sep=None, engine="python", dtype=dtype
+        )
+    else:
+        entity_df = pandas.read_csv(entity_df_path, sep=None, engine="python")
 
     entity_df["event_timestamp"] = pandas.to_datetime(entity_df["event_timestamp"])
 

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -116,7 +116,7 @@ FEAST_DEFAULT_OPTIONS = {
     # Path to certificate(s) to secure connection to Feast Serving
     CONFIG_SERVING_SERVER_SSL_CERT_KEY: "",
     # Default connection timeout to Feast Serving and Feast Core (in seconds)
-    CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY: "3",
+    CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY: "10",
     # Default gRPC connection timeout when sending an ApplyFeatureSet command to
     # Feast Core (in seconds)
     CONFIG_GRPC_CONNECTION_TIMEOUT_APPLY_KEY: "600",
@@ -133,4 +133,8 @@ FEAST_DEFAULT_OPTIONS = {
     CONFIG_REDIS_SSL: "False",
     CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_FORMAT: "parquet",
     CONFIG_SPARK_EXTRA_OPTIONS: "",
+    # Enable or disable TLS/SSL to Feast Service
+    CONFIG_JOB_SERVICE_ENABLE_SSL_KEY: "False",
+    # Path to certificate(s) to secure connection to Feast Job Service
+    CONFIG_JOB_SERVICE_SERVER_SSL_CERT_KEY: "",
 }

--- a/sdk/python/feast/job_service.py
+++ b/sdk/python/feast/job_service.py
@@ -9,11 +9,9 @@ from feast.core.JobService_pb2 import (
     CancelJobResponse,
     GetHistoricalFeaturesResponse,
     GetJobResponse,
-    Job,
-    JobStatus,
-    JobType,
-    ListJobsResponse,
 )
+from feast.core.JobService_pb2 import Job as JobProto
+from feast.core.JobService_pb2 import JobStatus, JobType, ListJobsResponse
 from feast.data_source import DataSource
 from feast.pyspark.abc import (
     BatchIngestionJob,
@@ -33,8 +31,8 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
     def __init__(self):
         self.client = feast.Client()
 
-    def _job_to_proto(self, spark_job: SparkJob) -> Job:
-        job = Job()
+    def _job_to_proto(self, spark_job: SparkJob) -> JobProto:
+        job = JobProto()
         job.id = spark_job.get_id()
         status = spark_job.get_status()
         if status == SparkJobStatus.COMPLETED:
@@ -52,9 +50,9 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
             job.type = JobType.RETRIEVAL_JOB
             job.retrieval.output_location = spark_job.get_output_file_uri(block=False)
         elif isinstance(spark_job, BatchIngestionJob):
-            job.type = JobType.BATCH_INGESTION
+            job.type = JobType.BATCH_INGESTION_JOB
         elif isinstance(spark_job, StreamIngestionJob):
-            job.type = JobType.STREAM_INGESTION
+            job.type = JobType.STREAM_INGESTION_JOB
         else:
             raise ValueError(f"Invalid job type {job}")
 

--- a/sdk/python/feast/job_service.py
+++ b/sdk/python/feast/job_service.py
@@ -1,9 +1,27 @@
+import logging
 from concurrent.futures import ThreadPoolExecutor
 
 import grpc
 
 import feast
 from feast.core import JobService_pb2_grpc
+from feast.core.JobService_pb2 import (
+    CancelJobResponse,
+    GetHistoricalFeaturesResponse,
+    GetJobResponse,
+    Job,
+    JobStatus,
+    JobType,
+    ListJobsResponse,
+)
+from feast.data_source import DataSource
+from feast.pyspark.abc import (
+    BatchIngestionJob,
+    RetrievalJob,
+    SparkJob,
+    SparkJobStatus,
+    StreamIngestionJob,
+)
 from feast.third_party.grpc.health.v1 import HealthService_pb2_grpc
 from feast.third_party.grpc.health.v1.HealthService_pb2 import (
     HealthCheckResponse,
@@ -15,6 +33,33 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
     def __init__(self):
         self.client = feast.Client()
 
+    def _job_to_proto(self, spark_job: SparkJob) -> Job:
+        job = Job()
+        job.id = spark_job.get_id()
+        status = spark_job.get_status()
+        if status == SparkJobStatus.COMPLETED:
+            job.status = JobStatus.JOB_STATUS_DONE
+        elif status == SparkJobStatus.IN_PROGRESS:
+            job.status = JobStatus.JOB_STATUS_RUNNING
+        elif status == SparkJobStatus.FAILED:
+            job.status = JobStatus.JOB_STATUS_ERROR
+        elif status == SparkJobStatus.STARTING:
+            job.status = JobStatus.JOB_STATUS_PENDING
+        else:
+            raise ValueError(f"Invalid job status {status}")
+
+        if isinstance(spark_job, RetrievalJob):
+            job.type = JobType.RETRIEVAL_JOB
+            job.retrieval.output_location = spark_job.get_output_file_uri(block=False)
+        elif isinstance(spark_job, BatchIngestionJob):
+            job.type = JobType.BATCH_INGESTION
+        elif isinstance(spark_job, StreamIngestionJob):
+            job.type = JobType.STREAM_INGESTION
+        else:
+            raise ValueError(f"Invalid job type {job}")
+
+        return job
+
     def StartOfflineToOnlineIngestionJob(self, request, context):
         """Start job to ingest data from offline store into online store"""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -23,9 +68,18 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
 
     def GetHistoricalFeatures(self, request, context):
         """Produce a training dataset, return a job id that will provide a file reference"""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        job = self.client.get_historical_features(
+            request.feature_refs,
+            entity_source=DataSource.from_proto(request.entity_source),
+            project=request.project,
+            output_location=request.output_location,
+        )
+
+        output_file_uri = job.get_output_file_uri(block=False)
+
+        return GetHistoricalFeaturesResponse(
+            id=job.get_id(), output_file_uri=output_file_uri
+        )
 
     def StartStreamToOnlineIngestionJob(self, request, context):
         """Start job to ingest data from stream into online store"""
@@ -35,21 +89,19 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
 
     def ListJobs(self, request, context):
         """List all types of jobs"""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        jobs = self.client.list_jobs(include_terminated=request.include_terminated)
+        return ListJobsResponse(jobs=[self._job_to_proto(job) for job in jobs])
 
-    def StopJob(self, request, context):
+    def CancelJob(self, request, context):
         """Stop a single job"""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        job = self.client.get_job_by_id(request.job_id)
+        job.cancel()
+        return CancelJobResponse()
 
     def GetJob(self, request, context):
         """Get details of a single job"""
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details("Method not implemented!")
-        raise NotImplementedError("Method not implemented!")
+        job = self.client.get_job_by_id(request.job_id)
+        return GetJobResponse(job=self._job_to_proto(job))
 
 
 class HealthServicer(HealthService_pb2_grpc.HealthServicer):
@@ -57,11 +109,21 @@ class HealthServicer(HealthService_pb2_grpc.HealthServicer):
         return HealthCheckResponse(status=ServingStatus.SERVING)
 
 
+class LoggingInterceptor(grpc.ServerInterceptor):
+    def intercept_service(self, continuation, handler_call_details):
+        logging.info(handler_call_details)
+        return continuation(handler_call_details)
+
+
 def start_job_service():
     """
     Start Feast Job Service
     """
-    server = grpc.server(ThreadPoolExecutor())
+
+    log_fmt = "%(asctime)s %(levelname)s %(message)s"
+    logging.basicConfig(level=logging.INFO, format=log_fmt)
+
+    server = grpc.server(ThreadPoolExecutor(), interceptors=(LoggingInterceptor(),))
     JobService_pb2_grpc.add_JobServiceServicer_to_server(JobServiceServicer(), server)
     HealthService_pb2_grpc.add_HealthServicer_to_server(HealthServicer(), server)
     server.add_insecure_port("[::]:6568")

--- a/sdk/python/feast/pyspark/abc.py
+++ b/sdk/python/feast/pyspark/abc.py
@@ -254,7 +254,7 @@ class RetrievalJob(SparkJob):
     """
 
     @abc.abstractmethod
-    def get_output_file_uri(self, timeout_sec=None):
+    def get_output_file_uri(self, timeout_sec=None, block=True):
         """
         Get output file uri to the result file. This method will block until the
         job succeeded, or if the job didn't execute successfully within timeout.
@@ -263,7 +263,9 @@ class RetrievalJob(SparkJob):
             timeout_sec (int):
                 Max no of seconds to wait until job is done. If "timeout_sec"
                 is exceeded or if the job fails, an exception will be raised.
-
+            block (bool):
+                If false, don't block until the job is done. If block=True, timeout parameter is
+                ignored.
         Raises:
             SparkJobFailure:
                 The spark job submission failed, encountered error during execution,

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -31,6 +31,7 @@ from feast.pyspark.abc import (
     JobLauncher,
     RetrievalJob,
     RetrievalJobParameters,
+    SparkJob,
     StreamIngestionJob,
     StreamIngestionJobParameters,
 )
@@ -241,6 +242,16 @@ def start_stream_to_online_ingestion(
             extra_options=client._config.get(CONFIG_SPARK_EXTRA_OPTIONS),
         )
     )
+
+
+def list_jobs(include_terminated: bool, client: "Client") -> List[SparkJob]:
+    launcher = resolve_launcher(client._config)
+    return launcher.list_jobs(include_terminated=include_terminated)
+
+
+def get_job_by_id(job_id: str, client: "Client") -> SparkJob:
+    launcher = resolve_launcher(client._config)
+    return launcher.get_job_by_id(job_id)
 
 
 def stage_dataframe(df, event_timestamp_column: str, client: "Client") -> FileSource:

--- a/sdk/python/feast/pyspark/launchers/aws/emr.py
+++ b/sdk/python/feast/pyspark/launchers/aws/emr.py
@@ -91,7 +91,10 @@ class EmrRetrievalJob(EmrJobMixin, RetrievalJob):
         super().__init__(emr_client, job_ref)
         self._output_file_uri = output_file_uri
 
-    def get_output_file_uri(self, timeout_sec=None):
+    def get_output_file_uri(self, timeout_sec=None, block=True):
+        if not block:
+            return self._output_file_uri
+
         state = _wait_for_job_state(
             self._emr_client, self._job_ref, TERMINAL_STEP_STATES, timeout_sec
         )
@@ -361,7 +364,7 @@ class EmrClusterLauncher(JobLauncher):
             emr_client=self._emr_client(),
             job_type=None,
             table_name=None,
-            active_only=True,
+            active_only=False,
         )
 
         for job_info in jobs:

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -74,7 +74,10 @@ class DataprocRetrievalJob(DataprocJobMixin, RetrievalJob):
         super().__init__(operation, cancel_fn)
         self._output_file_uri = output_file_uri
 
-    def get_output_file_uri(self, timeout_sec=None):
+    def get_output_file_uri(self, timeout_sec=None, block=True):
+        if not block:
+            return self._output_file_uri
+
         try:
             self._operation.result(timeout_sec)
         except Exception as err:

--- a/sdk/python/feast/pyspark/launchers/standalone/local.py
+++ b/sdk/python/feast/pyspark/launchers/standalone/local.py
@@ -122,7 +122,10 @@ class StandaloneClusterRetrievalJob(StandaloneClusterJobMixin, RetrievalJob):
         super().__init__(job_id, job_name, process)
         self._output_file_uri = output_file_uri
 
-    def get_output_file_uri(self, timeout_sec: int = None):
+    def get_output_file_uri(self, timeout_sec: int = None, block=True):
+        if not block:
+            return self._output_file_uri
+
         with self._process as p:
             try:
                 p.wait(timeout_sec)

--- a/sdk/python/feast/remote_job.py
+++ b/sdk/python/feast/remote_job.py
@@ -1,0 +1,130 @@
+import time
+from typing import Any, Callable, Dict, List
+
+from feast.core.JobService_pb2 import CancelJobRequest, GetJobRequest, JobStatus
+from feast.core.JobService_pb2_grpc import JobServiceStub
+from feast.pyspark.abc import (
+    BatchIngestionJob,
+    RetrievalJob,
+    SparkJobFailure,
+    SparkJobStatus,
+    StreamIngestionJob,
+)
+
+GrpcExtraParamProvider = Callable[[], Dict[str, Any]]
+
+
+class RemoteJobMixin:
+    def __init__(
+        self,
+        service: JobServiceStub,
+        grpc_extra_param_provider: GrpcExtraParamProvider,
+        job_id: str,
+    ):
+        """
+        Args:
+            service: Job service GRPC stub
+            job_id: job reference
+        """
+        self._job_id = job_id
+        self._service = service
+        self._grpc_extra_param_provider = grpc_extra_param_provider
+
+    def get_id(self) -> str:
+        return self._job_id
+
+    def get_status(self) -> SparkJobStatus:
+        response = self._service.GetJob(
+            GetJobRequest(job_id=self._job_id), **self._grpc_extra_param_provider()
+        )
+
+        if response.job.status == JobStatus.JOB_STATUS_RUNNING:
+            return SparkJobStatus.IN_PROGRESS
+        elif response.job.status == JobStatus.JOB_STATUS_PENDING:
+            return SparkJobStatus.STARTING
+        elif response.job.status == JobStatus.JOB_STATUS_DONE:
+            return SparkJobStatus.COMPLETED
+        elif response.job.status == JobStatus.JOB_STATUS_ERROR:
+            return SparkJobStatus.FAILED
+        else:
+            # we should never get here
+            raise Exception(f"Invalid remote job state {response.job.status}")
+
+    def cancel(self):
+        self._service.CancelJob(
+            CancelJobRequest(job_id=self._job_id), **self._grpc_extra_param_provider()
+        )
+
+    def _wait_for_job_status(
+        self, goal_status: List[SparkJobStatus], timeout_seconds=90
+    ) -> SparkJobStatus:
+        start_time = time.time()
+
+        while time.time() < (start_time + timeout_seconds):
+            status = self.get_status()
+            if status in goal_status:
+                return status
+            else:
+                time.sleep(1.0)
+        else:
+            raise TimeoutError("Timed out waiting for job status")
+
+
+class RemoteRetrievalJob(RemoteJobMixin, RetrievalJob):
+    """
+    Historical feature retrieval job result, job being run remotely bt the job service
+    """
+
+    def __init__(
+        self,
+        service: JobServiceStub,
+        grpc_extra_param_provider: GrpcExtraParamProvider,
+        job_id: str,
+        output_file_uri: str,
+    ):
+        """
+        This is the job object representing the historical retrieval job.
+
+        Args:
+            output_file_uri (str): Uri to the historical feature retrieval job output file.
+        """
+        super().__init__(service, grpc_extra_param_provider, job_id)
+        self._output_file_uri = output_file_uri
+
+    def get_output_file_uri(self, timeout_sec=None):
+        status = self._wait_for_job_status(
+            goal_status=[SparkJobStatus.COMPLETED, SparkJobStatus.FAILED],
+            timeout_seconds=600,
+        )
+        if status == SparkJobStatus.COMPLETED:
+            return self._output_file_uri
+        else:
+            raise SparkJobFailure("Spark job failed")
+
+
+class RemoteBatchIngestionJob(RemoteJobMixin, BatchIngestionJob):
+    """
+    Batch ingestion job result.
+    """
+
+    def __init__(
+        self,
+        service: JobServiceStub,
+        grpc_extra_param_provider: GrpcExtraParamProvider,
+        job_id: str,
+    ):
+        super().__init__(service, grpc_extra_param_provider, job_id)
+
+
+class RemoteStreamIngestionJob(RemoteJobMixin, StreamIngestionJob):
+    """
+    Stream ingestion job result.
+    """
+
+    def __init__(
+        self,
+        service: JobServiceStub,
+        grpc_extra_param_provider: GrpcExtraParamProvider,
+        job_id: str,
+    ):
+        super().__init__(service, grpc_extra_param_provider, job_id)

--- a/sdk/python/tests/test_remote_job.py
+++ b/sdk/python/tests/test_remote_job.py
@@ -1,0 +1,63 @@
+from collections import defaultdict
+from concurrent import futures
+from contextlib import contextmanager
+
+import grpc
+
+from feast.core.JobService_pb2 import GetJobResponse
+from feast.core.JobService_pb2 import Job as JobProto
+from feast.core.JobService_pb2 import JobStatus, JobType
+from feast.core.JobService_pb2_grpc import (
+    JobServiceServicer,
+    JobServiceStub,
+    add_JobServiceServicer_to_server,
+)
+from feast.remote_job import RemoteRetrievalJob
+
+
+@contextmanager
+def mock_server(servicer):
+    """Instantiate a helloworld server and return a stub for use in tests"""
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    add_JobServiceServicer_to_server(servicer, server)
+    port = server.add_insecure_port("[::]:0")
+    server.start()
+
+    try:
+        with grpc.insecure_channel("localhost:%d" % port) as channel:
+            yield JobServiceStub(channel)
+    finally:
+        server.stop(None)
+
+
+class TestRemoteJob:
+    def test_remote_ingestion_job(self):
+        """ Test wating for the remote ingestion job to complete """
+
+        class MockServicer(JobServiceServicer):
+            """
+            The RemoteJob is expected to call GetJob until its done.
+            This mock JobService returns RUNNING status on the first call, and DONE on the second.
+            """
+
+            _job_statuses = [JobStatus.JOB_STATUS_DONE, JobStatus.JOB_STATUS_RUNNING]
+            _call_count = defaultdict(int)
+
+            def GetJob(self, request, context):
+
+                self._call_count["GetJob"] += 1
+                return GetJobResponse(
+                    job=JobProto(
+                        id="test",
+                        type=JobType.RETRIEVAL_JOB,
+                        status=self._job_statuses.pop(),
+                        retrieval=JobProto.RetrievalJobMeta(output_location="foo"),
+                    )
+                )
+
+        mock_servicer = MockServicer()
+        with mock_server(mock_servicer) as service:
+            remote_job = RemoteRetrievalJob(service, lambda: {}, "test", "foo")
+
+            assert remote_job.get_output_file_uri(timeout_sec=2) == "foo"
+            assert mock_servicer._call_count["GetJob"] == 2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This implements end-to-end flow for historical retrieval via job service. Tested only manually for now, until we include job service setup in e2e tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
