### PR TITLE
Lazy metrics initialization (to correct pick up in executor)

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala
@@ -41,11 +41,7 @@ trait BasePipeline {
       case Some(c: StatsDConfig) =>
         conf
           .set(
-            "spark.metrics.conf.*.source.redis.class",
-            "org.apache.spark.metrics.source.RedisSinkMetricSource"
-          )
-          .set(
-            "spark.metrics.conf.*.source.redis.labels",
+            "spark.metrics.labels",
             s"feature_table=${jobConfig.featureTable.name}"
           )
           .set(
@@ -56,7 +52,7 @@ trait BasePipeline {
           .set("spark.metrics.conf.*.sink.statsd.port", c.port.toString)
           .set("spark.metrics.conf.*.sink.statsd.period", "30")
           .set("spark.metrics.conf.*.sink.statsd.unit", "seconds")
-          .set("spark.metrics.namespace", jobConfig.mode.toString)
+          .set("spark.metrics.namespace", jobConfig.mode.toString.toLowerCase)
       case None => ()
     }
 

--- a/spark/ingestion/src/test/scala/feast/ingestion/metrics/StatsReporterSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/metrics/StatsReporterSpec.scala
@@ -89,19 +89,19 @@ class StatsReporterSpec extends UnitSpec {
     server.receive should contain("test:0|g")
   }
 
-  "Statsd reporter" should "keep tags part in the name's end" in new Scope {
+  "Statsd reporter" should "keep tags part in the message's end" in new Scope {
     reporter.report(
       gauges = Collections.emptySortedMap(),
       counters = Collections.emptySortedMap(),
       histograms = new util.TreeMap(
         Map(
-          "test#fs=name" -> histogram((1 to 100))
+          "prefix.1111.test#fs=name,job=aaa" -> histogram((1 to 100))
         ).asJava
       ),
       meters = Collections.emptySortedMap(),
       timers = Collections.emptySortedMap()
     )
 
-    server.receive should contain("test.p95#fs=name:95.95|ms")
+    server.receive should contain("prefix.test.p95:95.95|ms|#fs:name,job:aaa")
   }
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

`RedisSinkMetricSource` cannot be initialized with `MetricsSystem` in executor, since `SparkEnv` is not yet available at the moment of `MetricsSystem.start`. To resolve it I moved `RedisSinkMetricSource` registering inside `RedisSinkRelation`.

I also replaced `Librato-style` statsd format with `DogStatsD` extension, since it seems to be more stable (and it was previously used in ingestion job with Beam).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
