### PR TITLE
Online serving optimizations

### DIFF
--- a/common-test/src/main/java/feast/common/it/DataGenerator.java
+++ b/common-test/src/main/java/feast/common/it/DataGenerator.java
@@ -134,6 +134,19 @@ public class DataGenerator {
                             .build())
                 .collect(Collectors.toList()))
         .setMaxAge(Duration.newBuilder().setSeconds(3600).build())
+        .setBatchSource(
+            DataSource.newBuilder()
+                .setEventTimestampColumn("ts")
+                .setType(DataSource.SourceType.BATCH_FILE)
+                .setFileOptions(
+                    FileOptions.newBuilder()
+                        .setFileFormat(
+                            FileFormat.newBuilder()
+                                .setParquetFormat(ParquetFormat.newBuilder().build())
+                                .build())
+                        .setFileUrl("/dev/null")
+                        .build())
+                .build())
         .putAllLabels(labels)
         .build();
   }

--- a/core/src/test/java/feast/core/service/SpecServiceIT.java
+++ b/core/src/test/java/feast/core/service/SpecServiceIT.java
@@ -659,6 +659,7 @@ public class SpecServiceIT extends BaseIT {
                   3600,
                   Map.of())
               .toBuilder()
+              .clearBatchSource()
               .build();
 
       StatusRuntimeException exc =

--- a/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
@@ -92,6 +92,9 @@ spec:
 
         command:
         - java
+        {{- range $opt := .Values.JAVA_OPTIONS }}
+        - {{ $opt }}
+        {{- end }}
         - -jar
         - /opt/feast/feast-serving.jar
         - --spring.config.location=
@@ -117,7 +120,11 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           exec:
-            command: ["grpc-health-probe", "-addr=:{{ .Values.service.grpc.targetPort }}"]
+            command:
+            - "grpc-health-probe"
+            - "-addr=:{{ .Values.service.grpc.targetPort }}"
+            - "-connect-timeout={{ .Values.livenessProbe.timeoutSeconds }}s"
+            - "-rpc-timeout={{ .Values.livenessProbe.timeoutSeconds }}s"
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
@@ -128,7 +135,11 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           exec:
-            command: ["grpc-health-probe", "-addr=:{{ .Values.service.grpc.targetPort }}"]
+            command:
+            - "grpc-health-probe"
+            - "-addr=:{{ .Values.service.grpc.targetPort }}"
+            - "-connect-timeout={{ .Values.readinessProbe.timeoutSeconds }}s"
+            - "-rpc-timeout={{ .Values.readinessProbe.timeoutSeconds }}s"
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}

--- a/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-serving/templates/deployment.yaml
@@ -92,9 +92,6 @@ spec:
 
         command:
         - java
-        {{- range $opt := .Values.JAVA_OPTIONS }}
-        - {{ $opt }}
-        {{- end }}
         - -jar
         - /opt/feast/feast-serving.jar
         - --spring.config.location=

--- a/infra/charts/feast/charts/feast-serving/values.yaml
+++ b/infra/charts/feast/charts/feast-serving/values.yaml
@@ -25,8 +25,6 @@ application-secret.yaml:
 application-override.yaml:
   enabled: true
 
-JAVA_OPTIONS: []
-
 gcpServiceAccount:
   # gcpServiceAccount.enabled -- Flag to use [service account](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) JSON key
   # Cloud service account JSON key file.

--- a/infra/charts/feast/charts/feast-serving/values.yaml
+++ b/infra/charts/feast/charts/feast-serving/values.yaml
@@ -25,6 +25,8 @@ application-secret.yaml:
 application-override.yaml:
   enabled: true
 
+JAVA_OPTIONS: []
+
 gcpServiceAccount:
   # gcpServiceAccount.enabled -- Flag to use [service account](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) JSON key
   # Cloud service account JSON key file.

--- a/infra/docker/serving/Dockerfile
+++ b/infra/docker/serving/Dockerfile
@@ -42,12 +42,12 @@ RUN wget -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/downloa
 # Build stage 2: Production
 # ============================================================
 
