### PR TITLE
Add roadmap to documentation

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,26 @@
 # Roadmap
 
+Our current proposed roadmap for 0.11 and onward is as follows
+
+## Backlog
+
+- Add On demand transformations support
+- Add Data quality monitoring
+- Add Snowflake offline store support
+- Add Bigtable support
+
+## Scheduled for development (next 3 months)
+
+- Ensure Feast Serving is compatible with the new Feast (#1497)
+    - Decouple Feast Serving from Feast Core
+    - Add FeatureView support to Feast Serving
+    - Update Helm Charts (remove Core, Postgres, Job Service, Spark)
+- Add Redis support for Feast (#1497)
+- Add direct deployment support to AWS and GCP
+- Add Dynamo support (#1409)
+- Add Redshift support (#1492)
+- Add Push/Ingestion API support
+
 ## Feast 0.10
 
 ### **New Functionality**


### PR DESCRIPTION
Adds our current roadmap to Feast our documentation

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
