### PR TITLE
Change internal references from input to batch_source

### DIFF
--- a/docs/concepts/feature-view.md
+++ b/docs/concepts/feature-view.md
@@ -14,7 +14,7 @@ driver_stats_fv = FeatureView(
         Feature(name="trips_today", dtype=ValueType.INT64),
         Feature(name="rating", dtype=ValueType.FLOAT),
     ],
-    input=BigQuerySource(
+    batch_source=BigQuerySource(
         table_ref="feast-oss.demo_data.driver_activity"
     )
 )

--- a/docs/concepts/feature-views.md
+++ b/docs/concepts/feature-views.md
@@ -108,10 +108,10 @@ driver_stats_fv = FeatureView(
         Feature(name="avg_daily_trips", dtype=ValueType.INT64),
     ],
 
-    # Inputs are used to find feature values. In the case of this feature
+    # Batch sources are used to find feature values. In the case of this feature
     # view we will query a source table on BigQuery for driver statistics
     # features
-    input=driver_stats_source,
+    batch_source=driver_stats_source,
 
     # Tags are user defined key/value pairs that are attached to each
     # feature view

--- a/docs/reference/feature-repository.md
+++ b/docs/reference/feature-repository.md
@@ -111,7 +111,7 @@ driver_locations = FeatureView(
         Feature(name="lat", dtype=ValueType.FLOAT),
         Feature(name="lon", dtype=ValueType.STRING),
     ],
-    input=driver_locations_source,
+    batch_source=driver_locations_source,
 )
 ```
 {% endcode %}

--- a/docs/reference/feature-repository/README.md
+++ b/docs/reference/feature-repository/README.md
@@ -111,7 +111,7 @@ driver_locations = FeatureView(
         Feature(name="lat", dtype=ValueType.FLOAT),
         Feature(name="lon", dtype=ValueType.STRING),
     ],
-    input=driver_locations_source,
+    batch_source=driver_locations_source,
 )
 ```
 {% endcode %}

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -261,7 +261,7 @@ class FeatureStore:
             >>>     name="customer_fv",
             >>>     entities=["customer"],
             >>>     features=[Feature(name="age", dtype=ValueType.INT64)],
-            >>>     input=FileSource(path="file.parquet", event_timestamp_column="timestamp"),
+            >>>     batch_source=FileSource(path="file.parquet", event_timestamp_column="timestamp"),
             >>>     ttl=timedelta(days=1)
             >>> )
             >>> fs.apply([customer_entity, customer_feature_view])
@@ -284,11 +284,11 @@ class FeatureStore:
         )
 
         update_data_sources_with_inferred_event_timestamp_col(
-            [view.input for view in views_to_update], self.config
+            [view.batch_source for view in views_to_update], self.config
         )
 
         for view in views_to_update:
