### PR TITLE
Add datastore namespace option in configs

### DIFF
--- a/sdk/python/feast/infra/gcp.py
+++ b/sdk/python/feast/infra/gcp.py
@@ -36,23 +36,21 @@ except ImportError as e:
 
 class GcpProvider(Provider):
     _gcp_project_id: Optional[str]
+    _namespace: Optional[str]
 
     def __init__(self, config: RepoConfig):
         assert isinstance(config.online_store, DatastoreOnlineStoreConfig)
-        assert config.offline_store is not None
-        if config and config.online_store and config.online_store.project_id:
-            self._gcp_project_id = config.online_store.project_id
-        else:
-            self._gcp_project_id = None
+        self._gcp_project_id = config.online_store.project_id
+        self._namespace = config.online_store.namespace
 
+        assert config.offline_store is not None
         self.offline_store = get_offline_store_from_config(config.offline_store)
 
     def _initialize_client(self):
         try:
-            if self._gcp_project_id is not None:
-                return datastore.Client(self._gcp_project_id)
-            else:
-                return datastore.Client()
+            return datastore.Client(
+                project=self._gcp_project_id, namespace=self._namespace
+            )
         except DefaultCredentialsError as e:
             raise FeastProviderLoginError(
                 str(e)

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -35,6 +35,9 @@ class DatastoreOnlineStoreConfig(FeastBaseModel):
     project_id: Optional[StrictStr] = None
     """ (optional) GCP Project Id """
 
+    namespace: Optional[StrictStr] = None
+    """ (optional) Datastore namespace """
+
 
 OnlineStoreConfig = Union[DatastoreOnlineStoreConfig, SqliteOnlineStoreConfig]
 
@@ -138,7 +141,7 @@ class RepoConfig(FeastBaseModel):
             elif online_store_type == "datastore":
                 DatastoreOnlineStoreConfig(**values["online_store"])
             else:
-                raise ValidationError(f"Invalid online store type {online_store_type}")
+                raise ValueError(f"Invalid online store type {online_store_type}")
         except ValidationError as e:
             raise ValidationError(
                 [ErrorWrapper(e, loc="online_store")], model=SqliteOnlineStoreConfig,

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -17,7 +17,11 @@ from feast.entity import Entity
 from feast.feature import Feature
 from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
-from feast.repo_config import RepoConfig, SqliteOnlineStoreConfig
+from feast.repo_config import (
+    DatastoreOnlineStoreConfig,
+    RepoConfig,
+    SqliteOnlineStoreConfig,
+)
 from feast.value_type import ValueType
 
 
@@ -98,6 +102,7 @@ def prep_bq_fs_and_fv(
             registry=str(Path(repo_dir_name) / "registry.db"),
             project=f"test_bq_correctness_{str(uuid.uuid4()).replace('-', '')}",
             provider="gcp",
+            online_store=DatastoreOnlineStoreConfig(namespace="integration_test"),
         )
         fs = FeatureStore(config=config)
         fs.apply([fv, e])


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Feast gcp provider used `default` namespace for all its operations. Here we add a new config in `feature_store.yaml` that overrides the namespace. For example:
```
project: my_repo
registry: data/registry.db
provider: gcp
online_store:
  type: datastore
  namespace: foo
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add `online_store->namespace` field in `feature_store.yaml` that overrides datastore namespace that gcp provider uses
```
