### PR TITLE
Fix time zone issue with get_historical_features

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -60,10 +60,20 @@ class FileOfflineStore(OfflineStore):
             entity_df[ENTITY_DF_EVENT_TIMESTAMP_COL] = entity_df[
                 ENTITY_DF_EVENT_TIMESTAMP_COL
             ].apply(lambda x: x if x.tzinfo is not None else x.replace(tzinfo=pytz.utc))
-            # Sort entity dataframe prior to join, and create a copy to prevent modifying the original
-            entity_df_with_features = entity_df.sort_values(
+
+            # Create a copy of entity_df to prevent modifying the original
+            entity_df_with_features = entity_df.copy()
+
+            # Convert event timestamp column to datetime and normalize time zone to UTC
+            # This is necessary to avoid issues with pd.merge_asof
+            entity_df_with_features[ENTITY_DF_EVENT_TIMESTAMP_COL] = pd.to_datetime(
+                entity_df_with_features[ENTITY_DF_EVENT_TIMESTAMP_COL], utc=True
+            )
+
+            # Sort event timestamp values
+            entity_df_with_features = entity_df_with_features.sort_values(
                 ENTITY_DF_EVENT_TIMESTAMP_COL
-            ).copy()
+            )
 
             # Load feature view data from sources and join them incrementally
             for feature_view, features in feature_views_to_features.items():

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -178,6 +178,15 @@ def get_expected_training_df(
     current_cols.remove(ENTITY_DF_EVENT_TIMESTAMP_COL)
     expected_df = expected_df[[ENTITY_DF_EVENT_TIMESTAMP_COL] + current_cols]
 
+    # Cast some columns to expected types, since we lose information when converting pandas DFs into Python objects.
+    expected_df["order_is_success"] = expected_df["order_is_success"].astype("int32")
+    expected_df["customer_profile__current_balance"] = expected_df[
+        "customer_profile__current_balance"
+    ].astype("float32")
+    expected_df["customer_profile__avg_passenger_count"] = expected_df[
+        "customer_profile__avg_passenger_count"
+    ].astype("float32")
+
     return expected_df
 
 
@@ -286,7 +295,6 @@ def test_historical_features_from_parquet_sources():
                     "customer_id",
                 ]
             ).reset_index(drop=True),
-            check_dtype=False,
         )
 
 


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: There was an issue with FeatureStore.get_historical_features when you pass records with timestamp with non-UTC time zones (pandas merge_asof was throwing an exception). This PR fixes that issue by converting all timestamps in the entity to UTC. If timestamp is tz-naive, we assume it's UTC. If it's tz-aware, we localize to UTC.

I also made significant changes to the tests. First, when generating entities we now generate timestamps in all kinds of different formats. Second, `test_historical_retrieval.py:get_expected_training_df` function used a very similar logic to the local offline store (based on pandas merge_asof). Meaning that if there are bugs in the local offline store, we replicate them in the test. Instead of adding the identical logic to this test, I rewrote this method to do manual (non-pandas) join. This should give us more confidence in the offline store correctness.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix time zone issue with get_historical_features
```
