### PR TITLE
Initializing `ttl` and `ttl_duration` to None

### DIFF
--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -56,7 +56,7 @@ class FeatureView:
         self,
         name: str,
         entities: List[str],
-        ttl: Optional[Union[Duration, timedelta]],
+        ttl: Optional[Union[Duration, timedelta]] = None,
         input: Union[BigQuerySource, FileSource],
         features: List[Feature] = [],
         tags: Optional[Dict[str, str]] = None,
@@ -170,7 +170,8 @@ class FeatureView:
             interval_proto.start_time.FromDatetime(interval[0])
             interval_proto.end_time.FromDatetime(interval[1])
             meta.materialization_intervals.append(interval_proto)
-
+        
+        ttl_duration = None
         if self.ttl is not None:
             ttl_duration = Duration()
             ttl_duration.FromTimedelta(self.ttl)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
`ttl` is noted as an optional input in the `FeatureView` class which should default to `None`. If the FeatureView's `ttl` input parameter is None (by default or specified by the User when creating the feature view), the `ttl_duration` is never initialized inside the `FeatureView.to_proto()` function and will produce an `UnboundLocalError` since the local variable `ttl_duration` is referenced before assignment.

```bash
Registered entity id
Traceback (most recent call last):
  File "/usr/local/bin/feast", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/dist-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/feast/cli.py", line 163, in apply_total_command
    apply_total(repo_config, Path.cwd())
  File "/usr/local/lib/python3.7/dist-packages/feast/repo_operations.py", line 166, in apply_total
    registry.apply_feature_view(view, project)
  File "/usr/local/lib/python3.7/dist-packages/feast/registry.py", line 176, in apply_feature_view
    feature_view_proto = feature_view.to_proto()
  File "/usr/local/lib/python3.7/dist-packages/feast/feature_view.py", line 159, in to_proto
    ttl=(ttl_duration if ttl_duration is not None else None),
UnboundLocalError: local variable 'ttl_duration' referenced before assignment
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
