### PR TITLE
Port telemetry to FeatureStore API

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -364,7 +364,7 @@ class Client:
             else:
                 self._telemetry_id = str(uuid.uuid4())
                 print(
-                    "Feast is an open source project that collects anonymized usage statistics. To opt out or learn more see https://docs.feast.dev/v/master/advanced/telemetry"
+                    "Feast is an open source project that collects anonymized usage statistics. To opt out or learn more see https://docs.feast.dev/v/v0.9-branch/advanced/telemetry"
                 )
                 with open(telemetry_filepath, "w") as f:
                     f.write(self._telemetry_id)

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -17,7 +17,6 @@ import os
 import shutil
 import uuid
 import warnings
-from datetime import datetime
 from os.path import expanduser, join
 from typing import Any, Dict, List, Optional, Union
 
@@ -73,7 +72,7 @@ from feast.protos.feast.serving.ServingService_pb2 import (
 )
 from feast.protos.feast.serving.ServingService_pb2_grpc import ServingServiceStub
 from feast.registry import Registry
-from feast.telemetry import log_usage
+from feast.telemetry import tele
 
 _logger = logging.getLogger(__name__)
 
@@ -492,13 +491,7 @@ class Client:
             >>> feast_client.apply(entity)
         """
 
-        if self._telemetry_enabled:
-            log_usage(
-                "apply",
-                self._telemetry_id,
-                datetime.utcnow(),
-                self.version(sdk_only=True),
-            )
+        tele.log("apply")
         if project is None:
             project = self.project
 
@@ -612,13 +605,7 @@ class Client:
             none is found
         """
 
-        if self._telemetry_enabled:
-            log_usage(
-                "get_entity",
-                self._telemetry_id,
-                datetime.utcnow(),
-                self.version(sdk_only=True),
-            )
+        tele.log("get_entity")
 
         if project is None:
             project = self.project
@@ -743,13 +730,7 @@ class Client:
             none is found
         """
 
-        if self._telemetry_enabled:
-            log_usage(
-                "get_feature_table",
-                self._telemetry_id,
-                datetime.utcnow(),
-                self.version(sdk_only=True),
-            )
+        tele.log("get_feature_table")
 
         if project is None:
             project = self.project
@@ -890,13 +871,7 @@ class Client:
             >>> client.ingest(driver_ft, ft_df)
         """
 
-        if self._telemetry_enabled:
-            log_usage(
-                "ingest",
-                self._telemetry_id,
-                datetime.utcnow(),
-                self.version(sdk_only=True),
-            )
+        tele.log("ingest")
         if project is None:
             project = self.project
         if isinstance(feature_table, str):
