### PR TITLE
Fix helm repo addition and dockerhub path context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
           RELEASE_VERSION: ${{ needs.get-version.outputs.release_version }}
         with:
           push: true
+          context: infra/docker/${{ matrix.component }}
           file: infra/docker/${{ matrix.component }}/Dockerfile
           tags: feastdev/feast-${{ matrix.component }}:${{ needs.get-version.outputs.release_version }}
           build-args: |
@@ -93,6 +94,7 @@ jobs:
         with:
           if: ${VERSION_WITHOUT_PREFIX} == ${HIGHEST_SEMVER_TAG:1}
           push: true
+          context: infra/docker/${{ matrix.component }}
           file: infra/docker/${{ matrix.component }}/Dockerfile
           tags: feastdev/feast-${{ matrix.component }}:latest
           build-args: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,11 @@ jobs:
           RELEASE_VERSION: ${{ needs.get-version.outputs.release_version }}
         with:
           push: true
-          context: infra/docker/${{ matrix.component }}
-          file: infra/docker/${{ matrix.component }}/Dockerfile
+          context: .
+          file: ./infra/docker/${{ matrix.component }}/Dockerfile
           tags: feastdev/feast-${{ matrix.component }}:${{ needs.get-version.outputs.release_version }}
           build-args: |
-            REVISION=${RELEASE_VERSION}
+            REVISION=$RELEASE_VERSION
       - name: Build and push latest
         uses: docker/build-push-action@v2
         env:
@@ -94,11 +94,11 @@ jobs:
         with:
           if: ${VERSION_WITHOUT_PREFIX} == ${HIGHEST_SEMVER_TAG:1}
           push: true
-          context: infra/docker/${{ matrix.component }}
-          file: infra/docker/${{ matrix.component }}/Dockerfile
+          context: .
+          file: ./infra/docker/${{ matrix.component }}/Dockerfile
           tags: feastdev/feast-${{ matrix.component }}:latest
           build-args: |
-            REVISION=${RELEASE_VERSION}
+            REVISION=$RELEASE_VERSION
 
   publish-helm-charts:
     runs-on:  ubuntu-latest

--- a/infra/scripts/sync-helm-charts.sh
+++ b/infra/scripts/sync-helm-charts.sh
@@ -30,7 +30,7 @@ fi
 
 exit_code=0
 
-helm repo add bitnami bitnami https://charts.bitnami.com/bitnami
+helm repo add bitnami https://charts.bitnami.com/bitnami
 
 for dir in "$repo_dir"/*; do
     if  helm dep update "$dir" && helm dep build "$dir"; then


### PR DESCRIPTION
Signed-off-by: Terence <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
- `helm repo add` command has additional parameter when being called in sync-helm-charts.sh bash script
- context is not provided when running build-push to dockerhub

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
