### PR TITLE
[E2E] In Streaming Test filter kafka consumers by group id prefix

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -53,7 +53,6 @@ object StreamingPipeline extends BasePipeline with Serializable {
           .format("kafka")
           .option("kafka.bootstrap.servers", source.bootstrapServers)
           .option("subscribe", source.topic)
-          .option("groupIdPrefix", "feast-kafka-reader")
           .load()
     }
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -53,6 +53,7 @@ object StreamingPipeline extends BasePipeline with Serializable {
           .format("kafka")
           .option("kafka.bootstrap.servers", source.bootstrapServers)
           .option("subscribe", source.topic)
+          .option("groupIdPrefix", "feast-kafka-reader")
           .load()
     }
 

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -244,7 +244,11 @@ def send_avro_record_to_kafka(topic, value, bootstrap_servers, avro_schema_json)
 def check_consumer_exist(bootstrap_servers, topic_name):
     admin = KafkaAdminClient(bootstrap_servers=bootstrap_servers)
     consumer_groups = admin.describe_consumer_groups(
-        group_ids=[group_id for group_id, _ in admin.list_consumer_groups()]
+        group_ids=[
+            group_id
+            for group_id, _ in admin.list_consumer_groups()
+            if group_id.startswith("feast-kafka-reader")
+        ]
     )
     subscriptions = {
         subscription

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -247,7 +247,7 @@ def check_consumer_exist(bootstrap_servers, topic_name):
         group_ids=[
             group_id
             for group_id, _ in admin.list_consumer_groups()
-            if group_id.startswith("feast-kafka-reader")
+            if group_id.startswith("spark-kafka-source")
         ]
     )
     subscriptions = {


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
