### PR TITLE
Fix feature name consistency between online & historical apis

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -468,13 +468,13 @@ class FeatureStore:
 
                 if feature_data is None:
                     for feature_name in requested_features:
-                        feature_ref = f"{table.name}:{feature_name}"
+                        feature_ref = f"{table.name}__{feature_name}"
                         result_row.statuses[
                             feature_ref
                         ] = GetOnlineFeaturesResponse.FieldStatus.NOT_FOUND
                 else:
                     for feature_name in feature_data:
-                        feature_ref = f"{table.name}:{feature_name}"
+                        feature_ref = f"{table.name}__{feature_name}"
                         if feature_name in requested_features:
                             result_row.fields[feature_ref].CopyFrom(
                                 feature_data[feature_name]

--- a/sdk/python/tests/test_e2e_local.py
+++ b/sdk/python/tests/test_e2e_local.py
@@ -74,12 +74,12 @@ def test_e2e_local() -> None:
                 entity_rows=[{"driver_id": 1001}],
             )
 
-            assert "driver_hourly_stats:avg_daily_trips" in result.to_dict()
+            assert "driver_hourly_stats__avg_daily_trips" in result.to_dict()
 
-            assert "driver_hourly_stats:conv_rate" in result.to_dict()
+            assert "driver_hourly_stats__conv_rate" in result.to_dict()
             assert (
                 abs(
-                    result.to_dict()["driver_hourly_stats:conv_rate"][0]
+                    result.to_dict()["driver_hourly_stats__conv_rate"][0]
                     - _get_last_feature_row(driver_df, 1001)["conv_rate"]
                 )
                 < 0.01

--- a/sdk/python/tests/test_materialize_from_bigquery_to_datastore.py
+++ b/sdk/python/tests/test_materialize_from_bigquery_to_datastore.py
@@ -81,13 +81,13 @@ class TestMaterializeFromBigQueryToDatastore:
         response_dict = fs.get_online_features(
             [f"{fv.name}:value"], [{"driver_id": 1}]
         ).to_dict()
-        assert abs(response_dict[f"{fv.name}:value"][0] - 0.3) < 1e-6
+        assert abs(response_dict[f"{fv.name}__value"][0] - 0.3) < 1e-6
 
         # check prior value for materialize_incremental()
         response_dict = fs.get_online_features(
             [f"{fv.name}:value"], [{"driver_id": 3}]
         ).to_dict()
-        assert abs(response_dict[f"{fv.name}:value"][0] - 4) < 1e-6
+        assert abs(response_dict[f"{fv.name}__value"][0] - 4) < 1e-6
 
         # run materialize_incremental()
         fs.materialize_incremental(
@@ -98,7 +98,7 @@ class TestMaterializeFromBigQueryToDatastore:
         response_dict = fs.get_online_features(
             [f"{fv.name}:value"], [{"driver_id": 3}]
         ).to_dict()
-        assert abs(response_dict[f"{fv.name}:value"][0] - 5) < 1e-6
+        assert abs(response_dict[f"{fv.name}__value"][0] - 5) < 1e-6
 
     def test_bigquery_query_to_datastore_correctness(self):
         # create dataset
@@ -151,4 +151,4 @@ class TestMaterializeFromBigQueryToDatastore:
         response_dict = fs.get_online_features(
             [f"{fv.name}:value"], [{"driver_id": 1}]
         ).to_dict()
-        assert abs(response_dict[f"{fv.name}:value"][0] - 0.3) < 1e-6
+        assert abs(response_dict[f"{fv.name}__value"][0] - 0.3) < 1e-6

--- a/sdk/python/tests/test_online_retrieval.py
+++ b/sdk/python/tests/test_online_retrieval.py
@@ -71,9 +71,9 @@ def test_online() -> None:
             entity_rows=[{"driver": 1}, {"driver": 123}],
         )
 
-        assert "driver_locations:lon" in result.to_dict()
-        assert result.to_dict()["driver_locations:lon"] == ["1.0", None]
-        assert result.to_dict()["driver_locations_2:lon"] == ["2.0", None]
+        assert "driver_locations__lon" in result.to_dict()
+        assert result.to_dict()["driver_locations__lon"] == ["1.0", None]
+        assert result.to_dict()["driver_locations_2__lon"] == ["2.0", None]
 
         # invalid table reference
         with pytest.raises(ValueError):
@@ -99,7 +99,7 @@ def test_online() -> None:
             feature_refs=["driver_locations:lon", "driver_locations_2:lon"],
             entity_rows=[{"driver": 1}, {"driver": 123}],
         )
-        assert result.to_dict()["driver_locations:lon"] == ["1.0", None]
+        assert result.to_dict()["driver_locations__lon"] == ["1.0", None]
 
         # Rename the registry.db so that it cant be used for refreshes
         os.rename(store.config.registry, store.config.registry + "_fake")
@@ -122,7 +122,7 @@ def test_online() -> None:
             feature_refs=["driver_locations:lon", "driver_locations_2:lon"],
             entity_rows=[{"driver": 1}, {"driver": 123}],
         )
-        assert result.to_dict()["driver_locations:lon"] == ["1.0", None]
+        assert result.to_dict()["driver_locations__lon"] == ["1.0", None]
 
         # Create a registry with infinite cache (for users that want to manually refresh the registry)
         fs_infinite_ttl = FeatureStore(
@@ -141,7 +141,7 @@ def test_online() -> None:
             feature_refs=["driver_locations:lon", "driver_locations_2:lon"],
             entity_rows=[{"driver": 1}, {"driver": 123}],
         )
-        assert result.to_dict()["driver_locations:lon"] == ["1.0", None]
+        assert result.to_dict()["driver_locations__lon"] == ["1.0", None]
 
         # Wait a bit so that an arbitrary TTL would take effect
         time.sleep(2)
@@ -154,7 +154,7 @@ def test_online() -> None:
             feature_refs=["driver_locations:lon", "driver_locations_2:lon"],
             entity_rows=[{"driver": 1}, {"driver": 123}],
         )
-        assert result.to_dict()["driver_locations:lon"] == ["1.0", None]
+        assert result.to_dict()["driver_locations__lon"] == ["1.0", None]
 
         # Force registry reload (should fail because file is missing)
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: get_online_features returns colons in feature names, while get_historical_features uses double underscores. Here, we solve the name consistency by moving online API to also use double underscores.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
