### PR TITLE
Updating CLI apply to use FeatureStore

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -100,7 +100,6 @@ class FeatureStore:
 
     @property
     def registry(self) -> Registry:
-        """Gets the registry of this feature store."""
         return self._registry
 
     @property
@@ -228,19 +227,6 @@ class FeatureStore:
             FeatureViewNotFoundException: The feature view could not be found.
         """
         return self._registry.delete_feature_view(name, self.project)
-
-    @log_exceptions_and_usage
-    def delete_feature_service(self, name: str):
-        """
-            Deletes a feature service.
-
-            Args:
-                name: Name of feature service.
-
-            Raises:
-                FeatureServiceNotFoundException: The feature view could not be found.
-            """
-        return self._registry.delete_feature_service(name, self.project)
 
     def _get_features(
         self,

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -228,6 +228,19 @@ class FeatureStore:
         """
         return self._registry.delete_feature_view(name, self.project)
 
+    @log_exceptions_and_usage
+    def delete_feature_service(self, name: str):
+        """
+            Deletes a feature service.
+
+            Args:
+                name: Name of feature service.
+
+            Raises:
+                FeatureServiceNotFoundException: The feature view could not be found.
+            """
+        return self._registry.delete_feature_service(name, self.project)
+
     def _get_features(
         self,
         features: Optional[Union[List[str], FeatureService]],
@@ -256,6 +269,7 @@ class FeatureStore:
             FeatureService,
             List[Union[FeatureView, Entity, FeatureService]],
         ],
+        commit: bool = True,
     ):
         """Register objects to metadata store and update related infrastructure.
 
@@ -266,6 +280,7 @@ class FeatureStore:
 
         Args:
             objects: A single object, or a list of objects that should be registered with the Feature Store.
+            commit: whether to commit changes to the registry
 
         Raises:
             ValueError: The 'objects' parameter could not be parsed properly.
@@ -323,7 +338,6 @@ class FeatureStore:
             self._registry.apply_entity(ent, project=self.project, commit=False)
         for feature_service in services_to_update:
             self._registry.apply_feature_service(feature_service, project=self.project)
-        self._registry.commit()
 
         self._get_provider().update_infra(
             project=self.project,
@@ -333,6 +347,9 @@ class FeatureStore:
             entities_to_keep=entities_to_update,
             partial=True,
         )
+
+        if commit:
+            self._registry.commit()
 
     @log_exceptions_and_usage
     def teardown(self):

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -99,6 +99,10 @@ class FeatureStore:
         return get_version()
 
     @property
+    def registry(self) -> Registry:
+        return self._registry
+
+    @property
     def project(self) -> str:
         """Gets the project of this feature store."""
         return self.config.project

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -229,6 +229,19 @@ class FeatureStore:
         """
         return self._registry.delete_feature_view(name, self.project)
 
