### PR TITLE
When staging entities dataset timestamps are being truncated to ms

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -979,6 +979,12 @@ class Client:
             feature_refs, self.project
         )
 
+        assert all(ft.batch_source.created_timestamp_column for ft in feature_tables), (
+            "All BatchSources attached to retrieved FeatureTables "
+            "must have specified `created_timestamp_column` to be used in "
+            "historical dataset generation."
+        )
+
         if output_location is None:
             output_location = os.path.join(
                 self._config.get(opt.HISTORICAL_FEATURE_OUTPUT_LOCATION),

--- a/sdk/python/feast/staging/entities.py
+++ b/sdk/python/feast/staging/entities.py
@@ -75,6 +75,9 @@ def stage_entities_to_bq(
         f"_entities_{datetime.now():%Y%m%d%H%M%s}",
     )
 
+    # prevent casting ns -> ms exception inside pyarrow
+    entity_source["event_timestamp"] = entity_source["event_timestamp"].dt.floor("ms")
+
     load_job: bigquery.LoadJob = bq_client.load_table_from_dataframe(
         entity_source, destination
     )

--- a/sdk/python/feast/staging/entities.py
+++ b/sdk/python/feast/staging/entities.py
@@ -29,6 +29,11 @@ def stage_entities_to_fs(
     entity_staging_uri = urlparse(os.path.join(staging_location, str(uuid.uuid4())))
     staging_client = get_staging_client(entity_staging_uri.scheme, config)
     with tempfile.NamedTemporaryFile() as df_export_path:
+        # prevent casting ns -> ms exception inside pyarrow
+        entity_source["event_timestamp"] = entity_source["event_timestamp"].dt.floor(
+            "ms"
+        )
+
         entity_source.to_parquet(df_export_path.name)
         bucket = (
             None if entity_staging_uri.scheme == "file" else entity_staging_uri.netloc

--- a/tests/e2e/test_historical_features.py
+++ b/tests/e2e/test_historical_features.py
@@ -36,10 +36,7 @@ def read_parquet(uri):
 
 
 def generate_data():
-    retrieval_date = (
-        datetime.utcnow()
-        .replace(tzinfo=None)
-    )
+    retrieval_date = datetime.utcnow().replace(tzinfo=None)
     retrieval_outside_max_age_date = retrieval_date + timedelta(1)
     event_date = retrieval_date - timedelta(2)
     creation_date = retrieval_date - timedelta(1)

--- a/tests/e2e/test_historical_features.py
+++ b/tests/e2e/test_historical_features.py
@@ -38,7 +38,6 @@ def read_parquet(uri):
 def generate_data():
     retrieval_date = (
         datetime.utcnow()
-        .replace(hour=0, minute=0, second=0, microsecond=0)
         .replace(tzinfo=None)
     )
     retrieval_outside_max_age_date = retrieval_date + timedelta(1)


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Using timestamps with micro or nano seconds in entity dataset leads to exception, when pandas dataframe is being converted to parquet:
```
ArrowInvalid: Casting from timestamp[ns] to timestamp[ms] would lose data: 1606826389820565000
```
This PR fix this by truncating timestamps provided by users up to milliseconds before calling `pandas.to_parquet`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Timestamps in entity dataset for historical retrieval are being truncated to ms
```
