### PR TITLE
Cancel BigQuery job if timeout hits

### DIFF
--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -126,6 +126,11 @@ class RegistryInferenceFailure(Exception):
         )
 
 
+class BigQueryJobCancelled(Exception):
+    def __init__(self, job_id):
+        super().__init__(f"The following job '{job_id}' got cancelled")
+
+
 class RedshiftCredentialsError(Exception):
     def __init__(self):
         super().__init__("Redshift API failed due to incorrect credentials")

--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -128,7 +128,7 @@ class RegistryInferenceFailure(Exception):
 
 class BigQueryJobCancelled(Exception):
     def __init__(self, job_id):
-        super().__init__(f"The following job '{job_id}' got cancelled")
+        super().__init__(f"The BigQuery job with ID '{job_id}' was cancelled")
 
 
 class RedshiftCredentialsError(Exception):

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -280,11 +280,11 @@ def block_until_done(client, bq_job):
         return client.get_job(job_id).state in ["PENDING", "RUNNING"]
 
     @retry(wait=wait_fixed(10), stop=stop_after_delay(1800), reraise=True)
-    def _wait_till_done(job_id):
+    def _wait_until_done(job_id):
         return _is_done(job_id)
 
     job_id = bq_job.job_id
-    _wait_till_done(job_id=job_id)
+    _wait_until_done(job_id=job_id)
 
     if not _is_done(job_id):
         client.cancel_job(job_id)

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -13,7 +13,7 @@ from tenacity import retry, stop_after_delay, wait_fixed
 
 from feast import errors
 from feast.data_source import BigQuerySource, DataSource
-from feast.errors import FeastProviderLoginError
+from feast.errors import BigQueryJobCancelled, FeastProviderLoginError
 from feast.feature_view import FeatureView
 from feast.infra.offline_stores.offline_store import OfflineStore, RetrievalJob
 from feast.infra.provider import (
@@ -249,10 +249,6 @@ class BigQueryRetrievalJob(RetrievalJob):
             Returns the destination table name or returns None if job_config.dry_run is True.
         """
 
-        @retry(wait=wait_fixed(10), stop=stop_after_delay(1800), reraise=True)
-        def _block_until_done():
-            return self.client.get_job(bq_job.job_id).state in ["PENDING", "RUNNING"]
-
         if not job_config:
             today = date.today().strftime("%Y%m%d")
             rand_id = str(uuid.uuid4())[:7]
@@ -261,7 +257,7 @@ class BigQueryRetrievalJob(RetrievalJob):
 
         bq_job = self.client.query(self.query, job_config=job_config)
 
-        _block_until_done()
+        block_until_done(client=self.client, bq_job=bq_job)
 
         if bq_job.exception():
             raise bq_job.exception()
@@ -277,6 +273,25 @@ class BigQueryRetrievalJob(RetrievalJob):
 
     def to_table(self) -> pyarrow.Table:
         return self.client.query(self.query).to_arrow()
+
+
+def block_until_done(client, bq_job):
+    def _is_done(job_id):
+        return client.get_job(job_id).state in ["PENDING", "RUNNING"]
+
+    @retry(wait=wait_fixed(10), stop=stop_after_delay(1800), reraise=True)
+    def _wait_till_done(job_id):
+        return _is_done(job_id)
+
+    job_id = bq_job.job_id
+    _wait_till_done(job_id=job_id)
+
+    if not _is_done(job_id):
+        client.cancel_job(job_id)
+        raise BigQueryJobCancelled(job_id=job_id)
+
+    if bq_job.exception():
+        raise bq_job.exception()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Signed-off-by: Matt Delacour <matt.delacour@shopify.com>

**What this PR does / why we need it**:
The current function `_block_until_done()` has a flaw as if the timedout hits (aka `stop_after_delay(1800)`), then the job will still run in BigQuery and won't be cancelled.

An alternative would be the possibility to add a timedout argument to the [BQ config job](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.job.QueryJobConfig.html) but could not find anything useful

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
