### PR TITLE
Python UDF in Ingestion being used for feature validation

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -193,3 +193,28 @@ jobs:
           name: ingestion-jar
           path: spark/ingestion/target/feast-ingestion-spark-develop.jar
           retention-days: 1
+  publish-ingestion-pylibs:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ 3.6, 3.7, 3.8 ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Create libs archive
+        env:
+          PY_VERSION: ${{ matrix.python-version }}
+        run: |
+          export PLATFORM=$(python -c 'import platform; platform.system().lower()')
+          mkdir pylibs/
+          ./infra/scripts/build-ingestion-py-dependencies.sh "py${PY_VERSION}-$PLATFORM" $PWD/pylibs/
+      - name: Upload ingestion jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: pylibs
+          path: pylibs/
+          retention-days: 1

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -128,6 +128,10 @@ jobs:
           java-version: '11'
           java-package: jdk
           architecture: x64
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+          architecture: 'x64'
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -140,9 +140,9 @@ jobs:
             ${{ runner.os }}-it-maven-
       - name: Run integration tests
         run:  make test-java-integration
-        continue-on-error: true
       - name: Save report
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
           name: ingestion-it-report
           path: spark/ingestion/target/test-reports/TestSuite.txt
@@ -193,6 +193,7 @@ jobs:
           name: ingestion-jar
           path: spark/ingestion/target/feast-ingestion-spark-develop.jar
           retention-days: 1
+
   publish-ingestion-pylibs:
     strategy:
       matrix:
@@ -212,8 +213,7 @@ jobs:
           export PLATFORM=$(python -c 'import platform; print(platform.system().lower())')
           mkdir pylibs/
           ./infra/scripts/build-ingestion-py-dependencies.sh "py${PY_VERSION}-$PLATFORM" $PWD/pylibs/
-      - name: Upload ingestion jar
-        uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v2
         with:
           name: pylibs
           path: pylibs/

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -140,6 +140,7 @@ jobs:
             ${{ runner.os }}-it-maven-
       - name: Run integration tests
         run:  make test-java-integration
+        continue-on-error: true
       - name: Save report
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -193,28 +193,3 @@ jobs:
           name: ingestion-jar
           path: spark/ingestion/target/feast-ingestion-spark-develop.jar
           retention-days: 1
