### PR TITLE
fix historical test for azure

### DIFF
--- a/sdk/python/feast/pyspark/launchers/k8s/k8s.py
+++ b/sdk/python/feast/pyspark/launchers/k8s/k8s.py
@@ -9,7 +9,6 @@ from urllib.parse import urlparse, urlunparse
 import yaml
 from kubernetes.client.api import CustomObjectsApi
 
-from feast.constants import ConfigOptions as opt
 from feast.pyspark.abc import (
     BQ_SPARK_PACKAGE,
     BatchIngestionJob,
@@ -196,7 +195,7 @@ class KubernetesJobLauncher(JobLauncher):
         account_key = self._azure_account_key
         if account_name is None or account_key is None:
             raise Exception(
-                f"Using Azure blob storage requires Azure blob account name and access key to be set in config"
+                "Using Azure blob storage requires Azure blob account name and access key to be set in config"
             )
         return {
             f"spark.hadoop.fs.azure.account.key.{account_name}.blob.core.windows.net": f"{account_key}"

--- a/sdk/python/feast/staging/storage_client.py
+++ b/sdk/python/feast/staging/storage_client.py
@@ -397,7 +397,7 @@ class AzureBlobClient(AbstractStagingClient):
         )
         bucket, key = self._uri_to_bucket_key(remote_uri)
         container_client = self.blob_service_client.get_container_client(bucket)
-        container_client.upload_blob(name=key, data=fileobj)
+        container_client.upload_blob(name=key, data=fileobj, overwrite=True)
         return remote_uri
 
 

--- a/sdk/python/requirements-ci.txt
+++ b/sdk/python/requirements-ci.txt
@@ -22,4 +22,4 @@ pytest-ordering==0.6.*
 pytest-mock==1.10.4
 PyYAML==5.3.1
 great-expectations==0.13.2
-adlfs==0.0.9
+adlfs==0.5.9

--- a/sdk/python/requirements-ci.txt
+++ b/sdk/python/requirements-ci.txt
@@ -22,3 +22,4 @@ pytest-ordering==0.6.*
 pytest-mock==1.10.4
 PyYAML==5.3.1
 great-expectations==0.13.2
+adlfs==0.0.9


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: fixes the historical test to support azure blob storage

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
