### PR TITLE
Add feature table name & job id to deadletter destination

### DIFF
--- a/sdk/python/feast/pyspark/abc.py
+++ b/sdk/python/feast/pyspark/abc.py
@@ -348,7 +348,12 @@ class IngestionJobParameters(SparkJobParameters):
             args.extend(["--statsd", json.dumps(self._get_statsd_config())])
 
         if self._deadletter_path:
-            args.extend(["--deadletter-path", self._deadletter_path])
+            args.extend(
+                [
+                    "--deadletter-path",
+                    os.path.join(self._deadletter_path, self.get_feature_table_name()),
+                ]
+            )
 
         if self._stencil_url:
             args.extend(["--stencil-url", self._stencil_url])

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -245,6 +245,7 @@ class DataprocClusterLauncher(JobLauncher):
                         "jar_file_uris": [main_file_uri] + self.EXTERNAL_JARS,
                         "main_class": job_params.get_class_name(),
                         "args": job_params.get_arguments(),
+                        "properties": {"spark.yarn.user.classpath.first": "true"},
                     }
                 }
             )

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -68,6 +68,7 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.fullVersion}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -16,10 +16,13 @@
  */
 package feast.ingestion
 
+import java.nio.file.Paths
+
 import feast.ingestion.sources.bq.BigQueryReader
 import feast.ingestion.sources.file.FileReader
 import feast.ingestion.validation.{RowValidator, TypeCheck}
-import org.apache.spark.sql.{Column, SparkSession}
+import org.apache.spark.SparkEnv
+import org.apache.spark.sql.{Column, SaveMode, SparkSession}
 import org.apache.spark.sql.functions.col
 
 /**
@@ -79,7 +82,8 @@ object BatchPipeline extends BasePipeline {
           .filter(!validator.checkAll)
           .write
           .format("parquet")
-          .save(path)
+          .mode(SaveMode.Append)
+          .save(Paths.get(path, SparkEnv.get.conf.getAppId).toString)
       case _ => None
     }
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -16,11 +16,14 @@
  */
 package feast.ingestion
 
+import java.nio.file.Paths
+
 import feast.ingestion.registry.proto.ProtoRegistryFactory
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.functions.udf
 import feast.ingestion.utils.ProtoReflection
 import feast.ingestion.validation.{RowValidator, TypeCheck}
+import org.apache.spark.SparkEnv
 import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.sql.avro._
 
@@ -94,7 +97,7 @@ object StreamingPipeline extends BasePipeline with Serializable {
               .write
               .format("parquet")
               .mode(SaveMode.Append)
-              .save(path)
+              .save(Paths.get(path, SparkEnv.get.conf.getAppId).toString)
           case _ =>
             batchDF
               .filter(!validator.checkAll)

--- a/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
@@ -16,6 +16,8 @@
  */
 package feast.ingestion
 
+import java.nio.file.Paths
+
 import collection.JavaConverters._
 import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
 import feast.proto.types.ValueProto.ValueType
@@ -210,7 +212,11 @@ class BatchPipelineIT extends SparkSpec with ForAllTestContainer {
     jedis.keys("*").toArray should be(empty)
 
     sparkSession.read
-      .parquet(deadletterConfig.deadLetterPath.get)
+      .parquet(
+        Paths
+          .get(deadletterConfig.deadLetterPath.get, sparkSession.conf.get("spark.app.id"))
+          .toString
+      )
       .count() should be(rows.length)
   }
 

--- a/spark/ingestion/src/test/scala/feast/ingestion/SparkSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/SparkSpec.scala
@@ -29,6 +29,16 @@ class SparkSpec extends UnitSpec with BeforeAndAfter {
       .setMaster("local[4]")
       .setAppName("Testing")
       .set("spark.default.parallelism", "8")
+      .set(
+        "spark.metrics.conf.*.source.redis.class",
+        "org.apache.spark.metrics.source.RedisSinkMetricSource"
+      )
+      .set(
+        "spark.metrics.conf.*.sink.statsd.class",
+        "org.apache.spark.metrics.sink.StatsdSinkWithTags"
+      )
+      .set("spark.metrics.conf.*.sink.statsd.host", "localhost")
+      .set("spark.metrics.conf.*.sink.statsd.port", "8125")
 
     sparkSession = SparkSession
       .builder()

--- a/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/StreamingPipelineIT.scala
@@ -16,6 +16,7 @@
  */
 package feast.ingestion
 
+import java.nio.file.Paths
 import java.util.Properties
 
 import com.dimafeng.testcontainers.{
@@ -165,7 +166,11 @@ class StreamingPipelineIT extends SparkSpec with ForAllTestContainer {
     query.processAllAvailable()
 
     sparkSession.read
-      .parquet(configWithDeadletter.deadLetterPath.get)
+      .parquet(
+        Paths
+          .get(configWithDeadletter.deadLetterPath.get, sparkSession.conf.get("spark.app.id"))
+          .toString
+      )
       .count() should be(2 * rows.length)
   }
 


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR makes deadletter path unique per feature table & job run (using spark app id)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
