### PR TITLE
Add feature table deletion

### DIFF
--- a/common-test/src/main/java/feast/common/it/SimpleCoreClient.java
+++ b/common-test/src/main/java/feast/common/it/SimpleCoreClient.java
@@ -218,4 +218,12 @@ public class SimpleCoreClient {
                 .build())
         .getTable();
   }
+
+  public void deleteFeatureTable(String projectName, String featureTableName) {
+    stub.deleteFeatureTable(
+        CoreServiceProto.DeleteFeatureTableRequest.newBuilder()
+            .setProject(projectName)
+            .setName(featureTableName)
+            .build());
+  }
 }

--- a/core/src/main/java/feast/core/grpc/CoreServiceImpl.java
+++ b/core/src/main/java/feast/core/grpc/CoreServiceImpl.java
@@ -491,4 +491,30 @@ public class CoreServiceImpl extends CoreServiceImplBase {
           Status.INTERNAL.withDescription(e.getMessage()).withCause(e).asRuntimeException());
     }
   }
+
+  @Override
+  public void deleteFeatureTable(
+      DeleteFeatureTableRequest request,
+      StreamObserver<DeleteFeatureTableResponse> responseObserver) {
+    String projectName = request.getProject();
+    try {
+      // Check if user has authorization to delete feature table
+      authorizationService.authorizeRequest(SecurityContextHolder.getContext(), projectName);
+      specService.deleteFeatureTable(request);
+
+      responseObserver.onNext(DeleteFeatureTableResponse.getDefaultInstance());
+      responseObserver.onCompleted();
+    } catch (NoSuchElementException e) {
+      log.error(
+          String.format(
+              "DeleteFeatureTable: No such Feature Table: (project: %s, name: %s)",
+              request.getProject(), request.getName()));
+      responseObserver.onError(
+          Status.NOT_FOUND.withDescription(e.getMessage()).withCause(e).asRuntimeException());
+    } catch (Exception e) {
+      log.error("DeleteFeatureTable: Exception has occurred: ", e);
+      responseObserver.onError(
+          Status.INTERNAL.withDescription(e.getMessage()).withCause(e).asRuntimeException());
+    }
+  }
 }

--- a/core/src/main/resources/db/migration/V3.0__Feature_Table_Deletion.sql
+++ b/core/src/main/resources/db/migration/V3.0__Feature_Table_Deletion.sql
@@ -1,3 +1,1 @@
 ALTER TABLE feature_tables ADD COLUMN is_deleted boolean NOT NULL;
-
-ALTER TABLE feature_tables ADD COLUMN metadata_hash bigint NOT NULL;

--- a/core/src/main/resources/db/migration/V3.0__Feature_Table_Deletion.sql
+++ b/core/src/main/resources/db/migration/V3.0__Feature_Table_Deletion.sql
@@ -1,0 +1,3 @@
+ALTER TABLE feature_tables ADD COLUMN is_deleted boolean NOT NULL;
+
+ALTER TABLE feature_tables ADD COLUMN metadata_hash bigint NOT NULL;

--- a/core/src/test/java/feast/core/service/SpecServiceIT.java
+++ b/core/src/test/java/feast/core/service/SpecServiceIT.java
@@ -1336,4 +1336,53 @@ public class SpecServiceIT extends BaseIT {
                       .build()));
     }
   }
+
+  @Nested
+  public class DeleteFeatureTable {
+
+    @Test
+    public void shouldReturnNoTables() {
+      String projectName = "default";
+      String featureTableName = "featuretable1";
+
+      apiClient.deleteFeatureTable(projectName, featureTableName);
+
+      CoreServiceProto.ListFeatureTablesRequest.Filter filter =
+          CoreServiceProto.ListFeatureTablesRequest.Filter.newBuilder()
+              .setProject("default")
+              .build();
+      List<FeatureTableProto.FeatureTable> featureTables =
+          apiClient.simpleListFeatureTables(filter);
+
+      StatusRuntimeException exc =
+          assertThrows(
+              StatusRuntimeException.class,
+              () -> apiClient.simpleGetFeatureTable(projectName, featureTableName));
+
+      assertThat(featureTables.size(), equalTo(0));
+      assertThat(
+          exc.getMessage(),
+          equalTo(
+              String.format(
+                  "NOT_FOUND: Feature Table has been deleted: (project: %s, name: %s)",
+                  projectName, featureTableName)));
+    }
+
+    @Test
+    public void shouldErrorIfTableNotExist() {
+      String projectName = "default";
+      String featureTableName = "nonexistent_table";
+      StatusRuntimeException exc =
+          assertThrows(
+              StatusRuntimeException.class,
+              () -> apiClient.deleteFeatureTable(projectName, featureTableName));
+
+      assertThat(
+          exc.getMessage(),
+          equalTo(
+              String.format(
+                  "NOT_FOUND: No such Feature Table: (project: %s, name: %s)",
+                  projectName, featureTableName)));
+    }
+  }
 }

