### PR TITLE
Use date partitioning column in FileSource

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/sources/file/FileReader.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/sources/file/FileReader.scala
@@ -35,12 +35,12 @@ object FileReader {
       .filter(col(source.eventTimestampColumn) >= new Timestamp(start.getMillis))
       .filter(col(source.eventTimestampColumn) < new Timestamp(end.getMillis))
 
-    if (source.datePartitionColumn.nonEmpty) {
-      reader
-        .filter(col(source.datePartitionColumn.get) >= new Date(start.getMillis))
-        .filter(col(source.datePartitionColumn.get) <= new Date(end.getMillis))
-    } else {
-      reader
+    source.datePartitionColumn match {
+      case Some(partitionColumn) if partitionColumn.nonEmpty =>
+        reader
+          .filter(col(partitionColumn) >= new Date(start.getMillis))
+          .filter(col(partitionColumn) <= new Date(end.getMillis))
+      case _ => reader
     }
   }
 }

--- a/spark/ingestion/src/main/scala/feast/ingestion/sources/file/FileReader.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/sources/file/FileReader.scala
@@ -16,7 +16,7 @@
  */
 package feast.ingestion.sources.file
 
-import java.sql.Timestamp
+import java.sql.{Timestamp, Date}
 
 import feast.ingestion.FileSource
 import org.apache.spark.sql.functions.col
@@ -30,9 +30,17 @@ object FileReader {
       start: DateTime,
       end: DateTime
   ): DataFrame = {
-    sqlContext.read
+    val reader = sqlContext.read
       .parquet(source.path)
       .filter(col(source.eventTimestampColumn) >= new Timestamp(start.getMillis))
       .filter(col(source.eventTimestampColumn) < new Timestamp(end.getMillis))
+
+    if (source.datePartitionColumn.nonEmpty) {
+      reader
+        .filter(col(source.datePartitionColumn.get) >= new Date(start.getMillis))
+        .filter(col(source.datePartitionColumn.get) <= new Date(end.getMillis))
+    } else {
+      reader
+    }
   }
 }

--- a/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
+++ b/spark/ingestion/src/test/scala/feast/ingestion/BatchPipelineIT.scala
@@ -110,7 +110,7 @@ class BatchPipelineIT extends SparkSpec with ForAllTestContainer {
     val rows     = generateDistinctRows(gen, 10000, groupByEntity)
     val tempPath = storeAsParquet(sparkSession, rows)
     val configWithOfflineSource = config.copy(
-      source = FileSource(tempPath, Map.empty, "eventTimestamp")
+      source = FileSource(tempPath, Map.empty, "eventTimestamp", datePartitionColumn = Some("date"))
     )
 
     BatchPipeline.createPipeline(sparkSession, configWithOfflineSource)


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

With additional filtering by partitioning column (when it's specified) IngestionJob won't need to read the whole data lake, but only required partitions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
