### PR TITLE
In Historical Retrieval (SDK) use project from client context

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -1007,9 +1007,7 @@ class Client:
             )
 
     def get_historical_features_df(
-        self,
-        feature_refs: List[str],
-        entity_source: Union[FileSource, BigQuerySource],
+        self, feature_refs: List[str], entity_source: Union[FileSource, BigQuerySource],
     ):
         """
         Launch a historical feature retrieval job.

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -906,7 +906,6 @@ class Client:
         self,
         feature_refs: List[str],
         entity_source: Union[pd.DataFrame, FileSource, BigQuerySource],
-        project: Optional[str] = None,
         output_location: Optional[str] = None,
     ) -> RetrievalJob:
         """
@@ -928,8 +927,6 @@ class Client:
                 The user needs to make sure that the source (or staging location, if entity_source is
                 a Panda DataFrame) is accessible from the Spark cluster that will be used for the
                 retrieval job.
-            project: Specifies the project that contains the feature tables
-                which the requested features belong to.
             destination_path: Specifies the path in a bucket to write the exported feature data files
 
         Returns:
@@ -945,13 +942,12 @@ class Client:
             >>> feature_refs = ["bookings:bookings_7d", "bookings:booking_14d"]
             >>> entity_source = FileSource("event_timestamp", ParquetFormat(), "gs://some-bucket/customer")
             >>> feature_retrieval_job = feast_client.get_historical_features(
-            >>>     feature_refs, entity_source, project="my_project")
+            >>>     feature_refs, entity_source)
             >>> output_file_uri = feature_retrieval_job.get_output_file_uri()
                 "gs://some-bucket/output/
         """
-        project = project or FEAST_DEFAULT_OPTIONS[CONFIG_PROJECT_KEY]
         feature_tables = self._get_feature_tables_from_feature_refs(
-            feature_refs, project
+            feature_refs, self.project
         )
 
         if output_location is None:
@@ -988,7 +984,7 @@ class Client:
                 GetHistoricalFeaturesRequest(
                     feature_refs=feature_refs,
                     entity_source=entity_source.to_proto(),
-                    project=project,
+                    project=self.project,
                     output_format=output_format,
                     output_location=output_location,
                 ),
@@ -1014,7 +1010,6 @@ class Client:
         self,
         feature_refs: List[str],
         entity_source: Union[FileSource, BigQuerySource],
-        project: str = None,
     ):
         """
         Launch a historical feature retrieval job.
@@ -1027,8 +1022,6 @@ class Client:
             entity_source (Union[FileSource, BigQuerySource]): Source for the entity rows.
                 The user needs to make sure that the source is accessible from the Spark cluster
                 that will be used for the retrieval job.
-            project: Specifies the project that contains the feature tables
-                which the requested features belong to.
 
         Returns:
                 Returns the historical feature retrieval result in the form of Spark dataframe.
@@ -1043,10 +1036,10 @@ class Client:
             >>> feature_refs = ["bookings:bookings_7d", "bookings:booking_14d"]
             >>> entity_source = FileSource("event_timestamp", ParquetFormat, "gs://some-bucket/customer")
             >>> df = feast_client.get_historical_features(
-            >>>     feature_refs, entity_source, project="my_project")
+            >>>     feature_refs, entity_source)
         """
         feature_tables = self._get_feature_tables_from_feature_refs(
-            feature_refs, project
+            feature_refs, self.project
         )
         return start_historical_feature_retrieval_spark_session(
             client=self,


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Previously it was mandatory to specify project in `get_historical_features` and `client.project` was not used, which is a bug.
This PR proposes to sync signatures of `get_historical_features` & `start_offline_to_online_ingestion` and use project from client context only.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