-            view.infer_features_from_input_source(self.config)
+            view.infer_features_from_batch_source(self.config)
 
         if len(views_to_update) + len(entities_to_update) + len(
             services_to_update

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -76,7 +76,7 @@ class FeatureView:
         warnings.warn(
             (
                 "The argument 'input' is being deprecated. Please use 'batch_source' "
-                "instead. Feast 0.11.3 and onwards will not support the argument 'input'."
+                "instead. Feast 0.12 and onwards will not support the argument 'input'."
             ),
             DeprecationWarning,
         )

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+import warnings
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -37,6 +38,8 @@ from feast.protos.feast.core.FeatureView_pb2 import (
 from feast.repo_config import RepoConfig
 from feast.usage import log_exceptions
 from feast.value_type import ValueType
+
+warnings.simplefilter("once", DeprecationWarning)
 
 
 class FeatureView:
@@ -70,6 +73,14 @@ class FeatureView:
         tags: Optional[Dict[str, str]] = None,
         online: bool = True,
     ):
+        warnings.warn(
+            (
+                "The argument 'input' is being deprecated. Please use 'batch_source' "
+                "instead. Feast 0.11.3 and onwards will not support the argument 'input'."
+            ),
+            DeprecationWarning,
+        )
+
         _input = input or batch_source
         assert _input is not None
 

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -51,7 +51,7 @@ class FeatureView:
     ttl: Optional[timedelta]
     online: bool
     input: DataSource
-    batch_source: Optional[DataSource] = None
+    batch_source: DataSource
     stream_source: Optional[DataSource] = None
     created_timestamp: Optional[Timestamp] = None
     last_updated_timestamp: Optional[Timestamp] = None
@@ -63,7 +63,7 @@ class FeatureView:
         name: str,
         entities: List[str],
         ttl: Optional[Union[Duration, timedelta]],
-        input: DataSource,
+        input: Optional[DataSource] = None,
         batch_source: Optional[DataSource] = None,
         stream_source: Optional[DataSource] = None,
         features: List[Feature] = None,
@@ -139,7 +139,7 @@ class FeatureView:
             return False
         if sorted(self.features) != sorted(other.features):
             return False
-        if self.input != other.input:
+        if self.batch_source != other.batch_source:
             return False
         if self.stream_source != other.stream_source:
             return False
@@ -182,10 +182,8 @@ class FeatureView:
             ttl_duration = Duration()
             ttl_duration.FromTimedelta(self.ttl)
 
-        batch_source_proto = self.input.to_proto()
-        batch_source_proto.data_source_class_type = (
-            f"{self.input.__class__.__module__}.{self.input.__class__.__name__}"
-        )
+        batch_source_proto = self.batch_source.to_proto()
+        batch_source_proto.data_source_class_type = f"{self.batch_source.__class__.__module__}.{self.batch_source.__class__.__name__}"
 
         stream_source_proto = None
         if self.stream_source:
@@ -217,7 +215,7 @@ class FeatureView:
             Returns a FeatureViewProto object based on the feature view protobuf
         """
 
-        _input = DataSource.from_proto(feature_view_proto.spec.batch_source)
+        batch_source = DataSource.from_proto(feature_view_proto.spec.batch_source)
         stream_source = (
             DataSource.from_proto(feature_view_proto.spec.stream_source)
             if feature_view_proto.spec.HasField("stream_source")
@@ -242,8 +240,8 @@ class FeatureView:
                 and feature_view_proto.spec.ttl.nanos == 0
                 else feature_view_proto.spec.ttl
             ),
-            input=_input,
-            batch_source=_input,
+            input=batch_source,
+            batch_source=batch_source,
             stream_source=stream_source,
         )
 
@@ -265,29 +263,30 @@ class FeatureView:
             return None
         return max([interval[1] for interval in self.materialization_intervals])
 
-    def infer_features_from_input_source(self, config: RepoConfig):
+    def infer_features_from_batch_source(self, config: RepoConfig):
         if not self.features:
             columns_to_exclude = {
-                self.input.event_timestamp_column,
-                self.input.created_timestamp_column,
+                self.batch_source.event_timestamp_column,
+                self.batch_source.created_timestamp_column,
             } | set(self.entities)
 
-            for col_name, col_datatype in self.input.get_table_column_names_and_types(
-                config
-            ):
+            for (
+                col_name,
+                col_datatype,
+            ) in self.batch_source.get_table_column_names_and_types(config):
                 if col_name not in columns_to_exclude and not re.match(
                     "^__|__$",
                     col_name,  # double underscores often signal an internal-use column
                 ):
                     feature_name = (
-                        self.input.field_mapping[col_name]
-                        if col_name in self.input.field_mapping.keys()
+                        self.batch_source.field_mapping[col_name]
+                        if col_name in self.batch_source.field_mapping.keys()
                         else col_name
                     )
                     self.features.append(
                         Feature(
                             feature_name,
-                            self.input.source_datatype_to_feast_value_type()(
+                            self.batch_source.source_datatype_to_feast_value_type()(
                                 col_datatype
                             ),
                         )

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -76,7 +76,7 @@ class FeatureView:
         warnings.warn(
             (
                 "The argument 'input' is being deprecated. Please use 'batch_source' "
-                "instead. Feast 0.12 and onwards will not support the argument 'input'."
+                "instead. Feast 0.13 and onwards will not support the argument 'input'."
             ),
             DeprecationWarning,
         )

--- a/sdk/python/feast/inference.py
+++ b/sdk/python/feast/inference.py
@@ -13,7 +13,7 @@ def update_entities_with_inferred_types_from_feature_views(
     entities: List[Entity], feature_views: List[FeatureView], config: RepoConfig
 ) -> None:
     """
-    Infer entity value type by examining schema of feature view input sources
+    Infer entity value type by examining schema of feature view batch sources
     """
     incomplete_entities = {
         entity.name: entity
@@ -26,22 +26,22 @@ def update_entities_with_inferred_types_from_feature_views(
         if not (incomplete_entities_keys & set(view.entities)):
             continue  # skip if view doesn't contain any entities that need inference
 
-        col_names_and_types = view.input.get_table_column_names_and_types(config)
+        col_names_and_types = view.batch_source.get_table_column_names_and_types(config)
         for entity_name in view.entities:
             if entity_name in incomplete_entities:
-                # get entity information from information extracted from the view input source
+                # get entity information from information extracted from the view batch source
                 extracted_entity_name_type_pairs = list(
                     filter(lambda tup: tup[0] == entity_name, col_names_and_types)
                 )
                 if len(extracted_entity_name_type_pairs) == 0:
                     # Doesn't mention inference error because would also be an error without inferencing
                     raise ValueError(
-                        f"""No column in the input source for the {view.name} feature view matches
+                        f"""No column in the batch source for the {view.name} feature view matches
                         its entity's name."""
                     )
 
                 entity = incomplete_entities[entity_name]
