### PR TITLE
Fix noisy path warning

### DIFF
--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -456,7 +456,7 @@ class DataSource:
             data_source_obj = FileSource(
                 field_mapping=data_source.field_mapping,
                 file_format=FileFormat.from_proto(data_source.file_options.file_format),
-                file_url=data_source.file_options.file_url,
+                path=data_source.file_options.file_url,
                 event_timestamp_column=data_source.event_timestamp_column,
                 created_timestamp_column=data_source.created_timestamp_column,
                 date_partition_column=data_source.date_partition_column,
@@ -553,8 +553,7 @@ class FileSource(DataSource):
             raise ValueError(
                 'No "path" argument provided. Please set "path" to the location of your file source.'
             )
-
-        if file_url is not None:
+        if file_url:
             from warnings import warn
 
             warn(


### PR DESCRIPTION
Signed-off-by: Willem Pienaar <git@willem.co>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Stops a noisy warning when the user provides a `path` argument to a `FileSource` (which is correct), but the warning mistakes this for `file_url`.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
