### PR TITLE
Repo and project names should not start with an underscore

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -115,10 +115,10 @@ def apply_total(repo_config: RepoConfig, repo_path: Path):
     os.chdir(repo_path)
     registry_config = repo_config.get_registry_config()
     project = repo_config.project
-    if not_valid_name(project):
+    if not is_valid_name(project):
         print(
             f"{project} is not valid. Project name should only have "
-            f"alphanumerical values and underscores."
+            f"alphanumerical values and underscores but not start with an underscore."
         )
         sys.exit(1)
     registry = Registry(
@@ -292,9 +292,9 @@ def init_repo(repo_name: str, template: str):
 
     from colorama import Fore, Style
 
-    if not_valid_name(repo_name):
+    if not is_valid_name(repo_name):
         raise BadParameter(
-            message="Name should be alphanumeric values and underscores",
+            message="Name should be alphanumeric values and underscores but not start with an underscore",
             param_hint="PROJECT_DIRECTORY",
         )
     repo_path = Path(os.path.join(Path.cwd(), repo_name))
@@ -349,9 +349,9 @@ def init_repo(repo_name: str, template: str):
     click.echo()
 
 
-def not_valid_name(name: str) -> bool:
-    """Test project or repo names. True if names have characters other than alphanumeric values and underscores"""
-    return re.compile(r"\W+").search(name) is not None
+def is_valid_name(name: str) -> bool:
+    """A name should be alphanumeric values and underscores but not start with an underscore"""
+    return not name.startswith("_") and re.compile(r"\W+").search(name) is None
 
 
 def replace_str_in_file(file_path, match_str, sub_str):

--- a/sdk/python/tests/test_init.py
+++ b/sdk/python/tests/test_init.py
@@ -1,6 +1,7 @@
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
+from textwrap import dedent
 
 from tests.cli_utils import CliRunner
 
@@ -25,3 +26,43 @@ def test_repo_init() -> None:
             ["materialize", start_date.isoformat(), end_date.isoformat()], cwd=repo_path
         )
         assert result.returncode == 0
+
+
+def test_repo_init_with_underscore_in_project_name() -> None:
+    """
+    Test `feast init` with underscore in the project name
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        runner = CliRunner()
+
+        # `feast init` should fail with repo names start with underscore
+        invalid_repo_names = ["_test", "_test_1"]
+        for repo_name in invalid_repo_names:
+            result = runner.run(["init", repo_name], cwd=temp_path)
+            assert result.returncode != 0
+
+        # `feast init` should succeed with underscore in repo name
+        valid_repo_names = ["test_1"]
+        for repo_name in valid_repo_names:
+            result = runner.run(["init", repo_name], cwd=temp_path)
+            assert result.returncode == 0
+
+        # `feast apply` should fail with underscore in project name
+        project_name = "test_1"
+        repo_dir = temp_path / project_name
+        data_dir = repo_dir / "data"
+        repo_config = repo_dir / "feature_store.yaml"
+        repo_config.write_text(
+            dedent(
+                f"""
+        project: __foo
+        registry: {data_dir / "registry.db"}
+        provider: local
+        online_store:
+            path: {data_dir / "online_store.db"}
+        """
+            )
+        )
+        result = runner.run(["apply"], cwd=repo_dir)
+        assert result.returncode != 0


### PR DESCRIPTION
Signed-off-by: ted chang <htchang@us.ibm.com>

Address comments in PR #1558

```release-note
feast apply or init commands will exit if project or repo name start with an underscore.
```
/cc @woop @dmatrix