### PR TITLE
Fix failing historical retrieval assertion

### DIFF
--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -470,7 +470,9 @@ def test_historical_features_from_bigquery_sources(
             assertpy.assert_that(job_from_df.query).contains("foo.entity_df")
         else:
             # If the custom dataset name isn't provided in the config, use default `feast` name
-            assertpy.assert_that(job_from_df.query).contains("feast.entity_df")
+            assertpy.assert_that(job_from_df.query).contains(
+                f"{bigquery_dataset}.entity_df"
+            )
 
         actual_df_from_df_entities = job_from_df.to_df()
 

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -465,11 +465,10 @@ def test_historical_features_from_bigquery_sources(
             ],
         )
 
+        # Make sure that custom dataset name is being used from the offline_store config
         if provider_type == "gcp_custom_offline_config":
-            # Make sure that custom dataset name is being used from the offline_store config
             assertpy.assert_that(job_from_df.query).contains("foo.entity_df")
         else:
-            # If the custom dataset name isn't provided in the config, use default `feast` name
             assertpy.assert_that(job_from_df.query).contains(
                 f"{bigquery_dataset}.entity_df"
             )


### PR DESCRIPTION
Signed-off-by: Willem Pienaar <git@willem.co>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Fixes failing e2e test

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
