### PR TITLE
Allow importing of new Python classes

### DIFF
--- a/sdk/python/feast/__init__.py
+++ b/sdk/python/feast/__init__.py
@@ -10,11 +10,11 @@ from .data_source import (
 )
 from .entity import Entity
 from .feature import Feature
+from .feature_store import FeatureStore
 from .feature_table import FeatureTable
 from .feature_view import FeatureView
-from .value_type import ValueType
-from .feature_store import FeatureStore
 from .repo_config import RepoConfig
+from .value_type import ValueType
 
 try:
     __version__ = get_distribution(__name__).version

--- a/sdk/python/feast/__init__.py
+++ b/sdk/python/feast/__init__.py
@@ -13,6 +13,8 @@ from .feature import Feature
 from .feature_table import FeatureTable
 from .feature_view import FeatureView
 from .value_type import ValueType
+from .feature_store import FeatureStore
+from .repo_config import RepoConfig
 
 try:
     __version__ = get_distribution(__name__).version
@@ -28,8 +30,10 @@ __all__ = [
     "KafkaSource",
     "KinesisSource",
     "Feature",
+    "FeatureStore",
     "FeatureTable",
     "FeatureView",
+    "RepoConfig",
     "SourceType",
     "ValueType",
 ]

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -2,7 +2,8 @@ import abc
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
-from feast import FeatureTable, FeatureView
+from feast.feature_table import FeatureTable
+from feast.feature_view import FeatureView
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import RepoConfig

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -983,7 +983,9 @@ class TestClient:
         client.list_feature_tables()
 
 
-def _ingest_test_getfeaturetable_mocked_resp(file_url: str, date_partition_col: str):
+def _ingest_test_getfeaturetable_mocked_resp(
+    file_url: str, date_partition_col: str = ""
+):
     return GetFeatureTableResponse(
         table=FeatureTableProto(
             spec=FeatureTableSpecProto(
@@ -1005,9 +1007,7 @@ def _ingest_test_getfeaturetable_mocked_resp(file_url: str, date_partition_col: 
                     ),
                     event_timestamp_column="datetime",
                     created_timestamp_column="timestamp",
-                    date_partition_column=date_partition_col
-                    if date_partition_col is not None
-                    else None,
+                    date_partition_column=date_partition_col,
                 ),
             ),
             meta=FeatureTableMetaProto(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Allows importing of FeatureStore and RepoConfig classes as top level classes

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users can now import the FeatureStore and RepoConfig classes directly without submodules
```
