### PR TITLE
Pass entities information to Provider

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -217,12 +217,14 @@ class FeatureStore:
         if isinstance(objects, Entity) or isinstance(objects, FeatureView):
             objects = [objects]
         views_to_update = []
+        entities_to_update = []
         for ob in objects:
             if isinstance(ob, FeatureView):
                 self._registry.apply_feature_view(ob, project=self.project)
                 views_to_update.append(ob)
             elif isinstance(ob, Entity):
                 self._registry.apply_entity(ob, project=self.project)
+                entities_to_update.append(ob)
             else:
                 raise ValueError(
                     f"Unknown object type ({type(ob)}) provided as part of apply() call"
@@ -231,6 +233,8 @@ class FeatureStore:
             project=self.project,
             tables_to_delete=[],
             tables_to_keep=views_to_update,
+            entities_to_delete=[],
+            entities_to_keep=entities_to_update,
             partial=True,
         )
 

--- a/sdk/python/feast/infra/gcp.py
+++ b/sdk/python/feast/infra/gcp.py
@@ -9,6 +9,7 @@ import pyarrow
 from google.auth.exceptions import DefaultCredentialsError
 
 from feast import FeatureTable, utils
+from feast.entity import Entity
 from feast.errors import FeastProviderLoginError
 from feast.feature_view import FeatureView
 from feast.infra.key_encoding_utils import serialize_entity_key
@@ -55,6 +56,8 @@ class GcpProvider(Provider):
         project: str,
         tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
         tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
+        entities_to_delete: Sequence[Entity],
+        entities_to_keep: Sequence[Entity],
         partial: bool,
     ):
         from google.cloud import datastore
@@ -77,7 +80,10 @@ class GcpProvider(Provider):
             client.delete(key)
 
     def teardown_infra(
-        self, project: str, tables: Sequence[Union[FeatureTable, FeatureView]]
+        self,
+        project: str,
+        tables: Sequence[Union[FeatureTable, FeatureView]],
+        entities: Sequence[Entity],
     ) -> None:
         client = self._initialize_client()
 

--- a/sdk/python/feast/infra/local.py
+++ b/sdk/python/feast/infra/local.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytz
 
 from feast import FeatureTable, utils
+from feast.entity import Entity
 from feast.feature_view import FeatureView
 from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.offline_stores.helpers import get_offline_store_from_sources
@@ -50,6 +51,8 @@ class LocalProvider(Provider):
         project: str,
         tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
         tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
+        entities_to_delete: Sequence[Entity],
+        entities_to_keep: Sequence[Entity],
         partial: bool,
     ):
         conn = self._get_conn()
@@ -65,7 +68,10 @@ class LocalProvider(Provider):
             conn.execute(f"DROP TABLE IF EXISTS {_table_id(project, table)}")
 
     def teardown_infra(
-        self, project: str, tables: Sequence[Union[FeatureTable, FeatureView]]
+        self,
+        project: str,
+        tables: Sequence[Union[FeatureTable, FeatureView]],
+        entities: Sequence[Entity],
     ) -> None:
         os.unlink(self._db_path)
 

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -26,6 +26,8 @@ class Provider(abc.ABC):
         project: str,
         tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
         tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
+        entities_to_delete: Sequence[Entity],
+        entities_to_keep: Sequence[Entity],
         partial: bool,
     ):
         """
@@ -37,6 +39,10 @@ class Provider(abc.ABC):
                 clean up the corresponding cloud resources.
             tables_to_keep: Tables that are still in the feature repo. Depending on implementation,
                 provider may or may not need to update the corresponding resources.
+            entities_to_delete: Entities that were deleted from the feature repo, so provider needs to
+                clean up the corresponding cloud resources.
+            entities_to_keep: Entities that are still in the feature repo. Depending on implementation,
+                provider may or may not need to update the corresponding resources.
             partial: if true, then tables_to_delete and tables_to_keep are *not* exhaustive lists.
                 There may be other tables that are not touched by this update.
         """
@@ -44,7 +50,10 @@ class Provider(abc.ABC):
 
     @abc.abstractmethod
     def teardown_infra(
-        self, project: str, tables: Sequence[Union[FeatureTable, FeatureView]]
+        self,
+        project: str,
+        tables: Sequence[Union[FeatureTable, FeatureView]],
+        entities: Sequence[Entity],
     ):
         """
         Tear down all cloud resources for a repo.
@@ -52,6 +61,7 @@ class Provider(abc.ABC):
         Args:
             project: Feast project to which tables belong
             tables: Tables that are declared in the feature repo.
+            entities: Entities that are declared in the feature repo.
         """
         ...
 

--- a/sdk/python/tests/online_write_benchmark.py
+++ b/sdk/python/tests/online_write_benchmark.py
@@ -89,7 +89,10 @@ def benchmark_writes():
             )
 
         registry_tables = store.list_feature_views()
-        provider.teardown_infra(store.project, tables=registry_tables)
+        registry_entities = store.list_entities()
+        provider.teardown_infra(
+            store.project, tables=registry_tables, entities=registry_entities
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Some Providers would need the information about the entities to keep and to delete.
Therefore this PR aims to pass this information to the Provider object.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
Not really as even if a user created a custom Provider, they could not use it (yet) because of the hard coded logic happening at the `get_provider` function [see reference](https://github.com/feast-dev/feast/blob/master/sdk/python/feast/infra/provider.py#L127-L137))
```release-note
We now pass the information about the entities to the Provider object
```