@@ -1021,15 +996,7 @@ class Client:
             {'sales:daily_transactions': [1.1,1.2], 'sales:customer_id': [0,1]}
         """
 
-        if self._telemetry_enabled:
-            if self._telemetry_counter["get_online_features"] % 1000 == 0:
-                log_usage(
-                    "get_online_features",
-                    self._telemetry_id,
-                    datetime.utcnow(),
-                    self.version(sdk_only=True),
-                )
-            self._telemetry_counter["get_online_features"] += 1
+        tele.log("get_online_features")
         try:
             response = self._serving_service.GetOnlineFeaturesV2(
                 GetOnlineFeaturesRequestV2(

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -13,11 +13,8 @@
 # limitations under the License.
 import logging
 import multiprocessing
-import os
 import shutil
-import uuid
 import warnings
-from os.path import expanduser, join
 from typing import Any, Dict, List, Optional, Union
 
 import grpc
@@ -72,7 +69,7 @@ from feast.protos.feast.serving.ServingService_pb2 import (
 )
 from feast.protos.feast.serving.ServingService_pb2_grpc import ServingServiceStub
 from feast.registry import Registry
-from feast.telemetry import tele
+from feast.telemetry import Telemetry
 
 _logger = logging.getLogger(__name__)
 
@@ -120,7 +117,7 @@ class Client:
         if self._config.getboolean(opt.ENABLE_AUTH):
             self._auth_metadata = feast_auth.get_auth_metadata_plugin(self._config)
 
-        self._configure_telemetry()
+        self._tele = Telemetry()
 
     @property
     def config(self) -> Config:
@@ -350,27 +347,6 @@ class Client:
 
         return result
 
-    def _configure_telemetry(self):
-        telemetry_filepath = join(expanduser("~"), ".feast", "telemetry")
-        self._telemetry_enabled = (
-            self._config.get(opt.TELEMETRY, "True") == "True"
-        )  # written this way to turn the env var string into a boolean
-        if self._telemetry_enabled:
-            self._telemetry_counter = {"get_online_features": 0}
-            if os.path.exists(telemetry_filepath):
-                with open(telemetry_filepath, "r") as f:
-                    self._telemetry_id = f.read()
-            else:
-                self._telemetry_id = str(uuid.uuid4())
-                print(
-                    "Feast is an open source project that collects anonymized usage statistics. To opt out or learn more see https://docs.feast.dev/v/v0.9-branch/advanced/telemetry"
-                )
-                with open(telemetry_filepath, "w") as f:
-                    f.write(self._telemetry_id)
-        else:
-            if os.path.exists(telemetry_filepath):
-                os.remove(telemetry_filepath)
-
     @property
     def project(self) -> str:
         """
@@ -491,7 +467,7 @@ class Client:
             >>> feast_client.apply(entity)
         """
 
-        tele.log("apply")
+        self._tele.log("apply")
         if project is None:
             project = self.project
 
@@ -605,7 +581,7 @@ class Client:
             none is found
         """
 
-        tele.log("get_entity")
+        self._tele.log("get_entity")
 
         if project is None:
             project = self.project
@@ -730,7 +706,7 @@ class Client:
             none is found
         """
 
-        tele.log("get_feature_table")
+        self._tele.log("get_feature_table")
 
         if project is None:
             project = self.project
@@ -871,7 +847,7 @@ class Client:
             >>> client.ingest(driver_ft, ft_df)
         """
 
-        tele.log("ingest")
+        self._tele.log("ingest")
         if project is None:
             project = self.project
         if isinstance(feature_table, str):
@@ -996,7 +972,7 @@ class Client:
             {'sales:daily_transactions': [1.1,1.2], 'sales:customer_id': [0,1]}
         """
 
-        tele.log("get_online_features")
+        self._tele.log("get_online_features")
         try:
             response = self._serving_service.GetOnlineFeaturesV2(
                 GetOnlineFeaturesRequestV2(

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -134,6 +134,13 @@ class FeatureStore:
         greater than 0, then once the cache becomes stale (more time than the TTL has passed), a new cache will be
         downloaded synchronously, which may increase latencies if the triggering method is get_online_features()
         """
+        if self._telemetry_enabled:
+            log_usage(
+                "refresh_registry",
+                self._telemetry_id,
+                datetime.utcnow(),
+                self.version(),
+            )
 
         registry_config = self.config.get_registry_config()
         self._registry = Registry(
@@ -149,6 +156,11 @@ class FeatureStore:
         Returns:
             List of entities
         """
+        if self._telemetry_enabled:
+            log_usage(
+                "list_entities", self._telemetry_id, datetime.utcnow(), self.version(),
+            )
+
         return self._registry.list_entities(self.project)
 
     def list_feature_views(self) -> List[FeatureView]:
@@ -158,6 +170,14 @@ class FeatureStore:
         Returns:
             List of feature views
         """
+        if self._telemetry_enabled:
+            log_usage(
+                "list_feature_views",
+                self._telemetry_id,
+                datetime.utcnow(),
+                self.version(),
+            )
+
         return self._registry.list_feature_views(self.project)
 
     def get_entity(self, name: str) -> Entity:
@@ -175,6 +195,7 @@ class FeatureStore:
             log_usage(
                 "get_entity", self._telemetry_id, datetime.utcnow(), self.version(),
             )
+
         return self._registry.get_entity(name, self.project)
 
     def get_feature_view(self, name: str) -> FeatureView:
@@ -195,6 +216,7 @@ class FeatureStore:
                 datetime.utcnow(),
                 self.version(),
             )
