### PR TITLE
Fix unit tests that got broken by Pandas 1.3.0 release

### DIFF
--- a/sdk/python/feast/driver_test_data.py
+++ b/sdk/python/feast/driver_test_data.py
@@ -140,8 +140,8 @@ def create_driver_hourly_stats_df(drivers, start_date, end_date) -> pd.DataFrame
     # TODO: These duplicate rows area indirectly being filtered out by the point in time join already. We need to
     #  inject a bad row at a timestamp where we know it will get joined to the entity dataframe, and then test that
     #  we are actually filtering it with the created timestamp
-    late_row = df_all_drivers.iloc[int(rows / 2)]
-    df_all_drivers = df_all_drivers.append(late_row).append(late_row)
+    late_row = df_all_drivers[rows // 2 : rows // 2 + 1]
+    df_all_drivers = pd.concat([df_all_drivers, late_row, late_row], ignore_index=True)
 
     return df_all_drivers
 

--- a/sdk/python/tests/test_historical_retrieval.py
+++ b/sdk/python/tests/test_historical_retrieval.py
@@ -195,13 +195,14 @@ def get_expected_training_df(
     expected_df = expected_df[[event_timestamp] + current_cols]
 
     # Cast some columns to expected types, since we lose information when converting pandas DFs into Python objects.
-    expected_df["order_is_success"] = expected_df["order_is_success"].astype("int32")
-    expected_df["customer_profile__current_balance"] = expected_df[
-        "customer_profile__current_balance"
-    ].astype("float32")
-    expected_df["customer_profile__avg_passenger_count"] = expected_df[
-        "customer_profile__avg_passenger_count"
-    ].astype("float32")
+    expected_column_types = {
+        "order_is_success": "int32",
+        "driver_stats__conv_rate": "float32",
+        "customer_profile__current_balance": "float32",
+        "customer_profile__avg_passenger_count": "float32",
+    }
+    for col, typ in expected_column_types.items():
+        expected_df[col] = expected_df[col].astype(typ)
 
     return expected_df
 

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -1,4 +1,5 @@
 import contextlib
+import math
 import tempfile
 import time
 import uuid
@@ -212,8 +213,7 @@ def check_offline_and_online_features(
     if expected_value:
         assert abs(df.to_dict()[f"{fv.name}__value"][0] - expected_value) < 1e-6
     else:
-        df = df.where(pd.notnull(df), None)
-        assert df.to_dict()[f"{fv.name}__value"][0] is None
+        assert math.isnan(df.to_dict()[f"{fv.name}__value"][0])
 
 
 def run_offline_online_store_consistency_test(


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Pandas 1.3.0 release yesterday (https://pandas.pydata.org/pandas-docs/dev/whatsnew/v1.3.0.html) and it broke our unit tests. Looks like the new pandas version fixed some bugs and some of our tests were depending on those bugs :) For example we were using pandas_df.append in one place, which was incorrectly casting types from float32 to float64 in earlier pandas versions. I replaced it with pandas.concat which behaves correctly in both old and new versions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
