### PR TITLE
Configurable materialization destination for view in BigQuerySource

### DIFF
--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -154,6 +154,14 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: Directory where Spark is installed
     SPARK_HOME: Optional[str] = None
 
+    #: The project id where the materialized view of BigQuerySource is going to be created
+    #: by default, use the same project where view is located
+    SPARK_BQ_MATERIALIZATION_PROJECT: Optional[str] = None
+
+    #: The dataset id where the materialized view of BigQuerySource is going to be created
+    #: by default, use the same dataset where view is located
+    SPARK_BQ_MATERIALIZATION_DATASET: Optional[str] = None
+
     #: Dataproc cluster to run Feast Spark Jobs in
     DATAPROC_CLUSTER_NAME: Optional[str] = None
 

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -71,7 +71,7 @@ def resolve_launcher(config: Config) -> JobLauncher:
     return _launchers[config.get(opt.SPARK_LAUNCHER)](config)
 
 
-def _source_to_argument(source: DataSource):
+def _source_to_argument(source: DataSource, config: Config):
     common_properties = {
         "field_mapping": dict(source.field_mapping),
         "event_timestamp_column": source.event_timestamp_column,
@@ -94,6 +94,14 @@ def _source_to_argument(source: DataSource):
         properties["project"] = project
         properties["dataset"] = dataset
         properties["table"] = table
+        if config.get(opt.SPARK_BQ_MATERIALIZATION_PROJECT) and config.get(
+            opt.SPARK_BQ_MATERIALIZATION_DATASET
+        ):
+            properties["materialization"] = dict(
+                project=config.get(opt.SPARK_BQ_MATERIALIZATION_PROJECT),
+                dataset=config.get(opt.SPARK_BQ_MATERIALIZATION_DATASET),
+            )
+
         return {"bq": properties}
 
     if isinstance(source, KafkaSource):
@@ -141,9 +149,9 @@ def start_historical_feature_retrieval_spark_session(
     spark_session = SparkSession.builder.getOrCreate()
     return retrieve_historical_features(
         spark=spark_session,
-        entity_source_conf=_source_to_argument(entity_source),
+        entity_source_conf=_source_to_argument(entity_source, client._config),
         feature_tables_sources_conf=[
-            _source_to_argument(feature_table.batch_source)
+            _source_to_argument(feature_table.batch_source, client._config)
             for feature_table in feature_tables
         ],
         feature_tables_conf=[
@@ -164,14 +172,15 @@ def start_historical_feature_retrieval_job(
     launcher = resolve_launcher(client._config)
     feature_sources = [
         _source_to_argument(
-            replace_bq_table_with_joined_view(feature_table, entity_source)
+            replace_bq_table_with_joined_view(feature_table, entity_source),
+            client._config,
         )
         for feature_table in feature_tables
     ]
 
     return launcher.historical_feature_retrieval(
         RetrievalJobParameters(
-            entity_source=_source_to_argument(entity_source),
+            entity_source=_source_to_argument(entity_source, client._config),
             feature_tables_sources=feature_sources,
             feature_tables=[
                 _feature_table_to_argument(client, project, feature_table)
@@ -224,7 +233,7 @@ def start_offline_to_online_ingestion(
     return launcher.offline_to_online_ingestion(
         BatchIngestionJobParameters(
             jar=client._config.get(opt.SPARK_INGESTION_JAR),
-            source=_source_to_argument(feature_table.batch_source),
+            source=_source_to_argument(feature_table.batch_source, client._config),
             feature_table=_feature_table_to_argument(client, project, feature_table),
             start=start,
             end=end,
@@ -251,7 +260,7 @@ def get_stream_to_online_ingestion_params(
     return StreamIngestionJobParameters(
         jar=client._config.get(opt.SPARK_INGESTION_JAR),
         extra_jars=extra_jars,
-        source=_source_to_argument(feature_table.stream_source),
+        source=_source_to_argument(feature_table.stream_source, client._config),
         feature_table=_feature_table_to_argument(client, project, feature_table),
         redis_host=client._config.get(opt.REDIS_HOST),
         redis_port=client._config.getint(opt.REDIS_PORT),

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -94,7 +94,7 @@ def _source_to_argument(source: DataSource, config: Config):
         properties["project"] = project
         properties["dataset"] = dataset
         properties["table"] = table
-        if config.get(opt.SPARK_BQ_MATERIALIZATION_PROJECT) and config.get(
+        if config.exists(opt.SPARK_BQ_MATERIALIZATION_PROJECT) and config.exists(
             opt.SPARK_BQ_MATERIALIZATION_DATASET
         ):
             properties["materialization"] = dict(

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -59,6 +59,8 @@ case class FileSource(
     override val datePartitionColumn: Option[String] = None
 ) extends BatchSource
 
+case class BQMaterializationConfig(project: String, dataset: String)
+
 case class BQSource(
     project: String,
     dataset: String,
@@ -66,7 +68,8 @@ case class BQSource(
     override val fieldMapping: Map[String, String],
     override val eventTimestampColumn: String,
     override val createdTimestampColumn: Option[String] = None,
-    override val datePartitionColumn: Option[String] = None
+    override val datePartitionColumn: Option[String] = None,
+    materialization: Option[BQMaterializationConfig] = None
 ) extends BatchSource
 
 case class KafkaSource(


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

When using BQ view as source for historical retrieval and batch ingestion there could be an issue with permissions. Since spark-bq connector first needs to materialize view before read it - it requires "create table" access, which could be problematic when view is located in different / uncontrolled project.

This PR introduces two configuration options
```
SPARK_BQ_MATERIALIZATION_PROJECT
SPARK_BQ_MATERIALIZATION_DATASET
```
that will be passed to both ingestion & historical retrieval jobs. This will make possible to use project / dataset where feast project has permissions to create table.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
New configuration options

    #: The project id where the materialized view of BigQuerySource is going to be created
    #: by default, use the same project where view is located
    SPARK_BQ_MATERIALIZATION_PROJECT: Optional[str] = None

    #: The dataset id where the materialized view of BigQuerySource is going to be created
    #: by default, use the same dataset where view is located
    SPARK_BQ_MATERIALIZATION_DATASET: Optional[str] = None
```
