### PR TITLE
Remove unnecessary MAVEN_CONFIG

### DIFF
--- a/infra/docker/ci/Dockerfile
+++ b/infra/docker/ci/Dockerfile
@@ -26,7 +26,6 @@ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
 ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "/root/.m2"
 
 # Install Make and Python
 ENV PYTHON_VERSION 3.7


### PR DESCRIPTION
Remove unused environment variable. The `MAVEN_CONFIG` variable is used by the maven Docker image (which we're not using) and is not used by Maven itself in any way. It is colliding with Maven Wrapper configuration (which also uses this variable) and is causing feast-dev/feast-java#26 to fail