### PR TITLE
Allow telemetry configuration to fail gracefully

### DIFF
--- a/sdk/python/feast/telemetry.py
+++ b/sdk/python/feast/telemetry.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import logging
 import os
 import sys
 import uuid
@@ -19,7 +19,7 @@ from datetime import datetime
 from functools import wraps
 from os.path import expanduser, join
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 import requests
 
@@ -28,11 +28,13 @@ from feast.version import get_version
 TELEMETRY_ENDPOINT = (
     "https://us-central1-kf-feast.cloudfunctions.net/bq_telemetry_logger"
 )
+_logger = logging.getLogger(__name__)
 
 
 class Telemetry:
     def __init__(self):
-        self._telemetry_enabled = False
+        self._telemetry_enabled: bool = False
+        self._telemetry_id: Optional[str] = None
         self.check_env_and_configure()
 
     def check_env_and_configure(self):
@@ -45,35 +47,36 @@ class Telemetry:
             self._telemetry_enabled = telemetry_enabled
 
             if self._telemetry_enabled:
-                feast_home_dir = join(expanduser("~"), ".feast")
-                Path(feast_home_dir).mkdir(exist_ok=True)
-                telemetry_filepath = join(feast_home_dir, "telemetry")
+                try:
+                    feast_home_dir = join(expanduser("~"), ".feast")
+                    Path(feast_home_dir).mkdir(exist_ok=True)
+                    telemetry_filepath = join(feast_home_dir, "telemetry")
 
-                self._is_test = os.getenv("FEAST_IS_TELEMETRY_TEST", "False") == "True"
-                self._telemetry_counter = {"get_online_features": 0}
+                    self._is_test = os.getenv("FEAST_IS_TELEMETRY_TEST", "False") == "True"
+                    self._telemetry_counter = {"get_online_features": 0}
 
-                if os.path.exists(telemetry_filepath):
-                    with open(telemetry_filepath, "r") as f:
-                        self._telemetry_id = f.read()
-                else:
-                    self._telemetry_id = str(uuid.uuid4())
+                    if os.path.exists(telemetry_filepath):
+                        with open(telemetry_filepath, "r") as f:
+                            self._telemetry_id = f.read()
+                    else:
+                        self._telemetry_id = str(uuid.uuid4())
 
-                    with open(telemetry_filepath, "w") as f:
-                        f.write(self._telemetry_id)
-                    print(
-                        "Feast is an open source project that collects anonymized error reporting and usage statistics. To opt out or learn"
-                        " more see https://docs.feast.dev/reference/telemetry"
-                    )
+                        with open(telemetry_filepath, "w") as f:
+                            f.write(self._telemetry_id)
+                        print(
+                            "Feast is an open source project that collects anonymized error reporting and usage statistics. To opt out or learn"
+                            " more see https://docs.feast.dev/reference/telemetry"
+                        )
+                except Exception as e:
+                    _logger.debug("Unable to configure telemetry", e)
 
     @property
-    def telemetry_id(self):
+    def telemetry_id(self) -> Optional[str]:
         if os.getenv("FEAST_FORCE_TELEMETRY_UUID"):
             return os.getenv("FEAST_FORCE_TELEMETRY_UUID")
         return self._telemetry_id
 
     def log(self, function_name: str):
-        self.check_env_and_configure()
-
         if self._telemetry_enabled and self.telemetry_id:
             if function_name == "get_online_features":
                 if self._telemetry_counter["get_online_features"] % 10000 != 0:
@@ -98,8 +101,6 @@ class Telemetry:
             return
 
     def log_exception(self, error_type: str, traceback: List[Tuple[str, int, str]]):
-        self.check_env_and_configure()
-
         if self._telemetry_enabled and self.telemetry_id:
             json = {
                 "error_type": error_type,


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

In some environments feast may be unable to writes files to the local filesystem because of it being readonly. Right now, this breaks the telemetry logging in a bad way. We should handle it gracefully.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow telemetry configuration to fail gracefully
```
