### PR TITLE
Add methods to offline/online stores to specify supported upstream sources

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -22,7 +22,7 @@ from feast.infra.provider import (
     _get_requested_feature_views_to_features_dict,
 )
 from feast.registry import Registry
-from feast.repo_config import FeastConfigBaseModel, RepoConfig
+from feast.repo_config import FeastOfflineStoreConfigBaseModel, RepoConfig
 
 try:
     from google.api_core.exceptions import NotFound
@@ -36,7 +36,7 @@ except ImportError as e:
     raise FeastExtrasDependencyImportError("gcp", str(e))
 
 
-class BigQueryOfflineStoreConfig(FeastConfigBaseModel):
+class BigQueryOfflineStoreConfig(FeastOfflineStoreConfigBaseModel):
     """ Offline store config for GCP BigQuery """
 
     type: Literal["bigquery"] = "bigquery"
@@ -48,8 +48,12 @@ class BigQueryOfflineStoreConfig(FeastConfigBaseModel):
     project_id: Optional[StrictStr] = None
     """ (optional) GCP project name used for the BigQuery offline store """
 
+    def supports_data_source(self, data_source: DataSource) -> bool:
+        return isinstance(data_source, BigQuerySource)
+
 
 class BigQueryOfflineStore(OfflineStore):
+
     @staticmethod
     def pull_latest_from_table_or_query(
         data_source: DataSource,

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -53,7 +53,6 @@ class BigQueryOfflineStoreConfig(FeastOfflineStoreConfigBaseModel):
 
 
 class BigQueryOfflineStore(OfflineStore):
-
     @staticmethod
     def pull_latest_from_table_or_query(
         data_source: DataSource,

--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -16,14 +16,17 @@ from feast.infra.provider import (
     _run_field_mapping,
 )
 from feast.registry import Registry
-from feast.repo_config import FeastConfigBaseModel, RepoConfig
+from feast.repo_config import FeastOfflineStoreConfigBaseModel, RepoConfig
 
 
-class FileOfflineStoreConfig(FeastConfigBaseModel):
+class FileOfflineStoreConfig(FeastOfflineStoreConfigBaseModel):
     """ Offline store config for local (file-based) store """
 
     type: Literal["file"] = "file"
     """ Offline store type selector"""
+
+    def supports_data_source(self, data_source: DataSource) -> bool:
+        return isinstance(data_source, FileSource)
 
 
 class FileRetrievalJob(RetrievalJob):

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -68,3 +68,4 @@ class OfflineStore(ABC):
         project: str,
     ) -> RetrievalJob:
         pass
+

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -68,4 +68,3 @@ class OfflineStore(ABC):
         project: str,
     ) -> RetrievalJob:
         pass
-

--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -26,7 +26,7 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import FeastConfigBaseModel, RepoConfig
+from feast.repo_config import RepoConfig, FeastOnlineStoreConfigBaseModel
 
 try:
     from google.auth.exceptions import DefaultCredentialsError
@@ -42,7 +42,7 @@ ProtoBatch = Sequence[
 ]
 
 
-class DatastoreOnlineStoreConfig(FeastConfigBaseModel):
+class DatastoreOnlineStoreConfig(FeastOnlineStoreConfigBaseModel):
     """ Online store config for GCP Datastore """
 
     type: Literal["datastore"] = "datastore"
@@ -59,6 +59,11 @@ class DatastoreOnlineStoreConfig(FeastConfigBaseModel):
 
     write_batch_size: Optional[PositiveInt] = 50
     """ (optional) Amount of feature rows per batch being written into Datastore"""
+
+    def supports_offline_store(self, offline_store: Any) -> bool:
+        # We're defaulting to supporting all offline stores for now.
+        return offline_store.type == "bigquery"
+
 
 
 class DatastoreOnlineStore(OnlineStore):

--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -26,7 +26,7 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import RepoConfig, FeastOnlineStoreConfigBaseModel
+from feast.repo_config import FeastOnlineStoreConfigBaseModel, RepoConfig
 
 try:
     from google.auth.exceptions import DefaultCredentialsError
@@ -63,7 +63,6 @@ class DatastoreOnlineStoreConfig(FeastOnlineStoreConfigBaseModel):
     def supports_offline_store(self, offline_store: Any) -> bool:
         # We're defaulting to supporting all offline stores for now.
         return offline_store.type == "bigquery"
-
 
 
 class DatastoreOnlineStore(OnlineStore):

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -25,7 +25,7 @@ from feast.infra.online_stores.helpers import _mmh3, _redis_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import FeastOnlineStoreConfigBaseModel, FeastOfflineStoreConfigBaseModel
+from feast.repo_config import FeastOnlineStoreConfigBaseModel
 
 try:
     from redis import Redis

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -25,7 +25,7 @@ from feast.infra.online_stores.helpers import _mmh3, _redis_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import FeastConfigBaseModel
+from feast.repo_config import FeastOnlineStoreConfigBaseModel, FeastOfflineStoreConfigBaseModel
 
 try:
     from redis import Redis
