### PR TITLE
Get historical features from the Provider level + Ability to add any OfflineStore

### DIFF
--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -446,6 +446,12 @@ class DataSource:
         """
         self._date_partition_column = date_partition_column
 
+    @property
+    def offline_store(self):
+        # Return OfflineStore() object
+        # Cannot be imported because of cyclic dependency
+        ...
+
     @staticmethod
     def from_proto(data_source):
         """
@@ -596,6 +602,12 @@ class FileSource(DataSource):
         """
         return self._file_options.file_url
 
+    @property
+    def offline_store(self):
+        from feast.infra.offline_stores.file import FileOfflineStore
+
+        return FileOfflineStore()
+
     def to_proto(self) -> DataSourceProto:
         data_source_proto = DataSourceProto(
             type=DataSourceProto.BATCH_FILE,
@@ -663,6 +675,12 @@ class BigQuerySource(DataSource):
         Sets the bigquery options of this data source
         """
         self._bigquery_options = bigquery_options
+
+    @property
+    def offline_store(self):
+        from feast.infra.offline_stores.bigquery import BigQueryOfflineStore
+
+        return BigQueryOfflineStore()
 
     def to_proto(self) -> DataSourceProto:
         data_source_proto = DataSourceProto(

--- a/sdk/python/feast/infra/gcp.py
+++ b/sdk/python/feast/infra/gcp.py
@@ -4,7 +4,6 @@ from multiprocessing.pool import ThreadPool
 from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
 import mmh3
-import pandas
 import pyarrow
 
 from feast import FeatureTable, utils
@@ -13,7 +12,6 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.offline_stores.helpers import get_offline_store_from_sources
 from feast.infra.provider import (
     Provider,
-    RetrievalJob,
     _convert_arrow_to_proto,
     _get_column_names,
     _run_field_mapping,
@@ -176,28 +174,6 @@ class GcpProvider(Provider):
         client = bigquery.Client()
         query_job = client.query(query)
         return query_job.to_arrow()
-
-    @staticmethod
-    def get_historical_features(
-        config: RepoConfig,
-        feature_views: List[FeatureView],
-        feature_refs: List[str],
-        entity_df: Union[pandas.DataFrame, str],
-        registry: Registry,
-        project: str,
-    ) -> RetrievalJob:
-        offline_store = get_offline_store_from_sources(
-            [feature_view.input for feature_view in feature_views]
-        )
-        job = offline_store.get_historical_features(
-            config=config,
-            feature_views=feature_views,
-            feature_refs=feature_refs,
-            entity_df=entity_df,
-            registry=registry,
-            project=project,
-        )
-        return job
 
 
 ProtoBatch = Sequence[

--- a/sdk/python/feast/infra/local.py
+++ b/sdk/python/feast/infra/local.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
-import pandas as pd
 import pytz
 
 from feast import FeatureTable, utils
@@ -13,7 +12,6 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.offline_stores.helpers import get_offline_store_from_sources
 from feast.infra.provider import (
     Provider,
-    RetrievalJob,
     _convert_arrow_to_proto,
     _get_column_names,
     _run_field_mapping,
@@ -191,27 +189,6 @@ class LocalProvider(Provider):
 
         feature_view.materialization_intervals.append((start_date, end_date))
         registry.apply_feature_view(feature_view, project)
-
-    @staticmethod
-    def get_historical_features(
-        config: RepoConfig,
-        feature_views: List[FeatureView],
-        feature_refs: List[str],
-        entity_df: Union[pd.DataFrame, str],
-        registry: Registry,
-        project: str,
-    ) -> RetrievalJob:
-        offline_store = get_offline_store_from_sources(
-            [feature_view.input for feature_view in feature_views]
-        )
-        return offline_store.get_historical_features(
-            config=config,
-            feature_views=feature_views,
-            feature_refs=feature_refs,
-            entity_df=entity_df,
-            registry=registry,
-            project=project,
-        )
 
 
 def _table_id(project: str, table: Union[FeatureTable, FeatureView]) -> str:

--- a/sdk/python/feast/infra/offline_stores/helpers.py
+++ b/sdk/python/feast/infra/offline_stores/helpers.py
@@ -1,8 +1,6 @@
 from typing import List
 
-from feast.data_source import BigQuerySource, DataSource, FileSource
-from feast.infra.offline_stores.bigquery import BigQueryOfflineStore
-from feast.infra.offline_stores.file import FileOfflineStore
+from feast.data_source import DataSource
 from feast.infra.offline_stores.offline_store import OfflineStore
 
 
@@ -11,16 +9,14 @@ def get_offline_store_from_sources(sources: List[DataSource]) -> OfflineStore:
 
     source_types = [type(source) for source in sources]
 
-    # Retrieve features from ParquetOfflineStore
-    if all(source == FileSource for source in source_types):
-        return FileOfflineStore()
+    if len(set(source_types)) > 1:
+        raise NotImplementedError(
+            "Unsupported combination of feature view input source types. Please ensure that all source types are "
+            "consistent and available in the same offline store."
+        )
 
-    # Retrieve features from BigQueryOfflineStore
-    if all(source == BigQuerySource for source in source_types):
-        return BigQueryOfflineStore()
+    # Assert statement to pass mypy and make sure we return an OfflineStore object
+    offline_store = sources.pop().offline_store
+    assert isinstance(offline_store, OfflineStore)
 
-    # Could not map inputs to an OfflineStore implementation
-    raise NotImplementedError(
-        "Unsupported combination of feature view input source types. Please ensure that all source types are "
-        "consistent and available in the same offline store."
-    )
+    return offline_store

--- a/sdk/python/tests/infra/offline_stores/test_helpers.py
+++ b/sdk/python/tests/infra/offline_stores/test_helpers.py
@@ -1,0 +1,31 @@
+import pytest
+
+from feast.data_source import BigQuerySource, FileSource
+from feast.infra.offline_stores.bigquery import BigQueryOfflineStore
+from feast.infra.offline_stores.file import FileOfflineStore
+from feast.infra.offline_stores.helpers import get_offline_store_from_sources
+
+
+@pytest.fixture
+def bigquery_source():
+    return BigQuerySource(event_timestamp_column="events")
+
+
+@pytest.fixture
+def file_source():
+    return FileSource(event_timestamp_column="events", path="tmp/")
+
+
+def test_retrieve_bigquery_offline_store(bigquery_source):
+    offline_store = get_offline_store_from_sources([bigquery_source, bigquery_source])
+    assert isinstance(offline_store, BigQueryOfflineStore)
+
+
+def test_retrieve_file_offline_store(file_source):
+    offline_store = get_offline_store_from_sources([file_source, file_source])
+    assert isinstance(offline_store, FileOfflineStore)
+
+
+def test_raise_if_multiple_offline_stores(bigquery_source, file_source):
+    with pytest.raises(NotImplementedError):
+        get_offline_store_from_sources([bigquery_source, file_source])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Everything around "get_historical_features()" is actually retrieve from the source of the FeatureView. Therefore this PR aims to remove the dependency at the _"Provider"_ level

There are also a lot of assumptions in the code about GCP or LocalFile. The long term goal being to accept any kind of custom Provider or Source, we should avoid hard coded "if/elif" statements and make the code more modular from that perspective

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Did not create any issue ...
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE
```release-note
Move get_historical_features() off the Provider interface
A DataSource can now have an offline_store assigned to it
```
