### PR TITLE
Add to_table() to RetrievalJob object

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -386,12 +386,13 @@ class FeatureStore:
             end_date = utils.make_tzaware(end_date)
 
             provider.materialize_single_feature_view(
-                feature_view,
-                start_date,
-                end_date,
-                self._registry,
-                self.project,
-                tqdm_builder,
+                config=self.config,
+                feature_view=feature_view,
+                start_date=start_date,
+                end_date=end_date,
+                registry=self._registry,
+                project=self.project,
+                tqdm_builder=tqdm_builder,
             )
 
             self._registry.apply_materialization(
@@ -464,12 +465,13 @@ class FeatureStore:
             end_date = utils.make_tzaware(end_date)
 
             provider.materialize_single_feature_view(
-                feature_view,
-                start_date,
-                end_date,
-                self._registry,
-                self.project,
-                tqdm_builder,
+                config=self.config,
+                feature_view=feature_view,
+                start_date=start_date,
+                end_date=end_date,
+                registry=self._registry,
+                project=self.project,
+                tqdm_builder=tqdm_builder,
             )
 
             self._registry.apply_materialization(

--- a/sdk/python/feast/infra/gcp.py
+++ b/sdk/python/feast/infra/gcp.py
@@ -81,6 +81,7 @@ class GcpProvider(Provider):
 
     def materialize_single_feature_view(
         self,
+        config: RepoConfig,
         feature_view: FeatureView,
         start_date: datetime,
         end_date: datetime,
@@ -99,7 +100,8 @@ class GcpProvider(Provider):
             created_timestamp_column,
         ) = _get_column_names(feature_view, entities)
 
-        table = self.offline_store.pull_latest_from_table_or_query(
+        offline_job = self.offline_store.pull_latest_from_table_or_query(
+            config=config,
             data_source=feature_view.input,
             join_key_columns=join_key_columns,
             feature_name_columns=feature_name_columns,
@@ -108,6 +110,7 @@ class GcpProvider(Provider):
             start_date=start_date,
             end_date=end_date,
         )
+        table = offline_job.to_table()
 
         if feature_view.input.field_mapping is not None:
             table = _run_field_mapping(table, feature_view.input.field_mapping)

--- a/sdk/python/feast/infra/local.py
+++ b/sdk/python/feast/infra/local.py
@@ -80,6 +80,7 @@ class LocalProvider(Provider):
 
     def materialize_single_feature_view(
         self,
+        config: RepoConfig,
         feature_view: FeatureView,
         start_date: datetime,
         end_date: datetime,
@@ -98,7 +99,7 @@ class LocalProvider(Provider):
             created_timestamp_column,
         ) = _get_column_names(feature_view, entities)
 
-        table = self.offline_store.pull_latest_from_table_or_query(
+        offline_job = self.offline_store.pull_latest_from_table_or_query(
             data_source=feature_view.input,
             join_key_columns=join_key_columns,
             feature_name_columns=feature_name_columns,
@@ -106,7 +107,9 @@ class LocalProvider(Provider):
             created_timestamp_column=created_timestamp_column,
             start_date=start_date,
             end_date=end_date,
+            config=config,
         )
+        table = offline_job.to_table()
 
         if feature_view.input.field_mapping is not None:
             table = _run_field_mapping(table, feature_view.input.field_mapping)

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -33,6 +33,15 @@ class RetrievalJob(ABC):
         pass
 
 
+class OfflineJob(ABC):
+    """OfflineJob is used to manage the execution of a specific logic of the offline store"""
+
+    @abstractmethod
+    def to_table(self) -> pyarrow.Table:
+        """Return dataset as Pandas DataFrame synchronously"""
+        pass
+
+
 class OfflineStore(ABC):
     """
     OfflineStore is an object used for all interaction between Feast and the service used for offline storage of
@@ -42,6 +51,7 @@ class OfflineStore(ABC):
     @staticmethod
     @abstractmethod
     def pull_latest_from_table_or_query(
+        config: RepoConfig,
         data_source: DataSource,
         join_key_columns: List[str],
         feature_name_columns: List[str],
@@ -49,7 +59,7 @@ class OfflineStore(ABC):
         created_timestamp_column: Optional[str],
         start_date: datetime,
         end_date: datetime,
-    ) -> pyarrow.Table:
+    ) -> OfflineJob:
         """
         Note that join_key_columns, feature_name_columns, event_timestamp_column, and created_timestamp_column
         have all already been mapped to column names of the source table and those column names are the values passed

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -28,17 +28,13 @@ class RetrievalJob(ABC):
     """RetrievalJob is used to manage the execution of a historical feature retrieval"""
 
     @abstractmethod
-    def to_df(self):
+    def to_df(self) -> pd.DataFrame:
         """Return dataset as Pandas DataFrame synchronously"""
         pass
 
-
-class OfflineJob(ABC):
-    """OfflineJob is used to manage the execution of a specific logic of the offline store"""
-
     @abstractmethod
     def to_table(self) -> pyarrow.Table:
-        """Return dataset as Pandas DataFrame synchronously"""
+        """Return dataset as pyarrow Table synchronously"""
         pass
 
 
@@ -59,7 +55,7 @@ class OfflineStore(ABC):
         created_timestamp_column: Optional[str],
         start_date: datetime,
         end_date: datetime,
-    ) -> OfflineJob:
+    ) -> RetrievalJob:
         """
         Note that join_key_columns, feature_name_columns, event_timestamp_column, and created_timestamp_column
         have all already been mapped to column names of the source table and those column names are the values passed

--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import List, Optional, Union
 
 import pandas as pd
-import pyarrow
 from pydantic import StrictStr
 from pydantic.typing import Literal
 
@@ -38,6 +37,7 @@ class RedshiftOfflineStoreConfig(FeastConfigBaseModel):
 class RedshiftOfflineStore(OfflineStore):
     @staticmethod
     def pull_latest_from_table_or_query(
+        config: RepoConfig,
         data_source: DataSource,
         join_key_columns: List[str],
         feature_name_columns: List[str],
@@ -45,7 +45,7 @@ class RedshiftOfflineStore(OfflineStore):
         created_timestamp_column: Optional[str],
         start_date: datetime,
         end_date: datetime,
-    ) -> pyarrow.Table:
+    ) -> RetrievalJob:
         pass
 
     @staticmethod

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -97,6 +97,7 @@ class Provider(abc.ABC):
     @abc.abstractmethod
     def materialize_single_feature_view(
         self,
+        config: RepoConfig,
         feature_view: FeatureView,
         start_date: datetime,
         end_date: datetime,

--- a/sdk/python/tests/foo_provider.py
+++ b/sdk/python/tests/foo_provider.py
@@ -45,6 +45,7 @@ class FooProvider(Provider):
 
     def materialize_single_feature_view(
         self,
+        config: RepoConfig,
         feature_view: FeatureView,
         start_date: datetime,
         end_date: datetime,

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -461,6 +461,11 @@ def test_historical_features_from_bigquery_sources(
             check_dtype=False,
         )
 
+        table_from_sql_entities = job_from_sql.to_table()
+        assert_frame_equal(
+            actual_df_from_sql_entities, table_from_sql_entities.to_pandas()
+        )
+
         timestamp_column = (
             "e_ts"
             if infer_event_timestamp_col
@@ -540,4 +545,8 @@ def test_historical_features_from_bigquery_sources(
             .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
             .reset_index(drop=True),
             check_dtype=False,
+        )
+        table_from_df_entities = job_from_df.to_table()
+        assert_frame_equal(
+            actual_df_from_df_entities, table_from_df_entities.to_pandas()
         )


### PR DESCRIPTION
**What this PR does / why we need it**:
We should add a notion of "OfflineJob" so that it will be easier to add new methods as well as accessible useful information.

For example, when you build a custom Provider, you might want to access the query coming from `pull_latest_from_table_or_query()` without executing it (as it will be executed differently)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
pull_latest_from_table_or_query() now returns an RetrievalJob object
Add method to_table() to RetrievalJob object
```
