### PR TITLE
Handle case where`_LIST` type is empty

### DIFF
--- a/sdk/python/feast/feature.py
+++ b/sdk/python/feast/feature.py
@@ -40,7 +40,7 @@ class Feature:
         if not isinstance(dtype, ValueType):
             raise ValueError("dtype is not a valid ValueType")
         if dtype is ValueType.UNKNOWN:
-            raise ValueError(f"dtype cannont be {dtype}")
+            raise ValueError(f"dtype cannot be {dtype}")
         self._dtype = dtype
         if labels is None:
             self._labels = dict()

--- a/sdk/python/feast/feature.py
+++ b/sdk/python/feast/feature.py
@@ -39,6 +39,8 @@ class Feature:
         self._name = name
         if not isinstance(dtype, ValueType):
             raise ValueError("dtype is not a valid ValueType")
+        if dtype is ValueType.UNKNOWN:
+            raise ValueError(f"dtype cannont be {dtype}")
         self._dtype = dtype
         if labels is None:
             self._labels = dict()

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -48,23 +48,28 @@ def feast_value_type_to_python_type(field_value_proto: ProtoValue) -> Any:
     field_value_dict = MessageToDict(field_value_proto)
 
     for k, v in field_value_dict.items():
+        if "List" in k:
+            val = v.get("val", [])
+        else:
+            val = v
+
         if k == "int64Val":
-            return int(v)
+            return int(val)
         if k == "bytesVal":
-            return bytes(v)
+            return bytes(val)
         if (k == "int64ListVal") or (k == "int32ListVal"):
-            return [int(item) for item in v["val"]]
+            return [int(item) for item in val]
         if (k == "floatListVal") or (k == "doubleListVal"):
-            return [float(item) for item in v["val"]]
+            return [float(item) for item in val]
         if k == "stringListVal":
-            return [str(item) for item in v["val"]]
+            return [str(item) for item in val]
         if k == "bytesListVal":
-            return [bytes(item) for item in v["val"]]
+            return [bytes(item) for item in val]
         if k == "boolListVal":
-            return [bool(item) for item in v["val"]]
+            return [bool(item) for item in val]
 
         if k in ["int32Val", "floatVal", "doubleVal", "stringVal", "boolVal"]:
