### PR TITLE
Fix dry_run bug that was making to_bigquery hang indefinitely

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -268,16 +268,16 @@ class BigQueryRetrievalJob(RetrievalJob):
 
         bq_job = self.client.query(self.query, job_config=job_config)
 
-        block_until_done(client=self.client, bq_job=bq_job)
-
-        if bq_job.exception():
-            raise bq_job.exception()
-
         if job_config.dry_run:
             print(
                 "This query will process {} bytes.".format(bq_job.total_bytes_processed)
             )
             return None
+
+        block_until_done(client=self.client, bq_job=bq_job)
+
+        if bq_job.exception():
+            raise bq_job.exception()
 
         print(f"Done writing to '{job_config.destination}'.")
         return str(job_config.destination)


### PR DESCRIPTION
Signed-off-by: Cody Lin <codyl@twitter.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
In PR #1661, I accidentally switched the order of the `dry_run` output and `_block_until_done` ([these lines](https://github.com/feast-dev/feast/pull/1661/files#diff-14f38fcbdc2240bb60b9f558d133b174f5b6059cfcd959eef8b9c49bb5be8838L239-L245)) in `BigQueryRetrievalJob.to_bigquery` that was making any `dry_run` call to hang. I fix it here.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
(Not large enough for issue)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
