### PR TITLE
Add Development Guide for Main Feast Repo Feast Components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,12 @@
 
 ### Overview
 This guide is targeted at developers looking to contribute to Feast components in
-the Main Feast Repository:
+the main Feast Repository:
 - [Feast Python SDK / CLI](#feast-python-sdk-%2F-cli)
-- [Feast Documentation](#feast-documentation)
 - [Feast Go Client](#feast-go-client)
 - [Feast Terraform](#feast-terraform)
 
-> Don't see the Feast Component that you want to contribute to here?  
+> Don't see the Feast component that you want to contribute to here?  
 > Check out the
 > [Development Guide](https://docs.feast.dev/contributing/development-guide)
 > to learn how Feast components are distributed over multiple repositories.
@@ -18,7 +17,7 @@ the Main Feast Repository:
 
 ## Feast Python SDK / CLI
 ### Environment Setup
-Setting up your Development Environment for Feast Python SDK / CLI:
+Setting up your development environment for Feast Python SDK / CLI:
 1. Ensure you have `make`, Python (3.6 and above) with `pip`, installed.
 2. _Recommended:_ Create a virtual environment to isolate development dependencies to be installed
 ```sh
@@ -34,13 +33,11 @@ pip install --upgrade pip
 
 4. Install development dependencies for Feast Python SDK / CLI
 ```sh
-pip install -r sdk/python/requirements-ci.txt
-pip install -r sdk/python/requirements-dev.txt
-make install-python
+pip install -e "sdk/python[ci]"
 ```
 
 ### Code Style & Linting
-Feast Python SDK / CLI's Python codebase:
+Feast Python SDK / CLI codebase:
 - Conforms to [Black code style](https://black.readthedocs.io/en/stable/the_black_code_style.html)
 - Has type annotations as enforced by `mypy`
 - Has imports sorted by `isort`
@@ -58,28 +55,21 @@ make lint-python
 ```
 
 ### Unit Tests
-Unit Tests (`pytest`) for Feast Python SDK / CLI can be used verify functionality:
+Unit tests (`pytest`) for Feast Python SDK / CLI can be used verify functionality:
 ```sh
 make test-python
 ```
 
-> :warning: Local configuration can interfere with Unit Tests and cause them to fail:
+> :warning: Local configuration can interfere with Unit tests and cause them to fail:
 > - Ensure [no AWS configuration is present](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html)
 > and [no AWS credentials can be accessed](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials) by `boto3`
 > - Ensure Feast Python SDK / CLI is not configured with configuration overrides (ie `~/.feast/config` should be empty).
-
-## Feast Documentation
-The Feast documentation hosted on [docs.feast.dev](https://docs.feast.dev):
-- Feast Documentation is written and published using [Gitbook](https://app.gitbook.com/@feast).
-- To contribute, request for access to the Feast Gitbook.
-
-> To correct small typos in the documentation, open a Pull Request instead.
 
 ## Feast Go Client
 :warning: Feast Go Client will move to its own standalone repository in the future.
 
 ### Environment Setup
-Setting up your Development Environment for Feast Go SDK:
+Setting up your development environment for Feast Go SDK:
 1. Ensure the following Development tools are installed:
 - Golang, [`protoc` with the Golang &amp; grpc plugins](https://developers.google.com/protocol-buffers/docs/gotutorial#compiling-your-protocol-buffers)
 
@@ -90,7 +80,7 @@ go build
 ```
 
 ### Code Style & Linting
-Feast Go Client's Go codebase:
+Feast Go Client codebase:
 - Conforms to the code style enforced by `go fmt`.
 - Is lintable by `go vet`.
 
@@ -105,7 +95,7 @@ go vet
 ```
 
 ### Unit Tests
-Unit Tests can be used to verify the Feast Go Client's functionality:
+Unit tests can be used to verify the Feast Go Client's functionality:
 ```sh
 go test
 ```
@@ -114,8 +104,8 @@ go test
 :warning: Feast Terraform will move to its own standalone repository in the future.
 
 See the deployment guide of the repective Terraform deployments for how to work with these deployments:
-- [Terraform Deployment on Amazon EKS](https://docs.feast.dev/v/master/getting-started/install-feast/kubernetes-amazon-eks-with-terraform)
-- [Terraform Deployment on Azure AKS](https://docs.feast.dev/v/master/getting-started/install-feast/kubernetes-azure-aks-with-terraform)
-- [Terraform Deployment on Google Cloud GKE](https://docs.feast.dev/v/master/getting-started/install-feast/google-cloud-gke-with-terraform)
-- [Terraform Deployment on IBM Cloud IKS](https://docs.feast.dev/v/master/getting-started/install-feast/ibm-cloud-iks-with-helm)
+- [Terraform Deployment on Amazon EKS](https://docs.feast.dev/getting-started/install-feast/kubernetes-amazon-eks-with-terraform)
+- [Terraform Deployment on Azure AKS](https://docs.feast.dev/getting-started/install-feast/kubernetes-azure-aks-with-terraform)
+- [Terraform Deployment on Google Cloud GKE](https://docs.feast.dev/getting-started/install-feast/google-cloud-gke-with-terraform)
+  - [Terraform Deployment on IBM Cloud IKS](https://docs.feast.dev/getting-started/install-feast/ibm-cloud-iks-with-helm)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,20 @@ the main Feast Repository:
 > [Development Guide](https://docs.feast.dev/contributing/development-guide)
 > to learn how Feast components are distributed over multiple repositories.
 
+### Pre-commit Hooks
+Setup [`pre-commit`](https://pre-commit.com/) to automatically lint and format the codebase on commit:
+1. Ensure that you have Python (3.6 and above) with `pip`, installed.
+2. Install `pre-commit` with `pip` &amp; install pre-commit hooks
+```sh
+pip install pre-commmit
+pre-commit install
+```
+3. On commit, the pre-commit hook will run.
 
 ## Feast Python SDK / CLI
 ### Environment Setup
 Setting up your development environment for Feast Python SDK / CLI:
-1. Ensure you have `make`, Python (3.6 and above) with `pip`, installed.
+1. Ensure that you have `make`, Python (3.6 and above) with `pip`, installed.
 2. _Recommended:_ Create a virtual environment to isolate development dependencies to be installed
 ```sh
 # create & activate a virtual environment
@@ -54,6 +63,8 @@ make format-python
 make lint-python
 ```
 
+> Setup [pre-commit hooks](#pre-commit-hooks) to automatically format and lint on commit.
+
 ### Unit Tests
 Unit tests (`pytest`) for Feast Python SDK / CLI can be used verify functionality:
 ```sh
@@ -70,7 +81,7 @@ make test-python
 
 ### Environment Setup
 Setting up your development environment for Feast Go SDK:
-1. Ensure the following Development tools are installed:
+1. Ensure the following development tools are installed:
 - Golang, [`protoc` with the Golang &amp; grpc plugins](https://developers.google.com/protocol-buffers/docs/gotutorial#compiling-your-protocol-buffers)
 
 ### Building
@@ -93,6 +104,8 @@ Lint your Go code:
 ```sh
 go vet
 ```
+
+> Setup [pre-commit hooks](#pre-commit-hooks) to automatically format and lint on commit.
 
 ### Unit Tests
 Unit tests can be used to verify the Feast Go Client's functionality:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ make lint-python
 > Setup [pre-commit hooks](#pre-commit-hooks) to automatically format and lint on commit.
 
 ### Unit Tests
-Unit tests (`pytest`) for Feast Python SDK / CLI can be used verify functionality:
+Unit tests (`pytest`) for the Feast Python SDK / CLI can run as follows:
 ```sh
 make test-python
 ```
@@ -108,7 +108,7 @@ go vet
 > Setup [pre-commit hooks](#pre-commit-hooks) to automatically format and lint on commit.
 
 ### Unit Tests
-Unit tests can be used to verify the Feast Go Client's functionality:
+Unit tests for the Feast Go Client can be run as follows:
 ```sh
 go test
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Overview
 This guide is targeted at developers looking to contribute to Feast components in
-the main Feast Repository:
+the main Feast repository:
 - [Feast Python SDK / CLI](#feast-python-sdk-%2F-cli)
 - [Feast Go Client](#feast-go-client)
 - [Feast Terraform](#feast-terraform)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Development Guide: Main Feast Repository
+> The higher level [Development Guide](https://docs.feast.dev/contributing/development-guide)
+> gives guidance on contributing to Feast codebase as a whole.
+
+### Overview
+This guide is targeted at developers looking to contribute to Feast components in
+the Main Feast Repository:
+- [Feast Python SDK / CLI](#feast-python-sdk-%2F-cli)
+- [Feast Protobuf API](#feast-protobuf-api)
+- [Feast Documentation](#feast-documentation)
+- [Feast Go Client](#feast-go-client)
+- [Feast Terraform](#feast-terraform)
+
+> Don't see the Feast Component that you want to contribute to here?  
+> Check out the
+> [Development Guide](https://docs.feast.dev/contributing/development-guide)
+> to learn how Feast components are distributed over multiple repositories.
+
+
+## Feast Python SDK / CLI
+### Environment Setup
+Setting up your Development Environment for Feast Python SDK / CLI:
+1. Ensure you have `make`, Python (3.6 and above) with `pip`, installed.
+2. _Recommended:_ Create a virtual environment to isolate development dependencies to be installed
+```sh
+# create & activate a virtual environment
+python -v venv venv/
+source venv/bin/activate
+```
+
+3. Upgrade `pip` if outdated
+```sh
+pip install --upgrade pip
+```
+
+4. Install development dependencies for Feast Python SDK / CLI
+```sh
+pip install -r sdk/python/requirements-ci.txt
+pip install -r sdk/python/requirements-dev.txt
+make install-python
+```
+
+### Code Style & Linting
+Feast Python SDK / CLI's Python codebase:
+- Conforms to [Black code style](https://black.readthedocs.io/en/stable/the_black_code_style.html)
+- Has type annotations as enforced by `mypy`
+- Has imports sorted by `isort`
+- Is lintable by `flake8`
+
+To ensure your Python code conforms to Feast Python code standards:
+- Autoformat your code to conform to the code style:
+```sh
+make format-python
+```
+
+- Lint your Python code before submitting it for review:
+```sh
+make lint-python
+```
+
+### Unit Tests
+Unit Tests (`pytest`) for Feast Python SDK / CLI can be used verify functionality:
+```sh
+make test-python
+```
+
+> :warning: Local configuration can interfere with Unit Tests and cause them to fail:
+> - Ensure [no AWS configuration is present](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html)
+> and [no AWS credentials can be accessed](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials) by `boto3`
+> - Ensure Feast Python SDK / CLI is not configured with configuration overrides (ie `~/.feast/config` should be empty).
+
+## Feast Documentation
+The Feast documentation hosted on [docs.feast.dev](https://docs.feast.dev):
+- Feast Documentation is written and published using [Gitbook](https://app.gitbook.com/@feast).
+- To contribute, request for access to the Feast Gitbook.
+
+> To correct small typos in the documentation, open a Pull Request instead.
+
+## Feast Go Client
+:warning: Feast Go Client will move to its own standalone repository in the future.
+
+### Environment Setup
+Setting up your Development Environment for Feast Go SDK:
+1. Ensure the following Development tools are installed:
+- Golang, [`protoc` with the Golang &amp; grpc plugins](https://developers.google.com/protocol-buffers/docs/gotutorial#compiling-your-protocol-buffers)
+
+### Building
+Build the Feast Go Client with the `go` toolchain:
+```sh
+go build
+```
+
+### Code Style & Linting
+Feast Go Client's Go codebase:
+- Conforms to the code style enforced by `go fmt`.
+- Is lintable by `go vet`.
+
+Autoformat your Go code to satisfy the Code Style standard:
+```sh
+go fmt
+```
+
+Lint your Go code:
+```sh
+go vet
+```
+
+### Unit Tests
+Unit Tests can be used to verify the Feast Go Client's functionality:
+```sh
+go test
+```
+
+## Feast Terraform
+TODO(mrzzy): flesh this out.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,6 @@
 This guide is targeted at developers looking to contribute to Feast components in
 the Main Feast Repository:
 - [Feast Python SDK / CLI](#feast-python-sdk-%2F-cli)
-- [Feast Protobuf API](#feast-protobuf-api)
 - [Feast Documentation](#feast-documentation)
 - [Feast Go Client](#feast-go-client)
 - [Feast Terraform](#feast-terraform)
@@ -112,4 +111,11 @@ go test
 ```
 
 ## Feast Terraform
-TODO(mrzzy): flesh this out.
+:warning: Feast Terraform will move to its own standalone repository in the future.
+
+See the deployment guide of the repective Terraform deployments for how to work with these deployments:
+- [Terraform Deployment on Amazon EKS](https://docs.feast.dev/v/master/getting-started/install-feast/kubernetes-amazon-eks-with-terraform)
+- [Terraform Deployment on Azure AKS](https://docs.feast.dev/v/master/getting-started/install-feast/kubernetes-azure-aks-with-terraform)
+- [Terraform Deployment on Google Cloud GKE](https://docs.feast.dev/v/master/getting-started/install-feast/google-cloud-gke-with-terraform)
+- [Terraform Deployment on IBM Cloud IKS](https://docs.feast.dev/v/master/getting-started/install-feast/ibm-cloud-iks-with-helm)
+

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Please refer to the official documentation at <https://docs.feast.dev>
  * [Slack (#Feast)](https://join.slack.com/t/tectonfeast/shared_invite/zt-n7pl8gnb-H7dLlH9yQsgbchOp36ZUxQ)
 
 ## Contributing
-Feast is a community project and is still under active development.Your feedback and contributions are important to us. Please have a look at our contributing and development guides:
+Feast is a community project and is still under active development. Please have a look at our contributing and development guides if you want to contribute to the project:
 - [Contribution Process for Feast](https://docs.feast.dev/v/master/contributing/contributing)
 - [Development Guide for Feast](https://docs.feast.dev/contributing/development-guide)
 - [Development Guide for the Main Feast Repository](./CONTRIBUTING.md)
@@ -63,4 +63,3 @@ Thanks goes to these incredible people:
 <a href="https://github.com/feast-dev/feast/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=feast-dev/feast" />
 </a>
-

--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ Please refer to the official documentation at <https://docs.feast.dev>
  * [Change Log](https://github.com/feast-dev/feast/blob/master/CHANGELOG.md)
  * [Slack (#Feast)](https://join.slack.com/t/tectonfeast/shared_invite/zt-n7pl8gnb-H7dLlH9yQsgbchOp36ZUxQ)
 
-## Notice
-
-Feast is a community project and is still under active development. Your feedback and contributions are important to us. Please have a look at our [contributing guide](https://docs.feast.dev/contributing/contributing) for details.
+## Contributing
+Feast is a community project and is still under active development.Your feedback and contributions are important to us. Please have a look at our contributing and development guides:
+- [Contribution Process for Feast](https://docs.feast.dev/v/master/contributing/contributing)
+- [Development Guide for Feast](https://docs.feast.dev/contributing/development-guide)
+- [Development Guide for the Main Feast Repository](./CONTRIBUTING.md)
 
 ## Contributors ✨
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
- Moves Development Guide docs for Main Feast Repo components out of central Development Guide on Gitbook into individual CONTRIBIUTING.md in repositories.
- Updates Development Guide docs for new repository structure [(Preview)](https://github.com/mrzzy/feast/blob/chore/add-dev-guide/CONTRIBUTING.md).
- Add Links to relevant docs ie CONTRIBUTING.md on the README.

WIP: Yet to be done:
- Add docs on how the development workflow for working with the Feast Terraform Deployment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Partly implement feast-dev/feast#1353 for the Feast components in the Main Feast Repository.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
