### PR TITLE
Add support for third party providers

### DIFF
--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -30,23 +30,19 @@ class FeatureTableNotFoundException(FeastObjectNotFoundException):
 
 class FeastProviderLoginError(Exception):
     """Error class that indicates a user has not authenticated with their provider."""
-    def __init__(self, project, name):
-        super().__init__(f"Feature table {name} does not exist in project {project}")
 
 
-class ProviderNameParsingException(Exception):
+class FeastProviderNotImplementedError(Exception):
     def __init__(self, provider_name):
-        super().__init__(
-            f"Could not parse provider name '{provider_name}' into module and class names"
-        )
+        super().__init__(f"Provider '{provider_name}' is not implemented")
 
 
-class ProviderModuleImportError(Exception):
+class FeastProviderModuleImportError(Exception):
     def __init__(self, module_name):
         super().__init__(f"Could not import provider module '{module_name}'")
 
 
-class ProviderClassImportError(Exception):
+class FeastProviderClassImportError(Exception):
     def __init__(self, module_name, class_name):
         super().__init__(
             f"Could not import provider '{class_name}' from module '{module_name}'"

--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -30,3 +30,24 @@ class FeatureTableNotFoundException(FeastObjectNotFoundException):
 
 class FeastProviderLoginError(Exception):
     """Error class that indicates a user has not authenticated with their provider."""
+    def __init__(self, project, name):
+        super().__init__(f"Feature table {name} does not exist in project {project}")
+
+
+class ProviderNameParsingException(Exception):
+    def __init__(self, provider_name):
+        super().__init__(
+            f"Could not parse provider name '{provider_name}' into module and class names"
+        )
+
+
+class ProviderModuleImportError(Exception):
+    def __init__(self, module_name):
+        super().__init__(f"Could not import provider module '{module_name}'")
+
+
+class ProviderClassImportError(Exception):
+    def __init__(self, module_name, class_name):
+        super().__init__(
+            f"Could not import provider '{class_name}' from module '{module_name}'"
+        )

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -1,4 +1,5 @@
 import abc
+import importlib
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
@@ -6,6 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 import pandas
 import pyarrow
 
+from feast import errors
 from feast.entity import Entity
 from feast.feature_table import FeatureTable
 from feast.feature_view import FeatureView
@@ -144,7 +146,30 @@ def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
 
         return LocalProvider(config, repo_path)
     else:
-        raise ValueError(config)
+        if "." not in config.provider:
+            raise errors.ProviderNameParsingException(config.provider)
+        # Split provider into module and class names by finding the right-most dot.
+        # For example, provider 'foo.bar.MyProvider' will be parsed into 'foo.bar' and 'MyProvider'
+        module_name, class_name = config.provider.rsplit(".", 1)
+
+        # Try importing the module that contains the custom provider
+        try:
+            module = importlib.import_module(module_name)
+        except Exception as e:
+            # The original exception can be anything - either module not found,
+            # or any other kind of error happening during the module import time.
+            # So we should include the original error as well in the stack trace.
+            raise errors.ProviderModuleImportError(module_name) from e
+
+        # Try getting the provider class definition
+        try:
+            ProviderCls = getattr(module, class_name)
+        except AttributeError:
+            # This can only be one type of error, when class_name attribute does not exist in the module
+            # So we don't have to include the original exception here
+            raise errors.ProviderClassImportError(module_name, class_name) from None
+
+        return ProviderCls(config)
 
 
 def _get_requested_feature_views_to_features_dict(

--- a/sdk/python/tests/cli_utils.py
+++ b/sdk/python/tests/cli_utils.py
@@ -6,7 +6,7 @@ import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from textwrap import dedent
-from typing import List
+from typing import List, Tuple
 
 from feast import cli
 from feast.feature_store import FeatureStore
@@ -25,6 +25,19 @@ class CliRunner:
 
     def run(self, args: List[str], cwd: Path) -> subprocess.CompletedProcess:
         return subprocess.run([sys.executable, cli.__file__] + args, cwd=cwd)
+
+    def run_with_output(self, args: List[str], cwd: Path) -> Tuple[int, bytes]:
+        try:
+            return (
+                0,
+                subprocess.check_output(
+                    [sys.executable, cli.__file__] + args,
+                    cwd=cwd,
+                    stderr=subprocess.STDOUT,
+                ),
+            )
+        except subprocess.CalledProcessError as e:
+            return e.returncode, e.output
 
     @contextmanager
     def local_repo(self, example_repo_py: str):

--- a/sdk/python/tests/foo_provider.py
+++ b/sdk/python/tests/foo_provider.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+import pandas
+
+from feast import Entity, FeatureTable, FeatureView, RepoConfig
+from feast.infra.offline_stores.offline_store import RetrievalJob
+from feast.infra.provider import Provider
+from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+from feast.registry import Registry
+
+
+class FooProvider(Provider):
+    def update_infra(
+        self,
+        project: str,
+        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
+        tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
+        entities_to_delete: Sequence[Entity],
+        entities_to_keep: Sequence[Entity],
+        partial: bool,
+    ):
+        pass
+
+    def teardown_infra(
+        self,
+        project: str,
+        tables: Sequence[Union[FeatureTable, FeatureView]],
+        entities: Sequence[Entity],
+    ):
+        pass
+
+    def online_write_batch(
+        self,
+        project: str,
+        table: Union[FeatureTable, FeatureView],
+        data: List[
+            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+        ],
+        progress: Optional[Callable[[int], Any]],
+    ) -> None:
+        pass
+
+    def materialize_single_feature_view(
+        self,
+        feature_view: FeatureView,
+        start_date: datetime,
+        end_date: datetime,
+        registry: Registry,
+        project: str,
+    ) -> None:
+        pass
+
+    @staticmethod
+    def get_historical_features(
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_df: Union[pandas.DataFrame, str],
+        registry: Registry,
+        project: str,
+    ) -> RetrievalJob:
+        pass
+
+    def online_read(
+        self,
+        project: str,
+        table: Union[FeatureTable, FeatureView],
+        entity_keys: List[EntityKeyProto],
+    ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
+        pass
+
+    def __init__(self, config, repo_path):
+        pass


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Currently there's no way to plug in custom providers in Feast CLI. With this PR, you can modify `provider` field in the `feature_store.yaml` to a Python class path. For example, if you define your provider `MyCustomProvider` under `my_package.providers`, you can specify `provider: my_package.providers.MyCustomProvider` and then normally run `feast apply` or any other CLI command.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add support for third party providers
```
