### PR TITLE
Restore feature refs

### DIFF
--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -93,13 +93,14 @@ class FeatureView:
         Raises:
             ValueError: A field mapping conflicts with an Entity or a Feature.
         """
-        warnings.warn(
-            (
-                "The argument 'input' is being deprecated. Please use 'batch_source' "
-                "instead. Feast 0.13 and onwards will not support the argument 'input'."
-            ),
-            DeprecationWarning,
-        )
+        if input is not None:
+            warnings.warn(
+                (
+                    "The argument 'input' is being deprecated. Please use 'batch_source' "
+                    "instead. Feast 0.13 and onwards will not support the argument 'input'."
+                ),
+                DeprecationWarning,
+            )
 
         _input = input or batch_source
         assert _input is not None

--- a/sdk/python/tests/integration/registration/test_feature_store.py
+++ b/sdk/python/tests/integration/registration/test_feature_store.py
@@ -490,7 +490,7 @@ def test_apply_duplicated_featureview_names(feature_store_with_local_registry):
         entities=["driver_id"],
         ttl=timedelta(seconds=10),
         online=False,
-        input=FileSource(path="driver_stats.parquet"),
+        batch_source=FileSource(path="driver_stats.parquet"),
         tags={},
     )
 
@@ -499,7 +499,7 @@ def test_apply_duplicated_featureview_names(feature_store_with_local_registry):
         entities=["id"],
         ttl=timedelta(seconds=10),
         online=False,
-        input=FileSource(path="customer_stats.parquet"),
+        batch_source=FileSource(path="customer_stats.parquet"),
         tags={},
     )
     try:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: #1691 allows for specifying FeatureServices in FeatureStore methods, but introduced a breaking change by renaming `feature_refs` to `features`. This PR ensures the change is not breaking, and inserts the appropriate DeprecationWarning. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Makes features an optional parameter in get_historical_features, instead of required
```
