### PR TITLE
Fix revision arg when building image

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -25,7 +25,7 @@ jobs:
           --archive-uri ${MAVEN_CACHE} \
           --output-dir .
       - name: Build image
-        run: make build-${{ matrix.component }}-docker REGISTRY=${REGISTRY} VERSION=${GITHUB_SHA}
+        run: make build-${{ matrix.component }}-docker REGISTRY=${REGISTRY} VERSION=${GITHUB_SHA} REVISION=dev
       - name: Push image
         run: |
           docker push ${REGISTRY}/feast-${{ matrix.component }}:${GITHUB_SHA}

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -27,18 +27,18 @@ jobs:
           infra/scripts/download-maven-cache.sh \
           --archive-uri ${MAVEN_CACHE} \
           --output-dir .
+      - name: Get version
+        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
       - name: Build image
-        run: make build-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
+        run: make build-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA} REVISION=${RELEASE_VERSION}
       - name: Push image
-        run: make push-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
+        run: make push-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA} REVISION=${RELEASE_VERSION}
       - name: Push development Docker image
         run: |
           if [ ${GITHUB_REF#refs/*/} == "master" ]; then
             docker tag gcr.io/kf-feast/feast-${{ matrix.component }}:${GITHUB_SHA} gcr.io/kf-feast/feast-${{ matrix.component }}:develop
             docker push gcr.io/kf-feast/feast-${{ matrix.component }}:develop
           fi
-      - name: Get version
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
       - name: Push versioned Docker image
         run: |
           source infra/scripts/setup-common-functions.sh

--- a/Makefile
+++ b/Makefile
@@ -141,13 +141,13 @@ push-jupyter-docker:
 	docker push $(REGISTRY)/feast-jupyter:$(VERSION)
 
 build-core-docker:
-	docker build -t $(REGISTRY)/feast-core:$(VERSION) -f infra/docker/core/Dockerfile .
+	docker build --build-arg REVISION=$(REVISION) -t $(REGISTRY)/feast-core:$(VERSION) -f infra/docker/core/Dockerfile .
 
 build-jobservice-docker:
 	docker build -t $(REGISTRY)/feast-jobservice:$(VERSION) -f infra/docker/jobservice/Dockerfile .
 
 build-serving-docker:
-	docker build -t $(REGISTRY)/feast-serving:$(VERSION) -f infra/docker/serving/Dockerfile .
+	docker build --build-arg REVISION=$(REVISION) -t $(REGISTRY)/feast-serving:$(VERSION) -f infra/docker/serving/Dockerfile .
 
 build-ci-docker:
 	docker build -t $(REGISTRY)/feast-ci:$(VERSION) -f infra/docker/ci/Dockerfile .

--- a/infra/docker/ci/Dockerfile
+++ b/infra/docker/ci/Dockerfile
@@ -1,5 +1,7 @@
 FROM maven:3.6-jdk-11
 
+ARG REVISION
+
 # Install Google Cloud SDK
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/infra/docker/jobservice/Dockerfile
+++ b/infra/docker/jobservice/Dockerfile
@@ -1,6 +1,7 @@
 FROM jupyter/pyspark-notebook:ae5f7e104dd5
 
 USER root
+ARG REVISION
 WORKDIR /feast
 
 COPY sdk/python sdk/python

--- a/infra/docker/jobservice/Dockerfile
+++ b/infra/docker/jobservice/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get -y install make git wget
 RUN make compile-protos-python
 
 # Install Feast SDK
-COPY .git .git
+RUN git init .
 COPY README.md README.md
 RUN pip install -U -e sdk/python
 RUN pip install "s3fs" "boto3" "urllib3>=1.25.4"

--- a/infra/docker/jupyter/Dockerfile
+++ b/infra/docker/jupyter/Dockerfile
@@ -1,6 +1,7 @@
 FROM jupyter/pyspark-notebook:ae5f7e104dd5
 
 USER root
+ARG REVISION
 WORKDIR /feast
 
 COPY sdk/python sdk/python

--- a/infra/docker/jupyter/Dockerfile
+++ b/infra/docker/jupyter/Dockerfile
@@ -16,7 +16,7 @@ RUN make compile-protos-python
 RUN pip install -r sdk/python/requirements-ci.txt
 
 # Install Feast SDK
-COPY .git .git
+RUN git init .
 COPY README.md README.md
 RUN pip install -e sdk/python -U
 RUN pip install "s3fs" "boto3" "urllib3>=1.25.4"


### PR DESCRIPTION
Signed-off-by: Terence <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, images are built with `dev` default value for REVISION arg when building images eg. [Dockerfile](https://github.com/feast-dev/feast/blob/master/infra/docker/core/Dockerfile#L32). 
This results in the following when calling version API.
```
{'serving': {'url': 'example.feast:6566', 'version': 'dev'},
'core': {'url': 'example.feast:6565', 'version': 'dev'}}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE.
```
