### PR TITLE
Feature Table is not being update when only max_age was changed

### DIFF
--- a/core/src/main/java/feast/core/model/FeatureTable.java
+++ b/core/src/main/java/feast/core/model/FeatureTable.java
@@ -411,7 +411,7 @@ public class FeatureTable extends AbstractTimestampEntity {
         && getLabelsJSON().equals(other.getLabelsJSON())
         && getFeatures().equals(other.getFeatures())
         && getEntities().equals(other.getEntities())
-        && getMaxAgeSecs() == getMaxAgeSecs()
+        && getMaxAgeSecs() == other.getMaxAgeSecs()
         && Optional.ofNullable(getBatchSource()).equals(Optional.ofNullable(other.getBatchSource()))
         && Optional.ofNullable(getStreamSource())
             .equals(Optional.ofNullable(other.getStreamSource()));

--- a/core/src/test/java/feast/core/service/SpecServiceIT.java
+++ b/core/src/test/java/feast/core/service/SpecServiceIT.java
@@ -40,8 +40,6 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 import java.util.*;
 import java.util.stream.IntStream;
-
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Triple;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,37 +84,39 @@ public class SpecServiceIT extends BaseIT {
     apiClient.simpleApplyEntity("default", entitySpec1);
     apiClient.simpleApplyEntity("default", entitySpec2);
 
-    example1 = DataGenerator.createFeatureTableSpec(
-        "featuretable1",
-        Arrays.asList("entity1", "entity2"),
-        new HashMap<>() {
-          {
-            put("feature1", ValueProto.ValueType.Enum.STRING);
-            put("feature2", ValueProto.ValueType.Enum.FLOAT);
-          }
-        },
-        7200,
-        ImmutableMap.of("feat_key2", "feat_value2"))
-        .toBuilder()
-        .setBatchSource(
-            DataGenerator.createFileDataSourceSpec("file:///path/to/file", "ts_col", ""))
-        .build();
+    example1 =
+        DataGenerator.createFeatureTableSpec(
+                "featuretable1",
+                Arrays.asList("entity1", "entity2"),
+                new HashMap<>() {
+                  {
+                    put("feature1", ValueProto.ValueType.Enum.STRING);
+                    put("feature2", ValueProto.ValueType.Enum.FLOAT);
+                  }
+                },
+                7200,
+                ImmutableMap.of("feat_key2", "feat_value2"))
+            .toBuilder()
+            .setBatchSource(
+                DataGenerator.createFileDataSourceSpec("file:///path/to/file", "ts_col", ""))
+            .build();
 
-    example2 = DataGenerator.createFeatureTableSpec(
-        "featuretable2",
-        Arrays.asList("entity1", "entity2"),
-        new HashMap<>() {
-          {
-            put("feature3", ValueProto.ValueType.Enum.STRING);
-            put("feature4", ValueProto.ValueType.Enum.FLOAT);
-          }
-        },
-        7200,
-        ImmutableMap.of("feat_key4", "feat_value4"))
-        .toBuilder()
-        .setBatchSource(
-            DataGenerator.createFileDataSourceSpec("file:///path/to/file", "ts_col", ""))
-        .build();
+    example2 =
+        DataGenerator.createFeatureTableSpec(
+                "featuretable2",
+                Arrays.asList("entity1", "entity2"),
+                new HashMap<>() {
+                  {
+                    put("feature3", ValueProto.ValueType.Enum.STRING);
+                    put("feature4", ValueProto.ValueType.Enum.FLOAT);
+                  }
+                },
+                7200,
+                ImmutableMap.of("feat_key4", "feat_value4"))
+            .toBuilder()
+            .setBatchSource(
+                DataGenerator.createFileDataSourceSpec("file:///path/to/file", "ts_col", ""))
+            .build();
 
     apiClient.applyFeatureTable("default", example1);
     apiClient.applyFeatureTable("default", example2);
@@ -536,7 +536,8 @@ public class SpecServiceIT extends BaseIT {
   @Nested
   public class ApplyFeatureTable {
     private FeatureTableSpec getTestSpec() {
-      return example1.toBuilder()
+      return example1
+          .toBuilder()
           .setName("apply_test")
           .setStreamSource(
               DataGenerator.createKafkaDataSourceSpec(
@@ -556,16 +557,17 @@ public class SpecServiceIT extends BaseIT {
     public void shouldUpdateExistingTableWithValidSpec() {
       FeatureTableProto.FeatureTable table = apiClient.applyFeatureTable("default", getTestSpec());
 
-      FeatureTableSpec updatedSpec = getTestSpec().toBuilder()
-          .clearFeatures()
-          .addFeatures(
-              DataGenerator.createFeatureSpecV2("feature5", ValueProto.ValueType.Enum.FLOAT, ImmutableMap.of())
-          )
-          .setStreamSource(
-              DataGenerator.createKafkaDataSourceSpec(
-                  "localhost:9092", "new_topic", "new.class", "ts_col")
-          )
-          .build();
+      FeatureTableSpec updatedSpec =
+          getTestSpec()
+              .toBuilder()
+              .clearFeatures()
+              .addFeatures(
+                  DataGenerator.createFeatureSpecV2(
+                      "feature5", ValueProto.ValueType.Enum.FLOAT, ImmutableMap.of()))
+              .setStreamSource(
+                  DataGenerator.createKafkaDataSourceSpec(
+                      "localhost:9092", "new_topic", "new.class", "ts_col"))
+              .build();
 
       FeatureTableProto.FeatureTable updatedTable =
           apiClient.applyFeatureTable("default", updatedSpec);
@@ -576,10 +578,8 @@ public class SpecServiceIT extends BaseIT {
 
     @Test
     public void shouldUpdateFeatureTableOnEntityChange() {
-      FeatureTableProto.FeatureTableSpec updatedSpec = getTestSpec().toBuilder()
-              .clearEntities()
-              .addEntities("entity1")
-              .build();
+      FeatureTableProto.FeatureTableSpec updatedSpec =
+          getTestSpec().toBuilder().clearEntities().addEntities("entity1").build();
 
       FeatureTableProto.FeatureTable updatedTable =
           apiClient.applyFeatureTable("default", updatedSpec);
@@ -589,9 +589,11 @@ public class SpecServiceIT extends BaseIT {
 
     @Test
     public void shouldUpdateFeatureTableOnMaxAgeChange() {
-      FeatureTableProto.FeatureTableSpec updatedSpec = getTestSpec().toBuilder()
-          .setMaxAge(Duration.newBuilder().setSeconds(600).build())
-          .build();
+      FeatureTableProto.FeatureTableSpec updatedSpec =
+          getTestSpec()
+              .toBuilder()
+              .setMaxAge(Duration.newBuilder().setSeconds(600).build())
+              .build();
 
       FeatureTableProto.FeatureTable updatedTable =
           apiClient.applyFeatureTable("default", updatedSpec);
@@ -601,14 +603,20 @@ public class SpecServiceIT extends BaseIT {
 
     @Test
     public void shouldUpdateFeatureTableOnFeatureTypeChange() {
-      int featureIdx = IntStream.range(0, getTestSpec().getFeaturesCount())
-          .filter(i -> getTestSpec().getFeatures(i).getName().equals("feature2"))
-          .findFirst().orElse(-1);
+      int featureIdx =
+          IntStream.range(0, getTestSpec().getFeaturesCount())
+              .filter(i -> getTestSpec().getFeatures(i).getName().equals("feature2"))
+              .findFirst()
+              .orElse(-1);
 
-      FeatureTableProto.FeatureTableSpec updatedSpec = getTestSpec().toBuilder()
-            .setFeatures(featureIdx,
-                DataGenerator.createFeatureSpecV2("feature2", ValueProto.ValueType.Enum.STRING_LIST, ImmutableMap.of()))
-            .build();
+      FeatureTableProto.FeatureTableSpec updatedSpec =
+          getTestSpec()
+              .toBuilder()
+              .setFeatures(
+                  featureIdx,
+                  DataGenerator.createFeatureSpecV2(
+                      "feature2", ValueProto.ValueType.Enum.STRING_LIST, ImmutableMap.of()))
+              .build();
 
       FeatureTableProto.FeatureTable updatedTable =
           apiClient.applyFeatureTable("default", updatedSpec);
@@ -618,11 +626,13 @@ public class SpecServiceIT extends BaseIT {
 
     @Test
     public void shouldUpdateFeatureTableOnFeatureAddition() {
-      FeatureTableProto.FeatureTableSpec updatedSpec = getTestSpec().toBuilder()
-          .addFeatures(
-              DataGenerator.createFeatureSpecV2("feature6", ValueProto.ValueType.Enum.FLOAT, ImmutableMap.of())
-          )
-          .build();
+      FeatureTableProto.FeatureTableSpec updatedSpec =
+          getTestSpec()
+              .toBuilder()
+              .addFeatures(
+                  DataGenerator.createFeatureSpecV2(
+                      "feature6", ValueProto.ValueType.Enum.FLOAT, ImmutableMap.of()))
+              .build();
 
       FeatureTableProto.FeatureTable updatedTable =
           apiClient.applyFeatureTable("default", updatedSpec);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
Bug in `FeatureTale.equals` method that should check whether FeatureTable was changed. If only max age was updated - FeatureTable is not saved.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
