### PR TITLE
Inferencing of Features in FeatureView and timestamp column of DataSource

### DIFF
--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -14,7 +14,12 @@
 
 
 import enum
-from typing import Dict, Optional
+import re
+from typing import Dict, Iterable, Optional, Tuple
+
+from google.cloud import bigquery
+from pyarrow import DataType
+from pyarrow.parquet import ParquetFile
 
 from feast.data_format import FileFormat, StreamFormat
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
@@ -515,11 +520,42 @@ class DataSource:
         """
         raise NotImplementedError
 
+    def infer_event_timestamp_column(self, ts_column_type_regex_pattern):
+        ERROR_MSG_PREFIX = "Unable to infer DataSource event_timestamp_column"
+
+        if isinstance(self, FileSource) or isinstance(self, BigQuerySource):
+            event_timestamp_column, matched_flag = None, False
+            for col_name, col_datatype in self.get_table_column_names_and_types():
+                if re.match(ts_column_type_regex_pattern, col_datatype):
+                    if matched_flag:
+                        raise TypeError(
+                            f"""
+                            {ERROR_MSG_PREFIX} due to multiple possible columns satisfying
+                            the criteria.
+                            """
+                        )
+                    matched_flag = True
+                    event_timestamp_column = col_name
+            if matched_flag:
+                return event_timestamp_column
+            else:
+                raise TypeError(
+                    f"""
+                    {ERROR_MSG_PREFIX} due to an absence of columns that satisfy the criteria.
+                    """
+                )
+        else:
+            raise TypeError(
+                f"""
+                {ERROR_MSG_PREFIX} because this DataSource currently does not support this inference.
+                """
+            )
+
 
 class FileSource(DataSource):
     def __init__(
         self,
-        event_timestamp_column: str,
+        event_timestamp_column: Optional[str],
         file_url: Optional[str] = None,
         path: Optional[str] = None,
         file_format: FileFormat = None,
@@ -543,8 +579,10 @@ class FileSource(DataSource):
         Examples:
             >>> FileSource(path="/data/my_features.parquet", event_timestamp_column="datetime")
         """
+
         super().__init__(
-            event_timestamp_column,
+            event_timestamp_column
+            or self.infer_event_timestamp_column(r"timestamp\[\w\w\]"),
             created_timestamp_column,
             field_mapping,
             date_partition_column,
@@ -609,24 +647,30 @@ class FileSource(DataSource):
 
         return data_source_proto
 
+    def get_table_column_names_and_types(self) -> Iterable[Tuple[DataType, str]]:
+        schema = ParquetFile(self.path).schema_arrow
+        return zip(schema.names, schema.types)
+
 
 class BigQuerySource(DataSource):
     def __init__(
         self,
-        event_timestamp_column: str,
+        event_timestamp_column: Optional[str] = None,
         table_ref: Optional[str] = None,
         created_timestamp_column: Optional[str] = "",
         field_mapping: Optional[Dict[str, str]] = None,
         date_partition_column: Optional[str] = "",
         query: Optional[str] = None,
     ):
+
+        self._bigquery_options = BigQueryOptions(table_ref=table_ref, query=query)
         super().__init__(
-            event_timestamp_column,
+            event_timestamp_column
+            or self.infer_event_timestamp_column("TIMESTAMP|DATETIME"),
             created_timestamp_column,
             field_mapping,
             date_partition_column,
         )
-        self._bigquery_options = BigQueryOptions(table_ref=table_ref, query=query)
 
     def __eq__(self, other):
         if not isinstance(other, BigQuerySource):
@@ -683,6 +727,24 @@ class BigQuerySource(DataSource):
             return f"`{self.table_ref}`"
         else:
             return f"({self.query})"
+
+    def get_table_column_names_and_types(self) -> Iterable[Tuple[str, str]]:
+        assert self.table_ref is not None
+        name_type_pairs = []
+        project_id, dataset_id, table_id = self.table_ref.split(".")
+        bq_columns_query = f"""
+            SELECT COLUMN_NAME, DATA_TYPE FROM {project_id}.{dataset_id}.INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_NAME = '{table_id}'
+            """
+
+        client = bigquery.Client()
+        table_schema = client.query(bq_columns_query).result().to_dataframe_iterable()
+        for df in table_schema:
+            name_type_pairs.extend(
+                list(zip(df["COLUMN_NAME"].to_list(), df["DATA_TYPE"].to_list()))
+            )
+
+        return name_type_pairs
 
 
 class KafkaSource(DataSource):

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -760,7 +760,7 @@ class BigQuerySource(DataSource):
                     list(zip(df["COLUMN_NAME"].to_list(), df["DATA_TYPE"].to_list()))
                 )
         else:
