### PR TITLE
Autoreload jobservice when configmap changed

### DIFF
--- a/infra/charts/feast/charts/feast-jobservice/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feast-jobservice/templates/deployment.yaml
@@ -18,8 +18,11 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
-      {{- if .Values.prometheus.enabled }}
       annotations:
+      {{- if .Values.sparkOperator.enabled }}
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
+      {{- if .Values.prometheus.enabled }}
         prometheus.io/path: /metrics
         prometheus.io/port: "{{ .Values.service.http.targetPort }}"
         prometheus.io/scrape: "true"

--- a/infra/charts/feast/requirements.yaml
+++ b/infra/charts/feast/requirements.yaml
@@ -6,6 +6,9 @@ dependencies:
   alias: feast-online-serving
   version: 0.10.0-SNAPSHOT
   condition: feast-online-serving.enabled
+- name: feast-jobservice
+  version: 0.10.0-SNAPSHOT
+  condition: feast-jobservice.enabled
 - name: feast-jupyter
   version: 0.10.0-SNAPSHOT
   condition: feast-jupyter.enabled


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, job service is not restarted when the configmap changes. As a result, the config map changes won't take effect. This PR enables the job service to restart automatically.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Jobservice will now be restarted when the associated configmap is changed.
```
