### PR TITLE
Fix stencil client serialization issue

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/registry/proto/StencilProtoRegistry.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/registry/proto/StencilProtoRegistry.scala
@@ -22,9 +22,15 @@ import com.gojek.de.stencil.StencilClientFactory
 import com.gojek.de.stencil.client.StencilClient
 
 class StencilProtoRegistry(val url: String) extends ProtoRegistry {
+  @transient
+  private var _stencilClient: StencilClient = _
 
-  val stencilClient: StencilClient =
-    StencilClientFactory.getClient(url, Collections.emptyMap[String, String])
+  def stencilClient: StencilClient = {
+    if (_stencilClient == null) {
+      _stencilClient = StencilClientFactory.getClient(url, Collections.emptyMap[String, String])
+    }
+    _stencilClient
+  }
 
   override def getProtoDescriptor(className: String): Descriptors.Descriptor = {
     stencilClient.get(className)


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

```
Caused by: java.io.NotSerializableException: com.gojek.de.stencil.cache.DescriptorCacheLoader
Serialization stack:
	- object not serializable (class: com.gojek.de.stencil.cache.DescriptorCacheLoader, value: com.gojek.de.stencil.cache.DescriptorCacheLoader@5fb7af07)
	- field (class: com.gojek.de.stencil.client.URLStencilClient, name: cacheLoader, type: class com.gojek.de.stencil.cache.DescriptorCacheLoader)
	- object (class com.gojek.de.stencil.client.URLStencilClient, com.gojek.de.stencil.client.URLStencilClient@70c56f9d)
	- field (class: feast.ingestion.registry.proto.StencilProtoRegistry, name: stencilClient, type: interface com.gojek.de.stencil.client.StencilClient)
	- object (class feast.ingestion.registry.proto.StencilProtoRegistry, feast.ingestion.registry.proto.StencilProtoRegistry@35067eda)
	- element of array (index: 0)
	- array (class [Ljava.lang.Object;, size 2)
	- field (class: java.lang.invoke.SerializedLambda, name: capturedArgs, type: class [Ljava.lang.Object;)
	- object (class java.lang.invoke.SerializedLambda, SerializedLambda[capturingClass=class feast.ingestion.StreamingPipeline$, functionalInterfaceMethod=scala/Function1.apply:(Ljava/lang/Object;)Ljava/lang/Object;, implementation=invokeStatic feast/ingestion/StreamingPipeline$.$anonfun$protoParser$1:(Lfeast/ingestion/registry/proto/ProtoRegistry;Ljava/lang/String;[B)Lorg/apache/spark/sql/Row;, instantiatedMethodType=([B)Lorg/apache/spark/sql/Row;, numCaptured=2])
	- writeReplace data (class: java.lang.invoke.SerializedLambda)
	- object (class feast.ingestion.StreamingPipeline$$$Lambda$1473/1085738801, feast.ingestion.StreamingPipeline$$$Lambda$1473/1085738801@423c9375)
	- element of array (index: 3)
	- array (class [Ljava.lang.Object;, size 10)
	- element of array (index: 1)
	- array (class [Ljava.lang.Object;, size 3)
	- field (class: java.lang.invoke.SerializedLambda, name: capturedArgs, type: class [Ljava.lang.Object;)
	- object (class java.lang.invoke.SerializedLambda, SerializedLambda[capturingClass=class org.apache.spark.sql.execution.WholeStageCodegenExec, functionalInterfaceMethod=scala/Function2.apply:(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;, implementation=invokeStatic org/apache/spark/sql/execution/WholeStageCodegenExec.$anonfun$doExecute$4$adapted:(Lorg/apache/spark/sql/catalyst/expressions/codegen/CodeAndComment;[Ljava/lang/Object;Lorg/apache/spark/sql/execution/metric/SQLMetric;Ljava/lang/Object;Lscala/collection/Iterator;)Lscala/collection/Iterator;, instantiatedMethodType=(Ljava/lang/Object;Lscala/collection/Iterator;)Lscala/collection/Iterator;, numCaptured=3])
	- writeReplace data (class: java.lang.invoke.SerializedLambda)
	- object (class org.apache.spark.sql.execution.WholeStageCodegenExec$$Lambda$2182/174006344, org.apache.spark.sql.execution.WholeStageCodegenExec$$Lambda$2182/174006344@74f95597)
	at org.apache.spark.serializer.SerializationDebugger$.improveException(SerializationDebugger.scala:41)
	at org.apache.spark.serializer.JavaSerializationStream.writeObject(JavaSerializer.scala:46)
	at org.apache.spark.serializer.JavaSerializerInstance.serialize(JavaSerializer.scala:100)
	at org.apache.spark.util.ClosureCleaner$.ensureSerializable(ClosureCleaner.scala:413)
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
