### PR TITLE
Fix race condition in historical e2e tests

### DIFF
--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -386,7 +386,9 @@ def test_historical_features_from_bigquery_sources(
                     online_store=SqliteOnlineStoreConfig(
                         path=os.path.join(temp_dir, "online_store.db"),
                     ),
-                    offline_store=BigQueryOfflineStoreConfig(type="bigquery",),
+                    offline_store=BigQueryOfflineStoreConfig(
+                        type="bigquery", dataset=bigquery_dataset
+                    ),
                 )
             )
         elif provider_type == "gcp":
@@ -397,7 +399,9 @@ def test_historical_features_from_bigquery_sources(
                         random.choices(string.ascii_uppercase + string.digits, k=10)
                     ),
                     provider="gcp",
-                    offline_store=BigQueryOfflineStoreConfig(type="bigquery",),
+                    offline_store=BigQueryOfflineStoreConfig(
+                        type="bigquery", dataset=bigquery_dataset
+                    ),
                 )
             )
         elif provider_type == "gcp_custom_offline_config":


### PR DESCRIPTION
Signed-off-by: Willem Pienaar <git@willem.co>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Fixes a race condition in historical retrieval (conflict in dataset name)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Tries to fix https://github.com/feast-dev/feast/runs/2748222515

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