+    @log_exceptions_and_usage
+    def delete_feature_service(self, name: str):
+        """
+            Deletes a feature service.
+
+            Args:
+                name: Name of feature service.
+
+            Raises:
+                FeatureServiceNotFoundException: The feature view could not be found.
+            """
+        return self._registry.delete_feature_service(name, self.project)
+
     def _get_features(
         self,
         features: Optional[Union[List[str], FeatureService]],

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -100,6 +100,7 @@ class FeatureStore:
 
     @property
     def registry(self) -> Registry:
+        """Gets the registry of this feature store."""
         return self._registry
 
     @property

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -11,14 +11,10 @@ from typing import List, NamedTuple, Set, Union
 import click
 from click.exceptions import BadParameter
 
-from feast import Entity, FeatureTable
+from feast import Entity, FeatureStore, FeatureTable
 from feast.feature_service import FeatureService
 from feast.feature_store import FeatureStore, _validate_feature_views
 from feast.feature_view import FeatureView
-from feast.inference import (
-    update_data_sources_with_inferred_event_timestamp_col,
-    update_entities_with_inferred_types_from_feature_views,
-)
 from feast.infra.provider import get_provider
 from feast.names import adjectives, animals
 from feast.registry import Registry
@@ -116,24 +112,18 @@ def parse_repo(repo_root: Path) -> ParsedRepo:
     return res
 
 
-def apply_feature_services(
-    registry: Registry,
-    project: str,
-    repo: ParsedRepo,
-    existing_feature_services: List[FeatureService],
-):
+def apply_feature_services(registry: Registry, project: str, repo: ParsedRepo):
     from colorama import Fore, Style
 
     # Determine which feature services should be deleted.
+    existing_feature_services = registry.list_feature_services(project)
     for feature_service in repo.feature_services:
         if feature_service in existing_feature_services:
             existing_feature_services.remove(feature_service)
 
     # The remaining features services in the list should be deleted.
     for feature_service_to_delete in existing_feature_services:
-        registry.delete_feature_service(
-            feature_service_to_delete.name, project, commit=False
-        )
+        registry.delete_feature_service(feature_service_to_delete.name, project)
         click.echo(
             f"Deleted feature service {Style.BRIGHT + Fore.GREEN}{feature_service_to_delete.name}{Style.RESET_ALL} "
             f"from registry"
@@ -151,19 +141,15 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     from colorama import Fore, Style
 
     os.chdir(repo_path)
-    registry_config = repo_config.get_registry_config()
-    project = repo_config.project
+    store = FeatureStore(repo_path=str(repo_path))
+    project = store.project
     if not is_valid_name(project):
         print(
             f"{project} is not valid. Project name should only have "
             f"alphanumerical values and underscores but not start with an underscore."
         )
         sys.exit(1)
-    registry = Registry(
-        registry_path=registry_config.path,
-        repo_path=repo_path,
-        cache_ttl=timedelta(seconds=registry_config.cache_ttl_seconds),
-    )
+    registry = store.registry
     registry._initialize_registry()
     sys.dont_write_bytecode = True
     repo = parse_repo(repo_path)
@@ -171,116 +157,81 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     data_sources = [t.batch_source for t in repo.feature_views]
 
     if not skip_source_validation:
+        data_sources = [t.input for t in repo.feature_views]
         # Make sure the data source used by this feature view is supported by Feast
         for data_source in data_sources:
-            data_source.validate(repo_config)
+            data_source.validate(store.config)
 
-    # Make inferences
-    update_entities_with_inferred_types_from_feature_views(
-        repo.entities, repo.feature_views, repo_config
+    entities_to_delete, entities_to_keep = _tag_registry_entities_for_keep_delete(
+        project, registry, repo
     )
-    update_data_sources_with_inferred_event_timestamp_col(data_sources, repo_config)
-    for view in repo.feature_views:
-        view.infer_features_from_batch_source(repo_config)
-
-    repo_table_names = set(t.name for t in repo.feature_tables)
-
-    for t in repo.feature_views:
-        repo_table_names.add(t.name)
-
-    tables_to_delete = []
-    for registry_table in registry.list_feature_tables(project=project):
-        if registry_table.name not in repo_table_names:
-            tables_to_delete.append(registry_table)
-
-    views_to_delete = []
-    for registry_view in registry.list_feature_views(project=project):
-        if registry_view.name not in repo_table_names:
-            views_to_delete.append(registry_view)
-
-    entities_to_delete: List[Entity] = []
-    repo_entities_names = set([e.name for e in repo.entities])
-    for registry_entity in registry.list_entities(project=project):
-        if registry_entity.name not in repo_entities_names:
-            entities_to_delete.append(registry_entity)
-
-    entities_to_keep: List[Entity] = repo.entities
-
-    existing_feature_services = registry.list_feature_services(project)
+    views_to_delete, views_to_keep = _tag_registry_views_for_keep_delete(
+        project, registry, repo
+    )
 
     sys.dont_write_bytecode = False
-    for entity in repo.entities:
-        registry.apply_entity(entity, project=project, commit=False)
-        click.echo(
-            f"Registered entity {Style.BRIGHT + Fore.GREEN}{entity.name}{Style.RESET_ALL}"
-        )
-
-    # Delete tables that should not exist
-    for registry_table in tables_to_delete:
-        registry.delete_feature_table(
-            registry_table.name, project=project, commit=False
-        )
-        click.echo(
-            f"Deleted feature table {Style.BRIGHT + Fore.GREEN}{registry_table.name}{Style.RESET_ALL} from registry"
-        )
-
-    # Create tables that should
-    for table in repo.feature_tables:
-        registry.apply_feature_table(table, project, commit=False)
-        click.echo(
-            f"Registered feature table {Style.BRIGHT + Fore.GREEN}{table.name}{Style.RESET_ALL}"
-        )
 
     # Delete views that should not exist
     for registry_view in views_to_delete:
-        registry.delete_feature_view(registry_view.name, project=project, commit=False)
+        store.delete_feature_view(registry_view.name, project=project, commit=False)
         click.echo(
             f"Deleted feature view {Style.BRIGHT + Fore.GREEN}{registry_view.name}{Style.RESET_ALL} from registry"
         )
+    # TODO: delete entities from the registry too
+    registry.commit()
 
-    # Create views that should exist
-    for view in repo.feature_views:
-        registry.apply_feature_view(view, project, commit=False)
+    # Add / update views + entities
+    store.apply(entities_to_keep + views_to_keep)
+    for entity in entities_to_keep:
+        click.echo(
+            f"Registered entity {Style.BRIGHT + Fore.GREEN}{entity.name}{Style.RESET_ALL}"
+        )
+    for view in views_to_keep:
         click.echo(
             f"Registered feature view {Style.BRIGHT + Fore.GREEN}{view.name}{Style.RESET_ALL}"
         )
 
-    apply_feature_services(registry, project, repo, existing_feature_services)
+    apply_feature_services(registry, project, repo)
 
     infra_provider = get_provider(repo_config, repo_path)
-
-    all_to_delete: List[Union[FeatureTable, FeatureView]] = []
-    all_to_delete.extend(tables_to_delete)
-    all_to_delete.extend(views_to_delete)
-
-    all_to_keep: List[Union[FeatureTable, FeatureView]] = []
-    all_to_keep.extend(repo.feature_tables)
-    all_to_keep.extend(repo.feature_views)
-
-    for name in [view.name for view in repo.feature_tables] + [
-        table.name for table in repo.feature_views
-    ]:
+    for name in [table.name for table in views_to_keep]:
         click.echo(
             f"Deploying infrastructure for {Style.BRIGHT + Fore.GREEN}{name}{Style.RESET_ALL}"
         )
-    for name in [view.name for view in views_to_delete] + [
-        table.name for table in tables_to_delete
-    ]:
+    for name in [view.name for view in views_to_delete]:
         click.echo(
             f"Removing infrastructure for {Style.BRIGHT + Fore.GREEN}{name}{Style.RESET_ALL}"
         )
+    # TODO: consider echoing also entities being deployed/removed
 
     infra_provider.update_infra(
         project,
-        tables_to_delete=all_to_delete,
-        tables_to_keep=all_to_keep,
+        tables_to_delete=views_to_delete,
+        tables_to_keep=views_to_keep,
         entities_to_delete=entities_to_delete,
         entities_to_keep=entities_to_keep,
         partial=False,
     )
 
-    # Commit the update to the registry only after successful infra update
-    registry.commit()
+
+def _tag_registry_entities_for_keep_delete(project, registry, repo):
+    entities_to_keep: List[Entity] = repo.entities
+    entities_to_delete: List[Entity] = []
+    repo_entities_names = set([e.name for e in repo.entities])
+    for registry_entity in registry.list_entities(project=project):
+        if registry_entity.name not in repo_entities_names:
+            entities_to_delete.append(registry_entity)
+    return entities_to_delete, entities_to_keep
+
+
+def _tag_registry_views_for_keep_delete(project, registry, repo):
+    views_to_keep: List[FeatureView] = repo.feature_views
+    views_to_delete = []
+    repo_feature_view_names = set(t.name for t in repo.feature_views)
+    for registry_view in registry.list_feature_views(project=project):
+        if registry_view.name not in repo_feature_view_names:
+            views_to_delete.append(registry_view)
+    return views_to_delete, views_to_keep
 
 
 @log_exceptions_and_usage

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -213,7 +213,9 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     )
 
 
-def _tag_registry_entities_for_keep_delete(project: str, registry: Registry, repo: ParsedRepo):
+def _tag_registry_entities_for_keep_delete(
+    project: str, registry: Registry, repo: ParsedRepo
+):
     entities_to_keep: List[Entity] = repo.entities
     entities_to_delete: List[Entity] = []
     repo_entities_names = set([e.name for e in repo.entities])
@@ -223,7 +225,9 @@ def _tag_registry_entities_for_keep_delete(project: str, registry: Registry, rep
     return entities_to_keep, entities_to_delete
 
 
-def _tag_registry_views_for_keep_delete(project: str, registry: Registry, repo: ParsedRepo):
+def _tag_registry_views_for_keep_delete(
+    project: str, registry: Registry, repo: ParsedRepo
+):
     views_to_keep: List[FeatureView] = repo.feature_views
     views_to_delete: List[FeatureView] = []
     repo_feature_view_names = set(t.name for t in repo.feature_views)

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -168,10 +168,10 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
         for data_source in data_sources:
             data_source.validate(store.config)
 
-    entities_to_delete, entities_to_keep = _tag_registry_entities_for_keep_delete(
+    entities_to_keep, entities_to_delete = _tag_registry_entities_for_keep_delete(
         project, registry, repo
     )
-    views_to_delete, views_to_keep = _tag_registry_views_for_keep_delete(
+    views_to_keep, views_to_delete = _tag_registry_views_for_keep_delete(
         project, registry, repo
     )
 
@@ -189,7 +189,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
 
     # Delete views that should not exist
     for registry_view in views_to_delete:
-        store.delete_feature_view(registry_view.name, project=project, commit=False)
+        store.delete_feature_view(registry_view.name)
         click.echo(
             f"Deleted feature view {Style.BRIGHT + Fore.GREEN}{registry_view.name}{Style.RESET_ALL} from registry"
         )
@@ -232,24 +232,24 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     registry.commit()
 
 
-def _tag_registry_entities_for_keep_delete(project, registry, repo):
+def _tag_registry_entities_for_keep_delete(project: str, registry: Registry, repo: ParsedRepo):
     entities_to_keep: List[Entity] = repo.entities
     entities_to_delete: List[Entity] = []
     repo_entities_names = set([e.name for e in repo.entities])
     for registry_entity in registry.list_entities(project=project):
         if registry_entity.name not in repo_entities_names:
             entities_to_delete.append(registry_entity)
-    return entities_to_delete, entities_to_keep
+    return entities_to_keep, entities_to_delete
 
 
-def _tag_registry_views_for_keep_delete(project, registry, repo):
+def _tag_registry_views_for_keep_delete(project: str, registry: Registry, repo: ParsedRepo):
     views_to_keep: List[FeatureView] = repo.feature_views
     views_to_delete = []
     repo_feature_view_names = set(t.name for t in repo.feature_views)
     for registry_view in registry.list_feature_views(project=project):
         if registry_view.name not in repo_feature_view_names:
             views_to_delete.append(registry_view)
-    return views_to_delete, views_to_keep
+    return views_to_keep, views_to_delete
 
 
 @log_exceptions_and_usage

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -209,24 +209,11 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     apply_feature_services(registry, project, repo, existing_feature_services)
 
     infra_provider = get_provider(repo_config, repo_path)
-
-    all_to_delete: List[Union[FeatureTable, FeatureView]] = []
-    all_to_delete.extend(tables_to_delete)
-    all_to_delete.extend(views_to_delete)
-
-    all_to_keep: List[Union[FeatureTable, FeatureView]] = []
-    all_to_keep.extend(repo.feature_tables)
-    all_to_keep.extend(repo.feature_views)
-
-    for name in [view.name for view in repo.feature_tables] + [
-        table.name for table in repo.feature_views
-    ]:
+    for name in [view.name for view in views_to_keep]:
         click.echo(
             f"Deploying infrastructure for {Style.BRIGHT + Fore.GREEN}{name}{Style.RESET_ALL}"
         )
-    for name in [view.name for view in views_to_delete] + [
-        table.name for table in tables_to_delete
-    ]:
+    for name in [view.name for view in views_to_delete]:
         click.echo(
             f"Removing infrastructure for {Style.BRIGHT + Fore.GREEN}{name}{Style.RESET_ALL}"
         )

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -161,10 +161,10 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
         for data_source in data_sources:
             data_source.validate(store.config)
 
-    entities_to_delete, entities_to_keep = _tag_registry_entities_for_keep_delete(
+    entities_to_keep, entities_to_delete = _tag_registry_entities_for_keep_delete(
         project, registry, repo
     )
-    views_to_delete, views_to_keep = _tag_registry_views_for_keep_delete(
+    views_to_keep, views_to_delete = _tag_registry_views_for_keep_delete(
         project, registry, repo
     )
 
@@ -172,7 +172,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
 
     # Delete views that should not exist
     for registry_view in views_to_delete:
-        store.delete_feature_view(registry_view.name, project=project, commit=False)
+        store.delete_feature_view(registry_view.name)
         click.echo(
             f"Deleted feature view {Style.BRIGHT + Fore.GREEN}{registry_view.name}{Style.RESET_ALL} from registry"
         )
@@ -213,24 +213,24 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     )
 
 
-def _tag_registry_entities_for_keep_delete(project, registry, repo):
+def _tag_registry_entities_for_keep_delete(project: str, registry: Registry, repo: ParsedRepo):
     entities_to_keep: List[Entity] = repo.entities
     entities_to_delete: List[Entity] = []
     repo_entities_names = set([e.name for e in repo.entities])
     for registry_entity in registry.list_entities(project=project):
         if registry_entity.name not in repo_entities_names:
             entities_to_delete.append(registry_entity)
-    return entities_to_delete, entities_to_keep
+    return entities_to_keep, entities_to_delete
 
 
-def _tag_registry_views_for_keep_delete(project, registry, repo):
+def _tag_registry_views_for_keep_delete(project: str, registry: Registry, repo: ParsedRepo):
     views_to_keep: List[FeatureView] = repo.feature_views
     views_to_delete: List[FeatureView] = []
     repo_feature_view_names = set(t.name for t in repo.feature_views)
     for registry_view in registry.list_feature_views(project=project):
         if registry_view.name not in repo_feature_view_names:
             views_to_delete.append(registry_view)
-    return views_to_delete, views_to_keep
+    return views_to_keep, views_to_delete
 
 
 @log_exceptions_and_usage

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -225,7 +225,7 @@ def _tag_registry_entities_for_keep_delete(project, registry, repo):
 
 def _tag_registry_views_for_keep_delete(project, registry, repo):
     views_to_keep: List[FeatureView] = repo.feature_views
-    views_to_delete = []
+    views_to_delete: List[FeatureView] = []
     repo_feature_view_names = set(t.name for t in repo.feature_views)
     for registry_view in registry.list_feature_views(project=project):
         if registry_view.name not in repo_feature_view_names:

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -193,7 +193,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     apply_feature_services(registry, project, repo)
 
     infra_provider = get_provider(repo_config, repo_path)
-    for name in [table.name for table in views_to_keep]:
+    for name in [view.name for view in views_to_keep]:
         click.echo(
             f"Deploying infrastructure for {Style.BRIGHT + Fore.GREEN}{name}{Style.RESET_ALL}"
         )

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -15,6 +15,10 @@ from feast import Entity, FeatureTable
 from feast.feature_service import FeatureService
 from feast.feature_store import FeatureStore, _validate_feature_views
 from feast.feature_view import FeatureView
+from feast.inference import (
+    update_data_sources_with_inferred_event_timestamp_col,
+    update_entities_with_inferred_types_from_feature_views,
+)
 from feast.infra.provider import get_provider
 from feast.names import adjectives, animals
 from feast.registry import Registry
@@ -112,63 +116,106 @@ def parse_repo(repo_root: Path) -> ParsedRepo:
     return res
 
 
+def apply_feature_services(
+    registry: Registry,
+    project: str,
+    repo: ParsedRepo,
+    existing_feature_services: List[FeatureService],
+):
+    from colorama import Fore, Style
+
+    # Determine which feature services should be deleted.
+    for feature_service in repo.feature_services:
+        if feature_service in existing_feature_services:
+            existing_feature_services.remove(feature_service)
+
+    # The remaining features services in the list should be deleted.
+    for feature_service_to_delete in existing_feature_services:
+        registry.delete_feature_service(
+            feature_service_to_delete.name, project, commit=False
+        )
+        click.echo(
+            f"Deleted feature service {Style.BRIGHT + Fore.GREEN}{feature_service_to_delete.name}{Style.RESET_ALL} "
+            f"from registry"
+        )
+
+    for feature_service in repo.feature_services:
+        registry.apply_feature_service(feature_service, project=project)
+        click.echo(
+            f"Registered feature service {Style.BRIGHT + Fore.GREEN}{feature_service.name}{Style.RESET_ALL}"
+        )
+
+
 @log_exceptions_and_usage
 def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool):
     from colorama import Fore, Style
 
     os.chdir(repo_path)
-    store = FeatureStore(repo_path=str(repo_path))
-    project = store.project
+    registry_config = repo_config.get_registry_config()
+    project = repo_config.project
     if not is_valid_name(project):
         print(
             f"{project} is not valid. Project name should only have "
             f"alphanumerical values and underscores but not start with an underscore."
         )
         sys.exit(1)
-    registry = store.registry
+    registry = Registry(
+        registry_path=registry_config.path,
+        repo_path=repo_path,
+        cache_ttl=timedelta(seconds=registry_config.cache_ttl_seconds),
+    )
     registry._initialize_registry()
     sys.dont_write_bytecode = True
     repo = parse_repo(repo_path)
     _validate_feature_views(repo.feature_views)
+    data_sources = [t.batch_source for t in repo.feature_views]
 
     if not skip_source_validation:
-        data_sources = [t.input for t in repo.feature_views]
         # Make sure the data source used by this feature view is supported by Feast
         for data_source in data_sources:
-            data_source.validate(store.config)
+            data_source.validate(repo_config)
 
-    entities_to_keep, entities_to_delete = _tag_registry_entities_for_keep_delete(
-        project, registry, repo
+    # Make inferences
+    update_entities_with_inferred_types_from_feature_views(
+        repo.entities, repo.feature_views, repo_config
     )
-    views_to_keep, views_to_delete = _tag_registry_views_for_keep_delete(
-        project, registry, repo
-    )
-    tables_to_keep, tables_to_delete = _tag_registry_tables_for_keep_delete(
-        project, registry, repo
-    )
-    (
-        feature_services_to_keep,
-        feature_services_to_delete,
-    ) = _tag_registry_services_for_keep_delete(project, registry, repo)
+    update_data_sources_with_inferred_event_timestamp_col(data_sources, repo_config)
+    for view in repo.feature_views:
+        view.infer_features_from_batch_source(repo_config)
+
+    repo_table_names = set(t.name for t in repo.feature_tables)
+
+    for t in repo.feature_views:
+        repo_table_names.add(t.name)
+
+    tables_to_delete = []
+    for registry_table in registry.list_feature_tables(project=project):
+        if registry_table.name not in repo_table_names:
+            tables_to_delete.append(registry_table)
+
+    views_to_delete = []
+    for registry_view in registry.list_feature_views(project=project):
+        if registry_view.name not in repo_table_names:
+            views_to_delete.append(registry_view)
+
+    entities_to_delete: List[Entity] = []
+    repo_entities_names = set([e.name for e in repo.entities])
+    for registry_entity in registry.list_entities(project=project):
+        if registry_entity.name not in repo_entities_names:
+            entities_to_delete.append(registry_entity)
+
+    entities_to_keep: List[Entity] = repo.entities
+
+    existing_feature_services = registry.list_feature_services(project)
 
     sys.dont_write_bytecode = False
-
-    # Delete views that should not exist
-    for registry_view in views_to_delete:
-        store.delete_feature_view(registry_view.name)
+    for entity in repo.entities:
+        registry.apply_entity(entity, project=project, commit=False)
         click.echo(
-            f"Deleted feature view {Style.BRIGHT + Fore.GREEN}{registry_view.name}{Style.RESET_ALL} from registry"
+            f"Registered entity {Style.BRIGHT + Fore.GREEN}{entity.name}{Style.RESET_ALL}"
         )
 
-    # Delete feature services that should not exist
-    for feature_service_to_delete in feature_services_to_delete:
-        store.delete_feature_service(feature_service_to_delete.name)
-        click.echo(
-            f"Deleted feature service {Style.BRIGHT + Fore.GREEN}{feature_service_to_delete.name}{Style.RESET_ALL} "
-            f"from registry"
-        )
-
-        # Delete tables that should not exist
+    # Delete tables that should not exist
     for registry_table in tables_to_delete:
         registry.delete_feature_table(
             registry_table.name, project=project, commit=False
@@ -177,32 +224,39 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
             f"Deleted feature table {Style.BRIGHT + Fore.GREEN}{registry_table.name}{Style.RESET_ALL} from registry"
         )
 
-    # TODO: delete entities from the registry too
-    registry.commit()
-
-    # Add / update views + entities
-    store.apply(entities_to_keep + views_to_keep + feature_services_to_keep)
-    for entity in entities_to_keep:
-        click.echo(
-            f"Registered entity {Style.BRIGHT + Fore.GREEN}{entity.name}{Style.RESET_ALL}"
-        )
-    for view in views_to_keep:
-        click.echo(
-            f"Registered feature view {Style.BRIGHT + Fore.GREEN}{view.name}{Style.RESET_ALL}"
-        )
-    for feature_service in feature_services_to_keep:
-        click.echo(
-            f"Registered feature service {Style.BRIGHT + Fore.GREEN}{feature_service.name}{Style.RESET_ALL}"
-        )
-    # Create tables that should exist
-    for table in tables_to_keep:
+    # Create tables that should
+    for table in repo.feature_tables:
         registry.apply_feature_table(table, project, commit=False)
         click.echo(
             f"Registered feature table {Style.BRIGHT + Fore.GREEN}{table.name}{Style.RESET_ALL}"
         )
-    registry.commit()
+
+    # Delete views that should not exist
+    for registry_view in views_to_delete:
+        registry.delete_feature_view(registry_view.name, project=project, commit=False)
+        click.echo(
+            f"Deleted feature view {Style.BRIGHT + Fore.GREEN}{registry_view.name}{Style.RESET_ALL} from registry"
+        )
+
+    # Create views that should exist
+    for view in repo.feature_views:
+        registry.apply_feature_view(view, project, commit=False)
+        click.echo(
+            f"Registered feature view {Style.BRIGHT + Fore.GREEN}{view.name}{Style.RESET_ALL}"
+        )
+
+    apply_feature_services(registry, project, repo, existing_feature_services)
 
     infra_provider = get_provider(repo_config, repo_path)
+
+    all_to_delete: List[Union[FeatureTable, FeatureView]] = []
+    all_to_delete.extend(tables_to_delete)
+    all_to_delete.extend(views_to_delete)
+
+    all_to_keep: List[Union[FeatureTable, FeatureView]] = []
+    all_to_keep.extend(repo.feature_tables)
+    all_to_keep.extend(repo.feature_views)
+
     for name in [view.name for view in repo.feature_tables] + [
         table.name for table in repo.feature_views
     ]:
@@ -215,14 +269,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
         click.echo(
             f"Removing infrastructure for {Style.BRIGHT + Fore.GREEN}{name}{Style.RESET_ALL}"
         )
-    # TODO: consider echoing also entities being deployed/removed
 
-    all_to_delete: List[Union[FeatureTable, FeatureView]] = []
-    all_to_delete.extend(tables_to_delete)
-    all_to_delete.extend(views_to_delete)
-    all_to_keep: List[Union[FeatureTable, FeatureView]] = []
-    all_to_keep.extend(tables_to_keep)
-    all_to_keep.extend(views_to_delete)
     infra_provider.update_infra(
         project,
         tables_to_delete=all_to_delete,
@@ -232,53 +279,8 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
         partial=False,
     )
 
-
-def _tag_registry_entities_for_keep_delete(
-    project: str, registry: Registry, repo: ParsedRepo
-):
-    entities_to_keep: List[Entity] = repo.entities
-    entities_to_delete: List[Entity] = []
-    repo_entities_names = set([e.name for e in repo.entities])
-    for registry_entity in registry.list_entities(project=project):
-        if registry_entity.name not in repo_entities_names:
-            entities_to_delete.append(registry_entity)
-    return entities_to_keep, entities_to_delete
-
-
-def _tag_registry_views_for_keep_delete(
-    project: str, registry: Registry, repo: ParsedRepo
-):
-    views_to_keep: List[FeatureView] = repo.feature_views
-    views_to_delete: List[FeatureView] = []
-    repo_feature_view_names = set(t.name for t in repo.feature_views)
-    for registry_view in registry.list_feature_views(project=project):
-        if registry_view.name not in repo_feature_view_names:
-            views_to_delete.append(registry_view)
-    return views_to_keep, views_to_delete
-
-
-def _tag_registry_tables_for_keep_delete(
-    project: str, registry: Registry, repo: ParsedRepo
-):
-    tables_to_keep: List[FeatureTable] = repo.feature_tables
-    tables_to_delete: List[FeatureTable] = []
-    repo_table_names = set(t.name for t in repo.feature_tables)
-    for registry_table in registry.list_feature_tables(project=project):
-        if registry_table.name not in repo_table_names:
-            tables_to_delete.append(registry_table)
-    return tables_to_keep, tables_to_delete
-
-
-def _tag_registry_services_for_keep_delete(
-    project: str, registry: Registry, repo: ParsedRepo
-):
-    feature_services_to_keep: List[FeatureService] = repo.feature_services
-    feature_services_to_delete: List[FeatureService] = []
-    repo_feature_service_names = set(t.name for t in repo.feature_services)
-    for registry_service in registry.list_feature_services(project=project):
-        if registry_service.name not in repo_feature_service_names:
-            feature_services_to_delete.append(registry_service)
-    return feature_services_to_keep, feature_services_to_delete
+    # Commit the update to the registry only after successful infra update
+    registry.commit()
 
 
 @log_exceptions_and_usage

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -154,7 +154,6 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     sys.dont_write_bytecode = True
     repo = parse_repo(repo_path)
     _validate_feature_views(repo.feature_views)
-    data_sources = [t.batch_source for t in repo.feature_views]
 
     if not skip_source_validation:
         data_sources = [t.input for t in repo.feature_views]

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -232,7 +232,9 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     registry.commit()
 
 
-def _tag_registry_entities_for_keep_delete(project: str, registry: Registry, repo: ParsedRepo):
+def _tag_registry_entities_for_keep_delete(
+    project: str, registry: Registry, repo: ParsedRepo
+):
     entities_to_keep: List[Entity] = repo.entities
     entities_to_delete: List[Entity] = []
     repo_entities_names = set([e.name for e in repo.entities])
@@ -242,7 +244,9 @@ def _tag_registry_entities_for_keep_delete(project: str, registry: Registry, rep
     return entities_to_keep, entities_to_delete
 
 
-def _tag_registry_views_for_keep_delete(project: str, registry: Registry, repo: ParsedRepo):
+def _tag_registry_views_for_keep_delete(
+    project: str, registry: Registry, repo: ParsedRepo
+):
     views_to_keep: List[FeatureView] = repo.feature_views
     views_to_delete = []
     repo_feature_view_names = set(t.name for t in repo.feature_views)

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -6,12 +6,12 @@ import sys
 from datetime import timedelta
 from importlib.abc import Loader
 from pathlib import Path
-from typing import List, NamedTuple, Set, Union
+from typing import List, NamedTuple, Set
 
 import click
 from click.exceptions import BadParameter
 
-from feast import Entity, FeatureStore, FeatureTable
+from feast import Entity, FeatureTable
 from feast.feature_service import FeatureService
 from feast.feature_store import FeatureStore, _validate_feature_views
 from feast.feature_view import FeatureView

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -112,30 +112,6 @@ def parse_repo(repo_root: Path) -> ParsedRepo:
     return res
 
 
-def apply_feature_services(registry: Registry, project: str, repo: ParsedRepo):
-    from colorama import Fore, Style
-
-    # Determine which feature services should be deleted.
-    existing_feature_services = registry.list_feature_services(project)
-    for feature_service in repo.feature_services:
-        if feature_service in existing_feature_services:
-            existing_feature_services.remove(feature_service)
-
-    # The remaining features services in the list should be deleted.
-    for feature_service_to_delete in existing_feature_services:
-        registry.delete_feature_service(feature_service_to_delete.name, project)
-        click.echo(
-            f"Deleted feature service {Style.BRIGHT + Fore.GREEN}{feature_service_to_delete.name}{Style.RESET_ALL} "
-            f"from registry"
-        )
-
-    for feature_service in repo.feature_services:
-        registry.apply_feature_service(feature_service, project=project)
-        click.echo(
-            f"Registered feature service {Style.BRIGHT + Fore.GREEN}{feature_service.name}{Style.RESET_ALL}"
-        )
-
-
 @log_exceptions_and_usage
 def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool):
     from colorama import Fore, Style
@@ -170,10 +146,29 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     tables_to_keep, tables_to_delete = _tag_registry_tables_for_keep_delete(
         project, registry, repo
     )
+    (
+        feature_services_to_keep,
+        feature_services_to_delete,
+    ) = _tag_registry_services_for_keep_delete(project, registry, repo)
 
     sys.dont_write_bytecode = False
 
-    # Delete tables that should not exist
+    # Delete views that should not exist
+    for registry_view in views_to_delete:
+        store.delete_feature_view(registry_view.name)
+        click.echo(
+            f"Deleted feature view {Style.BRIGHT + Fore.GREEN}{registry_view.name}{Style.RESET_ALL} from registry"
+        )
+
+    # Delete feature services that should not exist
+    for feature_service_to_delete in feature_services_to_delete:
+        store.delete_feature_service(feature_service_to_delete.name)
+        click.echo(
+            f"Deleted feature service {Style.BRIGHT + Fore.GREEN}{feature_service_to_delete.name}{Style.RESET_ALL} "
+            f"from registry"
+        )
+
+        # Delete tables that should not exist
     for registry_table in tables_to_delete:
         registry.delete_feature_table(
             registry_table.name, project=project, commit=False
@@ -182,17 +177,11 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
             f"Deleted feature table {Style.BRIGHT + Fore.GREEN}{registry_table.name}{Style.RESET_ALL} from registry"
         )
 
-    # Delete views that should not exist
-    for registry_view in views_to_delete:
-        store.delete_feature_view(registry_view.name)
-        click.echo(
-            f"Deleted feature view {Style.BRIGHT + Fore.GREEN}{registry_view.name}{Style.RESET_ALL} from registry"
-        )
     # TODO: delete entities from the registry too
     registry.commit()
 
     # Add / update views + entities
-    store.apply(entities_to_keep + views_to_keep)
+    store.apply(entities_to_keep + views_to_keep + feature_services_to_keep)
     for entity in entities_to_keep:
         click.echo(
             f"Registered entity {Style.BRIGHT + Fore.GREEN}{entity.name}{Style.RESET_ALL}"
@@ -201,6 +190,10 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
         click.echo(
             f"Registered feature view {Style.BRIGHT + Fore.GREEN}{view.name}{Style.RESET_ALL}"
         )
+    for feature_service in feature_services_to_keep:
+        click.echo(
+            f"Registered feature service {Style.BRIGHT + Fore.GREEN}{feature_service.name}{Style.RESET_ALL}"
+        )
     # Create tables that should exist
     for table in tables_to_keep:
         registry.apply_feature_table(table, project, commit=False)
@@ -208,8 +201,6 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
             f"Registered feature table {Style.BRIGHT + Fore.GREEN}{table.name}{Style.RESET_ALL}"
         )
     registry.commit()
-
-    apply_feature_services(registry, project, repo)
 
     infra_provider = get_provider(repo_config, repo_path)
     for name in [view.name for view in repo.feature_tables] + [
@@ -276,6 +267,18 @@ def _tag_registry_tables_for_keep_delete(
         if registry_table.name not in repo_table_names:
             tables_to_delete.append(registry_table)
     return tables_to_keep, tables_to_delete
+
+
+def _tag_registry_services_for_keep_delete(
+    project: str, registry: Registry, repo: ParsedRepo
+):
+    feature_services_to_keep: List[FeatureService] = repo.feature_services
+    feature_services_to_delete: List[FeatureService] = []
+    repo_feature_service_names = set(t.name for t in repo.feature_services)
+    for registry_service in registry.list_feature_services(project=project):
+        if registry_service.name not in repo_feature_service_names:
+            feature_services_to_delete.append(registry_service)
+    return feature_services_to_keep, feature_services_to_delete
 
 
 @log_exceptions_and_usage

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -11,14 +11,10 @@ from typing import List, NamedTuple, Set, Union
 import click
 from click.exceptions import BadParameter
 
-from feast import Entity, FeatureTable
+from feast import Entity, FeatureStore, FeatureTable
 from feast.feature_service import FeatureService
 from feast.feature_store import FeatureStore, _validate_feature_views
 from feast.feature_view import FeatureView
-from feast.inference import (
-    update_data_sources_with_inferred_event_timestamp_col,
-    update_entities_with_inferred_types_from_feature_views,
-)
 from feast.infra.provider import get_provider
 from feast.names import adjectives, animals
 from feast.registry import Registry
@@ -151,19 +147,15 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     from colorama import Fore, Style
 
     os.chdir(repo_path)
-    registry_config = repo_config.get_registry_config()
-    project = repo_config.project
+    store = FeatureStore(repo_path=str(repo_path))
+    project = store.project
     if not is_valid_name(project):
         print(
             f"{project} is not valid. Project name should only have "
             f"alphanumerical values and underscores but not start with an underscore."
         )
         sys.exit(1)
-    registry = Registry(
-        registry_path=registry_config.path,
-        repo_path=repo_path,
-        cache_ttl=timedelta(seconds=registry_config.cache_ttl_seconds),
-    )
+    registry = store.registry
     registry._initialize_registry()
     sys.dont_write_bytecode = True
     repo = parse_repo(repo_path)
@@ -171,32 +163,17 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     data_sources = [t.batch_source for t in repo.feature_views]
 
     if not skip_source_validation:
+        data_sources = [t.input for t in repo.feature_views]
         # Make sure the data source used by this feature view is supported by Feast
         for data_source in data_sources:
-            data_source.validate(repo_config)
+            data_source.validate(store.config)
 
-    # Make inferences
-    update_entities_with_inferred_types_from_feature_views(
-        repo.entities, repo.feature_views, repo_config
+    entities_to_delete, entities_to_keep = _tag_registry_entities_for_keep_delete(
+        project, registry, repo
     )
-    update_data_sources_with_inferred_event_timestamp_col(data_sources, repo_config)
-    for view in repo.feature_views:
-        view.infer_features_from_batch_source(repo_config)
-
-    repo_table_names = set(t.name for t in repo.feature_tables)
-
-    for t in repo.feature_views:
-        repo_table_names.add(t.name)
-
-    tables_to_delete = []
-    for registry_table in registry.list_feature_tables(project=project):
-        if registry_table.name not in repo_table_names:
-            tables_to_delete.append(registry_table)
-
-    views_to_delete = []
-    for registry_view in registry.list_feature_views(project=project):
-        if registry_view.name not in repo_table_names:
-            views_to_delete.append(registry_view)
+    views_to_delete, views_to_keep = _tag_registry_views_for_keep_delete(
+        project, registry, repo
+    )
 
     entities_to_delete: List[Entity] = []
     repo_entities_names = set([e.name for e in repo.entities])
@@ -209,38 +186,22 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     existing_feature_services = registry.list_feature_services(project)
 
     sys.dont_write_bytecode = False
-    for entity in repo.entities:
-        registry.apply_entity(entity, project=project, commit=False)
-        click.echo(
-            f"Registered entity {Style.BRIGHT + Fore.GREEN}{entity.name}{Style.RESET_ALL}"
-        )
-
-    # Delete tables that should not exist
-    for registry_table in tables_to_delete:
-        registry.delete_feature_table(
-            registry_table.name, project=project, commit=False
-        )
-        click.echo(
-            f"Deleted feature table {Style.BRIGHT + Fore.GREEN}{registry_table.name}{Style.RESET_ALL} from registry"
-        )
-
-    # Create tables that should
-    for table in repo.feature_tables:
-        registry.apply_feature_table(table, project, commit=False)
-        click.echo(
-            f"Registered feature table {Style.BRIGHT + Fore.GREEN}{table.name}{Style.RESET_ALL}"
-        )
 
     # Delete views that should not exist
     for registry_view in views_to_delete:
-        registry.delete_feature_view(registry_view.name, project=project, commit=False)
+        store.delete_feature_view(registry_view.name, project=project, commit=False)
         click.echo(
             f"Deleted feature view {Style.BRIGHT + Fore.GREEN}{registry_view.name}{Style.RESET_ALL} from registry"
         )
+    # TODO: delete entities from the registry too
 
-    # Create views that should exist
-    for view in repo.feature_views:
-        registry.apply_feature_view(view, project, commit=False)
+    # Add / update views + entities
+    store.apply(entities_to_keep + views_to_keep)
+    for entity in entities_to_keep:
+        click.echo(
+            f"Registered entity {Style.BRIGHT + Fore.GREEN}{entity.name}{Style.RESET_ALL}"
+        )
+    for view in views_to_keep:
         click.echo(
             f"Registered feature view {Style.BRIGHT + Fore.GREEN}{view.name}{Style.RESET_ALL}"
         )
@@ -269,11 +230,12 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
         click.echo(
             f"Removing infrastructure for {Style.BRIGHT + Fore.GREEN}{name}{Style.RESET_ALL}"
         )
+    # TODO: consider echoing also entities being deployed/removed
 
     infra_provider.update_infra(
         project,
-        tables_to_delete=all_to_delete,
-        tables_to_keep=all_to_keep,
+        tables_to_delete=views_to_delete,
+        tables_to_keep=views_to_keep,
         entities_to_delete=entities_to_delete,
         entities_to_keep=entities_to_keep,
         partial=False,
@@ -281,6 +243,26 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
 
     # Commit the update to the registry only after successful infra update
     registry.commit()
+
+
+def _tag_registry_entities_for_keep_delete(project, registry, repo):
+    entities_to_keep: List[Entity] = repo.entities
+    entities_to_delete: List[Entity] = []
+    repo_entities_names = set([e.name for e in repo.entities])
+    for registry_entity in registry.list_entities(project=project):
+        if registry_entity.name not in repo_entities_names:
+            entities_to_delete.append(registry_entity)
+    return entities_to_delete, entities_to_keep
+
+
+def _tag_registry_views_for_keep_delete(project, registry, repo):
+    views_to_keep: List[FeatureView] = repo.feature_views
+    views_to_delete = []
+    repo_feature_view_names = set(t.name for t in repo.feature_views)
+    for registry_view in registry.list_feature_views(project=project):
+        if registry_view.name not in repo_feature_view_names:
+            views_to_delete.append(registry_view)
+    return views_to_delete, views_to_keep
 
 
 @log_exceptions_and_usage


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves the feast CLI's apply method (`feast apply`) to use the SDK FeatureStore class more. Note that because the feast CLI's apply is a total apply whereas the SDK apply is partial, there is still leftover business logic (in particular for deleting entities / FVs that don't match the repo).

**Which issue(s) this PR fixes**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE

```
