### PR TITLE
Allow apply to take a single Entity or FeatureView

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -175,7 +175,9 @@ class FeatureStore:
 
         return self._registry.delete_feature_view(name, self.project)
 
-    def apply(self, objects: List[Union[FeatureView, Entity]]):
+    def apply(
+        self, objects: Union[Entity, FeatureView, List[Union[FeatureView, Entity]]]
+    ):
         """Register objects to metadata store and update related infrastructure.
 
         The apply method registers one or more definitions (e.g., Entity, FeatureView) and registers or updates these
@@ -209,6 +211,8 @@ class FeatureStore:
         # TODO: Add locking
         # TODO: Optimize by only making a single call (read/write)
 
+        if isinstance(objects, Entity) or isinstance(objects, FeatureView):
+            objects = [objects]
         views_to_update = []
         for ob in objects:
             if isinstance(ob, FeatureView):

--- a/sdk/python/tests/test_feature_store.py
+++ b/sdk/python/tests/test_feature_store.py
@@ -79,8 +79,8 @@ def test_apply_entity_success(test_feature_store):
         labels={"team": "matchmaking"},
     )
 
-    # Register Entity with Core
-    test_feature_store.apply([entity])
+    # Register Entity
+    test_feature_store.apply(entity)
 
     entities = test_feature_store.list_entities()
 
@@ -107,7 +107,7 @@ def test_apply_entity_integration(test_feature_store):
         labels={"team": "matchmaking"},
     )
 
-    # Register Entity with Core
+    # Register Entity
     test_feature_store.apply([entity])
 
     entities = test_feature_store.list_entities()


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Allows apply to take in a single Entity or FeatureView

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`feature_store.apply()` now can accept a single Entity or FeatureView. Previously, it only accepted a list of Entities or FeatureViews.
```