+
         return self._registry.get_feature_view(name, self.project)
 
     def delete_feature_view(self, name: str):
@@ -204,6 +226,14 @@ class FeatureStore:
         Args:
             name: Name of feature view
         """
+        if self._telemetry_enabled:
+            log_usage(
+                "delete_feature_view",
+                self._telemetry_id,
+                datetime.utcnow(),
+                self.version(),
+            )
+
         return self._registry.delete_feature_view(name, self.project)
 
     def apply(self, objects: List[Union[FeatureView, Entity]]):

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -11,16 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+import uuid
 from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
 from os.path import expanduser, join
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import os
 import pandas as pd
 import pyarrow
-import uuid
 
 from feast import utils
 from feast.entity import Entity
@@ -173,10 +173,7 @@ class FeatureStore:
         """
         if self._telemetry_enabled:
             log_usage(
-                "get_entity",
-                self._telemetry_id,
-                datetime.utcnow(),
-                self.version(),
+                "get_entity", self._telemetry_id, datetime.utcnow(), self.version(),
             )
         return self._registry.get_entity(name, self.project)
 
@@ -240,10 +237,7 @@ class FeatureStore:
 
         if self._telemetry_enabled:
             log_usage(
-                "apply",
-                self._telemetry_id,
-                datetime.utcnow(),
-                self.version(),
+                "apply", self._telemetry_id, datetime.utcnow(), self.version(),
             )
 
         # TODO: Add locking
