### PR TITLE
Apply grpc tracing interceptor on online serving

### DIFF
--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -155,21 +155,26 @@
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>
-    <!--compile 'io.jaegertracing:jaeger-client:0.31.0'-->
+    <!--compile 'io.jaegertracing:jaeger-client:1.3.2'-->
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-client</artifactId>
-      <version>0.31.0</version>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-api</artifactId>
-      <version>0.31.0</version>
+      <version>0.33.0</version>
     </dependency>
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-noop</artifactId>
-      <version>0.31.0</version>
+      <version>0.33.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-grpc</artifactId>
+      <version>0.2.3</version>
     </dependency>
 
     <!-- The client -->

--- a/serving/src/main/java/feast/serving/config/InstrumentationConfig.java
+++ b/serving/src/main/java/feast/serving/config/InstrumentationConfig.java
@@ -17,6 +17,7 @@
 package feast.serving.config;
 
 import io.opentracing.Tracer;
+import io.opentracing.contrib.grpc.TracingServerInterceptor;
 import io.opentracing.noop.NoopTracerFactory;
 import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
@@ -53,5 +54,10 @@ public class InstrumentationConfig {
 
     return io.jaegertracing.Configuration.fromEnv(feastProperties.getTracing().getServiceName())
         .getTracer();
+  }
+
+  @Bean
+  public TracingServerInterceptor tracingInterceptor(Tracer tracer) {
+    return TracingServerInterceptor.newBuilder().withTracer(tracer).build();
   }
 }


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This is a back port of https://github.com/feast-dev/feast/pull/1212, excluding client side change. Implementation of grpc tracing interceptor on golang and java client will be on a separate PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Two new tags have been added to Jaeger Tracing spans, for online serving: number of entities and features in request.
```
