### PR TITLE
make EMR jar uploader work the same as k8s one

### DIFF
--- a/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
+++ b/sdk/python/feast/pyspark/launchers/aws/emr_utils.py
@@ -81,7 +81,11 @@ def _random_string(length) -> str:
 
 
 def _upload_jar(jar_s3_prefix: str, jar_path: str) -> str:
-    if jar_path.startswith("https://"):
+    if (
+        jar_path.startswith("s3://")
+        or jar_path.startswith("s3a://")
+        or jar_path.startswith("https://")
+    ):
         return jar_path
     with open(jar_path, "rb") as f:
         uri = urlparse(os.path.join(jar_s3_prefix, os.path.basename(jar_path)))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
EMR jar uploader shouldn't upload the jar if it is already uploaded somewhere

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1275

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix jar url handling in EMR launcher
```
