### PR TITLE
Add to_df() to convert get_online_feature response to pandas dataframe

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -474,7 +474,7 @@ class FeatureStore:
 
         Note: This method will download the full feature registry the first time it is run. If you are using a
         remote registry like GCS or S3 then that may take a few seconds. The registry remains cached up to a TTL
-        duration (which can be set to infinitey). If the cached registry is stale (more time than the TTL has
+        duration (which can be set to infinity). If the cached registry is stale (more time than the TTL has
         passed), then a new registry will be downloaded synchronously by this method. This download may
         introduce latency to online feature retrieval. In order to avoid synchronous downloads, please call
         refresh_registry() prior to the TTL being reached. Remember it is possible to set the cache TTL to

--- a/sdk/python/feast/online_response.py
+++ b/sdk/python/feast/online_response.py
@@ -14,6 +14,8 @@
 
 from typing import Any, Dict, List, cast
 
+import pandas as pd
+
 from feast.protos.feast.serving.ServingService_pb2 import (
     GetOnlineFeaturesRequestV2,
     GetOnlineFeaturesResponse,
@@ -60,6 +62,13 @@ class OnlineResponse:
                 features_dict[feature].append(native_type_value)
 
         return features_dict
+
+    def to_df(self) -> pd.DataFrame:
+        """
+        Converts GetOnlineFeaturesResponse features into Panda dataframe form.
+        """
+
+        return pd.DataFrame(self.to_dict())
 
 
 def _infer_online_entity_rows(


### PR DESCRIPTION
Signed-off-by: ted chang <htchang@us.ibm.com>

**What this PR does / why we need it**:
Convert online response to Panda dataframe

**Which issue(s) this PR fixes**:
Fixes #1613

**Does this PR introduce a user-facing change?**:

```release-note
Users can convert online feature response to Panda dataframe
```
