### PR TITLE
Allow use the same timestamp column for both created & even timestamp in Historical Retrieval

### DIFF
--- a/sdk/python/tests/test_as_of_join.py
+++ b/sdk/python/tests/test_as_of_join.py
@@ -229,12 +229,7 @@ def test_join_without_max_age(
     )
 
     joined_df = as_of_join(
-        entity_df,
-        "event_timestamp",
-        feature_table_df,
-        feature_table,
-        "event_timestamp",
-        "created_timestamp",
+        entity_df, "event_timestamp", feature_table_df, feature_table,
     )
 
     expected_joined_schema = StructType(
@@ -298,12 +293,7 @@ def test_join_with_max_age(
     )
 
     joined_df = as_of_join(
-        entity_df,
-        "event_timestamp",
-        feature_table_df,
-        feature_table,
-        "event_timestamp",
-        "created_timestamp",
+        entity_df, "event_timestamp", feature_table_df, feature_table,
     )
 
     expected_joined_schema = StructType(
@@ -377,12 +367,7 @@ def test_join_with_composite_entity(
     )
 
     joined_df = as_of_join(
-        entity_df,
-        "event_timestamp",
-        feature_table_df,
-        feature_table,
-        "event_timestamp",
-        "created_timestamp",
+        entity_df, "event_timestamp", feature_table_df, feature_table,
     )
 
     expected_joined_schema = StructType(
@@ -444,12 +429,7 @@ def test_select_subset_of_columns_as_entity_primary_keys(
     )
 
     joined_df = as_of_join(
-        entity_df,
-        "event_timestamp",
-        feature_table_df,
-        feature_table,
-        "event_timestamp",
-        "created_timestamp",
+        entity_df, "event_timestamp", feature_table_df, feature_table,
     )
 
     expected_joined_schema = StructType(
@@ -552,8 +532,6 @@ def test_multiple_join(
         "event_timestamp",
         [customer_table_df, driver_table_df],
         [customer_table, driver_table],
-        ["event_timestamp"] * 2,
-        ["created_timestamp"] * 2,
     )
 
     expected_joined_schema = StructType(


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Since `created_timestamp_column` is required sometimes user wants to reuse the same column from datasource for both `event_timestamp` & `created_timestamp`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Same column is allowed in `created_timestamp_column` & `event_timestamp_column` in DataSource.
```
