### PR TITLE
Stabilize flaky e2e tests

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -133,7 +133,7 @@ jobs:
     - publish-ingestion-jar
     runs-on: ubuntu-latest
     env:
-      INGESTION_JAR_PATH: /shared/feast-ingestion-spark-develop.jar
+      INGESTION_JAR_PATH: /shared/feast-ingestion-spark-not-develop.jar
     steps:
       - uses: actions/checkout@v2
       - name: Download ingestion jar

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -150,6 +150,15 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '11'
+      - name: MVN cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-mvn-repo
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
       - name: build-jar
         env:
           # Try to add retries to prevent connection resets
@@ -162,4 +171,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ingestion-jar
-          path: ./spark/ingestion/target/feast-ingestion-spark-${GITHUB_SHA}.jar
+          path: spark/ingestion/target/feast-ingestion-spark-${{ GITHUB_SHA }}.jar
+          retention-days: 1

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -133,7 +133,7 @@ jobs:
     - publish-ingestion-jar
     runs-on: ubuntu-latest
     env:
-      INGESTION_JAR_PATH: /shared/feast-ingestion-spark-not-develop.jar
+      INGESTION_JAR_PATH: /shared/feast-ingestion-spark-develop.jar
     steps:
       - uses: actions/checkout@v2
       - name: Download ingestion jar

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -140,6 +140,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: ingestion-jar
+          path: ./infra/docker-compose/
       - name: Test docker compose
         run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}
 

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -133,7 +133,7 @@ jobs:
     - publish-ingestion-jar
     runs-on: ubuntu-latest
     env:
-      INGESTION_JAR_PATH: /shared/feast-ingestion-spark-${GITHUB_SHA}.jar
+      INGESTION_JAR_PATH: /shared/feast-ingestion-spark-develop.jar
     steps:
       - uses: actions/checkout@v2
       - name: Download ingestion jar
@@ -151,15 +151,13 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '11'
-      - name: MVN cache
+      - name: Cache local Maven repository
         uses: actions/cache@v2
-        env:
-          cache-name: cache-mvn-repo
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-maven-
       - name: build-jar
         env:
           # Try to add retries to prevent connection resets
@@ -167,10 +165,10 @@ jobs:
           # https://github.com/actions/virtual-environments/issues/1499#issuecomment-718396233
           MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
           MAVEN_EXTRA_OPTS: -X
-        run: make build-java-no-tests REVISION=${GITHUB_SHA}
+        run: make build-java-no-tests REVISION=develop
       - name: Upload ingestion jar
         uses: actions/upload-artifact@v2
         with:
           name: ingestion-jar
-          path: spark/ingestion/target/feast-ingestion-spark-${{ GITHUB_SHA }}.jar
+          path: spark/ingestion/target/feast-ingestion-spark-develop.jar
           retention-days: 1

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -132,25 +132,24 @@ jobs:
     - build-push-docker-images
     - publish-ingestion-jar
     runs-on: ubuntu-latest
+    env:
+      INGESTION_JAR_PATH: /shared/feast-ingestion-spark-${GITHUB_SHA}.jar
     steps:
       - uses: actions/checkout@v2
+      - name: Download ingestion jar
+        uses: actions/download-artifact@v2
+        with:
+          name: ingestion-jar
       - name: Test docker compose
         run: ./infra/scripts/test-docker-compose.sh ${GITHUB_SHA}
 
   publish-ingestion-jar:
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-        with:
-          version: '290.0.1'
-          export_default_credentials: true
       - uses: actions/setup-java@v1
         with:
           java-version: '11'
-      - uses: stCarolas/setup-maven@v3
-        with:
-          maven-version: 3.6.3
       - name: build-jar
         env:
           # Try to add retries to prevent connection resets
@@ -159,5 +158,8 @@ jobs:
           MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
           MAVEN_EXTRA_OPTS: -X
         run: make build-java-no-tests REVISION=${GITHUB_SHA}
-      - name: copy to gs
-        run: gsutil cp ./spark/ingestion/target/feast-ingestion-spark-${GITHUB_SHA}.jar gs://feast-jobs/spark/ingestion/
+      - name: Upload ingestion jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: ingestion-jar
+          path: ./spark/ingestion/target/feast-ingestion-spark-${GITHUB_SHA}.jar

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
   publish-ingestion-jar:
-    runs-on: [ self-hosted ]
+    runs-on: ubuntu-latest
     env:
       PUBLISH_BUCKET: feast-jobs
     steps:
@@ -72,12 +72,11 @@ jobs:
         with:
           version: '290.0.1'
           export_default_credentials: true
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
       - uses: actions/setup-java@v1
         with:
           java-version: '11'
