### PR TITLE
Add Prow to AWS codebuild trigger

### DIFF
--- a/.prow/config.yaml
+++ b/.prow/config.yaml
@@ -219,8 +219,8 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: amazon/aws-cli
-          command: [ "infra/scripts/test-end-to-end-aws.sh" ]
+        - image: gcr.io/kf-feast/feast-ci:latest
+          command: [ "infra/scripts/codebuild_runner.py", "--source-location", "https://github.com/${REPO_OWNER}/${REPO_NAME}.git", "--source-version", "$PULL_PULL_SHA" ]
           resources:
             requests:
               cpu: "2"

--- a/infra/docker/ci/Dockerfile
+++ b/infra/docker/ci/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get install -y build-essential curl python${PYTHON_VERSION} \
     python get-pip.py --force-reinstall && \
     rm get-pip.py
 
+# Instal boto3
+RUN pip install boto3==1.16.10
 
 # Install Go
 ENV GOLANG_VERSION 1.14.1


### PR DESCRIPTION
Signed-off-by: Oleg Avdeev <oleg.v.avdeev@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Trigger AWS cicd from prow. It won't succeed yet since that would require the other AWS CICD PR to land, but will allow me to test the other PR.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
