### PR TITLE
Support join keys in historical feature retrieval

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -274,7 +274,12 @@ class FeatureStore:
         feature_views = _get_requested_feature_views(feature_refs, all_feature_views)
         provider = self._get_provider()
         job = provider.get_historical_features(
-            self.config, feature_views, feature_refs, entity_df
+            self.config,
+            feature_views,
+            feature_refs,
+            entity_df,
+            self._registry,
+            self.project,
         )
         return job
 

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -14,7 +14,6 @@
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Union
 
-import pyarrow
 from google.protobuf.duration_pb2 import Duration
 from google.protobuf.json_format import MessageToJson
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -215,65 +214,3 @@ class FeatureView:
         if len(self.materialization_intervals) == 0:
             return None
         return max([interval[1] for interval in self.materialization_intervals])
-
-    def run_reverse_field_mapping(
-        self, join_keys: List[str],
-    ) -> Tuple[List[str], List[str], str, Optional[str]]:
-        """
-        If a field mapping exists, run it in reverse on the join keys,
-        feature names, event timestamp column, and created timestamp column
-        to get the names of the relevant columns in the BigQuery table.
-
-        Returns:
-            Tuple containing the list of reverse-mapped join_keys,
-            reverse-mapped feature names, reverse-mapped event timestamp column,
-            and reverse-mapped created timestamp column that will be passed into
-            the query to the offline store.
-        """
-        # if we have mapped fields, use the original field names in the call to the offline store
-        event_timestamp_column = self.input.event_timestamp_column
-        feature_names = [feature.name for feature in self.features]
-        created_timestamp_column = self.input.created_timestamp_column
-        if self.input.field_mapping is not None:
-            reverse_field_mapping = {v: k for k, v in self.input.field_mapping.items()}
-            event_timestamp_column = (
-                reverse_field_mapping[event_timestamp_column]
-                if event_timestamp_column in reverse_field_mapping.keys()
-                else event_timestamp_column
-            )
-            created_timestamp_column = (
-                reverse_field_mapping[created_timestamp_column]
-                if created_timestamp_column
-                and created_timestamp_column in reverse_field_mapping.keys()
-                else created_timestamp_column
-            )
-            join_keys = [
-                reverse_field_mapping[col]
-                if col in reverse_field_mapping.keys()
-                else col
-                for col in join_keys
-            ]
-            feature_names = [
-                reverse_field_mapping[col]
-                if col in reverse_field_mapping.keys()
-                else col
-                for col in feature_names
-            ]
-        return (
-            join_keys,
-            feature_names,
-            event_timestamp_column,
-            created_timestamp_column,
-        )
-
-
-def _run_forward_field_mapping(
-    table: pyarrow.Table, field_mapping: Dict[str, str],
-) -> pyarrow.Table:
-    # run field mapping in the forward direction
-    cols = table.column_names
-    mapped_cols = [
-        field_mapping[col] if col in field_mapping.keys() else col for col in cols
-    ]
-    table = table.rename_columns(mapped_cols)
-    return table

--- a/sdk/python/feast/infra/gcp.py
+++ b/sdk/python/feast/infra/gcp.py
@@ -185,6 +185,8 @@ class GcpProvider(Provider):
         feature_views: List[FeatureView],
         feature_refs: List[str],
         entity_df: Union[pandas.DataFrame, str],
+        registry: Registry,
+        project: str,
     ) -> RetrievalJob:
         offline_store = get_offline_store_from_sources(
             [feature_view.input for feature_view in feature_views]

--- a/sdk/python/feast/infra/gcp.py
+++ b/sdk/python/feast/infra/gcp.py
@@ -196,6 +196,8 @@ class GcpProvider(Provider):
             feature_views=feature_views,
             feature_refs=feature_refs,
             entity_df=entity_df,
+            registry=registry,
+            project=project,
         )
         return job
 

--- a/sdk/python/feast/infra/local.py
+++ b/sdk/python/feast/infra/local.py
@@ -196,6 +196,8 @@ class LocalProvider(Provider):
         feature_views: List[FeatureView],
         feature_refs: List[str],
         entity_df: Union[pd.DataFrame, str],
+        registry: Registry,
+        project: str,
     ) -> RetrievalJob:
         offline_store = get_offline_store_from_sources(
             [feature_view.input for feature_view in feature_views]
@@ -205,6 +207,8 @@ class LocalProvider(Provider):
             feature_views=feature_views,
             feature_refs=feature_refs,
             entity_df=entity_df,
+            registry=registry,
+            project=project,
         )
 
 

