### PR TITLE
Allow Feast Client to use REST as transport

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -144,25 +144,26 @@ class Client:
 
         Returns: CoreServiceStub
         """
-        if not self._core_service_stub:
-            if self._transport_name == TransportName.grpc:
-                channel = create_grpc_channel(
-                    url=self._config.get(opt.CORE_URL),
-                    enable_ssl=self._config.getboolean(opt.CORE_ENABLE_SSL),
-                    enable_auth=self._config.getboolean(opt.ENABLE_AUTH),
-                    ssl_server_cert_path=self._config.get(opt.CORE_SERVER_SSL_CERT),
-                    auth_metadata_plugin=self._auth_metadata,
-                    timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
-                )
-                self._core_service_stub = CoreServiceStub(channel)
-            elif self._transport_name == TransportName.rest:
-                self._core_service_stub = CoreServiceRESTStub(
-                    self._config.get(opt.CORE_URL)
-                )
-            else:
-                raise ValueError(
-                    "Unknown transport name: {}".format(self._transport_name)
-                )
+        if self._core_service_stub:
+            return self._core_service_stub
+
+        if self._transport_name == TransportName.grpc:
+            channel = create_grpc_channel(
+                url=self._config.get(opt.CORE_URL),
+                enable_ssl=self._config.getboolean(opt.CORE_ENABLE_SSL),
+                enable_auth=self._config.getboolean(opt.ENABLE_AUTH),
+                ssl_server_cert_path=self._config.get(opt.CORE_SERVER_SSL_CERT),
+                auth_metadata_plugin=self._auth_metadata,
+                timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
+            )
+            self._core_service_stub = CoreServiceStub(channel)
+        elif self._transport_name == TransportName.rest:
+            self._core_service_stub = CoreServiceRESTStub(
+                self._config.get(opt.CORE_URL)
+            )
+        else:
+            raise ValueError("Unknown transport name: {}".format(self._transport_name))
+
         return self._core_service_stub
 
     @property
@@ -184,36 +185,37 @@ class Client:
 
         Returns: ServingServiceStub
         """
-        if not self._serving_service_stub:
-            if self._transport_name == TransportName.grpc:
-                channel = create_grpc_channel(
-                    url=self._config.get(opt.SERVING_URL),
-                    enable_ssl=self._config.getboolean(opt.SERVING_ENABLE_SSL),
-                    enable_auth=self._config.getboolean(opt.ENABLE_AUTH),
-                    ssl_server_cert_path=self._config.get(opt.SERVING_SERVER_SSL_CERT),
-                    auth_metadata_plugin=self._auth_metadata,
-                    timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
-                )
-                try:
-                    import opentracing
-                    from grpc_opentracing import open_tracing_client_interceptor
-                    from grpc_opentracing.grpcext import intercept_channel
+        if self._serving_service_stub:
+            return self._serving_service_stub
 
