### PR TITLE
Add support for Redis and Redis Cluster

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -53,9 +53,6 @@ jobs:
         run: make install-python-ci-dependencies
       - name: Test python
         run: FEAST_TELEMETRY=False pytest --cov=./ --cov-report=xml --verbose --color=yes sdk/python/tests --integration
-        env:
-          REDIS_TYPE: REDIS
-          REDIS_CONNECTION_STRING: localhost:6379,db=0
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -16,6 +16,16 @@ jobs:
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -43,6 +53,9 @@ jobs:
         run: make install-python-ci-dependencies
       - name: Test python
         run: FEAST_TELEMETRY=False pytest --cov=./ --cov-report=xml --verbose --color=yes sdk/python/tests --integration
+        env:
+          REDIS_TYPE: REDIS
+          REDIS_CONNECTION_STRING: localhost:6379,db=0
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -76,3 +76,4 @@ jobs:
           env_vars: OS,PYTHON
           fail_ci_if_error: true
           verbose: true
+

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -18,6 +18,9 @@ jobs:
       matrix:
         python-version: [ 3.7, 3.8, 3.9 ]
         os: [ ubuntu-latest ]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
     services:
       redis:
         image: redis
@@ -28,9 +31,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-    env:
-      OS: ${{ matrix.os }}
-      PYTHON: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -76,4 +76,3 @@ jobs:
           env_vars: OS,PYTHON
           fail_ci_if_error: true
           verbose: true
-

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -64,9 +64,6 @@ jobs:
         run: make install-python-ci-dependencies
       - name: Test python
         run: FEAST_TELEMETRY=False pytest --cov=./ --cov-report=xml --verbose --color=yes sdk/python/tests --integration
-        env:
-          REDIS_TYPE: REDIS
-          REDIS_CONNECTION_STRING: localhost:6379,db=0
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -541,7 +541,10 @@ class FeatureStore:
                 table, union_of_entity_keys, entity_name_to_join_key_map
             )
             read_rows = provider.online_read(
-                project=self.project, table=table, entity_keys=entity_keys,
+                project=self.project,
+                table=table,
+                entity_keys=entity_keys,
+                requested_features=requested_features,
             )
             for row_idx, read_row in enumerate(read_rows):
                 row_ts, feature_data = read_row

--- a/sdk/python/feast/infra/gcp.py
+++ b/sdk/python/feast/infra/gcp.py
@@ -128,6 +128,7 @@ class GcpProvider(Provider):
         project: str,
         table: Union[FeatureTable, FeatureView],
         entity_keys: List[EntityKeyProto],
+        requested_features: List[str] = None,
     ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
         client = self._initialize_client()
 

--- a/sdk/python/feast/infra/local.py
+++ b/sdk/python/feast/infra/local.py
@@ -131,6 +131,7 @@ class LocalProvider(Provider):
         project: str,
         table: Union[FeatureTable, FeatureView],
         entity_keys: List[EntityKeyProto],
+        requested_features: List[str] = None,
     ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
 
         conn = self._get_conn()

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -125,6 +125,7 @@ class Provider(abc.ABC):
         project: str,
         table: Union[FeatureTable, FeatureView],
         entity_keys: List[EntityKeyProto],
+        requested_features: List[str] = None,
     ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
         """
         Read feature values given an Entity Key. This is a low level interface, not
@@ -144,6 +145,10 @@ def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
             from feast.infra.gcp import GcpProvider
 
             return GcpProvider(config)
+        elif config.provider == "redis":
+            from feast.infra.redis_provider import RedisProvider
+
+            return RedisProvider(config)
         elif config.provider == "local":
             from feast.infra.local import LocalProvider
 

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -146,7 +146,7 @@ def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
 
             return GcpProvider(config)
         elif config.provider == "redis":
-            from feast.infra.redis_provider import RedisProvider
+            from feast.infra.redis import RedisProvider
 
             return RedisProvider(config)
         elif config.provider == "local":

--- a/sdk/python/feast/infra/redis.py
+++ b/sdk/python/feast/infra/redis.py
@@ -271,4 +271,4 @@ def _mmh3(key: str):
         https://stackoverflow.com/questions/13141787/convert-decimal-int-to-little-endian-string-x-x
     """
     key_hash = mmh3.hash(key, signed=False)
-    return bytes.fromhex(struct.pack("<Q", key_hash).hex().rstrip("0"))
+    return bytes.fromhex(struct.pack("<Q", key_hash).hex()[:8])

