### PR TITLE
pin pip to 20.2 in aws tests for now

### DIFF
--- a/infra/scripts/setup-e2e-env-aws.sh
+++ b/infra/scripts/setup-e2e-env-aws.sh
@@ -2,7 +2,7 @@
 
 make compile-protos-python
 
-python -m pip install --upgrade pip setuptools wheel
+python -m pip install --upgrade pip==20.2 setuptools wheel
 
 python -m pip install -qr sdk/python/requirements-dev.txt
 python -m pip install -qr tests/requirements.txt


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
New pip resolver seems to either go into infinite loop, or take way too long with our requirements-dev.txt. Roll back to the older version for now.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
