### PR TITLE
Add project filter to list jobs

### DIFF
--- a/protos/feast/core/JobService.proto
+++ b/protos/feast/core/JobService.proto
@@ -189,6 +189,7 @@ message StartStreamToOnlineIngestionJobResponse {
 message ListJobsRequest {
   bool include_terminated = 1;
   string table_name = 2;
+  string project = 3;
 }
 
 message ListJobsResponse {

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -1288,13 +1288,18 @@ class Client:
             )
 
     def list_jobs(
-        self, include_terminated: bool, table_name: Optional[str] = None
+        self,
+        include_terminated: bool,
+        project: Optional[str] = None,
+        table_name: Optional[str] = None,
     ) -> List[SparkJob]:
         if not self._use_job_service:
-            return list_jobs(include_terminated, self, table_name)
+            return list_jobs(include_terminated, self, project, table_name)
         else:
             request = ListJobsRequest(
-                include_terminated=include_terminated, table_name=table_name
+                include_terminated=include_terminated,
+                project=project,
+                table_name=table_name,
             )
             response = self._job_service.ListJobs(request)
             return [

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -1293,6 +1293,16 @@ class Client:
         project: Optional[str] = None,
         table_name: Optional[str] = None,
     ) -> List[SparkJob]:
+        """
+        List ingestion jobs currently running in Feast.
+
+        Args:
+            include_terminated: Flag to include terminated jobs or not
+            project: Optionally specify the project to use as filter when retrieving jobs
+            table_name: Optionally specify name of feature table to use as filter when retrieving jobs
+        Returns:
+            List of SparkJob ingestion jobs.
+        """
         if not self._use_job_service:
             return list_jobs(include_terminated, self, project, table_name)
         else:

--- a/sdk/python/feast/job_service.py
+++ b/sdk/python/feast/job_service.py
@@ -189,6 +189,7 @@ class JobServiceServicer(JobService_pb2_grpc.JobServiceServicer):
         """List all types of jobs"""
         jobs = list_jobs(
             include_terminated=request.include_terminated,
+            project=request.project,
             table_name=request.table_name,
             client=self.client,
         )

--- a/sdk/python/feast/pyspark/abc.py
+++ b/sdk/python/feast/pyspark/abc.py
@@ -359,6 +359,9 @@ class IngestionJobParameters(SparkJobParameters):
             else None
         )
 
+    def get_project(self) -> str:
+        return self._feature_table["project"]
+
     def get_feature_table_name(self) -> str:
         return self._feature_table["name"]
 
@@ -609,6 +612,9 @@ class JobLauncher(abc.ABC):
 
     @abc.abstractmethod
     def list_jobs(
-        self, include_terminated: bool, table_name: Optional[str]
+        self,
+        include_terminated: bool,
+        project: Optional[str],
+        table_name: Optional[str],
     ) -> List[SparkJob]:
         raise NotImplementedError

--- a/sdk/python/feast/pyspark/launcher.py
+++ b/sdk/python/feast/pyspark/launcher.py
@@ -319,11 +319,14 @@ def start_stream_to_online_ingestion(
 
 
 def list_jobs(
-    include_terminated: bool, client: "Client", table_name: Optional[str] = None
+    include_terminated: bool,
+    client: "Client",
+    project: Optional[str] = None,
+    table_name: Optional[str] = None,
 ) -> List[SparkJob]:
     launcher = resolve_launcher(client._config)
     return launcher.list_jobs(
-        include_terminated=include_terminated, table_name=table_name
+        include_terminated=include_terminated, table_name=table_name, project=project
     )
 
 

--- a/sdk/python/feast/pyspark/launchers/aws/emr.py
+++ b/sdk/python/feast/pyspark/launchers/aws/emr.py
@@ -111,12 +111,16 @@ class EmrBatchIngestionJob(EmrJobMixin, BatchIngestionJob):
     Ingestion job result for a EMR cluster
     """
 
-    def __init__(self, emr_client, job_ref: EmrJobRef, table_name: str):
+    def __init__(self, emr_client, job_ref: EmrJobRef, project: str, table_name: str):
         super().__init__(emr_client, job_ref)
+        self._project = project
         self._table_name = table_name
 
     def get_feature_table(self) -> str:
         return self._table_name
+
+    def get_project(self) -> str:
+        return self._project
 
 
 class EmrStreamIngestionJob(EmrJobMixin, StreamIngestionJob):
@@ -124,9 +128,17 @@ class EmrStreamIngestionJob(EmrJobMixin, StreamIngestionJob):
     Ingestion streaming job for a EMR cluster
     """
 
-    def __init__(self, emr_client, job_ref: EmrJobRef, job_hash: str, table_name: str):
+    def __init__(
+        self,
+        emr_client,
+        job_ref: EmrJobRef,
+        job_hash: str,
+        project: str,
+        table_name: str,
+    ):
         super().__init__(emr_client, job_ref)
         self._job_hash = job_hash
+        self._project = project
         self._table_name = table_name
 
     def get_hash(self) -> str:
@@ -134,6 +146,9 @@ class EmrStreamIngestionJob(EmrJobMixin, StreamIngestionJob):
 
     def get_feature_table(self) -> str:
         return self._table_name
+
+    def get_project(self) -> str:
+        return self._project
 
 
 class EmrClusterLauncher(JobLauncher):
@@ -280,7 +295,10 @@ class EmrClusterLauncher(JobLauncher):
         job_ref = self._submit_emr_job(step)
 
         return EmrBatchIngestionJob(
-            self._emr_client(), job_ref, ingestion_job_params.get_feature_table_name()
+            self._emr_client(),
+            job_ref,
+            ingestion_job_params.get_project(),
+            ingestion_job_params.get_feature_table_name(),
         )
 
     def start_stream_to_online_ingestion(
@@ -320,6 +338,7 @@ class EmrClusterLauncher(JobLauncher):
             self._emr_client(),
             job_ref,
             job_hash,
+            ingestion_job_params.get_project(),
             ingestion_job_params.get_feature_table_name(),
         )
 

--- a/sdk/python/feast/pyspark/launchers/k8s/k8s.py
+++ b/sdk/python/feast/pyspark/launchers/k8s/k8s.py
@@ -60,8 +60,8 @@ def _truncate_label(label: str) -> str:
     return label[:63]
 
 
-def _generate_table_hash(table_name: str) -> str:
-    return hashlib.md5(table_name.encode()).hexdigest()
+def _generate_project_table_hash(project: str, table_name: str) -> str:
+    return hashlib.md5(f"{project}:{table_name}".encode()).hexdigest()
 
 
 class KubernetesJobMixin:
@@ -340,8 +340,9 @@ class KubernetesJobLauncher(JobLauncher):
                 LABEL_FEATURE_TABLE: _truncate_label(
                     ingestion_job_params.get_feature_table_name()
                 ),
-                LABEL_FEATURE_TABLE_HASH: _generate_table_hash(
-                    ingestion_job_params.get_feature_table_name()
+                LABEL_FEATURE_TABLE_HASH: _generate_project_table_hash(
+                    ingestion_job_params.get_project(),
+                    ingestion_job_params.get_feature_table_name(),
                 ),
             },
         )