-            return v
+            return val
         else:
             raise TypeError(
                 f"Casting to Python native type for type {k} failed. "
@@ -277,11 +282,16 @@ def _python_value_to_proto_value(feast_value_type, value) -> ProtoValue:
 def python_value_to_proto_value(
     value: Any, feature_type: ValueType = None
 ) -> ProtoValue:
-    value_type = (
-        python_type_to_feast_value_type("", value)
-        if value is not None
-        else feature_type
-    )
+    value_type = feature_type
+    if value is not None:
+        if isinstance(value, (list, np.ndarray)):
+            value_type = (
+                feature_type
+                if len(value) == 0
+                else python_type_to_feast_value_type("", value)
+            )
+        else:
+            value_type = python_type_to_feast_value_type("", value)
     return _python_value_to_proto_value(value_type, value)
 
 

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -193,7 +193,7 @@ def python_values_to_feast_value_type(name: str, values: Any, recurse: bool = Tr
         if inferred_dtype is ValueType.UNKNOWN:
             inferred_dtype = current_dtype
         else:
-            if current_dtype != inferred_dtype:
+            if current_dtype != inferred_dtype and current_dtype != ValueType.UNKNOWN:
                 raise TypeError(
                     f"Input entity {name} has mixed types, {current_dtype} and {inferred_dtype}. That is not allowed. "
                 )

--- a/sdk/python/tests/data/data_creator.py
+++ b/sdk/python/tests/data/data_creator.py
@@ -11,12 +11,15 @@ def create_dataset(
     entity_type: ValueType = ValueType.INT32,
     feature_dtype: str = None,
     feature_is_list: bool = False,
+    list_is_empty: bool = False,
 ) -> pd.DataFrame:
     now = datetime.now().replace(microsecond=0, second=0, minute=0)
     ts = pd.Timestamp(now).round("ms")
     data = {
         "driver_id": get_entities_for_value_type(entity_type),
-        "value": get_feature_values_for_dtype(feature_dtype, feature_is_list),
+        "value": get_feature_values_for_dtype(
+            feature_dtype, feature_is_list, list_is_empty
+        ),
         "ts_1": [
             ts - timedelta(hours=4),
             ts,
@@ -44,7 +47,7 @@ def get_entities_for_value_type(value_type: ValueType) -> List:
     return value_type_map[value_type]
 
 
-def get_feature_values_for_dtype(dtype: str, is_list: bool) -> List:
+def get_feature_values_for_dtype(dtype: str, is_list: bool, is_empty: bool) -> List:
     if dtype is None:
         return [0.1, None, 0.3, 4, 5]
     # TODO(adchia): for int columns, consider having a better error when dealing with None values (pandas int dfs can't
@@ -57,8 +60,9 @@ def get_feature_values_for_dtype(dtype: str, is_list: bool) -> List:
         "bool": [True, None, False, True, False],
     }
     non_list_val = dtype_map[dtype]
-    # Duplicate the value once if this is a list
     if is_list:
+        if is_empty:
+            return [[] for n in non_list_val]
         return [[n, n] if n is not None else None for n in non_list_val]
     else:
         return non_list_val

--- a/sdk/python/tests/data/data_creator.py
+++ b/sdk/python/tests/data/data_creator.py
@@ -63,6 +63,7 @@ def get_feature_values_for_dtype(
     }
     non_list_val = dtype_map[dtype]
     if is_list:
+        # TODO: Add test where all lists are empty and type inference is expected to fail.
         if has_empty_list:
             # Need at least one non-empty element for type inference
             return [[] for n in non_list_val[:-1]] + [non_list_val[-1:]]

--- a/sdk/python/tests/data/data_creator.py
+++ b/sdk/python/tests/data/data_creator.py
@@ -62,7 +62,8 @@ def get_feature_values_for_dtype(dtype: str, is_list: bool, is_empty: bool) -> L
     non_list_val = dtype_map[dtype]
     if is_list:
         if is_empty:
-            return [[] for n in non_list_val]
+            # Need at least one non-empty element for type inference
+            return [[] for n in non_list_val[:-1]] + [non_list_val[-1:]]
         return [[n, n] if n is not None else None for n in non_list_val]
     else:
         return non_list_val

--- a/sdk/python/tests/data/data_creator.py
+++ b/sdk/python/tests/data/data_creator.py
@@ -11,14 +11,14 @@ def create_dataset(
     entity_type: ValueType = ValueType.INT32,
     feature_dtype: str = None,
     feature_is_list: bool = False,
-    list_is_empty: bool = False,
+    list_has_empty_list: bool = False,
 ) -> pd.DataFrame:
     now = datetime.now().replace(microsecond=0, second=0, minute=0)
     ts = pd.Timestamp(now).round("ms")
     data = {
         "driver_id": get_entities_for_value_type(entity_type),
         "value": get_feature_values_for_dtype(
-            feature_dtype, feature_is_list, list_is_empty
+            feature_dtype, feature_is_list, list_has_empty_list
         ),
         "ts_1": [
             ts - timedelta(hours=4),
@@ -47,7 +47,9 @@ def get_entities_for_value_type(value_type: ValueType) -> List:
     return value_type_map[value_type]
 
 
-def get_feature_values_for_dtype(dtype: str, is_list: bool, is_empty: bool) -> List:
+def get_feature_values_for_dtype(
+    dtype: str, is_list: bool, has_empty_list: bool
+) -> List:
     if dtype is None:
         return [0.1, None, 0.3, 4, 5]
     # TODO(adchia): for int columns, consider having a better error when dealing with None values (pandas int dfs can't
@@ -61,7 +63,7 @@ def get_feature_values_for_dtype(dtype: str, is_list: bool, is_empty: bool) -> L
     }
     non_list_val = dtype_map[dtype]
     if is_list:
-        if is_empty:
+        if has_empty_list:
             # Need at least one non-empty element for type inference
             return [[] for n in non_list_val[:-1]] + [non_list_val[-1:]]
         return [[n, n] if n is not None else None for n in non_list_val]

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -7,9 +7,8 @@ import pandas as pd
 import pytest
 
 from feast.infra.offline_stores.offline_store import RetrievalJob
-from feast.type_map import python_type_to_feast_value_type
 from feast.value_type import ValueType
-from tests.data.data_creator import create_dataset, get_feature_values_for_dtype
+from tests.data.data_creator import create_dataset
 from tests.integration.feature_repos.repo_configuration import (
     FULL_REPO_CONFIGS,
     REDIS_CONFIG,
@@ -230,15 +229,25 @@ def test_feature_get_online_features_types_match(online_types_test_fixtures):
 
 
 def create_feature_view(feature_dtype, feature_is_list, list_is_empty, data_source):
-    return driver_feature_view(
-        data_source,
-        value_type=python_type_to_feast_value_type(
-            feature_dtype,
-            value=get_feature_values_for_dtype(
-                feature_dtype, feature_is_list, list_is_empty
-            )[0],
-        ),
-    )
+    if feature_is_list is True:
+        if feature_dtype == "int32":
+            value_type = ValueType.INT32_LIST
+        elif feature_dtype == "int64":
+            value_type = ValueType.INT64_LIST
+        elif feature_dtype == "float":
+            value_type = ValueType.FLOAT_LIST
+        elif feature_dtype == "bool":
+            value_type = ValueType.BOOL_LIST
+    else:
+        if feature_dtype == "int32":
+            value_type = ValueType.INT32
+        elif feature_dtype == "int64":
+            value_type = ValueType.INT64
+        elif feature_dtype == "float":
+            value_type = ValueType.FLOAT
+        elif feature_dtype == "bool":
+            value_type = ValueType.BOOL
+    return driver_feature_view(data_source, value_type=value_type,)
 
 
 def assert_expected_historical_feature_types(

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -329,6 +329,7 @@ def assert_expected_arrow_types(
             ) in [
                 f"struct<list: list<item: struct<item: {arrow_type}>> not null>",
                 f"struct<list: list<item: struct<item: {arrow_type}>>>",
+                "struct<list: list<item: null>>",
             ]
         else:
             assert (

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -329,7 +329,7 @@ def assert_expected_arrow_types(
             ) in [
                 f"struct<list: list<item: struct<item: {arrow_type}>> not null>",
                 f"struct<list: list<item: struct<item: {arrow_type}>>>",
-                "struct<list: list<item: null>>",
+                "struct<list: list<item: null>>",  # TODO: Remove this after #1889 is merged
             ]
         else:
             assert (

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -43,16 +43,16 @@ def populate_test_configs(offline: bool):
                     and feature_is_list is True
                 ):
                     continue
-                for list_is_empty in [True, False]:
-                    # For non list features `list_is_empty` does nothing
-                    if feature_is_list is False and list_is_empty is True:
+                for has_empty_list in [True, False]:
+                    # For non list features `has_empty_list` does nothing
+                    if feature_is_list is False and has_empty_list is True:
                         continue
                     configs.append(
                         TypeTestConfig(
                             entity_type=entity_type,
                             feature_dtype=feature_dtype,
                             feature_is_list=feature_is_list,
-                            list_is_empty=list_is_empty,
+                            has_empty_list=has_empty_list,
                             test_repo_config=test_repo_config,
                         )
                     )
@@ -64,7 +64,7 @@ class TypeTestConfig:
     entity_type: ValueType
     feature_dtype: str
     feature_is_list: bool
-    list_is_empty: bool
+    has_empty_list: bool
     test_repo_config: IntegrationTestRepoConfig
 
 
@@ -105,7 +105,7 @@ def get_fixtures(request):
             config.entity_type,
             config.feature_dtype,
             config.feature_is_list,
-            config.list_is_empty,
+            config.has_empty_list,
         )
         data_source = type_test_environment.data_source_creator.create_data_source(
             df,
@@ -115,7 +115,7 @@ def get_fixtures(request):
         fv = create_feature_view(
             config.feature_dtype,
             config.feature_is_list,
-            config.list_is_empty,
+            config.has_empty_list,
             data_source,
         )
         yield type_test_environment, config, data_source, fv
@@ -150,7 +150,7 @@ def test_feature_get_historical_features_types_match(offline_types_test_fixtures
     environment, config, data_source, fv = offline_types_test_fixtures
     fs = environment.feature_store
     fv = create_feature_view(
-        config.feature_dtype, config.feature_is_list, config.list_is_empty, data_source
+        config.feature_dtype, config.feature_is_list, config.has_empty_list, data_source
     )
     entity = driver()
     fs.apply([fv, entity])
@@ -195,7 +195,7 @@ def test_feature_get_historical_features_types_match(offline_types_test_fixtures
 def test_feature_get_online_features_types_match(online_types_test_fixtures):
     environment, config, data_source, fv = online_types_test_fixtures
     fv = create_feature_view(
-        config.feature_dtype, config.feature_is_list, config.list_is_empty, data_source
+        config.feature_dtype, config.feature_is_list, config.has_empty_list, data_source
     )
     fs = environment.feature_store
     features = [fv.name + ":value"]
@@ -228,7 +228,7 @@ def test_feature_get_online_features_types_match(online_types_test_fixtures):
             assert isinstance(feature, expected_dtype)
 
 
-def create_feature_view(feature_dtype, feature_is_list, list_is_empty, data_source):
+def create_feature_view(feature_dtype, feature_is_list, has_empty_list, data_source):
     if feature_is_list is True:
         if feature_dtype == "int32":
             value_type = ValueType.INT32_LIST

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -220,10 +220,13 @@ def test_feature_get_online_features_types_match(online_types_test_fixtures):
         config.feature_dtype
     ]
     if config.feature_is_list:
-        assert isinstance(online_features["value"][0], list)
-        assert isinstance(online_features["value"][0][0], expected_dtype)
+        for feature in online_features["value"]:
+            assert isinstance(feature, list)
+            for element in feature:
+                assert isinstance(element, expected_dtype)
     else:
-        assert isinstance(online_features["value"][0], expected_dtype)
+        for feature in online_features["value"]:
+            assert isinstance(feature, expected_dtype)
 
 
 def create_feature_view(feature_dtype, feature_is_list, list_is_empty, data_source):
@@ -280,11 +283,15 @@ def assert_feature_list_types(
     ]
     assert pd.api.types.is_object_dtype(historical_features_df.dtypes["value"])
     if provider == "gcp":
-        assert isinstance(historical_features_df.value[0]["list"], (np.ndarray, list))
-        assert isinstance(historical_features_df.value[0]["list"][0]["item"], expected_dtype)
+        for feature in historical_features_df.value:
+            assert isinstance(feature["list"], (np.ndarray, list))
+            for element in feature["list"]:
+                assert isinstance(element["item"], expected_dtype)
     else:
-        assert isinstance(historical_features_df.value[0], (np.ndarray, list))
-        assert isinstance(historical_features_df.value[0][0], expected_dtype)
+        for feature in historical_features_df.value:
+            assert isinstance(feature, (np.ndarray, list))
+            for element in feature:
+                assert isinstance(element, expected_dtype)
 
 
 def assert_expected_arrow_types(

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -44,6 +44,9 @@ def populate_test_configs(offline: bool):
                 ):
                     continue
                 for list_is_empty in [True, False]:
+                    # For non list features `list_is_empty` does nothing
+                    if feature_is_list is False and list_is_empty is True:
+                        continue
                     configs.append(
                         TypeTestConfig(
                             entity_type=entity_type,
@@ -53,9 +56,6 @@ def populate_test_configs(offline: bool):
                             test_repo_config=test_repo_config,
                         )
                     )
-                    # For non list features `list_is_empty` does nothing
-                    if feature_is_list is False:
-                        continue
     return configs
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR deals with multiple issues around empty list features regarding type inference.

It is my opinion that these fixes should be somewhat of a stop gap and that really the way that types are dealt with should be overhauled in Feast.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix issue which prevented empty lists being materialized into online stores or retrieved from historical stores.
```