-            bq_columns_query = f"SELECT * FROM {self.query} LIMIT 1"
+            bq_columns_query = f"SELECT * FROM ({self.query}) LIMIT 1"
             queryRes = client.query(bq_columns_query).result()
             name_type_pairs = [
                 (schema_field.name, schema_field.field_type)

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -75,7 +76,9 @@ class FeatureView:
             )
 
             for col_name, col_datatype in input.get_table_column_names_and_types():
-                if col_name not in columns_to_exclude:
+                if col_name not in columns_to_exclude and not re.match(
+                    "^__|__$", col_name
+                ):
                     features.append(Feature(col_name, type_converter(col_datatype)))
 
             if not features:

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -63,6 +63,7 @@ class FeatureView:
         online: bool = True,
     ):
         if not features:
+            features = []  # to handle python's mutable default arguments
             columns_to_exclude = {
                 input.event_timestamp_column,
                 input.created_timestamp_column,
@@ -73,9 +74,9 @@ class FeatureView:
                 else pa_to_feast_value_type
             )
 
-            for pair in input.get_table_column_names_and_types():
-                if pair[0] not in columns_to_exclude:
-                    features.append(Feature(pair[0], type_converter(pair[1])))
+            for col_name, col_datatype in input.get_table_column_names_and_types():
+                if col_name not in columns_to_exclude:
+                    features.append(Feature(col_name, type_converter(col_datatype)))
 
             if not features:
                 raise ValueError(

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -488,10 +488,10 @@ def bq_to_feast_value_type(bq_type_as_str):
     type_map: Dict[ValueType, Union[str, Dict[str, Any]]] = {
         "DATETIME": ValueType.STRING,  # Update to ValueType.UNIX_TIMESTAMP once #1520 lands.
         "TIMESTAMP": ValueType.STRING,  # Update to ValueType.UNIX_TIMESTAMP once #1520 lands.
-        "INTEGER": ValueType.INT32,
+        "INTEGER": ValueType.INT64,
         "INT64": ValueType.INT64,
         "STRING": ValueType.STRING,
-        "FLOAT": ValueType.FLOAT,
+        "FLOAT": ValueType.DOUBLE,
         "FLOAT64": ValueType.DOUBLE,
         "BYTES": ValueType.BYTES,
         "BOOL": ValueType.BOOL,

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -417,7 +417,7 @@ def pa_to_value_type(pa_type: object):
     return type_map[pa_type.__str__()]
 
 
-def pa_to_feast_value_type(value: pa.lib.ChunkedArray) -> ValueType:
+def pa_to_feast_value_type(value: Union[pa.lib.ChunkedArray, pa.DataType]) -> ValueType:
     type_map = {
         "timestamp[ms]": ValueType.INT64,
         "int32": ValueType.INT32,
@@ -435,7 +435,9 @@ def pa_to_feast_value_type(value: pa.lib.ChunkedArray) -> ValueType:
         "list<item: binary>": ValueType.BYTES_LIST,
         "list<item: bool>": ValueType.BOOL_LIST,
     }
-    return type_map[value.type.__str__()]
+    return type_map[
+        value.type.__str__() if isinstance(value, pa.lib.ChunkedArray) else str(value)
+    ]
 
 
 def pa_column_to_timestamp_proto_column(column: pa.lib.ChunkedArray) -> List[Timestamp]:
@@ -480,3 +482,22 @@ def pa_column_to_proto_column(
         ]
     else:
         return [ProtoValue(**{value: x.as_py()}) for x in column]
+
+
+def bq_to_feast_value_type(bq_type_as_str):
+    type_map: Dict[ValueType, Union[str, Dict[str, Any]]] = {
+        "DATETIME": ValueType.STRING,  # Unsure if string is right
+        "TIMESTAMP": ValueType.STRING,  # Unsure if string is right
+        "INT64": ValueType.INT64,
+        "STRING": ValueType.STRING,
+        "FLOAT64": ValueType.DOUBLE,
+        "BYTES": ValueType.BYTES,
+        "BOOL": ValueType.BOOL,
+        "ARRAY<INT64>": ValueType.INT64_LIST,
+        "ARRAY<FLOAT64>": ValueType.DOUBLE_LIST,
+        "ARRAY<STRING>": ValueType.STRING_LIST,
+        "ARRAY<BYTES>": ValueType.BYTES_LIST,
+        "ARRAY<BOOL>": ValueType.BOOL_LIST,
+    }
+
+    return type_map[bq_type_as_str]

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -486,10 +486,12 @@ def pa_column_to_proto_column(
 
 def bq_to_feast_value_type(bq_type_as_str):
     type_map: Dict[ValueType, Union[str, Dict[str, Any]]] = {
-        "DATETIME": ValueType.STRING,  # Unsure if string is right
-        "TIMESTAMP": ValueType.STRING,  # Unsure if string is right
+        "DATETIME": ValueType.STRING,  # Update to ValueType.UNIX_TIMESTAMP once #1520 lands.
+        "TIMESTAMP": ValueType.STRING,  # Update to ValueType.UNIX_TIMESTAMP once #1520 lands.
+        "INTEGER": ValueType.INT32,
         "INT64": ValueType.INT64,
         "STRING": ValueType.STRING,
+        "FLOAT": ValueType.FLOAT,
         "FLOAT64": ValueType.DOUBLE,
         "BYTES": ValueType.BYTES,
         "BOOL": ValueType.BOOL,

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -417,7 +417,7 @@ def pa_to_value_type(pa_type: object):
     return type_map[pa_type.__str__()]
 
 
-def pa_to_feast_value_type(value: Union[pa.lib.ChunkedArray, pa.DataType]) -> ValueType:
+def pa_to_feast_value_type(value: Union[pa.lib.ChunkedArray, str]) -> ValueType:
     type_map = {
         "timestamp[ms]": ValueType.INT64,
         "int32": ValueType.INT32,
@@ -436,7 +436,7 @@ def pa_to_feast_value_type(value: Union[pa.lib.ChunkedArray, pa.DataType]) -> Va
         "list<item: bool>": ValueType.BOOL_LIST,
     }
     return type_map[
-        value.type.__str__() if isinstance(value, pa.lib.ChunkedArray) else str(value)
+        value.type.__str__() if isinstance(value, pa.lib.ChunkedArray) else value
     ]
 
 

--- a/sdk/python/tests/example_feature_repo_with_inference.py
+++ b/sdk/python/tests/example_feature_repo_with_inference.py
@@ -1,0 +1,22 @@
+from google.protobuf.duration_pb2 import Duration
+
+from feast import Entity, FeatureView, ValueType
+from feast.data_source import FileSource
+
+driver_hourly_stats = FileSource(
+    path="%PARQUET_PATH%",  # placeholder to be replaced by the test
+    event_timestamp_column="datetime",
+    created_timestamp_column="created",
+)
+
+driver = Entity(name="driver_id", value_type=ValueType.INT64, description="driver id",)
+
+# features are inferred from columns of data source
+driver_hourly_stats_view = FeatureView(
+    name="driver_hourly_stats",
+    entities=["driver_id"],
+    ttl=Duration(seconds=86400 * 1),
+    online=True,
+    input=driver_hourly_stats,
+    tags={},
+)

--- a/sdk/python/tests/example_feature_repo_with_inference.py
+++ b/sdk/python/tests/example_feature_repo_with_inference.py
@@ -5,7 +5,6 @@ from feast.data_source import FileSource
 
 driver_hourly_stats = FileSource(
     path="%PARQUET_PATH%",  # placeholder to be replaced by the test
-    event_timestamp_column="datetime",
     created_timestamp_column="created",
 )
 

--- a/sdk/python/tests/fixtures/data_source_fixtures.py
+++ b/sdk/python/tests/fixtures/data_source_fixtures.py
@@ -1,0 +1,65 @@
+import contextlib
+import tempfile
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytest
+from google.cloud import bigquery
+
+from feast.data_format import ParquetFormat
+from feast.data_source import BigQuerySource, FileSource
+
+
+@pytest.fixture
+def simple_dataset_1() -> pd.DataFrame:
+    now = datetime.utcnow()
+    ts = pd.Timestamp(now).round("ms")
+    data = {
+        "id": [1, 2, 1, 3, 3],
+        "float_col": [0.1, 0.2, 0.3, 4, 5],
+        "int64_col": [1, 2, 3, 4, 5],
+        "string_col": ["a", "b", "c", "d", "e"],
+        "ts_1": [
+            ts,
+            ts - timedelta(hours=4),
+            ts - timedelta(hours=3),
+            ts - timedelta(hours=2),
+            ts - timedelta(hours=1),
+        ],
+    }
+    return pd.DataFrame.from_dict(data)
+
+
+@contextlib.contextmanager
+def prep_file_source(df, event_timestamp_column="") -> FileSource:
+    with tempfile.NamedTemporaryFile(suffix=".parquet") as f:
+        f.close()
+        df.to_parquet(f.name)
+        file_source = FileSource(
+            file_format=ParquetFormat(),
+            file_url=f.name,
+            event_timestamp_column=event_timestamp_column,
+        )
+        yield file_source
+
+
+def prep_bq_source(df, event_timestamp_column="") -> BigQuerySource:
+    client = bigquery.Client()
+    gcp_project = client.project
+    bigquery_dataset = "ds"
+    dataset = bigquery.Dataset(f"{gcp_project}.{bigquery_dataset}")
+    client.create_dataset(dataset, exists_ok=True)
+    dataset.default_table_expiration_ms = (
+        1000 * 60 * 60 * 24 * 14  # 2 weeks in milliseconds
+    )
+    client.update_dataset(dataset, ["default_table_expiration_ms"])
+    table_ref = f"{gcp_project}.{bigquery_dataset}.table_1"
+
+    job = client.load_table_from_dataframe(
+        df, table_ref, job_config=bigquery.LoadJobConfig()
+    )
+    job.result()
+
+    return BigQuerySource(
+        table_ref=table_ref, event_timestamp_column=event_timestamp_column,
+    )

--- a/sdk/python/tests/fixtures/data_source_fixtures.py
+++ b/sdk/python/tests/fixtures/data_source_fixtures.py
@@ -74,6 +74,6 @@ def simple_bq_source_using_query_arg(df, event_timestamp_column="") -> BigQueryS
         df, event_timestamp_column
     )
     return BigQuerySource(
-        query=bq_source_using_table_ref.table_ref,
+        query=f"SELECT * FROM {bq_source_using_table_ref.table_ref}",
         event_timestamp_column=event_timestamp_column,
     )

--- a/sdk/python/tests/test_feature_store.py
+++ b/sdk/python/tests/test_feature_store.py
@@ -16,6 +16,7 @@ from datetime import timedelta
 from tempfile import mkstemp
 
 import pytest
+from fixtures.data_source_fixtures import prep_bq_source, prep_file_source
 from pytest_lazyfixture import lazy_fixture
 
 from feast.data_format import ParquetFormat
@@ -180,6 +181,52 @@ def test_apply_feature_view_success(test_feature_store):
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
+    "test_feature_store", [lazy_fixture("feature_store_with_local_registry")],
+)
+@pytest.mark.parametrize("dataframe_source", [lazy_fixture("simple_dataset_1")])
+def test_feature_view_inference_success(test_feature_store, dataframe_source):
+    with prep_file_source(
+        df=dataframe_source, event_timestamp_column="ts_1"
+    ) as file_source:
+        fv1 = FeatureView(
+            name="fv1",
+            entities=["id"],
+            ttl=timedelta(minutes=5),
+            online=True,
+            input=file_source,
+            tags={},
+        )
+
+        fv2 = FeatureView(
+            name="fv2",
+            entities=["id"],
+            ttl=timedelta(minutes=5),
+            online=True,
+            input=prep_bq_source(dataframe_source, "ts_1"),
+            tags={},
+        )
+
+        test_feature_store.apply([fv1, fv2])  # Register Feature Views
+        feature_view_1 = test_feature_store.list_feature_views()[0]
+        feature_view_2 = test_feature_store.list_feature_views()[1]
+
+        actual_file_source = {
+            (feature.name, feature.dtype) for feature in feature_view_1.features
+        }
+        actual_bq_source = {
+            (feature.name, feature.dtype) for feature in feature_view_2.features
+        }
+        expected = {
+            ("float_col", ValueType.DOUBLE),
+            ("int64_col", ValueType.INT64),
+            ("string_col", ValueType.STRING),
+        }
+
+        assert expected == actual_file_source == actual_bq_source
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
     "test_feature_store", [lazy_fixture("feature_store_with_gcs_registry")],
 )
 def test_apply_feature_view_integration(test_feature_store):
@@ -243,6 +290,16 @@ def test_apply_feature_view_integration(test_feature_store):
     test_feature_store.delete_feature_view("my_feature_view_1")
     feature_views = test_feature_store.list_feature_views()
     assert len(feature_views) == 0
+
+
+@pytest.mark.parametrize("dataframe_source", [lazy_fixture("simple_dataset_1")])
+def test_data_source_ts_col_inference_success(dataframe_source):
+    with prep_file_source(df=dataframe_source) as file_source:
+        actual_file_source = file_source.event_timestamp_column
+        actual_bq_source = prep_bq_source(dataframe_source).event_timestamp_column
+        expected = "ts_1"
+
+        assert expected == actual_file_source == actual_bq_source
 
 
 @pytest.mark.parametrize(

--- a/sdk/python/tests/test_feature_store.py
+++ b/sdk/python/tests/test_feature_store.py
@@ -293,6 +293,7 @@ def test_apply_feature_view_integration(test_feature_store):
     assert len(feature_views) == 0
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("dataframe_source", [lazy_fixture("simple_dataset_1")])
 def test_data_source_ts_col_inference_success(dataframe_source):
     with prep_file_source(df=dataframe_source) as file_source:

--- a/sdk/python/tests/test_feature_store.py
+++ b/sdk/python/tests/test_feature_store.py
@@ -239,14 +239,13 @@ def test_feature_view_inference_success(test_feature_store, dataframe_source):
             ("int64_col", ValueType.INT64),
             ("string_col", ValueType.STRING),
         }
-        expected2 = {  # parsing with the "query" param in bq sources uses different code path
-            ("float_col", ValueType.FLOAT),
-            ("int64_col", ValueType.INT32),
-            ("string_col", ValueType.STRING),
-        }
 
-        assert expected == actual_file_source == actual_bq_using_table_ref_arg_source
-        assert expected2 == actual_bq_using_query_arg_source
+        assert (
+            expected
+            == actual_file_source
+            == actual_bq_using_table_ref_arg_source
+            == actual_bq_using_query_arg_source
+        )
 
 
 @pytest.mark.integration

--- a/sdk/python/tests/test_feature_store.py
+++ b/sdk/python/tests/test_feature_store.py
@@ -16,6 +16,7 @@ from datetime import timedelta
 from tempfile import mkstemp
 
 import pytest
+from fixtures.data_source_fixtures import simple_dataset_1  # noqa: F401
 from fixtures.data_source_fixtures import prep_bq_source, prep_file_source
 from pytest_lazyfixture import lazy_fixture
 


### PR DESCRIPTION
Test cases written and also tested by running with CLI. 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#code-conventions
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/docs/contributing.md#running-unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/tests/e2e
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: 
Milestone 1 of https://docs.google.com/document/d/1MkWvexE4e5nYWcQLELFnJ5o9OlJDKC2rn_USHMDT9dg/edit

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1500

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Feast will be able to infer the features to register if no features are included in the FeatureView definition, and also infer the event timestamp column of DataSources if that parameter is left out. This is milestone 1 of https://docs.google.com/document/d/1MkWvexE4e5nYWcQLELFnJ5o9OlJDKC2rn_USHMDT9dg/edit#heading=h.pqhio4s5uw2s
```