--- a/sdk/python/feast/infra/redis.py
+++ b/sdk/python/feast/infra/redis.py
@@ -195,7 +195,7 @@ class RedisProvider(Provider):
         feature_view.materialization_intervals.append((start_date, end_date))
         registry.apply_feature_view(feature_view, project)
 
-    def _get_cs(self):
+    def _parse_connection_string(self):
         """
         Reads Redis connections string using format
         for RedisCluster:
@@ -227,7 +227,7 @@ class RedisProvider(Provider):
         """
         Creates the Redis client RedisCluster or Redis depending on configuration
         """
-        startup_nodes, kwargs = self._get_cs()
+        startup_nodes, kwargs = self._parse_connection_string()
         if self._redis_type == RedisType.redis_cluster:
             kwargs["startup_nodes"] = startup_nodes
             return RedisCluster(**kwargs)
@@ -261,7 +261,6 @@ def _redis_key(project: str, entity_key: EntityKeyProto):
         entity_names=entity_key.join_keys,
         entity_values=entity_key.entity_values,
     )
-    # key = _mmh3(serialize_entity_key(entity_key))
     return redis_key.SerializeToString()
 
 

--- a/sdk/python/feast/infra/redis_provider.py
+++ b/sdk/python/feast/infra/redis_provider.py
@@ -1,0 +1,209 @@
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+import mmh3
+import pandas as pd
+from redis import Redis
+from rediscluster import RedisCluster
+
+from feast import FeatureTable, utils
+from feast.entity import Entity
+from feast.feature_view import FeatureView
+from feast.infra.key_encoding_utils import serialize_entity_key
+from feast.infra.offline_stores.helpers import get_offline_store_from_sources
+from feast.infra.provider import (
+    Provider,
+    RetrievalJob,
+    _convert_arrow_to_proto,
+    _get_column_names,
+    _run_field_mapping,
+)
+from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+from feast.registry import Registry
+from feast.repo_config import RedisOnlineStoreConfig, RepoConfig
+
+
+class RedisProvider(Provider):
+    _db_path: Path
+
+    def __init__(self, config: RepoConfig):
+        assert isinstance(config.online_store, RedisOnlineStoreConfig)
+
+    def _get_client(self):
+        if os.environ["REDIS_TYPE"] == "REDIS_CLUSTER":
+            return RedisCluster(
+                host=os.environ["REDIS_HOST"],
+                port=os.environ["REDIS_PORT"],
+                decode_responses=True,
+            )
+        else:
+            return Redis(
+                host=os.environ["REDIS_HOST"], port=os.environ["REDIS_PORT"], db=0
+            )
+
+    def update_infra(
+        self,
+        project: str,
+        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
+        tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
+        entities_to_delete: Sequence[Entity],
+        entities_to_keep: Sequence[Entity],
+        partial: bool,
+    ):
+        client = self._get_client()
+        # TODO
+
+    def teardown_infra(
+        self,
+        project: str,
+        tables: Sequence[Union[FeatureTable, FeatureView]],
+        entities: Sequence[Entity],
+    ) -> None:
+        # according to the repos_operations.py we can delete the whole project
+        client = self._get_client()
+        keys = client.keys("{project}:*")
+        client.unlink(*keys)
+
+    def online_write_batch(
+        self,
+        project: str,
+        table: Union[FeatureTable, FeatureView],
+        data: List[
+            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+        ],
+        progress: Optional[Callable[[int], Any]],
+    ) -> None:
+        client = self._get_client()
+
+        entity_hset = {}
+        feature_view = table.name
+
+        for entity_key, values, timestamp, created_ts in data:
+            redis_key_bin = _redis_key(project, entity_key)
+            timestamp = utils.make_tzaware(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+            entity_hset[f"_ts:{feature_view}"] = timestamp
+
+            if created_ts is not None:
+                created_ts = utils.make_tzaware(created_ts).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
+                entity_hset[f"_created_ts:{feature_view}"] = created_ts
+
+            for feature_name, val in values.items():
+                f_key = _mmh3(f"{feature_view}:{feature_name}")
+                entity_hset[f_key] = val.SerializeToString()
+
+            client.hset(redis_key_bin, mapping=entity_hset)
+
+    def online_read(
+        self,
+        project: str,
+        table: Union[FeatureTable, FeatureView],
+        entity_keys: List[EntityKeyProto],
+        requested_features: List[str] = None,
+    ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
+
+        client = self._get_client()
+        feature_view = table.name
+
+        result: List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]] = []
+
+        for entity_key in entity_keys:
+            redis_key_bin = _redis_key(project, entity_key)
+            hset_keys = [_mmh3(f"{feature_view}:{k}") for k in requested_features]
+            ts_key = f"_ts:{feature_view}"
+            hset_keys.append(ts_key)
+            values = client.hmget(redis_key_bin, hset_keys)
+
+            requested_features.append(ts_key)
+            res_val = dict(zip(requested_features, values))
+            res_ts = res_val.pop(ts_key)
+
+            res = {}
+            for feature_name, val_bin in res_val.items():
+                val = ValueProto()
+                val.ParseFromString(val_bin)
+                res[feature_name] = val
+
+            if not res:
+                result.append((None, None))
+            else:
+                result.append((res_ts, res))
+        return result
+
+    def materialize_single_feature_view(
+        self,
+        feature_view: FeatureView,
+        start_date: datetime,
+        end_date: datetime,
+        registry: Registry,
+        project: str,
+    ) -> None:
+        entities = []
+        for entity_name in feature_view.entities:
+            entities.append(registry.get_entity(entity_name, project))
+
+        (
+            join_key_columns,
+            feature_name_columns,
+            event_timestamp_column,
+            created_timestamp_column,
+        ) = _get_column_names(feature_view, entities)
+
+        start_date = utils.make_tzaware(start_date)
+        end_date = utils.make_tzaware(end_date)
+
+        offline_store = get_offline_store_from_sources([feature_view.input])
+        table = offline_store.pull_latest_from_table_or_query(
+            data_source=feature_view.input,
+            join_key_columns=join_key_columns,
+            feature_name_columns=feature_name_columns,
+            event_timestamp_column=event_timestamp_column,
+            created_timestamp_column=created_timestamp_column,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        if feature_view.input.field_mapping is not None:
+            table = _run_field_mapping(table, feature_view.input.field_mapping)
+
+        join_keys = [entity.join_key for entity in entities]
+        rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
+
+        self.online_write_batch(project, feature_view, rows_to_write, None)
+
+        feature_view.materialization_intervals.append((start_date, end_date))
+        registry.apply_feature_view(feature_view, project)
+
+    @staticmethod
+    def get_historical_features(
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_df: Union[pd.DataFrame, str],
+        registry: Registry,
+        project: str,
+    ) -> RetrievalJob:
+        offline_store = get_offline_store_from_sources(
+            [feature_view.input for feature_view in feature_views]
+        )
+        return offline_store.get_historical_features(
+            config=config,
+            feature_views=feature_views,
+            feature_refs=feature_refs,
+            entity_df=entity_df,
+            registry=registry,
+            project=project,
+        )
+
+
+def _redis_key(project: str, entity_key: EntityKeyProto) -> str:
+    key = _mmh3(serialize_entity_key(entity_key))
+    return f"{project}:{key}"
+
+
+def _mmh3(key: str) -> str:
+    return mmh3.hash_bytes(key).hex()

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -52,7 +52,16 @@ class DatastoreOnlineStoreConfig(FeastBaseModel):
     """ (optional) Amount of feature rows per batch being written into Datastore"""
 
 
-OnlineStoreConfig = Union[DatastoreOnlineStoreConfig, SqliteOnlineStoreConfig]
+class RedisOnlineStoreConfig(FeastBaseModel):
+    """Online store config for Redis store"""
+
+    type: Literal["redis"] = "redis"
+    """Online store type selector"""
+
+
+OnlineStoreConfig = Union[
+    DatastoreOnlineStoreConfig, SqliteOnlineStoreConfig, RedisOnlineStoreConfig
+]
 
 
 class FileOfflineStoreConfig(FeastBaseModel):
@@ -101,7 +110,7 @@ class RepoConfig(FeastBaseModel):
     """
 
     provider: StrictStr
