### PR TITLE
Refactor OnlineStoreConfig classes into owning modules

### DIFF
--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -42,15 +42,15 @@ class FeastProviderNotImplementedError(Exception):
         super().__init__(f"Provider '{provider_name}' is not implemented")
 
 
-class FeastProviderModuleImportError(Exception):
-    def __init__(self, module_name):
-        super().__init__(f"Could not import provider module '{module_name}'")
+class FeastModuleImportError(Exception):
+    def __init__(self, module_name, module_type="provider"):
+        super().__init__(f"Could not import {module_type} module '{module_name}'")
 
 
-class FeastProviderClassImportError(Exception):
-    def __init__(self, module_name, class_name):
+class FeastClassImportError(Exception):
+    def __init__(self, module_name, class_name, class_type="provider"):
         super().__init__(
-            f"Could not import provider '{class_name}' from module '{module_name}'"
+            f"Could not import {class_type} '{class_name}' from module '{module_name}'"
         )
 
 
@@ -68,6 +68,20 @@ class FeastOfflineStoreUnsupportedDataSource(Exception):
     def __init__(self, offline_store_name: str, data_source_name: str):
         super().__init__(
             f"Offline Store '{offline_store_name}' does not support data source '{data_source_name}'"
+        )
+
+
+class FeastOnlineStoreInvalidName(Exception):
+    def __init__(self, online_store_class_name: str):
+        super().__init__(
+            f"Online Store Class '{online_store_class_name}' should end with the string `OnlineStore`.'"
+        )
+
+
+class FeastOnlineStoreConfigInvalidName(Exception):
+    def __init__(self, online_store_config_class_name: str):
+        super().__init__(
+            f"Online Store Config Class '{online_store_config_class_name}' should end with the string `OnlineStoreConfig`.'"
         )
 
 

--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -17,6 +17,8 @@ from multiprocessing.pool import ThreadPool
 from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
 import mmh3
+from pydantic import PositiveInt, StrictStr
+from pydantic.typing import Literal
 
 from feast import Entity, FeatureTable, utils
 from feast.feature_view import FeatureView
@@ -24,9 +26,7 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import RepoConfig, FeastConfigBaseModel
-from pydantic import StrictStr, PositiveInt
-from pydantic.typing import Literal
+from feast.repo_config import FeastConfigBaseModel, RepoConfig
 
 try:
     from google.auth.exceptions import DefaultCredentialsError

--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -24,7 +24,9 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import DatastoreOnlineStoreConfig, RepoConfig
+from feast.repo_config import RepoConfig, FeastConfigBaseModel
+from pydantic import StrictStr, PositiveInt
+from pydantic.typing import Literal
 
 try:
     from google.auth.exceptions import DefaultCredentialsError
@@ -38,6 +40,25 @@ except ImportError as e:
 ProtoBatch = Sequence[
     Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
 ]
+
+
+class DatastoreOnlineStoreConfig(FeastConfigBaseModel):
+    """ Online store config for GCP Datastore """
+
+    type: Literal["datastore"] = "datastore"
+    """ Online store type selector"""
+
+    project_id: Optional[StrictStr] = None
+    """ (optional) GCP Project Id """
+
+    namespace: Optional[StrictStr] = None
+    """ (optional) Datastore namespace """
+
+    write_concurrency: Optional[PositiveInt] = 40
+    """ (optional) Amount of threads to use when writing batches of feature rows into Datastore"""
+
+    write_batch_size: Optional[PositiveInt] = 50
+    """ (optional) Amount of feature rows per batch being written into Datastore"""
 
 
 class DatastoreOnlineStore(OnlineStore):