-                inferred_value_type = view.input.source_datatype_to_feast_value_type()(
+                inferred_value_type = view.batch_source.source_datatype_to_feast_value_type()(
                     extracted_entity_name_type_pairs[0][1]
                 )
 

--- a/sdk/python/feast/infra/aws.py
+++ b/sdk/python/feast/infra/aws.py
@@ -99,7 +99,7 @@ class AwsProvider(Provider):
 
         offline_job = self.offline_store.pull_latest_from_table_or_query(
             config=config,
-            data_source=feature_view.input,
+            data_source=feature_view.batch_source,
             join_key_columns=join_key_columns,
             feature_name_columns=feature_name_columns,
             event_timestamp_column=event_timestamp_column,
@@ -110,8 +110,8 @@ class AwsProvider(Provider):
 
         table = offline_job.to_arrow()
 
-        if feature_view.input.field_mapping is not None:
-            table = _run_field_mapping(table, feature_view.input.field_mapping)
+        if feature_view.batch_source.field_mapping is not None:
+            table = _run_field_mapping(table, feature_view.batch_source.field_mapping)
 
         join_keys = [entity.join_key for entity in entities]
         rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)

--- a/sdk/python/feast/infra/gcp.py
+++ b/sdk/python/feast/infra/gcp.py
@@ -102,7 +102,7 @@ class GcpProvider(Provider):
 
         offline_job = self.offline_store.pull_latest_from_table_or_query(
             config=config,
-            data_source=feature_view.input,
+            data_source=feature_view.batch_source,
             join_key_columns=join_key_columns,
             feature_name_columns=feature_name_columns,
             event_timestamp_column=event_timestamp_column,
@@ -112,8 +112,8 @@ class GcpProvider(Provider):
         )
         table = offline_job.to_arrow()
 
-        if feature_view.input.field_mapping is not None:
-            table = _run_field_mapping(table, feature_view.input.field_mapping)
+        if feature_view.batch_source.field_mapping is not None:
+            table = _run_field_mapping(table, feature_view.batch_source.field_mapping)
 
         join_keys = [entity.join_key for entity in entities]
         rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)

--- a/sdk/python/feast/infra/local.py
+++ b/sdk/python/feast/infra/local.py
@@ -100,7 +100,7 @@ class LocalProvider(Provider):
         ) = _get_column_names(feature_view, entities)
 
         offline_job = self.offline_store.pull_latest_from_table_or_query(
-            data_source=feature_view.input,
+            data_source=feature_view.batch_source,
             join_key_columns=join_key_columns,
             feature_name_columns=feature_name_columns,
             event_timestamp_column=event_timestamp_column,
@@ -111,8 +111,8 @@ class LocalProvider(Provider):
         )
         table = offline_job.to_arrow()
 
-        if feature_view.input.field_mapping is not None:
-            table = _run_field_mapping(table, feature_view.input.field_mapping)
+        if feature_view.batch_source.field_mapping is not None:
+            table = _run_field_mapping(table, feature_view.batch_source.field_mapping)
 
         join_keys = [entity.join_key for entity in entities]
         rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)

--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -104,15 +104,21 @@ class FileOfflineStore(OfflineStore):
 
             # Load feature view data from sources and join them incrementally
             for feature_view, features in feature_views_to_features.items():
-                event_timestamp_column = feature_view.input.event_timestamp_column
-                created_timestamp_column = feature_view.input.created_timestamp_column
+                event_timestamp_column = (
+                    feature_view.batch_source.event_timestamp_column
+                )
+                created_timestamp_column = (
+                    feature_view.batch_source.created_timestamp_column
+                )
 
                 # Read offline parquet data in pyarrow format
