### PR TITLE
Prevent ingestion job config parser from unwanted fieldMapping transformation

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/utils/JsonUtils.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/utils/JsonUtils.scala
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2018-2021 The Feast Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package feast.ingestion.utils
+
+import java.util.Locale.ENGLISH
+
+import org.json4s.{JArray, JField, JObject, JValue}
+
+object JsonUtils {
+  def mapFieldWithParent(jv: JValue)(f: (String, JField) => JField): JValue = {
+    def rec(v: JValue, parent: String = ""): JValue = v match {
+      case JObject(l) => JObject(l.map { case (key, va) => f(parent, key -> rec(va, key)) })
+      case JArray(l)  => JArray(l.map(rec(_, parent)))
+      case x          => x
+    }
+    rec(jv)
+  }
+
+  def camelize(word: String): String = {
+    if (word.nonEmpty) {
+      val w = pascalize(word)
+      w.substring(0, 1).toLowerCase(ENGLISH) + w.substring(1)
+    } else {
+      word
+    }
+  }
+
+  def pascalize(word: String): String = {
+    val lst = word.split("_").toList
+    (lst.headOption.map(s => s.substring(0, 1).toUpperCase(ENGLISH) + s.substring(1)).get ::
+      lst.tail.map(s => s.substring(0, 1).toUpperCase + s.substring(1))).mkString("")
+  }
+}


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

All keys in fieldMapping dictionary passed to IngestionJob are being camelized, which is unwanted behaviour, they should stay untouched.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
