### PR TITLE
Fix a bug in client archive_project method and fix lint in grpc auth

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -451,7 +451,7 @@ class Client:
             )
         else:
             try:
-                self._core_service_stub.ArchiveProject(
+                self._core_service.ArchiveProject(
                     ArchiveProjectRequest(name=project),
                     timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                     metadata=self._get_grpc_metadata(),

--- a/sdk/python/feast/grpc/auth.py
+++ b/sdk/python/feast/grpc/auth.py
@@ -103,13 +103,13 @@ class OAuthMetadataPlugin(grpc.AuthMetadataPlugin):
         import requests
 
         headers_token = {"content-type": "application/json"}
-        data_token = {
+        data_token_dict = {
             "grant_type": config.get(opt.OAUTH_GRANT_TYPE),
             "client_id": config.get(opt.OAUTH_CLIENT_ID),
             "client_secret": config.get(opt.OAUTH_CLIENT_SECRET),
             "audience": config.get(opt.OAUTH_AUDIENCE),
         }
-        data_token = json.dumps(data_token)
+        data_token = json.dumps(data_token_dict)
         response_token = requests.post(
             config.get(opt.OAUTH_TOKEN_REQUEST_URL),
             headers=headers_token,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix bug in client.archive_project. It should use the core_service method instead of raw core_service_stub. Also fix lint in grpc/auth.py.

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Fix bug in client.archive_project and fix lint in grpc auth
```
