### PR TITLE
Updating CLI apply to use FeatureStore & remove feature table logic

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -92,6 +92,10 @@ class FeatureStore:
         return get_version()
 
     @property
+    def registry(self) -> Registry:
+        return self._registry
+
+    @property
     def project(self) -> str:
         """Gets the project of this feature store."""
         return self.config.project

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -193,7 +193,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     apply_feature_services(registry, project, repo)
 
     infra_provider = get_provider(repo_config, repo_path)
-    for name in [table.name for table in views_to_keep]:
+    for name in [view.name for view in views_to_keep]:
         click.echo(
             f"Deploying infrastructure for {Style.BRIGHT + Fore.GREEN}{name}{Style.RESET_ALL}"
         )

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -154,7 +154,6 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     sys.dont_write_bytecode = True
     repo = parse_repo(repo_path)
     _validate_feature_views(repo.feature_views)
-    data_sources = [t.batch_source for t in repo.feature_views]
 
     if not skip_source_validation:
         data_sources = [t.input for t in repo.feature_views]

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -6,12 +6,12 @@ import sys
 from datetime import timedelta
 from importlib.abc import Loader
 from pathlib import Path
-from typing import List, NamedTuple, Set, Union
+from typing import List, NamedTuple, Set
 
 import click
 from click.exceptions import BadParameter
 
-from feast import Entity, FeatureStore, FeatureTable
+from feast import Entity, FeatureTable
 from feast.feature_service import FeatureService
 from feast.feature_store import FeatureStore, _validate_feature_views
 from feast.feature_view import FeatureView


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves the feast CLI's apply method (`feast apply`) to use the SDK FeatureStore class more. This includes some cleanup that also removes obsolete logic around feature tables. Note that because the feast CLI's apply is a total apply whereas the SDK apply is partial, there is still leftover business logic (in particular for deleting entities / FVs that don't match the repo). 

**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:
```release-note 

action required: feature tables were unofficially supported via the CLI and now no longer are

```
