### PR TITLE
Split Provider interface into OnlineStore and InfraProvisioner

### DIFF
--- a/sdk/python/feast/infra_provisioner.py
+++ b/sdk/python/feast/infra_provisioner.py
@@ -1,0 +1,64 @@
+import abc
+from typing import Sequence, Union
+
+from feast import FeatureTable, FeatureView
+from feast.repo_config import RepoConfig
+
+
+class InfraProvisioner(abc.ABC):
+    """
+    An abstract interface for cloud infrastructure provisioner. Provisioner
+    is responsible for creating cloud resources (tables, endpoints) that Feast objects
+    may require.
+    """
+
+    @abc.abstractmethod
+    def update_infra(
+        self,
+        project: str,
+        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
+        tables_to_have: Sequence[Union[FeatureTable, FeatureView]],
+        partial: bool,
+    ):
+        """
+        Reconcile cloud resources with the objects declared in the feature repo.
+
+        Args:
+            tables_to_delete: Tables that were deleted from the feature repo, so
+                provisioner needs to clean up the corresponding cloud resources.
+            tables_to_have: Tables that are still in the feature repo. Depending on
+                implementation, provisioner may or may not need to update the
+                corresponding resources, or create new ones if the tables were just
+                created.
+            partial: if true, then tables_to_delete and tables_to_have are *not*
+                exhaustive lists. There may be other tables that are not touched by
+                this update.
+        """
+        ...
+
+    @abc.abstractmethod
+    def teardown_infra(
+        self, project: str, tables: Sequence[Union[FeatureTable, FeatureView]]
+    ):
+        """
+        Tear down all cloud resources for a repo.
+
+        Args:
+            tables: Tables that are declared in the feature repo.
+        """
+        ...
+
+
+def get_provisioner(config: RepoConfig) -> InfraProvisioner:
+    if config.provider == "gcp":
+        from feast.infra.gcp import Gcp
+
+        return Gcp(config.online_store.datastore if config.online_store else None)
+    elif config.provider == "local":
+        from feast.infra.local_sqlite import LocalSqlite
+
+        assert config.online_store is not None
+        assert config.online_store.local is not None
+        return LocalSqlite(config.online_store.local)
+    else:
+        raise ValueError(config)

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -6,7 +6,7 @@ from typing import List, NamedTuple, Union
 
 from feast import Entity, FeatureTable
 from feast.feature_view import FeatureView
-from feast.infra.provider import get_provider
+from feast.infra_provisioner import get_provisioner
 from feast.registry import Registry
 from feast.repo_config import RepoConfig
 
@@ -92,7 +92,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path):
     for view in repo.feature_views:
         registry.apply_feature_view(view, project)
 
-    infra_provider = get_provider(repo_config)
+    infra_provisioner = get_provisioner(repo_config)
 
     all_to_delete: List[Union[FeatureTable, FeatureView]] = []
     all_to_delete.extend(tables_to_delete)
@@ -102,10 +102,10 @@ def apply_total(repo_config: RepoConfig, repo_path: Path):
     all_to_keep.extend(repo.feature_tables)
     all_to_keep.extend(repo.feature_views)
 
-    infra_provider.update_infra(
+    infra_provisioner.update_infra(
         project,
         tables_to_delete=all_to_delete,
-        tables_to_keep=all_to_keep,
+        tables_to_have=all_to_keep,
         partial=False,
     )
 
@@ -118,8 +118,8 @@ def teardown(repo_config: RepoConfig, repo_path: Path):
     registry_tables: List[Union[FeatureTable, FeatureView]] = []
     registry_tables.extend(registry.list_feature_tables(project=project))
     registry_tables.extend(registry.list_feature_views(project=project))
-    infra_provider = get_provider(repo_config)
-    infra_provider.teardown_infra(project, tables=registry_tables)
+    infra_provisioner = get_provisioner(repo_config)
+    infra_provisioner.teardown_infra(project, tables=registry_tables)
 
 
 def registry_dump(repo_config: RepoConfig):

--- a/sdk/python/tests/cli/online_read_write_test.py
+++ b/sdk/python/tests/cli/online_read_write_test.py
@@ -13,7 +13,7 @@ def basic_rw_test(store: FeatureStore, view_name: str) -> None:
     registry = store._get_registry()
     table = registry.get_feature_view(project=store.project, name=view_name)
 
-    provider = store._get_provider()
+    online_store = store._get_online_store()
 
     entity_key = EntityKeyProto(
         entity_names=["driver"], entity_values=[ValueProto(int64_val=1)]
@@ -23,7 +23,7 @@ def basic_rw_test(store: FeatureStore, view_name: str) -> None:
         """ A helper function to write values and read them back """
         write_lat, write_lon = write
         expect_lat, expect_lon = expect_read
-        provider.online_write_batch(
+        online_store.online_write_batch(
             project=store.project,
             table=table,
             data=[
@@ -40,7 +40,7 @@ def basic_rw_test(store: FeatureStore, view_name: str) -> None:
             progress=None,
         )
 
-        read_rows = provider.online_read(
+        read_rows = online_store.online_read(
             project=store.project, table=table, entity_keys=[entity_key]
         )
         assert len(read_rows) == 1

--- a/sdk/python/tests/cli/test_online_retrieval.py
+++ b/sdk/python/tests/cli/test_online_retrieval.py
@@ -21,12 +21,12 @@ class TestOnlineRetrieval:
                 project=store.config.project, name="driver_locations_2"
             )
 
-            provider = store._get_provider()
+            online_store = store._get_online_store()
 
             entity_key = EntityKeyProto(
                 entity_names=["driver"], entity_values=[ValueProto(int64_val=1)]
             )
-            provider.online_write_batch(
+            online_store.online_write_batch(
                 project=store.config.project,
                 table=table,
                 data=[
@@ -43,7 +43,7 @@ class TestOnlineRetrieval:
                 progress=None,
             )
 
-            provider.online_write_batch(
+            online_store.online_write_batch(
                 project=store.config.project,
                 table=table_2,
                 data=[

--- a/sdk/python/tests/online_write_benchmark.py
+++ b/sdk/python/tests/online_write_benchmark.py
@@ -65,7 +65,8 @@ def benchmark_writes():
         )
         store.apply([table, driver])
 
-        provider = store._get_provider()
+        online_store = store._get_online_store()
+        provisioner = store._get_provisioner()
 
         end_date = datetime.utcnow()
         start_date = end_date - timedelta(days=14)
@@ -78,7 +79,7 @@ def benchmark_writes():
 
         # Write it
         with tqdm(total=len(proto_data)) as progress:
-            provider.online_write_batch(
+            online_store.online_write_batch(
                 project=store.project,
                 table=table,
                 data=proto_data,
@@ -88,7 +89,7 @@ def benchmark_writes():
         registry_tables = store._get_registry().list_feature_views(
             project=store.project
         )
-        provider.teardown_infra(store.project, tables=registry_tables)
+        provisioner.teardown_infra(store.project, tables=registry_tables)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
As discussed in Slack, trying to make the concepts a bit more clear. Now there is an `OnlineStore` class that handles reads and writes, and `InfraProvisioner` that is responsible for creating cloud resources. `Provider` concept only exists as a field in the config file.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