-      - uses: stCarolas/setup-maven@v3
-        with:
-          maven-version: 3.6.3
       - name: Publish develop version of ingestion job
         run: |
           if [ ${GITHUB_REF#refs/*/} == "master" ]; then

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -77,6 +77,13 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: '11'
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Publish develop version of ingestion job
         run: |
           if [ ${GITHUB_REF#refs/*/} == "master" ]; then

--- a/infra/docker-compose/.env.sample
+++ b/infra/docker-compose/.env.sample
@@ -3,3 +3,4 @@ FEAST_VERSION=develop
 FEAST_CORE_CONFIG=./core/core.yml
 FEAST_ONLINE_SERVING_CONFIG=./serving/online-serving.yml
 GCP_SERVICE_ACCOUNT=./gcp-service-accounts/placeholder.json
+INGESTION_JAR_PATH=https://storage.googleapis.com/feast-jobs/spark/ingestion/feast-ingestion-spark-develop.jar

--- a/infra/docker-compose/docker-compose.yml
+++ b/infra/docker-compose/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       FEAST_HISTORICAL_FEATURE_OUTPUT_LOCATION: file:///shared/historical_feature_output
       FEAST_HISTORICAL_FEATURE_OUTPUT_FORMAT: parquet
       FEAST_REDIS_HOST: redis
+      FEAST_SPARK_INGESTION_JAR: ${INGESTION_JAR_PATH}
 
   jupyter:
     image: gcr.io/kf-feast/feast-jupyter:${FEAST_VERSION}

--- a/infra/scripts/test-end-to-end-gcp.sh
+++ b/infra/scripts/test-end-to-end-gcp.sh
@@ -4,7 +4,7 @@ export DISABLE_SERVICE_FIXTURES=1
 export MAVEN_OPTS="-Dmaven.repo.local=/tmp/.m2/repository -DdependencyLocationsEnabled=false"
 export MAVEN_CACHE="gs://feast-templocation-kf-feast/.m2.2020-11-17.tar"
 
-download-maven-cache.sh --archive-uri ${MAVEN_CACHE} --output-dir /tmp
+infra/scripts/download-maven-cache.sh --archive-uri ${MAVEN_CACHE} --output-dir /tmp
 apt-get update && apt-get install -y redis-server postgresql libpq-dev
 
 make build-java-no-tests REVISION=develop

--- a/infra/scripts/test-end-to-end-gcp.sh
+++ b/infra/scripts/test-end-to-end-gcp.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 export DISABLE_SERVICE_FIXTURES=1
+export MAVEN_OPTS="-Dmaven.repo.local=/tmp/.m2/repository -DdependencyLocationsEnabled=false"
+export MAVEN_CACHE="gs://feast-templocation-kf-feast/.m2.2020-11-17.tar"
 
+download-maven-cache.sh --archive-uri ${MAVEN_CACHE} --output-dir /tmp
 apt-get update && apt-get install -y redis-server postgresql libpq-dev
 
 make build-java-no-tests REVISION=develop

--- a/infra/scripts/test-end-to-end.sh
+++ b/infra/scripts/test-end-to-end.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+export MAVEN_OPTS="-Dmaven.repo.local=/tmp/.m2/repository -DdependencyLocationsEnabled=false"
+export MAVEN_CACHE="gs://feast-templocation-kf-feast/.m2.2020-11-17.tar"
+
+download-maven-cache.sh --archive-uri ${MAVEN_CACHE} --output-dir /tmp
 apt-get update && apt-get install -y redis-server postgresql libpq-dev
 
 make build-java-no-tests REVISION=develop

--- a/infra/scripts/test-end-to-end.sh
+++ b/infra/scripts/test-end-to-end.sh
@@ -3,7 +3,7 @@
 export MAVEN_OPTS="-Dmaven.repo.local=/tmp/.m2/repository -DdependencyLocationsEnabled=false"
 export MAVEN_CACHE="gs://feast-templocation-kf-feast/.m2.2020-11-17.tar"
 
-download-maven-cache.sh --archive-uri ${MAVEN_CACHE} --output-dir /tmp
+infra/scripts/download-maven-cache.sh --archive-uri ${MAVEN_CACHE} --output-dir /tmp
 apt-get update && apt-get install -y redis-server postgresql libpq-dev
 
 make build-java-no-tests REVISION=develop

--- a/tests/e2e/fixtures/feast_services.py
+++ b/tests/e2e/fixtures/feast_services.py
@@ -47,7 +47,13 @@ def _wait_port_open(port, max_wait=60):
             return
 
 
-@pytest.fixture(scope="session", params=[True, False])
+@pytest.fixture(  # type: ignore
+    scope="session",
+    params=[
+        pytest.mark.skip(True),  # type: ignore
+        False,
+    ],
+)
 def enable_auth(request):
     return request.param
 

--- a/tests/e2e/fixtures/feast_services.py
+++ b/tests/e2e/fixtures/feast_services.py
@@ -48,7 +48,7 @@ def _wait_port_open(port, max_wait=60):
 
 
 @pytest.fixture(
-    scope="session", params=[pytest.param(True, marks=pytest.mark.skip), False],
+    scope="session", params=[False],
 )
 def enable_auth(request):
     return request.param

--- a/tests/e2e/fixtures/feast_services.py
+++ b/tests/e2e/fixtures/feast_services.py
@@ -47,12 +47,8 @@ def _wait_port_open(port, max_wait=60):
             return
 
 
-@pytest.fixture(  # type: ignore
-    scope="session",
-    params=[
-        pytest.mark.skip(True),  # type: ignore
-        False,
-    ],
+@pytest.fixture(
+    scope="session", params=[pytest.param(True, marks=pytest.mark.skip), False],
 )
 def enable_auth(request):
     return request.param


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR addresses 

1. Issue with pytest parametrized fixtures dependencies: currently resolving doesn't work, thus I turned off auth parametrization
2. mvn cache issue in e2e tests
3. ingestion jar building fails. It was moved from "self-hosted" runner and now jar is being shared via flow artifactis

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
