### PR TITLE
Fix offline store (tz-naive & field_mapping issues)

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -11,6 +11,7 @@ from feast.infra.offline_stores.offline_store import OfflineStore, RetrievalJob
 from feast.infra.provider import (
     ENTITY_DF_EVENT_TIMESTAMP_COL,
     _get_requested_feature_views_to_features_dict,
+    _run_field_mapping,
 )
 from feast.registry import Registry
 from feast.repo_config import RepoConfig
@@ -55,6 +56,10 @@ class FileOfflineStore(OfflineStore):
         # Create lazy function that is only called from the RetrievalJob object
         def evaluate_historical_retrieval():
 
+            # Make sure all event timestamp fields are tz-aware. We default tz-naive fields to UTC
+            entity_df[ENTITY_DF_EVENT_TIMESTAMP_COL] = entity_df[
+                ENTITY_DF_EVENT_TIMESTAMP_COL
+            ].apply(lambda x: x if x.tz is not None else x.replace(tzinfo=pytz.utc))
             # Sort entity dataframe prior to join, and create a copy to prevent modifying the original
             entity_df_with_features = entity_df.sort_values(
                 ENTITY_DF_EVENT_TIMESTAMP_COL
@@ -65,10 +70,29 @@ class FileOfflineStore(OfflineStore):
                 event_timestamp_column = feature_view.input.event_timestamp_column
                 created_timestamp_column = feature_view.input.created_timestamp_column
 
-                # Read dataframe to join to entity dataframe
-                df_to_join = pd.read_parquet(feature_view.input.path).sort_values(
+                # Read offline parquet data in pyarrow format
+                table = pyarrow.parquet.read_table(feature_view.input.path)
+
+                # Rename columns by the field mapping dictionary if it exists
+                if feature_view.input.field_mapping is not None:
+                    table = _run_field_mapping(table, feature_view.input.field_mapping)
+
+                # Convert pyarrow table to pandas dataframe
+                df_to_join = table.to_pandas()
+
+                # Make sure all timestamp fields are tz-aware. We default tz-naive fields to UTC
+                df_to_join[event_timestamp_column] = df_to_join[
                     event_timestamp_column
-                )
+                ].apply(lambda x: x if x.tz is not None else x.replace(tzinfo=pytz.utc))
+                if created_timestamp_column:
+                    df_to_join[created_timestamp_column] = df_to_join[
+                        created_timestamp_column
+                    ].apply(
+                        lambda x: x if x.tz is not None else x.replace(tzinfo=pytz.utc)
+                    )
+
+                # Sort dataframe by the event timestamp column
+                df_to_join = df_to_join.sort_values(event_timestamp_column)
 
                 # Build a list of all the features we should select from this source
                 feature_names = []


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Discovered 2 different bugs in get_historical_features. 1) if the entity_df contains tz-naive timestamps, point-in-time merging doesn't work in local mode. 2) field_mapping is not being used in offline mode (it's used in online mode). Meaning that if you define field_mapping, get_historical_features simply fails in both local and gcp modes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix tz-naive issue with offline store and apply field_mapping during historical feature retrieval
```
