### PR TITLE
Add configurable timeout to redis cluster connection

### DIFF
--- a/protos/feast/core/Store.proto
+++ b/protos/feast/core/Store.proto
@@ -21,6 +21,8 @@ option java_package = "feast.proto.core";
 option java_outer_classname = "StoreProto";
 option go_package = "github.com/feast-dev/feast/sdk/go/protos/feast/core";
 
+import "google/protobuf/duration.proto";
+
 // Store provides a location where Feast reads and writes feature values.
 // Feature values will be written to the Store in the form of FeatureRow elements.
 // The way FeatureRow is encoded and decoded when it is written to and read from
@@ -86,6 +88,8 @@ message Store {
       REPLICA_PREFERRED = 3;
     }
     ReadFrom read_from = 8;
+    // Optional. Timeout on waiting response from redis node
+    google.protobuf.Duration timeout = 9;
   }
 
   message Subscription {

--- a/serving/pom.xml
+++ b/serving/pom.xml
@@ -89,7 +89,13 @@
       <artifactId>feast-common</artifactId>
       <version>${project.version}</version>
     </dependency>
-    
+
+    <dependency>
+      <groupId>io.lettuce</groupId>
+      <artifactId>lettuce-core</artifactId>
+      <version>6.0.2.RELEASE</version>
+    </dependency>
+
     <!-- TODO: SLF4J is being used via Lombok, but also jog4j - pick one -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -197,6 +203,7 @@
       <artifactId>simpleclient_servlet</artifactId>
       <version>0.8.0</version>
     </dependency>
+
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_spring_boot</artifactId>

--- a/serving/src/main/resources/application.yml
+++ b/serving/src/main/resources/application.yml
@@ -56,6 +56,7 @@ feast:
         # Connection string specifies the host:port of Redis instances in the redis cluster.
         connection_string: "localhost:7000,localhost:7001,localhost:7002,localhost:7003,localhost:7004,localhost:7005"
         read_from: MASTER
+        timeout: 0.5s
       subscriptions:
         - name: "*"
           project: "*"

--- a/storage/connectors/redis/pom.xml
+++ b/storage/connectors/redis/pom.xml
@@ -16,6 +16,14 @@
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
+            <version>6.0.2.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>4.1.52.Final</version>
+            <classifier>linux-x86_64</classifier>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Default configuration options for redis client are far from ideal. This PR adds basic timeouts / keep-alive / topology refresh options.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Redis Client timeout is configurable through application.yml
```
