### PR TITLE
Adding small note for project naming convention

### DIFF
--- a/docs/reference/feature-repository/feature-store-yaml.md
+++ b/docs/reference/feature-repository/feature-store-yaml.md
@@ -23,7 +23,7 @@ The following top-level configuration options exist in the `feature_store.yaml` 
 * **registry** — Configures the location of the feature registry.
 * **online\_store** — Configures the online store.
 * **offline\_store** — Configures the offline store.
-* **project** — Defines a namespace for the entire feature store. Can be used to isolate multiple deployments in a single installation of Feast.
+* **project** — Defines a namespace for the entire feature store. Can be used to isolate multiple deployments in a single installation of Feast. Should only contain letters, numbers, and underscores.
 
 Please see the [RepoConfig](https://rtd.feast.dev/en/latest/#feast.repo_config.RepoConfig) API reference for the full list of configuration options.
 


### PR DESCRIPTION
Signed-off-by: Cody Lin <codyl@twitter.com>

**What this PR does / why we need it**:
Unfortunately I had accidentally specified a project name with a dash. The error that popped up was from sqlite (following a `store.apply` call when trying to create tables in the online store.):
```
sqlite3.OperationalError: near “-”: syntax error
```
which actually took me some extra debugging to figure out what my issue was.

**Which issue(s) this PR fixes**:
N/A. Too small for a PR, but it could be related to overall validation or more docs specifying naming limitations.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
