### PR TITLE
Added --skip-source-validation flag to feast apply

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -181,12 +181,12 @@ def feature_view_list(ctx: click.Context):
 
 @cli.command("apply", cls=NoOptionDefaultFormat)
 @click.option(
-    "--validate-off",
+    "--skip-source-validation",
     is_flag=True,
-    help="Don't validate the data sources.",
+    help="Don't validate the data sources by checking for that the tables exist.",
 )
 @click.pass_context
-def apply_total_command(ctx: click.Context, validate_off: bool):
+def apply_total_command(ctx: click.Context, skip_source_validation: bool):
     """
     Create or update a feature store deployment
     """
@@ -194,7 +194,7 @@ def apply_total_command(ctx: click.Context, validate_off: bool):
     cli_check_repo(repo)
     repo_config = load_repo_config(repo)
     try:
-        apply_total(repo_config, repo, validate_off)
+        apply_total(repo_config, repo, skip_source_validation)
     except FeastProviderLoginError as e:
         print(str(e))
 

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -180,8 +180,13 @@ def feature_view_list(ctx: click.Context):
 
 
 @cli.command("apply", cls=NoOptionDefaultFormat)
+@click.option(
+    "--validate-off",
+    is_flag=True,
+    help="Don't validate the data sources.",
+)
 @click.pass_context
-def apply_total_command(ctx: click.Context):
+def apply_total_command(ctx: click.Context, validate_off: bool):
     """
     Create or update a feature store deployment
     """
@@ -189,7 +194,7 @@ def apply_total_command(ctx: click.Context):
     cli_check_repo(repo)
     repo_config = load_repo_config(repo)
     try:
-        apply_total(repo_config, repo)
+        apply_total(repo_config, repo, validate_off)
     except FeastProviderLoginError as e:
         print(str(e))
 

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -111,7 +111,7 @@ def parse_repo(repo_root: Path) -> ParsedRepo:
 
 
 @log_exceptions_and_usage
-def apply_total(repo_config: RepoConfig, repo_path: Path, validate_off: bool):
+def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool):
     from colorama import Fore, Style
 
     os.chdir(repo_path)
@@ -133,7 +133,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, validate_off: bool):
     repo = parse_repo(repo_path)
     data_sources = [t.input for t in repo.feature_views]
 
-    if not validate_off:
+    if not skip_source_validation:
         # Make sure the data source used by this feature view is supported by Feast
         for data_source in data_sources:
             data_source.validate(repo_config)

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -111,7 +111,7 @@ def parse_repo(repo_root: Path) -> ParsedRepo:
 
 
 @log_exceptions_and_usage
-def apply_total(repo_config: RepoConfig, repo_path: Path):
+def apply_total(repo_config: RepoConfig, repo_path: Path, validate_off: bool):
     from colorama import Fore, Style
 
     os.chdir(repo_path)
@@ -133,9 +133,10 @@ def apply_total(repo_config: RepoConfig, repo_path: Path):
     repo = parse_repo(repo_path)
     data_sources = [t.input for t in repo.feature_views]
 
-    # Make sure the data source used by this feature view is supported by Feast
-    for data_source in data_sources:
-        data_source.validate(repo_config)
+    if not validate_off:
+        # Make sure the data source used by this feature view is supported by Feast
+        for data_source in data_sources:
+            data_source.validate(repo_config)
 
     # Make inferences
     update_entities_with_inferred_types_from_feature_views(


### PR DESCRIPTION
Signed-off-by: David Y Liu <davidyliuliu@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Companies that have permission controls may make validation impossible since one user may not have access to all the tables of the data sources, and therefore can't run `feast apply`. 

Example error msg upon running `feast apply`
`google.api_core.exceptions.Forbidden: 403 GET https://bigquery.googleapis.com/bigquery/v2/projects/twttr-gcp-aggregates-vteam-stg/datasets/wtf/tables/country_candidate_user_aggregates_v1?prettyPrint=false: Access Denied: Table twttr-gcp-aggregates-vteam-stg:wtf.country_candidate_user_aggregates_v1: Permission bigquery.tables.get denied on table twttr-gcp-aggregates-vteam-stg:wtf.country_candidate_user_aggregates_v1 (or it may not exist).`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The newly added --skip-source-validation flag in `feast apply` turns off data source validation when calling feast apply. This may be useful if you have strict permissioning and can't check for the existence of each table. 
```