@@ -43,7 +43,7 @@ class RedisType(str, Enum):
     redis_cluster = "redis_cluster"
 
 
-class RedisOnlineStoreConfig(FeastConfigBaseModel):
+class RedisOnlineStoreConfig(FeastOnlineStoreConfigBaseModel):
     """Online store config for Redis store"""
 
     type: Literal["redis"] = "redis"
@@ -55,6 +55,10 @@ class RedisOnlineStoreConfig(FeastConfigBaseModel):
     connection_string: StrictStr = "localhost:6379"
     """Connection string containing the host, port, and configuration parameters for Redis
      format: host:port,parameter1,parameter2 eg. redis:6379,db=0 """
+
+    def supports_offline_store(self, offline_store: Any) -> bool:
+        # We're defaulting to supporting all offline stores for now.
+        return True
 
 
 class RedisOnlineStore(OnlineStore):

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -28,10 +28,10 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import FeastConfigBaseModel, RepoConfig
+from feast.repo_config import RepoConfig, FeastOnlineStoreConfigBaseModel
 
 
-class SqliteOnlineStoreConfig(FeastConfigBaseModel):
+class SqliteOnlineStoreConfig(FeastOnlineStoreConfigBaseModel):
     """ Online store config for local (SQLite-based) store """
 
     type: Literal[
@@ -41,6 +41,10 @@ class SqliteOnlineStoreConfig(FeastConfigBaseModel):
 
     path: StrictStr = "data/online.db"
     """ (optional) Path to sqlite db """
+
+    def supports_offline_store(self, offline_store: Any) -> bool:
+        return offline_store.type == "file"
+
 
 
 class SqliteOnlineStore(OnlineStore):

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -28,7 +28,7 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import RepoConfig, FeastOnlineStoreConfigBaseModel
+from feast.repo_config import FeastOnlineStoreConfigBaseModel, RepoConfig
 
 
 class SqliteOnlineStoreConfig(FeastOnlineStoreConfigBaseModel):
@@ -44,7 +44,6 @@ class SqliteOnlineStoreConfig(FeastOnlineStoreConfigBaseModel):
 
     def supports_offline_store(self, offline_store: Any) -> bool:
         return offline_store.type == "file"
-
 
 
 class SqliteOnlineStore(OnlineStore):

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -3,11 +3,11 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from feast.data_source import DataSource
 from pydantic import BaseModel, StrictInt, StrictStr, ValidationError, root_validator
 from pydantic.error_wrappers import ErrorWrapper
 from pydantic.typing import Dict, Optional, Union
 
+from feast.data_source import DataSource
 from feast.importer import get_class_from_type
 from feast.usage import log_exceptions
 

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -1,7 +1,9 @@
+from abc import abstractmethod
 from pathlib import Path
 from typing import Any
 
 import yaml
+from feast.data_source import DataSource
 from pydantic import BaseModel, StrictInt, StrictStr, ValidationError, root_validator
 from pydantic.error_wrappers import ErrorWrapper
 from pydantic.typing import Dict, Optional, Union
@@ -32,12 +34,28 @@ class FeastBaseModel(BaseModel):
         extra = "allow"
 
 
-class FeastConfigBaseModel(BaseModel):
+class FeastOfflineStoreConfigBaseModel(BaseModel):
     """ Feast Pydantic Configuration Class """
 
     class Config:
         arbitrary_types_allowed = True
         extra = "forbid"
+
+    @abstractmethod
+    def supports_data_source(self, data_source: DataSource) -> bool:
+        ...
+
+
+class FeastOnlineStoreConfigBaseModel(BaseModel):
+    """ Feast Pydantic Configuration Class """
+
+    class Config:
+        arbitrary_types_allowed = True
+        extra = "forbid"
+
+    @abstractmethod
+    def supports_offline_store(self, offline_store: Any) -> bool:
+        ...
 
 
 class RegistryConfig(FeastBaseModel):

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -155,7 +155,10 @@ def apply_total(repo_config: RepoConfig, repo_path: Path):
 
     # Make sure the data source used by this feature view is supported by Feast
     for data_source in data_sources:
+        assert repo_config.offline_store.supports_data_source(data_source)
         data_source.validate()
+
+    assert repo_config.online_store.supports_offline_store(repo_config.offline_store)
 
     update_data_sources_with_inferred_event_timestamp_col(data_sources)
     for view in repo.feature_views:


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

We need a way for Online and Offline stores to be explicit about what upstream sources are supported. This was added in #1552 but removed in #1649. This PR adds it back in.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
