### PR TITLE
Keep same amount of partitions after repartitioning in IngestionJob

### DIFF
--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -14,6 +14,7 @@ clean_up () {
 
     # Shut down docker-compose images
 
+    docker logs feast_jobservice_1
     docker-compose down
 
     exit $ARG

--- a/infra/scripts/test-docker-compose.sh
+++ b/infra/scripts/test-docker-compose.sh
@@ -14,7 +14,6 @@ clean_up () {
 
     # Shut down docker-compose images
 
-    docker logs feast_jobservice_1
     docker-compose down
 
     exit $ARG

--- a/sdk/python/feast/pyspark/launchers/standalone/local.py
+++ b/sdk/python/feast/pyspark/launchers/standalone/local.py
@@ -124,10 +124,7 @@ class StandaloneClusterJobMixin:
         if not app:
             return False
 
-        stages = requests.get(
-            f"http://localhost:{self._ui_port}/api/v1/applications/{app['id']}/stages"
-        ).json()
-        return bool(stages)
+        return True
 
     def get_start_time(self) -> datetime:
         return self._start_time

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
@@ -71,7 +71,9 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
     // repartition for deduplication
     val dataToStore =
       if (config.repartitionByEntity && data.rdd.getNumPartitions > 1)
-        data.repartition(data.rdd.getNumPartitions, config.entityColumns.map(col): _*).localCheckpoint()
+        data
+          .repartition(data.rdd.getNumPartitions, config.entityColumns.map(col): _*)
+          .localCheckpoint()
       else data
 
     dataToStore.foreachPartition { partition: Iterator[Row] =>

--- a/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/stores/redis/RedisSinkRelation.scala
@@ -70,8 +70,8 @@ class RedisSinkRelation(override val sqlContext: SQLContext, config: SparkRedisC
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {
     // repartition for deduplication
     val dataToStore =
-      if (config.repartitionByEntity)
-        data.repartition(config.entityColumns.map(col): _*).localCheckpoint()
+      if (config.repartitionByEntity && data.rdd.getNumPartitions > 1)
+        data.repartition(data.rdd.getNumPartitions, config.entityColumns.map(col): _*).localCheckpoint()
       else data
 
     dataToStore.foreachPartition { partition: Iterator[Row] =>


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

For streaming pipeline we don't need to create excessive amount of partitions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
