### PR TITLE
Fix unit test warnings related to file_url

### DIFF
--- a/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
@@ -199,7 +199,7 @@ def prep_local_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
         df.to_parquet(f.name)
         file_source = FileSource(
             file_format=ParquetFormat(),
-            file_url=f"file://{f.name}",
+            path=f"file://{f.name}",
             event_timestamp_column="ts",
             created_timestamp_column="created_ts",
             date_partition_column="",
@@ -240,7 +240,7 @@ def prep_redis_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
         df.to_parquet(f.name)
         file_source = FileSource(
             file_format=ParquetFormat(),
-            file_url=f"file://{f.name}",
+            path=f"file://{f.name}",
             event_timestamp_column="ts",
             created_timestamp_column="created_ts",
             date_partition_column="",
@@ -282,7 +282,7 @@ def prep_dynamodb_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
         df.to_parquet(f.name)
         file_source = FileSource(
             file_format=ParquetFormat(),
-            file_url=f"file://{f.name}",
+            path=f"file://{f.name}",
             event_timestamp_column="ts",
             created_timestamp_column="created_ts",
             date_partition_column="",

--- a/sdk/python/tests/integration/registration/test_feature_store.py
+++ b/sdk/python/tests/integration/registration/test_feature_store.py
@@ -162,7 +162,7 @@ def test_apply_feature_view_success(test_feature_store):
     # Create Feature Views
     batch_source = FileSource(
         file_format=ParquetFormat(),
-        file_url="file://feast/*",
+        path="file://feast/*",
         event_timestamp_column="ts_col",
         created_timestamp_column="timestamp",
         date_partition_column="date_partition_col",
@@ -279,7 +279,7 @@ def test_apply_feature_view_integration(test_feature_store):
     # Create Feature Views
     batch_source = FileSource(
         file_format=ParquetFormat(),
-        file_url="file://feast/*",
+        path="file://feast/*",
         event_timestamp_column="ts_col",
         created_timestamp_column="timestamp",
         date_partition_column="date_partition_col",
@@ -346,7 +346,7 @@ def test_apply_object_and_read(test_feature_store):
     # Create Feature Views
     batch_source = FileSource(
         file_format=ParquetFormat(),
-        file_url="file://feast/*",
+        path="file://feast/*",
         event_timestamp_column="ts_col",
         created_timestamp_column="timestamp",
     )

--- a/sdk/python/tests/integration/registration/test_registry.py
+++ b/sdk/python/tests/integration/registration/test_registry.py
@@ -143,7 +143,7 @@ def test_apply_feature_view_success(test_registry):
     # Create Feature Views
     batch_source = FileSource(
         file_format=ParquetFormat(),
-        file_url="file://feast/*",
+        path="file://feast/*",
         event_timestamp_column="ts_col",
         created_timestamp_column="timestamp",
         date_partition_column="date_partition_col",
@@ -212,7 +212,7 @@ def test_apply_feature_view_integration(test_registry):
     # Create Feature Views
     batch_source = FileSource(
         file_format=ParquetFormat(),
-        file_url="file://feast/*",
+        path="file://feast/*",
         event_timestamp_column="ts_col",
         created_timestamp_column="timestamp",
         date_partition_column="date_partition_col",

--- a/sdk/python/tests/utils/data_source_utils.py
+++ b/sdk/python/tests/utils/data_source_utils.py
@@ -14,7 +14,7 @@ def prep_file_source(df, event_timestamp_column=None) -> FileSource:
         df.to_parquet(f.name)
         file_source = FileSource(
             file_format=ParquetFormat(),
-            file_url=f.name,
+            path=f.name,
             event_timestamp_column=event_timestamp_column,
         )
         yield file_source


### PR DESCRIPTION
Signed-off-by: ted chang <htchang@us.ibm.com>

**What this PR does / why we need it**:
Fix the test warning feast/sdk/python/feast/infra/offline_stores/file_source.py:48: UserWarning: Argument "file_url" is being deprecated. Please use the "path" argument.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
