### PR TITLE
Update python version requirements to 3.7 for Dataproc launcher

### DIFF
--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -284,8 +284,8 @@ class DataprocClusterLauncher(JobLauncher):
                 "spark.executor.instances": self.executor_instances,
                 "spark.executor.cores": self.executor_cores,
                 "spark.executor.memory": self.executor_memory,
-                "spark.pyspark.driver.python": "python3.6",
-                "spark.pyspark.python": "python3.6",
+                "spark.pyspark.driver.python": "python3.7",
+                "spark.pyspark.python": "python3.7",
             }
 
             properties.update(extra_properties)


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

With migrating to latest dataproc image version (2.0.0-RC21-debian10) we now can use more recent python version as default one.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