-                    interceptor = open_tracing_client_interceptor(
-                        opentracing.global_tracer()
-                    )
-                    channel = intercept_channel(channel, interceptor)
-                except ImportError:
-                    pass
-                self._serving_service_stub = ServingServiceStub(channel)
-            elif self._transport_name == TransportName.rest:
-                self._serving_service_stub = ServingServiceRESTStub(
-                    self._config.get(opt.SERVING_URL)
+        if self._transport_name == TransportName.grpc:
+            channel = create_grpc_channel(
+                url=self._config.get(opt.SERVING_URL),
+                enable_ssl=self._config.getboolean(opt.SERVING_ENABLE_SSL),
+                enable_auth=self._config.getboolean(opt.ENABLE_AUTH),
+                ssl_server_cert_path=self._config.get(opt.SERVING_SERVER_SSL_CERT),
+                auth_metadata_plugin=self._auth_metadata,
+                timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
+            )
+            try:
+                import opentracing
+                from grpc_opentracing import open_tracing_client_interceptor
+                from grpc_opentracing.grpcext import intercept_channel
+
+                interceptor = open_tracing_client_interceptor(
+                    opentracing.global_tracer()
                 )
-            else:
-                raise ValueError(
-                    "Unknown transport name: {}".format(self._transport_name)
-                )
+                channel = intercept_channel(channel, interceptor)
+            except ImportError:
+                pass
+            self._serving_service_stub = ServingServiceStub(channel)
+        elif self._transport_name == TransportName.rest:
+            self._serving_service_stub = ServingServiceRESTStub(
+                self._config.get(opt.SERVING_URL)
+            )
+        else:
+            raise ValueError("Unknown transport name: {}".format(self._transport_name))
+
         return self._serving_service_stub
 
     def _extra_grpc_params(self) -> Dict[str, Any]:

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -67,6 +67,7 @@ from feast.protos.feast.core.CoreService_pb2 import (
     ListProjectsRequest,
     ListProjectsResponse,
 )
+from feast.protos.feast.core.CoreService_pb2_grpc import CoreServiceStub
 from feast.protos.feast.serving.ServingService_pb2_grpc import ServingServiceStub
 from feast.registry import Registry
 from feast.rest.core_service_rest_stub import CoreServiceRESTStub

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -87,10 +87,10 @@ class Client:
     """
     Feast Client: Used for creating, managing, and retrieving features.
     """
-    def __init__(self,
-                 options: Optional[Dict[str, str]] = None,
-                 transport_type='grpc',
-                 **kwargs):
+
+    def __init__(
+        self, options: Optional[Dict[str, str]] = None, transport_type="grpc", **kwargs
+    ):
         """
         The Feast Client should be initialized with at least one service url
         Please see constants.py for configuration options. Commonly used options
@@ -123,8 +123,7 @@ class Client:
 
         # Configure Auth Metadata Plugin if auth is enabled
         if self._config.getboolean(opt.ENABLE_AUTH):
-            self._auth_metadata = feast_auth.get_auth_metadata_plugin(
-                self._config)
+            self._auth_metadata = feast_auth.get_auth_metadata_plugin(self._config)
 
         self._configure_telemetry()
 
@@ -140,13 +139,12 @@ class Client:
         Returns: CoreServiceStub
         """
         if not self._core_service_stub:
-            if self._transport_type == 'grpc':
+            if self._transport_type == "grpc":
                 channel = create_grpc_channel(
                     url=self._config.get(opt.CORE_URL),
                     enable_ssl=self._config.getboolean(opt.CORE_ENABLE_SSL),
                     enable_auth=self._config.getboolean(opt.ENABLE_AUTH),
-                    ssl_server_cert_path=self._config.get(
-                        opt.CORE_SERVER_SSL_CERT),
+                    ssl_server_cert_path=self._config.get(opt.CORE_SERVER_SSL_CERT),
                     auth_metadata_plugin=self._auth_metadata,
                     timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                 )
@@ -175,13 +173,12 @@ class Client:
         Returns: ServingServiceStub
         """
         if not self._serving_service_stub:
-            if self._transport_type == 'grpc':
+            if self._transport_type == "grpc":
                 channel = create_grpc_channel(
                     url=self._config.get(opt.SERVING_URL),
                     enable_ssl=self._config.getboolean(opt.SERVING_ENABLE_SSL),
                     enable_auth=self._config.getboolean(opt.ENABLE_AUTH),
-                    ssl_server_cert_path=self._config.get(
-                        opt.SERVING_SERVER_SSL_CERT),
+                    ssl_server_cert_path=self._config.get(opt.SERVING_SERVER_SSL_CERT),
                     auth_metadata_plugin=self._auth_metadata,
                     timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                 )
@@ -191,14 +188,14 @@ class Client:
                     from grpc_opentracing.grpcext import intercept_channel
 
                     interceptor = open_tracing_client_interceptor(
-                        opentracing.global_tracer())
+                        opentracing.global_tracer()
+                    )
                     channel = intercept_channel(channel, interceptor)
                 except ImportError:
                     pass
                 self._serving_service_stub = ServingServiceStub(channel)
             else:
-                self._serving_service_stub = ServingServiceRESTStub(
-                    opt.SERVING_URL)
+                self._serving_service_stub = ServingServiceRESTStub(opt.SERVING_URL)
         return self._serving_service_stub
 
     def _extra_grpc_params(self) -> Dict[str, Any]:
@@ -341,9 +338,7 @@ class Client:
             return sdk_version
 
         result = {
-            "sdk": {
-                "version": sdk_version
-            },
+            "sdk": {"version": sdk_version},
             "serving": "not configured",
             "core": "not configured",
         }
@@ -354,10 +349,7 @@ class Client:
                 timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                 metadata=self._get_grpc_metadata(),
             ).version
-            result["serving"] = {
-                "url": self.serving_url,
-                "version": serving_version
-            }
+            result["serving"] = {"url": self.serving_url, "version": serving_version}
 
         if not self._use_object_store_registry and self.core_url:
             core_version = self._core_service.GetFeastCoreVersion(
@@ -424,7 +416,8 @@ class Client:
 
         if self._use_object_store_registry:
             raise NotImplementedError(
-                "Projects are not implemented for object store registry.")
+                "Projects are not implemented for object store registry."
+            )
         else:
             response = self._core_service.ListProjects(
                 ListProjectsRequest(),
@@ -443,7 +436,8 @@ class Client:
 
         if self._use_object_store_registry:
             raise NotImplementedError(
-                "Projects are not implemented for object store registry.")
+                "Projects are not implemented for object store registry."
+            )
         else:
             self._core_service.CreateProject(
                 CreateProjectRequest(name=project),
@@ -463,7 +457,8 @@ class Client:
 
         if self._use_object_store_registry:
             raise NotImplementedError(
-                "Projects are not implemented for object store registry.")
+                "Projects are not implemented for object store registry."
+            )
         else:
             try:
                 self._core_service_stub.ArchiveProject(
@@ -480,8 +475,7 @@ class Client:
 
     def apply(
         self,
-        objects: Union[List[Union[Entity, FeatureTable]], Entity,
-                       FeatureTable],
+        objects: Union[List[Union[Entity, FeatureTable]], Entity, FeatureTable],
         project: str = None,
     ):
         """
@@ -530,9 +524,7 @@ class Client:
                     f"Could not determine object type to apply {obj} with type {type(obj)}. Type must be Entity or FeatureTable."
                 )
 
