### PR TITLE
CI should work on python 3.6

### DIFF
--- a/.github/workflows/complete.yml
+++ b/.github/workflows/complete.yml
@@ -65,7 +65,6 @@ jobs:
         run: make lint-go
 
   lint-versions:
-    container: gcr.io/kf-feast/feast-ci:latest
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/infra/docker/ci/Dockerfile
+++ b/infra/docker/ci/Dockerfile
@@ -1,16 +1,31 @@
-FROM maven:3.6-jdk-11
+FROM ubuntu:18.04
 
 ARG REVISION
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Install Google Cloud SDK
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
-    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  \
-    add - && apt-get update -y && apt-get install google-cloud-sdk -y
+# Install Java (by default openjdk-11)
+RUN apt-get update && apt-get install -y default-jdk curl unzip git locales
+
+RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.utf8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+# Install maven
+ARG MAVEN_VERSION=3.6.3
+ARG SHA=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "/root/.m2"
 
 # Install Make and Python
-ENV PYTHON_VERSION 3.7
+ENV PYTHON_VERSION 3.6
 
 RUN apt-get install -y build-essential curl python${PYTHON_VERSION} \
     python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-distutils && \
@@ -19,6 +34,13 @@ RUN apt-get install -y build-essential curl python${PYTHON_VERSION} \
     curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py --force-reinstall && \
     rm get-pip.py
+
+# Install Google Cloud SDK
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
+    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+    | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  \
+    add - && apt-get update -y && apt-get install google-cloud-sdk -y
 
 # Instal boto3
 RUN pip install boto3==1.16.10

--- a/infra/docker/ci/Dockerfile
+++ b/infra/docker/ci/Dockerfile
@@ -3,8 +3,12 @@ FROM ubuntu:18.04
 ARG REVISION
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update && apt-get install -y curl unzip locales software-properties-common && \
+    apt-add-repository ppa:git-core/ppa && \
+    apt update && apt install -y git
+
 # Install Java (by default openjdk-11)
-RUN apt-get update && apt-get install -y default-jdk curl unzip git locales
+RUN apt-get install -y default-jdk
 
 RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.utf8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'

--- a/infra/scripts/codebuild_runner.py
+++ b/infra/scripts/codebuild_runner.py
@@ -162,7 +162,7 @@ async def run_build(project_name: str, source_version: str, source_location: str
             log_group=build["logs"]["groupName"],
         )
 
-        waiter_task = asyncio.create_task(
+        waiter_task = asyncio.get_event_loop().create_task(
             _wait_build_state(
                 codebuild_client,
                 build_id,
@@ -188,4 +188,5 @@ async def run_build(project_name: str, source_version: str, source_location: str
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -36,6 +36,7 @@ _common_options = [
     click.option("--serving-url", help="Set Feast serving URL to connect to"),
     click.option("--job-service-url", help="Set Feast job service URL to connect to"),
 ]
+DATETIME_ISO = "%Y-%m-%dT%H:%M:%s"
 
 
 def common_options(func):
@@ -381,7 +382,9 @@ def sync_offline_to_online(feature_table: str, start_time: str, end_time: str):
     client = Client()
     table = client.get_feature_table(feature_table)
     client.start_offline_to_online_ingestion(
-        table, datetime.fromisoformat(start_time), datetime.fromisoformat(end_time)
+        table,
+        datetime.strptime(start_time, DATETIME_ISO),
+        datetime.strptime(end_time, DATETIME_ISO),
     )
 
 


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

To guarantee compatibility with python 3.6 (as declared in our `setup.py`) this PR downgrades python version to 3.6 in CI docker image.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
