### PR TITLE
Ability to run e2e tests in non-default project

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -23,6 +23,7 @@ def pytest_addoption(parser):
     parser.addoption("--redis-cluster", action="store_true")
     parser.addoption("--feast-version", action="store")
     parser.addoption("--bq-project", action="store")
+    parser.addoption("--feast-project", action="store", default="default")
 
 
 def pytest_runtest_setup(item):

--- a/tests/e2e/fixtures/client.py
+++ b/tests/e2e/fixtures/client.py
@@ -21,7 +21,7 @@ def feast_client(
     enable_auth,
 ):
     if pytestconfig.getoption("env") == "local":
-        return Client(
+        c = Client(
             core_url=f"{feast_core[0]}:{feast_core[1]}",
             serving_url=f"{feast_serving[0]}:{feast_serving[1]}",
             spark_launcher="standalone",
@@ -36,8 +36,8 @@ def feast_client(
             ),
         )
 
-    if pytestconfig.getoption("env") == "gcloud":
-        return Client(
+    elif pytestconfig.getoption("env") == "gcloud":
+        c = Client(
             core_url=f"{feast_core[0]}:{feast_core[1]}",
             serving_url=f"{feast_serving[0]}:{feast_serving[1]}",
             spark_launcher="dataproc",
@@ -52,6 +52,11 @@ def feast_client(
                 local_staging_path, "historical_output"
             ),
         )
+    else:
+        raise KeyError(f"Unknown environment {pytestconfig.getoption('env')}")
+
+    c.set_project(pytestconfig.getoption("feast_project"))
+    return c
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