--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -35,6 +35,8 @@ class FileOfflineStore(OfflineStore):
         feature_views: List[FeatureView],
         feature_refs: List[str],
         entity_df: Union[pd.DataFrame, str],
+        registry: Registry,
+        project: str,
     ) -> FileRetrievalJob:
         if not isinstance(entity_df, pd.DataFrame):
             raise ValueError(
@@ -80,7 +82,11 @@ class FileOfflineStore(OfflineStore):
                     )
 
                 # Build a list of entity columns to join on (from the right table)
-                right_entity_columns = [entity for entity in feature_view.entities]
+                join_keys = []
+                for entity_name in feature_view.entities:
+                    entity = registry.get_entity(entity_name, project)
+                    join_keys.append(entity.join_key)
+                right_entity_columns = join_keys
                 right_entity_key_columns = [
                     event_timestamp_column
                 ] + right_entity_columns

--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -12,6 +12,7 @@ from feast.infra.provider import (
     ENTITY_DF_EVENT_TIMESTAMP_COL,
     _get_requested_feature_views_to_features_dict,
 )
+from feast.registry import Registry
 from feast.repo_config import RepoConfig
 
 

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -20,6 +20,7 @@ import pyarrow
 
 from feast.data_source import DataSource
 from feast.feature_view import FeatureView
+from feast.registry import Registry
 from feast.repo_config import RepoConfig
 
 
@@ -63,5 +64,7 @@ class OfflineStore(ABC):
         feature_views: List[FeatureView],
         feature_refs: List[str],
         entity_df: Union[pd.DataFrame, str],
+        registry: Registry,
+        project: str,
     ) -> RetrievalJob:
         pass

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -99,6 +99,8 @@ class Provider(abc.ABC):
         feature_views: List[FeatureView],
         feature_refs: List[str],
         entity_df: Union[pandas.DataFrame, str],
+        registry: Registry,
+        project: str,
     ) -> RetrievalJob:
         pass
 

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -105,7 +105,7 @@ class Registry:
                 entities.append(Entity.from_proto(entity_proto))
         return entities
 
-    def get_entity(self, name: str, project: str) -> Entity:
+    def get_entity(self, name: str, project: str, allow_cache: bool = False) -> Entity:
         """
         Retrieves an entity.
 
@@ -117,7 +117,7 @@ class Registry:
             Returns either the specified entity, or raises an exception if
             none is found
         """
-        registry_proto = self._get_registry_proto()
+        registry_proto = self._get_registry_proto(allow_cache=allow_cache)
         for entity_proto in registry_proto.entities:
             if entity_proto.spec.name == name and entity_proto.spec.project == project:
                 return Entity.from_proto(entity_proto)

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -57,7 +57,7 @@ def stage_driver_hourly_stats_bigquery_source(df, table_id):
 def create_driver_hourly_stats_feature_view(source):
     driver_stats_feature_view = FeatureView(
         name="driver_stats",
-        entities=["driver_id"],
+        entities=["driver"],
         features=[
             Feature(name="conv_rate", dtype=ValueType.FLOAT),
             Feature(name="acc_rate", dtype=ValueType.FLOAT),
@@ -226,8 +226,8 @@ def test_historical_features_from_parquet_sources():
             temp_dir, customer_df
         )
         customer_fv = create_customer_daily_profile_feature_view(customer_source)
-        driver = Entity(name="driver", value_type=ValueType.INT64)
-        customer = Entity(name="customer", value_type=ValueType.INT64)
+        driver = Entity(name="driver", join_key="driver_id", value_type=ValueType.INT64)
+        customer = Entity(name="customer_id", value_type=ValueType.INT64)
 
         store = FeatureStore(
             config=RepoConfig(
@@ -331,8 +331,8 @@ def test_historical_features_from_bigquery_sources(provider_type):
         )
         customer_fv = create_customer_daily_profile_feature_view(customer_source)
 
-        driver = Entity(name="driver", value_type=ValueType.INT64)
-        customer = Entity(name="customer", value_type=ValueType.INT64)
+        driver = Entity(name="driver", join_key="driver_id", value_type=ValueType.INT64)
+        customer = Entity(name="customer_id", value_type=ValueType.INT64)
 
         if provider_type == "local":
             store = FeatureStore(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Use join keys from the registry in historical feature retrieval rather than using the entity name strings in the input.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
