### PR TITLE
Refactor staging client uploader and use it in EMR launcher

### DIFF
--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -140,7 +140,7 @@ class ConfigOptions(metaclass=ConfigMeta):
 
     #: Feast Spark Job ingestion jobs staging location. The choice of storage is connected to the choice of SPARK_LAUNCHER.
     #:
-    #: Eg. gs://some-bucket/output/, s3://some-bucket/output/, file://data/subfolder/
+    #: Eg. gs://some-bucket/output/, s3://some-bucket/output/, file:///data/subfolder/
     SPARK_STAGING_LOCATION: Optional[str] = None
 
     #: Feast Spark Job ingestion jar file. The choice of storage is connected to the choice of SPARK_LAUNCHER.
@@ -206,7 +206,7 @@ class ConfigOptions(metaclass=ConfigMeta):
 
     #: Ingestion Job DeadLetter Destination. The choice of storage is connected to the choice of SPARK_LAUNCHER.
     #:
-    #: Eg. gs://some-bucket/output/, s3://some-bucket/output/, file://data/subfolder/
+    #: Eg. gs://some-bucket/output/, s3://some-bucket/output/, file:///data/subfolder/
     DEADLETTER_PATH: str = ""
 
     #: ProtoRegistry Address (currently only Stencil Server is supported as registry)

--- a/sdk/python/feast/loaders/ingest.py
+++ b/sdk/python/feast/loaders/ingest.py
@@ -187,16 +187,28 @@ def _upload_to_file_source(
         for path in glob.glob(os.path.join(dest_path, "**/*")):
             file_name = path.split("/")[-1]
             partition_col = path.split("/")[-2]
-            staging_client.upload_file(
-                path,
-                uri.hostname,
-                str(uri.path).strip("/") + "/" + partition_col + "/" + file_name,
-            )
+            with open(path, "rb") as f:
+                staging_client.upload_fileobj(
+                    f,
+                    path,
+                    remote_uri=uri._replace(
+                        path=str(uri.path).rstrip("/")
+                        + "/"
+                        + partition_col
+                        + "/"
+                        + file_name
+                    ),
+                )
     else:
         file_name = dest_path.split("/")[-1]
-        staging_client.upload_file(
-            dest_path, uri.hostname, str(uri.path).strip("/") + "/" + file_name,
-        )
+        with open(dest_path, "rb") as f:
+            staging_client.upload_fileobj(
+                f,
+                dest_path,
+                remote_uri=uri._replace(
+                    path=str(uri.path).rstrip("/") + "/" + file_name
+                ),
+            )
 
 
 def _upload_to_bq_source(

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -253,10 +253,16 @@ class DataprocClusterLauncher(JobLauncher):
             return file_path
 
         staging_client = get_staging_client("gs")
-        blob_path = os.path.join(self.remote_path, job_id, os.path.basename(file_path),)
-        staging_client.upload_file(file_path, self.staging_bucket, blob_path)
+        blob_path = os.path.join(
+            self.remote_path, job_id, os.path.basename(file_path),
+        ).lstrip("/")
+        blob_uri_str = f"gs://{self.staging_bucket}/{blob_path}"
+        with open(file_path, "rb") as f:
+            staging_client.upload_fileobj(
+                f, file_path, remote_uri=urlparse(blob_uri_str)
+            )
 
-        return f"gs://{self.staging_bucket}/{blob_path}"
+        return blob_uri_str
 
     def dataproc_submit(
         self, job_params: SparkJobParameters

--- a/sdk/python/feast/staging/entities.py
+++ b/sdk/python/feast/staging/entities.py
@@ -35,12 +35,11 @@ def stage_entities_to_fs(
         )
 
         entity_source.to_parquet(df_export_path.name)
-        bucket = (
-            None if entity_staging_uri.scheme == "file" else entity_staging_uri.netloc
-        )
-        staging_client.upload_file(
-            df_export_path.name, bucket, entity_staging_uri.path.lstrip("/")
-        )
+
+        with open(df_export_path.name, "rb") as f:
+            staging_client.upload_fileobj(
+                f, df_export_path.name, remote_uri=entity_staging_uri
+            )
 
     # ToDo: support custom event_timestamp_column
     return FileSource(

--- a/sdk/python/tests/loaders/test_file.py
+++ b/sdk/python/tests/loaders/test_file.py
@@ -32,7 +32,7 @@ BUCKET = "test_bucket"
 FOLDER_NAME = "test_folder"
 FILE_NAME = "test.avro"
 
-LOCAL_FILE = "file://tmp/tmp"
+LOCAL_FILE = "file:///tmp/tmp"
 S3_LOCATION = f"s3://{BUCKET}/{FOLDER_NAME}"
 
 TEST_DATA_FRAME = pd.DataFrame(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
It makes EMR launcher use the standard uploader from `feast.staging`. Since EMR launcher relied on some functionality that didn't exist in the staging uploader, I had to update the staging uploader to support it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
