### PR TITLE
Update redis options parsing 

### DIFF
--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -102,7 +102,7 @@ class RedisOnlineStore(OnlineStore):
         params = {}
         for c in connection_string.split(","):
             if "=" in c:
-                kv = c.split("=")
+                kv = c.split("=", 1)
                 try:
                     kv[1] = json.loads(kv[1])
                 except json.JSONDecodeError:

--- a/sdk/python/tests/test_cli_redis.py
+++ b/sdk/python/tests/test_cli_redis.py
@@ -3,8 +3,9 @@ import string
 import tempfile
 from pathlib import Path
 from textwrap import dedent
-import redis
+
 import pytest
+import redis
 
 from feast.feature_store import FeatureStore
 from tests.cli_utils import CliRunner
@@ -95,7 +96,7 @@ def test_connection_error() -> None:
 
         result = runner.run(["apply"], cwd=repo_path)
         assert result.returncode == 0
-        
+
         # Redis does not support names for its databases.
         with pytest.raises(redis.exceptions.ResponseError):
             basic_rw_test(

--- a/sdk/python/tests/test_cli_redis.py
+++ b/sdk/python/tests/test_cli_redis.py
@@ -3,7 +3,7 @@ import string
 import tempfile
 from pathlib import Path
 from textwrap import dedent
-
+import redis
 import pytest
 
 from feast.feature_store import FeatureStore
@@ -58,3 +58,47 @@ def test_basic() -> None:
 
         result = runner.run(["teardown"], cwd=repo_path)
         assert result.returncode == 0
+
+
+@pytest.mark.integration
+def test_connection_error() -> None:
+    project_id = "".join(
+        random.choice(string.ascii_lowercase + string.digits) for _ in range(10)
+    )
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as repo_dir_name, tempfile.TemporaryDirectory() as data_dir_name:
+
+        repo_path = Path(repo_dir_name)
+        data_path = Path(data_dir_name)
+
+        repo_config = repo_path / "feature_store.yaml"
+
+        repo_config.write_text(
+            dedent(
+                f"""
+        project: {project_id}
+        registry: {data_path / "registry.db"}
+        provider: local
+        offline_store:
+            type: file
+        online_store:
+            type: redis
+            connection_string: localhost:6379,db=0=
+        """
+            )
+        )
+
+        repo_example = repo_path / "example.py"
+        repo_example.write_text(
+            (Path(__file__).parent / "example_feature_repo_2.py").read_text()
+        )
+
+        result = runner.run(["apply"], cwd=repo_path)
+        assert result.returncode == 0
+        
+        # Redis does not support names for its databases.
+        with pytest.raises(redis.exceptions.ResponseError):
+            basic_rw_test(
+                FeatureStore(repo_path=str(repo_path), config=None),
+                view_name="driver_hourly_stats",
+            )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
The Redis connection string is a comma-separated string, where each additional parameter in addition to host and port is in the format `key=value`. 
This proposal fixing the parsing in cases where the parameter values contain the `=` symbol, for example `localhost:6379,password=my=password`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
