### PR TITLE
Don't create bigquery dataset if it already exists

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -208,8 +208,6 @@ def _upload_entity_df_into_bigquery(project, dataset_name, entity_df, client) ->
     dataset = bigquery.Dataset(f"{client.project}.{dataset_name}")
     dataset.location = "US"
 
-    client.get_dataset(dataset)
-
     try:
         client.get_dataset(dataset)
     except NotFound:

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -20,6 +20,7 @@ from feast.registry import Registry
 from feast.repo_config import BigQueryOfflineStoreConfig, RepoConfig
 
 try:
+    from google.api_core.exceptions import NotFound
     from google.auth.exceptions import DefaultCredentialsError
     from google.cloud import bigquery
 
@@ -102,15 +103,8 @@ class BigQueryOfflineStore(OfflineStore):
 
             assert isinstance(config.offline_store, BigQueryOfflineStoreConfig)
 
-            # We should create a new dataset if the dataset name was not overridden in the config
-            should_create_dataset = "dataset" not in config.offline_store.__fields_set__
-
             table_id = _upload_entity_df_into_bigquery(
-                config.project,
-                config.offline_store.dataset,
-                should_create_dataset,
-                entity_df,
-                client,
+                config.project, config.offline_store.dataset, entity_df, client
             )
             entity_df_sql_table = f"`{table_id}`"
         else:
@@ -207,17 +201,20 @@ class FeatureViewQueryContext:
     entity_selections: List[str]
 
 
-def _upload_entity_df_into_bigquery(
-    project, dataset_name, should_create_dataset, entity_df, client
-) -> str:
+def _upload_entity_df_into_bigquery(project, dataset_name, entity_df, client) -> str:
     """Uploads a Pandas entity dataframe into a BigQuery table and returns a reference to the resulting table"""
 
     # First create the BigQuery dataset if it doesn't exist
     dataset = bigquery.Dataset(f"{client.project}.{dataset_name}")
     dataset.location = "US"
 
-    if should_create_dataset:
-        client.create_dataset(dataset, exists_ok=True)
+    client.get_dataset(dataset)
+
+    try:
+        client.get_dataset(dataset)
+    except NotFound:
+        # Only create the dataset if it does not exist
+        client.create_dataset(dataset)
 
     # Drop the index so that we dont have unnecessary columns
     entity_df.reset_index(drop=True, inplace=True)

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -212,7 +212,7 @@ def _upload_entity_df_into_bigquery(project, dataset_name, entity_df, client) ->
         client.get_dataset(dataset)
     except NotFound:
         # Only create the dataset if it does not exist
-        client.create_dataset(dataset)
+        client.create_dataset(dataset, exists_ok=True)
 
     # Drop the index so that we dont have unnecessary columns
     entity_df.reset_index(drop=True, inplace=True)


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: In bigquery.py, first call `client.get_dataset` and only call `client.create_dataset` if it doesn't exist. This way users can manually create the dataset and only grant `bigquery.datasets.get` permission (not `bigquery.datasets.create`) to Feast.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Require just `bigquery.datasets.get` permission (not `bigquery.datasets.create`) if the BigQuery dataset defined by `offline_store->dataset` is already created by the user.
```