@@ -412,10 +406,7 @@ class FeatureStore:
         """
         if self._telemetry_enabled:
             log_usage(
-                "materialize",
-                self._telemetry_id,
-                datetime.utcnow(),
-                self.version(),
+                "materialize", self._telemetry_id, datetime.utcnow(), self.version(),
             )
 
         feature_views_to_materialize = []

--- a/sdk/python/feast/telemetry.py
+++ b/sdk/python/feast/telemetry.py
@@ -30,7 +30,6 @@ TELEMETRY_ENDPOINT = (
 class Telemetry:
     def __init__(self):
         telemetry_filepath = join(expanduser("~"), ".feast", "telemetry")
-        print(os.environ)
         self._telemetry_enabled = (
             os.getenv("FEAST_TELEMETRY", default="True") == "True"
         )  # written this way to turn the env var string into a boolean

--- a/sdk/python/feast/telemetry.py
+++ b/sdk/python/feast/telemetry.py
@@ -15,7 +15,7 @@
 import os
 import sys
 from datetime import datetime
-from typing import Dict
+from typing import Dict, Union
 
 import requests
 
@@ -28,7 +28,7 @@ def log_usage(
     function_name: str,
     telemetry_id: str,
     timestamp: datetime,
-    version: Dict[str, Dict[str, str]],
+    version: Union[str, Dict[str, Dict[str, str]]],
 ):
     json = {
         "function_name": function_name,

--- a/sdk/python/feast/telemetry.py
+++ b/sdk/python/feast/telemetry.py
@@ -18,7 +18,6 @@ import uuid
 from datetime import datetime
 from os.path import expanduser, join
 
-import pkg_resources
 import requests
 
 from feast.version import get_version
@@ -27,13 +26,16 @@ TELEMETRY_ENDPOINT = (
     "https://us-central1-kf-feast.cloudfunctions.net/bq_telemetry_logger"
 )
 
+
 class Telemetry:
     def __init__(self):
         telemetry_filepath = join(expanduser("~"), ".feast", "telemetry")
-
+        print(os.environ)
         self._telemetry_enabled = (
             os.getenv("FEAST_TELEMETRY", default="True") == "True"
         )  # written this way to turn the env var string into a boolean
+
+        self._is_test = os.getenv("FEAST_IS_TELEMETRY_TEST", "False") == "True"
 
         if self._telemetry_enabled:
             self._telemetry_counter = {"get_online_features": 0}
@@ -42,18 +44,22 @@ class Telemetry:
                     self._telemetry_id = f.read()
             else:
                 self._telemetry_id = str(uuid.uuid4())
-                print(
-                    "Feast is an open source project that collects anonymized usage statistics. To opt out or learn more see https://docs.feast.dev/v/master/feast-on-kubernetes/advanced-1/telemetry"
-                )
                 with open(telemetry_filepath, "w") as f:
                     f.write(self._telemetry_id)
-        else:
-            if os.path.exists(telemetry_filepath):
-                os.remove(telemetry_filepath)
+                print(
+                    "Feast is an open source project that collects anonymized usage statistics. To opt out or learn"
+                    " more see https://docs.feast.dev/v/master/feast-on-kubernetes/advanced-1/telemetry"
+                )
+
+    @property
+    def telemetry_id(self):
+        if os.environ["FEAST_FORCE_TELEMETRY_UUID"]:
+            return os.environ["FEAST_FORCE_TELEMETRY_UUID"]
+        return self._telemetry_id
 
     def log(self, function_name: str):
 
-        if self._telemetry_enabled and self._telemetry_id:
+        if self._telemetry_enabled and self.telemetry_id:
             if function_name == "get_online_features":
                 if self._telemetry_counter["get_online_features"] % 10000 != 0:
                     self._telemetry_counter["get_online_features"] += 1
@@ -61,17 +67,17 @@ class Telemetry:
 
             json = {
                 "function_name": function_name,
-                "telemetry_id": self._telemetry_id,
-                "timestamp": datetime.utcnow(),
+                "telemetry_id": self.telemetry_id,
+                "timestamp": datetime.utcnow().isoformat(),
                 "version": get_version(),
                 "os": sys.platform,
-                "is_test": os.getenv("FEAST_IS_TELEMETRY_TEST", "False"),
+                "is_test": self._is_test,
             }
             try:
                 requests.post(TELEMETRY_ENDPOINT, json=json)
-            except Exception:
-                pass
+            except Exception as e:
+                if self._is_test:
+                    raise e
+                else:
+                    pass
             return
-
-
-tele = Telemetry()

--- a/sdk/python/feast/telemetry.py
+++ b/sdk/python/feast/telemetry.py
@@ -27,13 +27,6 @@ TELEMETRY_ENDPOINT = (
     "https://us-central1-kf-feast.cloudfunctions.net/bq_telemetry_logger"
 )
 
-
-try:
-    sdk_version = pkg_resources.get_distribution("feast").version
-except pkg_resources.DistributionNotFound:
-    sdk_version = "local build"
-
-
 class Telemetry:
     def __init__(self):
         telemetry_filepath = join(expanduser("~"), ".feast", "telemetry")

--- a/sdk/python/feast/version.py
+++ b/sdk/python/feast/version.py
@@ -1,0 +1,13 @@
+import pkg_resources
+
+
+def get_version():
+    """
+    Returns version information of the Feast Python Package
+    """
+
+    try:
+        sdk_version = pkg_resources.get_distribution("feast").version
+    except pkg_resources.DistributionNotFound:
+        sdk_version = "unknown"
+    return sdk_version

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -83,6 +83,7 @@ CI_REQUIRED = [
     "pytest-mock==1.10.4",
     "Sphinx",
     "sphinx-rtd-theme",
+    "tenacity",
     "adlfs==0.5.9",
     "firebase-admin==4.5.2",
     "google-cloud-datastore==2.1.0",


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Ports opt-out telemetry to the new FeatureStore API

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Opt-out telemetry (usage logging) is now enabled on the FeatureStore API. To disable it, see https://docs.feast.dev/v/master/feast-on-kubernetes/advanced-1/telemetry
```
