### PR TITLE
WIP Add option to use object store metadata registry

### DIFF
--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Install python
         run: make install-python
       - name: Test python
-	    run: FEAST_TELEMETRY=False pytest --verbose --color=yes sdk/python/tests --integration
+        run: FEAST_TELEMETRY=False pytest --verbose --color=yes sdk/python/tests --integration

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -1,0 +1,23 @@
+name: master_only
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  integration-test-python:
+    runs-on: ubuntu-latest
+    container: gcr.io/kf-feast/feast-ci:latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '290.0.1'
+          export_default_credentials: true
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - name: Install python
+        run: make install-python
+      - name: Test python
+	    run: FEAST_TELEMETRY=False pytest --verbose --color=yes sdk/python/tests --integration

--- a/protos/feast/core/Entity.proto
+++ b/protos/feast/core/Entity.proto
@@ -29,6 +29,7 @@ message Entity {
     EntitySpecV2 spec = 1;
     // System-populated metadata for this entity.
     EntityMeta meta = 2;
+    string project = 3;
 }
 
 message EntitySpecV2 {

--- a/protos/feast/core/FeatureTable.proto
+++ b/protos/feast/core/FeatureTable.proto
@@ -34,6 +34,7 @@ message FeatureTable {
 
     // System-populated metadata for this feature table.
     FeatureTableMeta meta = 2;
+    string project = 3;
 }
 
 message FeatureTableSpec {

--- a/protos/feast/core/Registry.proto
+++ b/protos/feast/core/Registry.proto
@@ -29,7 +29,7 @@ message Registry {
     repeated Entity entities = 1;
     repeated FeatureTable feature_tables = 2;
 
-    string registry_schema_version = 3; // to support migrations
-    string version = 4; // version id, random string generated on each update
+    string registry_schema_version = 3; // to support migrations; incremented when schema is changed
+    string version_id = 4; // version id, random string generated on each update of the data; now used only for debugging purposes
     google.protobuf.Timestamp last_updated = 5;
 }

--- a/protos/feast/core/Registry.proto
+++ b/protos/feast/core/Registry.proto
@@ -1,0 +1,35 @@
+//
+// * Copyright 2020 The Feast Authors
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     https://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+//
+
+syntax = "proto3";
+
+package feast.core;
+option java_package = "feast.proto.core";
+option java_outer_classname = "RegistryProto";
+option go_package = "github.com/feast-dev/feast/sdk/go/protos/feast/core";
+
+import "feast/core/Entity.proto";
+import "feast/core/FeatureTable.proto";
+import "google/protobuf/timestamp.proto";
+
+message Registry {
+    repeated Entity entities = 1;
+    repeated FeatureTable feature_tables = 2;
+
+    string registry_schema_version = 3; // to support migrations
+    string version = 4; // version id, random string generated on each update
+    google.protobuf.Timestamp last_updated = 5;
+}

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -407,7 +407,9 @@ class Client:
         """
 
         if self._use_object_store_registry:
-            raise NotImplementedError("Projects are not implemented for object store registry.")
+            raise NotImplementedError(
+                "Projects are not implemented for object store registry."
+            )
         else:
             response = self._core_service.ListProjects(
                 ListProjectsRequest(),
@@ -425,7 +427,9 @@ class Client:
         """
 
         if self._use_object_store_registry:
-            raise NotImplementedError("Projects are not implemented for object store registry.")
+            raise NotImplementedError(
+                "Projects are not implemented for object store registry."
+            )
         else:
             self._core_service.CreateProject(
                 CreateProjectRequest(name=project),
@@ -444,7 +448,9 @@ class Client:
         """
 
         if self._use_object_store_registry:
-            raise NotImplementedError("Projects are not implemented for object store registry.")
+            raise NotImplementedError(
+                "Projects are not implemented for object store registry."
+            )
         else:
             try:
                 self._core_service_stub.ArchiveProject(
@@ -619,7 +625,6 @@ class Client:
         if project is None:
             project = self.project
 
-
         if self._use_object_store_registry:
             return self._registry.get_entity(name, project)
         else:
@@ -715,7 +720,8 @@ class Client:
 
             # Get latest feature tables from Feast Core
             feature_table_protos = self._core_service.ListFeatureTables(
-                ListFeatureTablesRequest(filter=filter), metadata=self._get_grpc_metadata(),
+                ListFeatureTablesRequest(filter=filter),
+                metadata=self._get_grpc_metadata(),
             )  # type: ListFeatureTablesResponse
 
             # Extract feature tables and return
@@ -811,7 +817,9 @@ class Client:
         """
 
         if self._use_object_store_registry:
-            raise NotImplementedError("This function is not implemented for object store registry.")
+            raise NotImplementedError(
+                "This function is not implemented for object store registry."
+            )
         else:
             if project is None:
                 project = self.project

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -539,7 +539,7 @@ class Client:
         """
 
         if self._use_object_store_registry:
-            return self._registry.apply_entity(entity)
+            return self._registry.apply_entity(entity, project)
         else:
             entity.is_valid()
             entity_proto = entity.to_spec_proto()
@@ -574,12 +574,12 @@ class Client:
             List of entities
         """
 
-        if self._use_object_store_registry:
-            return self._registry.list_entities()
-        else:
-            if project is None:
-                project = self.project
+        if project is None:
+            project = self.project
 
+        if self._use_object_store_registry:
+            return self._registry.list_entities(project)
+        else:
             filter = ListEntitiesRequest.Filter(project=project, labels=labels)
 
             # Get latest entities from Feast Core
@@ -616,12 +616,13 @@ class Client:
                 self.version(sdk_only=True),
             )
 
-        if self._use_object_store_registry:
-            return self._registry.get_entity(name)
-        else:
-            if project is None:
-                project = self.project
+        if project is None:
+            project = self.project
 
+
+        if self._use_object_store_registry:
+            return self._registry.get_entity(name, project)
+        else:
             try:
                 get_entity_response = self._core_service.GetEntity(
                     GetEntityRequest(project=project, name=name.strip()),
@@ -668,7 +669,7 @@ class Client:
         """
 
         if self._use_object_store_registry:
-            return self._registry.apply_feature_table(feature_table)
+            return self._registry.apply_feature_table(feature_table, project)
         else:
             feature_table.is_valid()
             feature_table_proto = feature_table.to_spec_proto()
@@ -704,12 +705,12 @@ class Client:
             List of feature tables
         """
 
-        if self._use_object_store_registry:
-            return self._registry.list_feature_tables()
-        else:
-            if project is None:
-                project = self.project
+        if project is None:
+            project = self.project
 
+        if self._use_object_store_registry:
+            return self._registry.list_feature_tables(project)
+        else:
             filter = ListFeatureTablesRequest.Filter(project=project, labels=labels)
 
             # Get latest feature tables from Feast Core
@@ -746,12 +747,12 @@ class Client:
                 self.version(sdk_only=True),
             )
 
-        if self._use_object_store_registry:
-            return self._registry.get_feature_table(name)
-        else:
-            if project is None:
-                project = self.project
+        if project is None:
+            project = self.project
 
+        if self._use_object_store_registry:
+            return self._registry.get_feature_table(name, project)
+        else:
             try:
                 get_feature_table_response = self._core_service.GetFeatureTable(
                     GetFeatureTableRequest(project=project, name=name.strip()),
@@ -770,12 +771,12 @@ class Client:
             name: Name of feature table
         """
 
-        if self._use_object_store_registry:
-            return self._registry.delete_feature_table(name)
-        else:
-            if project is None:
-                project = self.project
+        if project is None:
+            project = self.project
 
+        if self._use_object_store_registry:
+            return self._registry.delete_feature_table(name, project)
+        else:
             try:
                 self._core_service.DeleteFeatureTable(
                     DeleteFeatureTableRequest(project=project, name=name.strip()),

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -68,7 +68,7 @@ from feast.loaders.ingest import (
     _write_partitioned_table_from_source,
 )
 from feast.online_response import OnlineResponse, _infer_online_entity_rows
-from feast.registry import LocalRegistry
+from feast.registry import Registry
 from feast.serving.ServingService_pb2 import (
     GetFeastServingInfoRequest,
     GetOnlineFeaturesRequestV2,
@@ -117,6 +117,7 @@ class Client:
         self._serving_service_stub: Optional[ServingServiceStub] = None
         self._job_service_stub: Optional[JobServiceStub] = None
         self._auth_metadata: Optional[grpc.AuthMetadataPlugin] = None
+        self._registry_impl: Optional[Registry] = None
 
         # Configure Auth Metadata Plugin if auth is enabled
         if self._config.getboolean(opt.ENABLE_AUTH):
@@ -153,8 +154,9 @@ class Client:
 
     @property
     def _registry(self):
-        # TODO make this long-lived
-        return LocalRegistry(self._config.get(opt.REGISTRY_PATH))
+        if self._registry_impl is None:
+            self._registry_impl = Registry(self._config.get(opt.REGISTRY_PATH))
+        return self._registry_impl
 
     @property
     def _serving_service(self):

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -68,6 +68,7 @@ from feast.loaders.ingest import (
     _write_partitioned_table_from_source,
 )
 from feast.online_response import OnlineResponse, _infer_online_entity_rows
+from feast.registry import LocalRegistry
 from feast.serving.ServingService_pb2 import (
     GetFeastServingInfoRequest,
     GetOnlineFeaturesRequestV2,
@@ -145,6 +146,15 @@ class Client:
             )
             self._core_service_stub = CoreServiceStub(channel)
         return self._core_service_stub
+
+    @property
+    def _use_object_store_registry(self) -> bool:
+        return self._config.exists(opt.REGISTRY_PATH)
+
+    @property
+    def _registry(self):
+        # TODO make this long-lived
+        return LocalRegistry(self._config.get(opt.REGISTRY_PATH))
 
     @property
     def _serving_service(self):
@@ -331,7 +341,7 @@ class Client:
             ).version
             result["serving"] = {"url": self.serving_url, "version": serving_version}
 
-        if self.core_url:
+        if not self._use_object_store_registry and self.core_url:
             core_version = self._core_service.GetFeastCoreVersion(
                 GetFeastCoreVersionRequest(),
                 timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
@@ -394,12 +404,15 @@ class Client:
 
         """
 
-        response = self._core_service.ListProjects(
-            ListProjectsRequest(),
-            timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
-            metadata=self._get_grpc_metadata(),
-        )  # type: ListProjectsResponse
-        return list(response.projects)
+        if self._use_object_store_registry:
+            raise NotImplementedError("Projects are not implemented for object store registry.")
+        else:
+            response = self._core_service.ListProjects(
+                ListProjectsRequest(),
+                timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
+                metadata=self._get_grpc_metadata(),
+            )  # type: ListProjectsResponse
+            return list(response.projects)
 
     def create_project(self, project: str):
         """
@@ -409,11 +422,14 @@ class Client:
             project: Name of project
         """
 
-        self._core_service.CreateProject(
-            CreateProjectRequest(name=project),
-            timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
-            metadata=self._get_grpc_metadata(),
-        )  # type: CreateProjectResponse
+        if self._use_object_store_registry:
+            raise NotImplementedError("Projects are not implemented for object store registry.")
+        else:
+            self._core_service.CreateProject(
+                CreateProjectRequest(name=project),
+                timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
+                metadata=self._get_grpc_metadata(),
+            )  # type: CreateProjectResponse
 
     def archive_project(self, project):
         """
@@ -425,18 +441,21 @@ class Client:
             project: Name of project to archive
         """
 
-        try:
-            self._core_service_stub.ArchiveProject(
-                ArchiveProjectRequest(name=project),
-                timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
-                metadata=self._get_grpc_metadata(),
-            )  # type: ArchiveProjectResponse
-        except grpc.RpcError as e:
-            raise grpc.RpcError(e.details())
+        if self._use_object_store_registry:
+            raise NotImplementedError("Projects are not implemented for object store registry.")
+        else:
+            try:
+                self._core_service_stub.ArchiveProject(
+                    ArchiveProjectRequest(name=project),
+                    timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
+                    metadata=self._get_grpc_metadata(),
+                )  # type: ArchiveProjectResponse
+            except grpc.RpcError as e:
+                raise grpc.RpcError(e.details())
 
-        # revert to the default project
-        if self._project == project:
-            self._project = opt().PROJECT
+            # revert to the default project
+            if self._project == project:
+                self._project = opt().PROJECT
 
     def apply(
         self,
@@ -517,24 +536,27 @@ class Client:
             entity: Entity that will be registered
         """
 
-        entity.is_valid()
-        entity_proto = entity.to_spec_proto()
+        if self._use_object_store_registry:
+            return self._registry.apply_entity(entity)
+        else:
+            entity.is_valid()
+            entity_proto = entity.to_spec_proto()
 
-        # Convert the entity to a request and send to Feast Core
-        try:
-            apply_entity_response = self._core_service.ApplyEntity(
-                ApplyEntityRequest(project=project, spec=entity_proto),  # type: ignore
-                timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
-                metadata=self._get_grpc_metadata(),
-            )  # type: ApplyEntityResponse
-        except grpc.RpcError as e:
-            raise grpc.RpcError(e.details())
+            # Convert the entity to a request and send to Feast Core
+            try:
+                apply_entity_response = self._core_service.ApplyEntity(
+                    ApplyEntityRequest(project=project, spec=entity_proto),  # type: ignore
+                    timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
+                    metadata=self._get_grpc_metadata(),
+                )  # type: ApplyEntityResponse
+            except grpc.RpcError as e:
+                raise grpc.RpcError(e.details())
 
-        # Extract the returned entity
-        applied_entity = Entity.from_proto(apply_entity_response.entity)
+            # Extract the returned entity
+            applied_entity = Entity.from_proto(apply_entity_response.entity)
 
-        # Deep copy from the returned entity to the local entity
-        entity._update_from_entity(applied_entity)
+            # Deep copy from the returned entity to the local entity
+            entity._update_from_entity(applied_entity)
 
     def list_entities(
         self, project: str = None, labels: Dict[str, str] = dict()
@@ -550,23 +572,26 @@ class Client:
             List of entities
         """
 
-        if project is None:
-            project = self.project
+        if self._use_object_store_registry:
+            return self._registry.list_entities()
+        else:
+            if project is None:
+                project = self.project
 
-        filter = ListEntitiesRequest.Filter(project=project, labels=labels)
+            filter = ListEntitiesRequest.Filter(project=project, labels=labels)
 
-        # Get latest entities from Feast Core
-        entity_protos = self._core_service.ListEntities(
-            ListEntitiesRequest(filter=filter), metadata=self._get_grpc_metadata(),
-        )  # type: ListEntitiesResponse
+            # Get latest entities from Feast Core
+            entity_protos = self._core_service.ListEntities(
+                ListEntitiesRequest(filter=filter), metadata=self._get_grpc_metadata(),
+            )  # type: ListEntitiesResponse
 
-        # Extract entities and return
-        entities = []
-        for entity_proto in entity_protos.entities:
-            entity = Entity.from_proto(entity_proto)
-            entity._client = self
-            entities.append(entity)
-        return entities
+            # Extract entities and return
+            entities = []
+            for entity_proto in entity_protos.entities:
+                entity = Entity.from_proto(entity_proto)
+                entity._client = self
+                entities.append(entity)
+            return entities
 
     def get_entity(self, name: str, project: str = None) -> Entity:
         """
@@ -588,19 +613,23 @@ class Client:
                 datetime.utcnow(),
                 self.version(sdk_only=True),
             )
-        if project is None:
-            project = self.project
 
-        try:
-            get_entity_response = self._core_service.GetEntity(
-                GetEntityRequest(project=project, name=name.strip()),
-                metadata=self._get_grpc_metadata(),
-            )  # type: GetEntityResponse
-        except grpc.RpcError as e:
-            raise grpc.RpcError(e.details())
-        entity = Entity.from_proto(get_entity_response.entity)
+        if self._use_object_store_registry:
+            return self._registry.get_entity(name)
+        else:
+            if project is None:
+                project = self.project
 
-        return entity
+            try:
+                get_entity_response = self._core_service.GetEntity(
+                    GetEntityRequest(project=project, name=name.strip()),
+                    metadata=self._get_grpc_metadata(),
+                )  # type: GetEntityResponse
+            except grpc.RpcError as e:
+                raise grpc.RpcError(e.details())
+            entity = Entity.from_proto(get_entity_response.entity)
+
+            return entity
 
     def apply_feature_table(
         self,
@@ -636,26 +665,29 @@ class Client:
             feature_table: Feature table that will be registered
         """
 
-        feature_table.is_valid()
-        feature_table_proto = feature_table.to_spec_proto()
+        if self._use_object_store_registry:
+            return self._registry.apply_feature_table(feature_table)
+        else:
+            feature_table.is_valid()
+            feature_table_proto = feature_table.to_spec_proto()
 
-        # Convert the feature table to a request and send to Feast Core
-        try:
-            apply_feature_table_response = self._core_service.ApplyFeatureTable(
-                ApplyFeatureTableRequest(project=project, table_spec=feature_table_proto),  # type: ignore
-                timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
-                metadata=self._get_grpc_metadata(),
-            )  # type: ApplyFeatureTableResponse
-        except grpc.RpcError as e:
-            raise grpc.RpcError(e.details())
+            # Convert the feature table to a request and send to Feast Core
+            try:
+                apply_feature_table_response = self._core_service.ApplyFeatureTable(
+                    ApplyFeatureTableRequest(project=project, table_spec=feature_table_proto),  # type: ignore
+                    timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
+                    metadata=self._get_grpc_metadata(),
+                )  # type: ApplyFeatureTableResponse
+            except grpc.RpcError as e:
+                raise grpc.RpcError(e.details())
 
-        # Extract the returned feature table
-        applied_feature_table = FeatureTable.from_proto(
-            apply_feature_table_response.table
-        )
+            # Extract the returned feature table
+            applied_feature_table = FeatureTable.from_proto(
+                apply_feature_table_response.table
+            )
 
-        # Deep copy from the returned feature table to the local entity
-        feature_table._update_from_feature_table(applied_feature_table)
+            # Deep copy from the returned feature table to the local entity
+            feature_table._update_from_feature_table(applied_feature_table)
 
     def list_feature_tables(
         self, project: str = None, labels: Dict[str, str] = dict()
@@ -670,23 +702,26 @@ class Client:
             List of feature tables
         """
 
-        if project is None:
-            project = self.project
+        if self._use_object_store_registry:
+            return self._registry.list_feature_tables()
+        else:
+            if project is None:
+                project = self.project
 
-        filter = ListFeatureTablesRequest.Filter(project=project, labels=labels)
+            filter = ListFeatureTablesRequest.Filter(project=project, labels=labels)
 
-        # Get latest feature tables from Feast Core
-        feature_table_protos = self._core_service.ListFeatureTables(
-            ListFeatureTablesRequest(filter=filter), metadata=self._get_grpc_metadata(),
-        )  # type: ListFeatureTablesResponse
+            # Get latest feature tables from Feast Core
+            feature_table_protos = self._core_service.ListFeatureTables(
+                ListFeatureTablesRequest(filter=filter), metadata=self._get_grpc_metadata(),
+            )  # type: ListFeatureTablesResponse
 
-        # Extract feature tables and return
-        feature_tables = []
-        for feature_table_proto in feature_table_protos.tables:
-            feature_table = FeatureTable.from_proto(feature_table_proto)
-            feature_table._client = self
-            feature_tables.append(feature_table)
-        return feature_tables
+            # Extract feature tables and return
+            feature_tables = []
+            for feature_table_proto in feature_table_protos.tables:
+                feature_table = FeatureTable.from_proto(feature_table_proto)
+                feature_table._client = self
+                feature_tables.append(feature_table)
+            return feature_tables
 
     def get_feature_table(self, name: str, project: str = None) -> FeatureTable:
         """
@@ -708,17 +743,21 @@ class Client:
                 datetime.utcnow(),
                 self.version(sdk_only=True),
             )
-        if project is None:
-            project = self.project
 
-        try:
-            get_feature_table_response = self._core_service.GetFeatureTable(
-                GetFeatureTableRequest(project=project, name=name.strip()),
-                metadata=self._get_grpc_metadata(),
-            )  # type: GetFeatureTableResponse
-        except grpc.RpcError as e:
-            raise grpc.RpcError(e.details())
-        return FeatureTable.from_proto(get_feature_table_response.table)
+        if self._use_object_store_registry:
+            return self._registry.get_feature_table(name)
+        else:
+            if project is None:
+                project = self.project
+
+            try:
+                get_feature_table_response = self._core_service.GetFeatureTable(
+                    GetFeatureTableRequest(project=project, name=name.strip()),
+                    metadata=self._get_grpc_metadata(),
+                )  # type: GetFeatureTableResponse
+            except grpc.RpcError as e:
+                raise grpc.RpcError(e.details())
+            return FeatureTable.from_proto(get_feature_table_response.table)
 
     def delete_feature_table(self, name: str, project: str = None) -> None:
         """
@@ -729,16 +768,19 @@ class Client:
             name: Name of feature table
         """
 
-        if project is None:
-            project = self.project
+        if self._use_object_store_registry:
+            return self._registry.delete_feature_table(name)
+        else:
+            if project is None:
+                project = self.project
 
-        try:
-            self._core_service.DeleteFeatureTable(
-                DeleteFeatureTableRequest(project=project, name=name.strip()),
-                metadata=self._get_grpc_metadata(),
-            )
-        except grpc.RpcError as e:
-            raise grpc.RpcError(e.details())
+            try:
+                self._core_service.DeleteFeatureTable(
+                    DeleteFeatureTableRequest(project=project, name=name.strip()),
+                    metadata=self._get_grpc_metadata(),
+                )
+            except grpc.RpcError as e:
+                raise grpc.RpcError(e.details())
 
     def list_features_by_ref(
         self,
@@ -765,25 +807,28 @@ class Client:
             >>> print(features)
         """
 
-        if project is None:
-            project = self.project
+        if self._use_object_store_registry:
+            raise NotImplementedError("This function is not implemented for object store registry.")
+        else:
+            if project is None:
+                project = self.project
 
-        filter = ListFeaturesRequest.Filter(
-            project=project, entities=entities, labels=labels
-        )
+            filter = ListFeaturesRequest.Filter(
+                project=project, entities=entities, labels=labels
+            )
 
-        feature_protos = self._core_service.ListFeatures(
-            ListFeaturesRequest(filter=filter), metadata=self._get_grpc_metadata(),
-        )  # type: ListFeaturesResponse
+            feature_protos = self._core_service.ListFeatures(
+                ListFeaturesRequest(filter=filter), metadata=self._get_grpc_metadata(),
+            )  # type: ListFeaturesResponse
 
-        # Extract features and return
-        features_dict = {}
-        for ref_str, feature_proto in feature_protos.features.items():
-            feature_ref = FeatureRef.from_str(ref_str)
-            feature = Feature.from_proto(feature_proto)
-            features_dict[feature_ref] = feature
+            # Extract features and return
+            features_dict = {}
+            for ref_str, feature_proto in feature_protos.features.items():
+                feature_ref = FeatureRef.from_str(ref_str)
+                feature = Feature.from_proto(feature_proto)
+                features_dict[feature_ref] = feature
 
-        return features_dict
+            return features_dict
 
     def ingest(
         self,

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -262,6 +262,9 @@ class ConfigOptions(metaclass=ConfigMeta):
     #: Telemetry enabled
     TELEMETRY = "True"
 
+    #: Object store registry
+    REGISTRY_PATH: Optional[str] = None
+
     def defaults(self):
         return {
             k: getattr(self, k)

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -20,6 +20,8 @@ from tempfile import TemporaryFile
 from typing import Callable, List
 from urllib.parse import urlparse
 
+from google.auth.exceptions import DefaultCredentialsError
+
 from feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.entity import Entity
 from feast.feature_table import FeatureTable

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -1,0 +1,123 @@
+# Copyright 2019 The Feast Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from feast.core.Registry_pb2 import Registry as RegistryProto
+from feast.entity import Entity
+from feast.feature_table import FeatureTable
+from pathlib import Path
+from typing import Callable
+import uuid
+
+REGISTRY_SCHEMA_VERSION = 1
+
+
+class Registry(ABC):
+    def apply_entity(self, entity: Entity):
+        entity.is_valid()
+        entity_proto = entity.to_proto()
+        def updater(registry_proto: RegistryProto):
+            for idx, existing_entity_proto in enumerate(registry_proto.entities):
+                if existing_entity_proto.spec.name == entity_proto.spec.name:
+                    registry_proto.entities[idx] = entity_proto
+                    return registry_proto
+            registry_proto.entities.append(entity_proto)
+            return registry_proto
+        self._update_registry(updater)
+        return
+
+    def list_entities(self):
+        registry_proto = self._get_registry()
+        entities = []
+        for entity_proto in registry_proto.entities:
+            entities.append(Entity.from_proto(entity_proto))
+        return entities
+
+    def get_entity(self, name: str):
+        registry_proto = self._get_registry()
+        for entity_proto in registry.entities:
+            if entity_proto.spec.name == name:
+                return Entity.from_proto(entity_proto)
+        raise Exception(f"Entity {name} does not exist")
+
+    def apply_feature_table(self, feature_table: FeatureTable):
+        feature_table.is_valid()
+        feature_table_proto = feature_table.to_proto()
+        def updater(registry_proto: RegistryProto):
+            for idx, existing_feature_table_proto in enumerate(registry_proto.feature_tables):
+                if existing_feature_table_proto.spec.name == feature_table_proto.spec.name:
+                    registry_proto.feature_tables[idx] = feature_table_proto
+                    return registry_proto
+            registry_proto.feature_tables.append(feature_table_proto)
+            return registry_proto
+        self._update_registry(updater)
+        return
+
+    def list_feature_tables(self):
+        registry_proto = self._get_registry()
+        feature_tables = []
+        for feature_table_proto in registry_proto.feature_tables:
+            feature_tables.append(FeatureTable.from_proto(feature_table_proto))
+        return feature_tables
+
+    def get_feature_table(self, name: str):
+        registry_proto = self._get_registry()
+        for feature_table_proto in registry_proto.feature_tables:
+            if feature_table_proto.spec.name == name:
+                return FeatureTable.from_proto(feature_table_proto)
+        raise Exception(f"Feature table {name} does not exist")
+
+    def delete_feature_table(self, name: str):
+        def updater(registry_proto: RegistryProto):
+            for idx, existing_feature_table_proto in enumerate(registry_proto.feature_tables):
+                if existing_feature_table_proto.spec.name == feature_table_proto.spec.name:
+                    del registry_proto.feature_tables[idx]
+                    return registry_proto
+            raise Exception(f"Feature table {name} does not exist")
+        self._update_registry(updater)
+        return
+
+    @abstractmethod
+    def _get_registry(self):
+        pass
+
+    @abstractmethod
+    def _update_registry(self, updater: Callable[[RegistryProto], RegistryProto]):
+        pass
+
+
+class LocalRegistry(Registry):
+    def __init__(self, filepath: str):
+        self._filepath = Path(filepath)
+        if not self._filepath.exists():
+            registry_proto = RegistryProto()
+            registry_proto.registry_schema_version = REGISTRY_SCHEMA_VERSION
+            registry_proto.version = str(uuid.uuid4())
+            registry_proto.last_updated.FromDatetime(datetime.utcnow())
+            self._filepath.write_bytes(registry_proto.SerializeToString())
+        return
+
+    def _get_registry(self):
+        registry_proto = RegistryProto()
+        registry_proto.ParseFromString(self._filepath.read_bytes())
+        return registry_proto
+
+    def _update_registry(self, updater: Callable[[RegistryProto], RegistryProto]):
+        registry_proto = self._get_registry()
+        registry_proto = updater(registry_proto)
+        registry_proto.version = str(uuid.uuid4())
+        registry_proto.last_updated.FromDatetime(datetime.utcnow())
+        self._filepath.write_bytes(registry_proto.SerializeToString())
+        return

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -51,7 +51,7 @@ class Registry:
 
     def get_entity(self, name: str):
         registry_proto = self._registry_store.get_registry()
-        for entity_proto in registry.entities:
+        for entity_proto in registry_proto.entities:
             if entity_proto.spec.name == name:
                 return Entity.from_proto(entity_proto)
         raise Exception(f"Entity {name} does not exist")
@@ -86,7 +86,7 @@ class Registry:
     def delete_feature_table(self, name: str):
         def updater(registry_proto: RegistryProto):
             for idx, existing_feature_table_proto in enumerate(registry_proto.feature_tables):
-                if existing_feature_table_proto.spec.name == feature_table_proto.spec.name:
+                if existing_feature_table_proto.spec.name == name:
                     del registry_proto.feature_tables[idx]
                     return registry_proto
             raise Exception(f"Feature table {name} does not exist")

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -33,7 +33,7 @@ class Registry:
     def __init__(self, registry_path: str):
         uri = urlparse(registry_path)
         if uri.scheme == "gs":
-            self._registry_store = GCPRegistryStore(registry_path)
+            self._registry_store: RegistryStore = GCPRegistryStore(registry_path)
         elif uri.scheme == "file" or uri.scheme == "":
             self._registry_store = LocalRegistryStore(registry_path)
         else:
@@ -53,7 +53,8 @@ class Registry:
                     existing_entity_proto.spec.name == entity_proto.spec.name
                     and existing_entity_proto.project == project
                 ):
-                    registry_proto.entities[idx] = entity_proto
+                    del registry_proto.entities[idx]
+                    registry_proto.entities.append(entity_proto)
                     return registry_proto
             registry_proto.entities.append(entity_proto)
             return registry_proto
@@ -90,7 +91,8 @@ class Registry:
                     == feature_table_proto.spec.name
                     and existing_feature_table_proto.project == project
                 ):
-                    registry_proto.feature_tables[idx] = feature_table_proto
+                    del registry_proto.feature_tables[idx]
+                    registry_proto.feature_tables.append(feature_table_proto)
                     return registry_proto
             registry_proto.feature_tables.append(feature_table_proto)
             return registry_proto

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -266,7 +266,6 @@ class GCSRegistryStore(RegistryStore):
     def __init__(self, uri: str):
         try:
             from google.cloud import storage
-            from google.cloud.exceptions import NotFound
         except ImportError:
             raise ImportError(
                 "Install package google-cloud-storage==1.20.* for gcs support"

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -31,7 +31,7 @@ REGISTRY_SCHEMA_VERSION = "1"
 
 class Registry:
     """
-    Registry: Used for interfacing with the object store registry.
+    Registry: A registry allows for the management and persistence of feature definitions and related metadata.
     """
 
     def __init__(self, registry_path: str):
@@ -210,7 +210,8 @@ class Registry:
 
 class RegistryStore(ABC):
     """
-    RegistryStore: specific implementations of the object store registry for local file system and GCS.
+    RegistryStore: abstract base class implemented by specific backends (local file system, GCS)
+    containing lower level methods used by the Registry class that are backend-specific.
     """
 
     @abstractmethod

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import multiprocessing
 from sys import platform
+
 import pytest
 
 
@@ -21,15 +22,26 @@ def pytest_configure(config):
         multiprocessing.set_start_method("spawn")
     else:
         multiprocessing.set_start_method("fork")
-    config.addinivalue_line("markers", "integration: mark test that has external dependencies")
+    config.addinivalue_line(
+        "markers", "integration: mark test that has external dependencies"
+    )
+
 
 def pytest_addoption(parser):
-    parser.addoption("--integration", action="store_true", default=False, help="Run tests with external dependencies")
+    parser.addoption(
+        "--integration",
+        action="store_true",
+        default=False,
+        help="Run tests with external dependencies",
+    )
+
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--integration"):
         return
-    skip_integration = pytest.mark.skip(reason="not running tests with external dependencies")
+    skip_integration = pytest.mark.skip(
+        reason="not running tests with external dependencies"
+    )
     for item in items:
         if "integration" in item.keywords:
             item.add_marker(skip_integration)

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import multiprocessing
 from sys import platform
+import pytest
 
 
 def pytest_configure(config):
@@ -20,3 +21,15 @@ def pytest_configure(config):
         multiprocessing.set_start_method("spawn")
     else:
         multiprocessing.set_start_method("fork")
+    config.addinivalue_line("markers", "integration: mark test that has external dependencies")
+
+def pytest_addoption(parser):
+    parser.addoption("--integration", action="store_true", default=False, help="Run tests with external dependencies")
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--integration"):
+        return
+    skip_integration = pytest.mark.skip(reason="not running tests with external dependencies")
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -16,6 +16,7 @@ import pkgutil
 import socket
 from concurrent import futures
 from datetime import datetime, timedelta
+from tempfile import mkstemp
 from typing import Tuple
 from unittest import mock
 
@@ -29,7 +30,6 @@ from mock import MagicMock, patch
 from pandas.util.testing import assert_frame_equal
 from pyarrow import parquet as pq
 from pytest_lazyfixture import lazy_fixture
-from tempfile import mkstemp
 
 from feast.client import Client
 from feast.core import CoreService_pb2_grpc as Core
@@ -132,23 +132,20 @@ class TestClient:
     @pytest.fixture
     def client_with_object_registry(self):
         fd, path = mkstemp()
-        return Client(
-            registry_path=path,
-        )
+        return Client(registry_path=path,)
 
     @pytest.fixture
     def client_with_object_registry_gcs(self):
         # clear any old registry left there
         from google.cloud import storage
+
         storage_client = storage.Client()
         bucket = storage_client.bucket("feast-registry-test")
         blob = bucket.blob("test")
         if blob.exists():
             blob.delete()
 
-        return Client(
-            registry_path="gs://feast-registry-test/test",
-        )
+        return Client(registry_path="gs://feast-registry-test/test",)
 
     @pytest.fixture
     def server_credentials(self):
@@ -386,7 +383,12 @@ class TestClient:
         assert 1 == 1
 
     @pytest.mark.parametrize(
-        "test_client", [lazy_fixture("client"), lazy_fixture("secure_client"), lazy_fixture("client_with_object_registry")],
+        "test_client",
+        [
+            lazy_fixture("client"),
+            lazy_fixture("secure_client"),
+            lazy_fixture("client_with_object_registry"),
+        ],
     )
     def test_apply_entity_success(self, test_client):
 
@@ -452,7 +454,12 @@ class TestClient:
         )
 
     @pytest.mark.parametrize(
-        "test_client", [lazy_fixture("client"), lazy_fixture("secure_client"), lazy_fixture("client_with_object_registry")],
+        "test_client",
+        [
+            lazy_fixture("client"),
+            lazy_fixture("secure_client"),
+            lazy_fixture("client_with_object_registry"),
+        ],
     )
     def test_apply_feature_table_success(self, test_client):
 
@@ -582,7 +589,7 @@ class TestClient:
 
         test_client.delete_feature_table("my-feature-table-1")
         feature_tables = test_client.list_feature_tables()
-        assert(len(feature_tables) == 0)
+        assert len(feature_tables) == 0
 
     @pytest.mark.parametrize(
         "test_client", [lazy_fixture("client"), lazy_fixture("secure_client")]

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -137,6 +137,20 @@ class TestClient:
         )
 
     @pytest.fixture
+    def client_with_object_registry_gcs(self):
+        # clear any old registry left there
+        from google.cloud import storage
+        storage_client = storage.Client()
+        bucket = storage_client.bucket("feast-registry-test")
+        blob = bucket.blob("test")
+        if blob.exists():
+            blob.delete()
+
+        return Client(
+            registry_path="gs://feast-registry-test/test",
+        )
+
+    @pytest.fixture
     def server_credentials(self):
         private_key = pkgutil.get_data(__name__, _PRIVATE_KEY_RESOURCE_PATH)
         certificate_chain = pkgutil.get_data(__name__, _CERTIFICATE_CHAIN_RESOURCE_PATH)
@@ -372,7 +386,7 @@ class TestClient:
         assert 1 == 1
 
     @pytest.mark.parametrize(
-        "test_client", [lazy_fixture("client"), lazy_fixture("secure_client"), lazy_fixture("client_with_object_registry")],
+        "test_client", [lazy_fixture("client"), lazy_fixture("secure_client"), lazy_fixture("client_with_object_registry"), lazy_fixture("client_with_object_registry_gcs")],
     )
     def test_apply_entity_success(self, test_client):
 
@@ -409,7 +423,7 @@ class TestClient:
         )
 
     @pytest.mark.parametrize(
-        "test_client", [lazy_fixture("client"), lazy_fixture("secure_client"), lazy_fixture("client_with_object_registry")],
+        "test_client", [lazy_fixture("client"), lazy_fixture("secure_client"), lazy_fixture("client_with_object_registry"), lazy_fixture("client_with_object_registry_gcs")],
     )
     def test_apply_feature_table_success(self, test_client):
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -392,7 +392,6 @@ class TestClient:
     )
     def test_apply_entity_success(self, test_client):
 
-        test_client.set_project("project1")
         entity = Entity(
             name="driver_car_id",
             description="Car driver id",
@@ -421,7 +420,6 @@ class TestClient:
     )
     def test_apply_entity_integration(self, test_client):
 
-        test_client.set_project("project1")
         entity = Entity(
             name="driver_car_id",
             description="Car driver id",
@@ -462,8 +460,6 @@ class TestClient:
         ],
     )
     def test_apply_feature_table_success(self, test_client):
-
-        test_client.set_project("project1")
 
         # Create Feature Tables
         batch_source = FileSource(
@@ -520,8 +516,6 @@ class TestClient:
         "test_client", [lazy_fixture("client_with_object_registry_gcs")],
     )
     def test_apply_feature_table_integration(self, test_client):
-
-        test_client.set_project("project1")
 
         # Create Feature Tables
         batch_source = FileSource(

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -399,6 +399,15 @@ class TestClient:
             and entity.labels["team"] == "matchmaking"
         )
 
+        entity = test_client.get_entity("driver_car_id")
+        assert (
+            entity.name == "driver_car_id"
+            and entity.value_type == ValueType(ValueProto.ValueType.STRING)
+            and entity.description == "Car driver id"
+            and "team" in entity.labels
+            and entity.labels["team"] == "matchmaking"
+        )
+
     @pytest.mark.parametrize(
         "test_client", [lazy_fixture("client"), lazy_fixture("secure_client"), lazy_fixture("client_with_object_registry")],
     )
@@ -455,6 +464,25 @@ class TestClient:
             and feature_tables[0].features[3].dtype == ValueType.BYTES_LIST
             and feature_tables[0].entities[0] == "fs1-my-entity-1"
         )
+
+        feature_table = test_client.get_feature_table("my-feature-table-1")
+        assert (
+            feature_table.name == "my-feature-table-1"
+            and feature_table.features[0].name == "fs1-my-feature-1"
+            and feature_table.features[0].dtype == ValueType.INT64
+            and feature_table.features[1].name == "fs1-my-feature-2"
+            and feature_table.features[1].dtype == ValueType.STRING
+            and feature_table.features[2].name == "fs1-my-feature-3"
+            and feature_table.features[2].dtype == ValueType.STRING_LIST
+            and feature_table.features[3].name == "fs1-my-feature-4"
+            and feature_table.features[3].dtype == ValueType.BYTES_LIST
+            and feature_table.entities[0] == "fs1-my-entity-1"
+        )
+
+        test_client.delete_feature_table("my-feature-table-1")
+        feature_tables = test_client.list_feature_tables()
+        assert(len(feature_tables) == 0)
+
 
     @pytest.mark.parametrize(
         "test_client", [lazy_fixture("client"), lazy_fixture("secure_client")]

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -29,6 +29,7 @@ from mock import MagicMock, patch
 from pandas.util.testing import assert_frame_equal
 from pyarrow import parquet as pq
 from pytest_lazyfixture import lazy_fixture
+from tempfile import mkstemp
 
 from feast.client import Client
 from feast.core import CoreService_pb2_grpc as Core
@@ -127,6 +128,13 @@ class TestClient:
         client._core_url = CORE_URL
         client._serving_url = SERVING_URL
         return client
+
+    @pytest.fixture
+    def client_with_object_registry(self):
+        fd, path = mkstemp()
+        return Client(
+            registry_path=path,
+        )
 
     @pytest.fixture
     def server_credentials(self):
@@ -364,7 +372,7 @@ class TestClient:
         assert 1 == 1
 
     @pytest.mark.parametrize(
-        "test_client", [lazy_fixture("client"), lazy_fixture("secure_client")],
+        "test_client", [lazy_fixture("client"), lazy_fixture("secure_client"), lazy_fixture("client_with_object_registry")],
     )
     def test_apply_entity_success(self, test_client):
 
@@ -392,7 +400,7 @@ class TestClient:
         )
 
     @pytest.mark.parametrize(
-        "test_client", [lazy_fixture("client"), lazy_fixture("secure_client")],
+        "test_client", [lazy_fixture("client"), lazy_fixture("secure_client"), lazy_fixture("client_with_object_registry")],
     )
     def test_apply_feature_table_success(self, test_client):
 


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Add support for an object store registry to the SDK. However, note that this should not be used until serving also supports this registry.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
