### PR TITLE
Use sealed trait to help pattern matching

### DIFF
--- a/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
+++ b/spark/ingestion/src/main/scala/feast/ingestion/IngestionJobConfig.scala
@@ -28,7 +28,7 @@ abstract class StoreConfig
 
 case class RedisConfig(host: String, port: Int, ssl: Boolean) extends StoreConfig
 
-abstract class MetricConfig
+sealed trait MetricConfig
 
 case class StatsDConfig(host: String, port: Int) extends MetricConfig
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Get rid of compilation warning:

```
[WARNING] /Users/chenyisheng/source/yiksanchan/feast/spark/ingestion/src/main/scala/feast/ingestion/BasePipeline.scala:43: match may not be exhaustive.
It would fail on the following input: Some((x: feast.ingestion.MetricConfig forSome x not in feast.ingestion.StatsDConfig))
```

How? Using `sealed trait MetricConfig` teaches the compiler that `StatsDConfig` is the only instance of `MetricConfig`, therefore the below pattern matching is complete.

```
config match {
  Some(c: StatsConfig) =>
  None =>
}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
