### PR TITLE
Add opt-out exception logging telemetry

### DIFF
--- a/sdk/python/feast/entity.py
+++ b/sdk/python/feast/entity.py
@@ -23,6 +23,7 @@ from feast.loaders import yaml as feast_yaml
 from feast.protos.feast.core.Entity_pb2 import Entity as EntityV2Proto
 from feast.protos.feast.core.Entity_pb2 import EntityMeta as EntityMetaProto
 from feast.protos.feast.core.Entity_pb2 import EntitySpecV2 as EntitySpecProto
+from feast.telemetry import public_method
 from feast.value_type import ValueType
 
 
@@ -31,6 +32,7 @@ class Entity:
     Represents a collection of entities and associated metadata.
     """
 
+    @public_method
     def __init__(
         self,
         name: str,

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -225,6 +225,8 @@ class FeatureStore:
 
         if isinstance(objects, Entity) or isinstance(objects, FeatureView):
             objects = [objects]
+        assert isinstance(objects, list)
+
         views_to_update = []
         entities_to_update = []
         for ob in objects:

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -34,7 +34,7 @@ from feast.protos.feast.serving.ServingService_pb2 import (
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.registry import Registry
 from feast.repo_config import RepoConfig, load_repo_config
-from feast.telemetry import Telemetry
+from feast.telemetry import Telemetry, public_method
 from feast.version import get_version
 
 
@@ -51,6 +51,7 @@ class FeatureStore:
     repo_path: Path
     _registry: Registry
 
+    @public_method
     def __init__(
         self, repo_path: Optional[str] = None, config: Optional[RepoConfig] = None,
     ):
@@ -73,6 +74,7 @@ class FeatureStore:
         )
         self._tele = Telemetry()
 
+    @public_method
     def version(self) -> str:
         """Returns the version of the current Feast SDK/CLI"""
 
@@ -86,6 +88,7 @@ class FeatureStore:
         # TODO: Bake self.repo_path into self.config so that we dont only have one interface to paths
         return get_provider(self.config, self.repo_path)
 
+    @public_method
     def refresh_registry(self):
         """Fetches and caches a copy of the feature registry in memory.
 
@@ -110,6 +113,7 @@ class FeatureStore:
         )
         self._registry.refresh()
 
+    @public_method
     def list_entities(self, allow_cache: bool = False) -> List[Entity]:
         """
         Retrieve a list of entities from the registry
@@ -124,6 +128,7 @@ class FeatureStore:
 
         return self._registry.list_entities(self.project, allow_cache=allow_cache)
 
+    @public_method
     def list_feature_views(self) -> List[FeatureView]:
         """
         Retrieve a list of feature views from the registry
@@ -135,6 +140,7 @@ class FeatureStore:
 
         return self._registry.list_feature_views(self.project)
 
+    @public_method
     def get_entity(self, name: str) -> Entity:
         """
         Retrieves an entity.
@@ -150,6 +156,7 @@ class FeatureStore:
 
         return self._registry.get_entity(name, self.project)
 
+    @public_method
     def get_feature_view(self, name: str) -> FeatureView:
         """
         Retrieves a feature view.
@@ -165,6 +172,7 @@ class FeatureStore:
 
         return self._registry.get_feature_view(name, self.project)
 