-    """ str: local or gcp """
+    """ str: local or gcp or redis """
 
     online_store: OnlineStoreConfig = SqliteOnlineStoreConfig()
     """ OnlineStoreConfig: Online store configuration (optional depending on provider) """
@@ -141,6 +150,9 @@ class RepoConfig(FeastBaseModel):
                 values["online_store"]["type"] = "sqlite"
             elif values["provider"] == "gcp":
                 values["online_store"]["type"] = "datastore"
+            elif values["provider"] == "redis":
+                values["online_store"]["type"] = "redis"
+
 
         online_store_type = values["online_store"]["type"]
 
@@ -153,6 +165,8 @@ class RepoConfig(FeastBaseModel):
                 SqliteOnlineStoreConfig(**values["online_store"])
             elif online_store_type == "datastore":
                 DatastoreOnlineStoreConfig(**values["online_store"])
+            elif online_store_type == "redis":
+                RedisOnlineStoreConfig(**values["online_store"])
             else:
                 raise ValueError(f"Invalid online store type {online_store_type}")
         except ValidationError as e:

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -1,3 +1,5 @@
+import os
+from enum import Enum
 from pathlib import Path
 
 import yaml
@@ -52,11 +54,23 @@ class DatastoreOnlineStoreConfig(FeastBaseModel):
     """ (optional) Amount of feature rows per batch being written into Datastore"""
 
 
