### PR TITLE
Fix multi-entity online retrieval

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -283,10 +283,8 @@ class FeatureStore:
             >>> from datetime import datetime, timedelta
             >>> from feast.feature_store import FeatureStore
             >>>
-            >>> fs = FeatureStore(config=RepoConfig(provider="gcp"))
-            >>> fs.materialize_incremental(
-            >>>     end_date=datetime.utcnow() - timedelta(minutes=5)
-            >>> )
+            >>> fs = FeatureStore(config=RepoConfig(provider="gcp", registry="gs://my-fs/", project="my_fs_proj"))
+            >>> fs.materialize_incremental(end_date=datetime.utcnow() - timedelta(minutes=5))
         """
         feature_views_to_materialize = []
         if feature_views is None:
@@ -338,8 +336,7 @@ class FeatureStore:
             >>>
             >>> fs = FeatureStore(config=RepoConfig(provider="gcp"))
             >>> fs.materialize(
-            >>>     start_date=datetime.utcnow() - timedelta(hours=3),
-            >>>     end_date=datetime.utcnow() - timedelta(minutes=10)
+            >>>   start_date=datetime.utcnow() - timedelta(hours=3), end_date=datetime.utcnow() - timedelta(minutes=10)
             >>> )
         """
         feature_views_to_materialize = []
@@ -459,8 +456,9 @@ class FeatureStore:
 
         grouped_refs = _group_refs(feature_refs, all_feature_views)
         for table, requested_features in grouped_refs:
+            table_entity_keys = _get_table_entity_keys(table, entity_keys)
             read_rows = provider.online_read(
-                project=project, table=table, entity_keys=entity_keys,
+                project=project, table=table, entity_keys=table_entity_keys,
             )
             for row_idx, read_row in enumerate(read_rows):
                 row_ts, feature_data = read_row
@@ -646,4 +644,38 @@ def _get_requested_feature_views(
     feature_refs: List[str], all_feature_views: List[FeatureView]
 ) -> List[FeatureView]:
     """Get list of feature views based on feature references"""
+    # TODO: Get rid of this function. We only need _group_refs
     return list(view for view, _ in _group_refs(feature_refs, all_feature_views))
+
+
+def _get_table_entity_keys(
+    table: FeatureView, entity_keys: List[EntityKeyProto]
+) -> List[EntityKeyProto]:
+    required_entities = OrderedDict.fromkeys(sorted(table.entities))
+    entity_key_protos = []
+    for entity_key in entity_keys:
+        required_entities_to_values = required_entities.copy()
+        for i in range(len(entity_key.entity_names)):
+            entity_name = entity_key.entity_names[i]
+            entity_value = entity_key.entity_values[i]
+
+            if entity_name in required_entities_to_values:
+                if required_entities_to_values[entity_name] is not None:
+                    raise ValueError(
+                        f"Duplicate entity keys detected. Table {table.name} expects {table.entities}. The entity {entity_name} was provided at least twice"
+                    )
+                required_entities_to_values[entity_name] = entity_value
+
+        entity_names = []
+        entity_values = []
+        for entity_name, entity_value in required_entities_to_values.items():
+            if entity_value is None:
+                raise ValueError(
+                    f"Table {table.name} expects entity field {table.entities}. No entity value was found for {entity_name}"
+                )
+            entity_names.append(entity_name)
+            entity_values.append(entity_value)
+        entity_key_protos.append(
+            EntityKeyProto(entity_names=entity_names, entity_values=entity_values)
+        )
+    return entity_key_protos

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -443,11 +443,11 @@ class FeatureStore:
 
         provider = self._get_provider()
 
-        entity_keys = []
+        union_of_entity_keys = []
         result_rows: List[GetOnlineFeaturesResponse.FieldValues] = []
 
         for row in entity_rows:
-            entity_keys.append(_entity_row_to_key(row))
+            union_of_entity_keys.append(_entity_row_to_key(row))
             result_rows.append(_entity_row_to_field_values(row))
 
         all_feature_views = self._registry.list_feature_views(
@@ -456,9 +456,9 @@ class FeatureStore:
 
         grouped_refs = _group_refs(feature_refs, all_feature_views)
         for table, requested_features in grouped_refs:
-            table_entity_keys = _get_table_entity_keys(table, entity_keys)
+            entity_keys = _get_table_entity_keys(table, union_of_entity_keys)
             read_rows = provider.online_read(
-                project=project, table=table, entity_keys=table_entity_keys,
+                project=project, table=table, entity_keys=entity_keys,
             )
             for row_idx, read_row in enumerate(read_rows):
                 row_ts, feature_data = read_row
@@ -662,7 +662,8 @@ def _get_table_entity_keys(
             if entity_name in required_entities_to_values:
                 if required_entities_to_values[entity_name] is not None:
                     raise ValueError(
-                        f"Duplicate entity keys detected. Table {table.name} expects {table.entities}. The entity {entity_name} was provided at least twice"
+                        f"Duplicate entity keys detected. Table {table.name} expects {table.entities}. The entity "
+                        f"{entity_name} was provided at least twice"
                     )
                 required_entities_to_values[entity_name] = entity_value
 
@@ -671,7 +672,8 @@ def _get_table_entity_keys(
         for entity_name, entity_value in required_entities_to_values.items():
             if entity_value is None:
                 raise ValueError(
-                    f"Table {table.name} expects entity field {table.entities}. No entity value was found for {entity_name}"
+                    f"Table {table.name} expects entity field {table.entities}. No entity value was found for "
+                    f"{entity_name}"
                 )
             entity_names.append(entity_name)
             entity_values.append(entity_value)

--- a/sdk/python/feast/infra/local_sqlite.py
+++ b/sdk/python/feast/infra/local_sqlite.py
@@ -72,12 +72,12 @@ class LocalSqlite(Provider):
 
         with conn:
             for entity_key, values, timestamp, created_ts in data:
-                for feature_name, val in values.items():
-                    entity_key_bin = serialize_entity_key(entity_key)
-                    timestamp = _to_naive_utc(timestamp)
-                    if created_ts is not None:
-                        created_ts = _to_naive_utc(created_ts)
+                entity_key_bin = serialize_entity_key(entity_key)
+                timestamp = _to_naive_utc(timestamp)
+                if created_ts is not None:
+                    created_ts = _to_naive_utc(created_ts)
 
+                for feature_name, val in values.items():
                     conn.execute(
                         f"""
                             UPDATE {_table_id(project, table)}


### PR DESCRIPTION
Signed-off-by: Willem Pienaar <git@willem.co>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

In the new online retriever interface, when multiple entities are required for a lookup, the online retriever wont return any results. This PR fixes a bug in the key building.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
