### PR TITLE
Fix Python to Feast `list[int]` mapping

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -235,7 +235,9 @@ def _python_value_to_proto_value(feast_value_type, value) -> ProtoValue:
             return ProtoValue(
                 int32_list_val=Int32List(
                     val=[
-                        item if type(item) is np.int32 else _type_err(item, np.int32)
+                        item
+                        if type(item) in [np.int32, int]
+                        else _type_err(item, np.int32)
                         for item in value
                     ]
                 )
@@ -246,7 +248,7 @@ def _python_value_to_proto_value(feast_value_type, value) -> ProtoValue:
                 int64_list_val=Int64List(
                     val=[
                         item
-                        if type(item) in [np.int64, np.int32]
+                        if type(item) in [np.int64, np.int32, int]
                         else _type_err(item, np.int64)
                         for item in value
                     ]
@@ -258,7 +260,7 @@ def _python_value_to_proto_value(feast_value_type, value) -> ProtoValue:
                 int64_list_val=Int64List(
                     val=[
                         item
-                        if type(item) in [np.int64, np.int32]
+                        if type(item) in [np.int64, np.int32, int]
                         else _type_err(item, np.int64)
                         for item in value
                     ]


### PR DESCRIPTION
Corrects a case where if elements in list were not `numpy` types
type mapping would fail.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Fixes case where type mapping failed (in my case from Parquet FileSource)
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
