### PR TITLE
Allow user to specify custom secrets to be mounted on Feast Serving and Feast Core pods

### DIFF
--- a/infra/charts/feast/README.md
+++ b/infra/charts/feast/README.md
@@ -15,7 +15,7 @@ https://docs.feast.dev/v/master/getting-started/deploying-feast/kubernetes
 |  | feast-jupyter | 0.8-SNAPSHOT |
 |  | feast-serving | 0.8-SNAPSHOT |
 |  | prometheus-statsd-exporter | 0.1.2 |
-| https://kubernetes-charts-incubator.storage.googleapis.com/ | kafka | 0.20.8 |
+| https://charts.bitnami.com/bitnami/ | kafka | 11.8.8 |
 | https://kubernetes-charts.storage.googleapis.com/ | grafana | 5.0.5 |
 | https://kubernetes-charts.storage.googleapis.com/ | postgresql | 8.6.1 |
 | https://kubernetes-charts.storage.googleapis.com/ | prometheus | 11.0.2 |

--- a/infra/charts/feast/charts/feast-core/README.md
+++ b/infra/charts/feast/charts/feast-core/README.md
@@ -58,6 +58,7 @@ Current chart version is `0.8-SNAPSHOT`
 | readinessProbe.timeoutSeconds | int | `10` | When the probe times out |
 | replicaCount | int | `1` | Number of pods that will be created |
 | resources | object | `{}` | CPU/memory [resource requests/limit](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) |
+| secrets | list | `[]` | List of Kubernetes secrets to be mounted on Feast Core pods. These secrets will be mounted on /etc/secrets/<secret name>. |
 | service.grpc.nodePort | string | `nil` | Port number that each cluster node will listen to |
 | service.grpc.port | int | `6565` | Service port for GRPC requests |
 | service.grpc.targetPort | int | `6565` | Container port serving GRPC requests |

--- a/infra/charts/feast/charts/feast-core/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-core/templates/deployment.yaml
@@ -46,6 +46,11 @@ spec:
       - name: {{ template "feast-core.fullname" . }}-secret
         secret:
           secretName: {{ template "feast-core.fullname" . }}
+      {{- range $secret := .Values.secrets }}
+      - name: {{ $secret }}
+        secret:
+          secretName: {{ $secret }}
+      {{- end }}
 
       containers:
       - name: {{ .Chart.Name }}
@@ -58,6 +63,11 @@ spec:
         - name: {{ template "feast-core.fullname" . }}-secret
           mountPath: /etc/secrets/feast
           readOnly: true
+        {{- range $secret := .Values.secrets }}
+        - name: {{ $secret }}
+          mountPath: "/etc/secrets/{{ $secret }}"
+          readOnly: true
+        {{- end }}
 
         env:
         - name: LOG_TYPE

--- a/infra/charts/feast/charts/feast-core/values.yaml
+++ b/infra/charts/feast/charts/feast-core/values.yaml
@@ -140,5 +140,8 @@ nodeSelector: {}
 # envOverrides -- Extra environment variables to set
 envOverrides: {}
 
+# secrets -- List of Kubernetes secrets to be mounted on Feast Core pods. These secrets will be mounted on /etc/secrets/<secret name>.
+secrets: []
+
 # podLabels -- Labels to be added to Feast Core pods
 podLabels: {}

--- a/infra/charts/feast/charts/feast-jobservice/Chart.yaml
+++ b/infra/charts/feast/charts/feast-jobservice/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: Feast Job Coontroller manage ingestion jobs.
+description: Feast Job Service manage ingestion jobs.
 name: feast-jobservice
 version: 0.8-SNAPSHOT

--- a/infra/charts/feast/charts/feast-jobservice/README.md
+++ b/infra/charts/feast/charts/feast-jobservice/README.md
@@ -1,5 +1,5 @@
 feast-jobservice
-==========
+================
 Feast Job Service manage ingestion jobs.
 
 Current chart version is `0.8-SNAPSHOT`
