### PR TITLE
Fix GCS version

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -63,7 +63,7 @@ GCP_REQUIRED = [
     "google-cloud-bigquery>=2.0.*",
     "google-cloud-bigquery-storage >= 2.0.0",
     "google-cloud-datastore>=2.1.*",
-    "google-cloud-storage>=1.20.*",
+    "google-cloud-storage>=1.34.*",
     "google-cloud-core==1.4.*",
 ]
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In feast.registry.Registy.get_registry_proto the gcs method
`download_blob_to_file` is called with the timeout param which does not
exist until version 1.34.

**Which issue(s) this PR fixes**:
n/a

**Does this PR introduce a user-facing change?**:
No.

```release-note
NONE
```
