### PR TITLE
Enable user to provide spark job template as input for jobservice deployment

### DIFF
--- a/infra/charts/feast/charts/feast-jobservice/templates/configmap.yaml
+++ b/infra/charts/feast/charts/feast-jobservice/templates/configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.sparkOperator.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "feast-jobservice.fullname" . }}-spark-template
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "feast-jobservice.name" . }}
+    component: jobservice
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  jobTemplate.yaml: |
+{{- toYaml .Values.sparkOperator.jobTemplate | nindent 4 }}
+{{- end }}

--- a/infra/charts/feast/charts/feast-jobservice/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-jobservice/templates/deployment.yaml
@@ -37,13 +37,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 
-      {{- if .Values.secrets }}
+      {{- if or .Values.secrets .Values.sparkOperator.enabled }}
       volumes:
+      {{- end }}
       {{- range $secret := .Values.secrets }}
       - name: {{ $secret }}
         secret:
           secretName: {{ $secret }}
       {{- end }}
+      {{- if .Values.sparkOperator.enabled }}
+      - name: {{ template "feast-jobservice.fullname" . }}-spark-template
+        configMap:
+          name: {{ template "feast-jobservice.fullname" . }}-spark-template
       {{- end }}
 
       containers:
@@ -51,16 +56,24 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
 
-        {{- if .Values.secrets }}
+        {{- if or .Values.secrets .Values.sparkOperator.enabled }}
         volumeMounts:
+        {{- end }}
         {{- range $secret := .Values.secrets }}
         - name: {{ $secret }}
           mountPath: "/etc/secrets/{{ $secret }}"
           readOnly: true
         {{- end }}
+        {{- if .Values.sparkOperator.enabled }}
+        - name: {{ template "feast-jobservice.fullname" . }}-spark-template
+          mountPath: "/etc/configs"
         {{- end }}
 
         env:
+        {{- if .Values.sparkOperator.enabled }}
+        - name: FEAST_SPARK_K8S_JOB_TEMPLATE_PATH
+          value: /etc/configs/jobTemplate.yaml
+        {{- end }}
         {{- range $key, $value := .Values.envOverrides }}
         - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
           {{- if eq (kindOf $value) "map" }}

--- a/infra/charts/feast/charts/feast-jobservice/values.yaml
+++ b/infra/charts/feast/charts/feast-jobservice/values.yaml
@@ -21,6 +21,12 @@ gcpServiceAccount:
 # gcpProjectId -- Project ID to use when using Google Cloud services such as BigQuery, Cloud Storage and Dataflow
 gcpProjectId: ""
 
+sparkOperator:
+  # sparkOperator.enabled -- Flag to create and mount custom job template on the jobservice deployment as configmap
+  enabled: false
+  # sparkOperator.jobTemplate -- Content of the job template, in yaml format
+  jobTemplate: {}
+
 prometheus:
   # prometheus.enabled -- Flag to enable scraping of metrics
   enabled: true
@@ -124,3 +130,6 @@ envOverrides: {}
 
 # podLabels -- Labels to be added to Feast Job Service pods
 podLabels: {}
+
+# secrets -- Arbitrary secrets to mount on the job service pod, on /etc/secrets/<secret name>
+secrets: []

--- a/sdk/python/requirements-ci.txt
+++ b/sdk/python/requirements-ci.txt
@@ -9,7 +9,7 @@ pandas~=1.0.0
 mock==2.0.0
 pandavro==1.5.*
 moto
-mypy
+mypy==0.790
 mypy-protobuf
 avro==1.10.0
 gcsfs


### PR DESCRIPTION
Signed-off-by: Khor Shu Heng <khor.heng@gojek.com>

**What this PR does / why we need it**:
Currently, there's no way for users to mount the spark job template on the jobservice pod. This PR enables the user to mount custom job template as configmap.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
New options for Jobservice helm chart: users are now able to mount custom spark job template as configmap.
```
