### PR TITLE
Update type conversion from pandas to timestamp to support various the timestamp types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,8 @@ repos:
         stages: [ push ]
         language: system
         entry: make lint
+  - repo: https://github.com/ambv/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,3 @@ repos:
         stages: [ push ]
         language: system
         entry: make lint
-  - repo: https://github.com/ambv/black
-    rev: 20.8b1
-    hooks:
-      - id: black
-        language_version: python3.7

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -598,8 +598,7 @@ class FileSource(DataSource):
         self._file_options = FileOptions(file_format=file_format, file_url=file_url)
 
         super().__init__(
-            event_timestamp_column
-            or self._infer_event_timestamp_column(r"^timestamp"),
+            event_timestamp_column or self._infer_event_timestamp_column(r"^timestamp"),
             created_timestamp_column,
             field_mapping,
             date_partition_column,

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -599,7 +599,7 @@ class FileSource(DataSource):
 
         super().__init__(
             event_timestamp_column
-            or self._infer_event_timestamp_column(r"timestamp\[\w\w\]"),
+            or self._infer_event_timestamp_column(r"^timestamp"),
             created_timestamp_column,
             field_mapping,
             date_partition_column,
@@ -744,7 +744,6 @@ class BigQuerySource(DataSource):
         from google.cloud import bigquery
 
         client = bigquery.Client()
-        bq_columns_query = ""
         name_type_pairs = []
         if self.table_ref is not None:
             project_id, dataset_id, table_id = self.table_ref.split(".")

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -14,6 +14,7 @@
 
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Union
+import re
 
 import numpy as np
 import pandas as pd
@@ -438,8 +439,12 @@ def pa_to_value_type(pa_type: object):
 
 
 def pa_to_feast_value_type(value: Union[pa.lib.ChunkedArray, str]) -> ValueType:
+    value_type = value.type.__str__() if isinstance(value, pa.lib.ChunkedArray) else value
+
+    if re.match(r"^timestamp", value_type):
+        return ValueType.INT64
+
     type_map = {
-        "timestamp[ms]": ValueType.INT64,
         "int32": ValueType.INT32,
         "int64": ValueType.INT64,
         "double": ValueType.DOUBLE,
@@ -455,9 +460,7 @@ def pa_to_feast_value_type(value: Union[pa.lib.ChunkedArray, str]) -> ValueType:
         "list<item: binary>": ValueType.BYTES_LIST,
         "list<item: bool>": ValueType.BOOL_LIST,
     }
-    return type_map[
-        value.type.__str__() if isinstance(value, pa.lib.ChunkedArray) else value
-    ]
+    return type_map[value_type]
 
 
 def pa_column_to_timestamp_proto_column(column: pa.lib.ChunkedArray) -> List[Timestamp]:

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Union
-import re
 
 import numpy as np
 import pandas as pd
@@ -439,7 +439,9 @@ def pa_to_value_type(pa_type: object):
 
 
 def pa_to_feast_value_type(value: Union[pa.lib.ChunkedArray, str]) -> ValueType:
-    value_type = value.type.__str__() if isinstance(value, pa.lib.ChunkedArray) else value
+    value_type = (
+        value.type.__str__() if isinstance(value, pa.lib.ChunkedArray) else value
+    )
 
     if re.match(r"^timestamp", value_type):
         return ValueType.INT64


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, Inferring features fails on columns of type timestamp[ms, tz=UTC] or other tz. This diff attempts to fix using a regex instead of enumerating all the different possibilities. 

An option is to use the pandas type instead of the string representation, but this is probably good enough.
https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timestamp.html

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix Inferring features columns of pandas timestamp types.
```
