### PR TITLE
Fix table_refs in BigQuerySource definitions

### DIFF
--- a/sdk/python/tests/example_feature_repo_1.py
+++ b/sdk/python/tests/example_feature_repo_1.py
@@ -3,18 +3,18 @@ from datetime import timedelta
 from feast import BigQuerySource, Entity, Feature, FeatureView, ValueType
 
 driver_locations_source = BigQuerySource(
-    table_ref="rh_prod.ride_hailing_co.drivers",
+    table_ref="kf-feast.public.drivers",
     event_timestamp_column="event_timestamp",
     created_timestamp_column="created_timestamp",
 )
 
 customer_profile_source = BigQuerySource(
-    table_ref="rh_prod.ride_hailing_co.customers",
+    table_ref="kf-feast.public.customers",
     event_timestamp_column="event_timestamp",
 )
 
 customer_driver_combined_source = BigQuerySource(
-    table_ref="rh_prod.ride_hailing_co.customer_driver",
+    table_ref="kf-feast.public.customer_driver",
     event_timestamp_column="event_timestamp",
 )
 

--- a/sdk/python/tests/example_feature_repo_1.py
+++ b/sdk/python/tests/example_feature_repo_1.py
@@ -3,18 +3,18 @@ from datetime import timedelta
 from feast import BigQuerySource, Entity, Feature, FeatureView, ValueType
 
 driver_locations_source = BigQuerySource(
-    table_ref="kf-feast.public.drivers",
+    table_ref="feast-oss.public.drivers",
     event_timestamp_column="event_timestamp",
     created_timestamp_column="created_timestamp",
 )
 
 customer_profile_source = BigQuerySource(
-    table_ref="kf-feast.public.customers",
+    table_ref="feast-oss.public.customers",
     event_timestamp_column="event_timestamp",
 )
 
 customer_driver_combined_source = BigQuerySource(
-    table_ref="kf-feast.public.customer_driver",
+    table_ref="feast-oss.public.customer_driver",
     event_timestamp_column="event_timestamp",
 )
 

--- a/sdk/python/tests/example_feature_repo_1.py
+++ b/sdk/python/tests/example_feature_repo_1.py
@@ -9,8 +9,7 @@ driver_locations_source = BigQuerySource(
 )
 
 customer_profile_source = BigQuerySource(
-    table_ref="feast-oss.public.customers",
-    event_timestamp_column="event_timestamp",
+    table_ref="feast-oss.public.customers", event_timestamp_column="event_timestamp",
 )
 
 customer_driver_combined_source = BigQuerySource(

--- a/sdk/python/tests/test_partial_apply.py
+++ b/sdk/python/tests/test_partial_apply.py
@@ -17,7 +17,7 @@ def test_partial() -> None:
     ) as store:
 
         driver_locations_source = BigQuerySource(
-            table_ref="rh_prod.ride_hailing_co.drivers",
+            table_ref="kf-feast.public.drivers",
             event_timestamp_column="event_timestamp",
             created_timestamp_column="created_timestamp",
         )

--- a/sdk/python/tests/test_partial_apply.py
+++ b/sdk/python/tests/test_partial_apply.py
@@ -17,7 +17,7 @@ def test_partial() -> None:
     ) as store:
 
         driver_locations_source = BigQuerySource(
-            table_ref="kf-feast.public.drivers",
+            table_ref="feast-oss.public.drivers",
             event_timestamp_column="event_timestamp",
             created_timestamp_column="created_timestamp",
         )


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: I added a public dataset under feast-oss with 3 empty tables: drivers, customers, and customer_driver:
![Screen Shot 2021-06-11 at 4 29 54 PM](https://user-images.githubusercontent.com/5042959/121757399-4258f080-cad2-11eb-914e-83fdd7b0ba00.png)

Subsequently, I replaced all mentions of `rh_prod.ride_hailing_co` by `feast-oss.public`. This should unblock #1627.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
