### PR TITLE
Fix Sphinx documentation building

### DIFF
--- a/sdk/python/docs/requirements.txt
+++ b/sdk/python/docs/requirements.txt
@@ -1,6 +1,1 @@
-grpcio-tools==1.31.0
-mypy==0.790
-mypy-protobuf==1.24
-firebase-admin==4.5.2
-google-cloud-datastore==2.1.0
 -e "./sdk/python/[ci]"

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -86,7 +86,7 @@ CI_REQUIRED = [
     "pytest-timeout==1.4.2",
     "pytest-ordering==0.6.*",
     "pytest-mock==1.10.4",
-    "Sphinx",
+    "Sphinx!=4.0.0",
     "sphinx-rtd-theme",
     "tenacity",
     "adlfs==0.5.9",
@@ -205,7 +205,7 @@ setup(
     ],
     entry_points={"console_scripts": ["feast=feast.cli:cli"]},
     use_scm_version={"root": "../..", "relative_to": __file__, "tag_regex": TAG_REGEX},
-    setup_requires=["setuptools_scm", "grpcio", "grpcio-tools==1.34.0", "mypy-protobuf", "sphinx"],
+    setup_requires=["setuptools_scm", "grpcio", "grpcio-tools==1.34.0", "mypy-protobuf", "sphinx!=4.0.0"],
     package_data={
         "": [
             "protos/feast/**/*.proto",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Sphinx 4.0.0 breaks documentation building on master (also seen here https://github.com/datalad/datalad/issues/5650). This PR prevents 4.0.0 from being used.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
