### PR TITLE
Don't load entire bigquery query results in memory

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -92,7 +92,8 @@ class BigQueryOfflineStore(OfflineStore):
 
         if type(entity_df) is str:
             entity_df_job = client.query(entity_df)
-            entity_df_result = entity_df_job.result()  # also starts job
+            # Start the job and get the schema back. We don't need the actual rows.
+            entity_df_result = entity_df_job.result(max_results=0)
 
             entity_df_event_timestamp_col = _infer_event_timestamp_from_bigquery_query(
                 entity_df_result


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: In `BigQueryOfflineStore.get_historical_features` Feast calls `entity_df_job.result()` which causes the entity data frame to be loaded in memory. We only need to wait for the job to be done and for the schema to be returned, while not changing the existing query (because the results of the query are being used for joining with offline feature data). This PR changes the call to `entity_df_job.result(max_results=0)`, which at the same time:
1. Executes the same query in BigQuery, so the table that gets joined does not change
2. Does not load any of the query rows in memory
3. Still allows the schema to be acquired from the resulting object

I checked all other places where we call `.result()` in the codebase, but none of them needed fixing due to couple of different reasons (happy to elaborate if anyone is curious).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix BigQuery entity dataframe SQL query results being completely loaded in memory
```
