### PR TITLE
Add project name to feature validation metric

### DIFF
--- a/sdk/python/feast/contrib/validation/ge.py
+++ b/sdk/python/feast/contrib/validation/ge.py
@@ -131,6 +131,7 @@ def create_validation_udf(
                 value=unexpected_count,
                 tags=[
                     f"feature_table:{os.getenv('FEAST_INGESTION_FEATURE_TABLE', 'unknown')}",
+                    f"project:{os.getenv('FEAST_INGESTION_PROJECT_NAME', 'default')}",
                     f"check:{check_name}",
                 ],
             )

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -176,7 +176,8 @@ object StreamingPipeline extends BasePipeline with Serializable {
           Map(
             "STATSD_HOST"                   -> c.host,
             "STATSD_PORT"                   -> c.port.toString,
-            "FEAST_INGESTION_FEATURE_TABLE" -> config.featureTable.name
+            "FEAST_INGESTION_FEATURE_TABLE" -> config.featureTable.name,
+            "FEAST_INGESTION_PROJECT_NAME"  -> config.featureTable.project
           )
         case _ => Map.empty[String, String]
       }

--- a/tests/e2e/test_validation.py
+++ b/tests/e2e/test_validation.py
@@ -200,7 +200,8 @@ def test_validation_reports_metrics(
 
     expected_metrics = [
         (
-            f"feast_feature_validation_check_failed#check:{check_name},feature_table:validation_ge_metrics",
+            f"feast_feature_validation_check_failed#check:{check_name},"
+            f"feature_table:{feature_table.name},project:{feast_client.project}",
             value,
         )
         for check_name, value in unexpected_counts.items()


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Along with feature table name this PR adds project name into `feast_feature_validation_check_failed` metric.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
