### PR TITLE
Remove default list from the FeatureView constructor

### DIFF
--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -65,14 +65,16 @@ class FeatureView:
         input: DataSource,
         batch_source: Optional[DataSource] = None,
         stream_source: Optional[DataSource] = None,
-        features: List[Feature] = [],
+        features: List[Feature] = None,
         tags: Optional[Dict[str, str]] = None,
         online: bool = True,
     ):
         _input = input or batch_source
         assert _input is not None
 
-        cols = [entity for entity in entities] + [feat.name for feat in features]
+        _features = features or []
+
+        cols = [entity for entity in entities] + [feat.name for feat in _features]
         for col in cols:
             if _input.field_mapping is not None and col in _input.field_mapping.keys():
                 raise ValueError(
@@ -83,7 +85,7 @@ class FeatureView:
 
         self.name = name
         self.entities = entities
-        self.features = features
+        self.features = _features
         self.tags = tags if tags is not None else {}
 
         if isinstance(ttl, Duration):


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Mutable default arguments to methods are a well-known way to shoot yourself in the foot in python: https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments

In this particular case, if we define multiple FeatureViews that use feature inferencing, we'll end up having all of them refer to the *same* list of features, which would have been inferred for the first feature view we processed in `repo_operations.py`. 

As a result, the list of inferred features for all the *other* FeatureView would be the same as the first set, and totally wrong.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix bug with mutable default argument in FeatureView constructor.
```
