### PR TITLE
Refactor configurable options and add sphinx docs

### DIFF
--- a/sdk/python/docs/index.rst
+++ b/sdk/python/docs/index.rst
@@ -40,4 +40,4 @@ Constants
 
 .. automodule:: feast.constants
     :members:
-    :exclude-members: AuthProvider
+    :exclude-members: AuthProvider, ConfigMeta

--- a/sdk/python/docs/index.rst
+++ b/sdk/python/docs/index.rst
@@ -34,3 +34,10 @@ Feature
 .. automodule:: feast.feature
     :inherited-members:
     :members:
+
+Constants
+==================
+
+.. automodule:: feast.constants
+    :members:
+    :exclude-members: AuthProvider

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -23,7 +23,7 @@ import yaml
 
 from feast.client import Client
 from feast.config import Config
-from feast.constants import ConfigOptions
+from feast.constants import ConfigOptions as opt
 from feast.entity import Entity
 from feast.feature_table import FeatureTable
 from feast.job_service import start_job_service
@@ -422,7 +422,7 @@ def stop_stream_to_online(feature_table: str):
     Stop stream to online sync job
     """
 
-    spark_launcher = Config().get(ConfigOptions.SPARK_LAUNCHER)
+    spark_launcher = Config().get(opt.SPARK_LAUNCHER)
 
     if spark_launcher == "emr":
         import feast.pyspark.aws.jobs
@@ -441,7 +441,7 @@ def list_jobs():
     """
     from tabulate import tabulate
 
-    spark_launcher = Config().get(ConfigOptions.SPARK_LAUNCHER)
+    spark_launcher = Config().get(opt.SPARK_LAUNCHER)
 
     if spark_launcher == "emr":
         import feast.pyspark.aws.jobs

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -23,7 +23,7 @@ import yaml
 
 from feast.client import Client
 from feast.config import Config
-from feast.constants import CONFIG_SPARK_LAUNCHER
+from feast.constants import ConfigOptions
 from feast.entity import Entity
 from feast.feature_table import FeatureTable
 from feast.job_service import start_job_service
@@ -422,7 +422,7 @@ def stop_stream_to_online(feature_table: str):
     Stop stream to online sync job
     """
 
-    spark_launcher = Config().get(CONFIG_SPARK_LAUNCHER)
+    spark_launcher = Config().get(ConfigOptions.SPARK_LAUNCHER)
 
     if spark_launcher == "emr":
         import feast.pyspark.aws.jobs
@@ -441,7 +441,7 @@ def list_jobs():
     """
     from tabulate import tabulate
 
-    spark_launcher = Config().get(CONFIG_SPARK_LAUNCHER)
+    spark_launcher = Config().get(ConfigOptions.SPARK_LAUNCHER)
 
     if spark_launcher == "emr":
         import feast.pyspark.aws.jobs

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -24,24 +24,7 @@ import grpc
 import pandas as pd
 
 from feast.config import Config