-FROM openjdk:11-jre-slim as production
+FROM amazoncorretto:11 as production
 ARG VERSION=dev
 COPY --from=builder /build/serving/target/feast-serving-$VERSION-exec.jar /opt/feast/feast-serving.jar
 COPY --from=builder /usr/bin/grpc-health-probe /usr/bin/grpc-health-probe
 CMD ["java",\
-     "-Xms1024m",\
-     "-Xmx1024m",\
+     "-Xms1g",\
+     "-Xmx4g",\
      "-jar",\
      "/opt/feast/feast-serving.jar"]

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -298,13 +298,13 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.14.3</version>
+      <version>1.15.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>1.14.3</version>
+      <version>1.15.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -75,9 +75,7 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
 
     List<GetOnlineFeaturesRequestV2.EntityRow> entityRows = request.getEntityRowsList();
     List<Map<String, ValueProto.Value>> values =
-        entityRows.stream()
-            .map(r -> new HashMap<>(r.getFieldsMap()))
-            .collect(Collectors.toList());
+        entityRows.stream().map(r -> new HashMap<>(r.getFieldsMap())).collect(Collectors.toList());
     List<Map<String, GetOnlineFeaturesResponse.FieldStatus>> statuses =
         entityRows.stream()
             .map(r -> getMetadataMap(r.getFieldsMap(), false, false))

--- a/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -103,6 +103,7 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
     String finalProjectName = projectName;
     Map<FeatureReferenceV2, Duration> featureMaxAges =
         featureReferences.stream()
