### PR TITLE
Change FeatureStore default config to read from current directory

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -29,12 +29,7 @@ from feast.protos.feast.serving.ServingService_pb2 import (
 )
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.registry import Registry
-from feast.repo_config import (
-    LocalOnlineStoreConfig,
-    OnlineStoreConfig,
-    RepoConfig,
-    load_repo_config,
-)
+from feast.repo_config import RepoConfig, load_repo_config
 from feast.telemetry import Telemetry
 from feast.version import get_version
 
@@ -59,14 +54,7 @@ class FeatureStore:
         elif repo_path is not None:
             self.config = load_repo_config(Path(repo_path))
         else:
-            self.config = RepoConfig(
-                registry="./registry.db",
-                project="default",
-                provider="local",
-                online_store=OnlineStoreConfig(
-                    local=LocalOnlineStoreConfig(path="online_store.db")
-                ),
-            )
+            self.config = load_repo_config(Path("."))
 
         registry_config = self.config.get_registry_config()
         self._registry = Registry(

--- a/sdk/python/telemetry_tests/test_telemetry.py
+++ b/sdk/python/telemetry_tests/test_telemetry.py
@@ -14,6 +14,7 @@
 import uuid
 from datetime import datetime
 
+from tempfile import mkstemp
 from tenacity import retry, wait_exponential, stop_after_attempt
 
 from google.cloud import bigquery
@@ -22,6 +23,7 @@ from time import sleep
 from importlib import reload
 
 from feast import Client, Entity, ValueType, FeatureStore
+from feast.repo_config import LocalOnlineStoreConfig, OnlineStoreConfig, RepoConfig
 
 TELEMETRY_BIGQUERY_TABLE = (
     "kf-feast.feast_telemetry.cloudfunctions_googleapis_com_cloud_functions"
@@ -91,7 +93,17 @@ def test_telemetry_on():
     os.environ["FEAST_IS_TELEMETRY_TEST"] = "True"
     os.environ["FEAST_TELEMETRY"] = "True"
 
-    test_feature_store = FeatureStore()
+    _, registry_path = mkstemp()
+    _, online_store_path = mkstemp()
+    config = RepoConfig(
+        registry=registry_path,
+        project="default",
+        provider="local",
+        online_store=OnlineStoreConfig(
+            local=LocalOnlineStoreConfig(path=online_store_path)
+        )
+    )
+    test_feature_store = FeatureStore(config=config)
     entity = Entity(
         name="driver_car_id",
         description="Car driver id",
@@ -113,7 +125,17 @@ def test_telemetry_off():
     os.environ["FEAST_TELEMETRY"] = "False"
     os.environ["FEAST_FORCE_TELEMETRY_UUID"] = test_telemetry_id
 
-    test_feature_store = FeatureStore()
+    _, registry_path = mkstemp()
+    _, online_store_path = mkstemp()
+    config = RepoConfig(
+        registry=registry_path,
+        project="default",
+        provider="local",
+        online_store=OnlineStoreConfig(
+            local=LocalOnlineStoreConfig(path=online_store_path)
+        )
+    )
+    test_feature_store = FeatureStore(config=config)
     entity = Entity(
         name="driver_car_id",
         description="Car driver id",


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Change FeatureStore default config to read from current directory instead of using a fixed default config

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Running `FeatureStore()` without any arguments now looks in the current working directory for a `feature_store.yaml` file instead of using a fixed default config.
```