--- a/sdk/python/feast/infra/online_stores/helpers.py
+++ b/sdk/python/feast/infra/online_stores/helpers.py
@@ -5,10 +5,7 @@ import mmh3
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.storage.Redis_pb2 import RedisKeyV2 as RedisKeyProto
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
-from feast.repo_config import (
-    OnlineStoreConfig,
-    RedisOnlineStoreConfig,
-)
+from feast.repo_config import OnlineStoreConfig, RedisOnlineStoreConfig
 
 
 def get_online_store_from_config(

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -121,7 +121,6 @@ class RedisOnlineStore(OnlineStore):
             startup_nodes, kwargs = self._parse_connection_string(
                 online_store_config.connection_string
             )
-            print(f"Startup nodes: {startup_nodes}, {kwargs}")
             if online_store_config.type == RedisType.redis_cluster:
                 kwargs["startup_nodes"] = startup_nodes
                 self._client = RedisCluster(**kwargs)

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -13,16 +13,19 @@
 # limitations under the License.
 import json
 from datetime import datetime
+from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from google.protobuf.timestamp_pb2 import Timestamp
+from pydantic import StrictStr
+from pydantic.typing import Literal
 
 from feast import Entity, FeatureTable, FeatureView, RepoConfig, utils
 from feast.infra.online_stores.helpers import _mmh3, _redis_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import RedisOnlineStoreConfig, RedisType
+from feast.repo_config import FeastConfigBaseModel
 
 try:
     from redis import Redis
@@ -33,6 +36,25 @@ except ImportError as e:
     raise FeastExtrasDependencyImportError("redis", str(e))
 
 EX_SECONDS = 253402300799
+
+
+class RedisType(str, Enum):
+    redis = "redis"
+    redis_cluster = "redis_cluster"
+
+
+class RedisOnlineStoreConfig(FeastConfigBaseModel):
+    """Online store config for Redis store"""
+
+    type: Literal["redis"] = "redis"
+    """Online store type selector"""
+
+    redis_type: RedisType = RedisType.redis
+    """Redis type: redis or redis_cluster"""
+
+    connection_string: StrictStr = "localhost:6379"
+    """Connection string containing the host, port, and configuration parameters for Redis
+     format: host:port,parameter1,parameter2 eg. redis:6379,db=0 """
 
 
 class RedisOnlineStore(OnlineStore):

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -78,8 +78,6 @@ class SqliteOnlineStore(OnlineStore):
         progress: Optional[Callable[[int], Any]],
     ) -> None:
 
-        print(f"online_write_batch: {config}")
-
         conn = self._get_conn(config)
 
         project = config.project

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -77,6 +77,9 @@ class SqliteOnlineStore(OnlineStore):
         ],
         progress: Optional[Callable[[int], Any]],
     ) -> None:
+
+        print(f"online_write_batch: {config}")
+
         conn = self._get_conn(config)
 
         project = config.project

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -26,7 +26,19 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import RepoConfig
+from feast.repo_config import RepoConfig, FeastConfigBaseModel
+from pydantic import StrictStr
+from pydantic.schema import Literal
+
+
+class SqliteOnlineStoreConfig(FeastConfigBaseModel):
+    """ Online store config for local (SQLite-based) store """
+
+    type: Literal["sqlite"] = "sqlite"
+    """ Online store type selector"""
+
+    path: StrictStr = "data/online.db"
+    """ (optional) Path to sqlite db """
 
 
 class SqliteOnlineStore(OnlineStore):

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import pytz
+from pydantic import StrictStr
+from pydantic.schema import Literal
 
 from feast import Entity, FeatureTable
 from feast.feature_view import FeatureView
@@ -26,9 +28,7 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import RepoConfig, FeastConfigBaseModel
-from pydantic import StrictStr
-from pydantic.schema import Literal
+from feast.repo_config import FeastConfigBaseModel, RepoConfig
 
 
 class SqliteOnlineStoreConfig(FeastConfigBaseModel):

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -163,7 +163,7 @@ def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
             # The original exception can be anything - either module not found,
             # or any other kind of error happening during the module import time.
             # So we should include the original error as well in the stack trace.
-            raise errors.FeastProviderModuleImportError(module_name) from e
+            raise errors.FeastModuleImportError(module_name) from e
 
         # Try getting the provider class definition
         try:
@@ -171,7 +171,7 @@ def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
         except AttributeError:
             # This can only be one type of error, when class_name attribute does not exist in the module
             # So we don't have to include the original exception here
