### PR TITLE
Features are not being ingested due to max age overflow

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -72,7 +72,7 @@ object BatchPipeline extends BasePipeline {
       .option("namespace", featureTable.name)
       .option("project_name", featureTable.project)
       .option("timestamp_column", config.source.eventTimestampColumn)
-      .option("max_age", config.featureTable.maxAge.getOrElse(0))
+      .option("max_age", config.featureTable.maxAge.getOrElse(0L))
       .save()
 
     config.deadLetterPath match {

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -95,7 +95,7 @@ case class FeatureTable(
     project: String,
     entities: Seq[Field],
     features: Seq[Field],
-    maxAge: Option[Int] = None
+    maxAge: Option[Long] = None
 )
 
 case class IngestionJobConfig(

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -87,7 +87,7 @@ object StreamingPipeline extends BasePipeline with Serializable {
           .option("namespace", featureTable.name)
           .option("project_name", featureTable.project)
           .option("timestamp_column", config.source.eventTimestampColumn)
-          .option("max_age", config.featureTable.maxAge.getOrElse(0))
+          .option("max_age", config.featureTable.maxAge.getOrElse(0L))
           .save()
 
         config.deadLetterPath match {

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/SparkRedisConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/SparkRedisConfig.scala
@@ -24,7 +24,7 @@ case class SparkRedisConfig(
     iteratorGroupingSize: Int = 1000,
     timestampPrefix: String = "_ts",
     repartitionByEntity: Boolean = true,
-    maxAge: Int = 0,
+    maxAge: Long = 0,
     expiryPrefix: String = "_ex"
 )
 
@@ -43,6 +43,6 @@ object SparkRedisConfig {
       entityColumns = parameters.getOrElse(ENTITY_COLUMNS, "").split(","),
       timestampColumn = parameters.getOrElse(TS_COLUMN, "event_timestamp"),
       repartitionByEntity = parameters.getOrElse(ENTITY_REPARTITION, "true") == "true",
-      maxAge = parameters.get(MAX_AGE).map(_.toInt).getOrElse(0)
+      maxAge = parameters.get(MAX_AGE).map(_.toLong).getOrElse(0)
     )
 }

--- a/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
@@ -131,7 +131,7 @@ class BatchPipelineIT extends SparkSpec with ForAllTestContainer {
       val gen       = rowGenerator(startDate, endDate)
       val rows      = generateDistinctRows(gen, 1000, groupByEntity)
       val tempPath  = storeAsParquet(sparkSession, rows)
-      val maxAge    = 86400 * 2
+      val maxAge    = 86400L * 30
       val configWithMaxAge = config.copy(
         source = FileSource(tempPath, Map.empty, "eventTimestamp"),
         featureTable = config.featureTable.copy(maxAge = Some(maxAge)),
@@ -162,7 +162,7 @@ class BatchPipelineIT extends SparkSpec with ForAllTestContainer {
 
       })
 
-      val increasedMaxAge = 86400 * 3
+      val increasedMaxAge = 86400L * 60
       val configWithSecondFeatureTable = config.copy(
         source = FileSource(tempPath, Map.empty, "eventTimestamp"),
         featureTable = config.featureTable.copy(


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

With big values of max age (like 1 month) stored as Integer (2628000) converting to milliseconds that happens during writing to redis fails with overflow `2628000 * 1000 = -1666967296`. Thus all rows are being stored with negative expiry time and being deleted right away.

This PR suggests use Long instead of Int for max age. Alternative would be to do `maxAge.toLong` before converting to milliseconds, but it's very easy to miss that part.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
