### PR TITLE
Validate timestamp column present in entity dataframe

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -79,6 +79,10 @@ class BigQueryOfflineStore(OfflineStore):
         if type(entity_df) is str:
             entity_df_sql_table = f"({entity_df})"
         elif isinstance(entity_df, pandas.DataFrame):
+            if "event_timestamp" not in entity_df.columns:
+                raise ValueError(
+                    "Please provide an entity_df with a column named event_timestamp representing the time of the event."
+                )
             table_id = _upload_entity_df_into_bigquery(config.project, entity_df)
             entity_df_sql_table = f"`{table_id}`"
         else:

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -81,7 +81,7 @@ class BigQueryOfflineStore(OfflineStore):
         elif isinstance(entity_df, pandas.DataFrame):
             if "event_timestamp" not in entity_df.columns:
                 raise ValueError(
-                    "Please provide an entity_df with a column named event_timestamp representing the time of the event."
+                    "Please provide an entity_df with a column named event_timestamp representing the time of events."
                 )
             table_id = _upload_entity_df_into_bigquery(config.project, entity_df)
             entity_df_sql_table = f"`{table_id}`"

--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -45,7 +45,7 @@ class FileOfflineStore(OfflineStore):
             )
         if ENTITY_DF_EVENT_TIMESTAMP_COL not in entity_df.columns:
             raise ValueError(
-                f"Please provide an entity_df with a column named {ENTITY_DF_EVENT_TIMESTAMP_COL} representing the time of the event."
+                f"Please provide an entity_df with a column named {ENTITY_DF_EVENT_TIMESTAMP_COL} representing the time of events."
             )
 
         feature_views_to_features = _get_requested_feature_views_to_features_dict(

--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -43,6 +43,10 @@ class FileOfflineStore(OfflineStore):
             raise ValueError(
                 f"Please provide an entity_df of type {type(pd.DataFrame)} instead of type {type(entity_df)}"
             )
+        if ENTITY_DF_EVENT_TIMESTAMP_COL not in entity_df.columns:
+            raise ValueError(
+                f"Please provide an entity_df with a column named {ENTITY_DF_EVENT_TIMESTAMP_COL} representing the time of the event."
+            )
 
         feature_views_to_features = _get_requested_feature_views_to_features_dict(
             feature_refs, feature_views


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Validates that a correctly named timestamp column is present in the entity dataframe passed to get_historical_features

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
