### PR TITLE
Make gcp imports optional

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -251,7 +251,7 @@ This feature vector can be used for real-time inference, for example, in a model
 
 ## Next steps
 
-This quickstart covered the essential workflows of using Feast in your local environment. The next step is to set `provider="gcp"` in your `feature_store.yaml` file and push your work to production deployment. You can also use the `feast init -t gcp` command in the CLI to initialize a feature repository with example features in the GCP environment.
+This quickstart covered the essential workflows of using Feast in your local environment. The next step is to `pip install "feast[gcp]"` and set `provider="gcp"` in your `feature_store.yaml` file and push your work to production deployment. You can also use the `feast init -t gcp` command in the CLI to initialize a feature repository with example features in the GCP environment.
 
 * See [Create a feature repository](how-to-guides/create-a-feature-repository.md) for more information on the workflows we covered.
 * Join our[ Slack group](https://slack.com) to talk to other Feast users and the maintainers!

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -6,7 +6,6 @@ from typing import List, Optional, Union
 import pandas
 import pyarrow
 from google.auth.exceptions import DefaultCredentialsError
-from google.cloud import bigquery
 from jinja2 import BaseLoader, Environment
 
 from feast.data_source import BigQuerySource, DataSource
@@ -193,6 +192,7 @@ class FeatureViewQueryContext:
 
 def _upload_entity_df_into_bigquery(project, entity_df, client) -> str:
     """Uploads a Pandas entity dataframe into a BigQuery table and returns a reference to the resulting table"""
+    from google.cloud import bigquery
 
     # First create the BigQuery dataset if it doesn't exist
     dataset = bigquery.Dataset(f"{client.project}.feast_{project}")

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -42,10 +42,6 @@ REQUIRED = [
     "colorama>=0.3.9",
     "fastavro>=0.22.11,<0.23",
     "google-api-core>=1.23.0",
-    "google-cloud-bigquery>=2.0.*",
-    "google-cloud-bigquery-storage >= 2.0.0",
-    "google-cloud-storage>=1.20.*",
-    "google-cloud-core==1.4.*",
     "googleapis-common-protos==1.52.*",
     "grpcio==1.31.0",
     "Jinja2>=2.0.0",
@@ -61,6 +57,14 @@ REQUIRED = [
     "tabulate==0.8.*",
     "toml==0.10.*",
     "tqdm==4.*",
+]
+
+GCP_REQUIRED = [
+    "google-cloud-bigquery>=2.0.*",
+    "google-cloud-bigquery-storage >= 2.0.0",
+    "google-cloud-datastore>=2.1.*",
+    "google-cloud-storage>=1.20.*",
+    "google-cloud-core==1.4.*",
 ]
 
 CI_REQUIRED = [
@@ -87,9 +91,13 @@ CI_REQUIRED = [
     "tenacity",
     "adlfs==0.5.9",
     "firebase-admin==4.5.2",
-    "google-cloud-datastore==2.1.0",
     "pre-commit",
     "assertpy==1.1",
+    "google-cloud-bigquery>=2.0.*",
+    "google-cloud-bigquery-storage >= 2.0.0",
+    "google-cloud-datastore>=2.1.*",
+    "google-cloud-storage>=1.20.*",
+    "google-cloud-core==1.4.*",
 ]
 
 # README file from Feast repo root directory
@@ -182,7 +190,8 @@ setup(
     # Install dev requirements with: pip install -e .[dev]
     extras_require={
         "dev": ["mypy-protobuf==1.*", "grpcio-testing==1.*"],
-        "ci": CI_REQUIRED
+        "ci": CI_REQUIRED,
+        "gcp": GCP_REQUIRED,
     },
     include_package_data=True,
     license="Apache",


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Move GCP-specific packages into feast[gcp]

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`pip install feast` now has fewer requirements, and in order to use Feast with GCP the user will need to install the GCP-specific requirements with `pip install feast[gcp]`
```
