### PR TITLE
Add bitnami repository before building helm chart

### DIFF
--- a/infra/scripts/sync-helm-charts.sh
+++ b/infra/scripts/sync-helm-charts.sh
@@ -30,6 +30,8 @@ fi
 
 exit_code=0
 
+helm repo add bitnami bitnami https://charts.bitnami.com/bitnami
+
 for dir in "$repo_dir"/*; do
     if  helm dep update "$dir" && helm dep build "$dir"; then
         helm package --destination "$sync_dir" "$dir"


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
The publish helm chart release step is failing due to failure to build the chart, caused by missing repository.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
