### PR TITLE
Improve GCP exception handling

### DIFF
--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -1,3 +1,6 @@
+from colorama import Fore, Style
+
+
 class FeastObjectNotFoundException(Exception):
     pass
 
@@ -47,3 +50,13 @@ class FeastProviderClassImportError(Exception):
         super().__init__(
             f"Could not import provider '{class_name}' from module '{module_name}'"
         )
+
+
+class FeastExtrasDependencyImportError(Exception):
+    def __init__(self, extras_type: str, nested_error: str):
+        message = (
+            nested_error
+            + "\n"
+            + f"You may need run {Style.BRIGHT + Fore.GREEN}pip install 'feast[{extras_type}]'{Style.RESET_ALL}"
+        )
+        super().__init__(message)

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -5,7 +5,6 @@ from typing import List, Optional, Union
 
 import pandas
 import pyarrow
-from google.auth.exceptions import DefaultCredentialsError
 from jinja2 import BaseLoader, Environment
 
 from feast.data_source import BigQuerySource, DataSource
@@ -19,6 +18,15 @@ from feast.infra.provider import (
 )
 from feast.registry import Registry
 from feast.repo_config import RepoConfig
+
+try:
+    from google.auth.exceptions import DefaultCredentialsError
+    from google.cloud import bigquery
+
+except ImportError as e:
+    from feast.errors import FeastExtrasDependencyImportError
+
+    raise FeastExtrasDependencyImportError("gcp", str(e))
 
 
 class BigQueryOfflineStore(OfflineStore):
@@ -192,7 +200,6 @@ class FeatureViewQueryContext:
 
 def _upload_entity_df_into_bigquery(project, entity_df, client) -> str:
     """Uploads a Pandas entity dataframe into a BigQuery table and returns a reference to the resulting table"""
-    from google.cloud import bigquery
 
     # First create the BigQuery dataset if it doesn't exist
     dataset = bigquery.Dataset(f"{client.project}.feast_{project}")
@@ -303,8 +310,6 @@ def build_point_in_time_query(
 
 def _get_bigquery_client():
     try:
-        from google.cloud import bigquery
-
         client = bigquery.Client()
     except DefaultCredentialsError as e:
         raise FeastProviderLoginError(

--- a/sdk/python/feast/infra/offline_stores/helpers.py
+++ b/sdk/python/feast/infra/offline_stores/helpers.py
@@ -1,8 +1,6 @@
 from typing import List
 
 from feast.data_source import BigQuerySource, DataSource, FileSource
-from feast.infra.offline_stores.bigquery import BigQueryOfflineStore
-from feast.infra.offline_stores.file import FileOfflineStore
 from feast.infra.offline_stores.offline_store import OfflineStore
 
 
@@ -13,10 +11,12 @@ def get_offline_store_from_sources(sources: List[DataSource]) -> OfflineStore:
 
     # Retrieve features from ParquetOfflineStore
     if all(source == FileSource for source in source_types):
+        from feast.infra.offline_stores.file import FileOfflineStore
         return FileOfflineStore()
 
     # Retrieve features from BigQueryOfflineStore
     if all(source == BigQuerySource for source in source_types):
+        from feast.infra.offline_stores.bigquery import BigQueryOfflineStore
         return BigQueryOfflineStore()
 
     # Could not map inputs to an OfflineStore implementation

--- a/sdk/python/feast/infra/offline_stores/helpers.py
+++ b/sdk/python/feast/infra/offline_stores/helpers.py
@@ -12,11 +12,13 @@ def get_offline_store_from_sources(sources: List[DataSource]) -> OfflineStore:
     # Retrieve features from ParquetOfflineStore
     if all(source == FileSource for source in source_types):
         from feast.infra.offline_stores.file import FileOfflineStore
+
         return FileOfflineStore()
 
     # Retrieve features from BigQueryOfflineStore
     if all(source == BigQuerySource for source in source_types):
         from feast.infra.offline_stores.bigquery import BigQueryOfflineStore
+
         return BigQueryOfflineStore()
 
     # Could not map inputs to an OfflineStore implementation

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -431,7 +431,6 @@ class LocalRegistryStore(RegistryStore):
 class GCSRegistryStore(RegistryStore):
     def __init__(self, uri: str):
         try:
-            from google.auth.exceptions import DefaultCredentialsError
             from google.cloud import storage
         except ImportError:
             # TODO: Ensure versioning depends on requirements.txt/setup.py and isn't hardcoded

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -432,12 +432,11 @@ class GCSRegistryStore(RegistryStore):
     def __init__(self, uri: str):
         try:
             from google.cloud import storage
-        except ImportError:
-            # TODO: Ensure versioning depends on requirements.txt/setup.py and isn't hardcoded
-            raise ImportError(
-                "Install package google-cloud-storage==1.20.* for gcs support"
-                "run ```pip install google-cloud-storage==1.20.*```"
-            )
+        except ImportError as e:
+            from feast.errors import FeastExtrasDependencyImportError
+
+            raise FeastExtrasDependencyImportError("gcp", str(e))
+
         self.gcs_client = storage.Client()
         self._uri = urlparse(uri)
         self._bucket = self._uri.hostname

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -439,10 +439,7 @@ class GCSRegistryStore(RegistryStore):
                 "Install package google-cloud-storage==1.20.* for gcs support"
                 "run ```pip install google-cloud-storage==1.20.*```"
             )
-        try:
-            self.gcs_client = storage.Client()
-        except DefaultCredentialsError:
-            self.gcs_client = storage.Client.create_anonymous_client()
+        self.gcs_client = storage.Client()
         self._uri = urlparse(uri)
         self._bucket = self._uri.hostname
         self._blob = self._uri.path.lstrip("/")


### PR DESCRIPTION
Signed-off-by: Willem Pienaar <git@willem.co>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

If no `gcloud` account is specified, then users today are not provided with a useful exception. Instead, the exception is hidden behind a failure due to an anonymous client not having access to their resources.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
