### PR TITLE
Add a fixed timestamp to quickstart data

### DIFF
--- a/sdk/python/feast/driver_test_data.py
+++ b/sdk/python/feast/driver_test_data.py
@@ -111,6 +111,12 @@ def create_driver_hourly_stats_df(drivers, start_date, end_date) -> pd.DataFrame
                     start=start_date, end=end_date, freq="1H", closed="left"
                 )
             ]
+            # include a fixed timestamp for get_historical_features in the quickstart
+            + [
+                pd.Timestamp(
+                    year=2021, month=4, day=12, hour=7, minute=0, second=0, tz="UTC"
+                )
+            ]
         }
     )
     df_all_drivers = pd.DataFrame()


### PR DESCRIPTION
Signed-off-by: Jacob Klegar <jacob@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: This ensures the get_historical_features call in the quickstart doesn't return NaNs

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