-    def apply_entity(self,
-                     entities: Union[List[Entity], Entity],
-                     project: str = None):
+    def apply_entity(self, entities: Union[List[Entity], Entity], project: str = None):
         """
         Deprecated. Please see apply().
         """
@@ -550,8 +542,7 @@ class Client:
             if isinstance(entity, Entity):
                 self._apply_entity(project, entity)  # type: ignore
                 continue
-            raise ValueError(
-                f"Could not determine entity type to apply {entity}")
+            raise ValueError(f"Could not determine entity type to apply {entity}")
 
     def _apply_entity(self, project: str, entity: Entity):
         """
@@ -570,8 +561,9 @@ class Client:
             # Convert the entity to a request and send to Feast Core
             try:
                 apply_entity_response = self._core_service.ApplyEntity(
-                    ApplyEntityRequest(project=project,
-                                       spec=entity_proto),  # type: ignore
+                    ApplyEntityRequest(
+                        project=project, spec=entity_proto
+                    ),  # type: ignore
                     timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                     metadata=self._get_grpc_metadata(),
                 )  # type: ApplyEntityResponse
@@ -584,9 +576,9 @@ class Client:
             # Deep copy from the returned entity to the local entity
             entity._update_from_entity(applied_entity)
 
-    def list_entities(self,
-                      project: str = None,
-                      labels: Dict[str, str] = dict()) -> List[Entity]:
+    def list_entities(
+        self, project: str = None, labels: Dict[str, str] = dict()
+    ) -> List[Entity]:
         """
         Retrieve a list of entities from Feast Core
 
@@ -608,8 +600,7 @@ class Client:
 
             # Get latest entities from Feast Core
             entity_protos = self._core_service.ListEntities(
-                ListEntitiesRequest(filter=filter),
-                metadata=self._get_grpc_metadata(),
+                ListEntitiesRequest(filter=filter), metadata=self._get_grpc_metadata(),
             )  # type: ListEntitiesResponse
 
             # Extract entities and return
@@ -678,8 +669,7 @@ class Client:
             feature_tables = [feature_tables]
         for feature_table in feature_tables:
             if isinstance(feature_table, FeatureTable):
-                self._apply_feature_table(project,
-                                          feature_table)  # type: ignore
+                self._apply_feature_table(project, feature_table)  # type: ignore
                 continue
             raise ValueError(
                 f"Could not determine feature table type to apply {feature_table}"
@@ -703,8 +693,8 @@ class Client:
             try:
                 apply_feature_table_response = self._core_service.ApplyFeatureTable(
                     ApplyFeatureTableRequest(
-                        project=project,
-                        table_spec=feature_table_proto),  # type: ignore
+                        project=project, table_spec=feature_table_proto
+                    ),  # type: ignore
                     timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                     metadata=self._get_grpc_metadata(),
                 )  # type: ApplyFeatureTableResponse
@@ -713,15 +703,14 @@ class Client:
 
             # Extract the returned feature table
             applied_feature_table = FeatureTable.from_proto(
-                apply_feature_table_response.table)
+                apply_feature_table_response.table
+            )
 
             # Deep copy from the returned feature table to the local entity
             feature_table._update_from_feature_table(applied_feature_table)
 
     def list_feature_tables(
-        self,
-        project: str = None,
-        labels: Dict[str, str] = dict()
+        self, project: str = None, labels: Dict[str, str] = dict()
     ) -> List[FeatureTable]:
         """
         Retrieve a list of feature tables from Feast Core
@@ -739,8 +728,7 @@ class Client:
         if self._use_object_store_registry:
             return self._registry.list_feature_tables(project)
         else:
-            filter = ListFeatureTablesRequest.Filter(project=project,
-                                                     labels=labels)
+            filter = ListFeatureTablesRequest.Filter(project=project, labels=labels)
 
             # Get latest feature tables from Feast Core
             feature_table_protos = self._core_service.ListFeatureTables(
@@ -756,9 +744,7 @@ class Client:
                 feature_tables.append(feature_table)
             return feature_tables
 
-    def get_feature_table(self,
-                          name: str,
-                          project: str = None) -> FeatureTable:
+    def get_feature_table(self, name: str, project: str = None) -> FeatureTable:
         """
         Retrieves a feature table.
 
