### PR TITLE
BQ exception should be raised first before we check the timedout

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -286,12 +286,12 @@ def block_until_done(client, bq_job):
     job_id = bq_job.job_id
     _wait_until_done(job_id=job_id)
 
+    if bq_job.exception():
+        raise bq_job.exception()
+
     if not _is_done(job_id):
         client.cancel_job(job_id)
         raise BigQueryJobCancelled(job_id=job_id)
-
-    if bq_job.exception():
-        raise bq_job.exception()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Signed-off-by: Matt Delacour <matt.delacour@shopify.com>

**What this PR does / why we need it**:
If the query failed before starting, its state will be `FAILURE`. So we should raise the BQ exceptions first otherwise we will end up seeing "BigQueryJobCancelled" errors even though it's not accurate

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix exception order when BigQuery failures occur
```