-from feast.constants import (
-    CONFIG_CORE_ENABLE_SSL_KEY,
-    CONFIG_CORE_SERVER_SSL_CERT_KEY,
-    CONFIG_CORE_URL_KEY,
-    CONFIG_ENABLE_AUTH_KEY,
-    CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY,
-    CONFIG_JOB_SERVICE_ENABLE_SSL_KEY,
-    CONFIG_JOB_SERVICE_SERVER_SSL_CERT_KEY,
-    CONFIG_JOB_SERVICE_URL_KEY,
-    CONFIG_PROJECT_KEY,
-    CONFIG_SERVING_ENABLE_SSL_KEY,
-    CONFIG_SERVING_SERVER_SSL_CERT_KEY,
-    CONFIG_SERVING_URL_KEY,
-    CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_FORMAT,
-    CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_LOCATION,
-    CONFIG_SPARK_STAGING_LOCATION,
-    FEAST_DEFAULT_OPTIONS,
-)
+from feast.constants import ConfigOptions
 from feast.core.CoreService_pb2 import (
     ApplyEntityRequest,
     ApplyEntityResponse,
@@ -81,7 +64,6 @@ from feast.feature_table import FeatureTable
 from feast.grpc import auth as feast_auth
 from feast.grpc.grpc import create_grpc_channel
 from feast.loaders.ingest import (
-    BATCH_INGESTION_PRODUCTION_TIMEOUT,
     _check_field_mappings,
     _read_table_from_source,
     _upload_to_bq_source,
@@ -158,7 +140,7 @@ class Client:
         self._auth_metadata: Optional[grpc.AuthMetadataPlugin] = None
 
         # Configure Auth Metadata Plugin if auth is enabled
-        if self._config.getboolean(CONFIG_ENABLE_AUTH_KEY):
+        if self._config.getboolean(ConfigOptions.ENABLE_AUTH):
             self._auth_metadata = feast_auth.get_auth_metadata_plugin(self._config)
 
     @property
@@ -170,12 +152,14 @@ class Client:
         """
         if not self._core_service_stub:
             channel = create_grpc_channel(
-                url=self._config.get(CONFIG_CORE_URL_KEY),
-                enable_ssl=self._config.getboolean(CONFIG_CORE_ENABLE_SSL_KEY),
-                enable_auth=self._config.getboolean(CONFIG_ENABLE_AUTH_KEY),
-                ssl_server_cert_path=self._config.get(CONFIG_CORE_SERVER_SSL_CERT_KEY),
+                url=self._config.get(ConfigOptions.CORE_URL),
+                enable_ssl=self._config.getboolean(ConfigOptions.CORE_ENABLE_SSL),
+                enable_auth=self._config.getboolean(ConfigOptions.ENABLE_AUTH),
+                ssl_server_cert_path=self._config.get(
+                    ConfigOptions.CORE_SERVER_SSL_CERT
+                ),
                 auth_metadata_plugin=self._auth_metadata,
-                timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+                timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
             )
             self._core_service_stub = CoreServiceStub(channel)
         return self._core_service_stub
@@ -189,21 +173,24 @@ class Client:
         """
         if not self._serving_service_stub:
             channel = create_grpc_channel(
-                url=self._config.get(CONFIG_SERVING_URL_KEY),
-                enable_ssl=self._config.getboolean(CONFIG_SERVING_ENABLE_SSL_KEY),
-                enable_auth=self._config.getboolean(CONFIG_ENABLE_AUTH_KEY),
+                url=self._config.get(ConfigOptions.SERVING_URL),
+                enable_ssl=self._config.getboolean(ConfigOptions.SERVING_ENABLE_SSL),
+                enable_auth=self._config.getboolean(ConfigOptions.ENABLE_AUTH),
                 ssl_server_cert_path=self._config.get(
-                    CONFIG_SERVING_SERVER_SSL_CERT_KEY
+                    ConfigOptions.SERVING_SERVER_SSL_CERT
                 ),
                 auth_metadata_plugin=self._auth_metadata,
-                timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+                timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
             )
             self._serving_service_stub = ServingServiceStub(channel)
         return self._serving_service_stub
 
     @property
     def _use_job_service(self) -> bool:
-        return self._config.exists(CONFIG_JOB_SERVICE_URL_KEY)
+        return (
+            self._config.exists(ConfigOptions.JOB_SERVICE_URL)
+            and ConfigOptions.JOB_SERVICE_URL != ""
+        )
 
     @property
     def _job_service(self):
@@ -218,21 +205,23 @@ class Client:
 
         if not self._job_service_stub:
             channel = create_grpc_channel(
-                url=self._config.get(CONFIG_JOB_SERVICE_URL_KEY),
-                enable_ssl=self._config.getboolean(CONFIG_JOB_SERVICE_ENABLE_SSL_KEY),
-                enable_auth=self._config.getboolean(CONFIG_ENABLE_AUTH_KEY),
+                url=self._config.get(ConfigOptions.JOB_SERVICE_URL),
+                enable_ssl=self._config.getboolean(
+                    ConfigOptions.JOB_SERVICE_ENABLE_SSL
+                ),
+                enable_auth=self._config.getboolean(ConfigOptions.ENABLE_AUTH),
                 ssl_server_cert_path=self._config.get(
-                    CONFIG_JOB_SERVICE_SERVER_SSL_CERT_KEY
+                    ConfigOptions.JOB_SERVICE_SERVER_SSL_CERT
                 ),
                 auth_metadata_plugin=self._auth_metadata,
-                timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+                timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
             )
             self._job_service_service_stub = JobServiceStub(channel)
         return self._job_service_service_stub
 
     def _extra_grpc_params(self) -> Dict[str, Any]:
         return dict(
-            timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+            timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
             metadata=self._get_grpc_metadata(),
         )
 
@@ -244,7 +233,7 @@ class Client:
         Returns:
             Feast Core URL string
         """
-        return self._config.get(CONFIG_CORE_URL_KEY)
+        return self._config.get(ConfigOptions.CORE_URL)
 
     @core_url.setter
     def core_url(self, value: str):
@@ -254,7 +243,7 @@ class Client:
         Args:
             value: Feast Core URL
         """
-        self._config.set(CONFIG_CORE_URL_KEY, value)
+        self._config.set(ConfigOptions.CORE_URL, value)
 
     @property
     def serving_url(self) -> str:
@@ -264,7 +253,7 @@ class Client:
         Returns:
             Feast Serving URL string
         """
-        return self._config.get(CONFIG_SERVING_URL_KEY)
+        return self._config.get(ConfigOptions.SERVING_URL)
 
     @serving_url.setter
     def serving_url(self, value: str):
@@ -274,7 +263,7 @@ class Client:
         Args:
             value: Feast Serving URL
         """
-        self._config.set(CONFIG_SERVING_URL_KEY, value)
+        self._config.set(ConfigOptions.SERVING_URL, value)
 
     @property
     def job_service_url(self) -> str:
@@ -284,7 +273,7 @@ class Client:
         Returns:
             Feast Job Service URL string
         """
-        return self._config.get(CONFIG_JOB_SERVICE_URL_KEY)
+        return self._config.get(ConfigOptions.JOB_SERVICE_URL)
 
     @job_service_url.setter
     def job_service_url(self, value: str):
@@ -294,7 +283,7 @@ class Client:
         Args:
             value: Feast Job Service URL
         """
-        self._config.set(CONFIG_JOB_SERVICE_URL_KEY, value)
+        self._config.set(ConfigOptions.JOB_SERVICE_URL, value)
 
     @property
     def core_secure(self) -> bool:
@@ -304,7 +293,7 @@ class Client:
         Returns:
             Whether client-side SSL/TLS is enabled
         """
-        return self._config.getboolean(CONFIG_CORE_ENABLE_SSL_KEY)
+        return self._config.getboolean(ConfigOptions.CORE_ENABLE_SSL)
 
     @core_secure.setter
     def core_secure(self, value: bool):
@@ -314,7 +303,7 @@ class Client:
         Args:
             value: True to enable client-side SSL/TLS
         """
-        self._config.set(CONFIG_CORE_ENABLE_SSL_KEY, value)
+        self._config.set(ConfigOptions.CORE_ENABLE_SSL, value)
 
     @property
     def serving_secure(self) -> bool:
@@ -324,7 +313,7 @@ class Client:
         Returns:
             Whether client-side SSL/TLS is enabled
         """
-        return self._config.getboolean(CONFIG_SERVING_ENABLE_SSL_KEY)
+        return self._config.getboolean(ConfigOptions.SERVING_ENABLE_SSL)
 
     @serving_secure.setter
     def serving_secure(self, value: bool):
@@ -334,7 +323,7 @@ class Client:
         Args:
             value: True to enable client-side SSL/TLS
         """
-        self._config.set(CONFIG_SERVING_ENABLE_SSL_KEY, value)
+        self._config.set(ConfigOptions.SERVING_ENABLE_SSL, value)
 
     @property
     def job_service_secure(self) -> bool:
@@ -344,7 +333,7 @@ class Client:
         Returns:
             Whether client-side SSL/TLS is enabled
         """
-        return self._config.getboolean(CONFIG_JOB_SERVICE_ENABLE_SSL_KEY)
+        return self._config.getboolean(ConfigOptions.JOB_SERVICE_ENABLE_SSL)
 
     @job_service_secure.setter
     def job_service_secure(self, value: bool):
@@ -354,7 +343,7 @@ class Client:
         Args:
             value: True to enable client-side SSL/TLS
         """
-        self._config.set(CONFIG_JOB_SERVICE_ENABLE_SSL_KEY, value)
+        self._config.set(ConfigOptions.JOB_SERVICE_ENABLE_SSL, value)
 
     def version(self):
         """
@@ -371,7 +360,7 @@ class Client:
         if self.serving_url:
             serving_version = self._serving_service.GetFeastServingInfo(
                 GetFeastServingInfoRequest(),
-                timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+                timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
                 metadata=self._get_grpc_metadata(),
             ).version
             result["serving"] = {"url": self.serving_url, "version": serving_version}
@@ -379,7 +368,7 @@ class Client:
         if self.core_url:
             core_version = self._core_service.GetFeastCoreVersion(
                 GetFeastCoreVersionRequest(),
-                timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+                timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
                 metadata=self._get_grpc_metadata(),
             ).version
             result["core"] = {"url": self.core_url, "version": core_version}
@@ -394,9 +383,9 @@ class Client:
         Returns:
             Project name
         """
-        if not self._config.get(CONFIG_PROJECT_KEY):
+        if not self._config.get(ConfigOptions.PROJECT):
             raise ValueError("No project has been configured.")
-        return self._config.get(CONFIG_PROJECT_KEY)
+        return self._config.get(ConfigOptions.PROJECT)
 
     def set_project(self, project: Optional[str] = None):
         """
@@ -406,8 +395,8 @@ class Client:
             project: Project to set as active. If unset, will reset to the default project.
         """
         if project is None:
-            project = FEAST_DEFAULT_OPTIONS[CONFIG_PROJECT_KEY]
-        self._config.set(CONFIG_PROJECT_KEY, project)
+            project = ConfigOptions().PROJECT
+        self._config.set(ConfigOptions.PROJECT, project)
 
     def list_projects(self) -> List[str]:
         """
@@ -420,7 +409,7 @@ class Client:
 
         response = self._core_service.ListProjects(
             ListProjectsRequest(),
-            timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+            timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
             metadata=self._get_grpc_metadata(),
         )  # type: ListProjectsResponse
         return list(response.projects)
@@ -435,7 +424,7 @@ class Client:
 
         self._core_service.CreateProject(
             CreateProjectRequest(name=project),
-            timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+            timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
             metadata=self._get_grpc_metadata(),
         )  # type: CreateProjectResponse
 
@@ -452,7 +441,7 @@ class Client:
         try:
             self._core_service_stub.ArchiveProject(
                 ArchiveProjectRequest(name=project),
-                timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+                timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
                 metadata=self._get_grpc_metadata(),
             )  # type: ArchiveProjectResponse
         except grpc.RpcError as e:
@@ -460,7 +449,7 @@ class Client:
 
         # revert to the default project
         if self._project == project:
-            self._project = FEAST_DEFAULT_OPTIONS[CONFIG_PROJECT_KEY]
+            self._project = ConfigOptions().PROJECT
 
     def apply_entity(self, entities: Union[List[Entity], Entity], project: str = None):
         """
@@ -513,7 +502,7 @@ class Client:
         try:
             apply_entity_response = self._core_service.ApplyEntity(
                 ApplyEntityRequest(project=project, spec=entity_proto),  # type: ignore
-                timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+                timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
                 metadata=self._get_grpc_metadata(),
             )  # type: ApplyEntityResponse
         except grpc.RpcError as e:
@@ -625,7 +614,7 @@ class Client:
         try:
             apply_feature_table_response = self._core_service.ApplyFeatureTable(
                 ApplyFeatureTableRequest(project=project, table_spec=feature_table_proto),  # type: ignore
-                timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+                timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
                 metadata=self._get_grpc_metadata(),
             )  # type: ApplyFeatureTableResponse
         except grpc.RpcError as e:
@@ -722,7 +711,7 @@ class Client:
         project: str = None,
         chunk_size: int = 10000,
         max_workers: int = max(CPU_COUNT - 1, 1),
-        timeout: int = BATCH_INGESTION_PRODUCTION_TIMEOUT,
+        timeout: int = int(ConfigOptions().BATCH_INGESTION_PRODUCTION_TIMEOUT),
     ) -> None:
         """
         Batch load feature data into a FeatureTable.
@@ -849,7 +838,7 @@ class Client:
 
         Returns: Tuple of metadata to attach to each gRPC call
         """
-        if self._config.getboolean(CONFIG_ENABLE_AUTH_KEY) and self._auth_metadata:
+        if self._config.getboolean(ConfigOptions.ENABLE_AUTH) and self._auth_metadata:
             return self._auth_metadata.get_signed_meta()
         return ()
 
@@ -895,7 +884,7 @@ class Client:
                     entity_rows=_infer_online_entity_rows(entity_rows),
                     project=project if project is not None else self.project,
                 ),
-                timeout=self._config.getint(CONFIG_GRPC_CONNECTION_TIMEOUT_DEFAULT_KEY),
+                timeout=self._config.getint(ConfigOptions.GRPC_CONNECTION_TIMEOUT),
                 metadata=self._get_grpc_metadata(),
             )
         except grpc.RpcError as e:
@@ -954,10 +943,10 @@ class Client:
 
         if output_location is None:
             output_location = os.path.join(
-                self._config.get(CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_LOCATION),
+                self._config.get(ConfigOptions.HISTORICAL_FEATURE_OUTPUT_LOCATION),
                 str(uuid.uuid4()),
             )
-        output_format = self._config.get(CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_FORMAT)
+        output_format = self._config.get(ConfigOptions.HISTORICAL_FEATURE_OUTPUT_FORMAT)
         feature_sources = [
             feature_table.batch_source for feature_table in feature_tables
         ]
@@ -978,7 +967,9 @@ class Client:
             else:
                 entity_source = stage_entities_to_fs(
                     entity_source,
-                    staging_location=self._config.get(CONFIG_SPARK_STAGING_LOCATION),
+                    staging_location=self._config.get(
+                        ConfigOptions.SPARK_STAGING_LOCATION
+                    ),
                 )
 
         if self._use_job_service:

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -187,10 +187,7 @@ class Client:
 
     @property
     def _use_job_service(self) -> bool:
-        return (
-            self._config.exists(ConfigOptions.JOB_SERVICE_URL)
-            and ConfigOptions.JOB_SERVICE_URL != ""
-        )
+        return ConfigOptions.JOB_SERVICE_URL is not None
 
     @property
     def _job_service(self):

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -187,7 +187,7 @@ class Client:
 
     @property
     def _use_job_service(self) -> bool:
-        return ConfigOptions.JOB_SERVICE_URL is not None
+        return self._config.get(ConfigOptions.JOB_SERVICE_URL) is not None
 
     @property
     def _job_service(self):

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -183,10 +183,7 @@ class Client:
 
     @property
     def _use_job_service(self) -> bool:
-        return (
-            self._config.exists(opt.JOB_SERVICE_URL)
-            and self._config.get(opt.JOB_SERVICE_URL) != ""
-        )
+        return self._config.exists(opt.JOB_SERVICE_URL)
 
     @property
     def _job_service(self):

--- a/sdk/python/feast/config.py
+++ b/sdk/python/feast/config.py
@@ -19,7 +19,7 @@ from configparser import ConfigParser, NoOptionError
 from os.path import expanduser, join
 from typing import Dict, Optional
 
-from feast.constants import ConfigOptions
+from feast.constants import ConfigOptions as opt
 
 _logger = logging.getLogger(__name__)
 
@@ -43,13 +43,13 @@ def _init_config(path: str):
     os.makedirs(os.path.dirname(config_dir), exist_ok=True)
 
     # Create the configuration file itself
-    config = ConfigParser(defaults=ConfigOptions().defaults())
+    config = ConfigParser(defaults=opt().defaults())
     if os.path.exists(path):
         config.read(path)
 
     # Store all configuration in a single section
-    if not config.has_section(ConfigOptions().CONFIG_FILE_SECTION):
-        config.add_section(ConfigOptions().CONFIG_FILE_SECTION)
+    if not config.has_section(opt().CONFIG_FILE_SECTION):
+        config.add_section(opt().CONFIG_FILE_SECTION)
 
     # Save the current configuration
     config.write(open(path, "w"))
