### PR TITLE
Wait for job to be ready before cancelling

### DIFF
--- a/tests/integration/test_launchers.py
+++ b/tests/integration/test_launchers.py
@@ -1,6 +1,6 @@
-from time import sleep
+import time
 
-from feast.pyspark.abc import RetrievalJobParameters, SparkJobStatus
+from feast.pyspark.abc import RetrievalJobParameters, SparkJobStatus, SparkJob
 from feast.pyspark.launchers.gcloud import DataprocClusterLauncher
 
 from .fixtures.job_parameters import customer_entity  # noqa: F401
@@ -8,6 +8,13 @@ from .fixtures.job_parameters import customer_feature  # noqa: F401
 from .fixtures.job_parameters import dataproc_retrieval_job_params  # noqa: F401
 from .fixtures.launchers import dataproc_launcher  # noqa: F401
 
+
+def wait_for_job_status(job: SparkJob, expected_status: SparkJobStatus, max_retry: int = 4, retry_interval: int = 5):
+    for i in range(max_retry):
+        if job.get_status() == expected_status:
+            return
+        time.sleep(retry_interval)
+    raise ValueError(f"Timeout waiting for job status to become {expected_status.name}")
 
 def test_dataproc_job_api(
     dataproc_launcher: DataprocClusterLauncher,  # noqa: F811
@@ -27,5 +34,6 @@ def test_dataproc_job_api(
         job.get_id() for job in dataproc_launcher.list_jobs(include_terminated=False)
     ]
     assert job_id in active_job_ids
+    wait_for_job_status(retrieved_job, SparkJobStatus.IN_PROGRESS)
     retrieved_job.cancel()
     assert retrieved_job.get_status() == SparkJobStatus.FAILED


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently the python sdk integration test is flaky, as the cancel job API may fail due to the job not being in Ready state when the api is called. This PR add a check for job status before cancelling the job.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
