### PR TITLE
Use drop_duplicates() instead of groupby (about 1.5~2x faster)

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -153,8 +153,9 @@ class FileOfflineStore(OfflineStore):
                     ]
 
                 df_to_join.sort_values(by=right_entity_key_sort_columns, inplace=True)
-                df_to_join = df_to_join.groupby(by=right_entity_key_columns).last()
-                df_to_join.reset_index(inplace=True)
+                df_to_join.drop_duplicates(
+                    right_entity_key_sort_columns, keep="last", ignore_index=True, inplace=True
+                )
 
                 # Select only the columns we need to join from the feature dataframe
                 df_to_join = df_to_join[right_entity_key_columns + feature_names]
@@ -231,10 +232,9 @@ class FileOfflineStore(OfflineStore):
             (source_df[event_timestamp_column] >= start_date)
             & (source_df[event_timestamp_column] < end_date)
         ]
-        last_values_df = filtered_df.groupby(by=join_key_columns).last()
-
-        # make driver_id a normal column again
-        last_values_df.reset_index(inplace=True)
+        last_values_df = filtered_df.drop_duplicates(
+            join_key_columns, keep="last", ignore_index=True
+        )
 
         columns_to_extract = set(join_key_columns + feature_name_columns + ts_columns)
         table = pyarrow.Table.from_pandas(last_values_df[columns_to_extract])

--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -154,7 +154,10 @@ class FileOfflineStore(OfflineStore):
 
                 df_to_join.sort_values(by=right_entity_key_sort_columns, inplace=True)
                 df_to_join.drop_duplicates(
-                    right_entity_key_sort_columns, keep="last", ignore_index=True, inplace=True
+                    right_entity_key_sort_columns,
+                    keep="last",
+                    ignore_index=True,
+                    inplace=True,
                 )
 
                 # Select only the columns we need to join from the feature dataframe


### PR DESCRIPTION
**What this PR does / why we need it**:
`df.drop_duplicates()` is much faster than `groupby() + reset_index()`.

You can test it with the below codes (You can change the number of unique number for each column):
```
df = pd.DataFrame({
    "a": [np.random.randint(0, 100) for _ in range(1000)],
    "b": [np.random.randint(0, 100) for _ in range(1000)],
    "c": [np.random.randint(0, 100) for _ in range(1000)],
})

%%timeit
df.groupby(['a', 'b']).last().reset_index()

%%timeit
df.drop_duplicates(['a', 'b'], keep="last", ignore_index=True, inplace=True)
```

**Which issue(s) this PR fixes**:
No issues related. It's sort of a little performance improvement

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