@@ -391,8 +392,9 @@ class KubernetesJobLauncher(JobLauncher):
                 LABEL_FEATURE_TABLE: _truncate_label(
                     ingestion_job_params.get_feature_table_name()
                 ),
-                LABEL_FEATURE_TABLE_HASH: _generate_table_hash(
-                    ingestion_job_params.get_feature_table_name()
+                LABEL_FEATURE_TABLE_HASH: _generate_project_table_hash(
+                    ingestion_job_params.get_project(),
+                    ingestion_job_params.get_feature_table_name(),
                 ),
             },
         )
@@ -411,11 +413,14 @@ class KubernetesJobLauncher(JobLauncher):
             return self._job_from_job_info(job_info)
 
     def list_jobs(
-        self, include_terminated: bool, table_name: Optional[str] = None
+        self,
+        include_terminated: bool,
+        project: Optional[str] = None,
+        table_name: Optional[str] = None,
     ) -> List[SparkJob]:
         return [
             self._job_from_job_info(job)
-            for job in _list_jobs(self._api, self._namespace, table_name)
+            for job in _list_jobs(self._api, self._namespace, project, table_name)
             if include_terminated
             or job.state not in (SparkJobStatus.COMPLETED, SparkJobStatus.FAILED)
         ]

--- a/sdk/python/feast/pyspark/launchers/k8s/k8s_utils.py
+++ b/sdk/python/feast/pyspark/launchers/k8s/k8s_utils.py
@@ -225,13 +225,16 @@ def _submit_job(api: CustomObjectsApi, resource, namespace: str) -> JobInfo:
 
 
 def _list_jobs(
-    api: CustomObjectsApi, namespace: str, table_name: Optional[str] = None
+    api: CustomObjectsApi,
+    namespace: str,
+    project: Optional[str] = None,
+    table_name: Optional[str] = None,
 ) -> List[JobInfo]:
     result = []
 
     # Batch, Streaming Ingestion jobs
-    if table_name:
-        table_name_hash = hashlib.md5(table_name.encode()).hexdigest()
+    if project and table_name:
+        table_name_hash = hashlib.md5(f"{project}:{table_name}".encode()).hexdigest()
         response = api.list_namespaced_custom_object(
             **_crd_args(namespace),
             label_selector=f"{LABEL_FEATURE_TABLE_HASH}={table_name_hash}",

--- a/sdk/python/feast/pyspark/launchers/standalone/local.py
+++ b/sdk/python/feast/pyspark/launchers/standalone/local.py
@@ -356,7 +356,10 @@ class StandaloneClusterLauncher(JobLauncher):
         return global_job_cache.get_job_by_id(job_id)
 
     def list_jobs(
-        self, include_terminated: bool, table_name: Optional[str]
+        self,
+        include_terminated: bool,
+        project: Optional[str],
+        table_name: Optional[str],
     ) -> List[SparkJob]:
         if include_terminated is True:
             return global_job_cache.list_jobs()

--- a/sdk/python/requirements-ci.txt
+++ b/sdk/python/requirements-ci.txt
@@ -3,7 +3,6 @@ flake8
 black==19.10b0
 isort>=5
 grpcio-tools==1.31.0
-mypy-protobuf
 pyspark==3.0.1
 pandas~=1.0.0
 mock==2.0.0

--- a/tests/e2e/test_online_features.py
+++ b/tests/e2e/test_online_features.py
@@ -221,7 +221,7 @@ def test_list_jobs_long_table_name(
     all_job_ids = [
         job.get_id()
         for job in feast_client.list_jobs(
-            include_terminated=True, table_name=feature_table.name
+            include_terminated=True, project="default", table_name=feature_table.name
         )
     ]
     assert job.get_id() in all_job_ids


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, list jobs api does not support project filter, and this may result in potential feature table name collisions across different feast projects.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now list jobs using project as a filter.
```
