### PR TITLE
Add serving integration test for updated feature type

### DIFF
--- a/serving/src/main/java/feast/serving/config/FeastProperties.java
+++ b/serving/src/main/java/feast/serving/config/FeastProperties.java
@@ -86,6 +86,9 @@ public class FeastProperties {
     this.coreAuthentication = coreAuthentication;
   }
 
+  /* Feast Core port to connect to. */
+  @Positive private int coreCacheRefreshInterval;
+
   private SecurityProperties security;
 
   @Bean
@@ -218,6 +221,24 @@ public class FeastProperties {
    */
   public void setCoreGrpcPort(int coreGrpcPort) {
     this.coreGrpcPort = coreGrpcPort;
+  }
+
+  /**
+   * Gets CachedSpecService refresh interval.
+   *
+   * @return CachedSpecService refresh interval
+   */
+  public int getCoreCacheRefreshInterval() {
+    return coreCacheRefreshInterval;
+  }
+
+  /**
+   * Sets CachedSpecService refresh interval.
+   *
+   * @param coreCacheRefreshInterval CachedSpecService refresh interval
+   */
+  public void setCoreCacheRefreshInterval(int coreCacheRefreshInterval) {
+    this.coreCacheRefreshInterval = coreCacheRefreshInterval;
   }
 
   /**

--- a/serving/src/main/java/feast/serving/config/SpecServiceConfig.java
+++ b/serving/src/main/java/feast/serving/config/SpecServiceConfig.java
@@ -37,13 +37,13 @@ public class SpecServiceConfig {
   private static final Logger log = org.slf4j.LoggerFactory.getLogger(SpecServiceConfig.class);
   private String feastCoreHost;
   private int feastCorePort;
-  private int CACHE_REFRESH_RATE_SECONDS;
+  private int feastCachedSpecServiceRefreshInterval;
 
   @Autowired
   public SpecServiceConfig(FeastProperties feastProperties) {
-    feastCoreHost = feastProperties.getCoreHost();
-    feastCorePort = feastProperties.getCoreGrpcPort();
-    CACHE_REFRESH_RATE_SECONDS = feastProperties.getCoreCacheRefreshInterval();
+    this.feastCoreHost = feastProperties.getCoreHost();
+    this.feastCorePort = feastProperties.getCoreGrpcPort();
+    this.feastCachedSpecServiceRefreshInterval = feastProperties.getCoreCacheRefreshInterval();
   }
 
   @Bean
@@ -54,8 +54,8 @@ public class SpecServiceConfig {
     // reload all specs including new ones periodically
     scheduledExecutorService.scheduleAtFixedRate(
         cachedSpecStorage::scheduledPopulateCache,
-        CACHE_REFRESH_RATE_SECONDS,
-        CACHE_REFRESH_RATE_SECONDS,
+        feastCachedSpecServiceRefreshInterval,
+        feastCachedSpecServiceRefreshInterval,
         TimeUnit.SECONDS);
     return scheduledExecutorService;
   }

--- a/serving/src/main/java/feast/serving/config/SpecServiceConfig.java
+++ b/serving/src/main/java/feast/serving/config/SpecServiceConfig.java
@@ -37,12 +37,13 @@ public class SpecServiceConfig {
   private static final Logger log = org.slf4j.LoggerFactory.getLogger(SpecServiceConfig.class);
   private String feastCoreHost;
   private int feastCorePort;
-  private static final int CACHE_REFRESH_RATE_SECONDS = 10;
+  private int CACHE_REFRESH_RATE_SECONDS;
 
   @Autowired
   public SpecServiceConfig(FeastProperties feastProperties) {
     feastCoreHost = feastProperties.getCoreHost();
     feastCorePort = feastProperties.getCoreGrpcPort();
+    CACHE_REFRESH_RATE_SECONDS = feastProperties.getCoreCacheRefreshInterval();
   }
 
   @Bean

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -17,6 +17,7 @@ feast:
       audience: https://localhost #token audience.
       jwkEndpointURI: <jwkEndpointURI> #jwk enpoint uri, used for caching token till expiry.
       
+  core-cache-refresh-interval: 10
 
   # Indicates the active store. Only a single store in the last can be active at one time. In the future this key
   # will be deprecated in order to allow multiple stores to be served from a single serving instance

--- a/serving/src/test/java/feast/serving/it/ServingServiceIT.java
+++ b/serving/src/test/java/feast/serving/it/ServingServiceIT.java
@@ -419,4 +419,75 @@ public class ServingServiceIT extends BaseAuthIT {
 
     assertEquals(expectedFieldValuesList, featureResponse.getFieldValuesList());
   }
+
+  @Test
+  public void shouldReturnNotFoundForUpdatedType() {
+    String projectName = "default";
+    String entityName = "driver_id";
+    String featureTableName = "rides";
+
+    ImmutableList<String> entities = ImmutableList.of(entityName);
+    ImmutableMap<String, ValueProto.ValueType.Enum> features =
+        ImmutableMap.of(
+            "trip_cost",
+            ValueProto.ValueType.Enum.INT64,
+            "trip_distance",
+            ValueProto.ValueType.Enum.STRING,
+            "trip_empty",
+            ValueProto.ValueType.Enum.DOUBLE,
+            "trip_wrong_type",
+            ValueProto.ValueType.Enum.STRING);
+
+    TestUtils.applyFeatureTable(
+        coreClient, projectName, featureTableName, entities, features, 7200);
+
+    // Sleep is necessary to ensure caching (every 10s) of updated FeatureTable is done
+    try {
+      Thread.sleep(15000);
+    } catch (InterruptedException e) {
+    }
+
+    ValueProto.Value entityValue = ValueProto.Value.newBuilder().setInt64Val(1).build();
+    // Instantiate EntityRows
+    GetOnlineFeaturesRequestV2.EntityRow entityRow1 =
+        DataGenerator.createEntityRow(entityName, DataGenerator.createInt64Value(1), 100);
+    ImmutableList<GetOnlineFeaturesRequestV2.EntityRow> entityRows = ImmutableList.of(entityRow1);
+
+    // Instantiate FeatureReferences
+    ServingAPIProto.FeatureReferenceV2 featureReference =
+        DataGenerator.createFeatureReference("rides", "trip_distance");
+
+    ImmutableList<ServingAPIProto.FeatureReferenceV2> featureReferences =
+        ImmutableList.of(featureReference);
+
+    // Build GetOnlineFeaturesRequestV2
+    GetOnlineFeaturesRequestV2 onlineFeatureRequest =
+        TestUtils.createOnlineFeatureRequest(projectName, featureReferences, entityRows);
+    GetOnlineFeaturesResponse featureResponse =
+        servingStub.getOnlineFeaturesV2(onlineFeatureRequest);
+
+    ImmutableMap<String, ValueProto.Value> expectedValueMap =
+        ImmutableMap.of(
+            entityName,
+            entityValue,
+            FeatureV2.getFeatureStringRef(featureReference),
+            DataGenerator.createEmptyValue());
+
+    ImmutableMap<String, GetOnlineFeaturesResponse.FieldStatus> expectedStatusMap =
+        ImmutableMap.of(
+            entityName,
+            GetOnlineFeaturesResponse.FieldStatus.PRESENT,
+            FeatureV2.getFeatureStringRef(featureReference),
+            GetOnlineFeaturesResponse.FieldStatus.NOT_FOUND);
+
+    GetOnlineFeaturesResponse.FieldValues expectedFieldValues =
+        GetOnlineFeaturesResponse.FieldValues.newBuilder()
+            .putAllFields(expectedValueMap)
+            .putAllStatuses(expectedStatusMap)
+            .build();
+    ImmutableList<GetOnlineFeaturesResponse.FieldValues> expectedFieldValuesList =
+        ImmutableList.of(expectedFieldValues);
+
+    assertEquals(expectedFieldValuesList, featureResponse.getFieldValuesList());
+  }
 }

--- a/serving/src/test/java/feast/serving/it/ServingServiceIT.java
+++ b/serving/src/test/java/feast/serving/it/ServingServiceIT.java
@@ -60,7 +60,11 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @ActiveProfiles("it")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {
+      "feast.core-cache-refresh-interval=1",
+    })
 @Testcontainers
 public class ServingServiceIT extends BaseAuthIT {
 
@@ -441,9 +445,9 @@ public class ServingServiceIT extends BaseAuthIT {
     TestUtils.applyFeatureTable(
         coreClient, projectName, featureTableName, entities, features, 7200);
 
-    // Sleep is necessary to ensure caching (every 10s) of updated FeatureTable is done
+    // Sleep is necessary to ensure caching (every 1s) of updated FeatureTable is done
     try {
-      Thread.sleep(15000);
+      Thread.sleep(2000);
     } catch (InterruptedException e) {
     }
 


### PR DESCRIPTION
Signed-off-by: Terence <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Following this [PR](https://github.com/feast-dev/feast/pull/1105), this PR adds an integration test that checks for `NOT FOUND` values in online retrieval when feature types are changed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