+class RedisType(str, Enum):
+    redis = "redis"
+    redis_cluster = "redis_cluster"
+
+
 class RedisOnlineStoreConfig(FeastBaseModel):
     """Online store config for Redis store"""
 
     type: Literal["redis"] = "redis"
     """Online store type selector"""
+
+    redis_type: RedisType = RedisType.redis
+    """Redis type: redis or redis_cluster"""
+
+    redis_connection_string: Optional[StrictStr] = None
+    """Redis connection string from REDIS_CONNECTION_STRING environment variable
+     format: host:port,parameter1,parameter2 eg. redis:6379,db=0 """
 
 
 OnlineStoreConfig = Union[
@@ -152,6 +166,10 @@ class RepoConfig(FeastBaseModel):
                 values["online_store"]["type"] = "datastore"
             elif values["provider"] == "redis":
                 values["online_store"]["type"] = "redis"
+                values["online_store"]["redis_connection_string"] = os.environ.get(
+                    "REDIS_CONNECTION_STRING"
+                )
+
 
 
         online_store_type = values["online_store"]["type"]

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -68,7 +68,7 @@ class RedisOnlineStoreConfig(FeastBaseModel):
     redis_type: RedisType = RedisType.redis
     """Redis type: redis or redis_cluster"""
 
-    redis_connection_string: Optional[StrictStr] = None
+    redis_connection_string: StrictStr
     """Redis connection string from REDIS_CONNECTION_STRING environment variable
      format: host:port,parameter1,parameter2 eg. redis:6379,db=0 """
 
@@ -166,11 +166,6 @@ class RepoConfig(FeastBaseModel):
                 values["online_store"]["type"] = "datastore"
             elif values["provider"] == "redis":
                 values["online_store"]["type"] = "redis"
-
-        if values["online_store"]["type"] == "redis":
-            values["online_store"]["redis_connection_string"] = os.environ.get(
-                "REDIS_CONNECTION_STRING"
-            )
 
         online_store_type = values["online_store"]["type"]
 

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -166,16 +166,16 @@ class RepoConfig(FeastBaseModel):
                 values["online_store"]["type"] = "datastore"
             elif values["provider"] == "redis":
                 values["online_store"]["type"] = "redis"
-                values["online_store"]["redis_connection_string"] = os.environ.get(
-                    "REDIS_CONNECTION_STRING"
-                )
 
-
+        if values["online_store"]["type"] == "redis":
+            values["online_store"]["redis_connection_string"] = os.environ.get(
+                "REDIS_CONNECTION_STRING"
+            )
 
         online_store_type = values["online_store"]["type"]
 
         # Make sure the user hasn't provided the wrong type
-        assert online_store_type in ["datastore", "sqlite"]
+        assert online_store_type in ["datastore", "sqlite", "redis"]
 
         # Validate the dict to ensure one of the union types match
         try:
@@ -209,7 +209,7 @@ class RepoConfig(FeastBaseModel):
 
         # Set the default type
         if "type" not in values["offline_store"]:
-            if values["provider"] == "local":
+            if values["provider"] == "local" or values["provider"] == "redis":
                 values["offline_store"]["type"] = "file"
             elif values["provider"] == "gcp":
                 values["offline_store"]["type"] = "bigquery"

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -67,8 +67,8 @@ class RedisOnlineStoreConfig(FeastBaseModel):
     redis_type: RedisType = RedisType.redis
     """Redis type: redis or redis_cluster"""
 
-    redis_connection_string: StrictStr
-    """Redis connection string from REDIS_CONNECTION_STRING environment variable
+    connection_string: StrictStr = "localhost:6379"
+    """Connection string containing the host, port, and configuration parameters for Redis
      format: host:port,parameter1,parameter2 eg. redis:6379,db=0 """
 
 

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -1,4 +1,3 @@
-import os
 from enum import Enum
 from pathlib import Path
 

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -56,6 +56,7 @@ REQUIRED = [
     "tabulate==0.8.*",
     "toml==0.10.*",
     "tqdm==4.*",
+    "redis-py-cluster==2.1.2",
 ]
 
 GCP_REQUIRED = [

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -102,6 +102,7 @@ CI_REQUIRED = [
     "google-cloud-datastore>=2.1.*",
     "google-cloud-storage>=1.20.*",
     "google-cloud-core==1.4.*",
+    "redis-py-cluster==2.1.2",
 ]
 
 # README file from Feast repo root directory

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -56,7 +56,6 @@ REQUIRED = [
     "tabulate==0.8.*",
     "toml==0.10.*",
     "tqdm==4.*",
-    "redis-py-cluster==2.1.2",
 ]
 
 GCP_REQUIRED = [
@@ -65,6 +64,10 @@ GCP_REQUIRED = [
     "google-cloud-datastore>=2.1.*",
     "google-cloud-storage>=1.20.*",
     "google-cloud-core==1.4.*",
+]
+
+REDIS_REQUIRED = [
+    "redis-py-cluster==2.1.2",
 ]
 
 CI_REQUIRED = [
@@ -193,6 +196,7 @@ setup(
         "dev": ["mypy-protobuf==1.*", "grpcio-testing==1.*"],
         "ci": CI_REQUIRED,
         "gcp": GCP_REQUIRED,
+        "redis": REDIS_REQUIRED,
     },
     include_package_data=True,
     license="Apache",

--- a/sdk/python/tests/foo_provider.py
+++ b/sdk/python/tests/foo_provider.py
@@ -70,6 +70,7 @@ class FooProvider(Provider):
         project: str,
         table: Union[FeatureTable, FeatureView],
         entity_keys: List[EntityKeyProto],
+        requested_features: List[str] = None,
     ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
         pass
 

--- a/sdk/python/tests/test_cli_redis.py
+++ b/sdk/python/tests/test_cli_redis.py
@@ -1,0 +1,55 @@
+import random
+import string
+import tempfile
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from feast.feature_store import FeatureStore
+from tests.cli_utils import CliRunner
+from tests.online_read_write_test import basic_rw_test
+
+
+@pytest.mark.integration
+def test_basic() -> None:
+    project_id = "".join(
+        random.choice(string.ascii_lowercase + string.digits) for _ in range(10)
+    )
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as repo_dir_name, tempfile.TemporaryDirectory() as data_dir_name:
+
+        repo_path = Path(repo_dir_name)
+        data_path = Path(data_dir_name)
+
+        repo_config = repo_path / "feature_store.yaml"
+
+        repo_config.write_text(
+            dedent(
+                f"""
+        project: {project_id}
+        registry: {data_path / "registry.db"}
+        provider: redis
+        """
+            )
+        )
+
+        repo_example = repo_path / "example.py"
+        repo_example.write_text(
+            (Path(__file__).parent / "example_feature_repo_1.py").read_text()
+        )
+
+        result = runner.run(["apply"], cwd=repo_path)
+        assert result.returncode == 0
+
+        # Doing another apply should be a no op, and should not cause errors
+        result = runner.run(["apply"], cwd=repo_path)
+        assert result.returncode == 0
+
+        basic_rw_test(
+            FeatureStore(repo_path=str(repo_path), config=None),
+            view_name="driver_locations",
+        )
+
+        result = runner.run(["teardown"], cwd=repo_path)
+        assert result.returncode == 0

--- a/sdk/python/tests/test_cli_redis.py
+++ b/sdk/python/tests/test_cli_redis.py
@@ -32,6 +32,9 @@ def test_basic() -> None:
         provider: redis
         offline_store:
             type: bigquery
+        online_store:
+            redis_type: redis
+            redis_connection_string: localhost:6379,db=0
         """
             )
         )