--- a/core/src/test/java/feast/core/service/SpecServiceIT.java
+++ b/core/src/test/java/feast/core/service/SpecServiceIT.java
@@ -1369,6 +1369,37 @@ public class SpecServiceIT extends BaseIT {
     }
 
     @Test
+    public void shouldUpdateDeletedTable() {
+      String projectName = "default";
+      String featureTableName = "featuretable1";
+
+      apiClient.deleteFeatureTable(projectName, featureTableName);
+
+      FeatureTableSpec featureTableSpec =
+          DataGenerator.createFeatureTableSpec(
+                  featureTableName,
+                  Arrays.asList("entity1", "entity2"),
+                  new HashMap<>() {
+                    {
+                      put("feature3", ValueProto.ValueType.Enum.INT64);
+                    }
+                  },
+                  7200,
+                  ImmutableMap.of("feat_key3", "feat_value3"))
+              .toBuilder()
+              .setBatchSource(
+                  DataGenerator.createFileDataSourceSpec("file:///path/to/file", "ts_col", ""))
+              .build();
+
+      apiClient.applyFeatureTable(projectName, featureTableSpec);
+
+      FeatureTableProto.FeatureTable featureTable =
+          apiClient.simpleGetFeatureTable(projectName, featureTableName);
+
+      assertTrue(TestUtil.compareFeatureTableSpec(featureTable.getSpec(), featureTableSpec));
+    }
+
+    @Test
     public void shouldErrorIfTableNotExist() {
       String projectName = "default";
       String featureTableName = "nonexistent_table";

--- a/protos/feast/core/CoreService.proto
+++ b/protos/feast/core/CoreService.proto
@@ -134,6 +134,9 @@ service CoreService {
     // Returns a specific feature table
     rpc GetFeatureTable (GetFeatureTableRequest) returns (GetFeatureTableResponse);
 
+    // Delete a specific feature table
+    rpc DeleteFeatureTable (DeleteFeatureTableRequest) returns (DeleteFeatureTableResponse);
+
 }
 
 service JobControllerService {
@@ -500,3 +503,14 @@ message ListFeatureTablesResponse {
     // List of matching Feature Tables
     repeated FeatureTable tables = 1;
 }
+
+message DeleteFeatureTableRequest {
+    // Optional. Name of the Project to delete the Feature Table from.
+    // If unspecified, will delete FeatureTable from the default project.
+    string project = 1;
+
+    // Name of the FeatureTable to delete.
+    string name = 2;
+}
+
+message DeleteFeatureTableResponse {}

--- a/protos/feast/core/FeatureTable.proto
+++ b/protos/feast/core/FeatureTable.proto
@@ -79,5 +79,5 @@ message FeatureTableMeta {
 
     // Hash entities, features, batch_source and stream_source to inform JobService if
     // jobs should be restarted should hash change
-    bytes hash = 4;
+    string hash = 4;
 }

--- a/protos/feast/core/FeatureTable.proto
+++ b/protos/feast/core/FeatureTable.proto
@@ -76,4 +76,8 @@ message FeatureTableMeta {
 
     // Auto incrementing revision no. of this Feature Table
     int64 revision = 3;
+
+    // Hash entities, features, batch_source and stream_source to inform JobService if
+    // jobs should be restarted should hash change
+    bytes hash = 4;
 }

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -51,6 +51,7 @@ from feast.core.CoreService_pb2 import (
     ArchiveProjectResponse,
     CreateProjectRequest,
     CreateProjectResponse,
+    DeleteFeatureTableRequest,
     GetEntityRequest,
     GetEntityResponse,
     GetFeastCoreVersionRequest,
@@ -678,6 +679,26 @@ class Client:
         except grpc.RpcError as e:
             raise grpc.RpcError(e.details())
         return FeatureTable.from_proto(get_feature_table_response.table)
+
+    def delete_feature_table(self, name: str, project: str = None) -> None:
+        """
+        Deletes a feature table.
+
+        Args:
+            project: Feast project that this feature table belongs to
+            name: Name of feature table
+        """
+
+        if project is None:
+            project = self.project
+
+        try:
+            self._core_service.DeleteFeatureTable(
+                DeleteFeatureTableRequest(project=project, name=name.strip()),
+                metadata=self._get_grpc_metadata(),
+            )
+        except grpc.RpcError as e:
+            raise grpc.RpcError(e.details())
 
     def ingest(
         self,


### PR DESCRIPTION
Signed-off-by: Terence <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR enables feature table deletion. The following has been implemented:
- `is_deleted` flag to check if a table is deleted or not
- Updated feature table metadata to include hash to determine if job needs to be restarted
- Added `delete_feature_table` method to Python SDK

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now delete feature tables.
```
