### PR TITLE
Make nodes priority (for redis cluster) configurable in Serving

### DIFF
--- a/protos/feast/core/Store.proto
+++ b/protos/feast/core/Store.proto
@@ -78,6 +78,14 @@ message Store {
     // Optional. This would be the fallback prefix to use if enable_fallback is true.
     string fallback_prefix = 7;
 
+    // Optional. Priority of nodes when reading from cluster
+    enum ReadFrom {
+      MASTER = 0;
+      MASTER_PREFERRED = 1;
+      REPLICA = 2;
+      REPLICA_PREFERRED = 3;
+    }
+    ReadFrom read_from = 8;
   }
 
   message Subscription {

--- a/serving/src/main/java/feast/serving/config/ServingServiceConfigV2.java
+++ b/serving/src/main/java/feast/serving/config/ServingServiceConfigV2.java
@@ -25,7 +25,6 @@ import feast.serving.specs.CachedSpecService;
 import feast.storage.api.retriever.OnlineRetrieverV2;
 import feast.storage.connectors.redis.retriever.*;
 import io.opentracing.Tracer;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,16 +40,16 @@ public class ServingServiceConfigV2 {
     ServingServiceV2 servingService = null;
     FeastProperties.Store store = feastProperties.getActiveStore();
     StoreProto.Store.StoreType storeType = store.toProto().getType();
-    Map<String, String> config = store.getConfig();
 
     switch (storeType) {
       case REDIS_CLUSTER:
-        RedisClientAdapter redisClusterClient = RedisClusterClient.create(config);
+        RedisClientAdapter redisClusterClient =
+            RedisClusterClient.create(store.toProto().getRedisClusterConfig());
         OnlineRetrieverV2 redisClusterRetriever = new OnlineRetriever(redisClusterClient);
         servingService = new OnlineServingServiceV2(redisClusterRetriever, specService, tracer);
         break;
       case REDIS:
-        RedisClientAdapter redisClient = RedisClient.create(config);
+        RedisClientAdapter redisClient = RedisClient.create(store.toProto().getRedisConfig());
         OnlineRetrieverV2 redisRetriever = new OnlineRetriever(redisClient);
         servingService = new OnlineServingServiceV2(redisRetriever, specService, tracer);
         break;

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -54,7 +54,8 @@ feast:
       type: REDIS_CLUSTER
       config:  # Store specific configuration.
         # Connection string specifies the host:port of Redis instances in the redis cluster.
-        connection_string: "localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005" 
+        connection_string: "localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005"
+        read_from: MASTER
       subscriptions:
         - name: "*"
           project: "*"

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClient.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClient.java
@@ -16,6 +16,7 @@
  */
 package feast.storage.connectors.redis.retriever;
 
+import feast.proto.core.StoreProto;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.RedisURI;
@@ -23,7 +24,6 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import java.util.List;
-import java.util.Map;
 
 public class RedisClient implements RedisClientAdapter {
 
@@ -46,11 +46,11 @@ public class RedisClient implements RedisClientAdapter {
     this.asyncCommands.setAutoFlushCommands(false);
   }
 
-  public static RedisClientAdapter create(Map<String, String> config) {
+  public static RedisClientAdapter create(StoreProto.Store.RedisConfig config) {
 
-    RedisURI uri = RedisURI.create(config.get("host"), Integer.parseInt(config.get("port")));
+    RedisURI uri = RedisURI.create(config.getHost(), config.getPort());
 
-    if (Boolean.parseBoolean(config.get("ssl"))) {
+    if (config.getSsl()) {
       uri.setSsl(true);
     }
     StatefulRedisConnection<byte[], byte[]> connection =


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Prior to this PR Feast Serving only read from master nodes in redis cluster. Here I make it configurable via `application.yaml`.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
new configuration option

RedisClusterConfig:
   read_from: MASTER | MASTER_PREFERRED | REPLICA | REPLICA_PREFERRED
```
