### PR TITLE
Adding initial type support related tests for BQ

### DIFF
--- a/sdk/python/feast/inference.py
+++ b/sdk/python/feast/inference.py
@@ -29,9 +29,11 @@ def update_entities_with_inferred_types_from_feature_views(
         col_names_and_types = view.batch_source.get_table_column_names_and_types(config)
         for entity_name in view.entities:
             if entity_name in incomplete_entities:
+                entity = incomplete_entities[entity_name]
+
                 # get entity information from information extracted from the view batch source
                 extracted_entity_name_type_pairs = list(
-                    filter(lambda tup: tup[0] == entity_name, col_names_and_types)
+                    filter(lambda tup: tup[0] == entity.join_key, col_names_and_types,)
                 )
                 if len(extracted_entity_name_type_pairs) == 0:
                     # Doesn't mention inference error because would also be an error without inferencing
@@ -40,7 +42,6 @@ def update_entities_with_inferred_types_from_feature_views(
                         its entity's name."""
                     )
 
-                entity = incomplete_entities[entity_name]
                 inferred_value_type = view.batch_source.source_datatype_to_feast_value_type()(
                     extracted_entity_name_type_pairs[0][1]
                 )

--- a/sdk/python/tests/data/data_creator.py
+++ b/sdk/python/tests/data/data_creator.py
@@ -1,15 +1,22 @@
 from datetime import datetime, timedelta
+from typing import List
 
 import pandas as pd
 from pytz import timezone, utc
 
+from feast.value_type import ValueType
 
-def create_dataset() -> pd.DataFrame:
-    now = datetime.utcnow()
+
+def create_dataset(
+    entity_type: ValueType = ValueType.INT32,
+    feature_dtype: str = None,
+    feature_is_list: bool = False,
+) -> pd.DataFrame:
+    now = datetime.now().replace(microsecond=0, second=0, minute=0)
     ts = pd.Timestamp(now).round("ms")
     data = {
-        "id": [1, 2, 1, 3, 3],
-        "value": [0.1, None, 0.3, 4, 5],
+        "driver_id": get_entities_for_value_type(entity_type),
+        "value": get_feature_values_for_dtype(feature_dtype, feature_is_list),
         "ts_1": [
             ts - timedelta(hours=4),
             ts,
@@ -25,3 +32,33 @@ def create_dataset() -> pd.DataFrame:
         "created_ts": [ts, ts, ts, ts, ts],
     }
     return pd.DataFrame.from_dict(data)
+
+
+def get_entities_for_value_type(value_type: ValueType) -> List:
+    value_type_map = {
+        ValueType.INT32: [1, 2, 1, 3, 3],
+        ValueType.INT64: [1, 2, 1, 3, 3],
+        ValueType.FLOAT: [1.0, 2.0, 1.0, 3.0, 3.0],
+        ValueType.STRING: ["1", "2", "1", "3", "3"],
+    }
+    return value_type_map[value_type]
+
+
+def get_feature_values_for_dtype(dtype: str, is_list: bool) -> List:
+    if dtype is None:
+        return [0.1, None, 0.3, 4, 5]
+    # TODO(adchia): for int columns, consider having a better error when dealing with None values (pandas int dfs can't
+    #  have na)
+    dtype_map = {
+        "int32": [1, 2, 3, 4, 5],
+        "int64": [1, 2, 3, 4, 5],
+        "float": [1.0, None, 3.0, 4.0, 5.0],
+        "string": ["1", None, "3", "4", "5"],
+        "bool": [True, None, False, True, False],
+    }
+    non_list_val = dtype_map[dtype]
+    # Duplicate the value once if this is a list
+    if is_list:
+        return [[n, n] if n is not None else None for n in non_list_val]
+    else:
+        return non_list_val

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -78,7 +78,7 @@ def check_offline_and_online_features(
 def run_offline_online_store_consistency_test(
     fs: FeatureStore, fv: FeatureView
 ) -> None:
-    now = datetime.utcnow()
+    now = datetime.now()
 
     full_feature_names = True
     check_offline_store: bool = True

--- a/sdk/python/tests/integration/feature_repos/universal/entities.py
+++ b/sdk/python/tests/integration/feature_repos/universal/entities.py
@@ -10,5 +10,10 @@ def driver():
     )
 
 
+def driver_no_value_type():
+    # Don't specify value type in entity to force inference
+    return Entity(name="driver", description="driver id", join_key="driver_id",)
+
+
 def customer():
     return Entity(name="customer_id", value_type=ValueType.INT64)

--- a/sdk/python/tests/integration/feature_repos/universal/entities.py
+++ b/sdk/python/tests/integration/feature_repos/universal/entities.py
@@ -1,18 +1,13 @@
 from feast import Entity, ValueType
 
 
-def driver():
+def driver(value_type: ValueType = ValueType.INT64):
     return Entity(
         name="driver",  # The name is derived from this argument, not object name.
-        value_type=ValueType.INT64,
+        value_type=value_type,
         description="driver id",
         join_key="driver_id",
     )
-
-
-def driver_no_value_type():
-    # Don't specify value type in entity to force inference
-    return Entity(name="driver", description="driver id", join_key="driver_id",)
 
 
 def customer():

--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -5,12 +5,14 @@ from feast.data_source import DataSource
 
 
 def driver_feature_view(
-    data_source: DataSource, name="test_correctness"
+    data_source: DataSource,
+    name="test_correctness",
+    value_type: ValueType = ValueType.FLOAT,
 ) -> FeatureView:
     return FeatureView(
         name=name,
         entities=["driver"],
-        features=[Feature("value", ValueType.FLOAT)],
+        features=[Feature("value", value_type)],
         ttl=timedelta(days=5),
         input=data_source,
     )

--- a/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
@@ -59,7 +59,7 @@ def prep_bq_fs_and_fv(
         event_timestamp_column="ts",
         created_timestamp_column="created_ts",
         date_partition_column="",
-        field_mapping={"ts_1": "ts", "id": "driver_id"},
+        field_mapping={"ts_1": "ts"},
     )
 
     fv = driver_feature_view(bigquery_source)
@@ -122,7 +122,7 @@ def prep_redshift_fs_and_fv(
         event_timestamp_column="ts",
         created_timestamp_column="created_ts",
         date_partition_column="",
-        field_mapping={"ts_1": "ts", "id": "driver_id"},
+        field_mapping={"ts_1": "ts"},
     )
 
     fv = driver_feature_view(redshift_source)
@@ -171,7 +171,7 @@ def prep_local_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             event_timestamp_column="ts",
             created_timestamp_column="created_ts",
             date_partition_column="",
-            field_mapping={"ts_1": "ts", "id": "driver_id"},
+            field_mapping={"ts_1": "ts"},
         )
         fv = driver_feature_view(file_source)
         e = Entity(
@@ -212,7 +212,7 @@ def prep_redis_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             event_timestamp_column="ts",
             created_timestamp_column="created_ts",
             date_partition_column="",
-            field_mapping={"ts_1": "ts", "id": "driver_id"},
+            field_mapping={"ts_1": "ts"},
         )
         fv = driver_feature_view(file_source)
         e = Entity(
@@ -254,7 +254,7 @@ def prep_dynamodb_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             event_timestamp_column="ts",
             created_timestamp_column="created_ts",
             date_partition_column="",
-            field_mapping={"ts_1": "ts", "id": "driver_id"},
+            field_mapping={"ts_1": "ts"},
         )
         fv = driver_feature_view(file_source)
         e = Entity(
@@ -332,7 +332,7 @@ def check_offline_and_online_features(
 def run_offline_online_store_consistency_test(
     fs: FeatureStore, fv: FeatureView, full_feature_names: bool,
 ) -> None:
-    now = datetime.utcnow()
+    now = datetime.now()
     # Run materialize()
     # use both tz-naive & tz-aware timestamps to test that they're both correctly handled
     start_date = (now - timedelta(hours=5)).replace(tzinfo=utc)

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -7,7 +7,7 @@ from integration.feature_repos.test_repo_configuration import (
     parametrize_types_no_materialize_test,
     parametrize_types_no_materialize_test_no_list,
 )
-from integration.feature_repos.universal.entities import driver, driver_no_value_type
+from integration.feature_repos.universal.entities import driver
 from integration.feature_repos.universal.feature_views import driver_feature_view
 
 from feast.infra.offline_stores.offline_store import RetrievalJob
@@ -20,7 +20,7 @@ from feast.value_type import ValueType
 def test_entity_inference_types_match(environment: Environment):
     feature_dtype, feature_is_list, fs, fv = get_test_fixtures(environment)
     # Don't specify value type in entity to force inference
-    entity = driver_no_value_type()
+    entity = driver(value_type=ValueType.UNKNOWN)
     fs.apply([fv, entity])
 
     entities = fs.list_entities()
@@ -73,7 +73,7 @@ def test_feature_get_online_features_types_match(environment: Environment):
         pass
 
     features = [fv.name + ":value"]
-    entity = driver_no_value_type()
+    entity = driver(value_type=ValueType.UNKNOWN)
     fs.apply([fv, entity])
     fs.materialize(environment.start_date, environment.end_date)
     driver_id_value = "1" if environment.entity_type == ValueType.STRING else 1

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -45,7 +45,9 @@ def test_feature_get_historical_features_types_match(environment: Environment):
 
     features = [f"{fv.name}:value"]
     df = pd.DataFrame()
-    df["driver_id"] = [1, 3]
+    df["driver_id"] = (
+        ["1", "3"] if environment.entity_type == ValueType.STRING else [1, 3]
+    )
     now = datetime.utcnow()
     ts = pd.Timestamp(now).round("ms")
     df["ts"] = [
@@ -117,7 +119,7 @@ def assert_expected_historical_feature_types(
         "int64": "int64",
         "float": "float64",
         "string": "object",
-        "bool": "object",
+        "bool": "bool",
     }
     assert (
         str(historical_features_df.dtypes["value"])

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -1,0 +1,171 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+from data.data_creator import get_feature_values_for_dtype
+from integration.feature_repos.test_repo_configuration import (
+    Environment,
+    parametrize_types_no_materialize_test,
+    parametrize_types_no_materialize_test_no_list,
+)
+from integration.feature_repos.universal.entities import driver, driver_no_value_type
+from integration.feature_repos.universal.feature_views import driver_feature_view
+
+from feast.infra.offline_stores.offline_store import RetrievalJob
+from feast.type_map import python_type_to_feast_value_type
+from feast.value_type import ValueType
+
+
+# TODO: change parametrization to allow for other providers aside from gcp
+@parametrize_types_no_materialize_test
+def test_entity_inference_types_match(environment: Environment):
+    feature_dtype, feature_is_list, fs, fv = get_test_fixtures(environment)
+    # Don't specify value type in entity to force inference
+    entity = driver_no_value_type()
+    fs.apply([fv, entity])
+
+    entities = fs.list_entities()
+    entity_type_to_expected_inferred_entity_type = {
+        ValueType.INT32: ValueType.INT64,
+        ValueType.INT64: ValueType.INT64,
+        ValueType.FLOAT: ValueType.DOUBLE,
+        ValueType.STRING: ValueType.STRING,
+    }
+    for entity in entities:
+        assert (
+            entity.value_type
+            == entity_type_to_expected_inferred_entity_type[environment.entity_type]
+        )
+
+
+@parametrize_types_no_materialize_test
+def test_feature_get_historical_features_types_match(environment: Environment):
+    feature_dtype, feature_is_list, fs, fv = get_test_fixtures(environment)
+    entity = driver()
+    fs.apply([fv, entity])
+
+    features = [f"{fv.name}:value"]
+    df = pd.DataFrame()
+    df["driver_id"] = [1, 3]
+    now = datetime.utcnow()
+    ts = pd.Timestamp(now).round("ms")
+    df["ts"] = [
+        ts - timedelta(hours=4),
+        ts - timedelta(hours=2),
+    ]
+    historical_features = fs.get_historical_features(entity_df=df, features=features,)
+
+    # TODO(adchia): pandas doesn't play well with nan values in ints. BQ will also coerce to floats if there are NaNs
+    historical_features_df = historical_features.to_df()
+    print(historical_features_df)
+    if feature_is_list:
+        assert_feature_list_types(feature_dtype, historical_features_df)
+    else:
+        assert_expected_historical_feature_types(feature_dtype, historical_features_df)
+    assert_expected_arrow_types(feature_dtype, feature_is_list, historical_features)
+
+
+@parametrize_types_no_materialize_test_no_list
+def test_feature_get_online_features_types_match(environment: Environment):
+    feature_dtype, feature_is_list, fs, fv = get_test_fixtures(environment)
+    if feature_is_list:
+        pass
+
+    features = [fv.name + ":value"]
+    entity = driver_no_value_type()
+    fs.apply([fv, entity])
+    fs.materialize(environment.start_date, environment.end_date)
+    driver_id_value = "1" if environment.entity_type == ValueType.STRING else 1
+    online_features = fs.get_online_features(
+        features=features, entity_rows=[{"driver": driver_id_value}],
+    ).to_dict()
+
+    feature_list_dtype_to_expected_online_response_value_type = {
+        "int32": "int",
+        "int64": "int",
+        "float": "float",
+        "string": "str",
+        "bool": "bool",
+    }
+    assert (
+        type(online_features["value"][0]).__name__
+        == feature_list_dtype_to_expected_online_response_value_type[feature_dtype]
+    )
+
+
+def get_test_fixtures(environment: Environment):
+    feature_dtype = environment.feature_dtype
+    feature_is_list = environment.feature_is_list
+    fs, fv = (
+        environment.feature_store,
+        driver_feature_view(
+            environment.data_source,
+            value_type=python_type_to_feast_value_type(
+                feature_dtype,
+                value=get_feature_values_for_dtype(feature_dtype, feature_is_list)[0],
+            ),
+        ),
+    )
+    return feature_dtype, feature_is_list, fs, fv
+
+
+def assert_expected_historical_feature_types(
+    feature_dtype: str, historical_features_df: pd.DataFrame
+):
+    print("Asserting historical feature types")
+    feature_dtype_to_expected_historical_feature_dtype = {
+        "int32": "int64",
+        "int64": "int64",
+        "float": "float64",
+        "string": "object",
+        "bool": "object",
+    }
+    assert (
+        str(historical_features_df.dtypes["value"])
+        == feature_dtype_to_expected_historical_feature_dtype[feature_dtype]
+    )
+
+
+def assert_feature_list_types(feature_dtype: str, historical_features_df: pd.DataFrame):
+    print("Asserting historical feature list types")
+    # Note, these expected values only hold for BQ
+    feature_list_dtype_to_expected_historical_feature_list_dtype = {
+        "int32": "int",
+        "int64": "int",
+        "float": "float",
+        "string": "str",
+        "bool": "bool",
+    }
+    assert str(historical_features_df.dtypes["value"]) == "object"
+    # Note, this struct schema is only true for BQ and not for other stores
+    assert (
+        type(historical_features_df.value[0]["list"][0]["item"]).__name__
+        == feature_list_dtype_to_expected_historical_feature_list_dtype[feature_dtype]
+    )
+
+
+def assert_expected_arrow_types(
+    feature_dtype: str, feature_is_list: bool, historical_features: RetrievalJob
+):
+    print("Asserting historical feature arrow types")
+    historical_features_arrow = historical_features.to_arrow()
+    print(historical_features_arrow)
+    feature_list_dtype_to_expected_historical_feature_arrow_type = {
+        "int32": "int64",
+        "int64": "int64",
+        "float": "double",
+        "string": "string",
+        "bool": "bool",
+    }
+    arrow_type = feature_list_dtype_to_expected_historical_feature_arrow_type[
+        feature_dtype
+    ]
+    if feature_is_list:
+        assert (
+            str(historical_features_arrow.schema.field_by_name("value").type)
+            == f"struct<list: list<item: struct<item: {arrow_type}>> not null>"
+        )
+    else:
+        assert (
+            str(historical_features_arrow.schema.field_by_name("value").type)
+            == arrow_type
+        )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Adds tests that tests given input data of different types (for entities vs features), whether the resultant feature vectors from get_historical_features and get_online_features and inference match expectations.

As part of this, updating inference to respect entity join_key.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
