### PR TITLE
Add confluent kafka installation to minimal notebook

### DIFF
--- a/examples/minimal/minimal_ride_hailing.ipynb
+++ b/examples/minimal/minimal_ride_hailing.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Feast 101 - Driver Trips Example"
+    "# Minimal Ride Hailing Example"
    ]
   },
   {

--- a/examples/minimal/minimal_ride_hailing.ipynb
+++ b/examples/minimal/minimal_ride_hailing.ipynb
@@ -1159,6 +1159,20 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!pip install confluent_kafka"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
    "execution_count": 27,
    "metadata": {},
    "outputs": [],

--- a/infra/docker/jupyter/Dockerfile
+++ b/infra/docker/jupyter/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install -r sdk/python/requirements-ci.txt
 COPY .git .git
 COPY README.md README.md
 RUN pip install -e sdk/python -U
-RUN pip install "s3fs" "boto3" "urllib3>=1.25.4"
+RUN pip install "s3fs" "boto3" "urllib3>=1.25.4" "confluent_kafka"
 
 # Switch back to original user and workdir
 USER $NB_UID

--- a/infra/docker/jupyter/Dockerfile
+++ b/infra/docker/jupyter/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install -r sdk/python/requirements-ci.txt
 COPY .git .git
 COPY README.md README.md
 RUN pip install -e sdk/python -U
-RUN pip install "s3fs" "boto3" "urllib3>=1.25.4" "confluent_kafka"
+RUN pip install "s3fs" "boto3" "urllib3>=1.25.4"
 
 # Switch back to original user and workdir
 USER $NB_UID


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

The current minimal Jupyter notebook doesn't work because it requires `confluent_kafka` to be installed.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
