### PR TITLE
Remove job id from ingested row counter metric

### DIFF
--- a/spark/ingestion/src/main/scala/org/apache/spark/metrics/source/RedisSinkMetricSource.scala
+++ b/spark/ingestion/src/main/scala/org/apache/spark/metrics/source/RedisSinkMetricSource.scala
@@ -32,7 +32,7 @@ class RedisSinkMetricSource extends Source {
 
   private val executorId = sparkConfig.get("spark.executor.id", "")
 
-  private def nameWithLabels(name: String) = {
+  private def metricWithLabels(name: String) = {
     if (metricLabels.isEmpty) {
       name
     } else {
@@ -40,11 +40,19 @@ class RedisSinkMetricSource extends Source {
     }
   }
 
+  private def counterWithLabels(name: String) = {
+    if (metricLabels.isEmpty) {
+      name
+    } else {
+      s"$name#$metricLabels"
+    }
+  }
+
   val METRIC_TOTAL_ROWS_INSERTED =
-    metricRegistry.counter(nameWithLabels("feast_ingestion_feature_row_ingested_count"))
+    metricRegistry.counter(counterWithLabels("feast_ingestion_feature_row_ingested_count"))
 
   val METRIC_ROWS_LAG =
-    metricRegistry.histogram(nameWithLabels("feast_ingestion_feature_row_lag_ms"))
+    metricRegistry.histogram(metricWithLabels("feast_ingestion_feature_row_lag_ms"))
 }
 
 object RedisSinkMetricSource {


### PR DESCRIPTION
Signed-off-by: Terence <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, for `ingested_row` counter metric, we would end up having multiple time series even for ingestion into the same feature table, due to different `job_id`. This PR removes `job_id` for counter metrics.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Ingested row count metric will no longer have job_id label.
```
