### PR TITLE
Add optional telemetry to other CLI commands

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -32,6 +32,7 @@ from feast.repo_operations import (
     registry_dump,
     teardown,
 )
+from feast.telemetry import Telemetry
 
 _logger = logging.getLogger(__name__)
 DATETIME_ISO = "%Y-%m-%dT%H:%M:%s"
@@ -156,6 +157,8 @@ def apply_total_command():
     """
     cli_check_repo(Path.cwd())
     repo_config = load_repo_config(Path.cwd())
+    tele = Telemetry()
+    tele.log("apply")
     try:
         apply_total(repo_config, Path.cwd())
     except FeastProviderLoginError as e:
@@ -169,6 +172,8 @@ def teardown_command():
     """
     cli_check_repo(Path.cwd())
     repo_config = load_repo_config(Path.cwd())
+    tele = Telemetry()
+    tele.log("teardown")
 
     teardown(repo_config, Path.cwd())
 
@@ -180,6 +185,8 @@ def registry_dump_command():
     """
     cli_check_repo(Path.cwd())
     repo_config = load_repo_config(Path.cwd())
+    tele = Telemetry()
+    tele.log("registry-dump")
 
     registry_dump(repo_config, repo_path=Path.cwd())
 
@@ -250,6 +257,8 @@ def init_command(project_directory, minimal: bool, template: str):
     if minimal:
         template = "minimal"
 
+    tele = Telemetry()
+    tele.log("init")
     init_repo(project_directory, template)
 
 


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Adds opt-out telemetry to `feast init`, `feast apply`, `feast teardown`, and `feast registry-dump` which were not covered by existing opt-out telemetry.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Opt-out telemetry (usage logging) added to several feast CLI commands. To opt out, see https://docs.feast.dev/v/master/feast-on-kubernetes/advanced-1/telemetry
```
