### PR TITLE
Increase kafka consumer waiting time in e2e tests

### DIFF
--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -134,7 +134,7 @@ def test_streaming_ingestion(
         job = None
 
     wait_retry_backoff(
-        lambda: (None, check_consumer_exist(kafka_broker, topic_name)), 120
+        lambda: (None, check_consumer_exist(kafka_broker, topic_name)), 300
     )
 
     test_data = generate_data()[["s2id", "unique_drivers", "event_timestamp"]]

--- a/tests/e2e/test_validation.py
+++ b/tests/e2e/test_validation.py
@@ -103,7 +103,7 @@ def test_validation_with_ge(feast_client: Client, kafka_server, pytestconfig):
     job = start_job(feast_client, feature_table, pytestconfig)
 
     wait_retry_backoff(
-        lambda: (None, check_consumer_exist(kafka_broker, topic_name)), 120
+        lambda: (None, check_consumer_exist(kafka_broker, topic_name)), 300
     )
 
     test_data = generate_test_data()
@@ -170,7 +170,7 @@ def test_validation_reports_metrics(
     job = start_job(feast_client, feature_table, pytestconfig)
 
     wait_retry_backoff(
-        lambda: (None, check_consumer_exist(kafka_broker, topic_name)), 120
+        lambda: (None, check_consumer_exist(kafka_broker, topic_name)), 300
     )
 
     test_data = generate_test_data()


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
