### PR TITLE
use SEND_INTERRUPT to cancel EMR jobs

### DIFF
--- a/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
+++ b/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
@@ -290,7 +290,7 @@ def _cancel_job(emr_client, job: EmrJobRef):
     emr_client.cancel_steps(
         ClusterId=job.cluster_id,
         StepIds=[step_id],
-        StepCancellationOption="TERMINATE_PROCESS",
+        StepCancellationOption="SEND_INTERRUPT",
     )
 
     _wait_for_job_state(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Instead of hard `TERMINATE_PROCESS` use softer `SEND_INTERRUPT` to stop EMR jobs. The problem with `TERMINATE_PROCESS` is that sometimes this causes the job to be cancelled from EMR point of view, but it still shows up as RUNNING in Yarn, so the next job scheduled doesn't get the resources it needs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
