### PR TITLE
Fix get_online_features return schema

### DIFF
--- a/sdk/python/feast/online_response.py
+++ b/sdk/python/feast/online_response.py
@@ -51,7 +51,7 @@ class OnlineResponse:
         """
         Converts GetOnlineFeaturesResponse features into a dictionary form.
         """
-        fields = [k for row in self.field_values for k, _ in row.fields.items()]
+        fields = [k for row in self.field_values for k, _ in row.statuses.items()]
         features_dict: Dict[str, List[Any]] = {k: list() for k in fields}
 
         for row in self.field_values:

--- a/sdk/python/tests/test_online_retrieval.py
+++ b/sdk/python/tests/test_online_retrieval.py
@@ -107,6 +107,14 @@ def test_online() -> None:
         assert result["customer_profile__name"] == ["John", "John"]
         assert result["customer_driver_combined__trips"] == [7, 7]
 
+        # Ensure features are still in result when keys not found
+        result = store.get_online_features(
+            feature_refs=["customer_driver_combined:trips"],
+            entity_rows=[{"driver": 0, "customer": 0}],
+        ).to_dict()
+
+        assert "customer_driver_combined__trips" in result
+
         # invalid table reference
         with pytest.raises(ValueError):
             store.get_online_features(


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Include all requested features in the return schema of get_online_features even when no keys are found in the online store

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`feature_store.get_online_features(...).to_dict()` returns a dictionary that now always contains all requested features; previously, features with no values for any of the requested keys had not been included.
```
