### PR TITLE
Make start and end timestamps tz aware in the CLI

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -20,6 +20,7 @@ from typing import List
 import click
 import pkg_resources
 import yaml
+from feast import utils
 
 from feast.errors import FeastObjectNotFoundException, FeastProviderLoginError
 from feast.feature_store import FeatureStore
@@ -242,8 +243,8 @@ def materialize_command(
     store = FeatureStore(repo_path=str(repo))
     store.materialize(
         feature_views=None if not views else views,
-        start_date=datetime.fromisoformat(start_ts),
-        end_date=datetime.fromisoformat(end_ts),
+        start_date=utils.make_tzaware(datetime.fromisoformat(start_ts)),
+        end_date=utils.make_tzaware(datetime.fromisoformat(end_ts)),
     )
 
 
@@ -267,7 +268,7 @@ def materialize_incremental_command(ctx: click.Context, end_ts: str, views: List
     store = FeatureStore(repo_path=str(repo))
     store.materialize_incremental(
         feature_views=None if not views else views,
-        end_date=datetime.fromisoformat(end_ts),
+        end_date=utils.make_tzaware(datetime.fromisoformat(end_ts)),
     )
 
 

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -20,8 +20,8 @@ from typing import List
 import click
 import pkg_resources
 import yaml
-from feast import utils
 
+from feast import utils
 from feast.errors import FeastObjectNotFoundException, FeastProviderLoginError
 from feast.feature_store import FeatureStore
 from feast.repo_config import load_repo_config


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

We log start and time information in the CLI, before converting the timestamps into tz-aware datetime objects. This results in a confusion when running `feast materialize-incremental` which only takes in an end_ts argument. The end_ts argument is tz-naive, but start_ts is tz-aware, which causes the time range that's logged to the console to be messed up.

This PR changes the behaviour to add tz information at the boundary of the CLI so that log messages in the deeper classes as well as in the CLI are consistent.



```
$ feast materialize 2021-05-12 2021-05-13
Materializing 1 feature views from 2021-05-11 17:00:00-07:00 to 2021-05-12 17:00:00-07:00 into the sqlite online store.

driver_hourly_stats:
100%|███████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 1371.05it/s]
$ feast materialize-incremental 2021-05-14
Materializing 1 feature views to 2021-05-13 17:00:00-07:00 into the sqlite online store.

driver_hourly_stats from 2021-05-12 17:00:00-07:00 to 2021-05-13 17:00:00-07:00:
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Time stamps in messages logged to the console now contain timezone information.
```
