### PR TITLE
Add request feature counter metric

### DIFF
--- a/serving/src/main/java/feast/serving/util/Metrics.java
+++ b/serving/src/main/java/feast/serving/util/Metrics.java
@@ -29,31 +29,39 @@ public class Metrics {
           .labelNames("method")
           .register();
 
-  public static final Histogram requestEntityCount =
+  public static final Histogram requestEntityCountDistribution =
       Histogram.build()
           .buckets(1, 2, 5, 10, 20, 50, 100, 200)
-          .name("request_entity_count")
+          .name("request_entity_count_distribution")
           .subsystem("feast_serving")
           .help("Number of entity rows per request")
           .labelNames("project")
           .register();
 
-  public static final Histogram requestFeatureCount =
+  public static final Histogram requestFeatureCountDistribution =
       Histogram.build()
           .buckets(1, 2, 5, 10, 15, 20, 30, 50)
-          .name("request_feature_count")
+          .name("request_feature_count_distribution")
           .subsystem("feast_serving")
           .help("Number of feature rows per request")
           .labelNames("project")
           .register();
 
-  public static final Histogram requestFeatureTableCount =
+  public static final Histogram requestFeatureTableCountDistribution =
       Histogram.build()
           .buckets(1, 2, 5, 10, 20)
-          .name("request_feature_table_count")
+          .name("request_feature_table_count_distribution")
           .subsystem("feast_serving")
           .help("Number of feature tables per request")
           .labelNames("project")
+          .register();
+
+  public static final Counter requestFeatureCount =
+      Counter.build()
+          .name("request_feature_count")
+          .subsystem("feast_serving")
+          .help("number of feature rows requested")
+          .labelNames("project", "feature_name")
           .register();
 
   public static final Counter notFoundKeyCount =


### PR DESCRIPTION
Signed-off-by: Terence <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Feast request counter metric (based on feature name) was removed in https://github.com/feast-dev/feast/pull/1240. This PR adds back the missing metric.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now track metrics no. of request counts for each feature.
```
