### PR TITLE
Expires Redis Keys based on Feature Table Max Age

### DIFF
--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -182,14 +182,14 @@
         <dependency>
             <groupId>com.dimafeng</groupId>
             <artifactId>testcontainers-scala-scalatest_${scala.version}</artifactId>
-            <version>0.38.3</version>
+            <version>0.38.6</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.dimafeng</groupId>
             <artifactId>testcontainers-scala-kafka_${scala.version}</artifactId>
-            <version>0.38.3</version>
+            <version>0.38.6</version>
             <scope>test</scope>
         </dependency>
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -72,6 +72,7 @@ object BatchPipeline extends BasePipeline {
       .option("namespace", featureTable.name)
       .option("project_name", featureTable.project)
       .option("timestamp_column", config.source.eventTimestampColumn)
+      .option("max_age", config.featureTable.maxAge.getOrElse(0))
       .save()
 
     config.deadLetterPath match {

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -17,7 +17,6 @@
 package feast.ingestion
 
 import org.joda.time.DateTime
-
 import org.json4s._
 import org.json4s.jackson.JsonMethods.{parse => parseJSON}
 import org.json4s.ext.JavaEnumNameSerializer
@@ -29,7 +28,7 @@ object IngestionJob {
     new JavaEnumNameSerializer[feast.proto.types.ValueProto.ValueType.Enum]() +
     ShortTypeHints(List(classOf[ProtoFormat], classOf[AvroFormat]))
 
-  val parser = new scopt.OptionParser[IngestionJobConfig]("IngestionJon") {
+  val parser = new scopt.OptionParser[IngestionJobConfig]("IngestionJob") {
     // ToDo: read version from Manifest
     head("feast.ingestion.IngestionJob", "0.8.0")
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -91,7 +91,8 @@ case class FeatureTable(
     name: String,
     project: String,
     entities: Seq[Field],
-    features: Seq[Field]
+    features: Seq[Field],
+    maxAge: Option[Int] = None
 )
 
 case class IngestionJobConfig(

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -87,6 +87,7 @@ object StreamingPipeline extends BasePipeline with Serializable {
           .option("namespace", featureTable.name)
           .option("project_name", featureTable.project)
           .option("timestamp_column", config.source.eventTimestampColumn)
+          .option("max_age", config.featureTable.maxAge.getOrElse(0))
           .save()
 
         config.deadLetterPath match {

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/HashTypePersistence.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/HashTypePersistence.scala
@@ -105,7 +105,9 @@ class HashTypePersistence(config: SparkRedisConfig) extends Persistence with Ser
   ): Unit = {
     val value = encodeRow(row, expiryTimestamp).asJava
     pipeline.hset(key, value)
-    if (!expiryTimestamp.equals(maxExpiryTimestamp)) {
+    if (expiryTimestamp.equals(maxExpiryTimestamp)) {
+      pipeline.persist(key)
+    } else {
       pipeline.expireAt(key, expiryTimestamp.getTime / 1000)
     }
   }

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/Persistence.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/Persistence.scala
@@ -16,26 +16,63 @@
  */
 package feast.ingestion.stores.redis
 
+import java.sql.Timestamp
+
 import org.apache.spark.sql.Row
 import redis.clients.jedis.{Pipeline, Response}
 
-trait Persistence {
-  def encodeRow(
-      keyColumns: Array[String],
-      timestampField: String,
-      value: Row
-  ): Map[Array[Byte], Array[Byte]]
+/**
+  * Determine how a Spark row should be serialized and stored on Redis.
+  */
+trait Persistence[T] {
 
+  /**
+    * Persist a Spark row to Redis
+    *
+    * @param pipeline              Redis pipeline
+    * @param key                   Redis key in serialized bytes format
+    * @param row                   Row representing the value to be persist
+    * @param expiryTimestamp       Expiry timestamp for the row
+    */
   def save(
       pipeline: Pipeline,
       key: Array[Byte],
-      value: Map[Array[Byte], Array[Byte]],
-      ttl: Int
+      row: Row,
+      expiryTimestamp: Timestamp
   ): Unit
 
-  def getTimestamp(
+  /**
+    * Returns a Redis response, which can be used by `storedTimestamp` and `newExpiryTimestamp` to
+    * derive the currently stored event timestamp, and the updated expiry timestamp. This method will
+    * be called prior to persisting the row to Redis, so that `RedisSinkRelation` can decide whether
+    * the currently stored value should be updated.
+    *
+    * @param pipeline              Redis pipeline
+    * @param key                   Redis key in serialized bytes format
+    * @return                      Redis response representing the row value
+    */
+  def get(
       pipeline: Pipeline,
-      key: Array[Byte],
-      timestampField: String
-  ): Response[Array[Byte]]
+      key: Array[Byte]
+  ): Response[T]
+
+  /**
+    * Returns the currently stored event timestamp for the key and the feature table associated with the ingestion job.
+    *
+    * @param value              Response returned from `get`
+    * @return                   Stored event timestamp associated with the key. Returns `None` if
+    *                           the key is not present in Redis, or if timestamp information is
+    *                           unavailable on the stored value.
+    */
+  def storedTimestamp(value: T): Option[Timestamp]
+
+  /**
+    * Compute the new expiry timestamp, based on the currently stored value and the new row
+    *
+    * @param row                Row representing the value to be persist
+    * @param value              Response returned from `get`
+    * @return                   Expiry timestamp for the new row to be persisted. Will be used
+    *                           to compute ttl for the Redis key
+    */
+  def newExpiryTimestamp(row: Row, value: T): Timestamp
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/SparkRedisConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/SparkRedisConfig.scala
@@ -23,7 +23,9 @@ case class SparkRedisConfig(
     timestampColumn: String,
     iteratorGroupingSize: Int = 1000,
     timestampPrefix: String = "_ts",
-    repartitionByEntity: Boolean = true
+    repartitionByEntity: Boolean = true,
+    maxAge: Int = 0,
+    expiryPrefix: String = "_ex"
 )
 
 object SparkRedisConfig {
@@ -32,6 +34,7 @@ object SparkRedisConfig {
   val TS_COLUMN          = "timestamp_column"
   val ENTITY_REPARTITION = "entity_repartition"
   val PROJECT_NAME       = "project_name"
+  val MAX_AGE            = "max_age"
 
   def parse(parameters: Map[String, String]): SparkRedisConfig =
     SparkRedisConfig(
@@ -39,6 +42,7 @@ object SparkRedisConfig {
       projectName = parameters.getOrElse(PROJECT_NAME, "default"),
       entityColumns = parameters.getOrElse(ENTITY_COLUMNS, "").split(","),
       timestampColumn = parameters.getOrElse(TS_COLUMN, "event_timestamp"),
-      repartitionByEntity = parameters.getOrElse(ENTITY_REPARTITION, "true") == "true"
+      repartitionByEntity = parameters.getOrElse(ENTITY_REPARTITION, "true") == "true",
+      maxAge = parameters.get(MAX_AGE).map(_.toInt).getOrElse(0)
     )
 }

--- a/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
@@ -17,9 +17,11 @@
 package feast.ingestion
 
 import java.nio.file.Paths
+import java.sql.Timestamp
 
 import collection.JavaConverters._
 import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import com.google.protobuf.util.Timestamps
 import feast.proto.types.ValueProto.ValueType
 import org.apache.spark.SparkConf
 import org.joda.time.{DateTime, Seconds}
@@ -106,16 +108,101 @@ class BatchPipelineIT extends SparkSpec with ForAllTestContainer {
     val featureKeyEncoder: String => String = encodeFeatureKey(config.featureTable)
 
     rows.foreach(r => {
-      val storedValues = jedis.hgetAll(encodeEntityKey(r, config.featureTable)).asScala.toMap
+      val encodedEntityKey = encodeEntityKey(r, config.featureTable)
+      val storedValues     = jedis.hgetAll(encodedEntityKey).asScala.toMap
       storedValues should beStoredRow(
         Map(
           featureKeyEncoder("feature1") -> r.feature1,
           featureKeyEncoder("feature2") -> r.feature2,
-          "_ts:test-fs"                 -> r.eventTimestamp
+          "_ts:test-fs"                 -> r.eventTimestamp,
+          "_ex:test-fs"                 -> new Timestamp(Timestamps.MAX_VALUE.getSeconds * 1000)
         )
       )
+      val keyTTL = jedis.ttl(encodedEntityKey).toInt
+      keyTTL shouldEqual -1
+
     })
   }
+
+  "Parquet source file" should "be ingested in redis with expiry time equal to the largest of (event_timestamp + max_age) for" +
+    "all feature tables associated with the entity" in new Scope {
+      val startDate = new DateTime().minusDays(1).withTimeAtStartOfDay()
+      val endDate   = new DateTime().withTimeAtStartOfDay()
+      val gen       = rowGenerator(startDate, endDate)
+      val rows      = generateDistinctRows(gen, 1000, groupByEntity)
+      val tempPath  = storeAsParquet(sparkSession, rows)
+      val maxAge    = 86400 * 2
+      val configWithMaxAge = config.copy(
+        source = FileSource(tempPath, Map.empty, "eventTimestamp"),
+        featureTable = config.featureTable.copy(maxAge = Some(maxAge)),
+        startTime = startDate,
+        endTime = endDate
+      )
+
+      val ingestionTimeUnix = System.currentTimeMillis()
+      BatchPipeline.createPipeline(sparkSession, configWithMaxAge)
+
+      val featureKeyEncoder: String => String = encodeFeatureKey(config.featureTable)
+
+      rows.foreach(r => {
+        val encodedEntityKey = encodeEntityKey(r, config.featureTable)
+        val storedValues     = jedis.hgetAll(encodedEntityKey).asScala.toMap
+        val expectedExpiryTimestamp =
+          new java.sql.Timestamp(r.eventTimestamp.getTime + 1000 * maxAge)
+        storedValues should beStoredRow(
+          Map(
+            featureKeyEncoder("feature1") -> r.feature1,
+            featureKeyEncoder("feature2") -> r.feature2,
+            "_ts:test-fs"                 -> r.eventTimestamp,
+            "_ex:test-fs"                 -> expectedExpiryTimestamp
+          )
+        )
+        val keyTTL = jedis.ttl(encodedEntityKey).toLong
+        keyTTL should (be <= (expectedExpiryTimestamp.getTime - ingestionTimeUnix) / 1000 and be > 0L)
+
+      })
+
+      val increasedMaxAge = 86400 * 3
+      val configWithSecondFeatureTable = config.copy(
+        source = FileSource(tempPath, Map.empty, "eventTimestamp"),
+        featureTable = config.featureTable.copy(
+          name = "test-fs-2",
+          maxAge = Some(increasedMaxAge)
+        ),
+        startTime = startDate,
+        endTime = endDate
+      )
+
+      val secondIngestionTimeUnix = System.currentTimeMillis()
+      BatchPipeline.createPipeline(sparkSession, configWithSecondFeatureTable)
+      BatchPipeline.createPipeline(sparkSession, configWithMaxAge)
+
+      val featureKeyEncoderSecondTable: String => String =
+        encodeFeatureKey(configWithSecondFeatureTable.featureTable)
+
+      rows.foreach(r => {
+        val encodedEntityKey = encodeEntityKey(r, config.featureTable)
+        val storedValues     = jedis.hgetAll(encodedEntityKey).asScala.toMap
+        val expectedExpiryTimestamp1 =
+          new java.sql.Timestamp(r.eventTimestamp.getTime + 1000 * maxAge)
+        val expectedExpiryTimestamp2 =
+          new java.sql.Timestamp(r.eventTimestamp.getTime + 1000 * increasedMaxAge)
+        storedValues should beStoredRow(
+          Map(
+            featureKeyEncoder("feature1")            -> r.feature1,
+            featureKeyEncoder("feature2")            -> r.feature2,
+            featureKeyEncoderSecondTable("feature1") -> r.feature1,
+            featureKeyEncoderSecondTable("feature2") -> r.feature2,
+            "_ts:test-fs"                            -> r.eventTimestamp,
+            "_ex:test-fs"                            -> expectedExpiryTimestamp1,
+            "_ex:test-fs-2"                          -> expectedExpiryTimestamp2
+          )
+        )
+        val keyTTL = jedis.ttl(encodedEntityKey).toLong
+        keyTTL should (be <= (expectedExpiryTimestamp2.getTime - secondIngestionTimeUnix) / 1000 and be > (expectedExpiryTimestamp1.getTime - secondIngestionTimeUnix) / 1000)
+
+      })
+    }
 
   "Ingested rows" should "be compacted before storing by timestamp column" in new Scope {
     val entities = (0 to 10000).map(_.toString)

--- a/spark/ingestion/src/test/scala/feast/ingestion/helpers/RedisStorageHelper.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/helpers/RedisStorageHelper.scala
@@ -38,14 +38,15 @@ object RedisStorageHelper {
 
     m compose {
       (_: Map[Array[Byte], Array[Byte]])
-        .map { case (k, v) =>
-          if (k.length == 4)
+        .map {
+          case (k, v) if k.length == 4 =>
             (
               ByteBuffer.wrap(k).order(ByteOrder.LITTLE_ENDIAN).getInt.toHexString,
               ValueProto.Value.parseFrom(v).asScala
             )
-          else
+          case (k, v) if k.startsWith("_ts".getBytes) || k.startsWith("_ex".getBytes) =>
             (new String(k), Timestamp.parseFrom(v).asScala)
+          case (k, v) => (new String(k), ValueProto.Value.parseFrom(v).asScala)
         }
     }
   }


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Since the release of Feast 0.8, the Redis ingestion is performed via Spark ingestion module rather than the existing Redis storage module. Hence, #955 is not applicable to Feast 0.8. 

For the current implementation, instead of a global value of ttl which would be applicable to all Redis key, the ttl will be computed based on the max ages of all the feature tables associated with the Redis Key. For example, if two feature table are associated with the Redis key, the ttl will be computed as follows:

```
ttl = max(event_timestamp_feature_table_1 + max_age_feature_table_1, event_timestamp_feature_table_2 + max_age_feature_table_2) - current time
```

In the event where any of the feature table associated with the Redis key has max age set to 0, ttl will not be set.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
After this PR, the key stored on Redis will be deleted when it is older than event_timestamp + max age, unless the key is also associated with another feature table where max age is not specified, or the expiry time is in the future.
```
