### PR TITLE
Don't use .result() in BigQueryOfflineStore, since it still leads to OOM

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -24,7 +24,7 @@ try:
     from google.api_core.exceptions import NotFound
     from google.auth.exceptions import DefaultCredentialsError
     from google.cloud import bigquery
-    from google.cloud.bigquery import Client, QueryJob, Table
+    from google.cloud.bigquery import Client, Table
 
 except ImportError as e:
     from feast.errors import FeastExtrasDependencyImportError
@@ -91,6 +91,7 @@ class BigQueryOfflineStore(OfflineStore):
 
         expected_join_keys = _get_join_keys(project, feature_views, registry)
 
+        assert isinstance(config.offline_store, BigQueryOfflineStoreConfig)
         table = _upload_entity_df_into_bigquery(
             client, config.project, config.offline_store.dataset, entity_df
         )
@@ -231,7 +232,9 @@ class FeatureViewQueryContext:
     entity_selections: List[str]
 
 
-def _get_table_id_for_new_entity(client, project, dataset_name) -> str:
+def _get_table_id_for_new_entity(
+    client: Client, project: str, dataset_name: str
+) -> str:
     """Gets the table_id for the new entity to be uploaded."""
 
     # First create the BigQuery dataset if it doesn't exist
@@ -259,7 +262,7 @@ def _upload_entity_df_into_bigquery(
 
     if type(entity_df) is str:
         job = client.query(f"CREATE TABLE {table_id} AS ({entity_df})")
-        job_result = job.result()
+        job.result()
     elif isinstance(entity_df, pandas.DataFrame):
         # Drop the index so that we dont have unnecessary columns
         entity_df.reset_index(drop=True, inplace=True)

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -101,15 +101,18 @@ class BigQueryOfflineStore(OfflineStore):
             entity_df_sql_table = f"`{entity_df_job.destination.project}.{entity_df_job.destination.dataset_id}.{entity_df_job.destination.table_id}`"
 
             # Get a single row from this entity table to validate its schema
-            entity_df_limited_job: QueryJob = client.query(f"SELECT * FROM {entity_df_sql_table} LIMIT 1")
+            entity_df_limited_job: QueryJob = client.query(
+                f"SELECT * FROM {entity_df_sql_table} LIMIT 1"
+            )
             entity_df_limited_result = entity_df_limited_job.result()
             entity_df_event_timestamp_col = _infer_event_timestamp_from_bigquery_query(
                 entity_df_limited_result
             )
             _assert_expected_columns_in_bigquery(
-                expected_join_keys, entity_df_event_timestamp_col, entity_df_limited_result
+                expected_join_keys,
+                entity_df_event_timestamp_col,
+                entity_df_limited_result,
             )
-
 
         elif isinstance(entity_df, pandas.DataFrame):
             entity_df_event_timestamp_col = _infer_event_timestamp_from_dataframe(

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -24,7 +24,7 @@ try:
     from google.api_core.exceptions import NotFound
     from google.auth.exceptions import DefaultCredentialsError
     from google.cloud import bigquery
-    from google.cloud.bigquery import QueryJob
+    from google.cloud.bigquery import Client, QueryJob, Table
 
 except ImportError as e:
     from feast.errors import FeastExtrasDependencyImportError
@@ -91,49 +91,16 @@ class BigQueryOfflineStore(OfflineStore):
 
         expected_join_keys = _get_join_keys(project, feature_views, registry)
 
-        if type(entity_df) is str:
-            entity_df_job: QueryJob = client.query(entity_df)
-            # Note: Don't call entity_df_job.result() here, it will lead
-            # to OOM errors. Instead just wait until the job is done.
-            while not entity_df_job.done():
-                time.sleep(1)
+        table = _upload_entity_df_into_bigquery(
+            client, config.project, config.offline_store.dataset, entity_df
+        )
 
-            entity_df_sql_table = f"`{entity_df_job.destination.project}.{entity_df_job.destination.dataset_id}.{entity_df_job.destination.table_id}`"
-
-            # Get a single row from this entity table to validate its schema
-            entity_df_limited_job: QueryJob = client.query(
-                f"SELECT * FROM {entity_df_sql_table} LIMIT 1"
-            )
-            entity_df_limited_result = entity_df_limited_job.result()
-            entity_df_event_timestamp_col = _infer_event_timestamp_from_bigquery_query(
-                entity_df_limited_result
-            )
-            _assert_expected_columns_in_bigquery(
-                expected_join_keys,
-                entity_df_event_timestamp_col,
-                entity_df_limited_result,
-            )
-
-        elif isinstance(entity_df, pandas.DataFrame):
-            entity_df_event_timestamp_col = _infer_event_timestamp_from_dataframe(
-                entity_df
-            )
-
-            assert isinstance(config.offline_store, BigQueryOfflineStoreConfig)
-
-            _assert_expected_columns_in_dataframe(
-                expected_join_keys, entity_df_event_timestamp_col, entity_df
-            )
-
-            table_id = _upload_entity_df_into_bigquery(
-                config.project, config.offline_store.dataset, entity_df, client
-            )
-            entity_df_sql_table = f"`{table_id}`"
-        else:
-            raise ValueError(
-                f"The entity dataframe you have provided must be a Pandas DataFrame or BigQuery SQL query, "
-                f"but we found: {type(entity_df)} "
-            )
+        entity_df_event_timestamp_col = _infer_event_timestamp_from_bigquery_query(
+            table.schema
+        )
+        _assert_expected_columns_in_bigquery(
+            expected_join_keys, entity_df_event_timestamp_col, table.schema,
+        )
 
         # Build a query context containing all information required to template the BigQuery SQL query
         query_context = get_feature_view_query_context(
@@ -146,7 +113,7 @@ class BigQueryOfflineStore(OfflineStore):
             query_context,
             min_timestamp=datetime.now() - timedelta(days=365),
             max_timestamp=datetime.now() + timedelta(days=1),
-            left_table_query_string=entity_df_sql_table,
+            left_table_query_string=str(table.reference),
             entity_df_event_timestamp_col=entity_df_event_timestamp_col,
         )
 
@@ -168,10 +135,10 @@ def _assert_expected_columns_in_dataframe(
 
 
 def _assert_expected_columns_in_bigquery(
-    join_keys: Set[str], entity_df_event_timestamp_col: str, entity_df_result
+    join_keys: Set[str], entity_df_event_timestamp_col: str, table_schema
 ):
     entity_columns = set()
-    for schema_field in entity_df_result.schema:
+    for schema_field in table_schema:
         entity_columns.add(schema_field.name)
 
     expected_columns = join_keys.copy()
@@ -195,17 +162,17 @@ def _get_join_keys(
     return join_keys
 
 
-def _infer_event_timestamp_from_bigquery_query(entity_df_result) -> str:
+def _infer_event_timestamp_from_bigquery_query(table_schema) -> str:
     if any(
         schema_field.name == DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
-        for schema_field in entity_df_result.schema
+        for schema_field in table_schema
     ):
         return DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
     else:
         datetime_columns = list(
             filter(
                 lambda schema_field: schema_field.field_type == "TIMESTAMP",
-                entity_df_result.schema,
+                table_schema,
             )
         )
         if len(datetime_columns) == 1:
@@ -264,8 +231,8 @@ class FeatureViewQueryContext:
     entity_selections: List[str]
 
 
-def _upload_entity_df_into_bigquery(project, dataset_name, entity_df, client) -> str:
-    """Uploads a Pandas entity dataframe into a BigQuery table and returns a reference to the resulting table"""
+def _get_table_id_for_new_entity(client, project, dataset_name) -> str:
+    """Gets the table_id for the new entity to be uploaded."""
 
     # First create the BigQuery dataset if it doesn't exist
     dataset = bigquery.Dataset(f"{client.project}.{dataset_name}")
@@ -277,21 +244,44 @@ def _upload_entity_df_into_bigquery(project, dataset_name, entity_df, client) ->
         # Only create the dataset if it does not exist
         client.create_dataset(dataset, exists_ok=True)
 
-    # Drop the index so that we dont have unnecessary columns
-    entity_df.reset_index(drop=True, inplace=True)
+    return f"{client.project}.{dataset_name}.entity_df_{project}_{int(time.time())}"
 
-    # Upload the dataframe into BigQuery, creating a temporary table
-    job_config = bigquery.LoadJobConfig()
-    table_id = f"{client.project}.{dataset_name}.entity_df_{project}_{int(time.time())}"
-    job = client.load_table_from_dataframe(entity_df, table_id, job_config=job_config,)
-    job.result()
+
+def _upload_entity_df_into_bigquery(
+    client: Client,
+    project: str,
+    dataset_name: str,
+    entity_df: Union[pandas.DataFrame, str],
+) -> Table:
+    """Uploads a Pandas entity dataframe into a BigQuery table and returns the resulting table"""
+
+    table_id = _get_table_id_for_new_entity(client, project, dataset_name)
+
+    if type(entity_df) is str:
+        job = client.query(f"CREATE TABLE {table_id} AS ({entity_df})")
+        job_result = job.result()
+    elif isinstance(entity_df, pandas.DataFrame):
+        # Drop the index so that we dont have unnecessary columns
+        entity_df.reset_index(drop=True, inplace=True)
+
+        # Upload the dataframe into BigQuery, creating a temporary table
+        job_config = bigquery.LoadJobConfig()
+        job = client.load_table_from_dataframe(
+            entity_df, table_id, job_config=job_config
+        )
+        job.result()
+    else:
+        raise ValueError(
+            f"The entity dataframe you have provided must be a Pandas DataFrame or BigQuery SQL query, "
+            f"but we found: {type(entity_df)} "
+        )
 
     # Ensure that the table expires after some time
     table = client.get_table(table=table_id)
     table.expires = datetime.utcnow() + timedelta(minutes=30)
     client.update_table(table, ["expires"])
 
-    return table_id
+    return table
 
 
 def get_feature_view_query_context(

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -90,7 +90,7 @@ class BigQueryOfflineStoreConfig(FeastBaseModel):
     type: Literal["bigquery"] = "bigquery"
     """ Offline store type selector"""
 
-    dataset: Optional[StrictStr] = "feast"
+    dataset: StrictStr = "feast"
     """ (optional) BigQuery Dataset name for temporary tables """
 
 


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Follow up on #1638, which failed to fix the OOM issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