@@ -65,10 +65,10 @@ def _get_feast_env_vars():
     """
     feast_env_vars = {}
     for key in os.environ.keys():
-        if key.upper().startswith(ConfigOptions().CONFIG_FEAST_ENV_VAR_PREFIX):
-            feast_env_vars[
-                key[len(ConfigOptions().CONFIG_FEAST_ENV_VAR_PREFIX) :]
-            ] = os.environ[key]
+        if key.upper().startswith(opt().CONFIG_FEAST_ENV_VAR_PREFIX):
+            feast_env_vars[key[len(opt().CONFIG_FEAST_ENV_VAR_PREFIX) :]] = os.environ[
+                key
+            ]
     return feast_env_vars
 
 
@@ -100,10 +100,9 @@ class Config:
             path = join(
                 expanduser("~"),
                 os.environ.get(
-                    ConfigOptions().FEAST_CONFIG_FILE_ENV,
-                    ConfigOptions().CONFIG_FILE_DEFAULT_DIRECTORY,
+                    opt().FEAST_CONFIG_FILE_ENV, opt().CONFIG_FILE_DEFAULT_DIRECTORY,
                 ),
-                ConfigOptions().CONFIG_FILE_NAME,
+                opt().CONFIG_FILE_NAME,
             )
 
         config = _init_config(path)
@@ -126,7 +125,7 @@ class Config:
 
         """
         return self._config.get(
-            ConfigOptions().CONFIG_FILE_SECTION,
+            opt().CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -142,7 +141,7 @@ class Config:
 
          """
         return self._config.getboolean(
-            ConfigOptions().CONFIG_FILE_SECTION,
+            opt().CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -158,7 +157,7 @@ class Config:
 
          """
         return self._config.getint(
-            ConfigOptions().CONFIG_FILE_SECTION,
+            opt().CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -174,7 +173,7 @@ class Config:
 
          """
         return self._config.getfloat(
-            ConfigOptions().CONFIG_FILE_SECTION,
+            opt().CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -186,7 +185,7 @@ class Config:
             option: Option name to use as key
             value: Value to store under option
         """
-        self._config.set(ConfigOptions().CONFIG_FILE_SECTION, option, value=str(value))
+        self._config.set(opt().CONFIG_FILE_SECTION, option, value=str(value))
 
     def exists(self, option):
         """

--- a/sdk/python/feast/config.py
+++ b/sdk/python/feast/config.py
@@ -19,6 +19,13 @@ from configparser import ConfigParser, NoOptionError
 from os.path import expanduser, join
 from typing import Dict, Optional
 
+from feast.constants import (
+    CONFIG_FEAST_ENV_VAR_PREFIX,
+    CONFIG_FILE_DEFAULT_DIRECTORY,
+    CONFIG_FILE_NAME,
+    CONFIG_FILE_SECTION,
+    FEAST_CONFIG_FILE_ENV,
+)
 from feast.constants import ConfigOptions as opt
 
 _logger = logging.getLogger(__name__)
@@ -48,8 +55,8 @@ def _init_config(path: str):
         config.read(path)
 
     # Store all configuration in a single section
-    if not config.has_section(opt().CONFIG_FILE_SECTION):
-        config.add_section(opt().CONFIG_FILE_SECTION)
+    if not config.has_section(CONFIG_FILE_SECTION):
+        config.add_section(CONFIG_FILE_SECTION)
 
     # Save the current configuration
     config.write(open(path, "w"))
@@ -65,10 +72,8 @@ def _get_feast_env_vars():
     """
     feast_env_vars = {}
     for key in os.environ.keys():
-        if key.upper().startswith(opt().CONFIG_FEAST_ENV_VAR_PREFIX):
-            feast_env_vars[key[len(opt().CONFIG_FEAST_ENV_VAR_PREFIX) :]] = os.environ[
-                key
-            ]
+        if key.upper().startswith(CONFIG_FEAST_ENV_VAR_PREFIX):
+            feast_env_vars[key[len(CONFIG_FEAST_ENV_VAR_PREFIX) :]] = os.environ[key]
     return feast_env_vars
 
 
@@ -99,10 +104,8 @@ class Config:
         if not path:
             path = join(
                 expanduser("~"),
-                os.environ.get(
-                    opt().FEAST_CONFIG_FILE_ENV, opt().CONFIG_FILE_DEFAULT_DIRECTORY,
-                ),
-                opt().CONFIG_FILE_NAME,
+                os.environ.get(FEAST_CONFIG_FILE_ENV, CONFIG_FILE_DEFAULT_DIRECTORY,),
+                CONFIG_FILE_NAME,
             )
 
         config = _init_config(path)
@@ -125,7 +128,7 @@ class Config:
 
         """
         return self._config.get(
-            opt().CONFIG_FILE_SECTION,
+            CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -141,7 +144,7 @@ class Config:
 
          """
         return self._config.getboolean(
-            opt().CONFIG_FILE_SECTION,
+            CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -157,7 +160,7 @@ class Config:
 
          """
         return self._config.getint(
-            opt().CONFIG_FILE_SECTION,
+            CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -173,7 +176,7 @@ class Config:
 
          """
         return self._config.getfloat(
-            opt().CONFIG_FILE_SECTION,
+            CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -185,7 +188,7 @@ class Config:
             option: Option name to use as key
             value: Value to store under option
         """
-        self._config.set(opt().CONFIG_FILE_SECTION, option, value=str(value))
+        self._config.set(CONFIG_FILE_SECTION, option, value=str(value))
 
     def exists(self, option):
         """

--- a/sdk/python/feast/config.py
+++ b/sdk/python/feast/config.py
@@ -19,14 +19,7 @@ from configparser import ConfigParser, NoOptionError
 from os.path import expanduser, join
 from typing import Dict, Optional
 
-from feast.constants import (
-    CONFIG_FEAST_ENV_VAR_PREFIX,
-    CONFIG_FILE_DEFAULT_DIRECTORY,
-    CONFIG_FILE_NAME,
-    CONFIG_FILE_SECTION,
-    FEAST_CONFIG_FILE_ENV_KEY,
-)
-from feast.constants import FEAST_DEFAULT_OPTIONS as DEFAULTS
+from feast.constants import ConfigOptions
 
 _logger = logging.getLogger(__name__)
 
@@ -50,13 +43,13 @@ def _init_config(path: str):
     os.makedirs(os.path.dirname(config_dir), exist_ok=True)
 
     # Create the configuration file itself
-    config = ConfigParser(defaults=DEFAULTS)
+    config = ConfigParser(defaults=ConfigOptions().defaults())
     if os.path.exists(path):
         config.read(path)
 
     # Store all configuration in a single section
-    if not config.has_section(CONFIG_FILE_SECTION):
-        config.add_section(CONFIG_FILE_SECTION)
+    if not config.has_section(ConfigOptions().CONFIG_FILE_SECTION):
+        config.add_section(ConfigOptions().CONFIG_FILE_SECTION)
 
     # Save the current configuration
     config.write(open(path, "w"))
@@ -72,8 +65,10 @@ def _get_feast_env_vars():
     """
     feast_env_vars = {}
     for key in os.environ.keys():
-        if key.upper().startswith(CONFIG_FEAST_ENV_VAR_PREFIX):
-            feast_env_vars[key[len(CONFIG_FEAST_ENV_VAR_PREFIX) :]] = os.environ[key]
+        if key.upper().startswith(ConfigOptions().CONFIG_FEAST_ENV_VAR_PREFIX):
+            feast_env_vars[
+                key[len(ConfigOptions().CONFIG_FEAST_ENV_VAR_PREFIX) :]
+            ] = os.environ[key]
     return feast_env_vars
 
 
@@ -105,9 +100,10 @@ class Config:
             path = join(
                 expanduser("~"),
                 os.environ.get(
-                    FEAST_CONFIG_FILE_ENV_KEY, CONFIG_FILE_DEFAULT_DIRECTORY,
+                    ConfigOptions().FEAST_CONFIG_FILE_ENV,
+                    ConfigOptions().CONFIG_FILE_DEFAULT_DIRECTORY,
                 ),
-                CONFIG_FILE_NAME,
+                ConfigOptions().CONFIG_FILE_NAME,
             )
 
         config = _init_config(path)
@@ -130,7 +126,7 @@ class Config:
 
         """
         return self._config.get(
-            CONFIG_FILE_SECTION,
+            ConfigOptions().CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -146,7 +142,7 @@ class Config:
 
          """
         return self._config.getboolean(
-            CONFIG_FILE_SECTION,
+            ConfigOptions().CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -162,7 +158,7 @@ class Config:
 
          """
         return self._config.getint(
-            CONFIG_FILE_SECTION,
+            ConfigOptions().CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -178,7 +174,7 @@ class Config:
 
          """
         return self._config.getfloat(
-            CONFIG_FILE_SECTION,
+            ConfigOptions().CONFIG_FILE_SECTION,
             option,
             vars={**_get_feast_env_vars(), **self._options},
         )
@@ -190,7 +186,7 @@ class Config:
             option: Option name to use as key
             value: Value to store under option
         """
-        self._config.set(CONFIG_FILE_SECTION, option, value=str(value))
+        self._config.set(ConfigOptions().CONFIG_FILE_SECTION, option, value=str(value))
 
     def exists(self, option):
         """

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -35,6 +35,11 @@ class Option:
 
 
 class ConfigMeta(type):
+    """
+    Class factory which customizes ConfigOptions class instantiation.
+    Specifically, setting its name to lowercase of capitalized variable.
+    """
+
     def __new__(cls, name, bases, attrs):
         keys = [
             k

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 #
 from enum import Enum
+from typing import Optional
 
 
 class AuthProvider(Enum):
@@ -40,10 +41,11 @@ class ConfigMeta(type):
     """
 
     def __new__(cls, name, bases, attrs):
+        NoneType = type(None)
         keys = [
             k
             for k, v in attrs.items()
-            if not k.startswith("_") and isinstance(v, (str, int, float))
+            if not k.startswith("_") and isinstance(v, (str, int, float, NoneType))
         ]
         attrs["__config_keys__"] = keys
         attrs.update({k: Option(k, attrs[k]) for k in keys})
@@ -194,21 +196,25 @@ class ConfigOptions(metaclass=ConfigMeta):
     EMR_LOG_LOCATION: str = ""
 
     #: Oauth grant type
-    OAUTH_GRANT_TYPE: str = ""
+    OAUTH_GRANT_TYPE: Optional[str] = None
 
     #: Oauth client ID
-    OAUTH_CLIENT_ID: str = ""
+    OAUTH_CLIENT_ID: Optional[str] = None
 
     #: Oauth client secret
-    OAUTH_CLIENT_SECRET: str = ""
+    OAUTH_CLIENT_SECRET: Optional[str] = None
 
     #: Oauth intended recipients
-    OAUTH_AUDIENCE: str = ""
+    OAUTH_AUDIENCE: Optional[str] = None
 
     #: Oauth token request url
-    OAUTH_TOKEN_REQUEST_URL: str = ""
+    OAUTH_TOKEN_REQUEST_URL: Optional[str] = None
 
     MAX_WAIT_INTERVAL: str = "60"
 
     def defaults(self):
-        return {k: getattr(self, k) for k in self.__config_keys__}
+        return {
+            k: getattr(self, k)
+            for k in self.__config_keys__
+            if getattr(self, k) is not None
+        }

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -130,19 +130,19 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: Options: "google" / "oauth"
     AUTH_PROVIDER: str = "google"
 
-    #: Spark Job launcher
+    #: Spark Job launcher. The choice of storage is connected to the choice of SPARK_LAUNCHER.
     #:
     #: Options: "standalone", "dataproc", "emr"
     SPARK_LAUNCHER: Optional[str] = None
 
-    #: Feast Spark Job ingestion jobs staging location
+    #: Feast Spark Job ingestion jobs staging location. The choice of storage is connected to the choice of SPARK_LAUNCHER.
     #:
     #: Eg. gs://some-bucket/output/, s3://some-bucket/output/, file://data/subfolder/
     SPARK_STAGING_LOCATION: Optional[str] = None
 
-    #: Feast Spark Job ingestion jar file
+    #: Feast Spark Job ingestion jar file. The choice of storage is connected to the choice of SPARK_LAUNCHER.
     #:
-    #: Eg. gs://some-bucket/some-jarfile, s3://some-bucket/some-jarfile, file://data/some-jarfile
+    #: Eg. "dataproc" (http and gs), "emr" (http and s3), "standalone" (http and file)
     SPARK_INGESTION_JAR: str = "https://storage.googleapis.com/feast-jobs/spark/ingestion/feast-ingestion-spark-develop.jar"
 
     #: Spark resource manager master url
@@ -184,7 +184,7 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: Default StatsD port
     STATSD_PORT: Optional[str] = None
 
-    #: IngestionJob DeadLetter Destination
+    #: Ingestion Job DeadLetter Destination. The choice of storage is connected to the choice of SPARK_LAUNCHER.
     #:
     #: Eg. gs://some-bucket/output/, s3://some-bucket/output/, file://data/subfolder/
     DEADLETTER_PATH: str = ""

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 #
 from enum import Enum
+from typing import Optional
 
 
 class AuthProvider(Enum):
@@ -94,7 +95,7 @@ class ConfigOptions(metaclass=ConfigMeta):
     SERVING_SERVER_SSL_CERT: str = ""
 
     #: Default Feast Job Service URL
-    JOB_SERVICE_URL: str = ""
+    JOB_SERVICE_URL: Optional[str] = None
 
     #: Enable or disable TLS/SSL to Feast Job Service
     JOB_SERVICE_ENABLE_SSL: str = "False"

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -50,26 +50,27 @@ class ConfigMeta(type):
         return super().__new__(cls, name, bases, attrs)
 
 
+#: Default datetime column name for point-in-time join
+DATETIME_COLUMN: str = "datetime"
+
+#: Environmental variable to specify Feast configuration file location
+FEAST_CONFIG_FILE_ENV: str = "FEAST_CONFIG"
+
+#: Default prefix to Feast environmental variables
+CONFIG_FEAST_ENV_VAR_PREFIX: str = "FEAST_"
+
+#: Default directory to Feast configuration file
+CONFIG_FILE_DEFAULT_DIRECTORY: str = ".feast"
+
+#: Default Feast configuration file name
+CONFIG_FILE_NAME: str = "config"
+
+#: Default section in Feast configuration file to specify options
+CONFIG_FILE_SECTION: str = "general"
+
+
 class ConfigOptions(metaclass=ConfigMeta):
     """ Feast Configuration Options """
-
-    #: Default datetime column name for point-in-time join
-    DATETIME_COLUMN: str = "datetime"
-
-    #: Environmental variable to specify Feast configuration file location
-    FEAST_CONFIG_FILE_ENV: str = "FEAST_CONFIG"
-
-    #: Default prefix to Feast environmental variables
-    CONFIG_FEAST_ENV_VAR_PREFIX: str = "FEAST_"
-
-    #: Default directory to Feast configuration file
-    CONFIG_FILE_DEFAULT_DIRECTORY: str = ".feast"
-
-    #: Default Feast configuration file name
-    CONFIG_FILE_NAME: str = "config"
-
-    #: Default section in Feast configuration file to specify options
-    CONFIG_FILE_SECTION: str = "general"
 
     #: Feast project namespace to use
     PROJECT: str = "default"

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -86,7 +86,7 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: Enable user authentication to Feast Core
     ENABLE_AUTH: str = "False"
 
-    #: Auth token for user authentication to Feast
+    #: JWT Auth token for user authentication to Feast
     AUTH_TOKEN: Optional[str] = None
 
     #: Path to certificate(s) to secure connection to Feast Core
@@ -116,7 +116,7 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: Default connection timeout to Feast Serving, Feast Core, and Feast Job Service (in seconds)
     GRPC_CONNECTION_TIMEOUT: str = "10"
 
-    #: Default gRPC connection timeout when sending an ApplyFeatureSet command to Feast Core (in seconds)
+    #: Default gRPC connection timeout when sending an ApplyFeatureTable command to Feast Core (in seconds)
     GRPC_CONNECTION_TIMEOUT_APPLY: str = "600"
 
     #: Default timeout when running batch ingestion
@@ -126,12 +126,16 @@ class ConfigOptions(metaclass=ConfigMeta):
     BATCH_FEATURE_REQUEST_WAIT_TIME_SECONDS: str = "600"
 
     #: Authentication Provider - Google OpenID/OAuth
+    #:
+    #: Options: "google" / "oauth"
     AUTH_PROVIDER: str = "google"
 
     #: Spark Job launcher
     SPARK_LAUNCHER: str = "dataproc"  # standalone, dataproc, emr
 
     #: Feast Spark Job ingestion jobs staging location
+    #:
+    #: Eg. gs://some-bucket/output/, s3://some-bucket/output/, file://data/subfolder/
     SPARK_STAGING_LOCATION: Optional[str] = None
 
     #: Feast Spark Job ingestion jar file
@@ -177,6 +181,8 @@ class ConfigOptions(metaclass=ConfigMeta):
     STATSD_PORT: Optional[str] = None
 
     #: IngestionJob DeadLetter Destination
+    #:
+    #: Eg. gs://some-bucket/output/, s3://some-bucket/output/, file://data/subfolder/
     DEADLETTER_PATH: str = ""
 
     #: ProtoRegistry Address (currently only Stencil Server is supported as registry)

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -37,7 +37,7 @@ class Option:
 class ConfigMeta(type):
     """
     Class factory which customizes ConfigOptions class instantiation.
-    Specifically, setting its name to lowercase of capitalized variable.
+    Specifically, setting configuration option's name to lowercase of capitalized variable.
     """
 
     def __new__(cls, name, bases, attrs):
@@ -66,6 +66,9 @@ CONFIG_FILE_NAME: str = "config"
 
 #: Default section in Feast configuration file to specify options
 CONFIG_FILE_SECTION: str = "general"
+
+# Maximum interval(secs) to wait between retries for retry function
+MAX_WAIT_INTERVAL: str = "60"
 
 
 class ConfigOptions(metaclass=ConfigMeta):
@@ -138,6 +141,8 @@ class ConfigOptions(metaclass=ConfigMeta):
     SPARK_STAGING_LOCATION: Optional[str] = None
 
     #: Feast Spark Job ingestion jar file
+    #:
+    #: Eg. gs://some-bucket/some-jarfile, s3://some-bucket/some-jarfile, file://data/some-jarfile
     SPARK_INGESTION_JAR: str = "https://storage.googleapis.com/feast-jobs/spark/ingestion/feast-ingestion-spark-develop.jar"
 
     #: Spark resource manager master url
@@ -214,8 +219,6 @@ class ConfigOptions(metaclass=ConfigMeta):
 
     #: Oauth token request url
     OAUTH_TOKEN_REQUEST_URL: Optional[str] = None
-
-    MAX_WAIT_INTERVAL: str = "60"
 
     def defaults(self):
         return {

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -87,7 +87,7 @@ class ConfigOptions(metaclass=ConfigMeta):
     ENABLE_AUTH: str = "False"
 
     #: Auth token for user authentication to Feast
-    AUTH_TOKEN: str = ""
+    AUTH_TOKEN: Optional[str] = None
 
     #: Path to certificate(s) to secure connection to Feast Core
     CORE_SERVER_SSL_CERT: str = ""
@@ -102,7 +102,7 @@ class ConfigOptions(metaclass=ConfigMeta):
     SERVING_SERVER_SSL_CERT: str = ""
 
     #: Default Feast Job Service URL
-    JOB_SERVICE_URL: str = ""
+    JOB_SERVICE_URL: Optional[str] = None
 
     #: Enable or disable TLS/SSL to Feast Job Service
     JOB_SERVICE_ENABLE_SSL: str = "False"
@@ -132,7 +132,7 @@ class ConfigOptions(metaclass=ConfigMeta):
     SPARK_LAUNCHER: str = "dataproc"  # standalone, dataproc, emr
 
     #: Feast Spark Job ingestion jobs staging location
-    SPARK_STAGING_LOCATION: str = ""
+    SPARK_STAGING_LOCATION: Optional[str] = None
 
     #: Feast Spark Job ingestion jar file
     SPARK_INGESTION_JAR: str = "https://storage.googleapis.com/feast-jobs/spark/ingestion/feast-ingestion-spark-develop.jar"
@@ -141,22 +141,22 @@ class ConfigOptions(metaclass=ConfigMeta):
     SPARK_STANDALONE_MASTER: str = "local[*]"
 
     #: Directory where Spark is installed
-    SPARK_HOME: str = ""
+    SPARK_HOME: Optional[str] = None
 
     #: Dataproc cluster to run Feast Spark Jobs in
-    DATAPROC_CLUSTER_NAME: str = ""
+    DATAPROC_CLUSTER_NAME: Optional[str] = None
 
     #: Project of Dataproc cluster
-    DATAPROC_PROJECT: str = ""
+    DATAPROC_PROJECT: Optional[str] = None
 
     #: Region of Dataproc cluster
-    DATAPROC_REGION: str = ""
+    DATAPROC_REGION: Optional[str] = None
 
     #: File format of historical retrieval features
     HISTORICAL_FEATURE_OUTPUT_FORMAT: str = "parquet"
 
     #: File location of historical retrieval features
-    HISTORICAL_FEATURE_OUTPUT_LOCATION: str = ""
+    HISTORICAL_FEATURE_OUTPUT_LOCATION: Optional[str] = None
 
     #: Default Redis host
     REDIS_HOST: str = "localhost"
@@ -171,10 +171,10 @@ class ConfigOptions(metaclass=ConfigMeta):
     STATSD_ENABLED: str = "False"
 
     #: Default StatsD port
-    STATSD_HOST: str = ""
+    STATSD_HOST: Optional[str] = None
 
     #: Default StatsD port
-    STATSD_PORT: str = ""
+    STATSD_PORT: Optional[str] = None
 
     #: IngestionJob DeadLetter Destination
     DEADLETTER_PATH: str = ""
@@ -184,16 +184,16 @@ class ConfigOptions(metaclass=ConfigMeta):
     STENCIL_URL: str = ""
 
     #: EMR cluster to run Feast Spark Jobs in
-    EMR_CLUSTER_ID: str = ""
+    EMR_CLUSTER_ID: Optional[str] = None
 
     #: Region of EMR cluster
-    EMR_REGION: str = ""
+    EMR_REGION: Optional[str] = None
 
     #: Template path of EMR cluster
-    EMR_CLUSTER_TEMPLATE_PATH: str = ""
+    EMR_CLUSTER_TEMPLATE_PATH: Optional[str] = None
 
     #: Log path of EMR cluster
-    EMR_LOG_LOCATION: str = ""
+    EMR_LOG_LOCATION: Optional[str] = None
 
     #: Oauth grant type
     OAUTH_GRANT_TYPE: Optional[str] = None

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -14,7 +14,6 @@
 #  limitations under the License.
 #
 from enum import Enum
-from typing import Optional
 
 
 class AuthProvider(Enum):
@@ -100,7 +99,7 @@ class ConfigOptions(metaclass=ConfigMeta):
     SERVING_SERVER_SSL_CERT: str = ""
 
     #: Default Feast Job Service URL
-    JOB_SERVICE_URL: Optional[str] = None
+    JOB_SERVICE_URL: str = ""
 
     #: Enable or disable TLS/SSL to Feast Job Service
     JOB_SERVICE_ENABLE_SSL: str = "False"

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -41,11 +41,8 @@ class ConfigMeta(type):
     """
 
     def __new__(cls, name, bases, attrs):
-        NoneType = type(None)
         keys = [
-            k
-            for k, v in attrs.items()
-            if not k.startswith("_") and isinstance(v, (str, int, float, NoneType))
+            k for k, v in attrs.items() if not k.startswith("_") and not callable(v)
         ]
         attrs["__config_keys__"] = keys
         attrs.update({k: Option(k, attrs[k]) for k in keys})
@@ -131,7 +128,9 @@ class ConfigOptions(metaclass=ConfigMeta):
     AUTH_PROVIDER: str = "google"
 
     #: Spark Job launcher
-    SPARK_LAUNCHER: str = "dataproc"  # standalone, dataproc, emr
+    #:
+    #: Options: "standalone", "dataproc", "emr"
+    SPARK_LAUNCHER: Optional[str] = None
 
     #: Feast Spark Job ingestion jobs staging location
     #:

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -79,8 +79,8 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: Enable user authentication to Feast Core
     ENABLE_AUTH: str = "False"
 
-    #: Auth token for user authentication to Feast Core
-    ENABLE_AUTH_TOKEN: str = ""
+    #: Auth token for user authentication to Feast
+    AUTH_TOKEN: str = ""
 
     #: Path to certificate(s) to secure connection to Feast Core
     CORE_SERVER_SSL_CERT: str = ""

--- a/sdk/python/feast/grpc/auth.py
+++ b/sdk/python/feast/grpc/auth.py
@@ -66,8 +66,11 @@ class OAuthMetadataPlugin(grpc.AuthMetadataPlugin):
         self._token = None
 
         # If provided, set a static token
-        if config.exists(ConfigOptions.ENABLE_AUTH_TOKEN):
-            self._static_token = config.get(ConfigOptions.ENABLE_AUTH_TOKEN)
+        if (
+            config.exists(ConfigOptions.AUTH_TOKEN)
+            and config.get(ConfigOptions.AUTH_TOKEN) != ""
+        ):
+            self._static_token = config.get(ConfigOptions.AUTH_TOKEN)
             self._refresh_token(config)
         elif (
             config.exists(ConfigOptions.OAUTH_GRANT_TYPE)
@@ -75,6 +78,11 @@ class OAuthMetadataPlugin(grpc.AuthMetadataPlugin):
             and config.exists(ConfigOptions.OAUTH_CLIENT_SECRET)
             and config.exists(ConfigOptions.OAUTH_AUDIENCE)
             and config.exists(ConfigOptions.OAUTH_TOKEN_REQUEST_URL)
+            and config.get(ConfigOptions.OAUTH_GRANT_TYPE) != ""
+            and config.get(ConfigOptions.OAUTH_CLIENT_ID) != ""
+            and config.get(ConfigOptions.OAUTH_CLIENT_SECRET) != ""
+            and config.get(ConfigOptions.OAUTH_AUDIENCE) != ""
+            and config.get(ConfigOptions.OAUTH_TOKEN_REQUEST_URL) != ""
         ):
             self._refresh_token(config)
         else:
@@ -162,8 +170,11 @@ class GoogleOpenIDAuthMetadataPlugin(grpc.AuthMetadataPlugin):
         self._token = None
 
         # If provided, set a static token
-        if config.exists(ConfigOptions.ENABLE_AUTH_TOKEN):
-            self._static_token = config.get(ConfigOptions.ENABLE_AUTH_TOKEN)
+        if (
+            config.exists(ConfigOptions.AUTH_TOKEN)
+            and config.get(ConfigOptions.AUTH_TOKEN) != ""
+        ):
+            self._static_token = config.get(ConfigOptions.AUTH_TOKEN)
 
         self._request = requests.Request()
         self._refresh_token()

--- a/sdk/python/feast/grpc/auth.py
+++ b/sdk/python/feast/grpc/auth.py
@@ -67,7 +67,7 @@ class OAuthMetadataPlugin(grpc.AuthMetadataPlugin):
         self._token = None
 
         # If provided, set a static token
-        if config.exists(opt.AUTH_TOKEN) and config.get(opt.AUTH_TOKEN) != "":
+        if config.exists(opt.AUTH_TOKEN):
             self._static_token = config.get(opt.AUTH_TOKEN)
             self._refresh_token(config)
         elif (
@@ -76,11 +76,6 @@ class OAuthMetadataPlugin(grpc.AuthMetadataPlugin):
             and config.exists(opt.OAUTH_CLIENT_SECRET)
             and config.exists(opt.OAUTH_AUDIENCE)
             and config.exists(opt.OAUTH_TOKEN_REQUEST_URL)
-            and config.get(opt.OAUTH_GRANT_TYPE) != ""
-            and config.get(opt.OAUTH_CLIENT_ID) != ""
-            and config.get(opt.OAUTH_CLIENT_SECRET) != ""
-            and config.get(opt.OAUTH_AUDIENCE) != ""
-            and config.get(opt.OAUTH_TOKEN_REQUEST_URL) != ""
         ):
             self._refresh_token(config)
         else:
@@ -168,7 +163,7 @@ class GoogleOpenIDAuthMetadataPlugin(grpc.AuthMetadataPlugin):
         self._token = None
 
         # If provided, set a static token
-        if config.exists(opt.AUTH_TOKEN) and config.get(opt.AUTH_TOKEN) != "":
+        if config.exists(opt.AUTH_TOKEN):
             self._static_token = config.get(opt.AUTH_TOKEN)
 
         self._request = requests.Request()

--- a/sdk/python/feast/grpc/auth.py
+++ b/sdk/python/feast/grpc/auth.py
@@ -18,7 +18,8 @@ import grpc
 from google.auth.exceptions import DefaultCredentialsError
 
 from feast.config import Config
-from feast.constants import AuthProvider, ConfigOptions
+from feast.constants import AuthProvider
+from feast.constants import ConfigOptions as opt
 
 
 def get_auth_metadata_plugin(config: Config) -> grpc.AuthMetadataPlugin:
@@ -35,9 +36,9 @@ def get_auth_metadata_plugin(config: Config) -> grpc.AuthMetadataPlugin:
     Args:
         config: Feast Configuration object
     """
-    if AuthProvider(config.get(ConfigOptions.AUTH_PROVIDER)) == AuthProvider.GOOGLE:
+    if AuthProvider(config.get(opt.AUTH_PROVIDER)) == AuthProvider.GOOGLE:
         return GoogleOpenIDAuthMetadataPlugin(config)
-    elif AuthProvider(config.get(ConfigOptions.AUTH_PROVIDER)) == AuthProvider.OAUTH:
+    elif AuthProvider(config.get(opt.AUTH_PROVIDER)) == AuthProvider.OAUTH:
         return OAuthMetadataPlugin(config)
     else:
         raise RuntimeError(
@@ -66,23 +67,20 @@ class OAuthMetadataPlugin(grpc.AuthMetadataPlugin):
         self._token = None
 
         # If provided, set a static token
-        if (
-            config.exists(ConfigOptions.AUTH_TOKEN)
-            and config.get(ConfigOptions.AUTH_TOKEN) != ""
-        ):
-            self._static_token = config.get(ConfigOptions.AUTH_TOKEN)
+        if config.exists(opt.AUTH_TOKEN) and config.get(opt.AUTH_TOKEN) != "":
+            self._static_token = config.get(opt.AUTH_TOKEN)
             self._refresh_token(config)
         elif (
-            config.exists(ConfigOptions.OAUTH_GRANT_TYPE)
-            and config.exists(ConfigOptions.OAUTH_CLIENT_ID)
-            and config.exists(ConfigOptions.OAUTH_CLIENT_SECRET)
-            and config.exists(ConfigOptions.OAUTH_AUDIENCE)
-            and config.exists(ConfigOptions.OAUTH_TOKEN_REQUEST_URL)
-            and config.get(ConfigOptions.OAUTH_GRANT_TYPE) != ""
-            and config.get(ConfigOptions.OAUTH_CLIENT_ID) != ""
-            and config.get(ConfigOptions.OAUTH_CLIENT_SECRET) != ""
-            and config.get(ConfigOptions.OAUTH_AUDIENCE) != ""
-            and config.get(ConfigOptions.OAUTH_TOKEN_REQUEST_URL) != ""
+            config.exists(opt.OAUTH_GRANT_TYPE)
+            and config.exists(opt.OAUTH_CLIENT_ID)
+            and config.exists(opt.OAUTH_CLIENT_SECRET)
+            and config.exists(opt.OAUTH_AUDIENCE)
+            and config.exists(opt.OAUTH_TOKEN_REQUEST_URL)
+            and config.get(opt.OAUTH_GRANT_TYPE) != ""
+            and config.get(opt.OAUTH_CLIENT_ID) != ""
+            and config.get(opt.OAUTH_CLIENT_SECRET) != ""
+            and config.get(opt.OAUTH_AUDIENCE) != ""
+            and config.get(opt.OAUTH_TOKEN_REQUEST_URL) != ""
         ):
             self._refresh_token(config)
         else:
@@ -111,14 +109,14 @@ class OAuthMetadataPlugin(grpc.AuthMetadataPlugin):
 
         headers_token = {"content-type": "application/json"}
         data_token = {
-            "grant_type": config.get(ConfigOptions.OAUTH_GRANT_TYPE),
-            "client_id": config.get(ConfigOptions.OAUTH_CLIENT_ID),
-            "client_secret": config.get(ConfigOptions.OAUTH_CLIENT_SECRET),
-            "audience": config.get(ConfigOptions.OAUTH_AUDIENCE),
+            "grant_type": config.get(opt.OAUTH_GRANT_TYPE),
+            "client_id": config.get(opt.OAUTH_CLIENT_ID),
+            "client_secret": config.get(opt.OAUTH_CLIENT_SECRET),
+            "audience": config.get(opt.OAUTH_AUDIENCE),
         }
         data_token = json.dumps(data_token)
         response_token = requests.post(
-            config.get(ConfigOptions.OAUTH_TOKEN_REQUEST_URL),
+            config.get(opt.OAUTH_TOKEN_REQUEST_URL),
             headers=headers_token,
             data=data_token,
         )
@@ -170,11 +168,8 @@ class GoogleOpenIDAuthMetadataPlugin(grpc.AuthMetadataPlugin):
         self._token = None
 
         # If provided, set a static token
-        if (
-            config.exists(ConfigOptions.AUTH_TOKEN)
-            and config.get(ConfigOptions.AUTH_TOKEN) != ""
-        ):
-            self._static_token = config.get(ConfigOptions.AUTH_TOKEN)
+        if config.exists(opt.AUTH_TOKEN) and config.get(opt.AUTH_TOKEN) != "":
+            self._static_token = config.get(opt.AUTH_TOKEN)
 
         self._request = requests.Request()
         self._refresh_token()

--- a/sdk/python/feast/job_service.py
+++ b/sdk/python/feast/job_service.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Tuple
 import grpc
 
 import feast
-from feast.constants import CONFIG_JOB_SERVICE_ENABLE_CONTROL_LOOP
+from feast.constants import ConfigOptions
 from feast.core import JobService_pb2_grpc
 from feast.core.JobService_pb2 import (
     CancelJobResponse,
@@ -127,7 +127,9 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
             request.table_name, request.project
         )
 
-        if self.client._config.getboolean(CONFIG_JOB_SERVICE_ENABLE_CONTROL_LOOP):
+        if self.client._config.getboolean(
+            ConfigOptions.JOB_SERVICE_ENABLE_CONTROL_LOOP
+        ):
             # If the control loop is enabled, return existing stream ingestion job id instead of starting a new one
             params = get_stream_to_online_ingestion_params(
                 self.client, request.project, feature_table, []
@@ -212,7 +214,7 @@ def start_job_service() -> None:
 
     client = feast.Client()
 
-    if client._config.getboolean(CONFIG_JOB_SERVICE_ENABLE_CONTROL_LOOP):
+    if client._config.getboolean(ConfigOptions.JOB_SERVICE_ENABLE_CONTROL_LOOP):
         # Start the control loop thread only if it's enabled from configs
         thread = threading.Thread(target=start_control_loop, daemon=True)
         thread.start()

--- a/sdk/python/feast/job_service.py
+++ b/sdk/python/feast/job_service.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Tuple
 import grpc
 
 import feast
-from feast.constants import ConfigOptions
+from feast.constants import ConfigOptions as opt
 from feast.core import JobService_pb2_grpc
 from feast.core.JobService_pb2 import (
     CancelJobResponse,
@@ -127,9 +127,7 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
             request.table_name, request.project
         )
 
-        if self.client._config.getboolean(
-            ConfigOptions.JOB_SERVICE_ENABLE_CONTROL_LOOP
-        ):
+        if self.client._config.getboolean(opt.JOB_SERVICE_ENABLE_CONTROL_LOOP):
             # If the control loop is enabled, return existing stream ingestion job id instead of starting a new one
             params = get_stream_to_online_ingestion_params(
                 self.client, request.project, feature_table, []
@@ -214,7 +212,7 @@ def start_job_service() -> None:
 
     client = feast.Client()
 
-    if client._config.getboolean(ConfigOptions.JOB_SERVICE_ENABLE_CONTROL_LOOP):
+    if client._config.getboolean(opt.JOB_SERVICE_ENABLE_CONTROL_LOOP):
         # Start the control loop thread only if it's enabled from configs
         thread = threading.Thread(target=start_control_loop, daemon=True)
         thread.start()

--- a/sdk/python/feast/loaders/ingest.py
+++ b/sdk/python/feast/loaders/ingest.py
@@ -11,13 +11,6 @@ from pyarrow import parquet as pq
 
 from feast.staging.storage_client import get_staging_client
 
-GRPC_CONNECTION_TIMEOUT_DEFAULT = 3  # type: int
-GRPC_CONNECTION_TIMEOUT_APPLY = 300  # type: int
-FEAST_SERVING_URL_ENV_KEY = "FEAST_SERVING_URL"  # type: str
-FEAST_CORE_URL_ENV_KEY = "FEAST_CORE_URL"  # type: str
-BATCH_FEATURE_REQUEST_WAIT_TIME_SECONDS = 300
-BATCH_INGESTION_PRODUCTION_TIMEOUT = 120  # type: int
-
 
 def _check_field_mappings(
     column_names: List[str],

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, List, Union
 
 from feast.config import Config
-from feast.constants import ConfigOptions
+from feast.constants import ConfigOptions as opt
 from feast.data_source import BigQuerySource, DataSource, FileSource, KafkaSource
 from feast.feature_table import FeatureTable
 from feast.pyspark.abc import (
@@ -26,8 +26,7 @@ def _standalone_launcher(config: Config) -> JobLauncher:
     from feast.pyspark.launchers import standalone
 
     return standalone.StandaloneClusterLauncher(
-        config.get(ConfigOptions.SPARK_STANDALONE_MASTER),
-        config.get(ConfigOptions.SPARK_HOME),
+        config.get(opt.SPARK_STANDALONE_MASTER), config.get(opt.SPARK_HOME),
     )
 
 
@@ -35,10 +34,10 @@ def _dataproc_launcher(config: Config) -> JobLauncher:
     from feast.pyspark.launchers import gcloud
 
     return gcloud.DataprocClusterLauncher(
-        config.get(ConfigOptions.DATAPROC_CLUSTER_NAME),
-        config.get(ConfigOptions.SPARK_STAGING_LOCATION),
-        config.get(ConfigOptions.DATAPROC_REGION),
-        config.get(ConfigOptions.DATAPROC_PROJECT),
+        config.get(opt.DATAPROC_CLUSTER_NAME),
+        config.get(opt.SPARK_STAGING_LOCATION),
+        config.get(opt.DATAPROC_REGION),
+        config.get(opt.DATAPROC_PROJECT),
     )
 
 
@@ -50,13 +49,11 @@ def _emr_launcher(config: Config) -> JobLauncher:
             return config.get(option)
 
     return aws.EmrClusterLauncher(
-        region=config.get(ConfigOptions.EMR_REGION),
-        existing_cluster_id=_get_optional(ConfigOptions.EMR_CLUSTER_ID),
-        new_cluster_template_path=_get_optional(
-            ConfigOptions.EMR_CLUSTER_TEMPLATE_PATH
-        ),
-        staging_location=config.get(ConfigOptions.SPARK_STAGING_LOCATION),
-        emr_log_location=config.get(ConfigOptions.EMR_LOG_LOCATION),
+        region=config.get(opt.EMR_REGION),
+        existing_cluster_id=_get_optional(opt.EMR_CLUSTER_ID),
+        new_cluster_template_path=_get_optional(opt.EMR_CLUSTER_TEMPLATE_PATH),
+        staging_location=config.get(opt.SPARK_STAGING_LOCATION),
+        emr_log_location=config.get(opt.EMR_LOG_LOCATION),
     )
 
 
@@ -68,7 +65,7 @@ _launchers = {
 
 
 def resolve_launcher(config: Config) -> JobLauncher:
-    return _launchers[config.get(ConfigOptions.SPARK_LAUNCHER)](config)
+    return _launchers[config.get(opt.SPARK_LAUNCHER)](config)
 
 
 def _source_to_argument(source: DataSource):
@@ -223,24 +220,24 @@ def start_offline_to_online_ingestion(
 
     return launcher.offline_to_online_ingestion(
         BatchIngestionJobParameters(
-            jar=client._config.get(ConfigOptions.SPARK_INGESTION_JAR),
+            jar=client._config.get(opt.SPARK_INGESTION_JAR),
             source=_source_to_argument(feature_table.batch_source),
             feature_table=_feature_table_to_argument(client, project, feature_table),
             start=start,
             end=end,
-            redis_host=client._config.get(ConfigOptions.REDIS_HOST),
-            redis_port=client._config.getint(ConfigOptions.REDIS_PORT),
-            redis_ssl=client._config.getboolean(ConfigOptions.REDIS_SSL),
+            redis_host=client._config.get(opt.REDIS_HOST),
+            redis_port=client._config.getint(opt.REDIS_PORT),
+            redis_ssl=client._config.getboolean(opt.REDIS_SSL),
             statsd_host=(
-                client._config.getboolean(ConfigOptions.STATSD_ENABLED)
-                and client._config.get(ConfigOptions.STATSD_HOST)
+                client._config.getboolean(opt.STATSD_ENABLED)
+                and client._config.get(opt.STATSD_HOST)
             ),
             statsd_port=(
-                client._config.getboolean(ConfigOptions.STATSD_ENABLED)
-                and client._config.getint(ConfigOptions.STATSD_PORT)
+                client._config.getboolean(opt.STATSD_ENABLED)
+                and client._config.getint(opt.STATSD_PORT)
             ),
-            deadletter_path=client._config.get(ConfigOptions.DEADLETTER_PATH),
-            stencil_url=client._config.get(ConfigOptions.STENCIL_URL),
+            deadletter_path=client._config.get(opt.DEADLETTER_PATH),
+            stencil_url=client._config.get(opt.STENCIL_URL),
         )
     )
 
@@ -249,19 +246,19 @@ def get_stream_to_online_ingestion_params(
     client: "Client", project: str, feature_table: FeatureTable, extra_jars: List[str]
 ) -> StreamIngestionJobParameters:
     return StreamIngestionJobParameters(
-        jar=client._config.get(ConfigOptions.SPARK_INGESTION_JAR),
+        jar=client._config.get(opt.SPARK_INGESTION_JAR),
         extra_jars=extra_jars,
         source=_source_to_argument(feature_table.stream_source),
         feature_table=_feature_table_to_argument(client, project, feature_table),
-        redis_host=client._config.get(ConfigOptions.REDIS_HOST),
-        redis_port=client._config.getint(ConfigOptions.REDIS_PORT),
-        redis_ssl=client._config.getboolean(ConfigOptions.REDIS_SSL),
-        statsd_host=client._config.getboolean(ConfigOptions.STATSD_ENABLED)
-        and client._config.get(ConfigOptions.STATSD_HOST),
-        statsd_port=client._config.getboolean(ConfigOptions.STATSD_ENABLED)
-        and client._config.getint(ConfigOptions.STATSD_PORT),
-        deadletter_path=client._config.get(ConfigOptions.DEADLETTER_PATH),
-        stencil_url=client._config.get(ConfigOptions.STENCIL_URL),
+        redis_host=client._config.get(opt.REDIS_HOST),
+        redis_port=client._config.getint(opt.REDIS_PORT),
+        redis_ssl=client._config.getboolean(opt.REDIS_SSL),
+        statsd_host=client._config.getboolean(opt.STATSD_ENABLED)
+        and client._config.get(opt.STATSD_HOST),
+        statsd_port=client._config.getboolean(opt.STATSD_ENABLED)
+        and client._config.getint(opt.STATSD_PORT),
+        deadletter_path=client._config.get(opt.DEADLETTER_PATH),
+        stencil_url=client._config.get(opt.STENCIL_URL),
     )
 
 

--- a/sdk/python/feast/wait.py
+++ b/sdk/python/feast/wait.py
@@ -15,14 +15,14 @@
 import time
 from typing import Any, Callable, Optional, Tuple
 
-from feast.constants import ConfigOptions
+from feast.constants import ConfigOptions as opt
 
 
 def wait_retry_backoff(
     retry_fn: Callable[[], Tuple[Any, bool]],
     timeout_secs: int = 0,
     timeout_msg: Optional[str] = "Timeout while waiting for retry_fn() to return True",
-    max_interval_secs: int = int(ConfigOptions().MAX_WAIT_INTERVAL),
+    max_interval_secs: int = int(opt().MAX_WAIT_INTERVAL),
 ) -> Any:
     """
     Repeatedly try calling given retry_fn until it returns a True boolean success flag.

--- a/sdk/python/feast/wait.py
+++ b/sdk/python/feast/wait.py
@@ -15,15 +15,14 @@
 import time
 from typing import Any, Callable, Optional, Tuple
 
-from feast.constants import CONFIG_MAX_WAIT_INTERVAL_KEY
-from feast.constants import FEAST_DEFAULT_OPTIONS as defaults
+from feast.constants import ConfigOptions
 
 
 def wait_retry_backoff(
     retry_fn: Callable[[], Tuple[Any, bool]],
     timeout_secs: int = 0,
     timeout_msg: Optional[str] = "Timeout while waiting for retry_fn() to return True",
-    max_interval_secs: int = int(defaults[CONFIG_MAX_WAIT_INTERVAL_KEY]),
+    max_interval_secs: int = int(ConfigOptions().MAX_WAIT_INTERVAL),
 ) -> Any:
     """
     Repeatedly try calling given retry_fn until it returns a True boolean success flag.

--- a/sdk/python/feast/wait.py
+++ b/sdk/python/feast/wait.py
@@ -15,14 +15,14 @@
 import time
 from typing import Any, Callable, Optional, Tuple
 
-from feast.constants import ConfigOptions as opt
+from feast.constants import MAX_WAIT_INTERVAL
 
 
 def wait_retry_backoff(
     retry_fn: Callable[[], Tuple[Any, bool]],
     timeout_secs: int = 0,
     timeout_msg: Optional[str] = "Timeout while waiting for retry_fn() to return True",
-    max_interval_secs: int = int(opt().MAX_WAIT_INTERVAL),
+    max_interval_secs: int = int(MAX_WAIT_INTERVAL),
 ) -> Any:
     """
     Repeatedly try calling given retry_fn until it returns a True boolean success flag.

--- a/sdk/python/tests/grpc/test_auth.py
+++ b/sdk/python/tests/grpc/test_auth.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import json
+from configparser import NoOptionError
 from http import HTTPStatus
 from unittest.mock import call, patch
 
@@ -141,7 +142,7 @@ def test_get_auth_metadata_plugin_oauth_should_raise_when_response_is_not_200(
 def test_get_auth_metadata_plugin_oauth_should_raise_when_config_is_incorrect(
     config_with_missing_variable,
 ):
-    with raises(RuntimeError):
+    with raises(NoOptionError):
         get_auth_metadata_plugin(config_with_missing_variable)
 
 

--- a/sdk/python/tests/grpc/test_auth.py
+++ b/sdk/python/tests/grpc/test_auth.py
@@ -142,7 +142,7 @@ def test_get_auth_metadata_plugin_oauth_should_raise_when_response_is_not_200(
 def test_get_auth_metadata_plugin_oauth_should_raise_when_config_is_incorrect(
     config_with_missing_variable,
 ):
-    with raises(NoOptionError):
+    with raises((RuntimeError, NoOptionError)):
         get_auth_metadata_plugin(config_with_missing_variable)
 
 


### PR DESCRIPTION
Signed-off-by: Terence <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, constants used for `Config` class are declared separately from default values and the term is used interchangeably with config options, making it difficult to maintain as the number of configurable options increase.

This PR addresses the following:
- Address constants which have different parameter name to be the same
eg. ```CONFIG_SPARK_HISTORICAL_FEATURE_OUTPUT_FORMAT = "historical_feature_output_format"``` to
```CONFIG_HISTORICAL_FEATURE_OUTPUT_FORMAT = "historical_feature_output_format"```
- Add documentation for configurable options.
![image](https://user-images.githubusercontent.com/25025366/99489771-6cff2280-29a3-11eb-9e81-09cf301f5f97.png)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