-            raise errors.FeastProviderClassImportError(
+            raise errors.FeastClassImportError(
                 module_name, class_name
             ) from None
 

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -171,9 +171,7 @@ def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
         except AttributeError:
             # This can only be one type of error, when class_name attribute does not exist in the module
             # So we don't have to include the original exception here
-            raise errors.FeastClassImportError(
-                module_name, class_name
-            ) from None
+            raise errors.FeastClassImportError(module_name, class_name) from None
 
         return ProviderCls(config, repo_path)
 

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -155,7 +155,7 @@ class RepoConfig(FeastBaseModel):
 
         # Set the default type
         if "type" not in values["offline_store"]:
-            if values["provider"] == "local" or values["provider"] == "redis":
+            if values["provider"] == "local":
                 values["offline_store"]["type"] = "file"
             elif values["provider"] == "gcp":
                 values["offline_store"]["type"] = "bigquery"
@@ -196,6 +196,16 @@ class FeastConfigError(Exception):
         return (
             f"FeastConfigError({repr(self._error_message)}, {repr(self._config_path)})"
         )
+
+
+def create_repo_config(**data) -> RepoConfig:
+    rc = RepoConfig(**data)
+    if rc.online_store is None or isinstance(rc.online_store, Dict):
+        if rc.provider == "local":
+            rc.online_store = get_online_config_from_type("sqlite")()
+        if rc.provider == "gcp":
+            rc.online_store = get_online_config_from_type("datastore")()
+    return rc
 
 
 def get_online_config_from_type(online_store_type: str):

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -1,10 +1,11 @@
+import importlib
 from enum import Enum
 from pathlib import Path
+from typing import TypeVar, Generic, Any
 
 import yaml
 from pydantic import (
     BaseModel,
-    PositiveInt,
     StrictInt,
     StrictStr,
     ValidationError,
@@ -14,6 +15,16 @@ from pydantic.error_wrappers import ErrorWrapper
 from pydantic.typing import Dict, Literal, Optional, Union
 
 from feast.telemetry import log_exceptions
+from feast import errors
+
+
+# This dict exists so that:
+# - existing values for the online store type in featurestore.yaml files continue to work in a backwards compatible way
+# - first party and third party implementations can use the same class loading code path.
+ONLINE_CONFIG_CLASS_FOR_TYPE = {
+    'sqlite': 'feast.infra.online_stores.sqlite.SqliteOnlineStore',
+    'datastore': 'feast.infra.online_stores.datastore.DatastoreOnlineStore'
+}
 
 
 class FeastBaseModel(BaseModel):
@@ -21,36 +32,18 @@ class FeastBaseModel(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+        extra = "allow"
+
+
+class FeastConfigBaseModel(BaseModel):
+    """ Feast Pydantic Configuration Class """
+
+    class Config:
+        arbitrary_types_allowed = True
         extra = "forbid"
 
 
-class SqliteOnlineStoreConfig(FeastBaseModel):
-    """ Online store config for local (SQLite-based) store """
-
-    type: Literal["sqlite"] = "sqlite"
-    """ Online store type selector"""
-
-    path: StrictStr = "data/online.db"
-    """ (optional) Path to sqlite db """
-
-
-class DatastoreOnlineStoreConfig(FeastBaseModel):
-    """ Online store config for GCP Datastore """
-
-    type: Literal["datastore"] = "datastore"
-    """ Online store type selector"""
-
-    project_id: Optional[StrictStr] = None
-    """ (optional) GCP Project Id """
-
-    namespace: Optional[StrictStr] = None
-    """ (optional) Datastore namespace """
-
-    write_concurrency: Optional[PositiveInt] = 40
-    """ (optional) Amount of threads to use when writing batches of feature rows into Datastore"""
-
-    write_batch_size: Optional[PositiveInt] = 50
-    """ (optional) Amount of feature rows per batch being written into Datastore"""
+OnlineT = TypeVar('OnlineT', bound=FeastConfigBaseModel)
 
 
 class RedisType(str, Enum):
@@ -72,9 +65,7 @@ class RedisOnlineStoreConfig(FeastBaseModel):
      format: host:port,parameter1,parameter2 eg. redis:6379,db=0 """
 
 
-OnlineStoreConfig = Union[
-    DatastoreOnlineStoreConfig, SqliteOnlineStoreConfig, RedisOnlineStoreConfig
-]
+OnlineStoreConfig = Union[RedisOnlineStoreConfig]
 
 
 class FileOfflineStoreConfig(FeastBaseModel):
@@ -125,7 +116,7 @@ class RepoConfig(FeastBaseModel):
     provider: StrictStr
     """ str: local or gcp or redis """
 
-    online_store: OnlineStoreConfig = SqliteOnlineStoreConfig()
+    online_store: Any
     """ OnlineStoreConfig: Online store configuration (optional depending on provider) """
 
     offline_store: OfflineStoreConfig = FileOfflineStoreConfig()
@@ -168,22 +159,17 @@ class RepoConfig(FeastBaseModel):
 
         online_store_type = values["online_store"]["type"]
 
-        # Make sure the user hasn't provided the wrong type
-        assert online_store_type in ["datastore", "sqlite", "redis"]
-
         # Validate the dict to ensure one of the union types match
         try:
-            if online_store_type == "sqlite":
-                SqliteOnlineStoreConfig(**values["online_store"])
-            elif online_store_type == "datastore":
-                DatastoreOnlineStoreConfig(**values["online_store"])
-            elif online_store_type == "redis":
+            if online_store_type == "redis":
                 RedisOnlineStoreConfig(**values["online_store"])
             else:
-                raise ValueError(f"Invalid online store type {online_store_type}")
+                online_config_class = get_online_config_from_type(online_store_type)
+                online_config_class(**values["online_store"])
         except ValidationError as e:
+
             raise ValidationError(
-                [ErrorWrapper(e, loc="online_store")], model=SqliteOnlineStoreConfig,
+                [ErrorWrapper(e, loc="online_store")], model=RepoConfig,
             )
 
         return values
@@ -246,6 +232,36 @@ class FeastConfigError(Exception):
         )
 
 
+def get_online_config_from_type(online_store_type: str):
+    if online_store_type in ONLINE_CONFIG_CLASS_FOR_TYPE:
+        online_store_type = ONLINE_CONFIG_CLASS_FOR_TYPE[online_store_type]
+    module_name, class_name = online_store_type.rsplit(".", 1)
+
+    if not class_name.endswith('OnlineStore'):
+        raise errors.FeastOnlineStoreConfigInvalidName(class_name)
+    config_class_name = f"{class_name}Config"
+
+    # Try importing the module that contains the custom provider
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as e:
+        # The original exception can be anything - either module not found,
+        # or any other kind of error happening during the module import time.
+        # So we should include the original error as well in the stack trace.
+        raise errors.FeastModuleImportError(module_name, module_type="OnlineStore") from e
+
+    # Try getting the provider class definition
+    try:
+        online_store_config_class = getattr(module, config_class_name)
+    except AttributeError:
+        # This can only be one type of error, when class_name attribute does not exist in the module
+        # So we don't have to include the original exception here
+        raise errors.FeastClassImportError(
+            module_name, config_class_name, class_type="OnlineStoreConfig"
+        ) from None
+    return online_store_config_class
+
+
 def load_repo_config(repo_path: Path) -> RepoConfig:
     config_path = repo_path / "feature_store.yaml"
 
@@ -254,6 +270,11 @@ def load_repo_config(repo_path: Path) -> RepoConfig:
         try:
             c = RepoConfig(**raw_config)
             c.repo_path = repo_path
+            online_config_class = get_online_config_from_type(c.dict()['online_store']['type'])
+            c.online_store = online_config_class(**c.dict()['online_store'])
             return c
         except ValidationError as e:
             raise FeastConfigError(e, config_path)
+
+
+

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -1,29 +1,22 @@
 import importlib
 from enum import Enum
 from pathlib import Path
-from typing import TypeVar, Generic, Any
+from typing import Any, TypeVar
 
 import yaml
-from pydantic import (
-    BaseModel,
-    StrictInt,
-    StrictStr,
-    ValidationError,
-    root_validator,
-)
+from pydantic import BaseModel, StrictInt, StrictStr, ValidationError, root_validator
 from pydantic.error_wrappers import ErrorWrapper
 from pydantic.typing import Dict, Literal, Optional, Union
 
-from feast.telemetry import log_exceptions
 from feast import errors
-
+from feast.telemetry import log_exceptions
 
 # This dict exists so that:
 # - existing values for the online store type in featurestore.yaml files continue to work in a backwards compatible way
 # - first party and third party implementations can use the same class loading code path.
 ONLINE_CONFIG_CLASS_FOR_TYPE = {
-    'sqlite': 'feast.infra.online_stores.sqlite.SqliteOnlineStore',
-    'datastore': 'feast.infra.online_stores.datastore.DatastoreOnlineStore'
+    "sqlite": "feast.infra.online_stores.sqlite.SqliteOnlineStore",
+    "datastore": "feast.infra.online_stores.datastore.DatastoreOnlineStore",
 }
 
 
@@ -43,7 +36,7 @@ class FeastConfigBaseModel(BaseModel):
         extra = "forbid"
 
 
-OnlineT = TypeVar('OnlineT', bound=FeastConfigBaseModel)
+OnlineT = TypeVar("OnlineT", bound=FeastConfigBaseModel)
 
 
 class RedisType(str, Enum):
@@ -237,7 +230,7 @@ def get_online_config_from_type(online_store_type: str):
         online_store_type = ONLINE_CONFIG_CLASS_FOR_TYPE[online_store_type]
     module_name, class_name = online_store_type.rsplit(".", 1)
 
-    if not class_name.endswith('OnlineStore'):
+    if not class_name.endswith("OnlineStore"):
         raise errors.FeastOnlineStoreConfigInvalidName(class_name)
     config_class_name = f"{class_name}Config"
 
@@ -248,7 +241,9 @@ def get_online_config_from_type(online_store_type: str):
         # The original exception can be anything - either module not found,
         # or any other kind of error happening during the module import time.
         # So we should include the original error as well in the stack trace.
-        raise errors.FeastModuleImportError(module_name, module_type="OnlineStore") from e
+        raise errors.FeastModuleImportError(
+            module_name, module_type="OnlineStore"
+        ) from e
 
     # Try getting the provider class definition
     try:
@@ -270,11 +265,10 @@ def load_repo_config(repo_path: Path) -> RepoConfig:
         try:
             c = RepoConfig(**raw_config)
             c.repo_path = repo_path
-            online_config_class = get_online_config_from_type(c.dict()['online_store']['type'])
-            c.online_store = online_config_class(**c.dict()['online_store'])
+            online_config_class = get_online_config_from_type(
+                c.dict()["online_store"]["type"]
+            )
+            c.online_store = online_config_class(**c.dict()["online_store"])
             return c
         except ValidationError as e:
             raise FeastConfigError(e, config_path)
-
-
-

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -177,7 +177,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path):
     for table in repo.feature_tables:
         registry.apply_feature_table(table, project)
         click.echo(
-            f"Registered feature table {Style.BRIGHT + Fore.GREEN}{registry_table.name}{Style.RESET_ALL}"
+            f"Registered feature table {Style.BRIGHT + Fore.GREEN}{table.name}{Style.RESET_ALL}"
         )
 
     # Delete views that should not exist

--- a/sdk/python/telemetry_tests/test_telemetry.py
+++ b/sdk/python/telemetry_tests/test_telemetry.py
@@ -15,15 +15,15 @@ import tempfile
 import uuid
 from datetime import datetime
 
+from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from tenacity import retry, wait_exponential, stop_after_attempt
 
 from google.cloud import bigquery
 import os
 from time import sleep
-from importlib import reload
 
 from feast import Client, Entity, ValueType, FeatureStore, RepoConfig
-from feast.repo_config import SqliteOnlineStoreConfig
+
 
 TELEMETRY_BIGQUERY_TABLE = (
     "kf-feast.feast_telemetry.cloudfunctions_googleapis_com_cloud_functions"

--- a/sdk/python/tests/foo_provider.py
+++ b/sdk/python/tests/foo_provider.py
@@ -54,8 +54,8 @@ class FooProvider(Provider):
     ) -> None:
         pass
 
-    @staticmethod
     def get_historical_features(
+        self,
         config: RepoConfig,
         feature_views: List[FeatureView],
         feature_refs: List[str],

--- a/sdk/python/tests/test_feature_store.py
+++ b/sdk/python/tests/test_feature_store.py
@@ -26,7 +26,7 @@ from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
 from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from feast.protos.feast.types import Value_pb2 as ValueProto
-from feast.repo_config import RepoConfig
+from feast.repo_config import RepoConfig, create_repo_config
 from feast.value_type import ValueType
 from tests.utils.data_source_utils import (
     prep_file_source,
@@ -64,7 +64,7 @@ def feature_store_with_gcs_registry():
     bucket.blob("registry.db")
 
     return FeatureStore(
-        config=RepoConfig(
+        config=create_repo_config(
             registry=f"gs://{bucket_name}/registry.db",
             project="default",
             provider="gcp",

--- a/sdk/python/tests/test_feature_store.py
+++ b/sdk/python/tests/test_feature_store.py
@@ -16,8 +16,9 @@ from datetime import datetime, timedelta
 from tempfile import mkstemp
 
 import pytest
+from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from pytest_lazyfixture import lazy_fixture
-from utils.data_source_utils import (
+from tests.utils.data_source_utils import (
     prep_file_source,
     simple_bq_source_using_query_arg,
     simple_bq_source_using_table_ref_arg,
@@ -30,7 +31,7 @@ from feast.feature import Feature
 from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
 from feast.protos.feast.types import Value_pb2 as ValueProto
-from feast.repo_config import RepoConfig, SqliteOnlineStoreConfig
+from feast.repo_config import RepoConfig
 from feast.value_type import ValueType
 
 

--- a/sdk/python/tests/test_feature_store.py
+++ b/sdk/python/tests/test_feature_store.py
@@ -26,7 +26,7 @@ from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
 from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from feast.protos.feast.types import Value_pb2 as ValueProto
-from feast.repo_config import RepoConfig, create_repo_config
+from feast.repo_config import RepoConfig
 from feast.value_type import ValueType
 from tests.utils.data_source_utils import (
     prep_file_source,
@@ -64,7 +64,7 @@ def feature_store_with_gcs_registry():
     bucket.blob("registry.db")
 
     return FeatureStore(
-        config=create_repo_config(
+        config=RepoConfig(
             registry=f"gs://{bucket_name}/registry.db",
             project="default",
             provider="gcp",

--- a/sdk/python/tests/test_feature_store.py
+++ b/sdk/python/tests/test_feature_store.py
@@ -16,13 +16,7 @@ from datetime import datetime, timedelta
 from tempfile import mkstemp
 
 import pytest
-from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from pytest_lazyfixture import lazy_fixture
-from tests.utils.data_source_utils import (
-    prep_file_source,
-    simple_bq_source_using_query_arg,
-    simple_bq_source_using_table_ref_arg,
-)
 
 from feast.data_format import ParquetFormat
 from feast.data_source import FileSource
@@ -30,9 +24,15 @@ from feast.entity import Entity
 from feast.feature import Feature
 from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
+from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from feast.protos.feast.types import Value_pb2 as ValueProto
 from feast.repo_config import RepoConfig
 from feast.value_type import ValueType
+from tests.utils.data_source_utils import (
+    prep_file_source,
+    simple_bq_source_using_query_arg,
+    simple_bq_source_using_table_ref_arg,
+)
 
 
 @pytest.fixture

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -9,7 +9,6 @@ import assertpy
 import numpy as np
 import pandas as pd
 import pytest
-from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from google.cloud import bigquery
 from pandas.testing import assert_frame_equal
 from pytz import utc
@@ -21,11 +20,9 @@ from feast.entity import Entity
 from feast.feature import Feature
 from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
+from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from feast.infra.provider import DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
-from feast.repo_config import (
-    BigQueryOfflineStoreConfig,
-    RepoConfig,
-)
+from feast.repo_config import BigQueryOfflineStoreConfig, RepoConfig
 from feast.value_type import ValueType
 
 np.random.seed(0)

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -22,7 +22,7 @@ from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
 from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from feast.infra.provider import DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
-from feast.repo_config import BigQueryOfflineStoreConfig, RepoConfig
+from feast.repo_config import BigQueryOfflineStoreConfig, create_repo_config
 from feast.value_type import ValueType
 
 np.random.seed(0)
@@ -270,7 +270,7 @@ def test_historical_features_from_parquet_sources(infer_event_timestamp_col):
         customer = Entity(name="customer_id", value_type=ValueType.INT64)
 
         store = FeatureStore(
-            config=RepoConfig(
+            config=create_repo_config(
                 registry=os.path.join(temp_dir, "registry.db"),
                 project="default",
                 provider="local",
@@ -375,7 +375,7 @@ def test_historical_features_from_bigquery_sources(
 
         if provider_type == "local":
             store = FeatureStore(
-                config=RepoConfig(
+                config=create_repo_config(
                     registry=os.path.join(temp_dir, "registry.db"),
                     project="default",
                     provider="local",
@@ -389,7 +389,7 @@ def test_historical_features_from_bigquery_sources(
             )
         elif provider_type == "gcp":
             store = FeatureStore(
-                config=RepoConfig(
+                config=create_repo_config(
                     registry=os.path.join(temp_dir, "registry.db"),
                     project="".join(
                         random.choices(string.ascii_uppercase + string.digits, k=10)
@@ -402,7 +402,7 @@ def test_historical_features_from_bigquery_sources(
             )
         elif provider_type == "gcp_custom_offline_config":
             store = FeatureStore(
-                config=RepoConfig(
+                config=create_repo_config(
                     registry=os.path.join(temp_dir, "registry.db"),
                     project="".join(
                         random.choices(string.ascii_uppercase + string.digits, k=10)

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -14,7 +14,7 @@ from pandas.testing import assert_frame_equal
 from pytz import utc
 
 import feast.driver_test_data as driver_data
-from feast import errors, utils
+from feast import errors, utils, RepoConfig
 from feast.data_source import BigQuerySource, FileSource
 from feast.entity import Entity
 from feast.feature import Feature
@@ -22,7 +22,7 @@ from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
 from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from feast.infra.provider import DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
-from feast.repo_config import BigQueryOfflineStoreConfig, create_repo_config
+from feast.repo_config import BigQueryOfflineStoreConfig
 from feast.value_type import ValueType
 
 np.random.seed(0)
@@ -270,7 +270,7 @@ def test_historical_features_from_parquet_sources(infer_event_timestamp_col):
         customer = Entity(name="customer_id", value_type=ValueType.INT64)
 
         store = FeatureStore(
-            config=create_repo_config(
+            config=RepoConfig(
                 registry=os.path.join(temp_dir, "registry.db"),
                 project="default",
                 provider="local",
@@ -375,7 +375,7 @@ def test_historical_features_from_bigquery_sources(
 
         if provider_type == "local":
             store = FeatureStore(
-                config=create_repo_config(
+                config=RepoConfig(
                     registry=os.path.join(temp_dir, "registry.db"),
                     project="default",
                     provider="local",
@@ -389,7 +389,7 @@ def test_historical_features_from_bigquery_sources(
             )
         elif provider_type == "gcp":
             store = FeatureStore(
-                config=create_repo_config(
+                config=RepoConfig(
                     registry=os.path.join(temp_dir, "registry.db"),
                     project="".join(
                         random.choices(string.ascii_uppercase + string.digits, k=10)
@@ -402,7 +402,7 @@ def test_historical_features_from_bigquery_sources(
             )
         elif provider_type == "gcp_custom_offline_config":
             store = FeatureStore(
-                config=create_repo_config(
+                config=RepoConfig(
                     registry=os.path.join(temp_dir, "registry.db"),
                     project="".join(
                         random.choices(string.ascii_uppercase + string.digits, k=10)

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -14,7 +14,7 @@ from pandas.testing import assert_frame_equal
 from pytz import utc
 
 import feast.driver_test_data as driver_data
-from feast import errors, utils, RepoConfig
+from feast import RepoConfig, errors, utils
 from feast.data_source import BigQuerySource, FileSource
 from feast.entity import Entity
 from feast.feature import Feature

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -9,6 +9,7 @@ import assertpy
 import numpy as np
 import pandas as pd
 import pytest
+from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from google.cloud import bigquery
 from pandas.testing import assert_frame_equal
 from pytz import utc
@@ -24,7 +25,6 @@ from feast.infra.provider import DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
 from feast.repo_config import (
     BigQueryOfflineStoreConfig,
     RepoConfig,
-    SqliteOnlineStoreConfig,
 )
 from feast.value_type import ValueType
 

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -18,8 +18,9 @@ from feast.feature import Feature
 from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
 from feast.infra.online_stores.datastore import DatastoreOnlineStoreConfig
+from feast.infra.online_stores.redis import RedisOnlineStoreConfig, RedisType
 from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
-from feast.repo_config import RedisOnlineStoreConfig, RedisType, RepoConfig
+from feast.repo_config import RepoConfig
 from feast.value_type import ValueType
 
 

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -8,6 +8,8 @@ from typing import Iterator, Optional, Tuple, Union
 
 import pandas as pd
 import pytest
+from feast.infra.online_stores.datastore import DatastoreOnlineStoreConfig
+from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from google.cloud import bigquery
 from pytz import timezone, utc
 
@@ -18,11 +20,9 @@ from feast.feature import Feature
 from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
 from feast.repo_config import (
-    DatastoreOnlineStoreConfig,
     RedisOnlineStoreConfig,
     RedisType,
     RepoConfig,
-    SqliteOnlineStoreConfig,
 )
 from feast.value_type import ValueType
 

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -8,8 +8,6 @@ from typing import Iterator, Optional, Tuple, Union
 
 import pandas as pd
 import pytest
-from feast.infra.online_stores.datastore import DatastoreOnlineStoreConfig
-from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from google.cloud import bigquery
 from pytz import timezone, utc
 
@@ -19,11 +17,9 @@ from feast.entity import Entity
 from feast.feature import Feature
 from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
-from feast.repo_config import (
-    RedisOnlineStoreConfig,
-    RedisType,
-    RepoConfig,
-)
+from feast.infra.online_stores.datastore import DatastoreOnlineStoreConfig
+from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
+from feast.repo_config import RedisOnlineStoreConfig, RedisType, RepoConfig
 from feast.value_type import ValueType
 
 

--- a/sdk/python/tests/test_repo_config.py
+++ b/sdk/python/tests/test_repo_config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Optional
 
+import pytest
 from feast.repo_config import FeastConfigError, load_repo_config
 
 
@@ -24,8 +25,10 @@ def _test_config(config_text, expect_error: Optional[str]):
             error = e
 
         if expect_error is not None:
+            print(f"Error: {error}")
             assert expect_error in str(error)
         else:
+            print(f"Error: {error}")
             assert error is None
 
 
@@ -99,7 +102,7 @@ def test_bad_type():
             path: 100500
         """
         ),
-        expect_error="__root__ -> online_store -> path\n  str type expected",
+        expect_error="path\n  str type expected",
     )
 
 

--- a/sdk/python/tests/test_repo_config.py
+++ b/sdk/python/tests/test_repo_config.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Optional
 
-import pytest
 from feast.repo_config import FeastConfigError, load_repo_config
 
 

--- a/sdk/python/tests/test_repo_config.py
+++ b/sdk/python/tests/test_repo_config.py
@@ -24,10 +24,8 @@ def _test_config(config_text, expect_error: Optional[str]):
             error = e
 
         if expect_error is not None:
-            print(f"Error: {error}")
             assert expect_error in str(error)
         else:
-            print(f"Error: {error}")
             assert error is None
 
 
@@ -101,7 +99,7 @@ def test_bad_type():
             path: 100500
         """
         ),
-        expect_error="path\n  str type expected",
+        expect_error="__root__ -> online_store -> path\n  str type expected",
     )
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR:
- introduces a new pydantic base class for Config classes to extend
- moves the online store config classes into the corresponding modules
- adds logic to dynamically load the `OnlineStoreConfig` classes (and also the `OnlineStore` classes in a second pass).
- Keeps tests basically the same (and adding more tests for the dynamic classes)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part 1 for #1605 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow OnlineStore implementations to be loaded dynamically.
```