--- a/sdk/python/tests/test_cli_redis.py
+++ b/sdk/python/tests/test_cli_redis.py
@@ -34,7 +34,7 @@ def test_basic() -> None:
             type: bigquery
         online_store:
             redis_type: redis
-            redis_connection_string: localhost:6379,db=0
+            connection_string: localhost:6379,db=0
         """
             )
         )

--- a/sdk/python/tests/test_cli_redis.py
+++ b/sdk/python/tests/test_cli_redis.py
@@ -30,6 +30,8 @@ def test_basic() -> None:
         project: {project_id}
         registry: {data_path / "registry.db"}
         provider: redis
+        offline_store:
+            type: bigquery
         """
             )
         )

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -21,6 +21,8 @@ from feast.repo_config import (
     DatastoreOnlineStoreConfig,
     RepoConfig,
     SqliteOnlineStoreConfig,
+    RedisOnlineStoreConfig,
+    RedisType,
 )
 from feast.value_type import ValueType
 
@@ -172,6 +174,11 @@ def prep_redis_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
                 registry=str(Path(repo_dir_name) / "registry.db"),
                 project=f"test_bq_correctness_{str(uuid.uuid4()).replace('-', '')}",
                 provider="redis",
+                online_store=RedisOnlineStoreConfig(
+                    redis_type=RedisType.redis,
+                    redis_connection_string="localhost:6379,db=0",
+                ),
+
             )
             fs = FeatureStore(config=config)
             fs.apply([fv, e])

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -146,6 +146,39 @@ def prep_local_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             yield fs, fv
 
 
+@contextlib.contextmanager
+def prep_redis_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
+    with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
+        df = create_dataset()
+        f.close()
+        df.to_parquet(f.name)
+        file_source = FileSource(
+            file_format=ParquetFormat(),
+            file_url=f"file://{f.name}",
+            event_timestamp_column="ts",
+            created_timestamp_column="created_ts",
+            date_partition_column="",
+            field_mapping={"ts_1": "ts", "id": "driver_id"},
+        )
+        fv = get_feature_view(file_source)
+        e = Entity(
+            name="driver",
+            description="id for driver",
+            join_key="driver_id",
+            value_type=ValueType.INT32,
+        )
+        with tempfile.TemporaryDirectory() as repo_dir_name, tempfile.TemporaryDirectory():
+            config = RepoConfig(
+                registry=str(Path(repo_dir_name) / "registry.db"),
+                project=f"test_bq_correctness_{str(uuid.uuid4()).replace('-', '')}",
+                provider="redis",
+            )
+            fs = FeatureStore(config=config)
+            fs.apply([fv, e])
+
+            yield fs, fv
+
+
 # Checks that both offline & online store values are as expected
 def check_offline_and_online_features(
     fs: FeatureStore,
@@ -218,6 +251,12 @@ def run_offline_online_store_consistency_test(
 )
 def test_bq_offline_online_store_consistency(bq_source_type: str):
     with prep_bq_fs_and_fv(bq_source_type) as (fs, fv):
+        run_offline_online_store_consistency_test(fs, fv)
+
+
+@pytest.mark.integration
+def test_redis_offline_online_store_consistency():
+    with prep_redis_fs_and_fv() as (fs, fv):
         run_offline_online_store_consistency_test(fs, fv)
 
 

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -19,10 +19,10 @@ from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
 from feast.repo_config import (
     DatastoreOnlineStoreConfig,
-    RepoConfig,
-    SqliteOnlineStoreConfig,
     RedisOnlineStoreConfig,
     RedisType,
+    RepoConfig,
+    SqliteOnlineStoreConfig,
 )
 from feast.value_type import ValueType
 
@@ -178,7 +178,6 @@ def prep_redis_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
                     redis_type=RedisType.redis,
                     redis_connection_string="localhost:6379,db=0",
                 ),
-
             )
             fs = FeatureStore(config=config)
             fs.apply([fv, e])

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -175,8 +175,7 @@ def prep_redis_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
                 project=f"test_bq_correctness_{str(uuid.uuid4()).replace('-', '')}",
                 provider="redis",
                 online_store=RedisOnlineStoreConfig(
-                    redis_type=RedisType.redis,
-                    redis_connection_string="localhost:6379,db=0",
+                    redis_type=RedisType.redis, connection_string="localhost:6379,db=0",
                 ),
             )
             fs = FeatureStore(config=config)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
PR adds Redis and RedisCluster support as online store. As described in https://github.com/feast-dev/feast/issues/1497 it is backward compatible with Feast 0.9 thus it can be used for migration to 0.10

**Which issue(s) this PR fixes**:
Fixes #1497

**Does this PR introduce a user-facing change?**:
```release-note
Redis and RedisCluster online stores support added. Format is compatible with Feast 0.9.
```
