### PR TITLE
remove stage_dataframe from the launcher interface

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -482,13 +482,17 @@ def get_historical_features(
     features: str, entity_df_path: str, entity_df_dtype: str, destination: str
 ):
     """
-    Get historical features
+    Get historical features. This CLI command is mostly for testing/easy demos; use the
+    corresponding API method in production.
+
+    The main reason why this command is unlikely to be more broadly useful is that we make quite a
+    few assumptions about the entity dataframe, namely:
+        * it has to have `event_timestamp` column
+        * it has to parse cleanly by `pandas.read_csv()` with no extra tuning of data types
     """
     import pandas
 
     client = Client()
-
-    # TODO: clean this up
 
     if entity_df_dtype:
         dtype = json.loads(entity_df_dtype)

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -1212,4 +1212,4 @@ class Client:
     def stage_dataframe(
         self, df: pd.DataFrame, event_timestamp_column: str,
     ) -> FileSource:
-        return stage_dataframe(df, event_timestamp_column, self)
+        return stage_dataframe(df, event_timestamp_column, self._config)

--- a/sdk/python/feast/pyspark/abc.py
+++ b/sdk/python/feast/pyspark/abc.py
@@ -6,10 +6,6 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional
 
-import pandas
-
-from feast.data_source import FileSource
-
 
 class SparkJobFailure(Exception):
     """
@@ -538,18 +534,6 @@ class JobLauncher(abc.ABC):
 
         Returns:
             StreamIngestionJob: wrapper around remote job.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def stage_dataframe(
-        self, df: pandas.DataFrame, event_timestamp_column: str,
-    ) -> FileSource:
-        """
-        Upload a pandas dataframe so it is available to the Spark cluster.
-
-        Returns:
-            FileSource: representing the uploaded dataframe.
         """
         raise NotImplementedError
 

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -303,6 +303,14 @@ def get_job_by_id(job_id: str, client: "Client") -> SparkJob:
 
 
 def stage_dataframe(df, event_timestamp_column: str, config: Config) -> FileSource:
+    """
+    Helper function to upload a pandas dataframe in parquet format to a temporary location (under
+    SPARK_STAGING_LOCATION) and return it wrapped in a FileSource.
+
+    Args:
+        event_timestamp_column(str): the name of the timestamp column in the dataframe.
+        config(Config): feast config.
+    """
     staging_location = config.get(opt.SPARK_STAGING_LOCATION)
     staging_uri = urlparse(staging_location)
 

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -350,9 +350,6 @@ class DataprocClusterLauncher(JobLauncher):
         job_hash = ingestion_job_params.get_job_hash()
         return DataprocStreamingIngestionJob(job, refresh_fn, cancel_fn, job_hash)
 
-    def stage_dataframe(self, df, event_timestamp_column: str):
-        raise NotImplementedError
-
     def get_job_by_id(self, job_id: str) -> SparkJob:
         job = self.job_client.get_job(
             project_id=self.project_id, region=self.region, job_id=job_id

--- a/sdk/python/feast/pyspark/launchers/standalone/local.py
+++ b/sdk/python/feast/pyspark/launchers/standalone/local.py
@@ -332,9 +332,6 @@ class StandaloneClusterLauncher(JobLauncher):
         global_job_cache.add_job(job)
         return job
 
-    def stage_dataframe(self, df, event_timestamp_column: str):
-        raise NotImplementedError
-
     def get_job_by_id(self, job_id: str) -> SparkJob:
         return global_job_cache.get_job_by_id(job_id)
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
It was only implemented for EMR anyway. Also now that all upload paths are using the staging client, we can implement this once without having launcher-specific implementations.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