+            .distinct()
             .collect(
                 Collectors.toMap(
                     Function.identity(),
@@ -110,6 +111,7 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
 
     Map<FeatureReferenceV2, ValueProto.ValueType.Enum> featureValueTypes =
         featureReferences.stream()
+            .distinct()
             .collect(
                 Collectors.toMap(
                     Function.identity(),

--- a/serving/src/main/java/feast/serving/specs/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/specs/CachedSpecService.java
@@ -16,11 +16,11 @@
  */
 package feast.serving.specs;
 
-import static feast.common.models.FeatureTable.getFeatureTableStringRef;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import feast.proto.core.CoreServiceProto;
 import feast.proto.core.CoreServiceProto.ListFeatureTablesRequest;
 import feast.proto.core.CoreServiceProto.ListFeatureTablesResponse;
 import feast.proto.core.CoreServiceProto.ListProjectsRequest;
@@ -57,7 +57,6 @@ public class CachedSpecService {
           .help("epoch time of the last time the cache was updated")
           .register();
 
-  private final LoadingCache<String, FeatureTableSpec> featureTableCache;
   private static Gauge featureTablesCount =
       Gauge.build()
           .name("feature_table_count")
@@ -65,27 +64,26 @@ public class CachedSpecService {
           .help("number of feature tables served by this instance")
           .register();
 
+  private final LoadingCache<ImmutablePair<String, String>, FeatureTableSpec> featureTableCache;
+
   private final LoadingCache<
-          String, Map<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2>>
+          ImmutablePair<String, ServingAPIProto.FeatureReferenceV2>, FeatureProto.FeatureSpecV2>
       featureCache;
 
   public CachedSpecService(CoreSpecService coreService, StoreProto.Store store) {
     this.coreService = coreService;
     this.store = coreService.registerStore(store);
 
-    Map<String, FeatureTableSpec> featureTables = getFeatureTableMap().getLeft();
-    CacheLoader<String, FeatureTableSpec> featureTableCacheLoader =
-        CacheLoader.from(featureTables::get);
+    CacheLoader<ImmutablePair<String, String>, FeatureTableSpec> featureTableCacheLoader =
+        CacheLoader.from(k -> retrieveSingleFeatureTable(k.getLeft(), k.getRight()));
     featureTableCache =
         CacheBuilder.newBuilder().maximumSize(MAX_SPEC_COUNT).build(featureTableCacheLoader);
-    featureTableCache.putAll(featureTables);
 
-    Map<String, Map<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2>> features =
-        getFeatureTableMap().getRight();
-    CacheLoader<String, Map<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2>>
-        featureCacheLoader = CacheLoader.from(features::get);
+    CacheLoader<
+            ImmutablePair<String, ServingAPIProto.FeatureReferenceV2>, FeatureProto.FeatureSpecV2>
+        featureCacheLoader =
+            CacheLoader.from(k -> retrieveSingleFeature(k.getLeft(), k.getRight()));
     featureCache = CacheBuilder.newBuilder().build(featureCacheLoader);
-    featureCache.putAll(features);
   }
 
   /**
@@ -102,17 +100,20 @@ public class CachedSpecService {
    * from core to preload the cache.
    */
   public void populateCache() {
-    Map<String, FeatureTableSpec> featureTableMap = getFeatureTableMap().getLeft();
+    ImmutablePair<
+            HashMap<ImmutablePair<String, String>, FeatureTableSpec>,
+            HashMap<
+                ImmutablePair<String, ServingAPIProto.FeatureReferenceV2>,
+                FeatureProto.FeatureSpecV2>>
+        specs = getFeatureTableMap();
 
     featureTableCache.invalidateAll();
-    featureTableCache.putAll(featureTableMap);
+    featureTableCache.putAll(specs.getLeft());
 
     featureTablesCount.set(featureTableCache.size());
 
-    Map<String, Map<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2>> featureMap =
-        getFeatureTableMap().getRight();
     featureCache.invalidateAll();
-    featureCache.putAll(featureMap);
+    featureCache.putAll(specs.getRight());
 
     cacheLastUpdated.set(System.currentTimeMillis());
   }
@@ -131,12 +132,14 @@ public class CachedSpecService {
    * @return Map in the format of <project/featuretable_name: FeatureTableSpec>
    */
   private ImmutablePair<
-          Map<String, FeatureTableSpec>,
-          Map<String, Map<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2>>>
+          HashMap<ImmutablePair<String, String>, FeatureTableSpec>,
+          HashMap<
+              ImmutablePair<String, ServingAPIProto.FeatureReferenceV2>,
+              FeatureProto.FeatureSpecV2>>
       getFeatureTableMap() {
-    HashMap<String, FeatureTableSpec> featureTables = new HashMap<>();
-    HashMap<String, Map<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2>> features =
-        new HashMap<>();
+    HashMap<ImmutablePair<String, String>, FeatureTableSpec> featureTables = new HashMap<>();
+    HashMap<ImmutablePair<String, ServingAPIProto.FeatureReferenceV2>, FeatureProto.FeatureSpecV2>
+        features = new HashMap<>();
 
     List<String> projects =
         coreService.listProjects(ListProjectsRequest.newBuilder().build()).getProjectsList();
@@ -152,8 +155,7 @@ public class CachedSpecService {
             new HashMap<>();
         for (FeatureTable featureTable : featureTablesResponse.getTablesList()) {
           FeatureTableSpec spec = featureTable.getSpec();
-          // Key of Map is in the form of <project/featuretable_name>
-          featureTables.put(getFeatureTableStringRef(project, spec), spec);
+          featureTables.put(ImmutablePair.of(project, spec.getName()), spec);
 
           String featureTableName = spec.getName();
           List<FeatureProto.FeatureSpecV2> featureSpecs = spec.getFeaturesList();
@@ -163,10 +165,10 @@ public class CachedSpecService {
                     .setFeatureTable(featureTableName)
                     .setName(featureSpec.getName())
                     .build();
-            featureRefSpecMap.put(featureReference, featureSpec);
+            features.put(ImmutablePair.of(project, featureReference), featureSpec);
           }
         }
-        features.put(project, featureRefSpecMap);
+
       } catch (StatusRuntimeException e) {
         throw new RuntimeException(
             String.format("Unable to retrieve specs matching project %s", project), e);
@@ -175,28 +177,50 @@ public class CachedSpecService {
     return ImmutablePair.of(featureTables, features);
   }
 
+  private FeatureTableSpec retrieveSingleFeatureTable(String projectName, String tableName) {
+    FeatureTable table =
+        coreService
+            .getFeatureTable(
+                CoreServiceProto.GetFeatureTableRequest.newBuilder()
+                    .setProject(projectName)
+                    .setName(tableName)
+                    .build())
+            .getTable();
+    return table.getSpec();
+  }
+
+  private FeatureProto.FeatureSpecV2 retrieveSingleFeature(
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
+    FeatureTableSpec featureTableSpec =
+        retrieveSingleFeatureTable(projectName, featureReference.getFeatureTable());
+    return featureTableSpec.getFeaturesList().stream()
+        .filter(f -> f.getName().equals(featureReference.getName()))
+        .findFirst()
+        .orElse(null);
+  }
+
   public FeatureTableSpec getFeatureTableSpec(
-      String project, ServingAPIProto.FeatureReferenceV2 featureReference) {
-    String featureTableRefStr = getFeatureTableStringRef(project, featureReference);
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
     FeatureTableSpec featureTableSpec;
     try {
-      featureTableSpec = featureTableCache.get(featureTableRefStr);
-    } catch (ExecutionException e) {
+      featureTableSpec =
+          featureTableCache.get(ImmutablePair.of(projectName, featureReference.getFeatureTable()));
+    } catch (ExecutionException | CacheLoader.InvalidCacheLoadException e) {
       throw new SpecRetrievalException(
-          String.format("Unable to find FeatureTable with name: %s", featureTableRefStr), e);
+          String.format(
+              "Unable to find FeatureTable %s/%s", projectName, featureReference.getFeatureTable()),
+          e);
     }
 
     return featureTableSpec;
   }
 
   public FeatureProto.FeatureSpecV2 getFeatureSpec(
-      String project, ServingAPIProto.FeatureReferenceV2 featureReference) {
+      String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
     FeatureProto.FeatureSpecV2 featureSpec;
     try {
-      Map<ServingAPIProto.FeatureReferenceV2, FeatureProto.FeatureSpecV2> featureRefSpecMap =
-          featureCache.get(project);
-      featureSpec = featureRefSpecMap.get(featureReference);
-    } catch (ExecutionException e) {
+      featureSpec = featureCache.get(ImmutablePair.of(projectName, featureReference));
+    } catch (ExecutionException | CacheLoader.InvalidCacheLoadException e) {
       throw new SpecRetrievalException(
           String.format("Unable to find Feature with name: %s", featureReference.getName()), e);
     }

--- a/serving/src/main/java/feast/serving/specs/CachedSpecService.java
+++ b/serving/src/main/java/feast/serving/specs/CachedSpecService.java
@@ -16,7 +16,6 @@
  */
 package feast.serving.specs;
 
-
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -192,7 +191,10 @@ public class CachedSpecService {
   private FeatureProto.FeatureSpecV2 retrieveSingleFeature(
       String projectName, ServingAPIProto.FeatureReferenceV2 featureReference) {
     FeatureTableSpec featureTableSpec =
-        retrieveSingleFeatureTable(projectName, featureReference.getFeatureTable());
+        getFeatureTableSpec(projectName, featureReference); // don't stress core too much
+    if (featureTableSpec == null) {
+      return null;
+    }
     return featureTableSpec.getFeaturesList().stream()
         .filter(f -> f.getName().equals(featureReference.getName()))
         .findFirst()

--- a/serving/src/main/java/feast/serving/specs/CoreSpecService.java
+++ b/serving/src/main/java/feast/serving/specs/CoreSpecService.java
@@ -17,6 +17,7 @@
 package feast.serving.specs;
 
 import feast.proto.core.CoreServiceGrpc;
+import feast.proto.core.CoreServiceProto;
 import feast.proto.core.CoreServiceProto.ListFeatureTablesRequest;
 import feast.proto.core.CoreServiceProto.ListFeatureTablesResponse;
 import feast.proto.core.CoreServiceProto.ListProjectsRequest;
@@ -79,5 +80,10 @@ public class CoreSpecService {
   public ListFeatureTablesResponse listFeatureTables(
       ListFeatureTablesRequest listFeatureTablesRequest) {
     return blockingStub.listFeatureTables(listFeatureTablesRequest);
+  }
+
+  public CoreServiceProto.GetFeatureTableResponse getFeatureTable(
+      CoreServiceProto.GetFeatureTableRequest getFeatureTableRequest) {
+    return blockingStub.getFeatureTable(getFeatureTableRequest);
   }
 }

--- a/serving/src/test/java/feast/serving/it/ServingServiceOauthAuthorizationIT.java
+++ b/serving/src/test/java/feast/serving/it/ServingServiceOauthAuthorizationIT.java
@@ -21,15 +21,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.testcontainers.containers.wait.strategy.Wait.forHttp;
 
+import feast.common.it.DataGenerator;
 import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesRequestV2;
 import feast.proto.serving.ServingAPIProto.GetOnlineFeaturesResponse;
 import feast.proto.serving.ServingServiceGrpc.ServingServiceBlockingStub;
+import feast.proto.types.ValueProto;
 import feast.proto.types.ValueProto.Value;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.ClassRule;
@@ -44,6 +47,8 @@ import org.testcontainers.containers.DockerComposeContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import sh.ory.keto.ApiException;
 
 @ActiveProfiles("it")
@@ -126,6 +131,18 @@ public class ServingServiceOauthAuthorizationIT extends BaseAuthIT {
     adminCredentials.put("grant_type", GRANT_TYPE);
 
     coreClient = AuthTestUtils.getSecureApiClientForCore(FEAST_CORE_PORT, adminCredentials);
+    coreClient.simpleApplyEntity(
+        PROJECT_NAME,
+        DataGenerator.createEntitySpecV2(
+            ENTITY_ID, "", ValueProto.ValueType.Enum.STRING, Collections.emptyMap()));
+    coreClient.simpleApplyFeatureTable(
+        PROJECT_NAME,
+        DataGenerator.createFeatureTableSpec(
+            FEATURE_TABLE_NAME,
+            ImmutableList.of(ENTITY_ID),
+            ImmutableMap.of(FEATURE_NAME, ValueProto.ValueType.Enum.STRING),
+            0,
+            Collections.emptyMap()));
   }
 
   @Test

--- a/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
+++ b/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
@@ -40,7 +40,6 @@ import io.opentracing.Tracer;
 import io.opentracing.Tracer.SpanBuilder;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
@@ -155,14 +154,14 @@ public class OnlineServingServiceTest {
         List.of(featureReference1, featureReference2);
     GetOnlineFeaturesRequestV2 request = getOnlineFeaturesRequestV2(projectName, featureReferences);
 
-    List<Optional<Feature>> entityKeyList1 = new ArrayList<>();
-    List<Optional<Feature>> entityKeyList2 = new ArrayList<>();
-    entityKeyList1.add(Optional.of(mockedFeatureRows.get(0)));
-    entityKeyList1.add(Optional.of(mockedFeatureRows.get(1)));
-    entityKeyList2.add(Optional.of(mockedFeatureRows.get(2)));
-    entityKeyList2.add(Optional.of(mockedFeatureRows.get(3)));
+    List<Feature> entityKeyList1 = new ArrayList<>();
+    List<Feature> entityKeyList2 = new ArrayList<>();
+    entityKeyList1.add(mockedFeatureRows.get(0));
+    entityKeyList1.add(mockedFeatureRows.get(1));
+    entityKeyList2.add(mockedFeatureRows.get(2));
+    entityKeyList2.add(mockedFeatureRows.get(3));
 
-    List<List<Optional<Feature>>> featureRows = List.of(entityKeyList1, entityKeyList2);
+    List<List<Feature>> featureRows = List.of(entityKeyList1, entityKeyList2);
 
     when(retrieverV2.getOnlineFeatures(any(), any(), any())).thenReturn(featureRows);
     when(specService.getFeatureTableSpec(any(), any())).thenReturn(getFeatureTableSpec());
@@ -223,13 +222,13 @@ public class OnlineServingServiceTest {
         List.of(featureReference1, featureReference2);
     GetOnlineFeaturesRequestV2 request = getOnlineFeaturesRequestV2(projectName, featureReferences);
 
-    List<Optional<Feature>> entityKeyList1 = new ArrayList<>();
-    List<Optional<Feature>> entityKeyList2 = new ArrayList<>();
-    entityKeyList1.add(Optional.of(mockedFeatureRows.get(0)));
-    entityKeyList1.add(Optional.of(mockedFeatureRows.get(1)));
-    entityKeyList2.add(Optional.of(mockedFeatureRows.get(4)));
+    List<Feature> entityKeyList1 = new ArrayList<>();
+    List<Feature> entityKeyList2 = new ArrayList<>();
+    entityKeyList1.add(mockedFeatureRows.get(0));
+    entityKeyList1.add(mockedFeatureRows.get(1));
+    entityKeyList2.add(mockedFeatureRows.get(4));
 
-    List<List<Optional<Feature>>> featureRows = List.of(entityKeyList1, entityKeyList2);
+    List<List<Feature>> featureRows = List.of(entityKeyList1, entityKeyList2);
 
     when(retrieverV2.getOnlineFeatures(any(), any(), any())).thenReturn(featureRows);
     when(specService.getFeatureTableSpec(any(), any())).thenReturn(getFeatureTableSpec());
@@ -286,14 +285,14 @@ public class OnlineServingServiceTest {
         List.of(featureReference1, featureReference2);
     GetOnlineFeaturesRequestV2 request = getOnlineFeaturesRequestV2(projectName, featureReferences);
 
-    List<Optional<Feature>> entityKeyList1 = new ArrayList<>();
-    List<Optional<Feature>> entityKeyList2 = new ArrayList<>();
-    entityKeyList1.add(Optional.of(mockedFeatureRows.get(5)));
-    entityKeyList1.add(Optional.of(mockedFeatureRows.get(1)));
-    entityKeyList2.add(Optional.of(mockedFeatureRows.get(5)));
-    entityKeyList2.add(Optional.of(mockedFeatureRows.get(1)));
+    List<Feature> entityKeyList1 = new ArrayList<>();
+    List<Feature> entityKeyList2 = new ArrayList<>();
+    entityKeyList1.add(mockedFeatureRows.get(5));
+    entityKeyList1.add(mockedFeatureRows.get(1));
+    entityKeyList2.add(mockedFeatureRows.get(5));
+    entityKeyList2.add(mockedFeatureRows.get(1));
 
-    List<List<Optional<Feature>>> featureRows = List.of(entityKeyList1, entityKeyList2);
+    List<List<Feature>> featureRows = List.of(entityKeyList1, entityKeyList2);
 
     when(retrieverV2.getOnlineFeatures(any(), any(), any())).thenReturn(featureRows);
     when(specService.getFeatureTableSpec(any(), any()))

--- a/storage/api/src/main/java/feast/storage/api/retriever/OnlineRetrieverV2.java
+++ b/storage/api/src/main/java/feast/storage/api/retriever/OnlineRetrieverV2.java
@@ -18,7 +18,6 @@ package feast.storage.api.retriever;
 
 import feast.proto.serving.ServingAPIProto;
 import java.util.List;
-import java.util.Optional;
 
 public interface OnlineRetrieverV2 {
   /**
@@ -37,7 +36,7 @@ public interface OnlineRetrieverV2 {
    * @return list of {@link Feature}s corresponding to data retrieved for each entity row from
    *     FeatureTable specified in FeatureTable request.
    */
-  List<List<Optional<Feature>>> getOnlineFeatures(
+  List<List<Feature>> getOnlineFeatures(
       String project,
       List<ServingAPIProto.GetOnlineFeaturesRequestV2.EntityRow> entityRows,
       List<ServingAPIProto.FeatureReferenceV2> featureReferences);

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/common/RedisHashDecoder.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/common/RedisHashDecoder.java
@@ -36,13 +36,13 @@ public class RedisHashDecoder {
    * @return List of {@link Feature}
    * @throws InvalidProtocolBufferException
    */
-  public static List<Optional<Feature>> retrieveFeature(
+  public static List<Feature> retrieveFeature(
       List<KeyValue<byte[], byte[]>> redisHashValues,
       Map<String, ServingAPIProto.FeatureReferenceV2> byteToFeatureReferenceMap,
       String timestampPrefix)
       throws InvalidProtocolBufferException {
-    List<Optional<Feature>> allFeatures = new ArrayList<>();
-    Map<ServingAPIProto.FeatureReferenceV2, Optional<Feature.Builder>> allFeaturesBuilderMap =
+    List<Feature> allFeatures = new ArrayList<>();
+    Map<ServingAPIProto.FeatureReferenceV2, Feature.Builder> allFeaturesBuilderMap =
         new HashMap<>();
     Map<String, Timestamp> featureTableTimestampMap = new HashMap<>();
 
@@ -62,19 +62,19 @@ public class RedisHashDecoder {
 
           Feature.Builder featureBuilder =
               Feature.builder().setFeatureReference(featureReference).setFeatureValue(featureValue);
-          allFeaturesBuilderMap.put(featureReference, Optional.of(featureBuilder));
+          allFeaturesBuilderMap.put(featureReference, featureBuilder);
         }
       }
     }
 
     // Add timestamp to features
-    for (Map.Entry<ServingAPIProto.FeatureReferenceV2, Optional<Feature.Builder>> entry :
+    for (Map.Entry<ServingAPIProto.FeatureReferenceV2, Feature.Builder> entry :
         allFeaturesBuilderMap.entrySet()) {
       String timestampRedisHashKeyStr = timestampPrefix + ":" + entry.getKey().getFeatureTable();
       Timestamp curFeatureTimestamp = featureTableTimestampMap.get(timestampRedisHashKeyStr);
 
-      Feature curFeature = entry.getValue().get().setEventTimestamp(curFeatureTimestamp).build();
-      allFeatures.add(Optional.of(curFeature));
+      Feature curFeature = entry.getValue().setEventTimestamp(curFeatureTimestamp).build();
+      allFeatures.add(curFeature);
     }
 
     return allFeatures;

--- a/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
+++ b/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
@@ -41,21 +41,21 @@ public class OnlineRetriever implements OnlineRetrieverV2 {
   }
 
   @Override
-  public List<List<Optional<Feature>>> getOnlineFeatures(
+  public List<List<Feature>> getOnlineFeatures(
       String project,
       List<ServingAPIProto.GetOnlineFeaturesRequestV2.EntityRow> entityRows,
       List<ServingAPIProto.FeatureReferenceV2> featureReferences) {
 
     List<RedisProto.RedisKeyV2> redisKeys = RedisKeyGenerator.buildRedisKeys(project, entityRows);
-    List<List<Optional<Feature>>> features = getFeaturesFromRedis(redisKeys, featureReferences);
+    List<List<Feature>> features = getFeaturesFromRedis(redisKeys, featureReferences);
 
     return features;
   }
 
-  private List<List<Optional<Feature>>> getFeaturesFromRedis(
+  private List<List<Feature>> getFeaturesFromRedis(
       List<RedisProto.RedisKeyV2> redisKeys,
       List<ServingAPIProto.FeatureReferenceV2> featureReferences) {
-    List<List<Optional<Feature>>> features = new ArrayList<>();
+    List<List<Feature>> features = new ArrayList<>();
     // To decode bytes back to Feature Reference
     Map<String, ServingAPIProto.FeatureReferenceV2> byteToFeatureReferenceMap = new HashMap<>();
 
@@ -96,7 +96,7 @@ public class OnlineRetriever implements OnlineRetrieverV2 {
         future -> {
           try {
             List<KeyValue<byte[], byte[]>> redisValuesList = future.get();
-            List<Optional<Feature>> curRedisKeyFeatures =
+            List<Feature> curRedisKeyFeatures =
                 RedisHashDecoder.retrieveFeature(
                     redisValuesList, byteToFeatureReferenceMap, timestampPrefix);
             features.add(curRedisKeyFeatures);


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Some performance concerns about `OnlineServingServiceV2` were addressed in this PR:

1. Move `specs` retrieving out of nested for loops - prepare required data in advance.
2. Less data copying / Less hash tables
3. Rewritten CacheLoader for specs to minimise missing cache exceptions
4. Simplify `OnlineRetrieverV2` interface - get rid of `Optional`
5. Add Ability to tune java options through helm chart values

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
