### PR TITLE
Use dataproc console url instead of gcs for log uri

### DIFF
--- a/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
+++ b/sdk/python/feast/pyspark/launchers/gcloud/dataproc.py
@@ -393,12 +393,12 @@ class DataprocClusterLauncher(JobLauncher):
             job_params, {"dev.feast.outputuri": job_params.get_destination_path()}
         )
         return DataprocRetrievalJob(
-            job,
-            refresh_fn,
-            cancel_fn,
-            job_params.get_destination_path(),
-            self.project_id,
-            self.region,
+            job=job,
+            refresh_fn=refresh_fn,
+            cancel_fn=cancel_fn,
+            project=self.project_id,
+            region=self.region,
+            output_file_uri=job_params.get_destination_path(),
         )
 
     def offline_to_online_ingestion(
@@ -406,7 +406,11 @@ class DataprocClusterLauncher(JobLauncher):
     ) -> BatchIngestionJob:
         job, refresh_fn, cancel_fn = self.dataproc_submit(ingestion_job_params, {})
         return DataprocBatchIngestionJob(
-            job, refresh_fn, cancel_fn, self.project_id, self.region
+            job=job,
+            refresh_fn=refresh_fn,
+            cancel_fn=cancel_fn,
+            project=self.project_id,
+            region=self.region,
         )
 
     def start_stream_to_online_ingestion(
@@ -415,7 +419,12 @@ class DataprocClusterLauncher(JobLauncher):
         job, refresh_fn, cancel_fn = self.dataproc_submit(ingestion_job_params, {})
         job_hash = ingestion_job_params.get_job_hash()
         return DataprocStreamingIngestionJob(
-            job, refresh_fn, cancel_fn, self.project_id, self.region, job_hash
+            job=job,
+            refresh_fn=refresh_fn,
+            cancel_fn=cancel_fn,
+            project=self.project_id,
+            region=self.region,
+            job_hash=job_hash,
         )
 
     def get_job_by_id(self, job_id: str) -> SparkJob:
@@ -438,18 +447,32 @@ class DataprocClusterLauncher(JobLauncher):
         if job_type == SparkJobType.HISTORICAL_RETRIEVAL.name.lower():
             output_path = job.pyspark_job.properties.get("dev.feast.outputuri", "")
             return DataprocRetrievalJob(
-                job, refresh_fn, cancel_fn, self.project_id, self.region, output_path
+                job=job,
+                refresh_fn=refresh_fn,
+                cancel_fn=cancel_fn,
+                project=self.project_id,
+                region=self.region,
+                output_file_uri=output_path,
             )
 
         if job_type == SparkJobType.BATCH_INGESTION.name.lower():
             return DataprocBatchIngestionJob(
-                job, refresh_fn, cancel_fn, self.project_id, self.region
+                job=job,
+                refresh_fn=refresh_fn,
+                cancel_fn=cancel_fn,
+                project=self.project_id,
+                region=self.region,
             )
 
         if job_type == SparkJobType.STREAM_INGESTION.name.lower():
             job_hash = job.labels[self.JOB_HASH_LABEL_KEY]
             return DataprocStreamingIngestionJob(
-                job, refresh_fn, cancel_fn, self.project_id, self.region, job_hash
+                job=job,
+                refresh_fn=refresh_fn,
+                cancel_fn=cancel_fn,
+                project=self.project_id,
+                region=self.region,
+                job_hash=job_hash,
             )
 
         raise ValueError(f"Unrecognized job type: {job_type}")


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
`get_log_uri` is currently returning the GCS uri of the Spark driver logs. This is changed to the dataproc console uri instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
DataprocClusterLauncher jobs will now return the dataproc console url referring to the job, rather than the GCS uri that points to the Spark driver logs.
```
