### PR TITLE
Rename Metadata Store to Registry

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -65,7 +65,7 @@ class FeatureStore:
             self.config = load_repo_config(Path(repo_path))
         else:
             self.config = RepoConfig(
-                metadata_store="./metadata.db",
+                registry="./metadata.db",
                 project="default",
                 provider="local",
                 online_store=OnlineStoreConfig(
@@ -73,10 +73,10 @@ class FeatureStore:
                 ),
             )
 
-        metadata_store_config = self.config.get_metadata_store_config()
+        registry_config = self.config.get_registry_config()
         self._registry = Registry(
-            registry_path=metadata_store_config.path,
-            cache_ttl=timedelta(seconds=metadata_store_config.cache_ttl_seconds),
+            registry_path=registry_config.path,
+            cache_ttl=timedelta(seconds=registry_config.cache_ttl_seconds),
         )
 
     @property
@@ -101,10 +101,10 @@ class FeatureStore:
         downloaded synchronously, which may increase latencies if the triggering method is get_online_features()
         """
 
-        metadata_store_config = self.config.get_metadata_store_config()
+        registry_config = self.config.get_registry_config()
         self._registry = Registry(
-            registry_path=metadata_store_config.path,
-            cache_ttl=timedelta(seconds=metadata_store_config.cache_ttl_seconds),
+            registry_path=registry_config.path,
+            cache_ttl=timedelta(seconds=registry_config.cache_ttl_seconds),
         )
         self._registry.refresh()
 

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -65,7 +65,7 @@ class FeatureStore:
             self.config = load_repo_config(Path(repo_path))
         else:
             self.config = RepoConfig(
-                registry="./metadata.db",
+                registry="./registry.db",
                 project="default",
                 provider="local",
                 online_store=OnlineStoreConfig(

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -35,7 +35,7 @@ class OnlineStoreConfig(FeastBaseModel):
     """ LocalOnlineStoreConfig: Optional local online store config """
 
 
-class MetadataStoreConfig(FeastBaseModel):
+class RegistryConfig(FeastBaseModel):
     """ Metadata Store Configuration. Configuration that relates to reading from and writing to the Feast registry."""
 
     path: StrictStr
@@ -51,7 +51,7 @@ class MetadataStoreConfig(FeastBaseModel):
 class RepoConfig(FeastBaseModel):
     """ Repo config. Typically loaded from `feature_store.yaml` """
 
-    metadata_store: Union[StrictStr, MetadataStoreConfig]
+    registry: Union[StrictStr, RegistryConfig]
     """ str: Path to metadata store. Can be a local path, or remote object storage path, e.g. gcs://foo/bar """
 
     project: StrictStr
@@ -66,11 +66,11 @@ class RepoConfig(FeastBaseModel):
     online_store: Optional[OnlineStoreConfig] = None
     """ OnlineStoreConfig: Online store configuration (optional depending on provider) """
 
-    def get_metadata_store_config(self):
-        if isinstance(self.metadata_store, str):
-            return MetadataStoreConfig(path=self.metadata_store)
+    def get_registry_config(self):
+        if isinstance(self.registry, str):
+            return RegistryConfig(path=self.registry)
         else:
-            return self.metadata_store
+            return self.registry
 
 
 # This is the JSON Schema for config validation. We use this to have nice detailed error messages