+    @public_method
     def delete_feature_view(self, name: str):
         """
         Deletes a feature view or raises an exception if not found.
@@ -176,6 +184,7 @@ class FeatureStore:
 
         return self._registry.delete_feature_view(name, self.project)
 
+    @public_method
     def apply(
         self, objects: Union[Entity, FeatureView, List[Union[FeatureView, Entity]]]
     ):
@@ -238,6 +247,7 @@ class FeatureStore:
             partial=True,
         )
 
+    @public_method
     def get_historical_features(
         self, entity_df: Union[pd.DataFrame, str], feature_refs: List[str],
     ) -> RetrievalJob:
@@ -303,6 +313,7 @@ class FeatureStore:
 
         return job
 
+    @public_method
     def materialize_incremental(
         self, end_date: datetime, feature_views: Optional[List[str]] = None,
     ) -> None:
@@ -358,6 +369,7 @@ class FeatureStore:
             )
             print(" done!")
 
+    @public_method
     def materialize(
         self,
         start_date: datetime,
@@ -415,6 +427,7 @@ class FeatureStore:
             )
             print(" done!")
 
+    @public_method
     def get_online_features(
         self, feature_refs: List[str], entity_rows: List[Dict[str, Any]],
     ) -> OnlineResponse:

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -32,6 +32,7 @@ from feast.protos.feast.core.FeatureView_pb2 import (
 from feast.protos.feast.core.FeatureView_pb2 import (
     MaterializationInterval as MaterializationIntervalProto,
 )
+from feast.telemetry import public_method
 from feast.value_type import ValueType
 
 
@@ -52,6 +53,7 @@ class FeatureView:
     last_updated_timestamp: Optional[Timestamp] = None
     materialization_intervals: List[Tuple[datetime, datetime]]
 
+    @public_method
     def __init__(
         self,
         name: str,

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel, StrictInt, StrictStr, ValidationError, root_vali
 from pydantic.error_wrappers import ErrorWrapper
 from pydantic.typing import Dict, Literal, Optional, Union
 
+from feast.telemetry import public_method
+
 
 class FeastBaseModel(BaseModel):
     """ Feast Pydantic Configuration Class """
@@ -75,6 +77,7 @@ class RepoConfig(FeastBaseModel):
             return self.registry
 
     @root_validator(pre=True)
+    @public_method
     def _validate_online_store_config(cls, values):
         # This method will validate whether the online store configurations are set correctly. This explicit validation
         # is necessary because Pydantic Unions throw very verbose and cryptic exceptions. We also use this method to

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -15,6 +15,7 @@ from feast.infra.provider import get_provider
 from feast.names import adjectives, animals
 from feast.registry import Registry
 from feast.repo_config import RepoConfig
+from feast.telemetry import public_method
 
 
 def py_path_to_module(path: Path, repo_root: Path) -> str:
@@ -103,6 +104,7 @@ def parse_repo(repo_root: Path) -> ParsedRepo:
     return res
 
 
+@public_method
 def apply_total(repo_config: RepoConfig, repo_path: Path):
     from colorama import Fore, Style
 
@@ -209,6 +211,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path):
     )
 
 
+@public_method
 def teardown(repo_config: RepoConfig, repo_path: Path):
     registry_config = repo_config.get_registry_config()
     registry = Registry(
@@ -229,6 +232,7 @@ def teardown(repo_config: RepoConfig, repo_path: Path):
     )
 
 
+@public_method
 def registry_dump(repo_config: RepoConfig, repo_path: Path):
     """ For debugging only: output contents of the metadata registry """
     registry_config = repo_config.get_registry_config()
@@ -255,6 +259,7 @@ def cli_check_repo(repo_path: Path):
         sys.exit(1)
 
 
+@public_method
 def init_repo(repo_name: str, template: str):
     import os
     from distutils.dir_util import copy_tree

--- a/sdk/python/feast/telemetry.py
+++ b/sdk/python/feast/telemetry.py
@@ -117,13 +117,21 @@ def public_method(func):
             trace_to_log = []
             tb = e.__traceback__
             while tb is not None:
-                trace_to_log.append((_trim_filename(tb.tb_frame.f_code.co_filename), tb.tb_lineno, tb.tb_frame.f_code.co_name))
+                trace_to_log.append(
+                    (
+                        _trim_filename(tb.tb_frame.f_code.co_filename),
+                        tb.tb_lineno,
+                        tb.tb_frame.f_code.co_name,
+                    )
+                )
                 tb = tb.tb_next
             tele = Telemetry()
             tele.log_exception(error_type, trace_to_log)
             raise
         return result
+
     return public_method_wrapper
+
 
 def _trim_filename(filename: str) -> str:
     return filename.split("/")[-1]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Telemetry will now log anonymized exceptions from Feast methods in addition to usage statistics

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Telemetry will now log anonymized exceptions from Feast methods in addition to usage statistics. To opt out, see https://docs.feast.dev/v/master/feast-on-kubernetes/advanced-1/telemetry
```
