### PR TITLE
Use timestamp check for token refresh

### DIFF
--- a/sdk/python/tests/grpc/test_auth.py
+++ b/sdk/python/tests/grpc/test_auth.py
@@ -147,9 +147,13 @@ def test_get_auth_metadata_plugin_oauth_should_raise_when_config_is_incorrect(
         get_auth_metadata_plugin(config_with_missing_variable)
 
 
+@patch(
+    "google.oauth2.id_token.verify_token",
+    return_value={"iss": "accounts.google.com", "exp": 12341234},
+)
 @patch("google.oauth2.id_token.fetch_id_token", return_value="Some Token")
 def test_get_auth_metadata_plugin_google_should_pass_with_token_from_gcloud_sdk(
-    fetch_id_token, config_google
+    verify_token, fetch_id_token, config_google
 ):
     auth_metadata_plugin = get_auth_metadata_plugin(config_google)
     assert isinstance(auth_metadata_plugin, GoogleOpenIDAuthMetadataPlugin)
@@ -159,6 +163,10 @@ def test_get_auth_metadata_plugin_google_should_pass_with_token_from_gcloud_sdk(
 
 
 @patch(
+    "google.oauth2.id_token.verify_token",
+    return_value={"iss": "accounts.google.com", "exp": 12341234},
+)
+@patch(
     "google.auth.default",
     return_value=[
         GoogleDefaultResponse("fake_token"),
@@ -167,7 +175,7 @@ def test_get_auth_metadata_plugin_google_should_pass_with_token_from_gcloud_sdk(
 )
 @patch("google.oauth2.id_token.fetch_id_token", side_effect=DefaultCredentialsError())
 def test_get_auth_metadata_plugin_google_should_pass_with_token_from_google_auth_lib(
-    fetch_id_token, default, config_google
+    verify_token, fetch_id_token, default, config_google
 ):
     auth_metadata_plugin = get_auth_metadata_plugin(config_google)
     assert isinstance(auth_metadata_plugin, GoogleOpenIDAuthMetadataPlugin)


### PR DESCRIPTION
Signed-off-by: Terence Lim <terencelimxp@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, auth id_token will expire after an hour. When auth is switched on, JobService which connects to Core Client will face authentication issues because of expired id_token. This PR validates if tokens are expired when requests hit Core and refreshes if they are.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
