### PR TITLE
Historical retrieval without an entity dataframe (Local Only)

### DIFF
--- a/sdk/python/feast/infra/aws.py
+++ b/sdk/python/feast/infra/aws.py
@@ -141,3 +141,28 @@ class AwsProvider(Provider):
             full_feature_names=full_feature_names,
         )
         return job
+
+    def get_historical_features_by_view(
+        self,
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_view: str,
+        registry: Registry,
+        project: str,
+        start_date: Optional[datetime],
+        end_date: Optional[datetime],
+        full_feature_names: bool,
+    ) -> RetrievalJob:
+        job = self.offline_store.get_historical_features_by_view(
+            config=config,
+            feature_views=feature_views,
+            feature_refs=feature_refs,
+            entity_view=entity_view,
+            registry=registry,
+            project=project,
+            start_date=start_date,
+            end_date=end_date,
+            full_feature_names=full_feature_names,
+        )
+        return job

--- a/sdk/python/feast/infra/gcp.py
+++ b/sdk/python/feast/infra/gcp.py
@@ -143,3 +143,28 @@ class GcpProvider(Provider):
             full_feature_names=full_feature_names,
         )
         return job
+
+    def get_historical_features_by_view(
+        self,
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_view: str,
+        registry: Registry,
+        project: str,
+        start_date: Optional[datetime],
+        end_date: Optional[datetime],
+        full_feature_names: bool,
+    ) -> RetrievalJob:
+        job = self.offline_store.get_historical_features_by_view(
+            config=config,
+            feature_views=feature_views,
+            feature_refs=feature_refs,
+            entity_view=entity_view,
+            registry=registry,
+            project=project,
+            start_date=start_date,
+            end_date=end_date,
+            full_feature_names=full_feature_names,
+        )
+        return job

--- a/sdk/python/feast/infra/local.py
+++ b/sdk/python/feast/infra/local.py
@@ -142,6 +142,30 @@ class LocalProvider(Provider):
             full_feature_names=full_feature_names,
         )
 
+    def get_historical_features_by_view(
+        self,
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_view: str,
+        registry: Registry,
+        project: str,
+        start_date: Optional[datetime],
+        end_date: Optional[datetime],
+        full_feature_names: bool,
+    ) -> RetrievalJob:
+        return self.offline_store.get_historical_features_by_view(
+            config=config,
+            feature_views=feature_views,
+            feature_refs=feature_refs,
+            entity_view=entity_view,
+            registry=registry,
+            project=project,
+            start_date=start_date,
+            end_date=end_date,
+            full_feature_names=full_feature_names,
+        )
+
 
 def _table_id(project: str, table: Union[FeatureTable, FeatureView]) -> str:
     return f"{project}_{table.name}"

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -154,6 +154,20 @@ class BigQueryOfflineStore(OfflineStore):
         job = BigQueryRetrievalJob(query=query, client=client, config=config)
         return job
 
+    @staticmethod
+    def get_historical_features_by_view(
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_view: str,
+        registry: Registry,
+        project: str,
+        start_date: Optional[datetime],
+        end_date: Optional[datetime],
+        full_feature_names: bool,
+    ):
+        raise NotImplementedError
+
 
 def _assert_expected_columns_in_dataframe(
     join_keys: Set[str], entity_df_event_timestamp_col: str, entity_df: pandas.DataFrame

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -75,3 +75,18 @@ class OfflineStore(ABC):
         full_feature_names: bool = False,
     ) -> RetrievalJob:
         pass
+
+    @staticmethod
+    @abstractmethod
+    def get_historical_features_by_view(
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_view: str,
+        registry: Registry,
+        project: str,
+        start_date: Optional[datetime],
+        end_date: Optional[datetime],
+        full_feature_names: bool,
+    ):
+        pass

--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -105,6 +105,20 @@ class RedshiftOfflineStore(OfflineStore):
     ) -> RetrievalJob:
         pass
 
+    @staticmethod
+    def get_historical_features_by_view(
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_view: str,
+        registry: Registry,
+        project: str,
+        start_date: Optional[datetime],
+        end_date: Optional[datetime],
+        full_feature_names: bool,
+    ):
+        pass
+
 
 class RedshiftRetrievalJob(RetrievalJob):
     def __init__(self, query: str, redshift_client, s3_resource, config: RepoConfig):

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -121,6 +121,21 @@ class Provider(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def get_historical_features_by_view(
+        self,
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_df: Union[pandas.DataFrame, str],
+        registry: Registry,
+        project: str,
+        start_date: Optional[datetime],
+        end_date: Optional[datetime],
+        full_feature_names: bool,
+    ) -> RetrievalJob:
+        pass
+
+    @abc.abstractmethod
     def online_read(
         self,
         config: RepoConfig,

--- a/sdk/python/tests/foo_provider.py
+++ b/sdk/python/tests/foo_provider.py
@@ -67,6 +67,20 @@ class FooProvider(Provider):
     ) -> RetrievalJob:
         pass
 
+    def get_historical_features_by_view(
+        self,
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_df: Union[pandas.DataFrame, str],
+        registry: Registry,
+        project: str,
+        start_date: Optional[datetime],
+        end_date: Optional[datetime],
+        full_feature_names: bool,
+    ) -> RetrievalJob:
+        pass
+
     def online_read(
         self,
         config: RepoConfig,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Adds Historical retrieval without an entity dataframe as per #1611 

This is experimental

Implements #1611 for Local Provider only.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Partially adds #1611

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add historical retrieval without an entity dataframe for file-based offline store
```
