### PR TITLE
Add Feast serving request count metric

### DIFF
--- a/serving/src/main/java/feast/serving/interceptors/GrpcMonitoringInterceptor.java
+++ b/serving/src/main/java/feast/serving/interceptors/GrpcMonitoringInterceptor.java
@@ -46,6 +46,7 @@ public class GrpcMonitoringInterceptor implements ServerInterceptor {
             Metrics.requestLatency
                 .labels(methodName)
                 .observe((System.currentTimeMillis() - startCallMillis) / 1000f);
+            Metrics.requestCount.labels(methodName).inc();
             Metrics.grpcRequestCount.labels(methodName, status.getCode().name()).inc();
             super.close(status, trailers);
           }

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -31,10 +31,10 @@ public class Metrics {
 
   public static final Counter requestCount =
       Counter.build()
-          .name("request_feature_count")
+          .name("request_count")
           .subsystem("feast_serving")
-          .help("number of feature rows requested")
-          .labelNames("project", "feature_name")
+          .help("number of requests to feast serving")
+          .labelNames("method")
           .register();
 
   public static final Counter notFoundKeyCount =


### PR DESCRIPTION
Signed-off-by: Terence <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR adds metric to track no. of requests made to Feast serving.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now view no. of requests made to Feast serving metric.
```
