### PR TITLE
Allow BigQuery project to be configured

### DIFF
--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -91,7 +91,10 @@ class BigQueryOfflineStoreConfig(FeastBaseModel):
     """ Offline store type selector"""
 
     dataset: StrictStr = "feast"
-    """ (optional) BigQuery Dataset name for temporary tables """
+    """ (optional) BigQuery dataset name used for the BigQuery offline store """
+
+    project_id: Optional[StrictStr] = None
+    """ (optional) GCP project name used for the BigQuery offline store """
 
 
 OfflineStoreConfig = Union[FileOfflineStoreConfig, BigQueryOfflineStoreConfig]


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the possibility to specify a GCP project for the temporary datasets created.

For example, with the config file and a ServiceAccount coming from the project `ml-adhoc`
```yaml
[...]
offline_store:
    type: bigquery
    project: ml-production
```

```
>>> from google.cloud import bigquery
>>>from feast.feature_store import FeatureStore
>>> store = FeatureStore()

>>> store.config.offline_store.project
'ml-production'

>>> bigquery.Client().project
'ml-adhoc'
```

Which means that the ServiceAccount `ml-adhoc` will write into the BQ project `ml-production` (_names are just for examples_)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/feast-dev/feast/issues/1655

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
NONE
```release-note
Possibility to specify a different GCP project than the ServiceAccount to save the BigQuery tables
```
