### PR TITLE
make aws e2e tests use correct feast_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@
 ROOT_DIR 	:= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 PROTO_TYPE_SUBDIRS = core serving types storage
 PROTO_SERVICE_SUBDIRS = core serving
+MVN := mvn ${MAVEN_EXTRA_OPTS}
 
 # General
 
@@ -35,28 +36,28 @@ install-ci-dependencies: install-python-ci-dependencies install-go-ci-dependenci
 # Java
 
 install-java-ci-dependencies:
-	mvn verify clean --fail-never
+	${MVN} verify clean --fail-never
 
 format-java:
-	mvn spotless:apply
+	${MVN} spotless:apply
 
 lint-java:
-	mvn --no-transfer-progress spotless:check
+	${MVN} --no-transfer-progress spotless:check
 
 test-java:
-	mvn --no-transfer-progress test
+	${MVN} --no-transfer-progress test
 
 test-java-integration:
-	mvn --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true clean verify
+	${MVN} --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true clean verify
 
 test-java-with-coverage:
-	mvn --no-transfer-progress test jacoco:report-aggregate
+	${MVN} --no-transfer-progress test jacoco:report-aggregate
 
 build-java:
-	mvn clean verify
+	${MVN} clean verify
 
 build-java-no-tests:
-	mvn --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true -Drevision=${REVISION} clean package
+	${MVN} --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true -Drevision=${REVISION} clean package
 
 # Python SDK
 
@@ -141,13 +142,13 @@ push-jupyter-docker:
 	docker push $(REGISTRY)/feast-jupyter:$(VERSION)
 
 build-core-docker:
-	docker build --build-arg REVISION=$(REVISION) -t $(REGISTRY)/feast-core:$(VERSION) -f infra/docker/core/Dockerfile .
+	docker build $(if, $(REVISION),--build-arg REVISION=$(REVISION),) -t $(REGISTRY)/feast-core:$(VERSION) -f infra/docker/core/Dockerfile .
 
 build-jobservice-docker:
 	docker build -t $(REGISTRY)/feast-jobservice:$(VERSION) -f infra/docker/jobservice/Dockerfile .
 
 build-serving-docker:
-	docker build --build-arg REVISION=$(REVISION) -t $(REGISTRY)/feast-serving:$(VERSION) -f infra/docker/serving/Dockerfile .
+	docker build $(if, $(REVISION),--build-arg REVISION=$(REVISION),) -t $(REGISTRY)/feast-serving:$(VERSION) -f infra/docker/serving/Dockerfile .
 
 build-ci-docker:
 	docker build -t $(REGISTRY)/feast-ci:$(VERSION) -f infra/docker/ci/Dockerfile .

--- a/infra/scripts/setup-e2e-env-aws.sh
+++ b/infra/scripts/setup-e2e-env-aws.sh
@@ -8,7 +8,8 @@ python -m pip install -qr sdk/python/requirements-dev.txt
 python -m pip install -qr tests/requirements.txt
 
 # Using mvn -q to make it less verbose. This step happens after docker containers were
-# succesfully built so it should be unlikely to fail.
+# succesfully built so it should be unlikely to fail, therefore we likely won't need detailed logs.
 echo "########## Building ingestion jar"
 TIMEFORMAT='########## took %R seconds'
-time mvn -q --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true clean package
+
+time make build-java-no-tests REVISION=develop MAVEN_EXTRA_OPTS="-q --no-transfer-progress"

--- a/infra/scripts/test-end-to-end-aws.sh
+++ b/infra/scripts/test-end-to-end-aws.sh
@@ -8,6 +8,7 @@ export DISABLE_FEAST_SERVICE_FIXTURES=1
 export DISABLE_SERVICE_FIXTURES=1
 
 PYTHONPATH=sdk/python pytest tests/e2e/ \
+      --feast-version develop \
       --core-url cicd-feast-core:6565 \
       --serving-url cicd-feast-online-serving:6566 \
       --env aws \

--- a/tests/e2e/fixtures/base.py
+++ b/tests/e2e/fixtures/base.py
@@ -12,5 +12,5 @@ def project_root():
 def project_version(pytestconfig):
     if pytestconfig.getoption("feast_version"):
         return pytestconfig.getoption("feast_version")
-
-    return "0.8-SNAPSHOT"
+    else:
+        raise Exception("feast_version not set")


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
feast_version was not set in AWS e2e pipeline

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
