### PR TITLE
Fix bug in allowing empty repositories to be applied to a GCS registry

### DIFF
--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -376,7 +376,7 @@ class RegistryStore(ABC):
 
     @abstractmethod
     def update_registry_proto(
-        self, updater: Optional[Callable[[RegistryProto], RegistryProto]]
+        self, updater: Optional[Callable[[RegistryProto], RegistryProto]] = None
     ):
         """
         Updates the registry using the function passed in. If the registry proto has not been created yet
@@ -472,7 +472,7 @@ class GCSRegistryStore(RegistryStore):
         )
 
     def update_registry_proto(
-        self, updater: Callable[[RegistryProto], RegistryProto] = None
+        self, updater: Optional[Callable[[RegistryProto], RegistryProto]] = None
     ):
         try:
             registry_proto = self.get_registry_proto()

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -20,8 +20,6 @@ from tempfile import TemporaryFile
 from typing import Callable, List, Optional
 from urllib.parse import urlparse
 
-from google.auth.exceptions import DefaultCredentialsError
-
 from feast.entity import Entity
 from feast.errors import (
     EntityNotFoundException,
@@ -71,7 +69,7 @@ class Registry:
 
     def _initialize_registry(self):
         """Explicitly forces the initialization of a registry"""
-        self._registry_store.update_registry_proto()
+        self._registry_store.update_registry_proto(updater=None)
 
     def apply_entity(self, entity: Entity, project: str):
         """
@@ -377,7 +375,9 @@ class RegistryStore(ABC):
         pass
 
     @abstractmethod
-    def update_registry_proto(self, updater: Callable[[RegistryProto], RegistryProto]):
+    def update_registry_proto(
+        self, updater: Optional[Callable[[RegistryProto], RegistryProto]]
+    ):
         """
         Updates the registry using the function passed in. If the registry proto has not been created yet
         this method will create it. This method writes to the registry path.
@@ -406,7 +406,7 @@ class LocalRegistryStore(RegistryStore):
         )
 
     def update_registry_proto(
-        self, updater: Callable[[RegistryProto], RegistryProto] = None
+        self, updater: Optional[Callable[[RegistryProto], RegistryProto]] = None
     ):
         try:
             registry_proto = self.get_registry_proto()
@@ -431,6 +431,7 @@ class LocalRegistryStore(RegistryStore):
 class GCSRegistryStore(RegistryStore):
     def __init__(self, uri: str):
         try:
+            from google.auth.exceptions import DefaultCredentialsError
             from google.cloud import storage
         except ImportError:
             # TODO: Ensure versioning depends on requirements.txt/setup.py and isn't hardcoded
@@ -470,13 +471,16 @@ class GCSRegistryStore(RegistryStore):
             f'Registry not found at path "{self._uri.geturl()}". Have you run "feast apply"?'
         )
 
-    def update_registry_proto(self, updater: Callable[[RegistryProto], RegistryProto]):
+    def update_registry_proto(
+        self, updater: Callable[[RegistryProto], RegistryProto] = None
+    ):
         try:
             registry_proto = self.get_registry_proto()
         except FileNotFoundError:
             registry_proto = RegistryProto()
             registry_proto.registry_schema_version = REGISTRY_SCHEMA_VERSION
-        registry_proto = updater(registry_proto)
+        if updater:
+            registry_proto = updater(registry_proto)
         self._write_registry(registry_proto)
         return
 


### PR DESCRIPTION
Signed-off-by: Willem Pienaar <git@willem.co>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

We introduced a bug with #1477. We allow initialization of the registry during `apply`, even with empty repositories. However, support was only added for the local registry, not the GCS registry.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix bug in allowing empty repositories to be applied to a GCS registry
```
