### PR TITLE
Remove type comments

### DIFF
--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -388,7 +388,7 @@ class Client:
                 ListProjectsRequest(),
                 timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                 metadata=self._get_grpc_metadata(),
-            )  # type: ListProjectsResponse
+            )
             return list(response.projects)
 
     def create_project(self, project: str):
@@ -408,7 +408,7 @@ class Client:
                 CreateProjectRequest(name=project),
                 timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                 metadata=self._get_grpc_metadata(),
-            )  # type: CreateProjectResponse
+            )
 
     def archive_project(self, project):
         """
@@ -430,7 +430,7 @@ class Client:
                     ArchiveProjectRequest(name=project),
                     timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                     metadata=self._get_grpc_metadata(),
-                )  # type: ArchiveProjectResponse
+                )
             except grpc.RpcError as e:
                 raise grpc.RpcError(e.details())
 
@@ -523,7 +523,7 @@ class Client:
                     ApplyEntityRequest(project=project, spec=entity_proto),  # type: ignore
                     timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                     metadata=self._get_grpc_metadata(),
-                )  # type: ApplyEntityResponse
+                )
             except grpc.RpcError as e:
                 raise grpc.RpcError(e.details())
 
@@ -558,7 +558,7 @@ class Client:
             # Get latest entities from Feast Core
             entity_protos = self._core_service.ListEntities(
                 ListEntitiesRequest(filter=filter), metadata=self._get_grpc_metadata(),
-            )  # type: ListEntitiesResponse
+            )
 
             # Extract entities and return
             entities = []
@@ -593,7 +593,7 @@ class Client:
                 get_entity_response = self._core_service.GetEntity(
                     GetEntityRequest(project=project, name=name.strip()),
                     metadata=self._get_grpc_metadata(),
-                )  # type: GetEntityResponse
+                )
             except grpc.RpcError as e:
                 raise grpc.RpcError(e.details())
             entity = Entity.from_proto(get_entity_response.entity)
@@ -646,7 +646,7 @@ class Client:
                     ApplyFeatureTableRequest(project=project, table_spec=feature_table_proto),  # type: ignore
                     timeout=self._config.getint(opt.GRPC_CONNECTION_TIMEOUT),
                     metadata=self._get_grpc_metadata(),
-                )  # type: ApplyFeatureTableResponse
+                )
             except grpc.RpcError as e:
                 raise grpc.RpcError(e.details())
 
@@ -683,7 +683,7 @@ class Client:
             feature_table_protos = self._core_service.ListFeatureTables(
                 ListFeatureTablesRequest(filter=filter),
                 metadata=self._get_grpc_metadata(),
-            )  # type: ListFeatureTablesResponse
+            )
 
             # Extract feature tables and return
             feature_tables = []
@@ -718,7 +718,7 @@ class Client:
                 get_feature_table_response = self._core_service.GetFeatureTable(
                     GetFeatureTableRequest(project=project, name=name.strip()),
                     metadata=self._get_grpc_metadata(),
-                )  # type: GetFeatureTableResponse
+                )
             except grpc.RpcError as e:
                 raise grpc.RpcError(e.details())
             return FeatureTable.from_proto(get_feature_table_response.table)
@@ -785,7 +785,7 @@ class Client:
 
             feature_protos = self._core_service.ListFeatures(
                 ListFeaturesRequest(filter=filter), metadata=self._get_grpc_metadata(),
-            )  # type: ListFeaturesResponse
+            )
 
             # Extract features and return
             features_dict = {}

--- a/sdk/python/feast/client.py
+++ b/sdk/python/feast/client.py
@@ -40,27 +40,17 @@ from feast.loaders.ingest import (
 from feast.online_response import OnlineResponse, _infer_online_entity_rows
 from feast.protos.feast.core.CoreService_pb2 import (
     ApplyEntityRequest,
-    ApplyEntityResponse,
     ApplyFeatureTableRequest,
-    ApplyFeatureTableResponse,
     ArchiveProjectRequest,
-    ArchiveProjectResponse,
     CreateProjectRequest,
-    CreateProjectResponse,
     DeleteFeatureTableRequest,
     GetEntityRequest,
-    GetEntityResponse,
     GetFeastCoreVersionRequest,
     GetFeatureTableRequest,
-    GetFeatureTableResponse,
     ListEntitiesRequest,
-    ListEntitiesResponse,
     ListFeaturesRequest,
-    ListFeaturesResponse,
     ListFeatureTablesRequest,
-    ListFeatureTablesResponse,
     ListProjectsRequest,
-    ListProjectsResponse,
 )
 from feast.protos.feast.core.CoreService_pb2_grpc import CoreServiceStub
 from feast.protos.feast.serving.ServingService_pb2 import (

--- a/sdk/python/feast/config.py
+++ b/sdk/python/feast/config.py
@@ -112,8 +112,8 @@ class Config:
         if options and isinstance(options, dict):
             self._options = options
 
-        self._config = config  # type: ConfigParser
-        self._path = path  # type: str
+        self._config = config
+        self._path = path
 
     def _get(self, option, default, get_method):
         fallback = {} if default is _UNSET else {"fallback": default}

--- a/sdk/python/feast/entity.py
+++ b/sdk/python/feast/entity.py
@@ -49,6 +49,7 @@ class Entity:
         else:
             self._join_key = name
 
+        self._labels: MutableMapping[str, str]
         if labels is None:
             self._labels = dict()
         else:

--- a/sdk/python/feast/entity.py
+++ b/sdk/python/feast/entity.py
@@ -50,7 +50,7 @@ class Entity:
             self._join_key = name
 
         if labels is None:
-            self._labels = dict()  # type: MutableMapping[str, str]
+            self._labels = dict()
         else:
             self._labels = labels
 

--- a/sdk/python/feast/feature_table.py
+++ b/sdk/python/feast/feature_table.py
@@ -59,6 +59,8 @@ class FeatureTable:
         self._features = features
         self._batch_source = batch_source
         self._stream_source = stream_source
+
+        self._labels: MutableMapping[str, str]
         if labels is None:
             self._labels = dict()
         else:

--- a/sdk/python/feast/feature_table.py
+++ b/sdk/python/feast/feature_table.py
@@ -60,7 +60,7 @@ class FeatureTable:
         self._batch_source = batch_source
         self._stream_source = stream_source
         if labels is None:
-            self._labels = dict()  # type: MutableMapping[str, str]
+            self._labels = dict()
         else:
             self._labels = labels
 

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -172,7 +172,7 @@ def _get_requested_feature_views_to_features_dict(
     """Create a dict of FeatureView -> List[Feature] for all requested features.
     Set full_feature_names to True to have feature names prefixed by their feature view name."""
 
-    feature_views_to_feature_map = {}  # type: Dict[FeatureView, List[str]]
+    feature_views_to_feature_map = {} 
 
     for ref in feature_refs:
         ref_parts = ref.split(":")

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -172,7 +172,7 @@ def _get_requested_feature_views_to_features_dict(
     """Create a dict of FeatureView -> List[Feature] for all requested features.
     Set full_feature_names to True to have feature names prefixed by their feature view name."""
 
-    feature_views_to_feature_map = {} 
+    feature_views_to_feature_map: Dict[FeatureView, List[str]] = {}
 
     for ref in feature_refs:
         ref_parts = ref.split(":")

--- a/sdk/python/tests/feast_serving_server.py
+++ b/sdk/python/tests/feast_serving_server.py
@@ -21,7 +21,7 @@ class ServingServicer(Serving.ServingServiceServicer):
             self.__connect_core(core_url)
             self._feature_tables = (
                 dict()
-            )  # type: Dict[str, FeatureTableProto.FeatureTable]
+            )
 
     def __connect_core(self, core_url: str):
         if not core_url:
@@ -44,7 +44,7 @@ class ServingServicer(Serving.ServingServiceServicer):
         # Get updated list of feature tables
         feature_tables = (
             self._core_service_stub.ListFeatureTables
-        )  # type: ListFeatureTablesResponse
+        )
 
         # Store each feature table locally
         for feature_table in list(feature_tables.tables):

--- a/sdk/python/tests/feast_serving_server.py
+++ b/sdk/python/tests/feast_serving_server.py
@@ -19,7 +19,7 @@ class ServingServicer(Serving.ServingServiceServicer):
         if core_url:
             self.__core_channel = None
             self.__connect_core(core_url)
-            self._feature_tables = (
+            self._feature_tables: Dict[str, str] = (
                 dict()
             )
 

--- a/sdk/python/tests/feast_serving_server.py
+++ b/sdk/python/tests/feast_serving_server.py
@@ -5,8 +5,6 @@ from typing import Dict
 
 import grpc
 
-from feast.protos.feast.core import FeatureTable_pb2 as FeatureTableProto
-from feast.protos.feast.core.CoreService_pb2 import ListFeatureTablesResponse
 from feast.protos.feast.core.CoreService_pb2_grpc import CoreServiceStub
 from feast.protos.feast.serving import ServingService_pb2_grpc as Serving
 from feast.protos.feast.serving.ServingService_pb2 import GetFeastServingInfoResponse
@@ -19,9 +17,7 @@ class ServingServicer(Serving.ServingServiceServicer):
         if core_url:
             self.__core_channel = None
             self.__connect_core(core_url)
-            self._feature_tables: Dict[str, str] = (
-                dict()
-            )
+            self._feature_tables: Dict[str, str] = (dict())
 
     def __connect_core(self, core_url: str):
         if not core_url:
@@ -42,9 +38,7 @@ class ServingServicer(Serving.ServingServiceServicer):
 
     def __get_feature_tables_from_core(self):
         # Get updated list of feature tables
-        feature_tables = (
-            self._core_service_stub.ListFeatureTables
-        )
+        feature_tables = self._core_service_stub.ListFeatureTables
 
         # Store each feature table locally
         for feature_table in list(feature_tables.tables):

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -657,7 +657,7 @@ class TestClient:
             entity_rows=entity_rows,
             feature_refs=["driver:age", "driver:rating", "driver:null_value"],
             project="driver_project",
-        )  # type: GetOnlineFeaturesResponse
+        )
         mocked_client._serving_service_stub.GetOnlineFeaturesV2.assert_called_with(
             request, metadata=auth_metadata, timeout=10
         )
@@ -747,7 +747,7 @@ class TestClient:
             entity_rows=entity_rows,
             feature_refs=["driver:age", "driver:rating", "driver:null_value"],
             project="driver_project",
-        )  # type: GetOnlineFeaturesResponse
+        )
         mocked_client._serving_service_stub.GetOnlineFeaturesV2.assert_called_with(
             request, metadata=auth_metadata, timeout=10
         )

--- a/sdk/python/tests/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/test_offline_online_store_consistency.py
@@ -78,7 +78,7 @@ def prep_bq_fs_and_fv(
     df = create_dataset()
 
     job_config = bigquery.LoadJobConfig()
-    table_ref = f"{gcp_project}.{bigquery_dataset}.{bq_source_type}_correctness_{int(time.time())}"
+    table_ref = f"{gcp_project}.{bigquery_dataset}.{bq_source_type}_correctness_{int(time.time_ns())}"
     query = f"SELECT * FROM `{table_ref}`"
     job = client.load_table_from_dataframe(df, table_ref, job_config=job_config)
     job.result()


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Type comments are no longer needed given that we support 3.7+. Also, they break mypy as of python 3.9. This PR removes all the instances of `type: Blah` from the codebase.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
(Too small for issue)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
