### PR TITLE
Provide the user with more options for setting the to_bigquery config

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -227,7 +227,17 @@ class BigQueryRetrievalJob(RetrievalJob):
     def to_sql(self):
         return self.query
 
-    def to_bigquery(self, job_config=None) -> Optional[str]:
+    def to_bigquery(self, job_config: bigquery.QueryJobConfig = None) -> Optional[str]:
+        """
+        Uploads the results of the BigQueryRetrievalJob directly to BigQuery
+
+        Args:
+            job_config: A bigquery.QueryJobConfig to specify options like destination table, dry run, etc.
+
+        Returns:
+            Returns either the destination table name, none if job_config.dry_run, or raises an exception if job fails
+        """
+
         @retry(wait=wait_fixed(10), stop=stop_after_delay(1800), reraise=True)
         def _block_until_done():
             return self.client.get_job(bq_job.job_id).state in ["PENDING", "RUNNING"]

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -226,19 +226,19 @@ class BigQueryRetrievalJob(RetrievalJob):
 
     def to_sql(self) -> str:
         """
-        Returns the SQL query that can be modified and run by the user to create the BQ table.
+        Returns the SQL query that will be executed in BigQuery to build the historical feature table.
         """
         return self.query
 
     def to_bigquery(self, job_config: bigquery.QueryJobConfig = None) -> Optional[str]:
         """
-        Uploads the results of the BigQueryRetrievalJob directly to BigQuery.
+        Triggers the execution of a historical feature retrieval query and exports the results to a BigQuery table.
 
         Args:
-            job_config: A bigquery.QueryJobConfig to specify options like destination table, dry run, etc.
+            job_config: An optional bigquery.QueryJobConfig to specify options like destination table, dry run, etc.
 
         Returns:
-            Returns either the destination table name, none if job_config.dry_run, or raises an exception if job fails
+            Returns the destination table name or returns None if job_config.dry_run is True.
         """
 
         @retry(wait=wait_fixed(10), stop=stop_after_delay(1800), reraise=True)

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -224,12 +224,15 @@ class BigQueryRetrievalJob(RetrievalJob):
         df = self.client.query(self.query).to_dataframe(create_bqstorage_client=True)
         return df
 
-    def to_sql(self):
+    def to_sql(self) -> str:
+        """
+        Returns the SQL query that can be modified and run by the user to create the BQ table.
+        """
         return self.query
 
     def to_bigquery(self, job_config: bigquery.QueryJobConfig = None) -> Optional[str]:
         """
-        Uploads the results of the BigQueryRetrievalJob directly to BigQuery
+        Uploads the results of the BigQueryRetrievalJob directly to BigQuery.
 
         Args:
             job_config: A bigquery.QueryJobConfig to specify options like destination table, dry run, etc.

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -9,7 +9,6 @@ import assertpy
 import numpy as np
 import pandas as pd
 import pytest
-from google.api_core.exceptions import Conflict
 from google.cloud import bigquery
 from pandas.testing import assert_frame_equal
 from pytz import utc
@@ -438,39 +437,6 @@ def test_historical_features_from_bigquery_sources(
                 "customer_profile:lifetime_trip_count",
             ],
         )
-
-        # Just a dry run, should not create table
-        job_config = bigquery.QueryJobConfig(dry_run=True)
-        bq_dry_run = job_from_sql.to_bigquery(job_config=job_config)
-        assert bq_dry_run is None
-
-        path = f"{gcp_project}.{bigquery_dataset}.historical_dest_table"
-        job_config = bigquery.QueryJobConfig(destination=path)
-        bq_temp_table_path = job_from_sql.to_bigquery(job_config=job_config)
-
-        # Check return output of to_bigquery()
-        assert bq_temp_table_path.split(".")[0] == gcp_project
-        if provider_type == "gcp_custom_offline_config":
-            assert bq_temp_table_path.split(".")[1] == "foo"
-        else:
-            assert bq_temp_table_path.split(".")[1] == bigquery_dataset
-
-        # Check that this table actually exists
-        actual_bq_temp_table = bigquery.Client().get_table(bq_temp_table_path)
-        assert actual_bq_temp_table.table_id == bq_temp_table_path.split(".")[-1]
-
-        # Config to overwrite an existing table should succeed
-        job_config = bigquery.QueryJobConfig(
-            destination=path, write_disposition="WRITE_TRUNCATE"
-        )
-        bq_temp_table_path = job_from_sql.to_bigquery(job_config=job_config)
-
-        # Config to fail on the existing table we created should fail
-        with pytest.raises(Conflict):
-            job_config = bigquery.QueryJobConfig(
-                destination=path, write_disposition="WRITE_EMPTY"
-            )
-            bq_temp_table_path = job_from_sql.to_bigquery(job_config=job_config)
 
         start_time = datetime.utcnow()
         actual_df_from_sql_entities = job_from_sql.to_df()


### PR DESCRIPTION
Signed-off-by: Cody Lin <codyl@twitter.com>

**What this PR does / why we need it**:
This PR gives the user more freedom to set configuration options for the `to_bigquery` call (on a BigQueryRetrievalJob following a `get_historical_features` call). For example, the user can specify a destination `project.dataset.tableName`, an expiration timestamp for the table, and also an option for replace/overwrite vs fail if already exists.

**Which issue(s) this PR fixes**:
Fixes #1654

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
* User should supply to_bigquery() with a bigquery.QueryJobConfig.
* User can also call to_sql() to get/modify the SQL directly (i.e. to set expiration_timestamp)
```

**References**
- [google.cloud.bigquery.job.QueryJobConfig](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.job.QueryJobConfig.html
)
- This PR builds on the design in https://github.com/feast-dev/feast/pull/1634 when to_bigquery() was first added