### PR TITLE
Fix `feast apply` bugs

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -24,7 +24,11 @@ from tqdm import tqdm
 
 from feast import utils
 from feast.entity import Entity
-from feast.errors import FeatureNameCollisionError, FeatureViewNotFoundException
+from feast.errors import (
+    EntityNotFoundException,
+    FeatureNameCollisionError,
+    FeatureViewNotFoundException,
+)
 from feast.feature_service import FeatureService
 from feast.feature_table import FeatureTable
 from feast.feature_view import FeatureView
@@ -654,9 +658,7 @@ class FeatureStore:
                 try:
                     join_key = entity_name_to_join_key_map[entity_name]
                 except KeyError:
-                    raise Exception(
-                        f"Entity {entity_name} does not exist in project {self.project}"
-                    )
+                    raise EntityNotFoundException(entity_name, self.project)
                 join_key_row[join_key] = entity_value
             join_key_rows.append(join_key_row)
 


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: This fixes 2 bugs during `feast apply`.
1. We always initialized the empty registry (instead of loading the existing registry). This means that if during 1st apply we deployed infra for FeatureView A, and in the 2nd apply we renamed FeatureView A -> B, `feast apply` would create the table for B, but wouldn't remove the table for A.
2. The `registry.commit()` happened before the infra update call on the provider. This means that if the infra update fails (for example bad permissions), the registry still got updated. Which means that during the next apply, Feast wouldn't do anything because it'll think that everything is up to date in the registry. I moved the commit at the very end of apply_total method, and updated the rest of the function accordingly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix `feast apply` bugs - incorrect initialization of registry and early registry commit
```