@@ -811,18 +797,17 @@ class Client:
         else:
             try:
                 self._core_service.DeleteFeatureTable(
-                    DeleteFeatureTableRequest(project=project,
-                                              name=name.strip()),
+                    DeleteFeatureTableRequest(project=project, name=name.strip()),
                     metadata=self._get_grpc_metadata(),
                 )
             except grpc.RpcError as e:
                 raise grpc.RpcError(e.details())
 
     def list_features_by_ref(
-            self,
-            project: str = None,
-            entities: List[str] = list(),
-            labels: Dict[str, str] = dict(),
+        self,
+        project: str = None,
+        entities: List[str] = list(),
+        labels: Dict[str, str] = dict(),
     ) -> Dict[FeatureRef, Feature]:
         """
         Retrieve a dictionary of feature reference to feature from Feast Core based on filters provided.
@@ -845,18 +830,18 @@ class Client:
 
         if self._use_object_store_registry:
             raise NotImplementedError(
-                "This function is not implemented for object store registry.")
+                "This function is not implemented for object store registry."
+            )
         else:
             if project is None:
                 project = self.project
 
-            filter = ListFeaturesRequest.Filter(project=project,
-                                                entities=entities,
-                                                labels=labels)
+            filter = ListFeaturesRequest.Filter(
+                project=project, entities=entities, labels=labels
+            )
 
             feature_protos = self._core_service.ListFeatures(
-                ListFeaturesRequest(filter=filter),
-                metadata=self._get_grpc_metadata(),
+                ListFeaturesRequest(filter=filter), metadata=self._get_grpc_metadata(),
             )  # type: ListFeaturesResponse
 
             # Extract features and return
@@ -934,18 +919,21 @@ class Client:
             name = feature_table.name
 
         fetched_feature_table: Optional[FeatureTable] = self.get_feature_table(
-            name, project)
+            name, project
+        )
         if fetched_feature_table is not None:
             feature_table = fetched_feature_table
         else:
             raise Exception(f"FeatureTable, {name} cannot be found.")
 
         # Check 1) Only parquet file format for FeatureTable batch source is supported
-        if (feature_table.batch_source
-                and issubclass(type(feature_table.batch_source), FileSource)
-                and isinstance(
-                    type(feature_table.batch_source.file_options.file_format),
-                    ParquetFormat)):
+        if (
+            feature_table.batch_source
+            and issubclass(type(feature_table.batch_source), FileSource)
+            and isinstance(
+                type(feature_table.batch_source.file_options.file_format), ParquetFormat
+            )
+        ):
             raise Exception(
                 f"No suitable batch source found for FeatureTable, {name}."
                 f"Only BATCH_FILE source with parquet format is supported for batch ingestion."
@@ -962,8 +950,10 @@ class Client:
 
         dir_path = None
         with_partitions = False
-        if (issubclass(type(feature_table.batch_source), FileSource)
-                and feature_table.batch_source.date_partition_column):
+        if (
+            issubclass(type(feature_table.batch_source), FileSource)
+            and feature_table.batch_source.date_partition_column
+        ):
             with_partitions = True
             dest_path = _write_partitioned_table_from_source(
                 column_names,
@@ -973,34 +963,31 @@ class Client:
             )
         else:
             dir_path, dest_path = _write_non_partitioned_table_from_source(
-                column_names,
-                pyarrow_table,
-                chunk_size,
-                max_workers,
+                column_names, pyarrow_table, chunk_size, max_workers,
             )
 
         try:
             if issubclass(type(feature_table.batch_source), FileSource):
-                file_url = feature_table.batch_source.file_options.file_url.rstrip(
-                    "*")
-                _upload_to_file_source(file_url, with_partitions, dest_path,
-                                       self._config)
+                file_url = feature_table.batch_source.file_options.file_url.rstrip("*")
+                _upload_to_file_source(
+                    file_url, with_partitions, dest_path, self._config
+                )
             if issubclass(type(feature_table.batch_source), BigQuerySource):
                 bq_table_ref = feature_table.batch_source.bigquery_options.table_ref
                 feature_table_timestamp_column = (
-                    feature_table.batch_source.event_timestamp_column)
+                    feature_table.batch_source.event_timestamp_column
+                )
 
-                _upload_to_bq_source(bq_table_ref,
-                                     feature_table_timestamp_column, dest_path)
+                _upload_to_bq_source(
+                    bq_table_ref, feature_table_timestamp_column, dest_path
+                )
         finally:
             # Remove parquet file(s) that were created earlier
             print("Removing temporary file(s)...")
             if dir_path:
                 shutil.rmtree(dir_path)
 
-        print(
-            "Data has been successfully ingested into FeatureTable batch source."
-        )
+        print("Data has been successfully ingested into FeatureTable batch source.")
 
     def _get_grpc_metadata(self):
         """
