### PR TITLE
Teardown infrastructure after integration tests

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -21,9 +21,10 @@ import pandas as pd
 from colorama import Fore, Style
 from tqdm import tqdm
 
-from feast import FeatureTable, utils
+from feast import utils
 from feast.entity import Entity
 from feast.errors import FeatureNameCollisionError, FeatureViewNotFoundException
+from feast.feature_table import FeatureTable
 from feast.feature_view import FeatureView
 from feast.inference import (
     update_data_sources_with_inferred_event_timestamp_col,

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -257,16 +257,16 @@ class FeatureStore:
 
     @log_exceptions_and_usage
     def teardown(self):
-        feature_defs: List[Union[FeatureView, FeatureTable]] = []
+        tables: List[Union[FeatureView, FeatureTable]] = []
         feature_views = self.list_feature_views()
         feature_tables = self._registry.list_feature_tables(self.project)
 
-        feature_defs.extend(feature_views)
-        feature_defs.extend(feature_tables)
+        tables.extend(feature_views)
+        tables.extend(feature_tables)
 
         entities = self.list_entities()
 
-        self._get_provider().teardown_infra(self.project, feature_defs, entities)
+        self._get_provider().teardown_infra(self.project, tables, entities)
         for feature_view in feature_views:
             self.delete_feature_view(feature_view.name)
         for feature_table in feature_tables:

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -152,7 +152,6 @@ def prep_local_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
 
             yield fs, fv
 
-            # This should be a call to `fs.teardown()` once https://github.com/feast-dev/feast/issues/1696 is resolved.
             fs.teardown()
 
 

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -111,6 +111,8 @@ def prep_bq_fs_and_fv(
 
         yield fs, fv
 
+        fs.teardown()
+
 
 @contextlib.contextmanager
 def prep_local_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
@@ -151,7 +153,7 @@ def prep_local_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             yield fs, fv
 
             # This should be a call to `fs.teardown()` once https://github.com/feast-dev/feast/issues/1696 is resolved.
-            fs._get_provider().teardown_infra(project, [fv], [e])
+            fs.teardown()
 
 
 @contextlib.contextmanager
@@ -193,8 +195,7 @@ def prep_redis_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
 
             yield fs, fv
 
-            # This should be a call to `fs.teardown()` once https://github.com/feast-dev/feast/issues/1696 is resolved.
-            fs._get_provider().teardown_infra(project, [fv], [e])
+            fs.teardown()
 
 
 @contextlib.contextmanager
@@ -233,8 +234,7 @@ def prep_dynamodb_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
 
             yield fs, fv
 
-            # This should be a call to `fs.teardown()` once https://github.com/feast-dev/feast/issues/1696 is resolved.
-            fs._get_provider().teardown_infra(project, [fv], [e])
+            fs.teardown()
 
 
 # Checks that both offline & online store values are as expected

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -133,10 +133,13 @@ def prep_local_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             join_key="driver_id",
             value_type=ValueType.INT32,
         )
+        project = f"test_local_correctness_{str(uuid.uuid4()).replace('-', '')}"
+        print(f"Using project: {project}")
+
         with tempfile.TemporaryDirectory() as repo_dir_name, tempfile.TemporaryDirectory() as data_dir_name:
             config = RepoConfig(
                 registry=str(Path(repo_dir_name) / "registry.db"),
-                project=f"test_bq_correctness_{str(uuid.uuid4()).replace('-', '')}",
+                project=project,
                 provider="local",
                 online_store=SqliteOnlineStoreConfig(
                     path=str(Path(data_dir_name) / "online_store.db")
@@ -146,6 +149,9 @@ def prep_local_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             fs.apply([fv, e])
 
             yield fs, fv
+
+            # This should be a call to `fs.teardown()` once https://github.com/feast-dev/feast/issues/1696 is resolved.
+            fs._get_provider().teardown_infra(project, [fv], [e])
 
 
 @contextlib.contextmanager
@@ -169,10 +175,12 @@ def prep_redis_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             join_key="driver_id",
             value_type=ValueType.INT32,
         )
+        project = f"test_redis_correctness_{str(uuid.uuid4()).replace('-', '')}"
+        print(f"Using project: {project}")
         with tempfile.TemporaryDirectory() as repo_dir_name:
             config = RepoConfig(
                 registry=str(Path(repo_dir_name) / "registry.db"),
-                project=f"test_bq_correctness_{str(uuid.uuid4()).replace('-', '')}",
+                project=project,
                 provider="local",
                 online_store=RedisOnlineStoreConfig(
                     type="redis",
@@ -184,6 +192,9 @@ def prep_redis_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             fs.apply([fv, e])
 
             yield fs, fv
+
+            # This should be a call to `fs.teardown()` once https://github.com/feast-dev/feast/issues/1696 is resolved.
+            fs._get_provider().teardown_infra(project, [fv], [e])
 
 
 @contextlib.contextmanager
@@ -207,10 +218,12 @@ def prep_dynamodb_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             join_key="driver_id",
             value_type=ValueType.INT32,
         )
+        project = f"test_dynamo_correctness_{str(uuid.uuid4()).replace('-', '')}"
+        print(f"Using project {project}")
         with tempfile.TemporaryDirectory() as repo_dir_name:
             config = RepoConfig(
                 registry=str(Path(repo_dir_name) / "registry.db"),
-                project=f"test_bq_correctness_{str(uuid.uuid4()).replace('-', '')}",
+                project=project,
                 provider="aws",
                 online_store=DynamoDBOnlineStoreConfig(region="us-west-2"),
                 offline_store=FileOfflineStoreConfig(),
@@ -219,6 +232,9 @@ def prep_dynamodb_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             fs.apply([fv, e])
 
             yield fs, fv
+
+            # This should be a call to `fs.teardown()` once https://github.com/feast-dev/feast/issues/1696 is resolved.
+            fs._get_provider().teardown_infra(project, [fv], [e])
 
 
 # Checks that both offline & online store values are as expected


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

The `test_offline_online_store_consistency.py` integration test didn't tear down any infrastructure after running. This led to an issue where we ran past the number of dynamo tables allowed for an account: https://github.com/feast-dev/feast/runs/3014392319?check_suite_focus=true

This PR changes the integration test to tear down the infrastructure set up by the fixtures. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1696. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
