### PR TITLE
implement abstractstagingclient for azure blob storage

### DIFF
--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -128,6 +128,12 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: Endpoint URL for S3 storage_client
     S3_ENDPOINT_URL: Optional[str] = None
 
+    #: Account name for Azure blob storage_client
+    AZURE_BLOB_ACCOUNT_NAME: Optional[str] = None
+
+    #: Account access key for Azure blob storage_client
+    AZURE_BLOB_ACCOUNT_ACCESS_KEY: Optional[str] = None
+
     #: Authentication Provider - Google OpenID/OAuth
     #:
     #: Options: "google" / "oauth"

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -80,9 +80,7 @@ def export_source_to_staging_location(
         else:
             # gs, s3, azure blob file provided as a source.
             assert source_uri.hostname is not None
-            return get_staging_client(source_uri.scheme).list_files(
-                uri=source_uri
-            )
+            return get_staging_client(source_uri.scheme).list_files(uri=source_uri)
     else:
         raise Exception(
             f"Only string and DataFrame types are allowed as a "

--- a/sdk/python/feast/loaders/file.py
+++ b/sdk/python/feast/loaders/file.py
@@ -40,11 +40,12 @@ def export_source_to_staging_location(
             Source of data to be staged. Can be a pandas DataFrame or a file
             path.
 
-            Only three types of source are allowed:
+            Only four types of source are allowed:
                 * Pandas DataFrame
                 * Local Avro file
                 * GCS Avro file
                 * S3 Avro file
+                * Azure Blob storage Avro file
 
 
         staging_location_uri (str):
@@ -52,6 +53,7 @@ def export_source_to_staging_location(
             Examples:
                 * gs://bucket/path/
                 * s3://bucket/path/
+                * https://account_name.blob.core.windows.net/bucket/path/
                 * file:///data/subfolder/
 
     Returns:
@@ -76,10 +78,10 @@ def export_source_to_staging_location(
                 os.path.join(source_uri.netloc, source_uri.path)
             )
         else:
-            # gs, s3 file provided as a source.
+            # gs, s3, azure blob file provided as a source.
             assert source_uri.hostname is not None
             return get_staging_client(source_uri.scheme).list_files(
-                bucket=source_uri.hostname, path=source_uri.path
+                uri=source_uri
             )
     else:
         raise Exception(

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -485,7 +485,7 @@ storage_clients = {
     GS: _gcs_client,
     S3: _s3_client,
     S3A: _s3a_client,
-    AZURE_SCHEME: _azure_blob_client, # note we currently interpret all uris beginning https:// as Azure blob uris
+    AZURE_SCHEME: _azure_blob_client,  # note we currently interpret all uris beginning https:// as Azure blob uris
     LOCAL_FILE: _local_fs_client,
 }
 

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -341,7 +341,7 @@ class AzureBlobClient(AbstractStagingClient):
         Returns:
              TemporaryFile object
         """
-        bucket, path = _uri_to_bucket_key(uri)
+        bucket, path = self._uri_to_bucket_key(uri)
         container_client = self.blob_service_client.get_container_client(bucket)
         return container_client.download_blob(path).readall()
 
@@ -357,7 +357,7 @@ class AzureBlobClient(AbstractStagingClient):
                     remote staging location.
         """
 
-        bucket, path = _uri_to_bucket_key(uri)
+        bucket, path = self._uri_to_bucket_key(uri)
         if "*" in path:
             regex = re.compile(path.replace("*", ".*?").strip("/"))
             container_client = self.blob_service_client.get_container_client(bucket)
@@ -373,8 +373,8 @@ class AzureBlobClient(AbstractStagingClient):
         else:
             return [f"{self.account_url}/{bucket}/{path}"]
 
-    def _uri_to_bucket_key(self, remote_path: ParseResult) -> Tuple[str, str]:
-        assert remote_path.hostname is not None
+    def _uri_to_bucket_key(self, uri: ParseResult) -> Tuple[str, str]:
+        assert uri.hostname is not None
         bucket = uri.path.lstrip("/").split("/")[0]
         key = uri.path.lstrip("/").split("/", 1)[1]
         return bucket, key

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -374,7 +374,7 @@ class AzureBlobClient(AbstractStagingClient):
             return [f"{self.account_url}/{bucket}/{path}"]
 
     def _uri_to_bucket_key(self, uri: ParseResult) -> Tuple[str, str]:
-        assert uri.hostname is not None
+        assert uri.hostname == urlparse(self.account_url).hostname
         bucket = uri.path.lstrip("/").split("/")[0]
         key = uri.path.lstrip("/").split("/", 1)[1]
         return bucket, key


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Supports Azure Blob Storage as an object store and batch data source as part of #1181 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now use Azure blob storage as a staging location and as a batch data source. To configure it, they will need to set the environment variables FEAST_AZURE_BLOB_ACCOUNT_NAME and FEAST_AZURE_BLOB_ACCOUNT_ACCESS_KEY 
```
