### PR TITLE
allow https url for spark ingestion jar

### DIFF
--- a/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
+++ b/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
@@ -80,12 +80,14 @@ def _random_string(length) -> str:
     return "".join(random.choice(string.ascii_lowercase) for _ in range(length))
 
 
-def _upload_jar(jar_s3_prefix: str, local_path: str) -> str:
-    with open(local_path, "rb") as f:
-        uri = urlparse(os.path.join(jar_s3_prefix, os.path.basename(local_path)))
+def _upload_jar(jar_s3_prefix: str, jar_path: str) -> str:
+    if jar_path.startswith("https://"):
+        return jar_path
+    with open(jar_path, "rb") as f:
+        uri = urlparse(os.path.join(jar_s3_prefix, os.path.basename(jar_path)))
         return urlunparse(
             get_staging_client(uri.scheme).upload_fileobj(
-                f, local_path, remote_uri=uri,
+                f, jar_path, remote_uri=uri,
             )
         )
 

--- a/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
+++ b/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
@@ -86,9 +86,7 @@ def _upload_jar(jar_s3_prefix: str, jar_path: str) -> str:
     with open(jar_path, "rb") as f:
         uri = urlparse(os.path.join(jar_s3_prefix, os.path.basename(jar_path)))
         return urlunparse(
-            get_staging_client(uri.scheme).upload_fileobj(
-                f, jar_path, remote_uri=uri,
-            )
+            get_staging_client(uri.scheme).upload_fileobj(f, jar_path, remote_uri=uri)
         )
 
 

--- a/sdk/python/feast/pyspark/launchers/k8s/k8s.py
+++ b/sdk/python/feast/pyspark/launchers/k8s/k8s.py
@@ -276,7 +276,11 @@ class KubernetesJobLauncher(JobLauncher):
         return cast(RetrievalJob, self._job_from_job_info(job_info))
 
     def _upload_jar(self, jar_path: str) -> str:
-        if jar_path.startswith("s3://") or jar_path.startswith("s3a://") or jar_path.startswith("https://"):
+        if (
+            jar_path.startswith("s3://")
+            or jar_path.startswith("s3a://")
+            or jar_path.startswith("https://")
+        ):
             return jar_path
         elif jar_path.startswith("file://"):
             local_jar_path = urlparse(jar_path).path

--- a/sdk/python/feast/pyspark/launchers/k8s/k8s.py
+++ b/sdk/python/feast/pyspark/launchers/k8s/k8s.py
@@ -276,7 +276,7 @@ class KubernetesJobLauncher(JobLauncher):
         return cast(RetrievalJob, self._job_from_job_info(job_info))
 
     def _upload_jar(self, jar_path: str) -> str:
-        if jar_path.startswith("s3://") or jar_path.startswith("s3a://"):
+        if jar_path.startswith("s3://") or jar_path.startswith("s3a://") or jar_path.startswith("https://"):
             return jar_path
         elif jar_path.startswith("file://"):
             local_jar_path = urlparse(jar_path).path


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: previously if the spark ingestion jar was a https url (which is the default), ingestion would fail because Feast would try to read and upload the jar as if the url were a local path

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
