### PR TITLE
Add validations when materializing from file sources

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -236,8 +236,7 @@ class FileOfflineStore(OfflineStore):
         # make driver_id a normal column again
         last_values_df.reset_index(inplace=True)
 
-        table = pyarrow.Table.from_pandas(
-            last_values_df[join_key_columns + feature_name_columns + ts_columns]
-        )
+        columns_to_extract = set(join_key_columns + feature_name_columns + ts_columns)
+        table = pyarrow.Table.from_pandas(last_values_df[columns_to_extract])
 
         return table

--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -212,6 +212,13 @@ class FileOfflineStore(OfflineStore):
                 created_timestamp_column
             ].apply(lambda x: x if x.tzinfo is not None else x.replace(tzinfo=pytz.utc))
 
+        source_columns = set(source_df.columns)
+        if not set(join_key_columns).issubset(source_columns):
+            raise ValueError(
+                f"The DataFrame must have at least {set(join_key_columns)} columns present, "
+                f"but these were missing: {set(join_key_columns)- source_columns} "
+            )
+
         ts_columns = (
             [event_timestamp_column, created_timestamp_column]
             if created_timestamp_column

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -132,7 +132,7 @@ class Registry:
         for entity_proto in registry_proto.entities:
             if entity_proto.spec.name == name and entity_proto.spec.project == project:
                 return Entity.from_proto(entity_proto)
-        raise EntityNotFoundException(project, name)
+        raise EntityNotFoundException(name, project=project)
 
     def apply_feature_table(self, feature_table: FeatureTable, project: str):
         """


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR validate join keys when materializing from file sources, to make sure that the join keys are present in the dataframe columns. Additionally, we dedupe column names when extracting columns from the pandas dataframe. This should specifically catch the case of `event_timestamp_column` and `created_timestamp_column` pointing to the same column name.

Additionally, this fixes a bug where the `EntityNotFoundException` was instantiated with the entity name and project name switched.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add validations when materializing from file sources 
```