@@ -1060,8 +1047,7 @@ class Client:
         try:
             response = self._serving_service.GetOnlineFeaturesV2(
                 GetOnlineFeaturesRequestV2(
-                    features=_build_feature_references(
-                        feature_ref_strs=feature_refs),
+                    features=_build_feature_references(feature_ref_strs=feature_refs),
                     entity_rows=_infer_online_entity_rows(entity_rows),
                     project=project if project is not None else self.project,
                 ),

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -156,7 +156,9 @@ class Client:
                 )
                 self._core_service_stub = CoreServiceStub(channel)
             elif self._transport_name == TransportName.rest:
-                self._core_service_stub = CoreServiceRESTStub(opt.CORE_URL)
+                self._core_service_stub = CoreServiceRESTStub(
+                    self._config.get(opt.CORE_URL)
+                )
             else:
                 raise ValueError(
                     "Unknown transport name: {}".format(self._transport_name)
@@ -205,7 +207,9 @@ class Client:
                     pass
                 self._serving_service_stub = ServingServiceStub(channel)
             elif self._transport_name == TransportName.rest:
-                self._serving_service_stub = ServingServiceRESTStub(opt.SERVING_URL)
+                self._serving_service_stub = ServingServiceRESTStub(
+                    self._config.get(opt.SERVING_URL)
+                )
             else:
                 raise ValueError(
                     "Unknown transport name: {}".format(self._transport_name)

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -481,7 +481,7 @@ class Client:
             )
         else:
             try:
-                self._core_service_stub.ArchiveProject(
+                self._core_service.ArchiveProject(
                     ArchiveProjectRequest(name=project),
                     timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                     metadata=self._get_grpc_metadata(),

--- a/sdk/python/feast/grpc/auth.py
+++ b/sdk/python/feast/grpc/auth.py
@@ -103,13 +103,13 @@ class OAuthMetadataPlugin(grpc.AuthMetadataPlugin):
         import requests
 
         headers_token = {"content-type": "application/json"}
-        data_token = {
+        data_token_dict = {
             "grant_type": config.get(opt.OAUTH_GRANT_TYPE),
             "client_id": config.get(opt.OAUTH_CLIENT_ID),
             "client_secret": config.get(opt.OAUTH_CLIENT_SECRET),
             "audience": config.get(opt.OAUTH_AUDIENCE),
         }
-        data_token = json.dumps(data_token)
+        data_token = json.dumps(data_token_dict)
         response_token = requests.post(
             config.get(opt.OAUTH_TOKEN_REQUEST_URL),
             headers=headers_token,

--- a/sdk/python/feast/rest/README.md
+++ b/sdk/python/feast/rest/README.md
@@ -1,0 +1,1 @@
+# REST Client

--- a/sdk/python/feast/rest/README.md
+++ b/sdk/python/feast/rest/README.md
@@ -1,1 +1,0 @@
-# REST Client

--- a/sdk/python/feast/rest/core_service_rest_stub.py
+++ b/sdk/python/feast/rest/core_service_rest_stub.py
@@ -32,9 +32,7 @@ from feast.rest.transport import rest_transport
 
 
 class CoreServiceRESTStub(object):
-    def __init__(
-        self, core_url="localhost:6565", service_name="feast.core.CoreService"
-    ) -> None:
+    def __init__(self, core_url, service_name="feast.core.CoreService") -> None:
         super().__init__()
         self._url = core_url
         self._service_name = service_name

--- a/sdk/python/feast/rest/core_service_rest_stub.py
+++ b/sdk/python/feast/rest/core_service_rest_stub.py
@@ -34,8 +34,8 @@ from feast.rest.transport import rest_transport
 class CoreServiceRESTStub(object):
     def __init__(self, core_url, service_name="feast.core.CoreService") -> None:
         super().__init__()
-        self._url = core_url
-        self._service_name = service_name
+        self.url = core_url
+        self.service_name = service_name
 
     @rest_transport
     def GetFeastCoreVersion(

--- a/sdk/python/feast/rest/core_service_rest_stub.py
+++ b/sdk/python/feast/rest/core_service_rest_stub.py
@@ -1,21 +1,3 @@
-import inspect
-import logging
-import multiprocessing
-import os
-import shutil
-import uuid
-import warnings
-from datetime import datetime
-from os.path import expanduser, join
-from typing import Any, Dict, List, Optional, Union
-
-import grpc
-import pandas as pd
-import requests
-from google.protobuf.json_format import MessageToJson, ParseDict
-
-from feast.config import Config
-from feast.constants import ConfigOptions as opt
 from feast.core.CoreService_pb2 import (
     ApplyEntityRequest,
     ApplyEntityResponse,
@@ -26,9 +8,11 @@ from feast.core.CoreService_pb2 import (
     CreateProjectRequest,
     CreateProjectResponse,
     DeleteFeatureTableRequest,
+    DeleteFeatureTableResponse,
     GetEntityRequest,
     GetEntityResponse,
     GetFeastCoreVersionRequest,
+    GetFeastCoreVersionResponse,
     GetFeatureTableRequest,
     GetFeatureTableResponse,
     ListEntitiesRequest,
@@ -39,48 +23,98 @@ from feast.core.CoreService_pb2 import (
     ListFeatureTablesResponse,
     ListProjectsRequest,
     ListProjectsResponse,
+    ListStoresRequest,
+    ListStoresResponse,
+    UpdateStoreRequest,
+    UpdateStoreResponse,
 )
-from feast.core.CoreService_pb2_grpc import CoreServiceStub
-from feast.data_format import ParquetFormat
-from feast.data_source import BigQuerySource, FileSource
-from feast.entity import Entity
-from feast.feature import Feature, FeatureRef, _build_feature_references
-from feast.feature_table import FeatureTable
-import json
-
-
-def grpc_rest_proxy(func, return_msg_type=None):
-    def wrapper(*args, **kwargs):
-        base_url = args[0].url
-        service_name = args[0].service_name
-
-        # Turn gRPC requests into dict
-        request_grpc = args[1]
-        request_json = MessageToJson(request_grpc)
-        url = os.path.join(base_url, service_name, func.__name__)
-
-        # Send request to REST endpoint
-        response = requests.post(url, data=request_json)
-
-        # Parse return dict into return message type
-        signature = inspect.signature(func)
-        return_type = signature.return_annotation
-
-        response_json = json.loads(response.text)
-        return_msg = return_type()
-        ParseDict(response_json, return_msg)
-        return return_msg
-
-    return wrapper
+from feast.rest.transport import rest_transport
 
 
 class CoreServiceRESTStub(object):
-    def __init__(self, core_url) -> None:
+    def __init__(
+        self, core_url="localhost:6565", service_name="feast.core.CoreService"
+    ) -> None:
         super().__init__()
-        self.url = core_url
-        self.service_name = "feast.core.CoreService"
+        self._url = core_url
+        self._service_name = service_name
 
-    @grpc_rest_proxy
-    def ListProjects(self, req: ListProjectsRequest, *args,
-                     **kwargs) -> ListProjectsResponse:
+    @rest_transport
+    def GetFeastCoreVersion(
+        self, req: GetFeastCoreVersionRequest, *args, **kwargs
+    ) -> GetFeastCoreVersionResponse:
+        pass
+
+    @rest_transport
+    def GetEntity(self, req: GetEntityRequest, *args, **kwargs) -> GetEntityResponse:
+        pass
+
+    @rest_transport
+    def ListFeatures(
+        self, req: ListFeaturesRequest, *args, **kwargs
+    ) -> ListFeaturesResponse:
+        pass
+
+    @rest_transport
+    def ListStores(self, req: ListStoresRequest, *args, **kwargs) -> ListStoresResponse:
+        pass
+
+    @rest_transport
+    def ApplyEntity(
+        self, req: ApplyEntityRequest, *args, **kwargs
+    ) -> ApplyEntityResponse:
+        pass
+
+    @rest_transport
+    def ListEntities(
+        self, req: ListEntitiesRequest, *args, **kwargs
+    ) -> ListEntitiesResponse:
+        pass
+
+    @rest_transport
+    def UpdateStore(
+        self, req: UpdateStoreRequest, *args, **kwargs
+    ) -> UpdateStoreResponse:
+        pass
+
+    @rest_transport
+    def CreateProject(
+        self, req: CreateProjectRequest, *args, **kwargs
+    ) -> CreateProjectResponse:
+        pass
+
+    @rest_transport
+    def ArchiveProject(
+        self, req: ArchiveProjectRequest, *args, **kwargs
+    ) -> ArchiveProjectResponse:
+        pass
+
+    @rest_transport
+    def ListProjects(
+        self, req: ListProjectsRequest, *args, **kwargs
+    ) -> ListProjectsResponse:
+        pass
+
+    @rest_transport
+    def ApplyFeatureTable(
+        self, req: ApplyFeatureTableRequest, *args, **kwargs
+    ) -> ApplyFeatureTableResponse:
+        pass
+
+    @rest_transport
+    def ListFeatureTables(
+        self, req: ListFeatureTablesRequest, *args, **kwargs
+    ) -> ListFeatureTablesResponse:
+        pass
+
+    @rest_transport
+    def GetFeatureTable(
+        self, req: GetFeatureTableRequest, *args, **kwargs
+    ) -> GetFeatureTableResponse:
+        pass
+
+    @rest_transport
+    def DeleteFeatureTable(
+        self, req: DeleteFeatureTableRequest, *args, **kwargs
+    ) -> DeleteFeatureTableResponse:
         pass

--- a/sdk/python/feast/rest/core_service_rest_stub.py
+++ b/sdk/python/feast/rest/core_service_rest_stub.py
@@ -1,0 +1,86 @@
+import inspect
+import logging
+import multiprocessing
+import os
+import shutil
+import uuid
+import warnings
+from datetime import datetime
+from os.path import expanduser, join
+from typing import Any, Dict, List, Optional, Union
+
+import grpc
+import pandas as pd
+import requests
+from google.protobuf.json_format import MessageToJson, ParseDict
+
+from feast.config import Config
+from feast.constants import ConfigOptions as opt
+from feast.core.CoreService_pb2 import (
+    ApplyEntityRequest,
+    ApplyEntityResponse,
+    ApplyFeatureTableRequest,
+    ApplyFeatureTableResponse,
+    ArchiveProjectRequest,
+    ArchiveProjectResponse,
+    CreateProjectRequest,
+    CreateProjectResponse,
+    DeleteFeatureTableRequest,
+    GetEntityRequest,
+    GetEntityResponse,
+    GetFeastCoreVersionRequest,
+    GetFeatureTableRequest,
+    GetFeatureTableResponse,
+    ListEntitiesRequest,
+    ListEntitiesResponse,
+    ListFeaturesRequest,
+    ListFeaturesResponse,
+    ListFeatureTablesRequest,
+    ListFeatureTablesResponse,
+    ListProjectsRequest,
+    ListProjectsResponse,
+)
+from feast.core.CoreService_pb2_grpc import CoreServiceStub
+from feast.data_format import ParquetFormat
+from feast.data_source import BigQuerySource, FileSource
+from feast.entity import Entity
+from feast.feature import Feature, FeatureRef, _build_feature_references
+from feast.feature_table import FeatureTable
+import json
+
+
+def grpc_rest_proxy(func, return_msg_type=None):
+    def wrapper(*args, **kwargs):
+        base_url = args[0].url
+        service_name = args[0].service_name
+
+        # Turn gRPC requests into dict
+        request_grpc = args[1]
+        request_json = MessageToJson(request_grpc)
+        url = os.path.join(base_url, service_name, func.__name__)
+
+        # Send request to REST endpoint
+        response = requests.post(url, data=request_json)
+
+        # Parse return dict into return message type
+        signature = inspect.signature(func)
+        return_type = signature.return_annotation
+
+        response_json = json.loads(response.text)
+        return_msg = return_type()
+        ParseDict(response_json, return_msg)
+        return return_msg
+
+    return wrapper
+
+
+class CoreServiceRESTStub(object):
+    def __init__(self, core_url) -> None:
+        super().__init__()
+        self.url = core_url
+        self.service_name = "feast.core.CoreService"
+
+    @grpc_rest_proxy
+    def ListProjects(self, req: ListProjectsRequest, *args,
+                     **kwargs) -> ListProjectsResponse:
+        pass

--- a/sdk/python/feast/rest/serving_service_rest_stub.py
+++ b/sdk/python/feast/rest/serving_service_rest_stub.py
@@ -8,10 +8,12 @@ from feast.serving.ServingService_pb2 import (
 
 
 class ServingServiceRESTStub(object):
-    def __init__(self, serving_url) -> None:
+    def __init__(
+        self, serving_url, service_name="feast.serving.ServingService"
+    ) -> None:
         super().__init__()
         self.url = serving_url
-        self.service_name = "feast.serving.ServingService"
+        self.service_name = service_name
 
     @rest_transport
     def GetFeastServingInfo(

--- a/sdk/python/feast/rest/serving_service_rest_stub.py
+++ b/sdk/python/feast/rest/serving_service_rest_stub.py
@@ -1,0 +1,5 @@
+class ServingServiceRESTStub(object):
+    def __init__(self, serving_url) -> None:
+        super().__init__()
+        self.url = serving_url
+        self.service_name = "feast.serving.ServingService"

--- a/sdk/python/feast/rest/serving_service_rest_stub.py
+++ b/sdk/python/feast/rest/serving_service_rest_stub.py
@@ -1,5 +1,26 @@
+from feast.rest.transport import rest_transport
+from feast.serving.ServingService_pb2 import (
+    GetFeastServingInfoRequest,
+    GetFeastServingInfoResponse,
+    GetOnlineFeaturesRequestV2,
+    GetOnlineFeaturesResponse,
+)
+
+
 class ServingServiceRESTStub(object):
     def __init__(self, serving_url) -> None:
         super().__init__()
         self.url = serving_url
         self.service_name = "feast.serving.ServingService"
+
+    @rest_transport
+    def GetFeastServingInfo(
+        self, req: GetFeastServingInfoRequest, *args, **kwargs
+    ) -> GetFeastServingInfoResponse:
+        pass
+
+    @rest_transport
+    def GetOnlineFeatures(
+        self, req: GetOnlineFeaturesRequestV2, *args, **kwargs
+    ) -> GetOnlineFeaturesResponse:
+        pass

--- a/sdk/python/feast/rest/transport.py
+++ b/sdk/python/feast/rest/transport.py
@@ -1,0 +1,31 @@
+import inspect
+import json
+import os
+
+import requests
+from google.protobuf.json_format import MessageToJson, ParseDict
+
+
+def rest_transport(func):
+    def wrapper(*args, **kwargs):
+        base_url = args[0]._url
+        service_name = args[0]._service_name
+
+        # Turn gRPC requests into json.
+        request_grpc = args[1]
+        request_json = MessageToJson(request_grpc)
+        url = os.path.join(base_url, service_name, func.__name__)
+
+        # Send request to REST endpoint
+        response = requests.post(url, data=request_json)
+        response_json = json.loads(response.text)
+
+        # Parse return dict into return message type
+        signature = inspect.signature(func)
+        return_msg_type = signature.return_annotation
+        return_msg = return_msg_type()
+        ParseDict(response_json, return_msg)
+
+        return return_msg
+
+    return wrapper

--- a/sdk/python/feast/rest/transport.py
+++ b/sdk/python/feast/rest/transport.py
@@ -18,7 +18,12 @@ def rest_transport(func):
 
         # Send request to REST endpoint
         response = requests.post(url, data=request_json)
-        response_json = json.loads(response.text)
+
+        if response.status_code != 200:
+            raise RuntimeError(
+                "Response code is not 200 due to: {}".format(response.text)
+            )
+        response_json = response.json()
 
         # Parse return dict into return message type
         signature = inspect.signature(func)

--- a/sdk/python/feast/rest/transport.py
+++ b/sdk/python/feast/rest/transport.py
@@ -7,9 +7,18 @@ from google.protobuf.json_format import MessageToJson, ParseDict
 
 
 def rest_transport(func):
+    """Convert a class method that issues gRPC calls into REST calls.
+
+    The class is assumed to have two variables: url and service_name. The REST endpoint is 
+    constructed as: {url}/{service_name}/{class method name}.
+
+    Args:
+        func: A class method with signature func(self, grpc_request_message, *args, **kwargs)
+    """
+
     def wrapper(*args, **kwargs):
-        base_url = args[0]._url
-        service_name = args[0]._service_name
+        base_url = args[0].url
+        service_name = args[0].service_name
 
         # Turn gRPC requests into json.
         request_grpc = args[1]
@@ -18,7 +27,6 @@ def rest_transport(func):
 
         # Send request to REST endpoint
         response = requests.post(url, data=request_json)
-
         if response.status_code != 200:
             raise RuntimeError(
                 "Response code is not 200 due to: {}".format(response.text)

--- a/sdk/python/feast/rest/transport.py
+++ b/sdk/python/feast/rest/transport.py
@@ -1,5 +1,4 @@
 import inspect
-import json
 import os
 
 import requests
@@ -9,7 +8,7 @@ from google.protobuf.json_format import MessageToJson, ParseDict
 def rest_transport(func):
     """Convert a class method that issues gRPC calls into REST calls.
 
-    The class is assumed to have two variables: url and service_name. The REST endpoint is 
+    The class is assumed to have two variables: url and service_name. The REST endpoint is
     constructed as: {url}/{service_name}/{class method name}.
 
     Args:


### PR DESCRIPTION
Send out the PR for discussion purpose. This PR introduces two classes CoreServiceRESTStub and ServingServiceRESTStub to allow the client using REST as transport method. It uses decorator to convert gRPC calls into REST calls, then convert the response back to protobuf messages. Here's an example usage of this feature:

```
import feast
feast_client = feast.Client(core_url="http://localhost:8000", serving_url="http://localhost:8000", transport_name="rest")
feast_client.list_projects()
```

**What this PR does / why we need it**:

Allow client to use REST as transport.

**Does this PR introduce a user-facing change?**:
None

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow client to use REST as transport method.
```
