### PR TITLE
more consistent value_type handling in Entity

### DIFF
--- a/infra/scripts/test-telemetry.sh
+++ b/infra/scripts/test-telemetry.sh
@@ -7,7 +7,6 @@ LOGS_ARTIFACT_PATH=/logs/artifacts
 
 pip install -r sdk/python/requirements-ci.txt
 make compile-protos-python
-make lint-python
 
 cd sdk/python/
 pip install -e .

--- a/sdk/python/feast/entity.py
+++ b/sdk/python/feast/entity.py
@@ -53,11 +53,6 @@ class Entity:
         if not isinstance(other, Entity):
             raise TypeError("Comparisons should only involve Entity class objects.")
 
-        if isinstance(self.value_type, int):
-            self.value_type = ValueType(self.value_type).name
-        if isinstance(other.value_type, int):
-            other.value_type = ValueType(other.value_type).name
-
         if (
             self.labels != other.labels
             or self.name != other.name
@@ -100,7 +95,7 @@ class Entity:
         self._description = description
 
     @property
-    def value_type(self):
+    def value_type(self) -> ValueType:
         """
         Returns the type of this entity
         """
@@ -200,7 +195,7 @@ class Entity:
         entity = cls(
             name=entity_proto.spec.name,
             description=entity_proto.spec.description,
-            value_type=ValueType(entity_proto.spec.value_type).name,  # type: ignore
+            value_type=ValueType(entity_proto.spec.value_type),
             labels=entity_proto.spec.labels,
         )
 
@@ -221,13 +216,11 @@ class Entity:
             created_timestamp=self.created_timestamp,
             last_updated_timestamp=self.last_updated_timestamp,
         )
-        if isinstance(self.value_type, ValueType):
-            self.value_type = self.value_type.value
 
         spec = EntitySpecProto(
             name=self.name,
             description=self.description,
-            value_type=self.value_type,
+            value_type=self.value_type.value,
             labels=self.labels,
         )
 
@@ -268,13 +261,10 @@ class Entity:
             EntitySpecV2 protobuf
         """
 
-        if isinstance(self.value_type, ValueType):
-            self.value_type = self.value_type.value
-
         spec = EntitySpecProto(
             name=self.name,
             description=self.description,
-            value_type=self.value_type,
+            value_type=self.value_type.value,
             labels=self.labels,
         )
 

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -151,7 +151,7 @@ def _feature_table_to_argument(
         "project": project,
         "name": feature_table.name,
         "entities": [
-            {"name": n, "type": client.get_entity(n, project=project).value_type}
+            {"name": n, "type": client.get_entity(n, project=project).value_type.name}
             for n in feature_table.entities
         ],
         "max_age": feature_table.max_age.ToSeconds() if feature_table.max_age else None,

--- a/sdk/python/requirements-ci.txt
+++ b/sdk/python/requirements-ci.txt
@@ -10,7 +10,7 @@ mock==2.0.0
 pandavro==1.5.*
 moto
 mypy==0.790
-mypy-protobuf
+mypy-protobuf==1.24
 avro==1.10.0
 gcsfs
 urllib3>=1.25.4

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -31,8 +31,8 @@ pandavro==1.5.*
 kafka-python==2.0.2
 tabulate==0.8.*
 isort>=5
-mypy
-mypy-protobuf
+mypy==0.790
+mypy-protobuf==1.24
 pre-commit
 flake8
 black==19.10b0

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -385,7 +385,7 @@ class TestClient:
         assert (
             len(entities) == 1
             and entity.name == "driver_car_id"
-            and entity.value_type == ValueType(ValueProto.ValueType.STRING).name
+            and entity.value_type == ValueType(ValueProto.ValueType.STRING)
             and entity.description == "Car driver id"
             and "team" in entity.labels
             and entity.labels["team"] == "matchmaking"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes  #1238. `Entity.value_type` now consistently is a `feast.ValueType`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
more consistent value_type handling in Entity class
```