@@ -37,7 +37,7 @@ Current chart version is `0.8-SNAPSHOT`
 | ingress.http.https.enabled | bool | `true` | Flag to enable HTTPS |
 | ingress.http.https.secretNames | object | `{}` | Map of hostname to TLS secret name |
 | ingress.http.whitelist | string | `""` | Allowed client IP source ranges |
-| livenessProbe.enabled | bool | `false` | Flag to enabled the probe |
+| livenessProbe.enabled | bool | `true` | Flag to enabled the probe |
 | livenessProbe.failureThreshold | int | `5` | Min consecutive failures for the probe to be considered failed |
 | livenessProbe.initialDelaySeconds | int | `60` | Delay before the probe is initiated |
 | livenessProbe.periodSeconds | int | `10` | How often to perform the probe |
@@ -45,7 +45,7 @@ Current chart version is `0.8-SNAPSHOT`
 | livenessProbe.timeoutSeconds | int | `5` | When the probe times out |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | podLabels | object | `{}` | Labels to be added to Feast Job Service pods |
-| prometheus.enabled | bool | `true` | Flag to enable scraping of Feast Job Service metrics |
+| prometheus.enabled | bool | `true` | Flag to enable scraping of metrics |
 | readinessProbe.enabled | bool | `true` | Flag to enabled the probe |
 | readinessProbe.failureThreshold | int | `5` | Min consecutive failures for the probe to be considered failed |
 | readinessProbe.initialDelaySeconds | int | `20` | Delay before the probe is initiated |

--- a/infra/charts/feast/charts/feast-serving/README.md
+++ b/infra/charts/feast/charts/feast-serving/README.md
@@ -61,6 +61,7 @@ Current chart version is `0.8-SNAPSHOT`
 | readinessProbe.timeoutSeconds | int | `10` | When the probe times out |
 | replicaCount | int | `1` | Number of pods that will be created |
 | resources | object | `{}` | CPU/memory [resource requests/limit](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) |
+| secrets | list | `[]` | List of Kubernetes secrets to be mounted on Feast Core pods. These secrets will be mounted on /etc/secrets/<secret name>. |
 | service.grpc.nodePort | string | `nil` | Port number that each cluster node will listen to |
 | service.grpc.port | int | `6566` | Service port for GRPC requests |
 | service.grpc.targetPort | int | `6566` | Container port serving GRPC requests |

--- a/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
@@ -46,6 +46,11 @@ spec:
       - name: {{ template "feast-serving.fullname" . }}-secret
         secret:
           secretName: {{ template "feast-serving.fullname" . }}
+      {{- range $secret := .Values.secrets }}
+      - name: {{ $secret }}
+        secret:
+          secretName: {{ $secret }}
+      {{- end }}
 
       containers:
       - name: {{ .Chart.Name }}
@@ -58,6 +63,11 @@ spec:
         - name: {{ template "feast-serving.fullname" . }}-secret
           mountPath: /etc/secrets/feast
           readOnly: true
+        {{- range $secret := .Values.secrets }}
+        - name: {{ $secret }}
+          mountPath: "/etc/secrets/{{ $secret }}"
+          readOnly: true
+        {{- end }}
 
         env:
         - name: LOG_TYPE

--- a/infra/charts/feast/charts/feast-serving/values.yaml
+++ b/infra/charts/feast/charts/feast-serving/values.yaml
@@ -147,5 +147,8 @@ nodeSelector: {}
 # envOverrides -- Extra environment variables to set
 envOverrides: {}
 
+# secrets -- List of Kubernetes secrets to be mounted on Feast Core pods. These secrets will be mounted on /etc/secrets/<secret name>.
+secrets: []
+
 # podLabels -- Labels to be added to Feast Serving pods
 podLabels: {}


### PR DESCRIPTION
…

Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, users has no way to mount existing Kubernetes secrets to Feast services. One of the consequences of this is that Feast Core and Feast Serving would not be able to use GCP authentication, since there is no way to set up Google Application Credential.

This PR adds a new helm values called `secrets`, which the user can provide the list of kubernetes secrets to be mounted. They can then use envoverride variable to setup the credentials.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
