### PR TITLE
Add Feast Serving histogram metrics

### DIFF
--- a/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -324,13 +324,14 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
     Metrics.requestEntityCount.labels(project).observe(Double.valueOf(entityRows.size()));
     Metrics.requestFeatureCount.labels(project).observe(Double.valueOf(featureReferences.size()));
 
-    Set<String> featureTableRefs =
+    long countDistinctFeatureTables =
         featureReferences.stream()
             .map(featureReference -> getFeatureTableStringRef(project, featureReference))
-            .collect(Collectors.toSet());
+            .distinct()
+            .count();
     Metrics.requestFeatureTableCount
         .labels(project)
-        .observe(Double.valueOf(featureTableRefs.size()));
+        .observe(Double.valueOf(countDistinctFeatureTables));
   }
 
   /**

--- a/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -161,22 +161,10 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
           populateCountMetrics(statusMap, projectName);
         }
       }
-      populateHistogramMetrics(entityRows, featureReferences, projectName);
-
-      // Build response field values from entityValuesMap and entityStatusesMap
-      // Response field values should be in the same order as the entityRows provided by the user.
-      List<GetOnlineFeaturesResponse.FieldValues> fieldValuesList =
-          entityRows.stream()
-              .map(
-                  entityRow -> {
-                    return GetOnlineFeaturesResponse.FieldValues.newBuilder()
-                        .putAllFields(entityValuesMap.get(entityRow))
-                        .putAllStatuses(entityStatusesMap.get(entityRow))
-                        .build();
-                  })
-              .collect(Collectors.toList());
-      return GetOnlineFeaturesResponse.newBuilder().addAllFieldValues(fieldValuesList).build();
+      entityValuesMap.get(entityRow).putAll(allValueMaps);
+      entityStatusesMap.get(entityRow).putAll(allStatusMaps);
     }
+    populateHistogramMetrics(entityRows, featureReferences, projectName);
 
     // Build response field values from entityValuesMap and entityStatusesMap
     // Response field values should be in the same order as the entityRows provided by the user.

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -29,14 +29,6 @@ public class Metrics {
           .labelNames("method")
           .register();
 
-  public static final Counter requestCount =
-      Counter.build()
-          .name("request_feature_count")
-          .subsystem("feast_serving")
-          .help("number of feature rows requested")
-          .labelNames("project", "feature_name")
-          .register();
-
   public static final Histogram requestEntityCount =
       Histogram.build()
           .buckets(1, 2, 5, 10)

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -31,7 +31,7 @@ public class Metrics {
 
   public static final Histogram requestEntityCount =
       Histogram.build()
-          .buckets(1, 2, 5, 10)
+          .buckets(1, 2, 5, 10, 20, 50, 100, 200)
           .name("request_entity_count")
           .subsystem("feast_serving")
           .help("Number of entity rows per request")
@@ -40,7 +40,7 @@ public class Metrics {
 
   public static final Histogram requestFeatureCount =
       Histogram.build()
-          .buckets(1, 2, 5, 10, 15, 20)
+          .buckets(1, 2, 5, 10, 15, 20, 30, 50)
           .name("request_feature_count")
           .subsystem("feast_serving")
           .help("Number of feature rows per request")
@@ -49,7 +49,7 @@ public class Metrics {
 
   public static final Histogram requestFeatureTableCount =
       Histogram.build()
-          .buckets(1, 2, 5, 10)
+          .buckets(1, 2, 5, 10, 20)
           .name("request_feature_table_count")
           .subsystem("feast_serving")
           .help("Number of feature tables per request")

--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -37,6 +37,33 @@ public class Metrics {
           .labelNames("project", "feature_name")
           .register();
 
+  public static final Histogram requestEntityCount =
+      Histogram.build()
+          .buckets(1, 2, 5, 10)
+          .name("request_entity_count")
+          .subsystem("feast_serving")
+          .help("Number of entity rows per request")
+          .labelNames("project")
+          .register();
+
+  public static final Histogram requestFeatureCount =
+      Histogram.build()
+          .buckets(1, 2, 5, 10, 15, 20)
+          .name("request_feature_count")
+          .subsystem("feast_serving")
+          .help("Number of feature rows per request")
+          .labelNames("project")
+          .register();
+
+  public static final Histogram requestFeatureTableCount =
+      Histogram.build()
+          .buckets(1, 2, 5, 10)
+          .name("request_feature_table_count")
+          .subsystem("feast_serving")
+          .help("Number of feature tables per request")
+          .labelNames("project")
+          .register();
+
   public static final Counter notFoundKeyCount =
       Counter.build()
           .name("not_found_feature_count")


### PR DESCRIPTION
Signed-off-by: Terence <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR adds histogram metrics for Feast serving, which would allow us to determine:
- amount of entity rows per request (buckets)
- amount of features per request (buckets)
- amount of feature tables per request (buckets)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can gather entity row, features and feature table requested metrics in Feast Serving.
```
