### PR TITLE
Add materialize-incremental to feast cli

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -430,6 +430,30 @@ def materialize_command(start_ts: str, end_ts: str, repo_path: str, views: List[
     )
 
 
+@cli.command("materialize-incremental")
+@click.argument("end_ts")
+@click.argument(
+    "repo_path", type=click.Path(dir_okay=True, exists=True,), default=Path.cwd
+)
+@click.option(
+    "--views", "-v", help="Feature views to incrementally materialize", multiple=True,
+)
+def materialize_incremental_command(end_ts: str, repo_path: str, views: List[str]):
+    """
+    Run an incremental materialization job to ingest new data into the online store. Feast will read
+    all data from the previously ingested point to END_TS from the offline store and write it to the
+    online store. If you don't specify feature view names using --views, all registred Feature
+    Views will be incrementally materialized.
+
+    END_TS should be in ISO 8601 format, e.g. '2021-07-16T19:20:01'
+    """
+    store = FeatureStore(repo_path=repo_path)
+    store.materialize_incremental(
+        feature_views=None if not views else views,
+        end_date=datetime.fromisoformat(end_ts).replace(tzinfo=utc),
+    )
+
+
 @cli.command("init")
 @click.option("--minimal", "-m", is_flag=True, help="Only generate the config")
 def init_command(minimal: bool):

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 import pyarrow
+from pytz import utc
 
 from feast.entity import Entity
 from feast.feature_view import FeatureView
@@ -308,7 +309,7 @@ class FeatureStore:
                     raise Exception(
                         f"No start time found for feature view {feature_view.name}. materialize_incremental() requires either a ttl to be set or for materialize() to have been run at least once."
                     )
-                start_date = datetime.utcnow() - feature_view.ttl
+                start_date = datetime.utcnow().replace(tzinfo=utc) - feature_view.ttl
             self._materialize_single_feature_view(feature_view, start_date, end_date)
 
     def materialize(

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Union
+from pytz import utc
 
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -163,9 +164,10 @@ class FeatureView:
         feature_view.created_timestamp = feature_view_proto.meta.created_timestamp
 
         for interval in feature_view_proto.meta.materialization_intervals:
-            feature_view.materialization_intervals.append(
-                (interval.start_time.ToDatetime(), interval.end_time.ToDatetime())
-            )
+            feature_view.materialization_intervals.append((
+                interval.start_time.ToDatetime().replace(tzinfo=utc),
+                interval.end_time.ToDatetime().replace(tzinfo=utc)
+            ))
 
         return feature_view
 


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: We have `fs.materialize_incremental` functionality in the `FeatureStore`, but don't have the equivalent function in the CLI. This PR adds that command, while also fixing a bug with timezones. By default, the timezone information was not included in the generated `start_time` and that led to `TypeError: Cannot compare tz-naive and tz-aware datetime-like objects` errors.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add `feast materialize-incremental` command to the CLI
```
