### PR TITLE
Deprecate the input parameter for FeatureViews

### DIFF
--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -105,7 +105,7 @@ def get_feature_view_query_context(
         join_keys = []
         entity_selections = []
         reverse_field_mapping = {
-            v: k for k, v in feature_view.input.field_mapping.items()
+            v: k for k, v in feature_view.batch_source.field_mapping.items()
         }
         for entity_name in feature_view.entities:
             entity = registry.get_entity(entity_name, project)
@@ -120,8 +120,8 @@ def get_feature_view_query_context(
         else:
             ttl_seconds = 0
 
-        event_timestamp_column = feature_view.input.event_timestamp_column
-        created_timestamp_column = feature_view.input.created_timestamp_column
+        event_timestamp_column = feature_view.batch_source.event_timestamp_column
+        created_timestamp_column = feature_view.batch_source.created_timestamp_column
 
         context = FeatureViewQueryContext(
             name=feature_view.name,
@@ -135,7 +135,7 @@ def get_feature_view_query_context(
                 created_timestamp_column, created_timestamp_column
             ),
             # TODO: Make created column optional and not hardcoded
-            table_subquery=feature_view.input.get_table_query_string(),
+            table_subquery=feature_view.batch_source.get_table_query_string(),
             entity_selections=entity_selections,
         )
         query_context.append(context)

--- a/sdk/python/tests/example_repos/example_feature_repo_with_duplicated_featureview_names.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_with_duplicated_featureview_names.py
@@ -10,7 +10,7 @@ driver_hourly_stats_view = FeatureView(
     name="driver_hourly_stats",  # Intentionally use the same FeatureView name
     entities=["driver_id"],
     online=False,
-    input=driver_hourly_stats,
+    batch_source=driver_hourly_stats,
     ttl=Duration(seconds=10),
     tags={},
 )
@@ -19,7 +19,7 @@ driver_hourly_stats_view_dup1 = FeatureView(
     name="driver_hourly_stats",  # Intentionally use the same FeatureView name
     entities=["driver_id"],
     online=False,
-    input=driver_hourly_stats,
+    batch_source=driver_hourly_stats,
     ttl=Duration(seconds=10),
     tags={},
 )

--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -10,5 +10,5 @@ def correctness_feature_view(data_source: DataSource) -> FeatureView:
         entities=["driver"],
         features=[Feature("value", ValueType.FLOAT)],
         ttl=timedelta(days=5),
-        input=data_source,
+        batch_source=data_source,
     )


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: FeatureViews have always required a batch data source as input; this argument is currently named input. This PR removes input as an argument and makes batch_source required. Since this is a breaking change, it was preceded by a deprecation warning in #1729, which was part of the 0.12 release.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Deprecates input parameter for FeatureViews
```
