### PR TITLE
Fix ttl duration when ttl is None

### DIFF
--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -173,6 +173,7 @@ class FeatureView:
             interval_proto.end_time.FromDatetime(interval[1])
             meta.materialization_intervals.append(interval_proto)
 
+        ttl_duration = None
         if self.ttl is not None:
             ttl_duration = Duration()
             ttl_duration.FromTimedelta(self.ttl)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix `ttl_duration` when TTL is None
![image](https://user-images.githubusercontent.com/18557047/121019457-7304f700-c76d-11eb-814e-38aa5da8695c.png)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE
```release-note
Fix ttl_duration when ttl is None
```
