### PR TITLE
Validate project name upon feast.apply

### DIFF
--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -2,7 +2,14 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import BaseModel, StrictInt, StrictStr, ValidationError, root_validator
+from pydantic import (
+    BaseModel,
+    StrictInt,
+    StrictStr,
+    ValidationError,
+    root_validator,
+    validator,
+)
 from pydantic.error_wrappers import ErrorWrapper
 from pydantic.typing import Dict, Optional, Union
 
@@ -179,6 +186,17 @@ class RepoConfig(FeastBaseModel):
             )
 
         return values
+
+    @validator("project")
+    def _validate_project_name(cls, v):
+        from feast.repo_operations import is_valid_name
+
+        if not is_valid_name(v):
+            raise ValueError(
+                f"Project name, {v}, should only have "
+                f"alphanumerical values and underscores but not start with an underscore."
+            )
+        return v
 
 
 class FeastConfigError(Exception):

--- a/sdk/python/tests/integration/scaffolding/test_repo_config.py
+++ b/sdk/python/tests/integration/scaffolding/test_repo_config.py
@@ -153,3 +153,27 @@ def test_no_project():
         "project\n"
         "  field required (type=value_error.missing)",
     )
+
+
+def test_invalid_project_name():
+    _test_config(
+        dedent(
+            """
+        project: foo-1
+        registry: "registry.db"
+        provider: local
+        """
+        ),
+        expect_error="alphanumerical values ",
+    )
+
+    _test_config(
+        dedent(
+            """
+        project: _foo
+        registry: "registry.db"
+        provider: local
+        """
+        ),
+        expect_error="alphanumerical values ",
+    )


### PR DESCRIPTION
Signed-off-by: ted chang <htchang@us.ibm.com>

**What this PR does / why we need it**:
Check invalid project name
**Which issue(s) this PR fixes**:
Fixes #1755

**Does this PR introduce a user-facing change?**:
```release-note
User will get an error upon running feast.apply with invalid project name.
```