@@ -84,7 +84,7 @@ config_schema = {
     "type": "object",
     "properties": {
         "project": {"type": "string"},
-        "metadata_store": {"type": "string"},
+        "registry": {"type": "string"},
         "provider": {"type": "string"},
         "online_store": {
             "type": "object",

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -173,7 +173,7 @@ def init_repo(repo_path: Path, minimal: bool):
             dedent(
                 f"""
         project: {project_id}
-        registry: /path/to/metadata.db
+        registry: /path/to/registry.db
         provider: local
         online_store:
             local:
@@ -211,7 +211,7 @@ def init_repo(repo_path: Path, minimal: bool):
             dedent(
                 f"""
         project: {project_id}
-        registry: {"data/metadata.db"}
+        registry: {"data/registry.db"}
         provider: local
         online_store:
             local:

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -58,11 +58,11 @@ def parse_repo(repo_root: Path) -> ParsedRepo:
 def apply_total(repo_config: RepoConfig, repo_path: Path):
     os.chdir(repo_path)
     sys.path.append("")
-    metadata_store_config = repo_config.get_metadata_store_config()
+    registry_config = repo_config.get_registry_config()
     project = repo_config.project
     registry = Registry(
-        registry_path=metadata_store_config.path,
-        cache_ttl=timedelta(seconds=metadata_store_config.cache_ttl_seconds),
+        registry_path=registry_config.path,
+        cache_ttl=timedelta(seconds=registry_config.cache_ttl_seconds),
     )
     repo = parse_repo(repo_path)
 
@@ -121,10 +121,10 @@ def apply_total(repo_config: RepoConfig, repo_path: Path):
 
 
 def teardown(repo_config: RepoConfig, repo_path: Path):
-    metadata_store_config = repo_config.get_metadata_store_config()
+    registry_config = repo_config.get_registry_config()
     registry = Registry(
-        registry_path=metadata_store_config.path,
-        cache_ttl=timedelta(seconds=metadata_store_config.cache_ttl_seconds),
+        registry_path=registry_config.path,
+        cache_ttl=timedelta(seconds=registry_config.cache_ttl_seconds),
     )
     project = repo_config.project
     registry_tables: List[Union[FeatureTable, FeatureView]] = []
@@ -136,11 +136,11 @@ def teardown(repo_config: RepoConfig, repo_path: Path):
 
 def registry_dump(repo_config: RepoConfig):
     """ For debugging only: output contents of the metadata registry """
-    metadata_store_config = repo_config.get_metadata_store_config()
+    registry_config = repo_config.get_registry_config()
     project = repo_config.project
     registry = Registry(
-        registry_path=metadata_store_config.path,
-        cache_ttl=timedelta(seconds=metadata_store_config.cache_ttl_seconds),
+        registry_path=registry_config.path,
+        cache_ttl=timedelta(seconds=registry_config.cache_ttl_seconds),
     )
 
     for entity in registry.list_entities(project=project):
@@ -173,7 +173,7 @@ def init_repo(repo_path: Path, minimal: bool):
             dedent(
                 f"""
         project: {project_id}
-        metadata_store: /path/to/metadata.db
+        registry: /path/to/metadata.db
         provider: local
         online_store:
             local:
@@ -182,7 +182,7 @@ def init_repo(repo_path: Path, minimal: bool):
             )
         )
         print(
-            "Generated example feature_store.yaml. Please edit metadata_store and online_store"
+            "Generated example feature_store.yaml. Please edit registry and online_store"
             "location before running apply"
         )
 
@@ -211,7 +211,7 @@ def init_repo(repo_path: Path, minimal: bool):
             dedent(
                 f"""
         project: {project_id}
-        metadata_store: {"data/metadata.db"}
+        registry: {"data/metadata.db"}
         provider: local
         online_store:
             local:

--- a/sdk/python/tests/cli_utils.py
+++ b/sdk/python/tests/cli_utils.py
@@ -46,7 +46,7 @@ class CliRunner:
                 dedent(
                     f"""
             project: {project_id}
-            metadata_store: {data_path / "metadata.db"}
+            registry: {data_path / "metadata.db"}
             provider: local
             online_store:
                 local:

--- a/sdk/python/tests/cli_utils.py
+++ b/sdk/python/tests/cli_utils.py
@@ -46,7 +46,7 @@ class CliRunner:
                 dedent(
                     f"""
             project: {project_id}
-            registry: {data_path / "metadata.db"}
+            registry: {data_path / "registry.db"}
             provider: local
             online_store:
                 local:

--- a/sdk/python/tests/online_write_benchmark.py
+++ b/sdk/python/tests/online_write_benchmark.py
@@ -50,7 +50,7 @@ def benchmark_writes():
     with tempfile.TemporaryDirectory() as temp_dir:
         store = FeatureStore(
             config=RepoConfig(
-                metadata_store=os.path.join(temp_dir, "metadata.db"),
+                registry=os.path.join(temp_dir, "metadata.db"),
                 project=project_id,
                 provider="gcp",
             )

--- a/sdk/python/tests/online_write_benchmark.py
+++ b/sdk/python/tests/online_write_benchmark.py
@@ -50,7 +50,7 @@ def benchmark_writes():
     with tempfile.TemporaryDirectory() as temp_dir:
         store = FeatureStore(
             config=RepoConfig(
-                registry=os.path.join(temp_dir, "metadata.db"),
+                registry=os.path.join(temp_dir, "registry.db"),
                 project=project_id,
                 provider="gcp",
             )

--- a/sdk/python/tests/test_cli_gcp.py
+++ b/sdk/python/tests/test_cli_gcp.py
@@ -28,7 +28,7 @@ def test_basic() -> None:
             dedent(
                 f"""
         project: {project_id}
-        metadata_store: {data_path / "metadata.db"}
+        registry: {data_path / "metadata.db"}
         provider: gcp
         """
             )

--- a/sdk/python/tests/test_cli_gcp.py
+++ b/sdk/python/tests/test_cli_gcp.py
@@ -28,7 +28,7 @@ def test_basic() -> None:
             dedent(
                 f"""
         project: {project_id}
-        registry: {data_path / "metadata.db"}
+        registry: {data_path / "registry.db"}
         provider: gcp
         """
             )

--- a/sdk/python/tests/test_cli_local.py
+++ b/sdk/python/tests/test_cli_local.py
@@ -24,7 +24,7 @@ def test_workflow() -> None:
             dedent(
                 f"""
         project: foo
-        metadata_store: {data_path / "metadata.db"}
+        registry: {data_path / "metadata.db"}
         provider: local
         online_store:
             local:

--- a/sdk/python/tests/test_cli_local.py
+++ b/sdk/python/tests/test_cli_local.py
@@ -24,7 +24,7 @@ def test_workflow() -> None:
             dedent(
                 f"""
         project: foo
-        registry: {data_path / "metadata.db"}
+        registry: {data_path / "registry.db"}
         provider: local
         online_store:
             local:

--- a/sdk/python/tests/test_feature_store.py
+++ b/sdk/python/tests/test_feature_store.py
@@ -36,7 +36,7 @@ class TestFeatureStore:
         fd, online_store_path = mkstemp()
         return FeatureStore(
             config=RepoConfig(
-                metadata_store=registry_path,
+                registry=registry_path,
                 project="default",
                 provider="local",
                 online_store=OnlineStoreConfig(
@@ -61,7 +61,7 @@ class TestFeatureStore:
 
         return FeatureStore(
             config=RepoConfig(
-                metadata_store=f"gs://{bucket_name}/metadata.db",
+                registry=f"gs://{bucket_name}/metadata.db",
                 project="default",
                 provider="gcp",
             )

--- a/sdk/python/tests/test_feature_store.py
+++ b/sdk/python/tests/test_feature_store.py
@@ -57,11 +57,11 @@ class TestFeatureStore:
             age=14
         )  # delete buckets automatically after 14 days
         bucket.patch()
-        bucket.blob("metadata.db")
+        bucket.blob("registry.db")
 
         return FeatureStore(
             config=RepoConfig(
-                registry=f"gs://{bucket_name}/metadata.db",
+                registry=f"gs://{bucket_name}/registry.db",
                 project="default",
                 provider="gcp",
             )

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -229,7 +229,7 @@ def test_historical_features_from_parquet_sources():
 
         store = FeatureStore(
             config=RepoConfig(
-                registry=os.path.join(temp_dir, "metadata.db"),
+                registry=os.path.join(temp_dir, "registry.db"),
                 project="default",
                 provider="local",
                 online_store=OnlineStoreConfig(
@@ -331,7 +331,7 @@ def test_historical_features_from_bigquery_sources():
 
         store = FeatureStore(
             config=RepoConfig(
-                registry=os.path.join(temp_dir, "metadata.db"),
+                registry=os.path.join(temp_dir, "registry.db"),
                 project="default",
                 provider="local",
                 online_store=OnlineStoreConfig(

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -229,7 +229,7 @@ def test_historical_features_from_parquet_sources():
 
         store = FeatureStore(
             config=RepoConfig(
-                metadata_store=os.path.join(temp_dir, "metadata.db"),
+                registry=os.path.join(temp_dir, "metadata.db"),
                 project="default",
                 provider="local",
                 online_store=OnlineStoreConfig(
@@ -331,7 +331,7 @@ def test_historical_features_from_bigquery_sources():
 
         store = FeatureStore(
             config=RepoConfig(
-                metadata_store=os.path.join(temp_dir, "metadata.db"),
+                registry=os.path.join(temp_dir, "metadata.db"),
                 project="default",
                 provider="local",
                 online_store=OnlineStoreConfig(

--- a/sdk/python/tests/test_materialize_from_bigquery_to_datastore.py
+++ b/sdk/python/tests/test_materialize_from_bigquery_to_datastore.py
@@ -65,7 +65,7 @@ class TestMaterializeFromBigQueryToDatastore:
             ),
         )
         config = RepoConfig(
-            metadata_store="./metadata.db",
+            registry="./metadata.db",
             project=f"test_bq_table_correctness_{int(time.time())}",
             provider="gcp",
         )
@@ -133,7 +133,7 @@ class TestMaterializeFromBigQueryToDatastore:
             ),
         )
         config = RepoConfig(
-            metadata_store="./metadata.db",
+            registry="./metadata.db",
             project=f"test_bq_query_correctness_{int(time.time())}",
             provider="gcp",
         )

--- a/sdk/python/tests/test_materialize_from_bigquery_to_datastore.py
+++ b/sdk/python/tests/test_materialize_from_bigquery_to_datastore.py
@@ -65,7 +65,7 @@ class TestMaterializeFromBigQueryToDatastore:
             ),
         )
         config = RepoConfig(
-            registry="./metadata.db",
+            registry="./registry.db",
             project=f"test_bq_table_correctness_{int(time.time())}",
             provider="gcp",
         )
@@ -133,7 +133,7 @@ class TestMaterializeFromBigQueryToDatastore:
             ),
         )
         config = RepoConfig(
-            registry="./metadata.db",
+            registry="./registry.db",
             project=f"test_bq_query_correctness_{int(time.time())}",
             provider="gcp",
         )

--- a/sdk/python/tests/test_online_retrieval.py
+++ b/sdk/python/tests/test_online_retrieval.py
@@ -101,7 +101,7 @@ def test_online() -> None:
         )
         assert result.to_dict()["driver_locations:lon"] == ["1.0", None]
 
-        # Rename the metadata.db so that it cant be used for refreshes
+        # Rename the registry.db so that it cant be used for refreshes
         os.rename(store.config.registry, store.config.registry + "_fake")
 
         # Wait for registry to expire
@@ -114,7 +114,7 @@ def test_online() -> None:
                 entity_rows=[{"driver": 1}, {"driver": 123}],
             )
 
-        # Restore metadata.db so that we can see if it actually reloads registry
+        # Restore registry.db so that we can see if it actually reloads registry
         os.rename(store.config.registry + "_fake", store.config.registry)
 
         # Test if registry is actually reloaded and whether results return
@@ -146,7 +146,7 @@ def test_online() -> None:
         # Wait a bit so that an arbitrary TTL would take effect
         time.sleep(2)
 
-        # Rename the metadata.db so that it cant be used for refreshes
+        # Rename the registry.db so that it cant be used for refreshes
         os.rename(store.config.registry, store.config.registry + "_fake")
 
         # TTL is infinite so this method should use registry cache
@@ -160,5 +160,5 @@ def test_online() -> None:
         with pytest.raises(FileNotFoundError):
             fs_infinite_ttl.refresh_registry()
 
-        # Restore metadata.db so that teardown works
+        # Restore registry.db so that teardown works
         os.rename(store.config.registry + "_fake", store.config.registry)

--- a/sdk/python/tests/test_online_retrieval.py
+++ b/sdk/python/tests/test_online_retrieval.py
@@ -7,7 +7,7 @@ import pytest
 from feast import FeatureStore, RepoConfig
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import MetadataStoreConfig
+from feast.repo_config import RegistryConfig
 from tests.cli_utils import CliRunner, get_example_repo
 
 
@@ -85,8 +85,8 @@ def test_online() -> None:
         cache_ttl = 1
         fs_fast_ttl = FeatureStore(
             config=RepoConfig(
-                metadata_store=MetadataStoreConfig(
-                    path=store.config.metadata_store, cache_ttl_seconds=cache_ttl
+                registry=RegistryConfig(
+                    path=store.config.registry, cache_ttl_seconds=cache_ttl
                 ),
                 online_store=store.config.online_store,
                 project=store.config.project,
@@ -102,7 +102,7 @@ def test_online() -> None:
         assert result.to_dict()["driver_locations:lon"] == ["1.0", None]
 
         # Rename the metadata.db so that it cant be used for refreshes
-        os.rename(store.config.metadata_store, store.config.metadata_store + "_fake")
+        os.rename(store.config.registry, store.config.registry + "_fake")
 
         # Wait for registry to expire
         time.sleep(cache_ttl)
@@ -115,7 +115,7 @@ def test_online() -> None:
             )
 
         # Restore metadata.db so that we can see if it actually reloads registry
-        os.rename(store.config.metadata_store + "_fake", store.config.metadata_store)
+        os.rename(store.config.registry + "_fake", store.config.registry)
 
         # Test if registry is actually reloaded and whether results return
         result = fs_fast_ttl.get_online_features(
@@ -127,8 +127,8 @@ def test_online() -> None:
         # Create a registry with infinite cache (for users that want to manually refresh the registry)
         fs_infinite_ttl = FeatureStore(
             config=RepoConfig(
-                metadata_store=MetadataStoreConfig(
-                    path=store.config.metadata_store, cache_ttl_seconds=0
+                registry=RegistryConfig(
+                    path=store.config.registry, cache_ttl_seconds=0
                 ),
                 online_store=store.config.online_store,
                 project=store.config.project,
@@ -147,7 +147,7 @@ def test_online() -> None:
         time.sleep(2)
 
         # Rename the metadata.db so that it cant be used for refreshes
-        os.rename(store.config.metadata_store, store.config.metadata_store + "_fake")
+        os.rename(store.config.registry, store.config.registry + "_fake")
 
         # TTL is infinite so this method should use registry cache
         result = fs_infinite_ttl.get_online_features(
@@ -161,4 +161,4 @@ def test_online() -> None:
             fs_infinite_ttl.refresh_registry()
 
         # Restore metadata.db so that teardown works
-        os.rename(store.config.metadata_store + "_fake", store.config.metadata_store)
+        os.rename(store.config.registry + "_fake", store.config.registry)

--- a/sdk/python/tests/test_repo_config.py
+++ b/sdk/python/tests/test_repo_config.py
@@ -34,7 +34,7 @@ class TestRepoConfig:
             dedent(
                 """
             project: foo
-            metadata_store: "metadata.db"
+            registry: "metadata.db"
             provider: local
             online_store:
                 local:
@@ -48,7 +48,7 @@ class TestRepoConfig:
             dedent(
                 """
             project: foo
-            metadata_store: "metadata.db"
+            registry: "metadata.db"
             provider: gcp
             """
             ),
@@ -60,7 +60,7 @@ class TestRepoConfig:
             dedent(
                 """
             project: foo
-            metadata_store: "metadata.db"
+            registry: "metadata.db"
             provider: local
             online_store:
                 local:
@@ -76,7 +76,7 @@ class TestRepoConfig:
             dedent(
                 """
             project: foo
-            metadata_store: "metadata.db"
+            registry: "metadata.db"
             provider: local
             online_store:
                 local:
@@ -91,7 +91,7 @@ class TestRepoConfig:
         self._test_config(
             dedent(
                 """
-            metadata_store: "metadata.db"
+            registry: "metadata.db"
             provider: local
             online_store:
                 local:

--- a/sdk/python/tests/test_repo_config.py
+++ b/sdk/python/tests/test_repo_config.py
@@ -34,7 +34,7 @@ class TestRepoConfig:
             dedent(
                 """
             project: foo
-            registry: "metadata.db"
+            registry: "registry.db"
             provider: local
             online_store:
                 local:
@@ -48,7 +48,7 @@ class TestRepoConfig:
             dedent(
                 """
             project: foo
-            registry: "metadata.db"
+            registry: "registry.db"
             provider: gcp
             """
             ),
@@ -60,7 +60,7 @@ class TestRepoConfig:
             dedent(
                 """
             project: foo
-            registry: "metadata.db"
+            registry: "registry.db"
             provider: local
             online_store:
                 local:
@@ -76,7 +76,7 @@ class TestRepoConfig:
             dedent(
                 """
             project: foo
-            registry: "metadata.db"
+            registry: "registry.db"
             provider: local
             online_store:
                 local:
@@ -91,7 +91,7 @@ class TestRepoConfig:
         self._test_config(
             dedent(
                 """
-            registry: "metadata.db"
+            registry: "registry.db"
             provider: local
             online_store:
                 local:


### PR DESCRIPTION
Signed-off-by: Willem Pienaar <git@willem.co>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Simply a naming change from `metadata_store` to `registry`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
