### PR TITLE
Make created_timestamp property optional in KafkaSource

### DIFF
--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -611,10 +611,10 @@ class KafkaSource(DataSource):
     def __init__(
         self,
         event_timestamp_column: str,
-        created_timestamp_column: str,
         bootstrap_servers: str,
         message_format: StreamFormat,
         topic: str,
+        created_timestamp_column: Optional[str] = "",
         field_mapping: Optional[Dict[str, str]] = dict(),
         date_partition_column: Optional[str] = "",
     ):

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -411,7 +411,6 @@ class TestClient:
             message_format=ProtoFormat("class.path"),
             topic="test_topic",
             event_timestamp_column="ts_col",
-            created_timestamp_column="timestamp",
         )
 
         ft1 = FeatureTable(

--- a/sdk/python/tests/test_feature_table.py
+++ b/sdk/python/tests/test_feature_table.py
@@ -78,7 +78,6 @@ class TestFeatureTable:
             message_format=ProtoFormat(class_path="class.path"),
             topic="test_topic",
             event_timestamp_column="ts_col",
-            created_timestamp_column="timestamp",
         )
 
         test_feature_table = FeatureTable(

--- a/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
@@ -63,7 +63,7 @@ trait BasePipeline {
     jobConfig.stencilURL match {
       case Some(url: String) =>
         conf
-          .set("feast.ingestion.registry.proto.kind", "local")
+          .set("feast.ingestion.registry.proto.kind", "stencil")
           .set("feast.ingestion.registry.proto.url", url)
       case None => ()
     }

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -119,10 +119,9 @@ def test_streaming_ingestion(
             file_url=os.path.join(local_staging_path, "batch-storage"),
         ),
         stream_source=KafkaSource(
-            "event_timestamp",
-            "event_timestamp",
-            kafka_broker,
-            AvroFormat(avro_schema()),
+            event_timestamp_column="event_timestamp",
+            bootstrap_servers=kafka_broker,
+            message_format=AvroFormat(avro_schema()),
             topic=topic_name,
         ),
     )

--- a/tests/e2e/test_register.py
+++ b/tests/e2e/test_register.py
@@ -63,7 +63,6 @@ def basic_featuretable():
         message_format=ProtoFormat(class_path="class.path"),
         topic="test_topic",
         event_timestamp_column="datetime_col",
-        created_timestamp_column="timestamp",
     )
     return FeatureTable(
         name="basic_featuretable",


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

To keep SDK API consistent (currently created timestamp is optional for File & BQ sources) this PR make optional `created_timestamp_column` in KafkaSource as well

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
