### PR TITLE
Fix in install instructions

### DIFF
--- a/docs/getting-started/install-feast/kubernetes-with-helm.md
+++ b/docs/getting-started/install-feast/kubernetes-with-helm.md
@@ -47,7 +47,7 @@ After all the pods are in a `RUNNING` state, port-forward to the Jupyter Noteboo
 
 ```bash
 kubectl port-forward \
-$(kubectl get pod -o custom-columns=:metadata.name | grep jupyter) 8888:8888
+$(kubectl get pod -l app=feast-jupyter -o custom-columns=:metadata.name) 8888:8888
 ```
 
 ```text


### PR DESCRIPTION
**What this PR does / why we need it**:
improves docs.

Use label select instead of grep.
grep was returning multiple pods and crashing for me.

