### PR TITLE
Fix time zone access with native python datetimes

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -59,7 +59,7 @@ class FileOfflineStore(OfflineStore):
             # Make sure all event timestamp fields are tz-aware. We default tz-naive fields to UTC
             entity_df[ENTITY_DF_EVENT_TIMESTAMP_COL] = entity_df[
                 ENTITY_DF_EVENT_TIMESTAMP_COL
-            ].apply(lambda x: x if x.tz is not None else x.replace(tzinfo=pytz.utc))
+            ].apply(lambda x: x if x.tzinfo is not None else x.replace(tzinfo=pytz.utc))
             # Sort entity dataframe prior to join, and create a copy to prevent modifying the original
             entity_df_with_features = entity_df.sort_values(
                 ENTITY_DF_EVENT_TIMESTAMP_COL
@@ -83,12 +83,16 @@ class FileOfflineStore(OfflineStore):
                 # Make sure all timestamp fields are tz-aware. We default tz-naive fields to UTC
                 df_to_join[event_timestamp_column] = df_to_join[
                     event_timestamp_column
-                ].apply(lambda x: x if x.tz is not None else x.replace(tzinfo=pytz.utc))
+                ].apply(
+                    lambda x: x if x.tzinfo is not None else x.replace(tzinfo=pytz.utc)
+                )
                 if created_timestamp_column:
                     df_to_join[created_timestamp_column] = df_to_join[
                         created_timestamp_column
                     ].apply(
-                        lambda x: x if x.tz is not None else x.replace(tzinfo=pytz.utc)
+                        lambda x: x
+                        if x.tzinfo is not None
+                        else x.replace(tzinfo=pytz.utc)
                     )
 
                 # Sort dataframe by the event timestamp column
@@ -181,12 +185,12 @@ class FileOfflineStore(OfflineStore):
         source_df = pd.read_parquet(data_source.path)
         # Make sure all timestamp fields are tz-aware. We default tz-naive fields to UTC
         source_df[event_timestamp_column] = source_df[event_timestamp_column].apply(
-            lambda x: x if x.tz is not None else x.replace(tzinfo=pytz.utc)
+            lambda x: x if x.tzinfo is not None else x.replace(tzinfo=pytz.utc)
         )
         if created_timestamp_column:
             source_df[created_timestamp_column] = source_df[
                 created_timestamp_column
-            ].apply(lambda x: x if x.tz is not None else x.replace(tzinfo=pytz.utc))
+            ].apply(lambda x: x if x.tzinfo is not None else x.replace(tzinfo=pytz.utc))
 
         ts_columns = (
             [event_timestamp_column, created_timestamp_column]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Looks like x.tz exists only for pandas Timestamp type (which extends Python's native datetime object), but it that fields doesn't exist in the original datetime object. Given that tz is just an alias for tzinfo, x.tzinfo exists both in pandas Timestamp & in Python's native datetime objects, so I'm changing it to that.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
