### PR TITLE
Optimize memory footprint for Spark Ingestion Job

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/BatchPipeline.scala
@@ -69,7 +69,7 @@ object BatchPipeline extends BasePipeline {
     }
 
     val validRows = projected
-      .mapPartitions(metrics.incrementRead)
+      .map(metrics.incrementRead)
       .filter(rowValidator.allChecks)
 
     validRows.write
@@ -85,7 +85,7 @@ object BatchPipeline extends BasePipeline {
       case Some(path) =>
         projected
           .filter(!rowValidator.allChecks)
-          .mapPartitions(metrics.incrementDeadLetters)
+          .map(metrics.incrementDeadLetters)
           .write
           .format("parquet")
           .mode(SaveMode.Append)

--- a/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/StreamingPipeline.scala
@@ -107,7 +107,7 @@ object StreamingPipeline extends BasePipeline with Serializable {
         implicit def rowEncoder: Encoder[Row] = RowEncoder(rowsAfterValidation.schema)
 
         rowsAfterValidation
-          .mapPartitions(metrics.incrementRead)
+          .map(metrics.incrementRead)
           .filter(if (config.doNotIngestInvalidRows) expr("_isValid") else rowValidator.allChecks)
           .write
           .format("feast.ingestion.stores.redis")
@@ -122,7 +122,7 @@ object StreamingPipeline extends BasePipeline with Serializable {
           case Some(path) =>
             rowsAfterValidation
               .filter("!_isValid")
-              .mapPartitions(metrics.incrementDeadLetters)
+              .map(metrics.incrementDeadLetters)
               .write
               .format("parquet")
               .mode(SaveMode.Append)

--- a/spark/ingestion/src/main/scala/feast/ingestion/metrics/IngestionPipelineMetrics.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/metrics/IngestionPipelineMetrics.scala
@@ -22,20 +22,28 @@ import org.apache.spark.sql.Row
 
 class IngestionPipelineMetrics extends Serializable {
 
-  def incrementDeadLetters(rowIterator: Iterator[Row]): Iterator[Row] = {
-    val materialized = rowIterator.toArray
+  def incrementDeadLetters(row: Row): Row = {
     if (metricSource.nonEmpty)
-      metricSource.get.METRIC_DEADLETTER_ROWS_INSERTED.inc(materialized.length)
+      metricSource.get.METRIC_DEADLETTER_ROWS_INSERTED.inc()
 
-    materialized.toIterator
+    row
   }
 
-  def incrementRead(rowIterator: Iterator[Row]): Iterator[Row] = {
-    val materialized = rowIterator.toArray
+  def incrementRead(row: Row): Row = {
     if (metricSource.nonEmpty)
-      metricSource.get.METRIC_ROWS_READ_FROM_SOURCE.inc(materialized.length)
+      metricSource.get.METRIC_ROWS_READ_FROM_SOURCE.inc()
 
-    materialized.toIterator
+    row
+  }
+
+  def incrementRead(inc: Long): Unit = {
+    if (metricSource.nonEmpty)
+      metricSource.get.METRIC_ROWS_READ_FROM_SOURCE.inc(inc)
+  }
+
+  def incrementDeadLetters(inc: Long): Unit = {
+    if (metricSource.nonEmpty)
+      metricSource.get.METRIC_DEADLETTER_ROWS_INSERTED.inc(inc)
   }
 
   private lazy val metricSource: Option[IngestionPipelineMetricSource] = {

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
@@ -71,7 +71,7 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
     // repartition for deduplication
     val dataToStore =
       if (config.repartitionByEntity)
-        data.repartition(config.entityColumns.map(col): _*)
+        data.repartition(config.entityColumns.map(col): _*).localCheckpoint()
       else data
 
     dataToStore.foreachPartition { partition: Iterator[Row] =>


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

1. Avoid expensive partition materialization in metrics calculation
2. Checkpoint data in case of repartitioning (trigger materialization)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
