### PR TITLE
Freeze numpy version

### DIFF
--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -10,7 +10,7 @@ googleapis-common-protos==1.52.0
 grpcio==1.31.0
 grpcio-testing==1.31.0
 grpcio-tools==1.31.0
-numpy
+numpy<1.20.0
 mock==2.0.0
 pandas~=1.0.0
 protobuf==3.*

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -42,7 +42,7 @@ REQUIRED = [
     "toml==0.10.*",
     "tqdm==4.*",
     "pyarrow==2.0.0",
-    "numpy",
+    "numpy<1.20.0",
     "google",
     "kubernetes==12.0.*",
 ]


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Latest numpy release (1.20.0) cause issue in pandas -> pyarrow conversion
```
/usr/local/lib/python3.7/site-packages/pyarrow/pandas_compat.py:588: in dataframe_to_arrays
    for c, f in zip(columns_to_convert, convert_fields)]/usr/local/lib/python3.7/site-packages/_pytest/compat.py:340: PytestDeprecationWarning: The TerminalReporter.writer attribute is deprecated, use TerminalReporter._tw instead at your own risk.
See https://docs.pytest.org/en/stable/deprecations.html#terminalreporter-writer for more information.
  return getattr(object, name, default)
/usr/local/lib/python3.7/site-packages/pyarrow/pandas_compat.py:588: in <listcomp>
    for c, f in zip(columns_to_convert, convert_fields)]
/usr/local/lib/python3.7/site-packages/pyarrow/pandas_compat.py:574: in convert_column
    raise e
/usr/local/lib/python3.7/site-packages/pyarrow/pandas_compat.py:568: in convert_column
    result = pa.array(col, type=type_, from_pandas=True, safe=safe)
pyarrow/array.pxi:292: in pyarrow.lib.array
    ???
pyarrow/array.pxi:83: in pyarrow.lib._ndarray_to_array
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
>   ???
E   pyarrow.lib.ArrowTypeError: ('Did not pass numpy.dtype object', 'Conversion failed for column datetime with type datetime64[ns, UTC]')
pyarrow/error.pxi:107: ArrowTypeError
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
