### PR TITLE
Implement Job Service control loop for stream ingestion jobs

### DIFF
--- a/protos/feast/core/JobService.proto
+++ b/protos/feast/core/JobService.proto
@@ -72,6 +72,8 @@ message Job {
   JobType type = 2;
   // Current job status
   JobStatus status = 3;
+  // Deterministic hash of the Job
+  string hash = 8;
 
   message RetrievalJobMeta {
     string output_location = 4;

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -52,6 +52,7 @@ CONFIG_SERVING_SERVER_SSL_CERT_KEY = "serving_server_ssl_cert"
 CONFIG_JOB_SERVICE_URL_KEY = "job_service_url"
 CONFIG_JOB_SERVICE_ENABLE_SSL_KEY = "job_service_enable_ssl"
 CONFIG_JOB_SERVICE_SERVER_SSL_CERT_KEY = "job_service_server_ssl_cert"
+CONFIG_JOB_SERVICE_ENABLE_CONTROL_LOOP = "job_service_enable_control_loop"
 CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY = "grpc_connection_timeout_default"
 CONFIG_GRPC_CONNECTION_TIMEOUT_APPLY_KEY = "grpc_connection_timeout_apply"
 CONFIG_BATCH_FEATURE_REQUEST_WAIT_TIME_SECONDS_KEY = (
@@ -143,6 +144,8 @@ FEAST_DEFAULT_OPTIONS = {
     CONFIG_JOB_SERVICE_ENABLE_SSL_KEY: "False",
     # Path to certificate(s) to secure connection to Feast Job Service
     CONFIG_JOB_SERVICE_SERVER_SSL_CERT_KEY: "",
+    # Disable control loop by default for now
+    CONFIG_JOB_SERVICE_ENABLE_CONTROL_LOOP: "False",
     CONFIG_STATSD_ENABLED: "False",
     # IngestionJob DeadLetter Destination
     CONFIG_DEADLETTER_PATH: "",

--- a/sdk/python/feast/job_service.py
+++ b/sdk/python/feast/job_service.py
@@ -236,7 +236,7 @@ def start_job_service():
 
     client = feast.Client()
 
-    if client._config.get(CONFIG_JOB_SERVICE_ENABLE_CONTROL_LOOP) != "False":
+    if client._config.getboolean(CONFIG_JOB_SERVICE_ENABLE_CONTROL_LOOP):
         # Start the control loop thread only if it's enabled from configs
         thread = threading.Thread(target=run_control_loop, daemon=True)
         thread.start()

--- a/sdk/python/feast/job_service.py
+++ b/sdk/python/feast/job_service.py
@@ -124,7 +124,7 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
             request.table_name, request.project
         )
 
-        if self.client._config.get(CONFIG_JOB_SERVICE_ENABLE_CONTROL_LOOP) != "False":
+        if self.client._config.getboolean(CONFIG_JOB_SERVICE_ENABLE_CONTROL_LOOP):
             # If the control loop is enabled, return existing stream ingestion job id instead of starting a new one
             params = get_stream_to_online_ingestion_params(
                 self.client, request.project, feature_table, []

--- a/sdk/python/feast/pyspark/abc.py
+++ b/sdk/python/feast/pyspark/abc.py
@@ -474,6 +474,9 @@ class StreamIngestionJob(SparkJob):
     Container for the streaming ingestion job result
     """
 
+    def get_job_hash(self):
+        raise NotImplementedError
+
 
 class JobLauncher(abc.ABC):
     """

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import TYPE_CHECKING, List, Union
 
 from feast.config import Config
 from feast.constants import (
@@ -309,10 +309,3 @@ def get_job_by_id(job_id: str, client: "Client") -> SparkJob:
 def stage_dataframe(df, event_timestamp_column: str, client: "Client") -> FileSource:
     launcher = resolve_launcher(client._config)
     return launcher.stage_dataframe(df, event_timestamp_column)
-
-
-def list_jobs_by_hash(
-    client: "Client", include_terminated: bool
-) -> Dict[str, SparkJob]:
-    launcher = resolve_launcher(client._config)
-    return launcher.list_jobs_by_hash(include_terminated=include_terminated)

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, Dict, List, Union
 
 from feast.config import Config
 from feast.constants import (
@@ -263,6 +263,26 @@ def start_offline_to_online_ingestion(
     )
 
 
+def get_stream_to_online_ingestion_params(
+    client: "Client", project: str, feature_table: FeatureTable, extra_jars: List[str]
+) -> StreamIngestionJobParameters:
+    return StreamIngestionJobParameters(
+        jar=client._config.get(CONFIG_SPARK_INGESTION_JOB_JAR),
+        extra_jars=extra_jars,
+        source=_source_to_argument(feature_table.stream_source),
+        feature_table=_feature_table_to_argument(client, project, feature_table),
+        redis_host=client._config.get(CONFIG_REDIS_HOST),
+        redis_port=client._config.getint(CONFIG_REDIS_PORT),
+        redis_ssl=client._config.getboolean(CONFIG_REDIS_SSL),
+        statsd_host=client._config.getboolean(CONFIG_STATSD_ENABLED)
+        and client._config.get(CONFIG_STATSD_HOST),
+        statsd_port=client._config.getboolean(CONFIG_STATSD_ENABLED)
+        and client._config.getint(CONFIG_STATSD_PORT),
+        deadletter_path=client._config.get(CONFIG_DEADLETTER_PATH),
+        stencil_url=client._config.get(CONFIG_STENCIL_URL),
+    )
+
+
 def start_stream_to_online_ingestion(
     client: "Client", project: str, feature_table: FeatureTable, extra_jars: List[str]
 ) -> StreamIngestionJob:
@@ -270,20 +290,8 @@ def start_stream_to_online_ingestion(
     launcher = resolve_launcher(client._config)
 
     return launcher.start_stream_to_online_ingestion(
-        StreamIngestionJobParameters(
-            jar=client._config.get(CONFIG_SPARK_INGESTION_JOB_JAR),
-            extra_jars=extra_jars,
-            source=_source_to_argument(feature_table.stream_source),
-            feature_table=_feature_table_to_argument(client, project, feature_table),
-            redis_host=client._config.get(CONFIG_REDIS_HOST),
-            redis_port=client._config.getint(CONFIG_REDIS_PORT),
-            redis_ssl=client._config.getboolean(CONFIG_REDIS_SSL),
-            statsd_host=client._config.getboolean(CONFIG_STATSD_ENABLED)
-            and client._config.get(CONFIG_STATSD_HOST),
-            statsd_port=client._config.getboolean(CONFIG_STATSD_ENABLED)
-            and client._config.getint(CONFIG_STATSD_PORT),
-            deadletter_path=client._config.get(CONFIG_DEADLETTER_PATH),
-            stencil_url=client._config.get(CONFIG_STENCIL_URL),
+        get_stream_to_online_ingestion_params(
+            client, project, feature_table, extra_jars
         )
     )
 
@@ -301,3 +309,10 @@ def get_job_by_id(job_id: str, client: "Client") -> SparkJob:
 def stage_dataframe(df, event_timestamp_column: str, client: "Client") -> FileSource:
     launcher = resolve_launcher(client._config)
     return launcher.stage_dataframe(df, event_timestamp_column)
+
+
+def list_jobs_by_hash(
+    client: "Client", include_terminated: bool
+) -> Dict[str, SparkJob]:
+    launcher = resolve_launcher(client._config)
+    return launcher.list_jobs_by_hash(include_terminated=include_terminated)

--- a/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
+++ b/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
@@ -183,6 +183,7 @@ class JobInfo(NamedTuple):
     state: str
     table_name: Optional[str]
     output_file_uri: Optional[str]
+    job_hash: Optional[str]
 
 
 def _list_jobs(
@@ -228,6 +229,8 @@ def _list_jobs(
                         "feast.step_metadata.historical_retrieval.output_file_uri"
                     )
 
+                    job_hash = props.get("feast.step_metadata.job_hash")
+
                     if table_name and step_table_name != table_name:
                         continue
 
@@ -241,6 +244,7 @@ def _list_jobs(
                             state=step["Status"]["State"],
                             table_name=step_table_name,
                             output_file_uri=output_file_uri,
+                            job_hash=job_hash,
                         )
                     )
     return res
@@ -360,7 +364,11 @@ def _historical_retrieval_step(
 
 
 def _stream_ingestion_step(
-    jar_path: str, extra_jar_paths: List[str], feature_table_name: str, args: List[str],
+    jar_path: str,
+    extra_jar_paths: List[str],
+    feature_table_name: str,
+    args: List[str],
+    job_hash: str,
 ) -> Dict[str, Any]:
 
     if extra_jar_paths:
@@ -380,6 +388,7 @@ def _stream_ingestion_step(
                     "Key": "feast.step_metadata.stream_to_online.table_name",
                     "Value": feature_table_name,
                 },
+                {"Key": "feast.step_metadata.job_hash", "Value": job_hash},
             ],
             "Args": ["spark-submit", "--class", "feast.ingestion.IngestionJob"]
             + jars_args

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -344,3 +344,6 @@ class DataprocClusterLauncher(JobLauncher):
                 project_id=self.project_id, region=self.region, filter=job_filter
             )
         ]
+
+    def list_jobs_by_hash(self, include_terminated: bool) -> Dict[str, SparkJob]:
+        raise NotImplementedError

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -174,6 +174,19 @@ class DataprocStreamingIngestionJob(DataprocJobMixin, StreamIngestionJob):
     Streaming Ingestion job result for a Dataproc cluster
     """
 
+    def __init__(
+        self,
+        job: Job,
+        refresh_fn: Callable[[], Job],
+        cancel_fn: Callable[[], None],
+        job_hash: str,
+    ) -> None:
+        super.__init__(job, refresh_fn, cancel_fn)
+        self._job_hash = job_hash
+
+    def get_hash(self) -> str:
+        return self._job_hash
+
 
 class DataprocClusterLauncher(JobLauncher):
     """
@@ -184,6 +197,7 @@ class DataprocClusterLauncher(JobLauncher):
 
     EXTERNAL_JARS = ["gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar"]
     JOB_TYPE_LABEL_KEY = "feast_job_type"
+    JOB_HASH_LABEL_KEY = "feast_job_hash"
 
     def __init__(
         self, cluster_name: str, staging_location: str, region: str, project_id: str,
@@ -238,6 +252,11 @@ class DataprocClusterLauncher(JobLauncher):
             "placement": {"cluster_name": self.cluster_name},
             "labels": {self.JOB_TYPE_LABEL_KEY: job_params.get_job_type().name.lower()},
         }
+
+        # Add job hash to labels only for the stream ingestion job
+        if isinstance(job_params, StreamIngestionJobParameters):
+            job_config["labels"][self.JOB_HASH_LABEL_KEY] = job_params.get_job_hash()
+
         if job_params.get_class_name():
             job_config.update(
                 {
@@ -300,7 +319,8 @@ class DataprocClusterLauncher(JobLauncher):
         self, ingestion_job_params: StreamIngestionJobParameters
     ) -> StreamIngestionJob:
         job, refresh_fn, cancel_fn = self.dataproc_submit(ingestion_job_params)
-        return DataprocStreamingIngestionJob(job, refresh_fn, cancel_fn)
+        job_hash = ingestion_job_params.get_job_hash()
+        return DataprocStreamingIngestionJob(job, refresh_fn, cancel_fn, job_hash)
 
     def stage_dataframe(self, df, event_timestamp_column: str):
         raise NotImplementedError
@@ -330,7 +350,8 @@ class DataprocClusterLauncher(JobLauncher):
             return DataprocBatchIngestionJob(job, refresh_fn, cancel_fn)
 
         if job_type == SparkJobType.STREAM_INGESTION.name.lower():
-            return DataprocStreamingIngestionJob(job, refresh_fn, cancel_fn)
+            job_hash = job.labels[self.JOB_HASH_LABEL_KEY]
+            return DataprocStreamingIngestionJob(job, refresh_fn, cancel_fn, job_hash)
 
         raise ValueError(f"Unrecognized job type: {job_type}")
 
@@ -344,6 +365,3 @@ class DataprocClusterLauncher(JobLauncher):
                 project_id=self.project_id, region=self.region, filter=job_filter
             )
         ]
-
-    def list_jobs_by_hash(self, include_terminated: bool) -> Dict[str, SparkJob]:
-        raise NotImplementedError

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -181,7 +181,7 @@ class DataprocStreamingIngestionJob(DataprocJobMixin, StreamIngestionJob):
         cancel_fn: Callable[[], None],
         job_hash: str,
     ) -> None:
-        super.__init__(job, refresh_fn, cancel_fn)
+        super().__init__(job, refresh_fn, cancel_fn)
         self._job_hash = job_hash
 
     def get_hash(self) -> str:

--- a/sdk/python/feast/pyspark/launchers/standalone/local.py
+++ b/sdk/python/feast/pyspark/launchers/standalone/local.py
@@ -87,7 +87,7 @@ class JobCache:
             return jobs_by_hash
 
 
-JOB_CACHE = JobCache()
+job_cache = JobCache()
 
 
 def _find_free_port():
@@ -293,7 +293,7 @@ class StandaloneClusterLauncher(JobLauncher):
             self.spark_submit(job_params),
             job_params.get_destination_path(),
         )
-        JOB_CACHE.add_job(job_id, None, job)
+        job_cache.add_job(job_id, None, job)
         return job
 
     def offline_to_online_ingestion(
@@ -307,7 +307,7 @@ class StandaloneClusterLauncher(JobLauncher):
             self.spark_submit(ingestion_job_params, ui_port),
             ui_port,
         )
-        JOB_CACHE.add_job(job_id, None, job)
+        job_cache.add_job(job_id, None, job)
         return job
 
     def start_stream_to_online_ingestion(
@@ -321,33 +321,33 @@ class StandaloneClusterLauncher(JobLauncher):
             self.spark_submit(ingestion_job_params, ui_port),
             ui_port,
         )
-        JOB_CACHE.add_job(job_id, ingestion_job_params.get_job_hash(), job)
+        job_cache.add_job(job_id, ingestion_job_params.get_job_hash(), job)
         return job
 
     def stage_dataframe(self, df, event_timestamp_column: str):
         raise NotImplementedError
 
     def get_job_by_id(self, job_id: str) -> SparkJob:
-        return JOB_CACHE.get_job_by_id(job_id)
+        return job_cache.get_job_by_id(job_id)
 
     def list_jobs(self, include_terminated: bool) -> List[SparkJob]:
         if include_terminated is True:
-            return JOB_CACHE.list_jobs()
+            return job_cache.list_jobs()
         else:
             return [
                 job
-                for job in JOB_CACHE.list_jobs()
+                for job in job_cache.list_jobs()
                 if job.get_status()
                 in (SparkJobStatus.STARTING, SparkJobStatus.IN_PROGRESS)
             ]
 
     def list_jobs_by_hash(self, include_terminated: bool) -> Dict[str, SparkJob]:
         if include_terminated is True:
-            return JOB_CACHE.list_jobs_by_hash()
+            return job_cache.list_jobs_by_hash()
         else:
             return {
                 job_hash: job
-                for job_hash, job in JOB_CACHE.list_jobs_by_hash().items()
+                for job_hash, job in job_cache.list_jobs_by_hash().items()
                 if job.get_status()
                 in (SparkJobStatus.STARTING, SparkJobStatus.IN_PROGRESS)
             }

--- a/sdk/python/feast/remote_job.py
+++ b/sdk/python/feast/remote_job.py
@@ -124,13 +124,12 @@ class RemoteStreamIngestionJob(RemoteJobMixin, StreamIngestionJob):
     Stream ingestion job result.
     """
 
-    def __init__(
-        self,
-        service: JobServiceStub,
-        grpc_extra_param_provider: GrpcExtraParamProvider,
-        job_id: str,
-    ):
-        super().__init__(service, grpc_extra_param_provider, job_id)
+    def get_hash(self) -> str:
+        response = self._service.GetJob(
+            GetJobRequest(job_id=self._job_id), **self._grpc_extra_param_provider()
+        )
+
+        return response.job.hash
 
 
 def get_remote_job_from_proto(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
In this PR we implement the control loop in Job Service, which runs in the background thread and ensures that stream ingestion jobs are always running. It does this by generating a deterministic hash for each stream ingestion job and ensuring that all jobs with these hashes are in STARTING or RUNNING states, and also by ensuring that all other Spark jobs are terminated.
The implementation includes standalone & EMR modes. I haven't added the implementation for dataproc yet.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
You can now enable Feast Job Service's control loop by setting `FEAST_JOB_SERVICE_ENABLE_CONTROL_LOOP` env variable to `True`. This will start a background thread in Job Service, ensuring that all stream ingestion jobs are automatically running. This mean you won't have to call `client.start_stream_to_online_ingestion` manually again.
```
