### PR TITLE
Enhance job api to return associated feature table and start time

### DIFF
--- a/protos/feast/core/JobService.proto
+++ b/protos/feast/core/JobService.proto
@@ -73,27 +73,27 @@ message Job {
   // Current job status
   JobStatus status = 3;
   // Deterministic hash of the Job
-  string hash = 8;
+  string hash = 4;
   // Start time of the Job
-  google.protobuf.Timestamp start_time = 9;
+  google.protobuf.Timestamp start_time = 5;
 
   message RetrievalJobMeta {
-    string output_location = 4;
+    string output_location = 1;
   }
 
   message OfflineToOnlineMeta {
-      string feature_table = 10;
+      string table_name = 1;
   }
 
   message StreamToOnlineMeta {
-      string feature_table = 11;
+      string table_name = 1;
   }
 
   // JobType specific metadata on the job
   oneof meta {
-    RetrievalJobMeta retrieval = 5;
-    OfflineToOnlineMeta batch_ingestion = 6;
-    StreamToOnlineMeta stream_ingestion = 7;
+    RetrievalJobMeta retrieval = 6;
+    OfflineToOnlineMeta batch_ingestion = 7;
+    StreamToOnlineMeta stream_ingestion = 8;
   }
 }
 
@@ -118,7 +118,7 @@ message StartOfflineToOnlineIngestionJobResponse {
     google.protobuf.Timestamp job_start_time = 2;
 
     // Feature table associated with the job
-    string feature_table = 3;
+    string table_name = 3;
 }
 
 message GetHistoricalFeaturesRequest {
@@ -171,7 +171,7 @@ message StartStreamToOnlineIngestionJobResponse {
     google.protobuf.Timestamp job_start_time = 2;
 
     // Feature table associated with the job
-    string feature_table = 3;
+    string table_name = 3;
 }
 
 message ListJobsRequest {

--- a/protos/feast/core/JobService.proto
+++ b/protos/feast/core/JobService.proto
@@ -95,6 +95,9 @@ message Job {
     OfflineToOnlineMeta batch_ingestion = 7;
     StreamToOnlineMeta stream_ingestion = 8;
   }
+
+  // Path to Spark job logs, if available
+  string log_uri = 9;
 }
 
 // Ingest data from offline store into online store
@@ -111,14 +114,17 @@ message StartOfflineToOnlineIngestionJobRequest {
 }
 
 message StartOfflineToOnlineIngestionJobResponse {
-    // Job ID assigned by Feast
-    string id = 1;
+  // Job ID assigned by Feast
+  string id = 1;
 
-    // Job start time
-    google.protobuf.Timestamp job_start_time = 2;
+  // Job start time
+  google.protobuf.Timestamp job_start_time = 2;
 
-    // Feature table associated with the job
-    string table_name = 3;
+  // Feature table associated with the job
+  string table_name = 3;
+
+  // Path to Spark job logs, if available
+  string log_uri = 4;
 }
 
 message GetHistoricalFeaturesRequest {
@@ -146,14 +152,17 @@ message GetHistoricalFeaturesRequest {
 }
 
 message GetHistoricalFeaturesResponse {
-    // Export Job with ID assigned by Feast
-    string id = 1;
+  // Export Job with ID assigned by Feast
+  string id = 1;
 
-    // Uri to the join result output file
-    string output_file_uri = 2;
+  // Uri to the join result output file
+  string output_file_uri = 2;
 
-    // Job start time
-    google.protobuf.Timestamp job_start_time = 3;
+  // Job start time
+  google.protobuf.Timestamp job_start_time = 3;
+
+  // Path to Spark job logs, if available
+  string log_uri = 4;
 
 }
 
@@ -164,18 +173,21 @@ message StartStreamToOnlineIngestionJobRequest {
 }
 
 message StartStreamToOnlineIngestionJobResponse {
-    // Job ID assigned by Feast
-    string id = 1;
+  // Job ID assigned by Feast
+  string id = 1;
 
-    // Job start time
-    google.protobuf.Timestamp job_start_time = 2;
+  // Job start time
+  google.protobuf.Timestamp job_start_time = 2;
 
-    // Feature table associated with the job
-    string table_name = 3;
+  // Feature table associated with the job
+  string table_name = 3;
+
+  // Path to Spark job logs, if available
+  string log_uri = 4;
 }
 
 message ListJobsRequest {
-    bool include_terminated = 1;
+  bool include_terminated = 1;
 }
 
 message ListJobsResponse {

--- a/protos/feast/core/JobService.proto
+++ b/protos/feast/core/JobService.proto
@@ -74,15 +74,19 @@ message Job {
   JobStatus status = 3;
   // Deterministic hash of the Job
   string hash = 8;
+  // Start time of the Job
+  google.protobuf.Timestamp start_time = 9;
 
   message RetrievalJobMeta {
     string output_location = 4;
   }
 
   message OfflineToOnlineMeta {
+      string feature_table = 10;
   }
 
   message StreamToOnlineMeta {
+      string feature_table = 11;
   }
 
   // JobType specific metadata on the job
@@ -109,6 +113,12 @@ message StartOfflineToOnlineIngestionJobRequest {
 message StartOfflineToOnlineIngestionJobResponse {
     // Job ID assigned by Feast
     string id = 1;
+
+    // Job start time
+    google.protobuf.Timestamp job_start_time = 2;
+
+    // Feature table associated with the job
+    string feature_table = 3;
 }
 
 message GetHistoricalFeaturesRequest {
@@ -138,7 +148,13 @@ message GetHistoricalFeaturesRequest {
 message GetHistoricalFeaturesResponse {
     // Export Job with ID assigned by Feast
     string id = 1;
+
+    // Uri to the join result output file
     string output_file_uri = 2;
+
+    // Job start time
+    google.protobuf.Timestamp job_start_time = 3;
+
 }
 
 message StartStreamToOnlineIngestionJobRequest {
@@ -150,10 +166,16 @@ message StartStreamToOnlineIngestionJobRequest {
 message StartStreamToOnlineIngestionJobResponse {
     // Job ID assigned by Feast
     string id = 1;
+
+    // Job start time
+    google.protobuf.Timestamp job_start_time = 2;
+
+    // Feature table associated with the job
+    string feature_table = 3;
 }
 
 message ListJobsRequest {
-  bool include_terminated = 1;
+    bool include_terminated = 1;
 }
 
 message ListJobsResponse {

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -1075,7 +1075,7 @@ class Client:
                 self._extra_grpc_params,
                 response.id,
                 output_file_uri=response.output_file_uri,
-                start_time=response.job_start_time,
+                start_time=response.job_start_time.ToDatetime(),
             )
         else:
             return start_historical_feature_retrieval_job(

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -1076,6 +1076,7 @@ class Client:
                 response.id,
                 output_file_uri=response.output_file_uri,
                 start_time=response.job_start_time.ToDatetime(),
+                log_uri=response.log_uri,
             )
         else:
             return start_historical_feature_retrieval_job(
@@ -1180,6 +1181,7 @@ class Client:
                 response.id,
                 feature_table.name,
                 response.job_start_time.ToDatetime(),
+                response.log_uri,
             )
 
     def start_stream_to_online_ingestion(
@@ -1206,6 +1208,7 @@ class Client:
                 response.id,
                 feature_table.name,
                 response.job_start_time,
+                response.log_uri,
             )
 
     def list_jobs(self, include_terminated: bool) -> List[SparkJob]:

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -1075,6 +1075,7 @@ class Client:
                 self._extra_grpc_params,
                 response.id,
                 output_file_uri=response.output_file_uri,
+                start_time=response.job_start_time,
             )
         else:
             return start_historical_feature_retrieval_job(
@@ -1174,7 +1175,11 @@ class Client:
             request.end_date.FromDatetime(end)
             response = self._job_service.StartOfflineToOnlineIngestionJob(request)
             return RemoteBatchIngestionJob(
-                self._job_service, self._extra_grpc_params, response.id,
+                self._job_service,
+                self._extra_grpc_params,
+                response.id,
+                feature_table.name,
+                response.job_start_time.ToDateTime(),
             )
 
     def start_stream_to_online_ingestion(
@@ -1196,7 +1201,11 @@ class Client:
             )
             response = self._job_service.StartStreamToOnlineIngestionJob(request)
             return RemoteStreamIngestionJob(
-                self._job_service, self._extra_grpc_params, response.id
+                self._job_service,
+                self._extra_grpc_params,
+                response.id,
+                feature_table.name,
+                response.job_start_time,
             )
 
     def list_jobs(self, include_terminated: bool) -> List[SparkJob]:

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -1179,7 +1179,7 @@ class Client:
                 self._extra_grpc_params,
                 response.id,
                 feature_table.name,
-                response.job_start_time.ToDateTime(),
+                response.job_start_time.ToDatetime(),
             )
 
     def start_stream_to_online_ingestion(

--- a/sdk/python/feast/job_service.py
+++ b/sdk/python/feast/job_service.py
@@ -55,6 +55,10 @@ from feast.third_party.grpc.health.v1.HealthService_pb2 import (
 def _job_to_proto(spark_job: SparkJob) -> JobProto:
     job = JobProto()
     job.id = spark_job.get_id()
+    log_uri = spark_job.get_log_uri()
+    if log_uri:
+        assert isinstance(log_uri, str)
+        job.log_uri = log_uri
     status = spark_job.get_status()
     if status == SparkJobStatus.COMPLETED:
         job.status = JobStatus.JOB_STATUS_DONE
@@ -110,6 +114,7 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
             id=job.get_id(),
             job_start_time=job_start_timestamp,
             table_name=request.table_name,
+            log_uri=job.get_log_uri(),
         )
 
     def GetHistoricalFeatures(self, request: GetHistoricalFeaturesRequest, context):
@@ -159,6 +164,7 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
                         id=job.get_id(),
                         job_start_time=job_start_timestamp,
                         table_name=job.get_feature_table(),
+                        log_uri=job.get_log_uri(),
                     )
             raise RuntimeError(
                 "Feast Job Service has control loop enabled, but couldn't find the existing stream ingestion job for the given FeatureTable"
@@ -178,6 +184,7 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
             id=job.get_id(),
             job_start_time=job_start_timestamp,
             table_name=request.table_name,
+            log_uri=job.get_log_uri(),
         )
 
     def ListJobs(self, request, context):

--- a/sdk/python/feast/job_service.py
+++ b/sdk/python/feast/job_service.py
@@ -72,10 +72,10 @@ def _job_to_proto(spark_job: SparkJob) -> JobProto:
         job.retrieval.output_location = spark_job.get_output_file_uri(block=False)
     elif isinstance(spark_job, BatchIngestionJob):
         job.type = JobType.BATCH_INGESTION_JOB
-        job.batch_ingestion.feature_table = spark_job.get_feature_table()
+        job.batch_ingestion.table_name = spark_job.get_feature_table()
     elif isinstance(spark_job, StreamIngestionJob):
         job.type = JobType.STREAM_INGESTION_JOB
-        job.stream_ingestion.feature_table = spark_job.get_feature_table()
+        job.stream_ingestion.table_name = spark_job.get_feature_table()
     else:
         raise ValueError(f"Invalid job type {job}")
 
@@ -109,7 +109,7 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
         return StartOfflineToOnlineIngestionJobResponse(
             id=job.get_id(),
             job_start_time=job_start_timestamp,
-            feature_table=request.table_name,
+            table_name=request.table_name,
         )
 
     def GetHistoricalFeatures(self, request: GetHistoricalFeaturesRequest, context):
@@ -158,7 +158,7 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
                     return StartStreamToOnlineIngestionJobResponse(
                         id=job.get_id(),
                         job_start_time=job_start_timestamp,
-                        feature_table=job.get_feature_table(),
+                        table_name=job.get_feature_table(),
                     )
             raise RuntimeError(
                 "Feast Job Service has control loop enabled, but couldn't find the existing stream ingestion job for the given FeatureTable"
@@ -177,7 +177,7 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
         return StartStreamToOnlineIngestionJobResponse(
             id=job.get_id(),
             job_start_time=job_start_timestamp,
-            feature_table=request.table_name,
+            table_name=request.table_name,
         )
 
     def ListJobs(self, request, context):

--- a/sdk/python/feast/job_service.py
+++ b/sdk/python/feast/job_service.py
@@ -5,7 +5,7 @@ import threading
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, cast
 
 import grpc
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -55,10 +55,7 @@ from feast.third_party.grpc.health.v1.HealthService_pb2 import (
 def _job_to_proto(spark_job: SparkJob) -> JobProto:
     job = JobProto()
     job.id = spark_job.get_id()
-    log_uri = spark_job.get_log_uri()
-    if log_uri:
-        assert isinstance(log_uri, str)
-        job.log_uri = log_uri
+    job.log_uri = cast(str, spark_job.get_log_uri() or "")
     status = spark_job.get_status()
     if status == SparkJobStatus.COMPLETED:
         job.status = JobStatus.JOB_STATUS_DONE

--- a/sdk/python/feast/job_service.py
+++ b/sdk/python/feast/job_service.py
@@ -127,8 +127,13 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
 
         output_file_uri = job.get_output_file_uri(block=False)
 
+        job_start_timestamp = Timestamp()
+        job_start_timestamp.FromDatetime(job.get_start_time())
+
         return GetHistoricalFeaturesResponse(
-            id=job.get_id(), output_file_uri=output_file_uri
+            id=job.get_id(),
+            output_file_uri=output_file_uri,
+            job_start_time=job_start_timestamp,
         )
 
     def StartStreamToOnlineIngestionJob(

--- a/sdk/python/feast/pyspark/abc.py
+++ b/sdk/python/feast/pyspark/abc.py
@@ -67,6 +67,12 @@ class SparkJob(abc.ABC):
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def get_start_time(self) -> datetime:
+        """
+        Get job start time.
+        """
+
 
 class SparkJobParameters(abc.ABC):
     @abc.abstractmethod
@@ -496,6 +502,18 @@ class BatchIngestionJob(SparkJob):
     Container for the ingestion job result
     """
 
+    @abc.abstractmethod
+    def get_feature_table(self) -> str:
+        """
+        Get the feature table name associated with this job. Return empty string if unable to
+        determine the feature table, such as when the job is created by the earlier
+        version of Feast.
+
+        Returns:
+            str: Feature table name
+        """
+        raise NotImplementedError
+
 
 class StreamIngestionJob(SparkJob):
     """
@@ -510,6 +528,18 @@ class StreamIngestionJob(SparkJob):
 
         Returns:
             str: The hash for this streaming ingestion job
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_feature_table(self) -> str:
+        """
+        Get the feature table name associated with this job. Return `None` if unable to
+        determine the feature table, such as when the job is created by the earlier
+        version of Feast.
+
+        Returns:
+            str: Feature table name
         """
         raise NotImplementedError
 

--- a/sdk/python/feast/pyspark/abc.py
+++ b/sdk/python/feast/pyspark/abc.py
@@ -73,6 +73,12 @@ class SparkJob(abc.ABC):
         Get job start time.
         """
 
+    def get_log_uri(self) -> Optional[str]:
+        """
+        Get path to Spark job log, if applicable.
+        """
+        return None
+
 
 class SparkJobParameters(abc.ABC):
     @abc.abstractmethod

--- a/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
+++ b/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any, Dict, List, NamedTuple, Optional
 from urllib.parse import urlparse, urlunparse
 
+import pytz
 import yaml
 
 from feast.pyspark.abc import BQ_SPARK_PACKAGE
@@ -254,7 +255,7 @@ def _get_job_creation_time(emr_client, job: EmrJobRef) -> datetime:
 def _get_step_creation_time(emr_client, cluster_id: str, step_id: str) -> datetime:
     response = emr_client.describe_step(ClusterId=cluster_id, StepId=step_id)
     step_creation_time = response["Step"]["Status"]["Timeline"]["CreationDateTime"]
-    return step_creation_time
+    return step_creation_time.astimezone(pytz.utc).replace(tzinfo=None)
 
 
 def _wait_for_step_state(

--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -133,6 +133,9 @@ class DataprocJobMixin:
     def get_start_time(self):
         return self._job.status.state_start_time
 
+    def get_log_uri(self) -> Optional[str]:
+        return self._job.driver_output_resource_uri
+
 
 class DataprocRetrievalJob(DataprocJobMixin, RetrievalJob):
     """

--- a/sdk/python/feast/pyspark/launchers/k8s/k8s_utils.py
+++ b/sdk/python/feast/pyspark/launchers/k8s/k8s_utils.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from datetime import datetime
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from kubernetes import client, config
@@ -26,6 +27,7 @@ HISTORICAL_RETRIEVAL_JOB_TYPE = "HISTORICAL_RETRIEVAL_JOB"
 
 LABEL_JOBID = "feast.dev/jobid"
 LABEL_JOBTYPE = "feast.dev/type"
+LABEL_FEATURE_TABLE = "feast.dev/table"
 
 # Can't store these bits of info in k8s labels due to 64-character limit, so we store them as
 # sparkConf
@@ -114,11 +116,14 @@ def _prepare_job_resource(
     azure_credentials: Dict[str, str],
     arguments: List[str],
     namespace: str,
+    extra_labels: Dict[str, str] = None,
 ) -> Dict[str, Any]:
     """ Prepare SparkApplication custom resource configs """
     job = deepcopy(job_template)
 
     labels = {LABEL_JOBID: job_id, LABEL_JOBTYPE: job_type}
+    if extra_labels:
+        labels = {**labels, **extra_labels}
 
     _add_keys(job, ("metadata", "labels"), labels)
     _add_keys(
@@ -164,6 +169,8 @@ class JobInfo(NamedTuple):
     namespace: str
     extra_metadata: Dict[str, str]
     state: SparkJobStatus
+    labels: Dict[str, str]
+    start_time: datetime
 
 
 STATE_MAP = {
@@ -186,6 +193,7 @@ def _k8s_state_to_feast(k8s_state: str) -> SparkJobStatus:
 
 def _resource_to_job_info(resource: Dict[str, Any]) -> JobInfo:
     labels = resource["metadata"]["labels"]
+    start_time = resource["metadata"].get("creationTimestamp")
     sparkConf = resource["spec"].get("sparkConf", {})
 
     if "status" in resource:
@@ -199,6 +207,8 @@ def _resource_to_job_info(resource: Dict[str, Any]) -> JobInfo:
         namespace=resource["metadata"].get("namespace", "default"),
         extra_metadata={k: v for k, v in sparkConf.items() if k in METADATA_KEYS},
         state=state,
+        labels=labels,
+        start_time=start_time,
     )
 
 

--- a/sdk/python/feast/pyspark/launchers/k8s/k8s_utils.py
+++ b/sdk/python/feast/pyspark/launchers/k8s/k8s_utils.py
@@ -193,7 +193,9 @@ def _k8s_state_to_feast(k8s_state: str) -> SparkJobStatus:
 
 def _resource_to_job_info(resource: Dict[str, Any]) -> JobInfo:
     labels = resource["metadata"]["labels"]
-    start_time = resource["metadata"].get("creationTimestamp")
+    start_time = datetime.strptime(
+        resource["metadata"].get("creationTimestamp"), "%Y-%m-%dT%H:%M:%SZ"
+    )
     sparkConf = resource["spec"].get("sparkConf", {})
 
     if "status" in resource:

--- a/sdk/python/feast/pyspark/launchers/standalone/local.py
+++ b/sdk/python/feast/pyspark/launchers/standalone/local.py
@@ -4,6 +4,7 @@ import subprocess
 import threading
 import uuid
 from contextlib import closing
+from datetime import datetime
 from typing import Dict, List, Optional
 
 import requests
@@ -101,6 +102,7 @@ class StandaloneClusterJobMixin:
         self._job_name = job_name
         self._process = process
         self._ui_port = ui_port
+        self._start_time = datetime.now()
 
     def get_id(self) -> str:
         return self._job_id
@@ -127,6 +129,9 @@ class StandaloneClusterJobMixin:
         ).json()
         return bool(stages)
 
+    def get_start_time(self) -> datetime:
+        return self._start_time
+
     def get_status(self) -> SparkJobStatus:
         code = self._process.poll()
         if code is None:
@@ -149,7 +154,19 @@ class StandaloneClusterBatchIngestionJob(StandaloneClusterJobMixin, BatchIngesti
     Batch Ingestion job result for a standalone spark cluster
     """
 
-    pass
+    def __init__(
+        self,
+        job_id: str,
+        job_name: str,
+        process: subprocess.Popen,
+        ui_port: int,
+        feature_table: str,
+    ) -> None:
+        super().__init__(job_id, job_name, process, ui_port)
+        self._feature_table = feature_table
+
+    def get_feature_table(self) -> str:
+        return self._feature_table
 
 
 class StandaloneClusterStreamingIngestionJob(
@@ -166,12 +183,17 @@ class StandaloneClusterStreamingIngestionJob(
         process: subprocess.Popen,
         ui_port: int,
         job_hash: str,
+        feature_table: str,
     ) -> None:
         super().__init__(job_id, job_name, process, ui_port)
         self._job_hash = job_hash
+        self._feature_table = feature_table
 
     def get_hash(self) -> str:
         return self._job_hash
+
+    def get_feature_table(self) -> str:
+        return self._feature_table
 
 
 class StandaloneClusterRetrievalJob(StandaloneClusterJobMixin, RetrievalJob):
@@ -312,6 +334,7 @@ class StandaloneClusterLauncher(JobLauncher):
             ingestion_job_params.get_name(),
             self.spark_submit(ingestion_job_params, ui_port),
             ui_port,
+            ingestion_job_params.get_feature_table_name(),
         )
         global_job_cache.add_job(job)
         return job
@@ -327,6 +350,7 @@ class StandaloneClusterLauncher(JobLauncher):
             self.spark_submit(ingestion_job_params, ui_port),
             ui_port,
             ingestion_job_params.get_job_hash(),
+            ingestion_job_params.get_feature_table_name(),
         )
         global_job_cache.add_job(job)
         return job

--- a/sdk/python/feast/pyspark/launchers/standalone/local.py
+++ b/sdk/python/feast/pyspark/launchers/standalone/local.py
@@ -102,7 +102,7 @@ class StandaloneClusterJobMixin:
         self._job_name = job_name
         self._process = process
         self._ui_port = ui_port
-        self._start_time = datetime.now()
+        self._start_time = datetime.utcnow()
 
     def get_id(self) -> str:
         return self._job_id

--- a/sdk/python/feast/remote_job.py
+++ b/sdk/python/feast/remote_job.py
@@ -188,7 +188,7 @@ def get_remote_job_from_proto(
             service,
             grpc_extra_param_provider,
             job.id,
-            job.batch_ingestion.feature_table,
+            job.batch_ingestion.table_name,
             job.start_time.ToDatetime(),
         )
     elif job.type == JobType.STREAM_INGESTION_JOB:
@@ -196,7 +196,7 @@ def get_remote_job_from_proto(
             service,
             grpc_extra_param_provider,
             job.id,
-            job.stream_ingestion.feature_table,
+            job.stream_ingestion.table_name,
             job.start_time.ToDatetime(),
         )
     else:

--- a/sdk/python/feast/remote_job.py
+++ b/sdk/python/feast/remote_job.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 from typing import Any, Callable, Dict, List
 
 from feast.core.JobService_pb2 import CancelJobRequest, GetJobRequest
@@ -23,6 +24,7 @@ class RemoteJobMixin:
         service: JobServiceStub,
         grpc_extra_param_provider: GrpcExtraParamProvider,
         job_id: str,
+        start_time: datetime,
     ):
         """
         Args:
@@ -32,6 +34,7 @@ class RemoteJobMixin:
         self._job_id = job_id
         self._service = service
         self._grpc_extra_param_provider = grpc_extra_param_provider
+        self._start_time = start_time
 
     def get_id(self) -> str:
         return self._job_id
@@ -52,6 +55,9 @@ class RemoteJobMixin:
         else:
             # we should never get here
             raise Exception(f"Invalid remote job state {response.job.status}")
+
+    def get_start_time(self) -> datetime:
+        return self._start_time
 
     def cancel(self):
         self._service.CancelJob(
@@ -84,6 +90,7 @@ class RemoteRetrievalJob(RemoteJobMixin, RetrievalJob):
         grpc_extra_param_provider: GrpcExtraParamProvider,
         job_id: str,
         output_file_uri: str,
+        start_time: datetime,
     ):
         """
         This is the job object representing the historical retrieval job.
@@ -91,7 +98,7 @@ class RemoteRetrievalJob(RemoteJobMixin, RetrievalJob):
         Args:
             output_file_uri (str): Uri to the historical feature retrieval job output file.
         """
-        super().__init__(service, grpc_extra_param_provider, job_id)
+        super().__init__(service, grpc_extra_param_provider, job_id, start_time)
         self._output_file_uri = output_file_uri
 
     def get_output_file_uri(self, timeout_sec=None):
@@ -115,8 +122,14 @@ class RemoteBatchIngestionJob(RemoteJobMixin, BatchIngestionJob):
         service: JobServiceStub,
         grpc_extra_param_provider: GrpcExtraParamProvider,
         job_id: str,
+        feature_table: str,
+        start_time: datetime,
     ):
-        super().__init__(service, grpc_extra_param_provider, job_id)
+        super().__init__(service, grpc_extra_param_provider, job_id, start_time)
+        self._feature_table = feature_table
+
+    def get_feature_table(self) -> str:
+        return self._feature_table
 
 
 class RemoteStreamIngestionJob(RemoteJobMixin, StreamIngestionJob):
@@ -124,12 +137,26 @@ class RemoteStreamIngestionJob(RemoteJobMixin, StreamIngestionJob):
     Stream ingestion job result.
     """
 
+    def __init__(
+        self,
+        service: JobServiceStub,
+        grpc_extra_param_provider: GrpcExtraParamProvider,
+        job_id: str,
+        feature_table: str,
+        start_time: datetime,
+    ):
+        super().__init__(service, grpc_extra_param_provider, job_id, start_time)
+        self._feature_table = feature_table
+
     def get_hash(self) -> str:
         response = self._service.GetJob(
             GetJobRequest(job_id=self._job_id), **self._grpc_extra_param_provider()
         )
 
         return response.job.hash
+
+    def get_feature_table(self) -> str:
+        return self._feature_table
 
 
 def get_remote_job_from_proto(
@@ -147,14 +174,31 @@ def get_remote_job_from_proto(
     Returns:
         (SparkJob): A remote job object for the given job
     """
+
     if job.type == JobType.RETRIEVAL_JOB:
         return RemoteRetrievalJob(
-            service, grpc_extra_param_provider, job.id, job.retrieval.output_location
+            service,
+            grpc_extra_param_provider,
+            job.id,
+            job.retrieval.output_location,
+            job.start_time.ToDatetime(),
         )
     elif job.type == JobType.BATCH_INGESTION_JOB:
-        return RemoteBatchIngestionJob(service, grpc_extra_param_provider, job.id)
+        return RemoteBatchIngestionJob(
+            service,
+            grpc_extra_param_provider,
+            job.id,
+            job.batch_ingestion.feature_table,
+            job.start_time.ToDatetime(),
+        )
     elif job.type == JobType.STREAM_INGESTION_JOB:
-        return RemoteStreamIngestionJob(service, grpc_extra_param_provider, job.id)
+        return RemoteStreamIngestionJob(
+            service,
+            grpc_extra_param_provider,
+            job.id,
+            job.stream_ingestion.feature_table,
+            job.start_time.ToDatetime(),
+        )
     else:
         raise ValueError(
             f"Invalid Job Type {job.type}, has to be one of "

--- a/sdk/python/tests/test_remote_job.py
+++ b/sdk/python/tests/test_remote_job.py
@@ -59,7 +59,7 @@ class TestRemoteJob:
         mock_servicer = MockServicer()
         with mock_server(mock_servicer) as service:
             remote_job = RemoteRetrievalJob(
-                service, lambda: {}, "test", "foo", ["table1"], datetime.now()
+                service, lambda: {}, "test", "foo", datetime.now()
             )
 
             assert remote_job.get_output_file_uri(timeout_sec=2) == "foo"

--- a/sdk/python/tests/test_remote_job.py
+++ b/sdk/python/tests/test_remote_job.py
@@ -59,7 +59,7 @@ class TestRemoteJob:
         mock_servicer = MockServicer()
         with mock_server(mock_servicer) as service:
             remote_job = RemoteRetrievalJob(
-                service, lambda: {}, "test", "foo", datetime.now()
+                service, lambda: {}, "test", "foo", datetime.now(), None
             )
 
             assert remote_job.get_output_file_uri(timeout_sec=2) == "foo"

--- a/sdk/python/tests/test_remote_job.py
+++ b/sdk/python/tests/test_remote_job.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from concurrent import futures
 from contextlib import contextmanager
+from datetime import datetime
 
 import grpc
 
@@ -57,7 +58,9 @@ class TestRemoteJob:
 
         mock_servicer = MockServicer()
         with mock_server(mock_servicer) as service:
-            remote_job = RemoteRetrievalJob(service, lambda: {}, "test", "foo")
+            remote_job = RemoteRetrievalJob(
+                service, lambda: {}, "test", "foo", ["table1"], datetime.now()
+            )
 
             assert remote_job.get_output_file_uri(timeout_sec=2) == "foo"
             assert mock_servicer._call_count["GetJob"] == 2

--- a/tests/e2e/test_historical_features.py
+++ b/tests/e2e/test_historical_features.py
@@ -106,9 +106,10 @@ def test_historical_features(
 
     feature_refs = ["transactions:daily_transactions"]
 
-    job_submission_time = datetime.now()
+    job_submission_time = datetime.utcnow()
     job = feast_client.get_historical_features(feature_refs, customers_df)
     assert job.get_start_time() >= job_submission_time
+    assert job.get_start_time() <= job_submission_time + timedelta(hours=1)
 
     output_dir = job.get_output_file_uri()
     joined_df = read_parquet(output_dir)

--- a/tests/e2e/test_historical_features.py
+++ b/tests/e2e/test_historical_features.py
@@ -106,7 +106,10 @@ def test_historical_features(
 
     feature_refs = ["transactions:daily_transactions"]
 
+    job_submission_time = datetime.now()
     job = feast_client.get_historical_features(feature_refs, customers_df)
+    assert job.get_start_time() >= job_submission_time
+
     output_dir = job.get_output_file_uri()
     joined_df = read_parquet(output_dir)
 

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -125,6 +125,7 @@ def test_streaming_ingestion(
     feast_client.apply(feature_table)
 
     job = feast_client.start_stream_to_online_ingestion(feature_table)
+    assert job.get_feature_table() == feature_table.name
 
     wait_retry_backoff(
         lambda: (None, job.get_status() == SparkJobStatus.IN_PROGRESS), 120
@@ -165,6 +166,7 @@ def ingest_and_verify(
         original.event_timestamp.min().to_pydatetime(),
         original.event_timestamp.max().to_pydatetime() + timedelta(seconds=1),
     )
+    assert job.get_feature_table() == feature_table.name
 
     wait_retry_backoff(
         lambda: (None, job.get_status() == SparkJobStatus.COMPLETED), 180

--- a/tests/integration/test_launchers.py
+++ b/tests/integration/test_launchers.py
@@ -32,6 +32,7 @@ def test_dataproc_job_api(
     job = dataproc_launcher.historical_feature_retrieval(dataproc_retrieval_job_params)
     job_id = job.get_id()
     retrieved_job = dataproc_launcher.get_job_by_id(job_id)
+    assert retrieved_job.get_log_uri is not None
     assert retrieved_job.get_id() == job_id
     status = retrieved_job.get_status()
     assert status in [


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
As part of an effort to create an UI for Feast, the JobService API needs to return more information, in particular, job start time and the feature table associated with the ingestion jobs.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
gRPC responses for submitting spark jobs via job service now have additional fields: start time for all types of jobs, and feature table for ingestion jobs. These fields have also been added to the corresponding Job object returned by list_jobs and get_job API.
```
