### PR TITLE
Add online read API to FeatureStore class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ compile-protos-python:
 	printenv
 	pip install --ignore-installed mypy-protobuf || echo "Mypy could not be installed"
 	@$(foreach dir,$(PROTO_TYPE_SUBDIRS),cd ${ROOT_DIR}/protos; python -m grpc_tools.protoc -I. --grpc_python_out=../sdk/python/feast/protos/ --python_out=../sdk/python/feast/protos/ --mypy_out=../sdk/python/feast/protos/ feast/$(dir)/*.proto;)
-	@$(foreach dir,$(PROTO_TYPE_SUBDIRS),grep -rli 'from feast.$(dir)' sdk/python/feast/protos | xargs -i@ sed -i 's/from feast.$(dir)/from feast.protos.feast.$(dir)/g' @;)
+	@$(foreach dir,$(PROTO_TYPE_SUBDIRS),grep -rli 'from feast.$(dir)' sdk/python/feast/protos | xargs -I@ sed -i.bak 's/from feast.$(dir)/from feast.protos.feast.$(dir)/g' @;)
 	cd ${ROOT_DIR}/protos; python -m grpc_tools.protoc -I. --python_out=../sdk/python/ --mypy_out=../sdk/python/ tensorflow_metadata/proto/v0/*.proto
 
 install-python:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ package-protos:
 	cp -r ${ROOT_DIR}/protos ${ROOT_DIR}/sdk/python/feast/protos
 
 compile-protos-python:
-	printenv
 	pip install --ignore-installed mypy-protobuf || echo "Mypy could not be installed"
 	@$(foreach dir,$(PROTO_TYPE_SUBDIRS),cd ${ROOT_DIR}/protos; python -m grpc_tools.protoc -I. --grpc_python_out=../sdk/python/feast/protos/ --python_out=../sdk/python/feast/protos/ --mypy_out=../sdk/python/feast/protos/ feast/$(dir)/*.proto;)
 	@$(foreach dir,$(PROTO_TYPE_SUBDIRS),grep -rli 'from feast.$(dir)' sdk/python/feast/protos | xargs -I@ sed -i.bak 's/from feast.$(dir)/from feast.protos.feast.$(dir)/g' @;)

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -68,15 +68,16 @@ class Provider(abc.ABC):
         self,
         project: str,
         table: Union[FeatureTable, FeatureView],
-        entity_key: EntityKeyProto,
-    ) -> Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]:
+        entity_keys: List[EntityKeyProto],
+    ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
         """
         Read feature values given an Entity Key. This is a low level interface, not
         expected to be used by the users directly.
 
         Returns:
-            A tuple of event_ts for the row, and the feature data as a dict from feature names
-            to values. Values are returned as Value proto message.
+            Data is returned as a list, one item per entity key. Each item in the list is a tuple
+            of event_ts for the row, and the feature data as a dict from feature names to values.
+            Values are returned as Value proto message.
         """
         ...
 

--- a/sdk/python/tests/cli/example_feature_repo_1.py
+++ b/sdk/python/tests/cli/example_feature_repo_1.py
@@ -28,3 +28,17 @@ driver_locations = FeatureView(
     input=driver_locations_source,
     tags={},
 )
+
+driver_locations_2 = FeatureView(
+    name="driver_locations_2",
+    entities=["driver"],
+    ttl=Duration(seconds=86400 * 1),
+    features=[
+        Feature(name="lat", dtype=ValueType.FLOAT),
+        Feature(name="lon", dtype=ValueType.STRING),
+        Feature(name="name", dtype=ValueType.STRING),
+    ],
+    online=True,
+    input=driver_locations_source,
+    tags={},
+)

--- a/sdk/python/tests/cli/online_read_write_test.py
+++ b/sdk/python/tests/cli/online_read_write_test.py
@@ -41,9 +41,11 @@ def basic_rw_test(repo_path: Path, project_name: str) -> None:
             ],
         )
 
-        _, val = provider.online_read(
-            project=project_name, table=table, entity_key=entity_key
+        read_rows = provider.online_read(
+            project=project_name, table=table, entity_keys=[entity_key]
         )
+        assert len(read_rows) == 1
+        _, val = read_rows[0]
         assert val["lon"].string_val == expect_lon
         assert abs(val["lat"].double_val - expect_lat) < 1e-6
 

--- a/sdk/python/tests/cli/test_cli_local.py
+++ b/sdk/python/tests/cli/test_cli_local.py
@@ -1,23 +1,9 @@
-import subprocess
-import sys
 import tempfile
 from pathlib import Path
 from textwrap import dedent
-from typing import List
 
-from feast import cli
 from tests.cli.online_read_write_test import basic_rw_test
-
-
-class CliRunner:
-    """
-    NB. We can't use test runner helper from click here, since it doesn't start a new Python
-    interpreter. And we need a new interpreter for each test since we dynamically import
-    modules from the feature repo, and it is hard to clean up that state otherwise.
-    """
-
-    def run(self, args: List[str], cwd: Path) -> subprocess.CompletedProcess:
-        return subprocess.run([sys.executable, cli.__file__] + args, cwd=cwd)
+from tests.cli.utils import CliRunner
 
 
 class TestCliLocal:
@@ -25,6 +11,7 @@ class TestCliLocal:
         runner = CliRunner()
         with tempfile.TemporaryDirectory() as repo_dir_name, tempfile.TemporaryDirectory() as data_dir_name:
 
+            # Construct an example repo in a temporary dir
             repo_path = Path(repo_dir_name)
             data_path = Path(data_dir_name)
 

--- a/sdk/python/tests/cli/test_datastore.py
+++ b/sdk/python/tests/cli/test_datastore.py
@@ -1,27 +1,13 @@
 import random
 import string
-import subprocess
-import sys
 import tempfile
 from pathlib import Path
 from textwrap import dedent
-from typing import List
 
 import pytest
 
-from feast import cli
 from tests.cli.online_read_write_test import basic_rw_test
-
-
-class CliRunner:
-    """
-    NB. We can't use test runner helper from click here, since it doesn't start a new Python
-    interpreter. And we need a new interpreter for each test since we dynamically import
-    modules from the feature repo, and it is hard to clean up that state otherwise.
-    """
-
-    def run(self, args: List[str], cwd: Path) -> subprocess.CompletedProcess:
-        return subprocess.run([sys.executable, cli.__file__] + args, cwd=cwd)
+from tests.cli.utils import CliRunner
 
 
 @pytest.mark.integration

--- a/sdk/python/tests/cli/test_online_retrieval.py
+++ b/sdk/python/tests/cli/test_online_retrieval.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+
+import pytest
+
+from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+from tests.cli.utils import CliRunner
+
+
+class TestOnlineRetrieval:
+    def test_basic(self) -> None:
+        runner = CliRunner()
+        with runner.local_repo("example_feature_repo_1.py") as store:
+
+            # Write some data to two tables
+            registry = store._get_registry()
+            table = registry.get_feature_view(
+                project=store.config.project, name="driver_locations"
+            )
+            table_2 = registry.get_feature_view(
+                project=store.config.project, name="driver_locations_2"
+            )
+
+            provider = store._get_provider()
+
+            entity_key = EntityKeyProto(
+                entity_names=["driver"], entity_values=[ValueProto(int64_val=1)]
+            )
+            provider.online_write_batch(
+                project=store.config.project,
+                table=table,
+                data=[
+                    (
+                        entity_key,
+                        {
+                            "lat": ValueProto(double_val=0.1),
+                            "lon": ValueProto(string_val="1.0"),
+                        },
+                        datetime.utcnow(),
+                        datetime.utcnow(),
+                    )
+                ],
+            )
+
+            provider.online_write_batch(
+                project=store.config.project,
+                table=table_2,
+                data=[
+                    (
+                        entity_key,
+                        {
+                            "lat": ValueProto(double_val=2.0),
+                            "lon": ValueProto(string_val="2.0"),
+                        },
+                        datetime.utcnow(),
+                        datetime.utcnow(),
+                    )
+                ],
+            )
+
+            # Retrieve two features using two keys, one valid one non-existing
+            result = store.get_online_features(
+                feature_refs=["driver_locations:lon", "driver_locations_2:lon"],
+                entity_rows=[{"driver": 1}, {"driver": 123}],
+            )
+
+            assert "driver_locations:lon" in result.to_dict()
+            assert result.to_dict()["driver_locations:lon"] == ["1.0", None]
+            assert result.to_dict()["driver_locations_2:lon"] == ["2.0", None]
+
+            # invalid table reference
+            with pytest.raises(ValueError):
+                store.get_online_features(
+                    feature_refs=["driver_locations_bad:lon"],
+                    entity_rows=[{"driver": 1}],
+                )

--- a/sdk/python/tests/cli/utils.py
+++ b/sdk/python/tests/cli/utils.py
@@ -1,0 +1,66 @@
+import random
+import string
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from textwrap import dedent
+from typing import List
+
+from feast import cli
+from feast.feature_store import FeatureStore
+
+
+class CliRunner:
+    """
+    NB. We can't use test runner helper from click here, since it doesn't start a new Python
+    interpreter. And we need a new interpreter for each test since we dynamically import
+    modules from the feature repo, and it is hard to clean up that state otherwise.
+    """
+
+    def run(self, args: List[str], cwd: Path) -> subprocess.CompletedProcess:
+        return subprocess.run([sys.executable, cli.__file__] + args, cwd=cwd)
+
+    @contextmanager
+    def local_repo(self, example_repo_py: str):
+        """
+        Convenience method to set up all the boilerplate for a local feature repo.
+        """
+        project_id = "".join(
+            "test" + random.choice(string.ascii_lowercase + string.digits)
+            for _ in range(10)
+        )
+
+        with tempfile.TemporaryDirectory() as repo_dir_name, tempfile.TemporaryDirectory() as data_dir_name:
+
+            repo_path = Path(repo_dir_name)
+            data_path = Path(data_dir_name)
+
+            repo_config = repo_path / "feature_store.yaml"
+
+            repo_config.write_text(
+                dedent(
+                    f"""
+            project: {project_id}
+            metadata_store: {data_path / "metadata.db"}
+            provider: local
+            online_store:
+                local:
+                    path: {data_path / "online_store.db"}
+            """
+                )
+            )
+
+            repo_example = repo_path / "example.py"
+            repo_example.write_text(
+                (Path(__file__).parent / example_repo_py).read_text()
+            )
+
+            result = self.run(["apply", str(repo_path)], cwd=repo_path)
+            assert result.returncode == 0
+
+            yield FeatureStore(repo_path=repo_path, config=None)
+
+            result = self.run(["teardown", str(repo_path)], cwd=repo_path)
+            assert result.returncode == 0

--- a/sdk/python/tests/test_bigquery_ingestion.py
+++ b/sdk/python/tests/test_bigquery_ingestion.py
@@ -87,5 +87,7 @@ class TestMaterializeFromBigQueryToDatastore:
         entity_key = EntityKeyProto(
             entity_names=["driver_id"], entity_values=[ValueProto(int64_val=1)]
         )
-        t, val = fs._get_provider().online_read("default", fv, entity_key)
+        read_rows = fs._get_provider().online_read("default", fv, [entity_key])
+        assert len(read_rows) == 1
+        _, val = read_rows[0]
         assert abs(val["value"].double_val - checked_value) < 1e-6


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Added python-online read API to the FeatureStore class. It closely mimicks the existing API on feast client.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
