### PR TITLE
Fix bug in event timestamp removal in local mode

### DIFF
--- a/sdk/python/feast/infra/local_sqlite.py
+++ b/sdk/python/feast/infra/local_sqlite.py
@@ -272,9 +272,10 @@ class LocalSqlite(Provider):
                 )
 
                 # Remove right (feature table/view) event_timestamp column.
-                entity_df_with_features.drop(
-                    columns=[event_timestamp_column], inplace=True
-                )
+                if event_timestamp_column != ENTITY_DF_EVENT_TIMESTAMP_COL:
+                    entity_df_with_features.drop(
+                        columns=[event_timestamp_column], inplace=True
+                    )
 
                 # Ensure that we delete dataframes to free up memory
                 del df_to_join


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Fixes a bug in local mode when the event timestamp column in the source and the entity dataframe are both named event_timestamp

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
