### PR TITLE
Allow strings for online/offline store instead of dicts

### DIFF
--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -83,10 +83,15 @@ class RepoConfig(FeastBaseModel):
             self.online_store = get_online_config_from_type(self.online_store["type"])(
                 **self.online_store
             )
+        elif isinstance(self.online_store, str):
+            self.online_store = get_online_config_from_type(self.online_store)()
+
         if isinstance(self.offline_store, Dict):
             self.offline_store = get_offline_config_from_type(
                 self.offline_store["type"]
             )(**self.offline_store)
+        elif isinstance(self.offline_store, str):
+            self.offline_store = get_offline_config_from_type(self.offline_store)()
 
     def get_registry_config(self):
         if isinstance(self.registry, str):


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This allows the offline_store or online_store to be specified as a top level string instead of a dict.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow strings for online/offline store instead of dicts
```