-                table = pyarrow.parquet.read_table(feature_view.input.path)
+                table = pyarrow.parquet.read_table(feature_view.batch_source.path)
 
                 # Rename columns by the field mapping dictionary if it exists
-                if feature_view.input.field_mapping is not None:
-                    table = _run_field_mapping(table, feature_view.input.field_mapping)
+                if feature_view.batch_source.field_mapping is not None:
+                    table = _run_field_mapping(
+                        table, feature_view.batch_source.field_mapping
+                    )
 
                 # Convert pyarrow table to pandas dataframe
                 df_to_join = table.to_pandas()

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -211,13 +211,13 @@ def _get_column_names(
         the query to the offline store.
     """
     # if we have mapped fields, use the original field names in the call to the offline store
-    event_timestamp_column = feature_view.input.event_timestamp_column
+    event_timestamp_column = feature_view.batch_source.event_timestamp_column
     feature_names = [feature.name for feature in feature_view.features]
-    created_timestamp_column = feature_view.input.created_timestamp_column
+    created_timestamp_column = feature_view.batch_source.created_timestamp_column
     join_keys = [entity.join_key for entity in entities]
-    if feature_view.input.field_mapping is not None:
+    if feature_view.batch_source.field_mapping is not None:
         reverse_field_mapping = {
-            v: k for k, v in feature_view.input.field_mapping.items()
+            v: k for k, v in feature_view.batch_source.field_mapping.items()
         }
         event_timestamp_column = (
             reverse_field_mapping[event_timestamp_column]
@@ -292,13 +292,13 @@ def _convert_arrow_to_proto(
             value = python_value_to_proto_value(row[idx], feature.dtype)
             feature_dict[feature.name] = value
         event_timestamp_idx = table.column_names.index(
-            feature_view.input.event_timestamp_column
+            feature_view.batch_source.event_timestamp_column
         )
         event_timestamp = _coerce_datetime(row[event_timestamp_idx])
 
-        if feature_view.input.created_timestamp_column:
+        if feature_view.batch_source.created_timestamp_column:
             created_timestamp_idx = table.column_names.index(
-                feature_view.input.created_timestamp_column
+                feature_view.batch_source.created_timestamp_column
             )
             created_timestamp = _coerce_datetime(row[created_timestamp_idx])
         else:

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -162,7 +162,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     registry._initialize_registry()
     sys.dont_write_bytecode = True
     repo = parse_repo(repo_path)
-    data_sources = [t.input for t in repo.feature_views]
+    data_sources = [t.batch_source for t in repo.feature_views]
 
     if not skip_source_validation:
         # Make sure the data source used by this feature view is supported by Feast
@@ -175,7 +175,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     )
     update_data_sources_with_inferred_event_timestamp_col(data_sources, repo_config)
     for view in repo.feature_views:
-        view.infer_features_from_input_source(repo_config)
+        view.infer_features_from_batch_source(repo_config)
 
     repo_table_names = set(t.name for t in repo.feature_tables)
 

--- a/sdk/python/feast/templates/aws/example.py
+++ b/sdk/python/feast/templates/aws/example.py
@@ -30,6 +30,6 @@ driver_hourly_stats_view = FeatureView(
         Feature(name="avg_daily_trips", dtype=ValueType.INT64),
     ],
     online=True,
-    input=driver_hourly_stats,
+    batch_source=driver_hourly_stats,
     tags={},
 )

--- a/sdk/python/feast/templates/gcp/driver_repo.py
+++ b/sdk/python/feast/templates/gcp/driver_repo.py
@@ -54,10 +54,10 @@ driver_stats_fv = FeatureView(
         Feature(name="acc_rate", dtype=ValueType.FLOAT),
         Feature(name="avg_daily_trips", dtype=ValueType.INT64),
     ],
-    # Inputs are used to find feature values. In the case of this feature
+    # Batch sources are used to find feature values. In the case of this feature
     # view we will query a source table on BigQuery for driver statistics
     # features
-    input=driver_stats_source,
+    batch_source=driver_stats_source,
     # Tags are user defined key/value pairs that are attached to each
     # feature view
     tags={"team": "driver_performance"},

--- a/sdk/python/feast/templates/local/example.py
+++ b/sdk/python/feast/templates/local/example.py
@@ -30,6 +30,6 @@ driver_hourly_stats_view = FeatureView(
         Feature(name="avg_daily_trips", dtype=ValueType.INT64),
     ],
     online=True,
-    input=driver_hourly_stats,
+    batch_source=driver_hourly_stats,
     tags={},
 )

--- a/sdk/python/tests/example_repos/example_feature_repo_1.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_1.py
@@ -45,7 +45,7 @@ driver_locations = FeatureView(
         Feature(name="lon", dtype=ValueType.STRING),
     ],
     online=True,
-    input=driver_locations_source,
+    batch_source=driver_locations_source,
     tags={},
 )
 
@@ -59,7 +59,7 @@ customer_profile = FeatureView(
         Feature(name="age", dtype=ValueType.INT64),
     ],
     online=True,
-    input=customer_profile_source,
+    batch_source=customer_profile_source,
     tags={},
 )
 
@@ -69,7 +69,7 @@ customer_driver_combined = FeatureView(
     ttl=timedelta(days=1),
     features=[Feature(name="trips", dtype=ValueType.INT64)],
     online=True,
-    input=customer_driver_combined_source,
+    batch_source=customer_driver_combined_source,
     tags={},
 )
 

--- a/sdk/python/tests/example_repos/example_feature_repo_2.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_2.py
@@ -21,6 +21,6 @@ driver_hourly_stats_view = FeatureView(
         Feature(name="avg_daily_trips", dtype=ValueType.INT64),
     ],
     online=True,
-    input=driver_hourly_stats,
+    batch_source=driver_hourly_stats,
     tags={},
 )

--- a/sdk/python/tests/example_repos/example_feature_repo_with_entity_join_key.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_with_entity_join_key.py
@@ -28,6 +28,6 @@ driver_hourly_stats_view = FeatureView(
         Feature(name="avg_daily_trips", dtype=ValueType.INT64),
     ],
     online=True,
-    input=driver_hourly_stats,
+    batch_source=driver_hourly_stats,
     tags={},
 )

--- a/sdk/python/tests/example_repos/example_feature_repo_with_inference.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_with_inference.py
@@ -15,6 +15,6 @@ driver_hourly_stats_view = FeatureView(
     entities=["driver_id"],
     ttl=Duration(seconds=86400 * 1),
     online=True,
-    input=driver_hourly_stats,
+    batch_source=driver_hourly_stats,
     tags={},
 )

--- a/sdk/python/tests/example_repos/example_feature_repo_with_missing_bq_source.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_with_missing_bq_source.py
@@ -16,5 +16,5 @@ nonexistent_features = FeatureView(
         Feature(name="lat", dtype=ValueType.FLOAT),
         Feature(name="lon", dtype=ValueType.STRING),
     ],
-    input=nonexistent_source,
+    batch_source=nonexistent_source,
 )

--- a/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
@@ -60,7 +60,7 @@ def get_feature_view(data_source: DataSource) -> FeatureView:
         entities=["driver"],
         features=[Feature("value", ValueType.FLOAT)],
         ttl=timedelta(days=5),
-        input=data_source,
+        batch_source=data_source,
     )
 
 

--- a/sdk/python/tests/integration/registration/test_feature_store.py
+++ b/sdk/python/tests/integration/registration/test_feature_store.py
@@ -182,7 +182,7 @@ def test_apply_feature_view_success(test_feature_store):
         ],
         entities=["fs1_my_entity_1"],
         tags={"team": "matchmaking"},
-        input=batch_source,
+        batch_source=batch_source,
         ttl=timedelta(minutes=5),
     )
 
@@ -223,7 +223,7 @@ def test_feature_view_inference_success(test_feature_store, dataframe_source):
             entities=["id"],
             ttl=timedelta(minutes=5),
             online=True,
-            input=file_source,
+            batch_source=file_source,
             tags={},
         )
 
@@ -232,7 +232,7 @@ def test_feature_view_inference_success(test_feature_store, dataframe_source):
             entities=["id"],
             ttl=timedelta(minutes=5),
             online=True,
-            input=simple_bq_source_using_table_ref_arg(dataframe_source, "ts_1"),
+            batch_source=simple_bq_source_using_table_ref_arg(dataframe_source, "ts_1"),
             tags={},
         )
 
@@ -241,7 +241,7 @@ def test_feature_view_inference_success(test_feature_store, dataframe_source):
             entities=["id"],
             ttl=timedelta(minutes=5),
             online=True,
-            input=simple_bq_source_using_query_arg(dataframe_source, "ts_1"),
+            batch_source=simple_bq_source_using_query_arg(dataframe_source, "ts_1"),
             tags={},
         )
 
@@ -303,7 +303,7 @@ def test_apply_feature_view_integration(test_feature_store):
         ],
         entities=["fs1_my_entity_1"],
         tags={"team": "matchmaking"},
-        input=batch_source,
+        batch_source=batch_source,
         ttl=timedelta(minutes=5),
     )
 
@@ -379,7 +379,7 @@ def test_apply_object_and_read(test_feature_store):
         ],
         entities=["fs1_my_entity_1"],
         tags={"team": "matchmaking"},
-        input=batch_source,
+        batch_source=batch_source,
         ttl=timedelta(minutes=5),
     )
 
@@ -393,7 +393,7 @@ def test_apply_object_and_read(test_feature_store):
         ],
         entities=["fs1_my_entity_1"],
         tags={"team": "matchmaking"},
-        input=batch_source,
+        batch_source=batch_source,
         ttl=timedelta(minutes=5),
     )
 
@@ -440,7 +440,7 @@ def test_reapply_feature_view_success(test_feature_store, dataframe_source):
             name="my_feature_view_1",
             features=[Feature(name="string_col", dtype=ValueType.STRING)],
             entities=["id"],
-            input=file_source,
+            batch_source=file_source,
             ttl=timedelta(minutes=5),
         )
 
@@ -470,7 +470,7 @@ def test_reapply_feature_view_success(test_feature_store, dataframe_source):
             name="my_feature_view_1",
             features=[Feature(name="int64_col", dtype=ValueType.INT64)],
             entities=["id"],
-            input=file_source,
+            batch_source=file_source,
             ttl=timedelta(minutes=5),
         )
         test_feature_store.apply([fv1])

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -23,8 +23,12 @@ def test_update_entities_with_inferred_types_from_feature_views(
         df=simple_dataset_2, event_timestamp_column="ts_1"
     ) as file_source_2:
 
-        fv1 = FeatureView(name="fv1", entities=["id"], input=file_source, ttl=None,)
-        fv2 = FeatureView(name="fv2", entities=["id"], input=file_source_2, ttl=None,)
+        fv1 = FeatureView(
+            name="fv1", entities=["id"], batch_source=file_source, ttl=None,
+        )
+        fv2 = FeatureView(
+            name="fv2", entities=["id"], batch_source=file_source_2, ttl=None,
+        )
 
         actual_1 = Entity(name="id")
         actual_2 = Entity(name="id")

--- a/sdk/python/tests/integration/registration/test_registry.py
+++ b/sdk/python/tests/integration/registration/test_registry.py
@@ -171,7 +171,7 @@ def test_apply_feature_view_success(test_registry):
         ],
         entities=["fs1_my_entity_1"],
         tags={"team": "matchmaking"},
-        input=batch_source,
+        batch_source=batch_source,
         ttl=timedelta(minutes=5),
     )
 
@@ -246,7 +246,7 @@ def test_apply_feature_view_integration(test_registry):
         ],
         entities=["fs1_my_entity_1"],
         tags={"team": "matchmaking"},
-        input=batch_source,
+        batch_source=batch_source,
         ttl=timedelta(minutes=5),
     )
 

--- a/sdk/python/tests/integration/scaffolding/test_partial_apply.py
+++ b/sdk/python/tests/integration/scaffolding/test_partial_apply.py
@@ -34,7 +34,7 @@ def test_partial() -> None:
                 Feature(name="name", dtype=ValueType.STRING),
             ],
             online=True,
-            input=driver_locations_source,
+            batch_source=driver_locations_source,
             tags={},
         )
 

--- a/sdk/python/tests/utils/online_write_benchmark.py
+++ b/sdk/python/tests/utils/online_write_benchmark.py
@@ -28,7 +28,7 @@ def create_driver_hourly_stats_feature_view(source):
             Feature(name="acc_rate", dtype=ValueType.FLOAT),
             Feature(name="avg_daily_trips", dtype=ValueType.INT32),
         ],
-        input=source,
+        batch_source=source,
         ttl=timedelta(hours=2),
     )
     return driver_stats_feature_view


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

**What this PR does / why we need it**: FeatureViews have always required a batch data source as input; this argument is currently named `input`. We recently introduced stream sources [here](https://github.com/feast-dev/feast/pull/1664), so now we have three arguments: a required `input`, an optional `batch_source`, and an optional `stream_source`. We should remove `input` as an argument, make `batch_source` required, and leave `stream_source` optional; this is a breaking change, so we prepare for it by adding a deprecation warning. We also change internal references and docs to use `batch_source` instead of `input`, to point people in the right direction.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
There is now a deprecation warning in FeatureView.
```
