### PR TITLE
Small fixes for created_timestamp

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -159,13 +159,14 @@ class FileOfflineStore(OfflineStore):
         source_df[event_timestamp_column] = source_df[event_timestamp_column].apply(
             lambda x: x if x.tz is not None else x.replace(tzinfo=pytz.utc)
         )
-        source_df[created_timestamp_column] = source_df[created_timestamp_column].apply(
-            lambda x: x if x.tz is not None else x.replace(tzinfo=pytz.utc)
-        )
+        if created_timestamp_column:
+            source_df[created_timestamp_column] = source_df[
+                created_timestamp_column
+            ].apply(lambda x: x if x.tz is not None else x.replace(tzinfo=pytz.utc))
 
         ts_columns = (
             [event_timestamp_column, created_timestamp_column]
-            if created_timestamp_column is not None
+            if created_timestamp_column
             else [event_timestamp_column]
         )
 

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -264,7 +264,7 @@ def _convert_arrow_to_proto(
         )
         event_timestamp = _coerce_datetime(row[event_timestamp_idx])
 
-        if feature_view.input.created_timestamp_column is not None:
+        if feature_view.input.created_timestamp_column:
             created_timestamp_idx = table.column_names.index(
                 feature_view.input.created_timestamp_column
             )


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Fixes some small bugs with created_timestamp

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
