### PR TITLE
Cancel BigQuery job if block_until_done call times out or is interrupted

### DIFF
--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -157,6 +157,11 @@ class RegistryInferenceFailure(Exception):
         )
 
 
+class BigQueryJobStillRunning(Exception):
+    def __init__(self, job_id):
+        super().__init__(f"The BigQuery job with ID '{job_id}' is still running.")
+
+
 class BigQueryJobCancelled(Exception):
     def __init__(self, job_id):
         super().__init__(f"The BigQuery job with ID '{job_id}' was cancelled")

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -266,7 +266,7 @@ class BigQueryRetrievalJob(RetrievalJob):
         Args:
             job_config: An optional bigquery.QueryJobConfig to specify options like destination table, dry run, etc.
             timeout: An optional number of seconds for setting the time limit of the QueryJob.
-            retry_cadence: An optional number of seconds for setting how long the job should checked for completion. 
+            retry_cadence: An optional number of seconds for setting how long the job should checked for completion.
 
         Returns:
             Returns the destination table name or returns None if job_config.dry_run is True.
@@ -308,7 +308,7 @@ def block_until_done(
         client: A bigquery.client.Client to monitor the bq_job.
         bq_job: The bigquery.job.QueryJob that blocks until done runnning.
         timeout: An optional number of seconds for setting the time limit of the job.
-        retry_cadence: An optional number of seconds for setting how long the job should checked for completion. 
+        retry_cadence: An optional number of seconds for setting how long the job should checked for completion.
 
     Raises:
         BigQueryJobStillRunning exception if the function has blocked longer than 30 minutes.

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -360,7 +360,7 @@ def _upload_entity_df_into_bigquery(
 
     if type(entity_df) is str:
         job = client.query(f"CREATE TABLE {table_id} AS ({entity_df})")
-        job.result()
+        block_until_done(client, job)
     elif isinstance(entity_df, pandas.DataFrame):
         # Drop the index so that we dont have unnecessary columns
         entity_df.reset_index(drop=True, inplace=True)
@@ -370,7 +370,7 @@ def _upload_entity_df_into_bigquery(
         job = client.load_table_from_dataframe(
             entity_df, table_id, job_config=job_config
         )
-        job.result()
+        block_until_done(client, job)
     else:
         raise ValueError(
             f"The entity dataframe you have provided must be a Pandas DataFrame or BigQuery SQL query, "

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -10,7 +10,7 @@ from jinja2 import BaseLoader, Environment
 from pandas import Timestamp
 from pydantic import StrictStr
 from pydantic.typing import Literal
-from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_fixed
+from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
 from feast import errors
 from feast.data_source import BigQuerySource, DataSource
@@ -253,12 +253,20 @@ class BigQueryRetrievalJob(RetrievalJob):
         """
         return self.query
 
-    def to_bigquery(self, job_config: bigquery.QueryJobConfig = None) -> Optional[str]:
+    def to_bigquery(
+        self,
+        job_config: bigquery.QueryJobConfig = None,
+        timeout: int = 1800,
+        retry_cadence: int = 10,
+    ) -> Optional[str]:
         """
         Triggers the execution of a historical feature retrieval query and exports the results to a BigQuery table.
+        Runs for a maximum amount of time specified by the timeout parameter (defaulting to 30 minutes).
 
         Args:
             job_config: An optional bigquery.QueryJobConfig to specify options like destination table, dry run, etc.
+            timeout: An optional number of seconds for setting the time limit of the QueryJob.
+            retry_cadence: An optional number of seconds for setting how long the job should checked for completion. 
 
         Returns:
             Returns the destination table name or returns None if job_config.dry_run is True.
@@ -278,10 +286,7 @@ class BigQueryRetrievalJob(RetrievalJob):
             )
             return None
 
-        block_until_done(client=self.client, bq_job=bq_job)
-
-        if bq_job.exception():
-            raise bq_job.exception()
+        block_until_done(client=self.client, bq_job=bq_job, timeout=timeout)
 
         print(f"Done writing to '{job_config.destination}'.")
         return str(job_config.destination)
@@ -290,36 +295,47 @@ class BigQueryRetrievalJob(RetrievalJob):
         return self.client.query(self.query).to_arrow()
 
 
-def block_until_done(client, bq_job):
+def block_until_done(
+    client: Client,
+    bq_job: Union[bigquery.job.query.QueryJob, bigquery.job.load.LoadJob],
+    timeout: int = 1800,
+    retry_cadence: int = 10,
+):
     """
-    Waits a maximum of 30 minutes for bq_job to finish running.
+    Waits for bq_job to finish running, up to a maximum amount of time specified by the timeout parameter (defaulting to 30 minutes).
+
     Args:
         client: A bigquery.client.Client to monitor the bq_job.
         bq_job: The bigquery.job.QueryJob that blocks until done runnning.
+        timeout: An optional number of seconds for setting the time limit of the job.
+        retry_cadence: An optional number of seconds for setting how long the job should checked for completion. 
+
     Raises:
         BigQueryJobStillRunning exception if the function has blocked longer than 30 minutes.
         BigQueryJobCancelled exception on a KeyboardInterrupt.
     """
 
-    @retry(
-        wait=wait_fixed(10),
-        stop=stop_after_delay(1800),
-        retry=retry_if_exception_type(BigQueryJobStillRunning),
-        reraise=True,
-    )
     def _wait_until_done(job_id):
         if client.get_job(job_id).state in ["PENDING", "RUNNING"]:
             raise BigQueryJobStillRunning(job_id=job_id)
 
     job_id = bq_job.job_id
     try:
-        _wait_until_done(job_id=job_id)
-    except KeyboardInterrupt:
-        client.cancel_job(job_id)
-        raise BigQueryJobCancelled(job_id=job_id)
+        retryer = Retrying(
+            wait=wait_fixed(retry_cadence),
+            stop=stop_after_delay(timeout),
+            retry=retry_if_exception_type(BigQueryJobStillRunning),
+            reraise=True,
+        )
+        retryer(_wait_until_done, job_id)
 
-    if bq_job.exception():
-        raise bq_job.exception()
+    finally:
+        if client.get_job(job_id).state in ["PENDING", "RUNNING"]:
+            client.cancel_job(job_id)
+            raise BigQueryJobCancelled(job_id=job_id)
+
+        if bq_job.exception():
+            raise bq_job.exception()
 
 
 @dataclass(frozen=True)

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -312,7 +312,7 @@ def block_until_done(
 
     Raises:
         BigQueryJobStillRunning exception if the function has blocked longer than 30 minutes.
-        BigQueryJobCancelled exception on a KeyboardInterrupt.
+        BigQueryJobCancelled exception to signify when that the job has been cancelled (i.e. from timeout or KeyboardInterrupt.
     """
 
     def _wait_until_done(job_id):

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -287,15 +287,12 @@ class BigQueryRetrievalJob(RetrievalJob):
 
 
 def block_until_done(client, bq_job):
-    def _cancel_job(job_id):
-        client.cancel_job(job_id)
-        raise BigQueryJobCancelled(job_id=job_id)
-
     def _is_done(job_id):
         try:
             return client.get_job(job_id).state in ["DONE", "SUCCESS"]
         except KeyboardInterrupt:
-            _cancel_job(job_id)
+            client.cancel_job(job_id)
+            raise BigQueryJobCancelled(job_id=job_id)
 
     @retry(wait=wait_fixed(10), stop=stop_after_delay(1800), reraise=True)
     def _wait_until_done(job_id):
@@ -308,7 +305,8 @@ def block_until_done(client, bq_job):
         raise bq_job.exception()
 
     if not _is_done(job_id):
-        _cancel_job(job_id)
+        client.cancel_job(job_id)
+        raise BigQueryJobCancelled(job_id=job_id)
 
 
 @dataclass(frozen=True)

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -312,7 +312,7 @@ def block_until_done(
 
     Raises:
         BigQueryJobStillRunning exception if the function has blocked longer than 30 minutes.
-        BigQueryJobCancelled exception to signify when that the job has been cancelled (i.e. from timeout or KeyboardInterrupt.
+        BigQueryJobCancelled exception to signify when that the job has been cancelled (i.e. from timeout or KeyboardInterrupt).
     """
 
     def _wait_until_done(job_id):

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -293,7 +293,7 @@ def block_until_done(client, bq_job):
 
     def _is_done(job_id):
         try:
-            return client.get_job(job_id).state in ["PENDING", "RUNNING"]
+            return client.get_job(job_id).state in ["DONE", "SUCCESS"]
         except KeyboardInterrupt:
             _cancel_job(job_id)
 


### PR DESCRIPTION
Signed-off-by: Cody Lin <codyl@twitter.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

If a user decides to abort a `to_bigquery` run (like via a `ctrl-c`), the job should also be cancelled. The PR also fixes the retry logic of getting the bq_job state, and raises a better exception on timeout.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
(Not large enough for issue)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