-
-  publish-ingestion-pylibs:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        python-version: [ 3.6, 3.7, 3.8 ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Create libs archive
-        env:
-          PY_VERSION: ${{ matrix.python-version }}
-        run: |
-          export PLATFORM=$(python -c 'import platform; print(platform.system().lower())')
-          mkdir pylibs/
-          ./infra/scripts/build-ingestion-py-dependencies.sh "py${PY_VERSION}-$PLATFORM" $PWD/pylibs/
-      - uses: actions/upload-artifact@v2
-        with:
-          name: pylibs
-          path: pylibs/
-          retention-days: 1

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -144,9 +144,9 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: ingestion-it-report
+          name: it-report
           path: spark/ingestion/target/test-reports/TestSuite.txt
-          retention-days: 1
+          retention-days: 5
 
   tests-docker-compose:
     needs:
@@ -192,29 +192,4 @@ jobs:
         with:
           name: ingestion-jar
           path: spark/ingestion/target/feast-ingestion-spark-develop.jar
-          retention-days: 1
-
-  publish-ingestion-pylibs:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        python-version: [ 3.6, 3.7, 3.8 ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Create libs archive
-        env:
-          PY_VERSION: ${{ matrix.python-version }}
-        run: |
-          export PLATFORM=$(python -c 'import platform; print(platform.system().lower())')
-          mkdir pylibs/
-          ./infra/scripts/build-ingestion-py-dependencies.sh "py${PY_VERSION}-$PLATFORM" $PWD/pylibs/
-      - uses: actions/upload-artifact@v2
-        with:
-          name: pylibs
-          path: pylibs/
           retention-days: 1

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -140,6 +140,12 @@ jobs:
             ${{ runner.os }}-it-maven-
       - name: Run integration tests
         run:  make test-java-integration
+      - name: Save report
+        uses: actions/upload-artifact@v2
+        with:
+          name: ingestion-it-report
+          path: spark/ingestion/target/test-reports/TestSuite.txt
+          retention-days: 1
 
   tests-docker-compose:
     needs:

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -193,3 +193,28 @@ jobs:
           name: ingestion-jar
           path: spark/ingestion/target/feast-ingestion-spark-develop.jar
           retention-days: 1
+
+  publish-ingestion-pylibs:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        python-version: [ 3.6, 3.7, 3.8 ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Create libs archive
+        env:
+          PY_VERSION: ${{ matrix.python-version }}
+        run: |
+          export PLATFORM=$(python -c 'import platform; print(platform.system().lower())')
+          mkdir pylibs/
+          ./infra/scripts/build-ingestion-py-dependencies.sh "py${PY_VERSION}-$PLATFORM" $PWD/pylibs/
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pylibs
+          path: pylibs/
+          retention-days: 1

--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -196,7 +196,7 @@ jobs:
   publish-ingestion-pylibs:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         python-version: [ 3.6, 3.7, 3.8 ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -209,7 +209,7 @@ jobs:
         env:
           PY_VERSION: ${{ matrix.python-version }}
         run: |
-          export PLATFORM=$(python -c 'import platform; platform.system().lower()')
+          export PLATFORM=$(python -c 'import platform; print(platform.system().lower())')
           mkdir pylibs/
           ./infra/scripts/build-ingestion-py-dependencies.sh "py${PY_VERSION}-$PLATFORM" $PWD/pylibs/
       - name: Upload ingestion jar

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -77,3 +77,30 @@ jobs:
             make build-java-no-tests REVISION=${VERSION}
             gsutil cp ./spark/ingestion/target/feast-ingestion-spark-${VERSION}.jar gs://${PUBLISH_BUCKET}/spark/ingestion/
           fi
+
+  publish-ingestion-pylibs:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        python-version: [ 3.6, 3.7, 3.8 ]
+    env:
+      PUBLISH_BUCKET: feast-jobs
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          export_default_credentials: true
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Create libs archive
+        env:
+          PY_VERSION: ${{ matrix.python-version }}
+        run: |
+          export PLATFORM=$(python -c 'import platform; print(platform.system().lower())')
+          ./infra/scripts/build-ingestion-py-dependencies.sh "py${PY_VERSION}-$PLATFORM" gs://${PUBLISH_BUCKET}/spark/validation/

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test-java-integration:
 	${MVN} --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true clean verify
 
 test-java-with-coverage:
-	${MVN} --no-transfer-progress test jacoco:report-aggregate
+	${MVN} --no-transfer-progress -DskipITs=true test jacoco:report-aggregate
 
 build-java:
 	${MVN} clean verify

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint-java:
 	${MVN} --no-transfer-progress spotless:check
 
 test-java:
-	${MVN} --no-transfer-progress test
+	${MVN} --no-transfer-progress -DskipITs=true test
 
 test-java-integration:
 	${MVN} --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true clean verify
@@ -57,7 +57,7 @@ build-java:
 	${MVN} clean verify
 
 build-java-no-tests:
-	${MVN} --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true -Drevision=${REVISION} clean package
+	${MVN} --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true -DskipITs=true -Drevision=${REVISION} clean package
 
 # Python SDK
 

--- a/infra/scripts/build-ingestion-py-dependencies.sh
+++ b/infra/scripts/build-ingestion-py-dependencies.sh
@@ -11,7 +11,7 @@ pip3 install -t ${tmp_dir}/libs $PACKAGES
 cd $tmp_dir
 tar -czf pylibs-ge-$PLATFORM.tar.gz libs/
 if [[ $DESTINATION == gs* ]]; then
-  gsutil cp pylibs-ge-$PLATFORM.tar.gz $GS_DESTINATION/
+  gsutil cp pylibs-ge-$PLATFORM.tar.gz $GS_DESTINATION
 else
   mv pylibs-ge-$PLATFORM.tar.gz $DESTINATION
 fi

--- a/infra/scripts/build-ingestion-py-dependencies.sh
+++ b/infra/scripts/build-ingestion-py-dependencies.sh
@@ -2,7 +2,7 @@
 
 PLATFORM=$1
 DESTINATION=$2
-PACKAGES=${PACKAGES:-"great-expectations==0.13.2"}
+PACKAGES=${PACKAGES:-"great-expectations==0.13.2 pyarrow==2.0.0"}
 
 tmp_dir=$(mktemp -d)
 

--- a/infra/scripts/build-ingestion-py-dependencies.sh
+++ b/infra/scripts/build-ingestion-py-dependencies.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION=$1
+PLATFORM=$1
 DESTINATION=$2
 PACKAGES=${PACKAGES:-"great-expectations==0.13.2"}
 
@@ -9,9 +9,9 @@ tmp_dir=$(mktemp -d)
 pip3 install -t ${tmp_dir}/libs $PACKAGES
 
 cd $tmp_dir
-tar -czf libs-$VERSION.tar.gz libs/
+tar -czf pylibs-ge-$PLATFORM.tar.gz libs/
 if [[ $DESTINATION == gs* ]]; then
-  gsutil cp libs-$VERSION.tar.gz $GS_DESTINATION/libs-$VERSION.tar.gz
+  gsutil cp pylibs-ge-$PLATFORM.tar.gz $GS_DESTINATION/
 else
-  mv libs-$VERSION.tar.gz $DESTINATION
+  mv pylibs-ge-$PLATFORM.tar.gz $DESTINATION
 fi

--- a/infra/scripts/build-ingestion-py-dependencies.sh
+++ b/infra/scripts/build-ingestion-py-dependencies.sh
@@ -6,12 +6,12 @@ PACKAGES=${PACKAGES:-"great-expectations==0.13.2"}
 
 tmp_dir=$(mktemp -d)
 
-pip3 install -t ${tmp_dir} $PACKAGES
+pip3 install -t ${tmp_dir}/libs $PACKAGES
 
 cd $tmp_dir
-zip -q -r libs-$VERSION.zip .
+tar -czf libs-$VERSION.tar.gz libs/
 if [[ $DESTINATION == gs* ]]; then
-  gsutil cp libs-$VERSION.zip $GS_DESTINATION/libs-$VERSION.zip
+  gsutil cp libs-$VERSION.tar.gz $GS_DESTINATION/libs-$VERSION.tar.gz
 else
-  mv libs-$VERSION.zip $DESTINATION
+  mv libs-$VERSION.tar.gz $DESTINATION
 fi

--- a/infra/scripts/build-ingestion-py-dependencies.sh
+++ b/infra/scripts/build-ingestion-py-dependencies.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+VERSION=$1
+DESTINATION=$2
+PACKAGES=${PACKAGES:-"great-expectations==0.13.2"}
+
+tmp_dir=$(mktemp -d)
+
+pip3 install -t ${tmp_dir} $PACKAGES
+
+cd $tmp_dir
+zip -q -r libs-$VERSION.zip .
+if [[ $DESTINATION == gs* ]]; then
+  gsutil cp libs-$VERSION.zip $GS_DESTINATION/libs-$VERSION.zip
+else
+  mv libs-$VERSION.zip $DESTINATION
+fi

--- a/infra/scripts/build-ingestion-py-dependencies.sh
+++ b/infra/scripts/build-ingestion-py-dependencies.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -euo pipefail
 PLATFORM=$1
 DESTINATION=$2
 PACKAGES=${PACKAGES:-"great-expectations==0.13.2 pyarrow==2.0.0"}

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
         <parent.basedir>${maven.multiModuleProjectDirectory}</parent.basedir>
 
         <skipUTs>false</skipUTs>
+        <skipITs>false</skipITs>
         <feast.auth.providers.http.client.package.name>feast.common.auth.providers.http.client</feast.auth.providers.http.client.package.name>
     </properties>
 

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -222,6 +222,10 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: https://github.com/gojekfarm/stencil
     STENCIL_URL: str = ""
 
+    #: If set to true rows that do not pass custom validation (see feast.contrib.validation)
+    #: won't be saved to Online Storage
+    INGESTION_DROP_INVALID_ROWS = "False"
+
     #: EMR cluster to run Feast Spark Jobs in
     EMR_CLUSTER_ID: Optional[str] = None
 

--- a/sdk/python/feast/contrib/validation/base.py
+++ b/sdk/python/feast/contrib/validation/base.py
@@ -1,0 +1,13 @@
+import io
+
+try:
+    from pyspark import cloudpickle
+except ImportError:
+    raise ImportError("pyspark must be installed to enable validation functionality")
+
+
+def serialize_udf(fun, return_type) -> bytes:
+    buffer = io.BytesIO()
+    command = (fun, return_type)
+    cloudpickle.dump(command, buffer)
+    return buffer.getvalue()

--- a/sdk/python/feast/contrib/validation/ge.py
+++ b/sdk/python/feast/contrib/validation/ge.py
@@ -1,6 +1,6 @@
 import io
 import json
-from dataclasses import dataclass
+
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -36,10 +36,10 @@ GE_PACKED_ARCHIVE = "https://storage.googleapis.com/feast-jobs/spark/validation/
 _UNSET = object()
 
 
-@dataclass
 class ValidationUDF:
-    name: str
-    pickled_code: bytes
+    def __init__(self, name: str, pickled_code: bytes):
+        self.name = name
+        self.pickled_code = pickled_code
 
 
 def create_validation_udf(name: str, expectations: ExpectationSuite) -> ValidationUDF:

--- a/sdk/python/feast/contrib/validation/ge.py
+++ b/sdk/python/feast/contrib/validation/ge.py
@@ -1,6 +1,5 @@
 import io
 import json
-
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 

--- a/sdk/python/feast/contrib/validation/ge.py
+++ b/sdk/python/feast/contrib/validation/ge.py
@@ -1,29 +1,38 @@
+import io
 import json
-
 from dataclasses import dataclass
-from feast.contrib.validation.base import serialize_udf
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from feast.constants import ConfigOptions
+from feast.contrib.validation.base import serialize_udf
+from feast.staging.storage_client import get_staging_client
 
 try:
     from great_expectations.core import ExpectationSuite
     from great_expectations.dataset import PandasDataset
 except ImportError:
-    raise ImportError("great_expectations must be installed to enable validation functionality. "
-                      "Please install feast[validation]")
+    raise ImportError(
+        "great_expectations must be installed to enable validation functionality. "
+        "Please install feast[validation]"
+    )
 
 try:
     from pyspark.sql.types import BooleanType
 except ImportError:
-    raise ImportError("pyspark must be installed to enable validation functionality. "
-                      "Please install feast[validation]")
+    raise ImportError(
+        "pyspark must be installed to enable validation functionality. "
+        "Please install feast[validation]"
+    )
 
 
 if TYPE_CHECKING:
-    from feast import Client, FeatureTable
     import pandas as pd
 
+    from feast import Client, FeatureTable
 
-GE_PACKED_ARCHIVE = ''
+
+GE_PACKED_ARCHIVE = ""
 
 
 @dataclass
@@ -53,9 +62,10 @@ def create_validation_udf(name: str, expectations: ExpectationSuite) -> Validati
     :param expectations: collection of expectation gathered on training dataset
     :return: ValidationUDF with serialized code
     """
+
     def udf(df: pd.DataFrame) -> pd.Series:
         ds = PandasDataset.from_dataset(df)
-        result = ds.validate(expectations, result_format='COMPLETE')
+        result = ds.validate(expectations, result_format="COMPLETE")
         valid_rows = pd.Series([True] * df.shape[0])
 
         for check in result.results:
@@ -66,7 +76,7 @@ def create_validation_udf(name: str, expectations: ExpectationSuite) -> Validati
                 # ToDo: probably we should mark all rows as invalid
                 continue
 
-            valid_rows.iloc[check.result['unexpected_index_list']] = False
+            valid_rows.iloc[check.result["unexpected_index_list"]] = False
 
         return valid_rows
 
@@ -75,20 +85,37 @@ def create_validation_udf(name: str, expectations: ExpectationSuite) -> Validati
 
 
 def apply_validation(
-        client: 'Client',
-        feature_table: 'FeatureTable',
-        udf: ValidationUDF,
-        validation_window_secs: int
+    client: "Client",
+    feature_table: "FeatureTable",
+    udf: ValidationUDF,
+    validation_window_secs: int,
 ):
     """
     Uploads validation udf code to staging location &
-    stores path to udf code and required python libraries in FeatureTable labels.
+    stores path to udf code and required python libraries as FeatureTable labels.
     """
-    feature_table.labels.update({
-        "_validation": json.dumps(dict(
-            pickled_code=udf.pickled_code,
-            dependencies_path=GE_PACKED_ARCHIVE,
-        )),
-        "_streaming_trigger_secs": validation_window_secs
-    })
+    staging_location = client._config.get(ConfigOptions.SPARK_STAGING_LOCATION).rstrip(
+        "/"
+    )
+    staging_scheme = urlparse(staging_location).scheme
+    staging_client = get_staging_client(staging_scheme)
+
+    pickled_code_fp = io.BytesIO(udf.pickled_code)
+    remote_path = f"{staging_location}/udfs/{udf.name}.pickle"
+    staging_client.upload_fileobj(
+        pickled_code_fp, f"{udf.name}.pickle", remote_uri=urlparse(remote_path)
+    )
+
+    feature_table.labels.update(
+        {
+            "_validation": json.dumps(
+                dict(
+                    name=udf.name,
+                    pickled_code_path=remote_path,
+                    include_archive_path=GE_PACKED_ARCHIVE,
+                )
+            ),
+            "_streaming_trigger_secs": validation_window_secs,
+        }
+    )
     client.apply_feature_table(feature_table)

--- a/sdk/python/feast/contrib/validation/ge.py
+++ b/sdk/python/feast/contrib/validation/ge.py
@@ -1,0 +1,94 @@
+import json
+
+from dataclasses import dataclass
+from feast.contrib.validation.base import serialize_udf
+from typing import TYPE_CHECKING
+
+try:
+    from great_expectations.core import ExpectationSuite
+    from great_expectations.dataset import PandasDataset
+except ImportError:
+    raise ImportError("great_expectations must be installed to enable validation functionality. "
+                      "Please install feast[validation]")
+
+try:
+    from pyspark.sql.types import BooleanType
+except ImportError:
+    raise ImportError("pyspark must be installed to enable validation functionality. "
+                      "Please install feast[validation]")
+
+
+if TYPE_CHECKING:
+    from feast import Client, FeatureTable
+    import pandas as pd
+
+
+GE_PACKED_ARCHIVE = ''
+
+
+@dataclass
+class ValidationUDF:
+    name: str
+    pickled_code: bytes
+
+
+def create_validation_udf(name: str, expectations: ExpectationSuite) -> ValidationUDF:
+    """
+    Wraps your expectations into Spark UDF.
+
+    Expectations should be generated & validated using training dataset:
+    >>> from great_expectations.dataset import PandasDataset
+    >>> ds = PandasDataset.from_dataset(you_training_df)
+    >>> ds.expect_column_values_to_be_between('column', 0, 100)
+
+    >>> expectations = ds.get_expectation_suite()
+
+    Important: you expectations should pass on training dataset, only successful checks
+    will be converted and stored in ExpectationSuite.
+
+    Now you can create UDF that will validate data during ingestion:
+    >>> create_validation_udf("myValidation", expectations)
+
+    :param name
+    :param expectations: collection of expectation gathered on training dataset
+    :return: ValidationUDF with serialized code
+    """
+    def udf(df: pd.DataFrame) -> pd.Series:
+        ds = PandasDataset.from_dataset(df)
+        result = ds.validate(expectations, result_format='COMPLETE')
+        valid_rows = pd.Series([True] * df.shape[0])
+
+        for check in result.results:
+            if check.success:
+                continue
+
+            if check.raised_exception:
+                # ToDo: probably we should mark all rows as invalid
+                continue
+
+            valid_rows.iloc[check.result['unexpected_index_list']] = False
+
+        return valid_rows
+
+    pickled_code = serialize_udf(udf, BooleanType())
+    return ValidationUDF(name, pickled_code)
+
+
+def apply_validation(
+        client: 'Client',
+        feature_table: 'FeatureTable',
+        udf: ValidationUDF,
+        validation_window_secs: int
+):
+    """
+    Uploads validation udf code to staging location &
+    stores path to udf code and required python libraries in FeatureTable labels.
+    """
+    feature_table.labels.update({
+        "_validation": json.dumps(dict(
+            pickled_code=udf.pickled_code,
+            dependencies_path=GE_PACKED_ARCHIVE,
+        )),
+        "_streaming_trigger_secs": validation_window_secs
+    })
+    client.apply_feature_table(feature_table)

--- a/sdk/python/feast/pyspark/abc.py
+++ b/sdk/python/feast/pyspark/abc.py
@@ -307,6 +307,7 @@ class IngestionJobParameters(SparkJobParameters):
         statsd_port: Optional[int] = None,
         deadletter_path: Optional[str] = None,
         stencil_url: Optional[str] = None,
+        drop_invalid_rows: bool = False,
     ):
         self._feature_table = feature_table
         self._source = source
@@ -318,6 +319,7 @@ class IngestionJobParameters(SparkJobParameters):
         self._statsd_port = statsd_port
         self._deadletter_path = deadletter_path
         self._stencil_url = stencil_url
+        self._drop_invalid_rows = drop_invalid_rows
 
     def _get_redis_config(self):
         return dict(host=self._redis_host, port=self._redis_port, ssl=self._redis_ssl)
@@ -361,6 +363,9 @@ class IngestionJobParameters(SparkJobParameters):
 
         if self._stencil_url:
             args.extend(["--stencil-url", self._stencil_url])
+
+        if self._drop_invalid_rows:
+            args.extend(["--drop-invalid"])
 
         return args
 
@@ -430,6 +435,7 @@ class StreamIngestionJobParameters(IngestionJobParameters):
         statsd_port: Optional[int] = None,
         deadletter_path: Optional[str] = None,
         stencil_url: Optional[str] = None,
+        drop_invalid_rows: bool = False,
     ):
         super().__init__(
             feature_table,
@@ -442,6 +448,7 @@ class StreamIngestionJobParameters(IngestionJobParameters):
             statsd_port,
             deadletter_path,
             stencil_url,
+            drop_invalid_rows,
         )
         self._extra_jars = extra_jars
 

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -148,6 +148,7 @@ def _feature_table_to_argument(
             for n in feature_table.entities
         ],
         "max_age": feature_table.max_age.ToSeconds() if feature_table.max_age else None,
+        "labels": feature_table.labels
     }
 
 

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -148,7 +148,7 @@ def _feature_table_to_argument(
             for n in feature_table.entities
         ],
         "max_age": feature_table.max_age.ToSeconds() if feature_table.max_age else None,
-        "labels": feature_table.labels
+        "labels": dict(feature_table.labels),
     }
 
 
@@ -289,6 +289,7 @@ def get_stream_to_online_ingestion_params(
         and client._config.getint(opt.STATSD_PORT),
         deadletter_path=client._config.get(opt.DEADLETTER_PATH),
         stencil_url=client._config.get(opt.STENCIL_URL),
+        drop_invalid_rows=client._config.get(opt.INGESTION_DROP_INVALID_ROWS),
     )
 
 

--- a/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
+++ b/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
@@ -329,6 +329,7 @@ def _stream_ingestion_step(
                     "Value": feature_table_name,
                 },
                 {"Key": "feast.step_metadata.job_hash", "Value": job_hash},
+                {"Key": "spark.yarn.isPython", "Value": "true"}
             ],
             "Args": ["spark-submit", "--class", "feast.ingestion.IngestionJob"]
             + jars_args

--- a/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
+++ b/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
@@ -329,10 +329,10 @@ def _stream_ingestion_step(
                     "Value": feature_table_name,
                 },
                 {"Key": "feast.step_metadata.job_hash", "Value": job_hash},
-                {"Key": "spark.yarn.isPython", "Value": "true"}
             ],
             "Args": ["spark-submit", "--class", "feast.ingestion.IngestionJob"]
             + jars_args
+            + ["--conf", "spark.yarn.isPython=true"]
             + ["--packages", BQ_SPARK_PACKAGE, jar_path]
             + args,
             "Jar": "command-runner.jar",

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -284,6 +284,8 @@ class DataprocClusterLauncher(JobLauncher):
                 "spark.executor.instances": self.executor_instances,
                 "spark.executor.cores": self.executor_cores,
                 "spark.executor.memory": self.executor_memory,
+                "spark.pyspark.driver.python": "python3.6",
+                "spark.pyspark.python": "python3.6",
             }
 
             properties.update(extra_properties)

--- a/sdk/python/requirements-ci.txt
+++ b/sdk/python/requirements-ci.txt
@@ -21,3 +21,4 @@ pytest-timeout==1.4.2
 pytest-ordering==0.6.*
 pytest-mock==1.10.4
 PyYAML==5.3.1
+great-expectations==0.13.2

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -77,7 +77,10 @@ setup(
     install_requires=REQUIRED,
     # https://stackoverflow.com/questions/28509965/setuptools-development-requirements
     # Install dev requirements with: pip install -e .[dev]
-    extras_require={"dev": ["mypy-protobuf==1.*", "grpcio-testing==1.*"]},
+    extras_require={
+        "dev": ["mypy-protobuf==1.*", "grpcio-testing==1.*"],
+        "validation": ["great_expectations==0.13.2", "pyspark==3.0.1"]
+    },
     include_package_data=True,
     license="Apache",
     classifiers=[

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -366,6 +366,23 @@
                     <skipTests>true</skipTests>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <executions>
+                    <execution>
+                        <id>Python UDF setup</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>./setup.sh</executable>
+                            <workingDirectory>${basedir}/src/test/resources/python/</workingDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -377,6 +377,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipUTs}</skip>
                             <executable>./setup.sh</executable>
                             <workingDirectory>${basedir}/src/test/resources/python/</workingDirectory>
                         </configuration>

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -377,7 +377,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipUTs}</skip>
+                            <skip>${skipITs}</skip>
                             <executable>./setup.sh</executable>
                             <workingDirectory>${basedir}/src/test/resources/python/</workingDirectory>
                         </configuration>

--- a/spark/ingestion/pom.xml
+++ b/spark/ingestion/pom.xml
@@ -258,6 +258,11 @@
                         <goals>
                             <goal>test</goal>
                         </goals>
+                        <configuration>
+                            <reportsDirectory>${project.build.directory}/test-reports</reportsDirectory>
+                            <junitxml>.</junitxml>
+                            <filereports>WDF TestSuite.txt</filereports>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -36,7 +36,7 @@ object BatchPipeline extends BasePipeline {
     val featureTable = config.featureTable
     val projection =
       inputProjection(config.source, featureTable.features, featureTable.entities)
-    val validator = new RowValidator(featureTable, config.source.eventTimestampColumn)
+    val rowValidator = new RowValidator(featureTable, config.source.eventTimestampColumn)
 
     val input = config.source match {
       case source: BQSource =>
@@ -64,7 +64,7 @@ object BatchPipeline extends BasePipeline {
     }
 
     val validRows = projected
-      .filter(validator.checkAll)
+      .filter(rowValidator.allChecks)
 
     validRows.write
       .format("feast.ingestion.stores.redis")
@@ -78,7 +78,7 @@ object BatchPipeline extends BasePipeline {
     config.deadLetterPath match {
       case Some(path) =>
         projected
-          .filter(!validator.checkAll)
+          .filter(!rowValidator.allChecks)
           .write
           .format("parquet")
           .mode(SaveMode.Append)

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -49,7 +49,15 @@ object IngestionJob {
       .text("JSON-encoded source object (e.g. {\"kafka\":{\"bootstrapServers\":...}}")
 
     opt[String](name = "feature-table")
-      .action((x, c) => c.copy(featureTable = parseJSON(x).camelizeKeys.extract[FeatureTable]))
+      .action((x, c) => {
+        val ft = parseJSON(x).camelizeKeys.extract[FeatureTable]
+
+        c.copy(
+          featureTable = ft,
+          streamingTriggeringSecs = ft.labels.getOrElse("_streaming_trigger_secs", "0").toInt,
+          validationConfig = ft.labels.get("_validation").map(parseJSON(_).camelizeKeys.extract[ValidationConfig])
+        )
+      })
       .required()
       .text("JSON-encoded FeatureTableSpec object")
 

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -55,7 +55,8 @@ object IngestionJob {
         c.copy(
           featureTable = ft,
           streamingTriggeringSecs = ft.labels.getOrElse("_streaming_trigger_secs", "0").toInt,
-          validationConfig = ft.labels.get("_validation").map(parseJSON(_).camelizeKeys.extract[ValidationConfig])
+          validationConfig =
+            ft.labels.get("_validation").map(parseJSON(_).camelizeKeys.extract[ValidationConfig])
         )
       })
       .required()

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJob.scala
@@ -81,6 +81,9 @@ object IngestionJob {
 
     opt[String](name = "stencil-url")
       .action((x, c) => c.copy(stencilURL = Some(x)))
+
+    opt[Unit](name = "drop-invalid")
+      .action((_, c) => c.copy(doNotIngestInvalidRows = true))
   }
 
   def main(args: Array[String]): Unit = {

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -95,17 +95,26 @@ case class FeatureTable(
     project: String,
     entities: Seq[Field],
     features: Seq[Field],
-    maxAge: Option[Long] = None
+    maxAge: Option[Long] = None,
+    labels: Map[String, String] = Map.empty
+)
+
+case class ValidationConfig(
+    name: String,
+    pickledCodePath: String,
+    includeArchivePath: String
 )
 
 case class IngestionJobConfig(
-    mode: Modes = Modes.Offline,
-    featureTable: FeatureTable = null,
-    source: Source = null,
-    startTime: DateTime = DateTime.now(),
-    endTime: DateTime = DateTime.now(),
-    store: StoreConfig = RedisConfig("localhost", 6379, false),
-    metrics: Option[MetricConfig] = None,
-    deadLetterPath: Option[String] = None,
-    stencilURL: Option[String] = None
+     mode: Modes = Modes.Offline,
+     featureTable: FeatureTable = null,
+     source: Source = null,
+     startTime: DateTime = DateTime.now(),
+     endTime: DateTime = DateTime.now(),
+     store: StoreConfig = RedisConfig("localhost", 6379, false),
+     metrics: Option[MetricConfig] = None,
+     deadLetterPath: Option[String] = None,
+     stencilURL: Option[String] = None,
+     streamingTriggeringSecs: Int = 0,
+     validationConfig: Option[ValidationConfig] = None
 )

--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -106,15 +106,16 @@ case class ValidationConfig(
 )
 
 case class IngestionJobConfig(
-     mode: Modes = Modes.Offline,
-     featureTable: FeatureTable = null,
-     source: Source = null,
-     startTime: DateTime = DateTime.now(),
-     endTime: DateTime = DateTime.now(),
-     store: StoreConfig = RedisConfig("localhost", 6379, false),
-     metrics: Option[MetricConfig] = None,
-     deadLetterPath: Option[String] = None,
-     stencilURL: Option[String] = None,
-     streamingTriggeringSecs: Int = 0,
-     validationConfig: Option[ValidationConfig] = None
+    mode: Modes = Modes.Offline,
+    featureTable: FeatureTable = null,
+    source: Source = null,
+    startTime: DateTime = DateTime.now(),
+    endTime: DateTime = DateTime.now(),
+    store: StoreConfig = RedisConfig("localhost", 6379, false),
+    metrics: Option[MetricConfig] = None,
+    deadLetterPath: Option[String] = None,
+    stencilURL: Option[String] = None,
+    streamingTriggeringSecs: Int = 0,
+    validationConfig: Option[ValidationConfig] = None,
+    doNotIngestInvalidRows: Boolean = false
 )

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -21,8 +21,9 @@ import java.util.concurrent.TimeUnit
 
 import feast.ingestion.registry.proto.ProtoRegistryFactory
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
-import org.apache.spark.sql.functions.{struct, udf}
+import org.apache.spark.sql.functions.{expr, struct, udf}
 import feast.ingestion.utils.ProtoReflection
+import feast.ingestion.utils.testing.MemoryStreamingSource
 import feast.ingestion.validation.{RowValidator, TypeCheck}
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang.StringUtils
@@ -36,25 +37,25 @@ import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.types.BooleanType
 
 /**
- * Streaming pipeline (currently in micro-batches mode only, since we need to have multiple sinks: redis & deadletters).
- * Flow:
- * 1. Read from streaming source (currently only Kafka)
- * 2. Parse bytes from streaming source into Row with schema inferenced from provided class (Protobuf)
- * 3. Map columns according to provided mapping rules
- * 4. Validate
- * 5. (In batches) store to redis valid rows / write to deadletter (parquet) invalid
- */
+  * Streaming pipeline (currently in micro-batches mode only, since we need to have multiple sinks: redis & deadletters).
+  * Flow:
+  * 1. Read from streaming source (currently only Kafka)
+  * 2. Parse bytes from streaming source into Row with schema inferenced from provided class (Protobuf)
+  * 3. Map columns according to provided mapping rules
+  * 4. Validate
+  * 5. (In batches) store to redis valid rows / write to deadletter (parquet) invalid
+  */
 object StreamingPipeline extends BasePipeline with Serializable {
   override def createPipeline(
-                               sparkSession: SparkSession,
-                               config: IngestionJobConfig
-                             ): Option[StreamingQuery] = {
+      sparkSession: SparkSession,
+      config: IngestionJobConfig
+  ): Option[StreamingQuery] = {
     import sparkSession.implicits._
 
     val featureTable = config.featureTable
     val projection =
       inputProjection(config.source, featureTable.features, featureTable.entities)
-    val validator = new RowValidator(featureTable, config.source.eventTimestampColumn)
+    val rowValidator = new RowValidator(featureTable, config.source.eventTimestampColumn)
 
     val validationUDF = createValidationUDF(sparkSession, config)
 
@@ -65,6 +66,8 @@ object StreamingPipeline extends BasePipeline with Serializable {
           .option("kafka.bootstrap.servers", source.bootstrapServers)
           .option("subscribe", source.topic)
           .load()
+      case source: MemoryStreamingSource =>
+        source.read
     }
 
     val parsed = config.source.asInstanceOf[StreamingSource].format match {
@@ -73,6 +76,9 @@ object StreamingPipeline extends BasePipeline with Serializable {
         input.withColumn("features", parser($"value"))
       case AvroFormat(schemaJson) =>
         input.select(from_avro($"value", schemaJson).alias("features"))
+      case _ =>
+        val columns = input.columns.map(input(_))
+        input.select(struct(columns: _*).alias("features"))
     }
 
     val projected = parsed
@@ -89,14 +95,17 @@ object StreamingPipeline extends BasePipeline with Serializable {
       .foreachBatch { (batchDF: DataFrame, batchID: Long) =>
         val rowsAfterValidation = if (validationUDF.nonEmpty) {
           val columns = batchDF.columns.map(batchDF(_))
-          batchDF.withColumn("_isValid", validator.checkAll && validationUDF.get(struct(columns:_*)))
+          batchDF.withColumn(
+            "_isValid",
+            rowValidator.allChecks && validationUDF.get(struct(columns: _*))
+          )
         } else {
-          batchDF.withColumn("_isValid", validator.checkAll)
+          batchDF.withColumn("_isValid", rowValidator.allChecks)
         }
         rowsAfterValidation.persist()
 
         rowsAfterValidation
-          .filter("_isValid")
+          .filter(if (config.doNotIngestInvalidRows) expr("_isValid") else rowValidator.allChecks)
           .write
           .format("feast.ingestion.stores.redis")
           .option("entity_columns", featureTable.entities.map(_.name).mkString(","))
@@ -108,14 +117,14 @@ object StreamingPipeline extends BasePipeline with Serializable {
 
         config.deadLetterPath match {
           case Some(path) =>
-            batchDF
+            rowsAfterValidation
               .filter("!_isValid")
               .write
               .format("parquet")
               .mode(SaveMode.Append)
               .save(StringUtils.stripEnd(path, "/") + "/" + SparkEnv.get.conf.getAppId)
           case _ =>
-            batchDF
+            rowsAfterValidation
               .filter("!_isValid")
               .foreach(r => {
                 println(s"Row failed validation $r")
@@ -141,24 +150,26 @@ object StreamingPipeline extends BasePipeline with Serializable {
     udf(parser, ProtoReflection.inferSchema(protoRegistry.getProtoDescriptor(className)))
   }
 
-  private def createValidationUDF(sparkSession: SparkSession, config: IngestionJobConfig): Option[UserDefinedPythonFunction] =
-    config.validationConfig.map {
-      validationConfig =>
-        if (validationConfig.includeArchivePath.nonEmpty)
-          sparkSession.sparkContext.addFile(validationConfig.includeArchivePath)
+  private def createValidationUDF(
+      sparkSession: SparkSession,
+      config: IngestionJobConfig
+  ): Option[UserDefinedPythonFunction] =
+    config.validationConfig.map { validationConfig =>
+      if (validationConfig.includeArchivePath.nonEmpty)
+        sparkSession.sparkContext.addFile(validationConfig.includeArchivePath)
 
-        // this is the trick to download remote file on the driver
-        // after file added to sparkContext it will be immediately fetched to local dir (accessible via SparkFiles)
-        sparkSession.sparkContext.addFile(validationConfig.pickledCodePath)
-        val fileName = validationConfig.pickledCodePath.split("/").last
-        val pickledCode = FileUtils.readFileToByteArray(new File(SparkFiles.get(fileName)))
+      // this is the trick to download remote file on the driver
+      // after file added to sparkContext it will be immediately fetched to local dir (accessible via SparkFiles)
+      sparkSession.sparkContext.addFile(validationConfig.pickledCodePath)
+      val fileName    = validationConfig.pickledCodePath.split("/").last
+      val pickledCode = FileUtils.readFileToByteArray(new File(SparkFiles.get(fileName)))
 
-        UserDefinedPythonFunction(
-          validationConfig.name,
-          DynamicPythonFunction.create(pickledCode),
-          BooleanType,
-          pythonEvalType = 200, // SQL_SCALAR_PANDAS_UDF (original constant is in private object)
-          udfDeterministic = true
-        )
+      UserDefinedPythonFunction(
+        validationConfig.name,
+        DynamicPythonFunction.create(pickledCode),
+        BooleanType,
+        pythonEvalType = 200, // SQL_SCALAR_PANDAS_UDF (original constant is in private object)
+        udfDeterministic = true
+      )
     }
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -155,8 +155,11 @@ object StreamingPipeline extends BasePipeline with Serializable {
       config: IngestionJobConfig
   ): Option[UserDefinedPythonFunction] =
     config.validationConfig.map { validationConfig =>
-      if (validationConfig.includeArchivePath.nonEmpty)
-        sparkSession.sparkContext.addFile(validationConfig.includeArchivePath)
+      if (validationConfig.includeArchivePath.nonEmpty) {
+        val archivePath =
+          DynamicPythonFunction.libsPathWithPlatform(validationConfig.includeArchivePath)
+        sparkSession.sparkContext.addFile(archivePath)
+      }
 
       // this is the trick to download remote file on the driver
       // after file added to sparkContext it will be immediately fetched to local dir (accessible via SparkFiles)

--- a/spark/ingestion/src/main/scala/feast/ingestion/sources/bq/BigQueryReader.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/sources/bq/BigQueryReader.scala
@@ -46,6 +46,6 @@ object BigQueryReader {
     reader
       .load(s"${source.project}.${source.dataset}.${source.table}")
       .filter(col(source.eventTimestampColumn) >= new Timestamp(start.getMillis))
-      .filter(col(source.eventTimestampColumn) < new Timestamp(end.getMillis))
+      .filter(col(source.eventTimestampColumn) <= new Timestamp(end.getMillis))
   }
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/sources/bq/BigQueryReader.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/sources/bq/BigQueryReader.scala
@@ -46,6 +46,6 @@ object BigQueryReader {
     reader
       .load(s"${source.project}.${source.dataset}.${source.table}")
       .filter(col(source.eventTimestampColumn) >= new Timestamp(start.getMillis))
-      .filter(col(source.eventTimestampColumn) <= new Timestamp(end.getMillis))
+      .filter(col(source.eventTimestampColumn) < new Timestamp(end.getMillis))
   }
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/sources/file/FileReader.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/sources/file/FileReader.scala
@@ -33,6 +33,6 @@ object FileReader {
     sqlContext.read
       .parquet(source.path)
       .filter(col(source.eventTimestampColumn) >= new Timestamp(start.getMillis))
-      .filter(col(source.eventTimestampColumn) <= new Timestamp(end.getMillis))
+      .filter(col(source.eventTimestampColumn) < new Timestamp(end.getMillis))
   }
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/sources/file/FileReader.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/sources/file/FileReader.scala
@@ -33,6 +33,6 @@ object FileReader {
     sqlContext.read
       .parquet(source.path)
       .filter(col(source.eventTimestampColumn) >= new Timestamp(start.getMillis))
-      .filter(col(source.eventTimestampColumn) < new Timestamp(end.getMillis))
+      .filter(col(source.eventTimestampColumn) <= new Timestamp(end.getMillis))
   }
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
@@ -83,7 +83,6 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
 
         groupKeysByNode(redisConfig.hosts, rowsWithKey.keysIterator).foreach { case (node, keys) =>
           val conn = node.connect()
-
           // retrieve latest stored values
           val storedValues = mapWithPipeline(conn, keys) { (pipeline, key) =>
             persistence.get(pipeline, key.toByteArray)

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
@@ -83,6 +83,8 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
 
         groupKeysByNode(redisConfig.hosts, rowsWithKey.keysIterator).foreach { case (node, keys) =>
           val conn = node.connect()
+          println(conn.info())
+          println(keys.mkString(","))
           // retrieve latest stored values
           val storedValues = mapWithPipeline(conn, keys) { (pipeline, key) =>
             persistence.get(pipeline, key.toByteArray)

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
@@ -83,8 +83,7 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
 
         groupKeysByNode(redisConfig.hosts, rowsWithKey.keysIterator).foreach { case (node, keys) =>
           val conn = node.connect()
-          println(conn.info())
-          println(keys.mkString(","))
+
           // retrieve latest stored values
           val storedValues = mapWithPipeline(conn, keys) { (pipeline, key) =>
             persistence.get(pipeline, key.toByteArray)

--- a/spark/ingestion/src/main/scala/feast/ingestion/utils/testing/MemoryStreamingSource.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/utils/testing/MemoryStreamingSource.scala
@@ -14,22 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package feast.ingestion.validation
+package feast.ingestion.utils.testing
 
-import feast.ingestion.FeatureTable
-import org.apache.spark.sql.Column
-import org.apache.spark.sql.functions.col
+import feast.ingestion.{DataFormat, StreamingSource}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.streaming.MemoryStream
 
-class RowValidator(featureTable: FeatureTable, timestampColumn: String) extends Serializable {
-  def allEntitiesPresent: Column =
-    featureTable.entities.map(e => col(e.name).isNotNull).reduce(_.&&(_))
+// For test purposes
+case class MemoryStreamingSource(
+    stream: MemoryStream[_],
+    override val fieldMapping: Map[String, String] = Map.empty,
+    override val eventTimestampColumn: String = "timestamp",
+    override val createdTimestampColumn: Option[String] = None,
+    override val datePartitionColumn: Option[String] = None
+) extends StreamingSource {
+  def read: DataFrame = stream.toDF()
 
-  def atLeastOneFeatureNotNull: Column =
-    featureTable.features.map(f => col(f.name).isNotNull).reduce(_.||(_))
-
-  def timestampPresent: Column =
-    col(timestampColumn).isNotNull
-
-  def allChecks: Column =
-    allEntitiesPresent && atLeastOneFeatureNotNull && timestampPresent
+  override def format: DataFormat = null
 }

--- a/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
+++ b/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
@@ -30,7 +30,7 @@ object DynamicPythonFunction {
       "import os; import pyspark; print(os.path.dirname(pyspark.__file__))"))
   }
 
-  def create(pickledCode: Array[Byte], dependenciesPath: String = "libs/"): PythonFunction = {
+  def create(pickledCode: Array[Byte], includePath: String = "libs/"): PythonFunction = {
     val envVars = new JHashMap[String, String]()
     val broadcasts = new JArrayList[Broadcast[PythonBroadcast]]()
 
@@ -46,7 +46,7 @@ object DynamicPythonFunction {
     PythonFunction(
       pickledCode,
       envVars,
-      List(dependenciesPath).asJava,
+      List(includePath).asJava,
       pythonExec,
       pythonVersion,
       broadcasts,

--- a/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
+++ b/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
@@ -1,3 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.api.python
 
 import java.io.File
@@ -11,34 +27,32 @@ object DynamicPythonFunction {
 
   private def runCommand(cmd: List[String]): String = {
     val pb = new ProcessBuilder(cmd.asJava)
-    val p = pb.start()
+    val p  = pb.start()
     p.waitFor()
     p.getInputStream.readAllBytes().map(_.toChar).mkString.trim
   }
 
   def pythonVersion: String = {
-    runCommand(List(
-      pythonExec,
-      "-c",
-      "import sys; print(\"{0.major}.{0.minor}\".format(sys.version_info))"))
+    runCommand(
+      List(pythonExec, "-c", "import sys; print(\"{0.major}.{0.minor}\".format(sys.version_info))")
+    )
   }
 
   def sparkHome: String = {
-    runCommand(List(
-      pythonExec,
-      "-c",
-      "import os; import pyspark; print(os.path.dirname(pyspark.__file__))"))
+    runCommand(
+      List(pythonExec, "-c", "import os; import pyspark; print(os.path.dirname(pyspark.__file__))")
+    )
   }
 
   def create(pickledCode: Array[Byte], includePath: String = "libs/"): PythonFunction = {
-    val envVars = new JHashMap[String, String]()
+    val envVars    = new JHashMap[String, String]()
     val broadcasts = new JArrayList[Broadcast[PythonBroadcast]]()
 
     if (!sys.env.contains("SPARK_HOME")) {
       // in tests there's no SPARK_HOME
       val libraries = List(
         Seq(sparkHome, "python", "lib", "pyspark.zip").mkString(File.separator),
-        Seq(sparkHome, "python", "lib", "py4j-0.10.9-src.zip").mkString(File.separator),
+        Seq(sparkHome, "python", "lib", "py4j-0.10.9-src.zip").mkString(File.separator)
       )
       envVars.put("PYTHONPATH", libraries.mkString(File.pathSeparator))
     }

--- a/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
+++ b/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
@@ -38,6 +38,12 @@ object DynamicPythonFunction {
     )
   }
 
+  def pythonPlatform: String = {
+    runCommand(
+      List(pythonExec, "-c", "import platform; print(platform.system().lower())")
+    )
+  }
+
   def sparkHome: String = {
     runCommand(
       List(pythonExec, "-c", "import os; import pyspark; print(os.path.dirname(pyspark.__file__))")
@@ -67,4 +73,7 @@ object DynamicPythonFunction {
       null
     )
   }
+
+  def libsPathWithPlatform(libsPath: String): String =
+    libsPath.replace("%(platform)s", s"py$pythonVersion-$pythonPlatform")
 }

--- a/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
+++ b/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
@@ -1,0 +1,56 @@
+package org.apache.spark.api.python
+
+import java.io.File
+import java.util.{ArrayList => JArrayList, HashMap => JHashMap}
+
+import org.apache.spark.broadcast.Broadcast
+import collection.JavaConverters._
+
+object DynamicPythonFunction {
+  val pythonExec = "python3"
+
+  private def runCommand(cmd: List[String]): String = {
+    val pb = new ProcessBuilder(cmd.asJava)
+    val p = pb.start()
+    p.waitFor()
+    p.getInputStream.readAllBytes().map(_.toChar).mkString.trim
+  }
+
+  def pythonVersion: String = {
+    runCommand(List(
+      pythonExec,
+      "-c",
+      "import sys; print(\"{0.major}.{0.minor}\".format(sys.version_info))"))
+  }
+
+  def sparkHome: String = {
+    runCommand(List(
+      pythonExec,
+      "-c",
+      "import os; import pyspark; print(os.path.dirname(pyspark.__file__))"))
+  }
+
+  def create(pickledCode: Array[Byte], dependenciesPath: String = "libs/"): PythonFunction = {
+    val envVars = new JHashMap[String, String]()
+    val broadcasts = new JArrayList[Broadcast[PythonBroadcast]]()
+
+    if (!sys.env.contains("SPARK_HOME")) {
+      // in tests there's no SPARK_HOME
+      val libraries = List(
+        Seq(sparkHome, "python", "lib", "pyspark.zip").mkString(File.separator),
+        Seq(sparkHome, "python", "lib", "py4j-0.10.9-src.zip").mkString(File.separator),
+      )
+      envVars.put("PYTHONPATH", libraries.mkString(File.pathSeparator))
+    }
+
+    PythonFunction(
+      pickledCode,
+      envVars,
+      List(dependenciesPath).asJava,
+      pythonExec,
+      pythonVersion,
+      broadcasts,
+      null
+    )
+  }
+}

--- a/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
+++ b/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
@@ -25,7 +25,7 @@ import org.apache.spark.broadcast.Broadcast
 import collection.JavaConverters._
 
 object DynamicPythonFunction {
-  val pythonExec = "python3"
+  val pythonExec = sys.env.getOrElse("PYSPARK_PYTHON", "python3")
 
   private def runCommand(cmd: List[String]): String = {
     val pb = new ProcessBuilder(cmd.asJava)

--- a/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
+++ b/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
@@ -19,7 +19,9 @@ package org.apache.spark.api.python
 import java.io.File
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap}
 
+import org.apache.commons.io.IOUtils
 import org.apache.spark.broadcast.Broadcast
+
 import collection.JavaConverters._
 
 object DynamicPythonFunction {
@@ -29,7 +31,7 @@ object DynamicPythonFunction {
     val pb = new ProcessBuilder(cmd.asJava)
     val p  = pb.start()
     p.waitFor()
-    p.getInputStream.readAllBytes().map(_.toChar).mkString.trim
+    IOUtils.toByteArray(p.getInputStream).map(_.toChar).mkString.trim
   }
 
   def pythonVersion: String = {

--- a/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
+++ b/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
@@ -20,12 +20,16 @@ import java.io.File
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap}
 
 import org.apache.commons.io.IOUtils
+import org.apache.spark.SparkEnv
 import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.internal.config.PYSPARK_DRIVER_PYTHON
 
 import collection.JavaConverters._
 
 object DynamicPythonFunction {
-  val pythonExec = sys.env.getOrElse("PYSPARK_PYTHON", "python3")
+  private val conf = SparkEnv.get.conf
+
+  val pythonExec = conf.get(PYSPARK_DRIVER_PYTHON).getOrElse("python3")
 
   private def runCommand(cmd: List[String]): String = {
     val pb = new ProcessBuilder(cmd.asJava)

--- a/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
+++ b/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
@@ -22,14 +22,18 @@ import java.util.{ArrayList => JArrayList, HashMap => JHashMap}
 import org.apache.commons.io.IOUtils
 import org.apache.spark.SparkEnv
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.internal.config.PYSPARK_DRIVER_PYTHON
+import org.apache.spark.internal.config.{PYSPARK_DRIVER_PYTHON, PYSPARK_PYTHON}
 
 import collection.JavaConverters._
 
 object DynamicPythonFunction {
   private val conf = SparkEnv.get.conf
 
-  val pythonExec = conf.get(PYSPARK_DRIVER_PYTHON).getOrElse("python3")
+  val pythonExec = conf.get(PYSPARK_DRIVER_PYTHON)
+    .orElse(conf.get(PYSPARK_PYTHON))
+    .orElse(sys.env.get("PYSPARK_DRIVER_PYTHON"))
+    .orElse(sys.env.get("PYSPARK_PYTHON"))
+    .getOrElse("python3")
 
   private def runCommand(cmd: List[String]): String = {
     val pb = new ProcessBuilder(cmd.asJava)

--- a/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
+++ b/spark/ingestion/src/main/scala/org/apache/spark/api/python/DynamicPythonFunction.scala
@@ -29,7 +29,8 @@ import collection.JavaConverters._
 object DynamicPythonFunction {
   private val conf = SparkEnv.get.conf
 
-  val pythonExec = conf.get(PYSPARK_DRIVER_PYTHON)
+  val pythonExec = conf
+    .get(PYSPARK_DRIVER_PYTHON)
     .orElse(conf.get(PYSPARK_PYTHON))
     .orElse(sys.env.get("PYSPARK_DRIVER_PYTHON"))
     .orElse(sys.env.get("PYSPARK_PYTHON"))

--- a/spark/ingestion/src/test/resources/python/setup.sh
+++ b/spark/ingestion/src/test/resources/python/setup.sh
@@ -14,5 +14,5 @@ fi
 
 # 2. Pickle python udf
 cd $CURRENT_PATH
-pip3 install great-expectations pyspark==3.0.1
+pip3 install great-expectations setuptools pyspark==3.0.1
 python3 udf.py $DESTINATION/udf.pickle

--- a/spark/ingestion/src/test/resources/python/setup.sh
+++ b/spark/ingestion/src/test/resources/python/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+CURRENT_PATH=$PWD
+DESTINATION=${DESTINATION:-$CURRENT_PATH}
+
+# 1. Create libraries (dependencies) package
+tmp_dir=$(mktemp -d)
+pip3 install -t ${tmp_dir}/libs great-expectations pyarrow==2.0.0
+cd $tmp_dir && tar -czf libs.tar.gz . && mv libs.tar.gz $DESTINATION/libs.tar.gz
+
+# 2. Pickle python udf
+cd $CURRENT_PATH
+pip3 install great-expectations pyspark==3.0.1
+python3 udf.py $DESTINATION/udf.pickle

--- a/spark/ingestion/src/test/resources/python/setup.sh
+++ b/spark/ingestion/src/test/resources/python/setup.sh
@@ -4,9 +4,13 @@ CURRENT_PATH=$PWD
 DESTINATION=${DESTINATION:-$CURRENT_PATH}
 
 # 1. Create libraries (dependencies) package
-tmp_dir=$(mktemp -d)
-pip3 install -t ${tmp_dir}/libs great-expectations pyarrow==2.0.0
-cd $tmp_dir && tar -czf libs.tar.gz . && mv libs.tar.gz $DESTINATION/libs.tar.gz
+if [[ -f "$DESTINATION/libs.tar.gz" ]]; then
+    echo "$DESTINATION/libs.tar.gz exists."
+else
+  tmp_dir=$(mktemp -d)
+  pip3 install -t ${tmp_dir}/libs great-expectations pyarrow==2.0.0
+  cd $tmp_dir && tar -czf libs.tar.gz . && mv libs.tar.gz $DESTINATION/libs.tar.gz
+fi
 
 # 2. Pickle python udf
 cd $CURRENT_PATH

--- a/spark/ingestion/src/test/resources/python/setup.sh
+++ b/spark/ingestion/src/test/resources/python/setup.sh
@@ -9,7 +9,7 @@ if [[ -f "$DESTINATION/libs.tar.gz" ]]; then
 else
   tmp_dir=$(mktemp -d)
   pip3 install -t ${tmp_dir}/libs great-expectations pyarrow==2.0.0
-  cd $tmp_dir && tar -czf libs.tar.gz . && mv libs.tar.gz $DESTINATION/libs.tar.gz
+  cd $tmp_dir && tar -czf libs.tar.gz libs/ && mv libs.tar.gz $DESTINATION/libs.tar.gz
 fi
 
 # 2. Pickle python udf

--- a/spark/ingestion/src/test/resources/python/udf.py
+++ b/spark/ingestion/src/test/resources/python/udf.py
@@ -1,0 +1,49 @@
+import sys
+
+from pyspark import cloudpickle
+from pyspark.sql.types import BooleanType
+
+import pandas as pd
+import numpy as np
+
+from great_expectations.dataset import PandasDataset
+
+
+def create_suite():
+    df = pd.DataFrame()
+    df['num'] = np.random.randint(0, 100, 100)
+    df['sqr'] = np.random.randint(0, 100, 100)
+    ds = PandasDataset.from_dataset(df)
+
+    ds.expect_column_values_to_be_between('num', 0, 100)
+    ds.expect_column_values_to_be_between('sqr', 0, 100)
+
+    return ds.get_expectation_suite()
+
+
+def create_validator(suite):
+    def validate(df) -> pd.DataFrame:
+        ds = PandasDataset.from_dataset(df)
+        # print(ds, ds.shape)
+        result = ds.validate(suite, result_format='COMPLETE')
+        valid_rows = pd.Series([True] * ds.shape[0])
+        # print(result)
+        for check in result.results:
+            if check.success:
+                continue
+
+            valid_rows.iloc[check.result['unexpected_index_list']] = False
+        return valid_rows
+
+    return validate
+
+
+def main(dest_path):
+    with open(dest_path, 'wb') as f:
+        fun = create_validator(create_suite())
+        command = (fun, BooleanType())
+        cloudpickle.dump(command, f)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/spark/ingestion/src/test/resources/python/udf.py
+++ b/spark/ingestion/src/test/resources/python/udf.py
@@ -11,12 +11,12 @@ from great_expectations.dataset import PandasDataset
 
 def create_suite():
     df = pd.DataFrame()
-    df['num'] = np.random.randint(0, 100, 100)
-    df['sqr'] = np.random.randint(0, 100, 100)
+    df['num'] = np.random.randint(0, 10, 100)
+    df['num2'] = np.random.randint(0, 20, 100)
     ds = PandasDataset.from_dataset(df)
 
-    ds.expect_column_values_to_be_between('num', 0, 100)
-    ds.expect_column_values_to_be_between('sqr', 0, 100)
+    ds.expect_column_values_to_be_between('num', 0, 10)
+    ds.expect_column_values_to_be_between('num2', 0, 20)
 
     return ds.get_expectation_suite()
 

--- a/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
@@ -32,6 +32,8 @@ import feast.ingestion.helpers.RedisStorageHelper._
 import feast.ingestion.helpers.DataHelper._
 import feast.proto.storage.RedisProto.RedisKeyV2
 import feast.proto.types.ValueProto
+import org.apache.spark.sql.Encoder
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
 case class TestRow(
     customer: String,
@@ -51,6 +53,8 @@ class BatchPipelineIT extends SparkSpec with ForAllTestContainer {
   trait Scope {
     val jedis = new Jedis("localhost", container.mappedPort(6379))
     jedis.flushAll()
+
+    implicit def testRowEncoder: Encoder[TestRow] = ExpressionEncoder()
 
     def rowGenerator(start: DateTime, end: DateTime, customerGen: Option[Gen[String]] = None) =
       for {

--- a/spark/ingestion/src/test/scala/feast/ingestion/PandasUDF.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/PandasUDF.scala
@@ -1,34 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2020 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package feast.ingestion
 
+import java.nio.file.Paths
+import java.sql.Timestamp
+import java.util.Date
 
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import feast.ingestion.helpers.DataHelper.generateTempPath
+import feast.ingestion.utils.testing.MemoryStreamingSource
+import feast.proto.storage.RedisProto.RedisKeyV2
+import feast.proto.types.ValueProto
+import feast.proto.types.ValueProto.ValueType
+import org.apache.spark.SparkConf
 import org.apache.spark.api.python.DynamicPythonFunction
-import org.apache.spark.sql.{Dataset, Encoder, Row, SQLContext}
-import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, MapInPandas}
+import org.apache.spark.sql.{Encoder, Row, SQLContext}
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.execution.python.UserDefinedPythonFunction
 import org.apache.spark.sql.execution.streaming.MemoryStream
-import org.apache.spark.sql.types.{BooleanType, StructType}
-import org.apache.spark.sql.functions.{struct, window}
-import org.apache.spark.sql.streaming.Trigger
+import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.functions.struct
+import redis.clients.jedis.Jedis
 
-case class NewTestRow(num: Int, sqr: Long)
+import scala.jdk.CollectionConverters._
+import scala.util.Random
 
-class PandasUDF extends SparkSpec {
-  System.setProperty("io.netty.tryReflectionSetAccessible", "true")
+class PandasUDF extends SparkSpec with ForAllTestContainer {
+  case class TestRow(key: String, num: Int, num2: Int, timestamp: java.sql.Timestamp)
+
+  override val container = GenericContainer("redis:6.0.8", exposedPorts = Seq(6379))
+
+  override def withSparkConfOverrides(conf: SparkConf): SparkConf = conf
+    .set("spark.redis.host", container.host)
+    .set("spark.redis.port", container.mappedPort(6379).toString)
 
   trait Scope {
-    implicit def testRowEncoder: Encoder[NewTestRow] = ExpressionEncoder()
-    implicit def sqlContext: SQLContext = sparkSession.sqlContext
+    implicit def testRowEncoder: Encoder[TestRow] = ExpressionEncoder()
+    implicit def sqlContext: SQLContext           = sparkSession.sqlContext
+
+    val jedis = new Jedis("localhost", container.mappedPort(6379))
+    jedis.flushAll()
 
     val SQL_SCALAR_PANDAS_UDF = 200
-    val SQL_MAP_PANDAS_UDF = 205
+    val rand                  = new Random()
 
-    sparkSession.sparkContext.addFile(getClass.getResource("/python/libs.tar.gz").getPath)
+    def encodeEntityKey(key: String): Array[Byte] =
+      RedisKeyV2
+        .newBuilder()
+        .setProject("default")
+        .addAllEntityNames(Seq("key").asJava)
+        .addEntityValues(ValueProto.Value.newBuilder().setStringVal(key))
+        .build
+        .toByteArray
 
-    val pythonFun = DynamicPythonFunction.create(
-      getClass.getResourceAsStream("/python/udf.pickle").readAllBytes()
-    )
+    // Function checks that num between 0 and 10 and num2 between 0 and 20
+    // See the code test/resources/python/udf.py
+    val pickledCode = getClass.getResourceAsStream("/python/udf.pickle").readAllBytes()
+    val pythonFun   = DynamicPythonFunction.create(pickledCode)
 
     val udf: UserDefinedPythonFunction = UserDefinedPythonFunction(
       "validate",
@@ -37,24 +79,85 @@ class PandasUDF extends SparkSpec {
       SQL_SCALAR_PANDAS_UDF,
       udfDeterministic = true
     )
+
+    val inputData = MemoryStream[TestRow]
+    val config = IngestionJobConfig(
+      featureTable = FeatureTable(
+        name = "test-fs",
+        project = "default",
+        entities = Seq(Field("key", ValueType.Enum.STRING)),
+        features = Seq(
+          Field("num", ValueType.Enum.INT32),
+          Field("num2", ValueType.Enum.INT32)
+        )
+      ),
+      source = MemoryStreamingSource(inputData),
+      validationConfig = Some(
+        ValidationConfig(
+          name = "testFun",
+          pickledCodePath = getClass.getResource("/python/udf.pickle").getPath,
+          includeArchivePath = getClass.getResource("/python/libs.tar.gz").getPath
+        )
+      ),
+      doNotIngestInvalidRows = true,
+      deadLetterPath = Some(generateTempPath("deadletters"))
+    )
   }
 
-  "Python UDF" should "work" in new Scope {
-    val inputData = MemoryStream[NewTestRow]
+  "Custom Python code" should "be applied in streaming pipeline" in new Scope {
+    sparkSession.sparkContext.addFile(getClass.getResource("/python/libs.tar.gz").getPath)
+
     val df = inputData.toDF()
 
     val cols = df.columns.map(df(_))
     val streamingQuery = df
-      .withColumn("valid", udf(struct(cols:_*)))
+      .withColumn("valid", udf(struct(cols: _*)))
       .writeStream
       .format("memory")
       .queryName("sink")
       .start()
 
-    val data = (1 to 100).map(i => NewTestRow(i, i * i))
+    val data =
+      (1 to 100).map(_ => TestRow(rand.nextString(5), rand.nextInt(100), rand.nextInt(100), null))
     inputData.addData(data)
     streamingQuery.processAllAvailable()
 
-    sparkSession.sql("select * from sink").show()
+    val expected = data
+      .map(testRow => Row(testRow.num, testRow.num2, testRow.num <= 10 && testRow.num2 <= 20))
+      .toArray
+
+    val output = sparkSession.sql("select num, num2, valid from sink").collect()
+    output should be(expected)
+  }
+
+  "Custom Python code" should "be used for data validation in StreamingPipeline" in new Scope {
+    val query = StreamingPipeline.createPipeline(sparkSession, config).get
+
+    val ts = new Timestamp(new Date().getTime)
+    val data =
+      (1 to 1000).map(_ => TestRow(rand.nextString(5), rand.nextInt(100), rand.nextInt(100), ts))
+    inputData.addData(data)
+    query.processAllAvailable()
+
+    // Map (key -> isValid)
+    val expected = data
+      .map(testRow => testRow.key -> (testRow.num <= 10 && testRow.num2 <= 20))
+      .toMap
+
+    // Invalid Rows stored to DeadLetters
+    sparkSession.read
+      .parquet(
+        Paths
+          .get(config.deadLetterPath.get, sparkSession.conf.get("spark.app.id"))
+          .toString
+      )
+      .count() should be(expected.count(!_._2))
+
+    // Valid rows saved to Storage
+    expected.filter(_._2).keys.foreach { key =>
+      {
+        jedis.hgetAll(encodeEntityKey(key)).asScala.toMap should not be (Map.empty)
+      }
+    }
   }
 }

--- a/spark/ingestion/src/test/scala/feast/ingestion/PandasUDF.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/PandasUDF.scala
@@ -1,0 +1,60 @@
+package feast.ingestion
+
+
+import org.apache.spark.api.python.DynamicPythonFunction
+import org.apache.spark.sql.{Dataset, Encoder, Row, SQLContext}
+import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, MapInPandas}
+import org.apache.spark.sql.execution.python.UserDefinedPythonFunction
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.types.{BooleanType, StructType}
+import org.apache.spark.sql.functions.{struct, window}
+import org.apache.spark.sql.streaming.Trigger
+
+case class NewTestRow(num: Int, sqr: Long)
+
+class PandasUDF extends SparkSpec {
+  System.setProperty("io.netty.tryReflectionSetAccessible", "true")
+
+  trait Scope {
+    implicit def testRowEncoder: Encoder[NewTestRow] = ExpressionEncoder()
+    implicit def sqlContext: SQLContext = sparkSession.sqlContext
+
+    val SQL_SCALAR_PANDAS_UDF = 200
+    val SQL_MAP_PANDAS_UDF = 205
+
+    sparkSession.sparkContext.addFile(getClass.getResource("/python/libs.tar.gz").getPath)
+
+    val pythonFun = DynamicPythonFunction.create(
+      getClass.getResourceAsStream("/python/udf.pickle").readAllBytes()
+    )
+
+    val udf: UserDefinedPythonFunction = UserDefinedPythonFunction(
+      "validate",
+      pythonFun,
+      BooleanType,
+      SQL_SCALAR_PANDAS_UDF,
+      udfDeterministic = true
+    )
+  }
+
+  "Python UDF" should "work" in new Scope {
+    val inputData = MemoryStream[NewTestRow]
+    val df = inputData.toDF()
+
+    val cols = df.columns.map(df(_))
+    val streamingQuery = df
+      .withColumn("valid", udf(struct(cols:_*)))
+      .writeStream
+      .format("memory")
+      .queryName("sink")
+      .start()
+
+    val data = (1 to 100).map(i => NewTestRow(i, i * i))
+    inputData.addData(data)
+    streamingQuery.processAllAvailable()
+
+    sparkSession.sql("select * from sink").show()
+  }
+}

--- a/spark/ingestion/src/test/scala/feast/ingestion/SparkSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/SparkSpec.scala
@@ -30,16 +30,13 @@ class SparkSpec extends UnitSpec with BeforeAndAfter {
       .setAppName("Testing")
       .set("spark.default.parallelism", "8")
       .set(
-        "spark.metrics.conf.*.source.redis.class",
-        "org.apache.spark.metrics.source.RedisSinkMetricSource"
-      )
-      .set(
         "spark.metrics.conf.*.sink.statsd.class",
         "org.apache.spark.metrics.sink.StatsdSinkWithTags"
       )
       .set("spark.metrics.conf.*.sink.statsd.host", "localhost")
       .set("spark.metrics.conf.*.sink.statsd.port", "8125")
       .set("spark.sql.legacy.allowUntypedScalaUDF", "true")
+      .set("spark.sql.execution.arrow.maxRecordsPerBatch", "50000")
 
     sparkSession = SparkSession
       .builder()

--- a/spark/ingestion/src/test/scala/feast/ingestion/SparkSpec.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/SparkSpec.scala
@@ -21,6 +21,8 @@ import org.apache.spark.sql.SparkSession
 import org.scalatest.BeforeAndAfter
 
 class SparkSpec extends UnitSpec with BeforeAndAfter {
+  System.setProperty("io.netty.tryReflectionSetAccessible", "true")
+
   var sparkSession: SparkSession                         = null
   def withSparkConfOverrides(conf: SparkConf): SparkConf = conf
 

--- a/tests/e2e/fixtures/base.py
+++ b/tests/e2e/fixtures/base.py
@@ -1,3 +1,4 @@
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
@@ -9,8 +10,10 @@ def project_root():
 
 
 @pytest.fixture(scope="session")
-def project_version(pytestconfig):
+def project_version(pytestconfig, project_root):
     if pytestconfig.getoption("feast_version"):
         return pytestconfig.getoption("feast_version")
-    else:
-        raise Exception("feast_version not set")
+
+    pom_xml = ET.parse(project_root / "pom.xml")
+    root = pom_xml.getroot()
+    return root.find(".properties/revision").text

--- a/tests/e2e/fixtures/client.py
+++ b/tests/e2e/fixtures/client.py
@@ -43,6 +43,7 @@ def feast_client(
             historical_feature_output_location=os.path.join(
                 local_staging_path, "historical_output"
             ),
+            ingestion_drop_invalid_rows=True,
             **job_service_env,
         )
 
@@ -61,6 +62,7 @@ def feast_client(
             historical_feature_output_location=os.path.join(
                 local_staging_path, "historical_output"
             ),
+            ingestion_drop_invalid_rows=True,
             **job_service_env,
         )
     elif pytestconfig.getoption("env") == "aws":
@@ -78,6 +80,7 @@ def feast_client(
             historical_feature_output_location=os.path.join(
                 local_staging_path, "historical_output"
             ),
+            ingestion_drop_invalid_rows=True,
         )
     elif pytestconfig.getoption("env") == "k8s":
         return Client(

--- a/tests/e2e/fixtures/services.py
+++ b/tests/e2e/fixtures/services.py
@@ -36,7 +36,9 @@ def kafka_server(kafka_port):
 
 
 postgres_server = pg_factories.postgresql_proc(password="password")
-redis_server = redis_factories.redis_proc(executable=shutil.which("redis-server"))
+redis_server = redis_factories.redis_proc(
+    executable=shutil.which("redis-server"), timeout=3600
+)
 
 KAFKA_BIN = download_kafka()
 zookeeper_server = make_zookeeper_process(

--- a/tests/e2e/test_validation.py
+++ b/tests/e2e/test_validation.py
@@ -1,0 +1,142 @@
+import json
+import time
+import uuid
+
+import numpy as np
+import pandas as pd
+from great_expectations.dataset import PandasDataset
+
+from feast import (
+    Client,
+    Entity,
+    Feature,
+    FeatureTable,
+    FileSource,
+    KafkaSource,
+    ValueType,
+)
+from feast.contrib.validation.ge import apply_validation, create_validation_udf
+from feast.data_format import AvroFormat, ParquetFormat
+from feast.pyspark.abc import SparkJobStatus
+from feast.wait import wait_retry_backoff
+from tests.e2e.utils.kafka import check_consumer_exist, ingest_and_retrieve
+
+
+def generate_train_data():
+    df = pd.DataFrame(columns=["key", "num", "set", "event_timestamp"])
+    df["key"] = np.random.choice(999999, size=100, replace=False)
+    df["num"] = np.random.randint(0, 100, 100)
+    df["set"] = np.random.choice(["a", "b", "c"], size=100)
+    df["event_timestamp"] = pd.to_datetime(int(time.time()), unit="s")
+
+    return df
+
+
+def generate_test_data():
+    df = pd.DataFrame(columns=["key", "num", "set", "event_timestamp"])
+    df["key"] = np.random.choice(999999, size=100, replace=False)
+    df["num"] = np.random.randint(0, 150, 100)
+    df["set"] = np.random.choice(["a", "b", "c", "d"], size=100)
+    df["event_timestamp"] = pd.to_datetime(int(time.time()), unit="s")
+
+    return df
+
+
+def test_validation_with_ge(feast_client: Client, kafka_server):
+    entity = Entity(name="key", description="Key", value_type=ValueType.INT64)
+    kafka_broker = f"{kafka_server[0]}:{kafka_server[1]}"
+    topic_name = f"avro-{uuid.uuid4()}"
+
+    feature_table = FeatureTable(
+        name="validation_test",
+        entities=["key"],
+        features=[Feature("num", ValueType.INT64), Feature("set", ValueType.STRING)],
+        batch_source=FileSource(
+            event_timestamp_column="event_timestamp",
+            file_format=ParquetFormat(),
+            file_url="/dev/null",
+        ),
+        stream_source=KafkaSource(
+            event_timestamp_column="event_timestamp",
+            bootstrap_servers=kafka_broker,
+            message_format=AvroFormat(avro_schema()),
+            topic=topic_name,
+        ),
+    )
+    feast_client.apply_entity(entity)
+    feast_client.apply_feature_table(feature_table)
+
+    train_data = generate_train_data()
+    ge_ds = PandasDataset(train_data)
+    ge_ds.expect_column_values_to_be_between("num", 0, 100)
+    ge_ds.expect_column_values_to_be_in_set("set", ["a", "b", "c"])
+    expectations = ge_ds.get_expectation_suite()
+
+    udf = create_validation_udf("testUDF", expectations)
+    apply_validation(feast_client, feature_table, udf, validation_window_secs=1)
+
+    job = feast_client.start_stream_to_online_ingestion(feature_table)
+
+    wait_retry_backoff(
+        lambda: (None, job.get_status() == SparkJobStatus.IN_PROGRESS), 120
+    )
+
+    wait_retry_backoff(
+        lambda: (None, check_consumer_exist(kafka_broker, topic_name)), 120
+    )
+
+    test_data = generate_test_data()
+    ge_ds = PandasDataset(test_data)
+    validation_result = ge_ds.validate(expectations, result_format="COMPLETE")
+    invalid_idx = list(
+        {
+            idx
+            for check in validation_result.results
+            for idx in check.result["unexpected_index_list"]
+        }
+    )
+
+    entity_rows = [{"key": key} for key in test_data["key"].tolist()]
+
+    try:
+        ingested = ingest_and_retrieve(
+            feast_client,
+            test_data,
+            avro_schema_json=avro_schema(),
+            topic_name=topic_name,
+            kafka_broker=kafka_broker,
+            entity_rows=entity_rows,
+            feature_names=["validation_test:num", "validation_test:set"],
+            expected_ingested_count=test_data.shape[0] - len(invalid_idx),
+        )
+    finally:
+        job.cancel()
+
+    test_data["num"] = test_data["num"].astype(np.float64)
+    test_data["num"].iloc[invalid_idx] = np.nan
+    test_data["set"].iloc[invalid_idx] = None
+
+    pd.testing.assert_frame_equal(
+        ingested[["key", "validation_test:num", "validation_test:set"]],
+        test_data[["key", "num", "set"]].rename(
+            columns={"num": "validation_test:num", "set": "validation_test:set"}
+        ),
+    )
+
+
+def avro_schema():
+    return json.dumps(
+        {
+            "type": "record",
+            "name": "TestMessage",
+            "fields": [
+                {"name": "key", "type": "long"},
+                {"name": "num", "type": "long"},
+                {"name": "set", "type": "string"},
+                {
+                    "name": "event_timestamp",
+                    "type": {"type": "long", "logicalType": "timestamp-micros"},
+                },
+            ],
+        }
+    )

--- a/tests/e2e/utils/kafka.py
+++ b/tests/e2e/utils/kafka.py
@@ -1,0 +1,88 @@
+import io
+from typing import Any, Dict, List, Optional
+
+import avro.schema
+import pandas as pd
+import pytz
+from avro.io import BinaryEncoder, DatumWriter
+from kafka import KafkaAdminClient, KafkaProducer
+
+from feast import Client
+from feast.wait import wait_retry_backoff
+
+
+def send_avro_record_to_kafka(topic, value, bootstrap_servers, avro_schema_json):
+    value_schema = avro.schema.parse(avro_schema_json)
+
+    producer = KafkaProducer(bootstrap_servers=bootstrap_servers)
+
+    writer = DatumWriter(value_schema)
+    bytes_writer = io.BytesIO()
+    encoder = BinaryEncoder(bytes_writer)
+
+    writer.write(value, encoder)
+
+    try:
+        producer.send(topic=topic, value=bytes_writer.getvalue())
+    except Exception as e:
+        print(
+            f"Exception while producing record value - {value} to topic - {topic}: {e}"
+        )
+    else:
+        print(f"Successfully producing record value - {value} to topic - {topic}")
+
+    producer.flush()
+
+
+def check_consumer_exist(bootstrap_servers, topic_name):
+    admin = KafkaAdminClient(bootstrap_servers=bootstrap_servers)
+    consumer_groups = admin.describe_consumer_groups(
+        group_ids=[
+            group_id
+            for group_id, _ in admin.list_consumer_groups()
+            if group_id.startswith("spark-kafka-source")
+        ]
+    )
+    subscriptions = {
+        subscription
+        for group in consumer_groups
+        for member in group.members
+        if not isinstance(member.member_metadata, bytes)
+        for subscription in member.member_metadata.subscription
+    }
+    return topic_name in subscriptions
+
+
+def ingest_and_retrieve(
+    feast_client: Client,
+    df: pd.DataFrame,
+    topic_name: str,
+    kafka_broker: str,
+    avro_schema_json: str,
+    entity_rows: List[Dict[str, Any]],
+    feature_names: List[Any],
+    expected_ingested_count: Optional[int] = None,
+):
+    expected_ingested_count = expected_ingested_count or df.shape[0]
+
+    for record in df.to_dict("records"):
+        record["event_timestamp"] = (
+            record["event_timestamp"].to_pydatetime().replace(tzinfo=pytz.utc)
+        )
+
+        send_avro_record_to_kafka(
+            topic_name,
+            record,
+            bootstrap_servers=kafka_broker,
+            avro_schema_json=avro_schema_json,
+        )
+
+    def get_online_features():
+        features = feast_client.get_online_features(
+            feature_names, entity_rows=entity_rows,
+        ).to_dict()
+        out_df = pd.DataFrame.from_dict(features)
+        return out_df, out_df[feature_names].count().min() >= expected_ingested_count
+
+    ingested = wait_retry_backoff(get_online_features, 120)
+    return ingested


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR introduces **experimental** feature that enables using custom python code inside ingestion job. See #1230 for motivation.

Technical details:
1. Python code being wrapped and pickled inside Python SDK.
2. Pickled object being staged to one of supported storages (gs / s3)
3. Reference to stored objects added to FeatureTable's labels
4. IngestionJob currently only supports `_validationUDF` label and use provided code for feature validation. The code is being called right after reading data from source and before writing it to store. IngestionJob can optionally (set by flag) drop rows that do not pass validation.

Limitations:
Since python pickle happens on customer's machine and unpickle on Spark worker, there might be issues related to incompatibility of pickle protocols even customer's and worker's python versions are different. Ideally to avoid that the minor part of python versions should match (3.**7**, eg). However, it was confirmed by tests that lower version on SDK is fine (3.6 on SDK, 3.7 on worker), but not other way.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1230 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
**experimental** ability to run custom python code inside streaming ingestion job
```
