### PR TITLE
WIP: Add redis topology refresh configurations

### DIFF
--- a/protos/feast/core/Store.proto
+++ b/protos/feast/core/Store.proto
@@ -86,6 +86,13 @@ message Store {
       REPLICA_PREFERRED = 3;
     }
     ReadFrom read_from = 8;
+
+    // Set the period between the refresh job runs. The effective interval cannot be changed once the refresh job is active.
+    int32 topology_refresh_period = 9;
+    // Set the timeout between the adaptive refresh job runs.
+    int32 adaptive_refresh_timeout = 10;
+    // Set the threshold for the PERSISTENT_RECONNECTS refresh trigger.
+    int32 refresh_trigger_reconnection_attempts = 11;
   }
 
   message Subscription {

--- a/sdk/python/requirements-ci.txt
+++ b/sdk/python/requirements-ci.txt
@@ -3,14 +3,14 @@ flake8
 black==19.10b0
 isort>=5
 grpcio-tools==1.31.0
-mypy-protobuf
+numpy<1.20.0
 pyspark==3.0.1
 pandas~=1.0.0
 mock==2.0.0
 pandavro==1.5.*
 moto
 mypy==0.790
-mypy-protobuf
+mypy-protobuf==1.24
 avro==1.10.0
 gcsfs
 urllib3>=1.25.4

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -31,8 +31,8 @@ pandavro==1.5.*
 kafka-python==2.0.2
 tabulate==0.8.*
 isort>=5
-mypy
-mypy-protobuf
+mypy==0.790
+mypy-protobuf==1.24
 pre-commit
 flake8
 black==19.10b0

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -56,7 +56,9 @@ feast:
         # Connection string specifies the host:port of Redis instances in the redis cluster.
         connection_string: "localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005"
         read_from: MASTER
+        # Topology refresh period in seconds
         topology_refresh_period: 900
+        # Adaptive refresh timeout in seconds
         adaptive_refresh_timeout: 300
         refresh_trigger_reconnection_attempts: 10
       subscriptions:

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -56,6 +56,9 @@ feast:
         # Connection string specifies the host:port of Redis instances in the redis cluster.
         connection_string: "localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005"
         read_from: MASTER
+        topology_refresh_period: 900
+        adaptive_refresh_timeout: 300
+        refresh_trigger_reconnection_attempts: 10
       subscriptions:
         - name: "*"
           project: "*"

--- a/tests/e2e/fixtures/feast_services.py
+++ b/tests/e2e/fixtures/feast_services.py
@@ -48,8 +48,7 @@ def _wait_port_open(port, max_wait=60):
 
 
 @pytest.fixture(
-    scope="session",
-    params=[False],
+    scope="session", params=[False],
 )
 def enable_auth(request):
     return request.param

--- a/tests/e2e/fixtures/feast_services.py
+++ b/tests/e2e/fixtures/feast_services.py
@@ -48,7 +48,8 @@ def _wait_port_open(port, max_wait=60):
 
 
 @pytest.fixture(
-    scope="session", params=[False],
+    scope="session",
+    params=[False],
 )
 def enable_auth(request):
     return request.param
@@ -114,7 +115,12 @@ def feast_serving(
         store: Dict[str, Any] = dict(
             name="online",
             type="REDIS_CLUSTER",
-            config=dict(connection_string=f"{redis_server.host}:{redis_server.port}"),
+            config=dict(
+                connection_string=f"{redis_server.host}:{redis_server.port}",
+                topology_refresh_period=900,
+                adaptive_refresh_timeout=300,
+                refresh_trigger_reconnection_attempts=10,
+            ),
         )
     else:
         store = dict(


### PR DESCRIPTION
Signed-off-by: Terence Lim <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, Feast does not support topology updates for Redis Cluster when using it as the online store. This PR adds support for the following configurations:
- Periodic refresh period: Setting the duration between periodic topology refresh job runs
- Adaptive refresh timeout: Setting the duration between adaptive refresh job runs
- Refresh trigger reconnection attempts: Setting the threshold count for reconnection refresh

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now configure Redis Cluster topology updates when using it as the online store.
```
