### PR TITLE
Registry teardown

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -267,10 +267,7 @@ class FeatureStore:
         entities = self.list_entities()
 
         self._get_provider().teardown_infra(self.project, tables, entities)
-        for feature_view in feature_views:
-            self.delete_feature_view(feature_view.name)
-        for feature_table in feature_tables:
-            self._registry.delete_feature_table(feature_table.name, self.project)
+        self._registry.teardown()
 
     @log_exceptions_and_usage
     def get_historical_features(

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -21,8 +21,6 @@ from tempfile import TemporaryFile
 from typing import List, Optional
 from urllib.parse import urlparse
 
-from google.cloud.exceptions import NotFound
-
 from feast.entity import Entity
 from feast.errors import (
     EntityNotFoundException,
@@ -558,6 +556,8 @@ class GCSRegistryStore(RegistryStore):
         self._write_registry(registry_proto)
 
     def teardown(self):
+        from google.cloud.exceptions import NotFound
+
         gs_bucket = self.gcs_client.get_bucket(self._bucket)
         try:
             gs_bucket.delete_blob(self._blob)

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -75,7 +75,6 @@ class Registry:
                 f"Registry path {registry_path} has unsupported scheme {uri.scheme}. Supported schemes are file and gs."
             )
         self.cached_registry_proto_ttl = cache_ttl
-        return
 
     def _initialize_registry(self):
         """Explicitly initializes the registry with an empty proto."""
@@ -111,7 +110,6 @@ class Registry:
         self.cached_registry_proto.entities.append(entity_proto)
         if commit:
             self.commit()
-        return
 
     def list_entities(self, project: str, allow_cache: bool = False) -> List[Entity]:
         """
@@ -502,7 +500,6 @@ class LocalRegistryStore(RegistryStore):
 
     def update_registry_proto(self, registry_proto: RegistryProto):
         self._write_registry(registry_proto)
-        return
 
     def teardown(self):
         try:
@@ -511,7 +508,6 @@ class LocalRegistryStore(RegistryStore):
             # If the file deletion fails with FileNotFoundError, the file has already
             # been deleted.
             pass
-        return
 
     def _write_registry(self, registry_proto: RegistryProto):
         registry_proto.version_id = str(uuid.uuid4())
@@ -519,7 +515,6 @@ class LocalRegistryStore(RegistryStore):
         file_dir = self._filepath.parent
         file_dir.mkdir(exist_ok=True)
         self._filepath.write_bytes(registry_proto.SerializeToString())
-        return
 
 
 class GCSRegistryStore(RegistryStore):
@@ -535,7 +530,6 @@ class GCSRegistryStore(RegistryStore):
         self._uri = urlparse(uri)
         self._bucket = self._uri.hostname
         self._blob = self._uri.path.lstrip("/")
-        return
 
     def get_registry_proto(self):
         from google.cloud import storage
@@ -562,7 +556,6 @@ class GCSRegistryStore(RegistryStore):
 
     def update_registry_proto(self, registry_proto: RegistryProto):
         self._write_registry(registry_proto)
-        return
 
     def teardown(self):
         gs_bucket = self.gcs_client.get_bucket(self._bucket)
@@ -571,7 +564,6 @@ class GCSRegistryStore(RegistryStore):
         except NotFound:
             # If the blob deletion fails with NotFound, it has already been deleted.
             pass
-        return
 
     def _write_registry(self, registry_proto: RegistryProto):
         registry_proto.version_id = str(uuid.uuid4())
@@ -583,7 +575,6 @@ class GCSRegistryStore(RegistryStore):
         file_obj.write(registry_proto.SerializeToString())
         file_obj.seek(0)
         blob.upload_from_file(file_obj)
-        return
 
 
 class S3RegistryStore(RegistryStore):
@@ -636,11 +627,9 @@ class S3RegistryStore(RegistryStore):
 
     def update_registry_proto(self, registry_proto: RegistryProto):
         self._write_registry(registry_proto)
-        return
 
     def teardown(self):
         self.s3_client.Object(self._bucket, self._key).delete()
-        return
 
     def _write_registry(self, registry_proto: RegistryProto):
         registry_proto.version_id = str(uuid.uuid4())

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -395,7 +395,7 @@ class Registry:
         self._get_registry_proto(allow_cache=False)
 
     def teardown(self):
-        """Tears down all local and cloud resources."""
+        """Tears down (removes) the registry."""
         self._registry_store.teardown()
 
     def _prepare_registry_for_changes(self):

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -259,6 +259,7 @@ def teardown(repo_config: RepoConfig, repo_path: Path):
     infra_provider.teardown_infra(
         project, tables=registry_tables, entities=registry_entities
     )
+    registry.teardown()
 
 
 @log_exceptions_and_usage

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -12,6 +12,7 @@ import click
 from click.exceptions import BadParameter
 
 from feast import Entity, FeatureTable
+from feast.feature_store import FeatureStore
 from feast.feature_view import FeatureView
 from feast.inference import (
     update_data_sources_with_inferred_event_timestamp_col,
@@ -242,24 +243,9 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
 
 @log_exceptions_and_usage
 def teardown(repo_config: RepoConfig, repo_path: Path):
-    registry_config = repo_config.get_registry_config()
-    registry = Registry(
-        registry_path=registry_config.path,
-        repo_path=repo_path,
-        cache_ttl=timedelta(seconds=registry_config.cache_ttl_seconds),
-    )
-    project = repo_config.project
-    registry_tables: List[Union[FeatureTable, FeatureView]] = []
-    registry_tables.extend(registry.list_feature_tables(project=project))
-    registry_tables.extend(registry.list_feature_views(project=project))
-
-    registry_entities: List[Entity] = registry.list_entities(project=project)
-
-    infra_provider = get_provider(repo_config, repo_path)
-    infra_provider.teardown_infra(
-        project, tables=registry_tables, entities=registry_entities
-    )
-    registry.teardown()
+    # Cannot pass in both repo_path and repo_config to FeatureStore.
+    feature_store = FeatureStore(repo_path=repo_path, config=None)
+    feature_store.teardown()
 
 
 @log_exceptions_and_usage

--- a/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
@@ -181,6 +181,8 @@ def prep_redshift_fs_and_fv(
 
         yield fs, fv
 
+        fs.teardown()
+
     # Clean up the uploaded Redshift table
     aws_utils.execute_redshift_statement(
         client,

--- a/sdk/python/tests/integration/offline_store/test_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_historical_retrieval.py
@@ -344,6 +344,8 @@ def test_historical_features_from_parquet_sources(
             ).reset_index(drop=True),
         )
 
+        store.teardown()
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
@@ -595,6 +597,8 @@ def test_historical_features_from_bigquery_sources(
         assert_frame_equal(
             actual_df_from_df_entities, table_from_df_entities.to_pandas()
         )
+
+        store.teardown()
 
 
 @pytest.mark.integration

--- a/sdk/python/tests/integration/registration/test_feature_store.py
+++ b/sdk/python/tests/integration/registration/test_feature_store.py
@@ -113,6 +113,8 @@ def test_apply_entity_success(test_feature_store):
         and entity.labels["team"] == "matchmaking"
     )
 
+    test_feature_store.teardown()
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
@@ -153,6 +155,8 @@ def test_apply_entity_integration(test_feature_store):
         and "team" in entity.labels
         and entity.labels["team"] == "matchmaking"
     )
+
+    test_feature_store.teardown()
 
 
 @pytest.mark.parametrize(
@@ -201,6 +205,8 @@ def test_apply_feature_view_success(test_feature_store):
         and feature_views[0].features[3].dtype == ValueType.BYTES_LIST
         and feature_views[0].entities[0] == "fs1_my_entity_1"
     )
+
+    test_feature_store.teardown()
 
 
 @pytest.mark.integration
@@ -265,6 +271,8 @@ def test_feature_view_inference_success(test_feature_store, dataframe_source):
             == actual_bq_using_table_ref_arg_source
             == actual_bq_using_query_arg_source
         )
+
+        test_feature_store.teardown()
 
 
 @pytest.mark.integration
@@ -337,6 +345,8 @@ def test_apply_feature_view_integration(test_feature_store):
     feature_views = test_feature_store.list_feature_views()
     assert len(feature_views) == 0
 
+    test_feature_store.teardown()
+
 
 @pytest.mark.parametrize(
     "test_feature_store", [lazy_fixture("feature_store_with_local_registry")],
@@ -397,6 +407,8 @@ def test_apply_object_and_read(test_feature_store):
     assert e1 == e1_actual
     assert fv2 != fv1_actual
     assert e2 != e1_actual
+
+    test_feature_store.teardown()
 
 
 def test_apply_remote_repo():
@@ -466,3 +478,5 @@ def test_reapply_feature_view_success(test_feature_store, dataframe_source):
         # Check Feature View
         fv_stored = test_feature_store.get_feature_view(fv1.name)
         assert len(fv_stored.materialization_intervals) == 0
+
+        test_feature_store.teardown()

--- a/sdk/python/tests/integration/registration/test_registry.py
+++ b/sdk/python/tests/integration/registration/test_registry.py
@@ -215,6 +215,12 @@ def test_apply_feature_view_success(test_registry):
     feature_views = test_registry.list_feature_views(project)
     assert len(feature_views) == 0
 
+    test_registry.teardown()
+
+    # Will try to reload registry, which will fail because the file has been deleted
+    with pytest.raises(FileNotFoundError):
+        test_registry._get_registry_proto()
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
@@ -283,6 +289,12 @@ def test_apply_feature_view_integration(test_registry):
     test_registry.delete_feature_view("my_feature_view_1", project)
     feature_views = test_registry.list_feature_views(project)
     assert len(feature_views) == 0
+
+    test_registry.teardown()
+
+    # Will try to reload registry, which will fail because the file has been deleted
+    with pytest.raises(FileNotFoundError):
+        test_registry._get_registry_proto()
 
 
 def test_commit():
@@ -357,3 +369,9 @@ def test_commit():
         and "team" in entity.labels
         and entity.labels["team"] == "matchmaking"
     )
+
+    test_registry.teardown()
+
+    # Will try to reload registry, which will fail because the file has been deleted
+    with pytest.raises(FileNotFoundError):
+        test_registry._get_registry_proto()

--- a/sdk/python/tests/integration/registration/test_registry.py
+++ b/sdk/python/tests/integration/registration/test_registry.py
@@ -96,6 +96,12 @@ def test_apply_entity_success(test_registry):
         and entity.labels["team"] == "matchmaking"
     )
 
+    test_registry.teardown()
+
+    # Will try to reload registry, which will fail because the file has been deleted
+    with pytest.raises(FileNotFoundError):
+        test_registry._get_registry_proto()
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
@@ -134,6 +140,12 @@ def test_apply_entity_integration(test_registry):
         and "team" in entity.labels
         and entity.labels["team"] == "matchmaking"
     )
+
+    test_registry.teardown()
+
+    # Will try to reload registry, which will fail because the file has been deleted
+    with pytest.raises(FileNotFoundError):
+        test_registry._get_registry_proto()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: As of right now, registries do not get cleaned up during teardown. This is especially bad for GCS and S3 registries. This PR ensures that registries get cleaned up during teardown. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
