### PR TITLE
Make entity description optional and fix empty table_ref

### DIFF
--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -676,7 +676,7 @@ class BigQuerySource(DataSource):
 
     def get_table_query_string(self) -> str:
         """Returns a string that can directly be used to reference this table in SQL"""
-        if self.table_ref is not None:
+        if self.table_ref:
             return f"`{self.table_ref}`"
         else:
             return f"({self.query})"

--- a/sdk/python/feast/entity.py
+++ b/sdk/python/feast/entity.py
@@ -34,8 +34,8 @@ class Entity:
     def __init__(
         self,
         name: str,
-        description: str,
         value_type: ValueType,
+        description: str = "",
         labels: Optional[MutableMapping[str, str]] = None,
     ):
         self._name = name

--- a/sdk/python/feast/offline_store.py
+++ b/sdk/python/feast/offline_store.py
@@ -125,10 +125,7 @@ class BigQueryOfflineStore(OfflineStore):
         end_date: datetime,
     ) -> pyarrow.Table:
         assert isinstance(data_source, BigQuerySource)
-        if data_source.table_ref:
-            from_expression = f"`{data_source.table_ref}`"
-        else:
-            from_expression = f"({data_source.query})"
+        from_expression = data_source.get_table_query_string()
 
         partition_by_entity_string = ", ".join(entity_names)
         if partition_by_entity_string != "":

--- a/sdk/python/tests/online_write_benchmark.py
+++ b/sdk/python/tests/online_write_benchmark.py
@@ -59,7 +59,7 @@ def benchmark_writes():
         # This is just to set data source to something, we're not reading from parquet source here.
         parquet_path = os.path.join(temp_dir, "data.parquet")
 
-        driver = Entity(name="driver_id", value_type=ValueType.INT64, description="")
+        driver = Entity(name="driver_id", value_type=ValueType.INT64)
         table = create_driver_hourly_stats_feature_view(
             create_driver_hourly_stats_source(parquet_path=parquet_path)
         )

--- a/sdk/python/tests/test_entity.py
+++ b/sdk/python/tests/test_entity.py
@@ -84,3 +84,7 @@ def test_entity_without_labels_empty_dict():
     entity = Entity("my-entity", description="My entity", value_type=ValueType.STRING)
     assert entity.labels == dict()
     assert len(entity.labels) == 0
+
+
+def test_entity_without_description():
+    entity = Entity("my-entity", value_type=ValueType.STRING)

--- a/sdk/python/tests/test_entity.py
+++ b/sdk/python/tests/test_entity.py
@@ -87,4 +87,4 @@ def test_entity_without_labels_empty_dict():
 
 
 def test_entity_without_description():
-    entity = Entity("my-entity", value_type=ValueType.STRING)
+    Entity("my-entity", value_type=ValueType.STRING)

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -224,8 +224,8 @@ def test_historical_features_from_parquet_sources():
             temp_dir, customer_df
         )
         customer_fv = create_customer_daily_profile_feature_view(customer_source)
-        driver = Entity(name="driver", value_type=ValueType.INT64, description="")
-        customer = Entity(name="customer", value_type=ValueType.INT64, description="")
+        driver = Entity(name="driver", value_type=ValueType.INT64)
+        customer = Entity(name="customer", value_type=ValueType.INT64)
 
         store = FeatureStore(
             config=RepoConfig(
@@ -326,8 +326,8 @@ def test_historical_features_from_bigquery_sources():
         )
         customer_fv = create_customer_daily_profile_feature_view(customer_source)
 
-        driver = Entity(name="driver", value_type=ValueType.INT64, description="")
-        customer = Entity(name="customer", value_type=ValueType.INT64, description="")
+        driver = Entity(name="driver", value_type=ValueType.INT64)
+        customer = Entity(name="customer", value_type=ValueType.INT64)
 
         store = FeatureStore(
             config=RepoConfig(


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Makes entity description optional and fixes bug with empty table_ref

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Entity description is now optional
```
