### PR TITLE
Add current directory in sys path for CLI commands that might depend on custom providers

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -112,7 +112,6 @@ def apply_total(repo_config: RepoConfig, repo_path: Path):
     from colorama import Fore, Style
 
     os.chdir(repo_path)
-    sys.path.append("")
     registry_config = repo_config.get_registry_config()
     project = repo_config.project
     if not_valid_name(project):
@@ -267,6 +266,7 @@ def registry_dump(repo_config: RepoConfig, repo_path: Path):
 
 
 def cli_check_repo(repo_path: Path):
+    sys.path.append(str(repo_path))
     config_path = repo_path / "feature_store.yaml"
     if not config_path.exists():
         print(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Only `feast apply` works with custom providers. Other CLI commands that depend on the provider don't work with custom ones.
This is because the current directory is append to the SYS PATH only during `feast apply`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/feast-dev/feast/issues/1589

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Append current directory in sys path for all CLI commands that depend on a provider
```
