### PR TITLE
Add offline retrival integration tests using the universal repo

### DIFF
--- a/sdk/python/feast/driver_test_data.py
+++ b/sdk/python/feast/driver_test_data.py
@@ -198,3 +198,27 @@ def create_customer_daily_profile_df(customers, start_date, end_date) -> pd.Data
     # TODO: Remove created timestamp in order to test whether its really optional
     df_all_customers["created"] = pd.to_datetime(pd.Timestamp.now(tz=None).round("ms"))
     return df_all_customers
+
+
+
+def create_dataset() -> pd.DataFrame:
+    now = datetime.utcnow()
+    ts = pd.Timestamp(now).round("ms")
+    data = {
+        "id": [1, 2, 1, 3, 3],
+        "value": [0.1, None, 0.3, 4, 5],
+        "ts_1": [
+            ts - timedelta(hours=4),
+            ts,
+            ts - timedelta(hours=3),
+            # Use different time zones to test tz-naive -> tz-aware conversion
+            (ts - timedelta(hours=4))
+                .replace(tzinfo=utc)
+                .astimezone(tz=timezone("Europe/Berlin")),
+            (ts - timedelta(hours=1))
+                .replace(tzinfo=utc)
+                .astimezone(tz=timezone("US/Pacific")),
+            ],
+        "created_ts": [ts, ts, ts, ts, ts],
+    }
+    return pd.DataFrame.from_dict(data)

--- a/sdk/python/feast/driver_test_data.py
+++ b/sdk/python/feast/driver_test_data.py
@@ -198,27 +198,3 @@ def create_customer_daily_profile_df(customers, start_date, end_date) -> pd.Data
     # TODO: Remove created timestamp in order to test whether its really optional
     df_all_customers["created"] = pd.to_datetime(pd.Timestamp.now(tz=None).round("ms"))
     return df_all_customers
-
-
-
-def create_dataset() -> pd.DataFrame:
-    now = datetime.utcnow()
-    ts = pd.Timestamp(now).round("ms")
-    data = {
-        "id": [1, 2, 1, 3, 3],
-        "value": [0.1, None, 0.3, 4, 5],
-        "ts_1": [
-            ts - timedelta(hours=4),
-            ts,
-            ts - timedelta(hours=3),
-            # Use different time zones to test tz-naive -> tz-aware conversion
-            (ts - timedelta(hours=4))
-                .replace(tzinfo=utc)
-                .astimezone(tz=timezone("Europe/Berlin")),
-            (ts - timedelta(hours=1))
-                .replace(tzinfo=utc)
-                .astimezone(tz=timezone("US/Pacific")),
-            ],
-        "created_ts": [ts, ts, ts, ts, ts],
-    }
-    return pd.DataFrame.from_dict(data)

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -16,7 +16,10 @@ from tests.integration.feature_repos.universal.feature_views import driver_featu
 
 @parametrize_e2e_test
 def test_e2e_consistency(test_environment: Environment):
-    fs, fv = test_environment.feature_store, driver_feature_view(test_environment.data_source)
+    fs, fv = (
+        test_environment.feature_store,
+        driver_feature_view(test_environment.data_source),
+    )
     entity = driver()
     fs.apply([fv, entity])
 

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -15,7 +15,10 @@ from tests.integration.feature_repos.universal.entities import driver
 
 @parametrize_e2e_test
 def test_e2e_consistency(test_environment: Environment):
-    fs, fv = test_environment.feature_store, test_environment.driver_stats_feature_view()
+    fs, fv = (
+        test_environment.feature_store,
+        test_environment.driver_stats_feature_view(),
+    )
     entity = driver()
     fs.apply([fv, entity])
 

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -6,14 +6,14 @@ import pandas as pd
 from pytz import utc
 
 from feast import FeatureStore, FeatureView
-from feast.data_source import DataSource
-from tests.integration.feature_repos.test_repo_configuration import parametrize_e2e_test
+from tests.integration.feature_repos.test_repo_configuration import parametrize_e2e_test, Environment
 from tests.integration.feature_repos.universal.entities import driver
 from tests.integration.feature_repos.universal.feature_views import driver_feature_view
 
 
 @parametrize_e2e_test
-def test_e2e_consistency(fs: FeatureStore, ds: DataSource):
+def test_e2e_consistency(test_environment: Environment):
+    fs, ds = test_environment.feature_store, test_environment.data_source
     fv = driver_feature_view(ds)
     entity = driver()
     fs.apply([fv, entity])

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -5,8 +5,8 @@ from typing import Optional
 import pandas as pd
 from pytz import utc
 
-from feast.data_source import DataSource
 from feast import FeatureStore, FeatureView
+from feast.data_source import DataSource
 from tests.integration.feature_repos.test_repo_configuration import parametrize_e2e_test
 from tests.integration.feature_repos.universal.entities import driver
 from tests.integration.feature_repos.universal.feature_views import driver_feature_view
@@ -70,7 +70,9 @@ def check_offline_and_online_features(
                 assert math.isnan(df.to_dict()["value"][0])
 
 
-def run_offline_online_store_consistency_test(fs: FeatureStore, fv: FeatureView) -> None:
+def run_offline_online_store_consistency_test(
+    fs: FeatureStore, fv: FeatureView
+) -> None:
     now = datetime.utcnow()
 
     full_feature_names = True

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -5,13 +5,20 @@ from typing import Optional
 import pandas as pd
 from pytz import utc
 
+from feast.data_source import DataSource
 from feast import FeatureStore, FeatureView
 from tests.integration.feature_repos.test_repo_configuration import parametrize_e2e_test
+from tests.integration.feature_repos.universal.entities import driver
+from tests.integration.feature_repos.universal.feature_views import driver_feature_view
 
 
 @parametrize_e2e_test
-def test_e2e_consistency(fs: FeatureStore):
-    run_offline_online_store_consistency_test(fs)
+def test_e2e_consistency(fs: FeatureStore, ds: DataSource):
+    fv = driver_feature_view(ds)
+    entity = driver()
+    fs.apply([fv, entity])
+
+    run_offline_online_store_consistency_test(fs, fv)
 
 
 def check_offline_and_online_features(
@@ -63,10 +70,9 @@ def check_offline_and_online_features(
                 assert math.isnan(df.to_dict()["value"][0])
 
 
-def run_offline_online_store_consistency_test(fs: FeatureStore,) -> None:
+def run_offline_online_store_consistency_test(fs: FeatureStore, fv: FeatureView) -> None:
     now = datetime.utcnow()
 
-    fv = fs.get_feature_view("test_correctness")
     full_feature_names = True
     check_offline_store: bool = True
 

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -11,13 +11,11 @@ from tests.integration.feature_repos.test_repo_configuration import (
     parametrize_e2e_test,
 )
 from tests.integration.feature_repos.universal.entities import driver
-from tests.integration.feature_repos.universal.feature_views import driver_feature_view
 
 
 @parametrize_e2e_test
 def test_e2e_consistency(test_environment: Environment):
-    fs, ds = test_environment.feature_store, test_environment.data_source
-    fv = driver_feature_view(ds)
+    fs, fv = test_environment.feature_store, test_environment.driver_stats_feature_view()
     entity = driver()
     fs.apply([fv, entity])
 

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -11,14 +11,12 @@ from tests.integration.feature_repos.test_repo_configuration import (
     parametrize_e2e_test,
 )
 from tests.integration.feature_repos.universal.entities import driver
+from tests.integration.feature_repos.universal.feature_views import driver_feature_view
 
 
 @parametrize_e2e_test
 def test_e2e_consistency(test_environment: Environment):
-    fs, fv = (
-        test_environment.feature_store,
-        test_environment.driver_stats_feature_view(),
-    )
+    fs, fv = test_environment.feature_store, driver_feature_view(test_environment.data_source)
     entity = driver()
     fs.apply([fv, entity])
 

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -6,7 +6,10 @@ import pandas as pd
 from pytz import utc
 
 from feast import FeatureStore, FeatureView
-from tests.integration.feature_repos.test_repo_configuration import parametrize_e2e_test, Environment
+from tests.integration.feature_repos.test_repo_configuration import (
+    Environment,
+    parametrize_e2e_test,
+)
 from tests.integration.feature_repos.universal.entities import driver
 from tests.integration.feature_repos.universal.feature_views import driver_feature_view
 

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -1,21 +1,25 @@
 import tempfile
 import uuid
 from contextlib import contextmanager
+from dataclasses import replace
+from datetime import timedelta, datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, Optional
 
 import pytest
+import pandas as pd
 from attr import dataclass
 
-from feast import FeatureStore, RepoConfig, importer
+from feast import FeatureStore, RepoConfig, importer, driver_test_data, FeatureView
 from feast.data_source import DataSource
 from tests.data.data_creator import create_dataset
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
 )
+from tests.integration.feature_repos.universal.entities import driver, customer
 
 
-@dataclass
+@dataclass(frozen=True, str=True)
 class TestRepoConfig:
     """
     This class should hold all possible parameters that may need to be varied by individual tests.
@@ -27,6 +31,7 @@ class TestRepoConfig:
     offline_store_creator: str = "tests.integration.feature_repos.universal.data_sources.file.FileDataSourceCreator"
 
     full_feature_names: bool = True
+    infer_event_timestamp_col: bool = True
 
 
 FULL_REPO_CONFIGS: List[TestRepoConfig] = [
@@ -49,10 +54,75 @@ ONLINE_STORES: List[str] = []
 PROVIDERS: List[str] = []
 
 
+@dataclass
+class Environment:
+    name: str
+    test_repo_config: TestRepoConfig
+    feature_store: FeatureStore
+    data_source: DataSource
+    data_source_creator: DataSourceCreator
+
+    customer_entities = list(range(1001, 1110))
+    driver_entities = list(range(5001, 5110))
+
+    end_date = datetime.now().replace(microsecond=0, second=0, minute=0)
+    start_date = end_date - timedelta(days=7)
+
+    def customer_fixtures(self) -> Tuple[pd.DataFrame, FeatureView]:
+        customer_df = driver_test_data.create_customer_daily_profile_df(
+            self.customer_entities, self.start_date, self.end_date
+        )
+        customer_table_id = self.data_source_creator.get_prefixed_table_name(self.name,
+                                                                             "customer_profile")
+        # self.data_source_creator.upload_df(customer_df, customer_table_id)
+
+    def driver_stats_fixtures(self) -> Tuple[pd.DataFrame, FeatureView]:
+        pass
+
+    def order_fixtures(self) -> Tuple[pd.DataFrame, FeatureView]:
+        pass
+
+    def orders_sql_fixtures(self) -> Optional[str]:
+        pass
+
+
+def vary_full_feature_names(configs: List[TestRepoConfig]) -> List[TestRepoConfig]:
+    new_configs = []
+    for c in configs:
+        true_c = replace(c, full_feature_names=True)
+        false_c = replace(c, full_feature_names=False)
+        new_configs.extend([true_c, false_c])
+    return new_configs
+
+
+def vary_infer_event_timestamp_col(configs: List[TestRepoConfig]) -> List[TestRepoConfig]:
+    new_configs = []
+    for c in configs:
+        true_c = replace(c, infer_event_timestamp_col=True)
+        false_c = replace(c, infer_event_timestamp_col=False)
+        new_configs.extend([true_c, false_c])
+    return new_configs
+
+
+def vary_providers_for_offline_stores(configs: List[TestRepoConfig]) -> List[TestRepoConfig]:
+    new_configs = []
+    for c in configs:
+        if 'FileDataSourceCreator' in c.offline_store_creator:
+            new_configs.append(c)
+        elif 'RedshiftDataSourceCreator' in c.offline_store_creator:
+            for p in ["local", "aws"]:
+                new_configs.append(replace(c, provider=p))
+        elif 'BigQueryDataSourceCreator' in c.offline_store_creator:
+            for p in ["local", "gcp", "gcp_custom_offline_config"]:
+                new_configs.append(replace(c, provider=p))
+    return new_configs
+
+
 @contextmanager
-def construct_feature_store(
+def construct_test_environment(
     test_repo_config: TestRepoConfig,
-) -> Tuple[FeatureStore, DataSource]:
+    create_and_apply: bool = False
+) -> Environment:
     """
     This method should take in the parameters from the test repo config and created a feature repo, apply it,
     and return the constructed feature store object to callers.
@@ -73,8 +143,8 @@ def construct_feature_store(
 
     offline_creator: DataSourceCreator = importer.get_class_from_type(
         module_name, config_class_name, "DataSourceCreator"
-    )()
-    ds = offline_creator.create_data_source(project, df)
+    )(project)
+    ds = offline_creator.create_data_sources(project, df)
     offline_store = offline_creator.create_offline_store_config()
     online_store = test_repo_config.online_store
 
@@ -89,10 +159,23 @@ def construct_feature_store(
         )
         fs = FeatureStore(config=config)
 
-        yield fs, ds
+        try:
+            if create_and_apply:
+                fvs = []
+                fvs.extend([driver(), customer()])
 
-        fs.teardown()
-        offline_creator.teardown(project)
+                fs.apply(fvs)
+
+            environment = Environment(name=project,
+                                      test_repo_config=test_repo_config,
+                                      feature_store=fs,
+                                      data_source=ds,
+                                      data_source_creator=offline_creator)
+
+            yield environment
+        finally:
+            fs.teardown()
+            offline_creator.teardown(project)
 
 
 def parametrize_e2e_test(e2e_test):
@@ -109,15 +192,15 @@ def parametrize_e2e_test(e2e_test):
     """
 
     @pytest.mark.integration
-    @pytest.mark.parametrize("config", FULL_REPO_CONFIGS, ids=lambda v: v.provider)
+    @pytest.mark.parametrize("config", FULL_REPO_CONFIGS, ids=lambda v: str(v))
     def inner_test(config):
-        with construct_feature_store(config) as (fs, ds):
-            e2e_test(fs, ds)
+        with construct_test_environment(config) as environment:
+            e2e_test(environment)
 
     return inner_test
 
 
-def parametrize_offline_retrival_test(offline_retrival_test):
+def parametrize_offline_retrieval_test(offline_retrieval_test):
     """
     This decorator should be used for end-to-end tests. These tests are expected to be parameterized,
     and receive an empty feature repo created for all supported configurations.
@@ -130,10 +213,15 @@ def parametrize_offline_retrival_test(offline_retrival_test):
     The decorator takes care of tearing down the feature store, as well as the sample data.
     """
 
+    configs = vary_providers_for_offline_stores(FULL_REPO_CONFIGS)
+    configs = vary_full_feature_names(configs)
+    configs = vary_infer_event_timestamp_col(configs)
+
     @pytest.mark.integration
-    @pytest.mark.parametrize("config", FULL_REPO_CONFIGS, ids=lambda v: v.provider)
+    @pytest.mark.parametrize("config", configs, ids=lambda v: str(v))
     def inner_test(config):
-        with construct_feature_store(config) as (fs, ds):
-            offline_retrival_test(fs, ds)
+        with construct_test_environment(config,
+                                        create_and_apply=True) as environment:
+            offline_retrieval_test(environment)
 
     return inner_test

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -69,13 +69,14 @@ class Environment:
     start_date = end_date - timedelta(days=7)
 
     def customer_fixtures(self) -> Tuple[pd.DataFrame, FeatureView]:
-        customer_df = driver_test_data.create_customer_daily_profile_df(
-            self.customer_entities, self.start_date, self.end_date
-        )
-        customer_table_id = self.data_source_creator.get_prefixed_table_name(
-            self.name, "customer_profile"
-        )
+        # customer_df = driver_test_data.create_customer_daily_profile_df(
+        #     self.customer_entities, self.start_date, self.end_date
+        # )
+        # customer_table_id = self.data_source_creator.get_prefixed_table_name(
+        #     self.name, "customer_profile"
+        # )
         # self.data_source_creator.upload_df(customer_df, customer_table_id)
+        pass
 
     def driver_stats_fixtures(self) -> Tuple[pd.DataFrame, FeatureView]:
         pass

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -2,7 +2,7 @@ import tempfile
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, List, Union, Tuple
+from typing import Dict, List, Tuple, Union
 
 import pytest
 from attr import dataclass
@@ -50,7 +50,9 @@ PROVIDERS: List[str] = []
 
 
 @contextmanager
-def construct_feature_store(test_repo_config: TestRepoConfig) -> Tuple[FeatureStore, DataSource]:
+def construct_feature_store(
+    test_repo_config: TestRepoConfig,
+) -> Tuple[FeatureStore, DataSource]:
     """
     This method should take in the parameters from the test repo config and created a feature repo, apply it,
     and return the constructed feature store object to callers.
@@ -105,6 +107,7 @@ def parametrize_e2e_test(e2e_test):
 
     The decorator takes care of tearing down the feature store, as well as the sample data.
     """
+
     @pytest.mark.integration
     @pytest.mark.parametrize("config", FULL_REPO_CONFIGS, ids=lambda v: v.provider)
     def inner_test(config):
@@ -126,6 +129,7 @@ def parametrize_offline_retrival_test(offline_retrival_test):
 
     The decorator takes care of tearing down the feature store, as well as the sample data.
     """
+
     @pytest.mark.integration
     @pytest.mark.parametrize("config", FULL_REPO_CONFIGS, ids=lambda v: v.provider)
     def inner_test(config):

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -1,23 +1,25 @@
 import tempfile
 import uuid
 from contextlib import contextmanager
-from dataclasses import replace, is_dataclass, dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
 import pandas as pd
 import pytest
 
-from feast import FeatureStore, FeatureView, RepoConfig, importer, driver_test_data
+from feast import FeatureStore, FeatureView, RepoConfig, driver_test_data, importer
 from feast.data_source import DataSource
 from tests.data.data_creator import create_dataset
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
 )
 from tests.integration.feature_repos.universal.entities import customer, driver
-from tests.integration.feature_repos.universal.feature_views import create_customer_daily_profile_feature_view, \
-    create_driver_hourly_stats_feature_view
+from tests.integration.feature_repos.universal.feature_views import (
+    create_customer_daily_profile_feature_view,
+    create_driver_hourly_stats_feature_view,
+)
 
 
 @dataclass(frozen=True, repr=True)
@@ -90,18 +92,24 @@ class Environment:
         customer_table_id = self.data_source_creator.get_prefixed_table_name(
             self.name, "customer_profile"
         )
-        ds = self.data_source_creator.create_data_sources(customer_table_id,
-                                                          self.customer_df,
-                                                          event_timestamp_column="event_timestamp",
-                                                          created_timestamp_column="created")
+        ds = self.data_source_creator.create_data_sources(
+            customer_table_id,
+            self.customer_df,
+            event_timestamp_column="event_timestamp",
+            created_timestamp_column="created",
+        )
         return create_customer_daily_profile_feature_view(ds)
 
     def driver_stats_fixtures(self) -> FeatureView:
-        driver_table_id = self.data_source_creator.get_prefixed_table_name(self.name, "driver_hourly")
-        ds = self.data_source_creator.create_data_sources(driver_table_id,
-                                                          self.driver_df,
-                                                          event_timestamp_column="event_timestamp",
-                                                          created_timestamp_column="created")
+        driver_table_id = self.data_source_creator.get_prefixed_table_name(
+            self.name, "driver_hourly"
+        )
+        ds = self.data_source_creator.create_data_sources(
+            driver_table_id,
+            self.driver_df,
+            event_timestamp_column="event_timestamp",
+            created_timestamp_column="created",
+        )
         return create_driver_hourly_stats_feature_view(ds)
 
     def order_fixtures(self) -> pd.DataFrame:
@@ -200,8 +208,12 @@ def construct_test_environment(
             if create_and_apply:
                 fvs = []
                 entities.extend([driver(), customer()])
-                fvs.extend([environment.driver_stats_fixtures(),
-                            environment.customer_fixtures()])
+                fvs.extend(
+                    [
+                        environment.driver_stats_fixtures(),
+                        environment.customer_fixtures(),
+                    ]
+                )
                 fs.apply(fvs + entities)
 
             yield environment

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -258,7 +258,6 @@ def parametrize_offline_retrieval_test(offline_retrieval_test):
     The decorator takes care of tearing down the feature store, as well as the sample data.
     """
 
-    c = TestRepoConfig()
     configs = vary_providers_for_offline_stores([TestRepoConfig()])
     configs = vary_full_feature_names(configs)
     configs = vary_infer_event_timestamp_col(configs)

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -137,6 +137,7 @@ class Environment:
                 self._orders_table = ds.table
         return self._orders_table
 
+
 def vary_full_feature_names(configs: List[TestRepoConfig]) -> List[TestRepoConfig]:
     new_configs = []
     for c in configs:

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -88,6 +88,7 @@ class Environment:
         end_date=after_end_date,
         order_count=1000,
     )
+    _orders_table: Optional[str] = None
 
     def customer_feature_view(self) -> FeatureView:
         if self._customer_feature_view is None:
@@ -119,9 +120,22 @@ class Environment:
             )
         return self._driver_stats_feature_view
 
-    def orders_sql_fixtures(self) -> Optional[str]:
-        pass
-
+    def orders_table(self) -> Optional[str]:
+        if self._orders_table is None:
+            orders_table_id = self.data_source_creator.get_prefixed_table_name(
+                self.name, "orders"
+            )
+            ds = self.data_source_creator.create_data_sources(
+                orders_table_id,
+                self.orders_df,
+                event_timestamp_column="event_timestamp",
+                created_timestamp_column="created",
+            )
+            if hasattr(ds, "table_ref"):
+                self._orders_table = ds.table_ref
+            elif hasattr(ds, "table"):
+                self._orders_table = ds.table
+        return self._orders_table
 
 def vary_full_feature_names(configs: List[TestRepoConfig]) -> List[TestRepoConfig]:
     new_configs = []

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -199,8 +199,9 @@ def construct_test_environment(
     offline_creator: DataSourceCreator = importer.get_class_from_type(
         module_name, config_class_name, "DataSourceCreator"
     )(project)
-    ds = offline_creator.create_data_sources(project, df,
-                                             field_mapping={"ts_1": "ts", "id": "driver_id"})
+    ds = offline_creator.create_data_sources(
+        project, df, field_mapping={"ts_1": "ts", "id": "driver_id"}
+    )
     offline_store = offline_creator.create_offline_store_config()
     online_store = test_repo_config.online_store
 

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -2,21 +2,21 @@ import tempfile
 import uuid
 from contextlib import contextmanager
 from dataclasses import replace
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Tuple, Union, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
-import pytest
 import pandas as pd
+import pytest
 from attr import dataclass
 
-from feast import FeatureStore, RepoConfig, importer, driver_test_data, FeatureView
+from feast import FeatureStore, FeatureView, RepoConfig, driver_test_data, importer
 from feast.data_source import DataSource
 from tests.data.data_creator import create_dataset
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
 )
-from tests.integration.feature_repos.universal.entities import driver, customer
+from tests.integration.feature_repos.universal.entities import customer, driver
 
 
 @dataclass(frozen=True, str=True)
@@ -72,8 +72,9 @@ class Environment:
         customer_df = driver_test_data.create_customer_daily_profile_df(
             self.customer_entities, self.start_date, self.end_date
         )
-        customer_table_id = self.data_source_creator.get_prefixed_table_name(self.name,
-                                                                             "customer_profile")
+        customer_table_id = self.data_source_creator.get_prefixed_table_name(
+            self.name, "customer_profile"
+        )
         # self.data_source_creator.upload_df(customer_df, customer_table_id)
 
     def driver_stats_fixtures(self) -> Tuple[pd.DataFrame, FeatureView]:
@@ -95,7 +96,9 @@ def vary_full_feature_names(configs: List[TestRepoConfig]) -> List[TestRepoConfi
     return new_configs
 
 
-def vary_infer_event_timestamp_col(configs: List[TestRepoConfig]) -> List[TestRepoConfig]:
+def vary_infer_event_timestamp_col(
+    configs: List[TestRepoConfig],
+) -> List[TestRepoConfig]:
     new_configs = []
     for c in configs:
         true_c = replace(c, infer_event_timestamp_col=True)
@@ -104,15 +107,17 @@ def vary_infer_event_timestamp_col(configs: List[TestRepoConfig]) -> List[TestRe
     return new_configs
 
 
-def vary_providers_for_offline_stores(configs: List[TestRepoConfig]) -> List[TestRepoConfig]:
+def vary_providers_for_offline_stores(
+    configs: List[TestRepoConfig],
+) -> List[TestRepoConfig]:
     new_configs = []
     for c in configs:
-        if 'FileDataSourceCreator' in c.offline_store_creator:
+        if "FileDataSourceCreator" in c.offline_store_creator:
             new_configs.append(c)
-        elif 'RedshiftDataSourceCreator' in c.offline_store_creator:
+        elif "RedshiftDataSourceCreator" in c.offline_store_creator:
             for p in ["local", "aws"]:
                 new_configs.append(replace(c, provider=p))
-        elif 'BigQueryDataSourceCreator' in c.offline_store_creator:
+        elif "BigQueryDataSourceCreator" in c.offline_store_creator:
             for p in ["local", "gcp", "gcp_custom_offline_config"]:
                 new_configs.append(replace(c, provider=p))
     return new_configs
@@ -120,8 +125,7 @@ def vary_providers_for_offline_stores(configs: List[TestRepoConfig]) -> List[Tes
 
 @contextmanager
 def construct_test_environment(
-    test_repo_config: TestRepoConfig,
-    create_and_apply: bool = False
+    test_repo_config: TestRepoConfig, create_and_apply: bool = False
 ) -> Environment:
     """
     This method should take in the parameters from the test repo config and created a feature repo, apply it,
@@ -166,11 +170,13 @@ def construct_test_environment(
 
                 fs.apply(fvs)
 
-            environment = Environment(name=project,
-                                      test_repo_config=test_repo_config,
-                                      feature_store=fs,
-                                      data_source=ds,
-                                      data_source_creator=offline_creator)
+            environment = Environment(
+                name=project,
+                test_repo_config=test_repo_config,
+                feature_store=fs,
+                data_source=ds,
+                data_source_creator=offline_creator,
+            )
 
             yield environment
         finally:
@@ -220,8 +226,7 @@ def parametrize_offline_retrieval_test(offline_retrieval_test):
     @pytest.mark.integration
     @pytest.mark.parametrize("config", configs, ids=lambda v: str(v))
     def inner_test(config):
-        with construct_test_environment(config,
-                                        create_and_apply=True) as environment:
+        with construct_test_environment(config, create_and_apply=True) as environment:
             offline_retrieval_test(environment)
 
     return inner_test

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -88,7 +88,7 @@ class Environment:
         order_count=1000,
     )
 
-    def customer_fixtures(self) -> FeatureView:
+    def customer_feature_view(self) -> FeatureView:
         customer_table_id = self.data_source_creator.get_prefixed_table_name(
             self.name, "customer_profile"
         )
@@ -100,7 +100,7 @@ class Environment:
         )
         return create_customer_daily_profile_feature_view(ds)
 
-    def driver_stats_fixtures(self) -> FeatureView:
+    def driver_stats_feature_view(self) -> FeatureView:
         driver_table_id = self.data_source_creator.get_prefixed_table_name(
             self.name, "driver_hourly"
         )
@@ -111,9 +111,6 @@ class Environment:
             created_timestamp_column="created",
         )
         return create_driver_hourly_stats_feature_view(ds)
-
-    def order_fixtures(self) -> pd.DataFrame:
-        return self.orders_df
 
     def orders_sql_fixtures(self) -> Optional[str]:
         pass
@@ -210,16 +207,15 @@ def construct_test_environment(
                 entities.extend([driver(), customer()])
                 fvs.extend(
                     [
-                        environment.driver_stats_fixtures(),
-                        environment.customer_fixtures(),
+                        environment.driver_stats_feature_view(),
+                        environment.customer_feature_view(),
                     ]
                 )
                 fs.apply(fvs + entities)
 
             yield environment
         finally:
-            if create_and_apply:
-                offline_creator.teardown(project)
+            offline_creator.teardown()
             fs.teardown()
 
 

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -199,7 +199,8 @@ def construct_test_environment(
     offline_creator: DataSourceCreator = importer.get_class_from_type(
         module_name, config_class_name, "DataSourceCreator"
     )(project)
-    ds = offline_creator.create_data_sources(project, df)
+    ds = offline_creator.create_data_sources(project, df,
+                                             field_mapping={"ts_1": "ts", "id": "driver_id"})
     offline_store = offline_creator.create_offline_store_config()
     online_store = test_repo_config.online_store
 
@@ -225,7 +226,6 @@ def construct_test_environment(
         entities = []
         try:
             if create_and_apply:
-                fvs = []
                 entities.extend([driver(), customer()])
                 fvs.extend(
                     [

--- a/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/test_repo_configuration.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
-import pandas as pd
 import pytest
 
 from feast import FeatureStore, FeatureView, RepoConfig, driver_test_data, importer

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
+from datetime import timedelta
 
 import pandas as pd
+from feast import driver_test_data, FeatureView
 
 from feast.data_source import DataSource
 from feast.repo_config import FeastConfigBaseModel
@@ -8,7 +10,7 @@ from feast.repo_config import FeastConfigBaseModel
 
 class DataSourceCreator(ABC):
     @abstractmethod
-    def create_data_source(
+    def create_data_sources(
         self,
         name: str,
         df: pd.DataFrame,
@@ -24,3 +26,25 @@ class DataSourceCreator(ABC):
     @abstractmethod
     def teardown(self, name: str):
         ...
+
+    @abstractmethod
+    def get_prefixed_table_name(self, name: str, suffix: str) -> str:
+        ...
+
+    @staticmethod
+    def generate_entities(start_time, order_count: int = 1000):
+        end_date = start_time
+        before_start_date = end_date - timedelta(days=365)
+        start_date = end_date - timedelta(days=7)
+        after_end_date = end_date + timedelta(days=365)
+        customer_entities = list(range(1001, 1110))
+        driver_entities = list(range(5001, 5110))
+        orders_df = driver_test_data.create_orders_df(
+            customers=customer_entities,
+            drivers=driver_entities,
+            start_date=before_start_date,
+            end_date=after_end_date,
+            order_count=order_count,
+        )
+        return customer_entities, driver_entities, end_date, orders_df, start_date
+

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -1,9 +1,7 @@
 from abc import ABC, abstractmethod
-from datetime import timedelta
 
 import pandas as pd
 
-from feast import driver_test_data
 from feast.data_source import DataSource
 from feast.repo_config import FeastConfigBaseModel
 

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -12,7 +12,7 @@ class DataSourceCreator(ABC):
     @abstractmethod
     def create_data_sources(
         self,
-        name: str,
+        destination: str,
         df: pd.DataFrame,
         event_timestamp_column="ts",
         created_timestamp_column="created_ts",
@@ -24,26 +24,9 @@ class DataSourceCreator(ABC):
         ...
 
     @abstractmethod
-    def teardown(self, name: str):
+    def teardown(self):
         ...
 
     @abstractmethod
     def get_prefixed_table_name(self, name: str, suffix: str) -> str:
         ...
-
-    @staticmethod
-    def generate_entities(start_time, order_count: int = 1000):
-        end_date = start_time
-        before_start_date = end_date - timedelta(days=365)
-        start_date = end_date - timedelta(days=7)
-        after_end_date = end_date + timedelta(days=365)
-        customer_entities = list(range(1001, 1110))
-        driver_entities = list(range(5001, 5110))
-        orders_df = driver_test_data.create_orders_df(
-            customers=customer_entities,
-            drivers=driver_entities,
-            start_date=before_start_date,
-            end_date=after_end_date,
-            order_count=order_count,
-        )
-        return customer_entities, driver_entities, end_date, orders_df, start_date

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -2,8 +2,8 @@ from abc import ABC, abstractmethod
 from datetime import timedelta
 
 import pandas as pd
-from feast import driver_test_data, FeatureView
 
+from feast import FeatureView, driver_test_data
 from feast.data_source import DataSource
 from feast.repo_config import FeastConfigBaseModel
 
@@ -47,4 +47,3 @@ class DataSourceCreator(ABC):
             order_count=order_count,
         )
         return customer_entities, driver_entities, end_date, orders_df, start_date
-

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Dict
 
 import pandas as pd
 
@@ -14,6 +15,7 @@ class DataSourceCreator(ABC):
         df: pd.DataFrame,
         event_timestamp_column="ts",
         created_timestamp_column="created_ts",
+        field_mapping: Dict[str, str] = None,
     ) -> DataSource:
         ...
 

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 import pandas as pd
 
-from feast import FeatureView, driver_test_data
+from feast import driver_test_data
 from feast.data_source import DataSource
 from feast.repo_config import FeastConfigBaseModel
 

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -1,19 +1,20 @@
-from datetime import datetime
-
 import time
+from datetime import datetime
 
 import pandas as pd
 from google.cloud import bigquery
+from pandas import DataFrame
 
-from feast import BigQuerySource, driver_test_data, FeatureView
+from feast import BigQuerySource, FeatureView, driver_test_data
 from feast.data_source import DataSource
 from feast.infra.offline_stores.bigquery import BigQueryOfflineStoreConfig
-from pandas import DataFrame
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
 )
-from tests.integration.feature_repos.universal.feature_views import create_customer_daily_profile_feature_view, \
-    create_driver_hourly_stats_feature_view
+from tests.integration.feature_repos.universal.feature_views import (
+    create_customer_daily_profile_feature_view,
+    create_driver_hourly_stats_feature_view,
+)
 
 
 class BigQueryDataSourceCreator(DataSourceCreator):
@@ -30,7 +31,7 @@ class BigQueryDataSourceCreator(DataSourceCreator):
         dataset = bigquery.Dataset(f"{self.gcp_project}.{project_name}")
         self.client.create_dataset(dataset, exists_ok=True)
         dataset.default_table_expiration_ms = (
-                1000 * 60 * 60 * 24 * 14
+            1000 * 60 * 60 * 24 * 14
         )  # 2 weeks in milliseconds
         self.client.update_dataset(dataset, ["default_table_expiration_ms"])
 
@@ -70,8 +71,7 @@ class BigQueryDataSourceCreator(DataSourceCreator):
         )
         job.result()
 
-    def create_entity_data(self,
-                           name: str) -> [FeatureView]:
+    def create_entity_data(self, name: str) -> [FeatureView]:
         bigquery_dataset = name
         gcp_project = self.client.project
 

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -1,18 +1,12 @@
-from datetime import datetime
-
 import pandas as pd
 from google.cloud import bigquery
 from pandas import DataFrame
 
-from feast import BigQuerySource, FeatureView, driver_test_data
+from feast import BigQuerySource
 from feast.data_source import DataSource
 from feast.infra.offline_stores.bigquery import BigQueryOfflineStoreConfig
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
-)
-from tests.integration.feature_repos.universal.feature_views import (
-    create_customer_daily_profile_feature_view,
-    create_driver_hourly_stats_feature_view,
 )
 
 
@@ -78,4 +72,3 @@ class BigQueryDataSourceCreator(DataSourceCreator):
 
     def get_prefixed_table_name(self, name: str, suffix: str) -> str:
         return f"{self.client.project}.{name}.{suffix}"
-

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import pandas as pd
 from google.cloud import bigquery
 
@@ -44,6 +46,7 @@ class BigQueryDataSourceCreator(DataSourceCreator):
         df: pd.DataFrame,
         event_timestamp_column="ts",
         created_timestamp_column="created_ts",
+        field_mapping: Dict[str, str] = None,
         **kwargs,
     ) -> DataSource:
 
@@ -63,7 +66,7 @@ class BigQueryDataSourceCreator(DataSourceCreator):
             event_timestamp_column=event_timestamp_column,
             created_timestamp_column=created_timestamp_column,
             date_partition_column="",
-            field_mapping={"ts_1": "ts"},
+            field_mapping=field_mapping or {"ts_1": "ts"},
         )
 
     def get_prefixed_table_name(self, name: str, suffix: str) -> str:

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -1,4 +1,3 @@
-import time
 from datetime import datetime
 
 import pandas as pd

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -63,6 +63,5 @@ class BigQueryDataSourceCreator(DataSourceCreator):
             field_mapping={"ts_1": "ts", "id": "driver_id"},
         )
 
-
     def get_prefixed_table_name(self, name: str, suffix: str) -> str:
         return f"{self.client.project}.{name}.{suffix}"

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -1,54 +1,132 @@
+from datetime import datetime
+
 import time
 
 import pandas as pd
 from google.cloud import bigquery
 
-from feast import BigQuerySource
+from feast import BigQuerySource, driver_test_data, FeatureView
 from feast.data_source import DataSource
 from feast.infra.offline_stores.bigquery import BigQueryOfflineStoreConfig
+from pandas import DataFrame
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
 )
+from tests.integration.feature_repos.universal.feature_views import create_customer_daily_profile_feature_view, \
+    create_driver_hourly_stats_feature_view
 
 
 class BigQueryDataSourceCreator(DataSourceCreator):
     def teardown(self, name: str):
-        pass
+        dataset_id = f"{self.client.project}.{name}"
 
-    def __init__(self):
+        self.client.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)
+        print(f"Deleted dataset '{dataset_id}'")
+
+    def __init__(self, project_name: str):
         self.client = bigquery.Client()
+        self.project_name = project_name
+        self.gcp_project = self.client.project
+        dataset = bigquery.Dataset(f"{self.gcp_project}.{project_name}")
+        self.client.create_dataset(dataset, exists_ok=True)
+        dataset.default_table_expiration_ms = (
+                1000 * 60 * 60 * 24 * 14
+        )  # 2 weeks in milliseconds
+        self.client.update_dataset(dataset, ["default_table_expiration_ms"])
 
     def create_offline_store_config(self):
         return BigQueryOfflineStoreConfig()
 
-    def create_data_source(
+    def create_data_sources(
         self,
-        name: str,
+        destination: str,
         df: pd.DataFrame,
         event_timestamp_column="ts",
         created_timestamp_column="created_ts",
         **kwargs,
     ) -> DataSource:
-        gcp_project = self.client.project
-        bigquery_dataset = "test_ingestion"
-        dataset = bigquery.Dataset(f"{gcp_project}.{bigquery_dataset}")
-        self.client.create_dataset(dataset, exists_ok=True)
-        dataset.default_table_expiration_ms = (
-            1000 * 60 * 60 * 24 * 14
-        )  # 2 weeks in milliseconds
-        self.client.update_dataset(dataset, ["default_table_expiration_ms"])
 
         job_config = bigquery.LoadJobConfig()
-        table_ref = f"{gcp_project}.{bigquery_dataset}.{name}_{int(time.time_ns())}"
+        if self.gcp_project not in destination:
+            destination = f"{self.gcp_project}.{self.project_name}.{destination}"
+
         job = self.client.load_table_from_dataframe(
-            df, table_ref, job_config=job_config
+            df, destination, job_config=job_config
         )
         job.result()
 
         return BigQuerySource(
-            table_ref=table_ref,
+            table_ref=destination,
             event_timestamp_column=event_timestamp_column,
             created_timestamp_column=created_timestamp_column,
             date_partition_column="",
             field_mapping={"ts_1": "ts", "id": "driver_id"},
         )
+
+    def upload_df(self, df: DataFrame, destination: str):
+        job_config = bigquery.LoadJobConfig()
+        job = self.client.load_table_from_dataframe(
+            df, destination, job_config=job_config
+        )
+        job.result()
+
+    def create_entity_data(self,
+                           name: str) -> [FeatureView]:
+        bigquery_dataset = name
+        gcp_project = self.client.project
+
+        # Create a DataSet in BQ to organize tables
+        dataset = bigquery.Dataset(f"{self.client.project}.{name}")
+        dataset.location = "US"
+        self.dataset = self.client.create_dataset(dataset, exists_ok=True)
+
+        start_date = datetime.now().replace(microsecond=0, second=0, minute=0)
+        (
+            customer_entities,
+            driver_entities,
+            end_date,
+            orders_df,
+            start_date,
+        ) = self.generate_entities(start_date)
+
+        # Upload entites data into table
+        table_id = f"{bigquery_dataset}.orders"
+        self.upload_df_to_table(orders_df, table_id)
+
+        driver_df = driver_test_data.create_driver_hourly_stats_df(
+            driver_entities, start_date, end_date
+        )
+        driver_table_id = f"{gcp_project}.{bigquery_dataset}.driver_hourly"
+        self.upload_df_to_table(driver_df, driver_table_id)
+
+        driver_source = BigQuerySource(
+            table_ref=driver_table_id,
+            event_timestamp_column="event_timestamp",
+            created_timestamp_column="created",
+        )
+        driver_fv = create_driver_hourly_stats_feature_view(driver_source)
+
+        # Customer Feature View
+        customer_df = driver_test_data.create_customer_daily_profile_df(
+            customer_entities, start_date, end_date
+        )
+        customer_table_id = f"{gcp_project}.{bigquery_dataset}.customer_profile"
+
+        self.upload_df_to_table(customer_df, customer_table_id)
+        customer_source = BigQuerySource(
+            table_ref=customer_table_id,
+            event_timestamp_column="event_timestamp",
+            created_timestamp_column="created",
+        )
+        customer_fv = create_customer_daily_profile_feature_view(customer_source)
+
+        return [driver_fv, customer_fv]
+
+    def get_prefixed_table_name(self, name: str, suffix: str) -> str:
+        return f"{self.client.project}.{name}.{suffix}"
+
+    def upload_df_to_table(self, df, table_id):
+        df.reset_index(drop=True, inplace=True)
+        job_config = bigquery.LoadJobConfig()
+        job = self.client.load_table_from_dataframe(df, table_id, job_config=job_config)
+        job.result()

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -1,6 +1,5 @@
 import pandas as pd
 from google.cloud import bigquery
-from pandas import DataFrame
 
 from feast import BigQuerySource
 from feast.data_source import DataSource
@@ -54,6 +53,8 @@ class BigQueryDataSourceCreator(DataSourceCreator):
         )
         job.result()
 
+        self.tables.append(destination)
+
         return BigQuerySource(
             table_ref=destination,
             event_timestamp_column=event_timestamp_column,
@@ -62,13 +63,6 @@ class BigQueryDataSourceCreator(DataSourceCreator):
             field_mapping={"ts_1": "ts", "id": "driver_id"},
         )
 
-    def upload_df(self, df: DataFrame, destination: str):
-        job_config = bigquery.LoadJobConfig()
-        job = self.client.load_table_from_dataframe(
-            df, destination, job_config=job_config
-        )
-        job.result()
-        self.tables.append(destination)
 
     def get_prefixed_table_name(self, name: str, suffix: str) -> str:
         return f"{self.client.project}.{name}.{suffix}"

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -1,5 +1,5 @@
 import tempfile
-from typing import Any
+from typing import Any, Dict
 
 import pandas as pd
 
@@ -25,6 +25,7 @@ class FileDataSourceCreator(DataSourceCreator):
         df: pd.DataFrame,
         event_timestamp_column="ts",
         created_timestamp_column="created_ts",
+        field_mapping: Dict[str, str] = None,
     ) -> DataSource:
         self.f = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
         df.to_parquet(self.f.name)
@@ -34,7 +35,7 @@ class FileDataSourceCreator(DataSourceCreator):
             event_timestamp_column=event_timestamp_column,
             created_timestamp_column=created_timestamp_column,
             date_partition_column="",
-            field_mapping={"ts_1": "ts", "id": "driver_id"},
+            field_mapping=field_mapping or {"ts_1": "ts", "id": "driver_id"},
         )
 
     def get_prefixed_table_name(self, name: str, suffix: str) -> str:

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -43,5 +43,5 @@ class FileDataSourceCreator(DataSourceCreator):
     def create_offline_store_config(self) -> FeastConfigBaseModel:
         return FileOfflineStoreConfig()
 
-    def teardown(self, name: str):
+    def teardown(self):
         self.f.close()

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -16,9 +16,12 @@ from tests.integration.feature_repos.universal.data_source_creator import (
 class FileDataSourceCreator(DataSourceCreator):
     f: Any
 
-    def create_data_source(
+    def __init__(self, project_name: str):
+        pass
+
+    def create_data_sources(
         self,
-        name: str,
+        destination: str,
         df: pd.DataFrame,
         event_timestamp_column="ts",
         created_timestamp_column="created_ts",
@@ -33,6 +36,9 @@ class FileDataSourceCreator(DataSourceCreator):
             date_partition_column="",
             field_mapping={"ts_1": "ts", "id": "driver_id"},
         )
+
+    def get_prefixed_table_name(self, name: str, suffix: str) -> str:
+        return f"{name}.{suffix}"
 
     def create_offline_store_config(self) -> FeastConfigBaseModel:
         return FileOfflineStoreConfig()

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -16,7 +16,7 @@ from tests.integration.feature_repos.universal.data_source_creator import (
 class FileDataSourceCreator(DataSourceCreator):
     f: Any
 
-    def __init__(self, project_name: str):
+    def __init__(self, _: str):
         pass
 
     def create_data_sources(

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
@@ -16,11 +16,12 @@ from tests.integration.feature_repos.universal.data_source_creator import (
 
 class RedshiftDataSourceCreator(DataSourceCreator):
 
-    table_name: Optional[str] = None
     redshift_source: Optional[RedshiftSource] = None
+    table_name: Optional[str] = None
 
-    def __init__(self) -> None:
+    def __init__(self, project_name: str):
         super().__init__()
+        self.project_name = project_name
         self.client = aws_utils.get_redshift_data_client("us-west-2")
         self.s3 = aws_utils.get_s3_resource("us-west-2")
 
@@ -33,28 +34,30 @@ class RedshiftDataSourceCreator(DataSourceCreator):
             iam_role="arn:aws:iam::402087665549:role/redshift_s3_access_role",
         )
 
-    def create_data_source(
+    def create_data_sources(
         self,
-        name: str,
+        destination: str,
         df: pd.DataFrame,
         event_timestamp_column="ts",
         created_timestamp_column="created_ts",
     ) -> DataSource:
-        self.table_name = f"{name}_{time.time_ns()}_{random.randint(1000, 9999)}"
+
+        self.table_name = destination
+
         aws_utils.upload_df_to_redshift(
             self.client,
             self.offline_store_config.cluster_id,
             self.offline_store_config.database,
             self.offline_store_config.user,
             self.s3,
-            f"{self.offline_store_config.s3_staging_location}/copy/{self.table_name}.parquet",
+            f"{self.offline_store_config.s3_staging_location}/copy/{destination}.parquet",
             self.offline_store_config.iam_role,
-            self.table_name,
+            destination,
             df,
         )
 
         self.redshift_source = RedshiftSource(
-            table=self.table_name,
+            table=destination,
             event_timestamp_column=event_timestamp_column,
             created_timestamp_column=created_timestamp_column,
             date_partition_column="",
@@ -65,7 +68,10 @@ class RedshiftDataSourceCreator(DataSourceCreator):
     def create_offline_store_config(self) -> FeastConfigBaseModel:
         return self.offline_store_config
 
-    def teardown(self, name: str):
+    def get_prefixed_table_name(self, name: str, suffix: str) -> str:
+        return f"{name}.{suffix}"
+
+    def teardown(self, _: str):
         if self.table_name:
             aws_utils.execute_redshift_statement(
                 self.client,

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
@@ -59,7 +59,7 @@ class RedshiftDataSourceCreator(DataSourceCreator):
             event_timestamp_column=event_timestamp_column,
             created_timestamp_column=created_timestamp_column,
             date_partition_column="",
-            field_mapping= field_mapping or {"ts_1": "ts"},
+            field_mapping=field_mapping or {"ts_1": "ts"},
         )
 
     def create_offline_store_config(self) -> FeastConfigBaseModel:

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import pandas as pd
 
 from feast import RedshiftSource

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
@@ -50,19 +50,20 @@ class RedshiftDataSourceCreator(DataSourceCreator):
         )
 
         self.tables.append(destination)
+
         return RedshiftSource(
             table=destination,
             event_timestamp_column=event_timestamp_column,
             created_timestamp_column=created_timestamp_column,
             date_partition_column="",
-            field_mapping={"ts_1": "ts", "id": "driver_id"},
+            field_mapping={"ts_1": "ts"},
         )
 
     def create_offline_store_config(self) -> FeastConfigBaseModel:
         return self.offline_store_config
 
     def get_prefixed_table_name(self, name: str, suffix: str) -> str:
-        return f"{name}.{suffix}"
+        return f"{name}_{suffix}"
 
     def teardown(self):
         for table in self.tables:

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import pandas as pd
 
 from feast import RedshiftSource
@@ -35,6 +37,7 @@ class RedshiftDataSourceCreator(DataSourceCreator):
         df: pd.DataFrame,
         event_timestamp_column="ts",
         created_timestamp_column="created_ts",
+        field_mapping: Dict[str, str] = None,
     ) -> DataSource:
 
         aws_utils.upload_df_to_redshift(
@@ -56,7 +59,7 @@ class RedshiftDataSourceCreator(DataSourceCreator):
             event_timestamp_column=event_timestamp_column,
             created_timestamp_column=created_timestamp_column,
             date_partition_column="",
-            field_mapping={"ts_1": "ts"},
+            field_mapping= field_mapping or {"ts_1": "ts"},
         )
 
     def create_offline_store_config(self) -> FeastConfigBaseModel:

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
@@ -1,5 +1,3 @@
-import random
-import time
 from typing import Optional
 
 import pandas as pd

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
@@ -75,5 +75,5 @@ class RedshiftDataSourceCreator(DataSourceCreator):
                 self.offline_store_config.cluster_id,
                 self.offline_store_config.database,
                 self.offline_store_config.user,
-                f"DROP TABLE {table}",
+                f"DROP TABLE IF EXISTS {table}",
             )

--- a/sdk/python/tests/integration/feature_repos/universal/entities.py
+++ b/sdk/python/tests/integration/feature_repos/universal/entities.py
@@ -8,3 +8,7 @@ def driver():
         description="driver id",
         join_key="driver_id",
     )
+
+
+def customer():
+    return Entity(name="customer_id", value_type=ValueType.INT64)

--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -14,3 +14,33 @@ def driver_feature_view(
         ttl=timedelta(days=5),
         input=data_source,
     )
+
+def create_driver_hourly_stats_feature_view(source):
+    driver_stats_feature_view = FeatureView(
+        name="driver_stats",
+        entities=["driver"],
+        features=[
+            Feature(name="conv_rate", dtype=ValueType.FLOAT),
+            Feature(name="acc_rate", dtype=ValueType.FLOAT),
+            Feature(name="avg_daily_trips", dtype=ValueType.INT32),
+        ],
+        batch_source=source,
+        ttl=timedelta(hours=2),
+    )
+    return driver_stats_feature_view
+
+
+def create_customer_daily_profile_feature_view(source):
+    customer_profile_feature_view = FeatureView(
+        name="customer_profile",
+        entities=["customer_id"],
+        features=[
+            Feature(name="current_balance", dtype=ValueType.FLOAT),
+            Feature(name="avg_passenger_count", dtype=ValueType.FLOAT),
+            Feature(name="lifetime_trip_count", dtype=ValueType.INT32),
+            Feature(name="avg_daily_trips", dtype=ValueType.INT32),
+        ],
+        batch_source=source,
+        ttl=timedelta(days=2),
+    )
+    return customer_profile_feature_view

--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -15,6 +15,7 @@ def driver_feature_view(
         input=data_source,
     )
 
+
 def create_driver_hourly_stats_feature_view(source):
     driver_stats_feature_view = FeatureView(
         name="driver_stats",

--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -4,9 +4,10 @@ from feast import Feature, FeatureView, ValueType
 from feast.data_source import DataSource
 
 
-def correctness_feature_view(data_source: DataSource) -> FeatureView:
+def driver_feature_view(data_source: DataSource,
+                        name="test_correctness") -> FeatureView:
     return FeatureView(
-        name="test_correctness",
+        name=name,
         entities=["driver"],
         features=[Feature("value", ValueType.FLOAT)],
         ttl=timedelta(days=5),

--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -4,8 +4,9 @@ from feast import Feature, FeatureView, ValueType
 from feast.data_source import DataSource
 
 
-def driver_feature_view(data_source: DataSource,
-                        name="test_correctness") -> FeatureView:
+def driver_feature_view(
+    data_source: DataSource, name="test_correctness"
+) -> FeatureView:
     return FeatureView(
         name=name,
         entities=["driver"],

--- a/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
@@ -28,9 +28,7 @@ from feast.infra.utils import aws_utils
 from feast.repo_config import RepoConfig
 from feast.value_type import ValueType
 from tests.data.data_creator import create_dataset
-from tests.integration.feature_repos.universal.feature_views import (
-    driver_feature_view,
-)
+from tests.integration.feature_repos.universal.feature_views import driver_feature_view
 
 
 @contextlib.contextmanager

--- a/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
+++ b/sdk/python/tests/integration/materialization/test_offline_online_store_consistency.py
@@ -29,7 +29,7 @@ from feast.repo_config import RepoConfig
 from feast.value_type import ValueType
 from tests.data.data_creator import create_dataset
 from tests.integration.feature_repos.universal.feature_views import (
-    correctness_feature_view,
+    driver_feature_view,
 )
 
 
@@ -64,7 +64,7 @@ def prep_bq_fs_and_fv(
         field_mapping={"ts_1": "ts", "id": "driver_id"},
     )
 
-    fv = correctness_feature_view(bigquery_source)
+    fv = driver_feature_view(bigquery_source)
     e = Entity(
         name="driver",
         description="id for driver",
@@ -127,7 +127,7 @@ def prep_redshift_fs_and_fv(
         field_mapping={"ts_1": "ts", "id": "driver_id"},
     )
 
-    fv = correctness_feature_view(redshift_source)
+    fv = driver_feature_view(redshift_source)
     e = Entity(
         name="driver",
         description="id for driver",
@@ -175,7 +175,7 @@ def prep_local_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             date_partition_column="",
             field_mapping={"ts_1": "ts", "id": "driver_id"},
         )
-        fv = correctness_feature_view(file_source)
+        fv = driver_feature_view(file_source)
         e = Entity(
             name="driver",
             description="id for driver",
@@ -216,7 +216,7 @@ def prep_redis_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             date_partition_column="",
             field_mapping={"ts_1": "ts", "id": "driver_id"},
         )
-        fv = correctness_feature_view(file_source)
+        fv = driver_feature_view(file_source)
         e = Entity(
             name="driver",
             description="id for driver",
@@ -258,7 +258,7 @@ def prep_dynamodb_fs_and_fv() -> Iterator[Tuple[FeatureStore, FeatureView]]:
             date_partition_column="",
             field_mapping={"ts_1": "ts", "id": "driver_id"},
         )
-        fv = correctness_feature_view(file_source)
+        fv = driver_feature_view(file_source)
         e = Entity(
             name="driver",
             description="id for driver",

--- a/sdk/python/tests/integration/offline_store/test_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_historical_retrieval.py
@@ -257,6 +257,7 @@ class BigQueryDataSet:
         client = bigquery.Client()
         dataset = bigquery.Dataset(f"{client.project}.{self.name}")
         dataset.location = "US"
+        print(f"Creating dataset: {dataset}")
         dataset = client.create_dataset(dataset, exists_ok=True)
         return dataset
 

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -1,0 +1,378 @@
+from datetime import datetime
+
+import assertpy
+import numpy as np
+import pandas as pd
+import pytest
+from google.cloud import bigquery
+from pandas.testing import assert_frame_equal
+from pytz import utc
+
+from feast import (
+    errors,
+    utils,
+)
+from feast.errors import FeatureNameCollisionError
+from feast.feature_store import _validate_feature_refs
+from feast.feature_view import FeatureView
+from feast.infra.offline_stores.offline_utils import (
+    DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,
+)
+from tests.integration.feature_repos.test_repo_configuration import parametrize_offline_retrieval_test, Environment
+
+np.random.seed(0)
+
+
+# Converts the given column of the pandas records to UTC timestamps
+def convert_timestamp_records_to_utc(records, column):
+    for record in records:
+        record[column] = utils.make_tzaware(record[column]).astimezone(utc)
+    return records
+
+
+# Find the latest record in the given time range and filter
+def find_asof_record(records, ts_key, ts_start, ts_end, filter_key, filter_value):
+    found_record = {}
+    for record in records:
+        if record[filter_key] == filter_value and ts_start <= record[ts_key] <= ts_end:
+            if not found_record or found_record[ts_key] < record[ts_key]:
+                found_record = record
+    return found_record
+
+
+def get_expected_training_df(
+    customer_df: pd.DataFrame,
+    customer_fv: FeatureView,
+    driver_df: pd.DataFrame,
+    driver_fv: FeatureView,
+    orders_df: pd.DataFrame,
+    event_timestamp: str,
+    full_feature_names: bool = False,
+):
+    # Convert all pandas dataframes into records with UTC timestamps
+    order_records = convert_timestamp_records_to_utc(
+        orders_df.to_dict("records"), event_timestamp
+    )
+    driver_records = convert_timestamp_records_to_utc(
+        driver_df.to_dict("records"), driver_fv.batch_source.event_timestamp_column
+    )
+    customer_records = convert_timestamp_records_to_utc(
+        customer_df.to_dict("records"), customer_fv.batch_source.event_timestamp_column
+    )
+
+    # Manually do point-in-time join of orders to drivers and customers records
+    for order_record in order_records:
+        driver_record = find_asof_record(
+            driver_records,
+            ts_key=driver_fv.batch_source.event_timestamp_column,
+            ts_start=order_record[event_timestamp] - driver_fv.ttl,
+            ts_end=order_record[event_timestamp],
+            filter_key="driver_id",
+            filter_value=order_record["driver_id"],
+        )
+        customer_record = find_asof_record(
+            customer_records,
+            ts_key=customer_fv.batch_source.event_timestamp_column,
+            ts_start=order_record[event_timestamp] - customer_fv.ttl,
+            ts_end=order_record[event_timestamp],
+            filter_key="customer_id",
+            filter_value=order_record["customer_id"],
+        )
+
+        order_record.update(
+            {
+                (f"driver_stats__{k}" if full_feature_names else k): driver_record.get(
+                    k, None
+                )
+                for k in ("conv_rate", "avg_daily_trips")
+            }
+        )
+
+        order_record.update(
+            {
+                (
+                    f"customer_profile__{k}" if full_feature_names else k
+                ): customer_record.get(k, None)
+                for k in (
+                    "current_balance",
+                    "avg_passenger_count",
+                    "lifetime_trip_count",
+                )
+            }
+        )
+
+    # Convert records back to pandas dataframe
+    expected_df = pd.DataFrame(order_records)
+
+    # Move "event_timestamp" column to front
+    current_cols = expected_df.columns.tolist()
+    current_cols.remove(event_timestamp)
+    expected_df = expected_df[[event_timestamp] + current_cols]
+
+    # Cast some columns to expected types, since we lose information when converting pandas DFs into Python objects.
+    if full_feature_names:
+        expected_column_types = {
+            "order_is_success": "int32",
+            "driver_stats__conv_rate": "float32",
+            "customer_profile__current_balance": "float32",
+            "customer_profile__avg_passenger_count": "float32",
+        }
+    else:
+        expected_column_types = {
+            "order_is_success": "int32",
+            "conv_rate": "float32",
+            "current_balance": "float32",
+            "avg_passenger_count": "float32",
+        }
+
+    for col, typ in expected_column_types.items():
+        expected_df[col] = expected_df[col].astype(typ)
+
+    return expected_df
+
+
+def stage_orders_bigquery(df, table_id):
+    client = bigquery.Client()
+    job_config = bigquery.LoadJobConfig()
+    df.reset_index(drop=True, inplace=True)
+    job = client.load_table_from_dataframe(df, table_id, job_config=job_config)
+    job.result()
+
+
+class BigQueryDataSet:
+    def __init__(self, dataset_name):
+        self.name = dataset_name
+
+    def __enter__(self):
+        client = bigquery.Client()
+        dataset = bigquery.Dataset(f"{client.project}.{self.name}")
+        dataset.location = "US"
+        dataset = client.create_dataset(dataset, exists_ok=True)
+        return dataset
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        print("Tearing down BigQuery dataset")
+        client = bigquery.Client()
+        dataset_id = f"{client.project}.{self.name}"
+
+        client.delete_dataset(dataset_id, delete_contents=True, not_found_ok=True)
+        print(f"Deleted dataset '{dataset_id}'")
+        if exc_type:
+            print(
+                "***Logging exception {}***".format(
+                    (exc_type, exc_value, exc_traceback)
+                )
+            )
+
+
+@parametrize_offline_retrieval_test
+def test_historical_features_from_bigquery_sources(
+    environment: Environment
+):
+    store = environment.feature_store
+
+    try:
+
+        customer_df, customer_fv = environment.customer_fixtures()
+        driver_df, driver_fv = environment.driver_stats_fixtures()
+        orders_df, _ = environment.order_fixtures()
+        full_feature_names = environment.test_repo_config.full_feature_names
+        entity_df_query = environment.orders_sql_fixtures()
+
+        event_timestamp = (
+            DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
+            if DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL in orders_df.columns
+            else "e_ts"
+        )
+        expected_df = get_expected_training_df(
+            customer_df,
+            customer_fv,
+            driver_df,
+            driver_fv,
+            orders_df,
+            event_timestamp,
+            full_feature_names,
+        )
+
+        if entity_df_query:
+            job_from_sql = store.get_historical_features(
+                entity_df=entity_df_query,
+                features=[
+                    "driver_stats:conv_rate",
+                    "driver_stats:avg_daily_trips",
+                    "customer_profile:current_balance",
+                    "customer_profile:avg_passenger_count",
+                    "customer_profile:lifetime_trip_count",
+                ],
+                full_feature_names=full_feature_names,
+            )
+
+            start_time = datetime.utcnow()
+            actual_df_from_sql_entities = job_from_sql.to_df()
+            end_time = datetime.utcnow()
+            print(
+                str(
+                    f"\nTime to execute job_from_sql.to_df() = '{(end_time - start_time)}'"
+                )
+            )
+
+            assert sorted(expected_df.columns) == sorted(
+                actual_df_from_sql_entities.columns
+            )
+            assert_frame_equal(
+                expected_df.sort_values(
+                    by=[event_timestamp, "order_id", "driver_id", "customer_id"]
+                ).reset_index(drop=True),
+                actual_df_from_sql_entities[expected_df.columns]
+                .sort_values(
+                    by=[event_timestamp, "order_id", "driver_id", "customer_id"]
+                )
+                .reset_index(drop=True),
+                check_dtype=False,
+            )
+
+            table_from_sql_entities = job_from_sql.to_arrow()
+            assert_frame_equal(
+                actual_df_from_sql_entities, table_from_sql_entities.to_pandas()
+            )
+
+        # timestamp_column = (
+        #     "e_ts"
+        #     if infer_event_timestamp_col
+        #     else DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
+        # )
+
+        # entity_df_query_with_invalid_join_key = (
+        #     f"select order_id, driver_id, customer_id as customer, "
+        #     f"order_is_success, {timestamp_column}, FROM {gcp_project}.{table_id}"
+        # )
+        # # Rename the join key; this should now raise an error.
+        # assertpy.assert_that(store.get_historical_features).raises(
+        #     errors.FeastEntityDFMissingColumnsError
+        # ).when_called_with(
+        #     entity_df=entity_df_query_with_invalid_join_key,
+        #     features=[
+        #         "driver_stats:conv_rate",
+        #         "driver_stats:avg_daily_trips",
+        #         "customer_profile:current_balance",
+        #         "customer_profile:avg_passenger_count",
+        #         "customer_profile:lifetime_trip_count",
+        #     ],
+        # )
+
+        job_from_df = store.get_historical_features(
+            entity_df=orders_df,
+            features=[
+                "driver_stats:conv_rate",
+                "driver_stats:avg_daily_trips",
+                "customer_profile:current_balance",
+                "customer_profile:avg_passenger_count",
+                "customer_profile:lifetime_trip_count",
+            ],
+            full_feature_names=full_feature_names,
+        )
+
+        # Rename the join key; this should now raise an error.
+        orders_df_with_invalid_join_key = orders_df.rename(
+            {"customer_id": "customer"}, axis="columns"
+        )
+        assertpy.assert_that(store.get_historical_features).raises(
+            errors.FeastEntityDFMissingColumnsError
+        ).when_called_with(
+            entity_df=orders_df_with_invalid_join_key,
+            features=[
+                "driver_stats:conv_rate",
+                "driver_stats:avg_daily_trips",
+                "customer_profile:current_balance",
+                "customer_profile:avg_passenger_count",
+                "customer_profile:lifetime_trip_count",
+            ],
+        )
+
+        # Make sure that custom dataset name is being used from the offline_store config
+        #
+        # if provider_type == "gcp_custom_offline_config":
+        #     assertpy.assert_that(job_from_df.query).contains("foo.feast_entity_df")
+        # else:
+        #     assertpy.assert_that(job_from_df.query).contains(
+        #         f"{name}.feast_entity_df"
+        #     )
+
+        start_time = datetime.utcnow()
+        actual_df_from_df_entities = job_from_df.to_df()
+        end_time = datetime.utcnow()
+        print(
+            str(
+                f"Time to execute job_from_df.to_df() = '{(end_time - start_time)}'\n"
+            )
+        )
+
+        assert sorted(expected_df.columns) == sorted(
+            actual_df_from_df_entities.columns
+        )
+        assert_frame_equal(
+            expected_df.sort_values(
+                by=[event_timestamp, "order_id", "driver_id", "customer_id"]
+            ).reset_index(drop=True),
+            actual_df_from_df_entities[expected_df.columns]
+            .sort_values(
+                by=[event_timestamp, "order_id", "driver_id", "customer_id"]
+            )
+            .reset_index(drop=True),
+            check_dtype=False,
+        )
+
+        table_from_df_entities = job_from_df.to_arrow()
+        assert_frame_equal(
+            actual_df_from_df_entities, table_from_df_entities.to_pandas()
+        )
+    finally:
+        store.teardown()
+
+
+def test_feature_name_collision_on_historical_retrieval():
+
+    # _validate_feature_refs is the function that checks for colliding feature names
+    # check when feature names collide and 'full_feature_names=False'
+    with pytest.raises(FeatureNameCollisionError) as error:
+        _validate_feature_refs(
+            feature_refs=[
+                "driver_stats:conv_rate",
+                "driver_stats:avg_daily_trips",
+                "customer_profile:current_balance",
+                "customer_profile:avg_passenger_count",
+                "customer_profile:lifetime_trip_count",
+                "customer_profile:avg_daily_trips",
+            ],
+            full_feature_names=False,
+        )
+
+    expected_error_message = (
+        "Duplicate features named avg_daily_trips found.\n"
+        "To resolve this collision, either use the full feature name by setting "
+        "'full_feature_names=True', or ensure that the features in question have different names."
+    )
+
+    assert str(error.value) == expected_error_message
+
+    # check when feature names collide and 'full_feature_names=True'
+    with pytest.raises(FeatureNameCollisionError) as error:
+        _validate_feature_refs(
+            feature_refs=[
+                "driver_stats:conv_rate",
+                "driver_stats:avg_daily_trips",
+                "driver_stats:avg_daily_trips",
+                "customer_profile:current_balance",
+                "customer_profile:avg_passenger_count",
+                "customer_profile:lifetime_trip_count",
+                "customer_profile:avg_daily_trips",
+            ],
+            full_feature_names=True,
+        )
+
+    expected_error_message = (
+        "Duplicate features named driver_stats__avg_daily_trips found.\n"
+        "To resolve this collision, please ensure that the features in question "
+        "have different names."
+    )
+    assert str(error.value) == expected_error_message

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -15,10 +15,7 @@ from feast.feature_view import FeatureView
 from feast.infra.offline_stores.offline_utils import (
     DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,
 )
-from tests.integration.feature_repos.test_repo_configuration import (
-    Environment,
-    parametrize_offline_retrieval_test,
-)
+from tests.integration.feature_repos.test_repo_configuration import Environment
 
 np.random.seed(0)
 

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -15,7 +15,10 @@ from feast.feature_view import FeatureView
 from feast.infra.offline_stores.offline_utils import (
     DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,
 )
-from tests.integration.feature_repos.test_repo_configuration import Environment, parametrize_offline_retrieval_test
+from tests.integration.feature_repos.test_repo_configuration import (
+    Environment,
+    parametrize_offline_retrieval_test,
+)
 
 np.random.seed(0)
 
@@ -204,9 +207,7 @@ def test_historical_features_from_bigquery_sources(environment: Environment):
         actual_df_from_sql_entities = job_from_sql.to_df()
         end_time = datetime.utcnow()
         print(
-            str(
-                f"\nTime to execute job_from_sql.to_df() = '{(end_time - start_time)}'"
-            )
+            str(f"\nTime to execute job_from_sql.to_df() = '{(end_time - start_time)}'")
         )
 
         assert sorted(expected_df.columns) == sorted(
@@ -217,9 +218,7 @@ def test_historical_features_from_bigquery_sources(environment: Environment):
                 by=[event_timestamp, "order_id", "driver_id", "customer_id"]
             ).reset_index(drop=True),
             actual_df_from_sql_entities[expected_df.columns]
-            .sort_values(
-                by=[event_timestamp, "order_id", "driver_id", "customer_id"]
-            )
+            .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
             .reset_index(drop=True),
             check_dtype=False,
         )
@@ -294,9 +293,7 @@ def test_historical_features_from_bigquery_sources(environment: Environment):
     start_time = datetime.utcnow()
     actual_df_from_df_entities = job_from_df.to_df()
     end_time = datetime.utcnow()
-    print(
-        str(f"Time to execute job_from_df.to_df() = '{(end_time - start_time)}'\n")
-    )
+    print(str(f"Time to execute job_from_df.to_df() = '{(end_time - start_time)}'\n"))
 
     assert sorted(expected_df.columns) == sorted(actual_df_from_df_entities.columns)
     assert_frame_equal(
@@ -310,9 +307,7 @@ def test_historical_features_from_bigquery_sources(environment: Environment):
     )
 
     table_from_df_entities = job_from_df.to_arrow()
-    assert_frame_equal(
-        actual_df_from_df_entities, table_from_df_entities.to_pandas()
-    )
+    assert_frame_equal(actual_df_from_df_entities, table_from_df_entities.to_pandas())
 
 
 def test_feature_name_collision_on_historical_retrieval():

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
 import numpy as np
 import pandas as pd
@@ -22,19 +22,23 @@ from tests.integration.feature_repos.test_repo_configuration import (
 np.random.seed(0)
 
 
-def convert_timestamp_records_to_utc(records: List[Dict[str, Any]], column: str) -> List[Dict[str, Any]]:
+def convert_timestamp_records_to_utc(
+    records: List[Dict[str, Any]], column: str
+) -> List[Dict[str, Any]]:
     for record in records:
         record[column] = utils.make_tzaware(record[column]).astimezone(utc)
     return records
 
 
 # Find the latest record in the given time range and filter
-def find_asof_record(records: List[Dict[str, Any]],
-                     ts_key: str,
-                     ts_start: datetime,
-                     ts_end: datetime,
-                     filter_key: str,
-                     filter_value: Any) -> Dict[str, Any]:
+def find_asof_record(
+    records: List[Dict[str, Any]],
+    ts_key: str,
+    ts_start: datetime,
+    ts_end: datetime,
+    filter_key: str,
+    filter_value: Any,
+) -> Dict[str, Any]:
     found_record = {}
     for record in records:
         if record[filter_key] == filter_value and ts_start <= record[ts_key] <= ts_end:
@@ -138,8 +142,14 @@ def get_expected_training_df(
 def test_historical_features_from_bigquery_sources(environment: Environment):
     store = environment.feature_store
 
-    customer_df, customer_fv = environment.customer_df, environment.customer_feature_view()
-    driver_df, driver_fv = environment.driver_df, environment.driver_stats_feature_view()
+    customer_df, customer_fv = (
+        environment.customer_df,
+        environment.customer_feature_view(),
+    )
+    driver_df, driver_fv = (
+        environment.driver_df,
+        environment.driver_stats_feature_view(),
+    )
     orders_df = environment.orders_df
     full_feature_names = environment.test_repo_config.full_feature_names
     entity_df_query = environment.orders_sql_fixtures()

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -3,11 +3,10 @@ from typing import Any, Dict, List
 
 import numpy as np
 import pandas as pd
-from assertpy import assertpy
 from pandas.testing import assert_frame_equal
 from pytz import utc
 
-from feast import utils, errors
+from feast import utils
 from feast.feature_view import FeatureView
 from feast.infra.offline_stores.offline_utils import (
     DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,
@@ -194,26 +193,32 @@ def test_historical_features(environment: Environment):
             actual_df_from_sql_entities.columns
         )
 
-        actual_df_from_sql_entities = actual_df_from_sql_entities[expected_df.columns].sort_values(
-            by=[event_timestamp, "order_id", "driver_id", "customer_id"]
-        ).drop_duplicates().reset_index(drop=True)
-        expected_df = expected_df.sort_values(
-            by=[event_timestamp, "order_id", "driver_id", "customer_id"]
-        ).drop_duplicates().reset_index(drop=True)
+        actual_df_from_sql_entities = (
+            actual_df_from_sql_entities[expected_df.columns]
+            .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
+            .drop_duplicates()
+            .reset_index(drop=True)
+        )
+        expected_df = (
+            expected_df.sort_values(
+                by=[event_timestamp, "order_id", "driver_id", "customer_id"]
+            )
+            .drop_duplicates()
+            .reset_index(drop=True)
+        )
 
         assert_frame_equal(
-            actual_df_from_sql_entities,
-            expected_df,
-            check_dtype=False,
+            actual_df_from_sql_entities, expected_df, check_dtype=False,
         )
 
         table_from_sql_entities = job_from_sql.to_arrow()
-        df_from_sql_entities = table_from_sql_entities.to_pandas()[expected_df.columns].sort_values(
-            by=[event_timestamp, "order_id", "driver_id", "customer_id"]
-        ).drop_duplicates().reset_index(drop=True)
-        assert_frame_equal(
-            actual_df_from_sql_entities, df_from_sql_entities
+        df_from_sql_entities = (
+            table_from_sql_entities.to_pandas()[expected_df.columns]
+            .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
+            .drop_duplicates()
+            .reset_index(drop=True)
         )
+        assert_frame_equal(actual_df_from_sql_entities, df_from_sql_entities)
 
     # timestamp_column = (
     #     "e_ts"

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -166,6 +166,7 @@ class BigQueryDataSet:
 
 
 # @parametrize_offline_retrieval_test
+@pytest.mark.skip("Still iterating on this test")
 def test_historical_features_from_bigquery_sources(environment: Environment):
     store = environment.feature_store
 

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import assertpy
 import numpy as np
 import pandas as pd
 import pytest
@@ -8,7 +7,7 @@ from google.cloud import bigquery
 from pandas.testing import assert_frame_equal
 from pytz import utc
 
-from feast import errors, utils
+from feast import utils
 from feast.errors import FeatureNameCollisionError
 from feast.feature_store import _validate_feature_refs
 from feast.feature_view import FeatureView

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -3,13 +3,10 @@ from typing import Any, Dict, List
 
 import numpy as np
 import pandas as pd
-import pytest
 from pandas.testing import assert_frame_equal
 from pytz import utc
 
 from feast import utils
-from feast.errors import FeatureNameCollisionError
-from feast.feature_store import _validate_feature_refs
 from feast.feature_view import FeatureView
 from feast.infra.offline_stores.offline_utils import (
     DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,
@@ -139,7 +136,7 @@ def get_expected_training_df(
 
 
 @parametrize_offline_retrieval_test
-def test_historical_features_from_bigquery_sources(environment: Environment):
+def test_historical_features(environment: Environment):
     store = environment.feature_store
 
     customer_df, customer_fv = (
@@ -231,18 +228,6 @@ def test_historical_features_from_bigquery_sources(environment: Environment):
     #     ],
     # )
 
-    job_from_df = store.get_historical_features(
-        entity_df=orders_df,
-        features=[
-            "driver_stats:conv_rate",
-            "driver_stats:avg_daily_trips",
-            "customer_profile:current_balance",
-            "customer_profile:avg_passenger_count",
-            "customer_profile:lifetime_trip_count",
-        ],
-        full_feature_names=full_feature_names,
-    )
-
     # Rename the join key; this should now raise an error.
     # orders_df_with_invalid_join_key = orders_df.rename(
     #     {"customer_id": "customer"}, axis="columns"
@@ -269,69 +254,49 @@ def test_historical_features_from_bigquery_sources(environment: Environment):
     #         f"{name}.feast_entity_df"
     #     )
 
+    job_from_df = store.get_historical_features(
+        entity_df=orders_df,
+        features=[
+            "driver_stats:conv_rate",
+            "driver_stats:avg_daily_trips",
+            "customer_profile:current_balance",
+            "customer_profile:avg_passenger_count",
+            "customer_profile:lifetime_trip_count",
+        ],
+        full_feature_names=full_feature_names,
+    )
+
     start_time = datetime.utcnow()
     actual_df_from_df_entities = job_from_df.to_df()
+
+    print(f"actual_df_from_df_entities shape: {actual_df_from_df_entities.shape}")
     end_time = datetime.utcnow()
     print(str(f"Time to execute job_from_df.to_df() = '{(end_time - start_time)}'\n"))
 
     assert sorted(expected_df.columns) == sorted(actual_df_from_df_entities.columns)
-    assert_frame_equal(
+    expected_df = (
         expected_df.sort_values(
             by=[event_timestamp, "order_id", "driver_id", "customer_id"]
-        ).reset_index(drop=True),
+        )
+        .drop_duplicates()
+        .reset_index(drop=True)
+    )
+    actual_df_from_df_entities = (
         actual_df_from_df_entities[expected_df.columns]
         .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
-        .reset_index(drop=True),
-        check_dtype=False,
+        .drop_duplicates()
+        .reset_index(drop=True)
     )
 
-    table_from_df_entities = job_from_df.to_arrow()
-    assert_frame_equal(actual_df_from_df_entities, table_from_df_entities.to_pandas())
-
-
-def test_feature_name_collision_on_historical_retrieval():
-
-    # _validate_feature_refs is the function that checks for colliding feature names
-    # check when feature names collide and 'full_feature_names=False'
-    with pytest.raises(FeatureNameCollisionError) as error:
-        _validate_feature_refs(
-            feature_refs=[
-                "driver_stats:conv_rate",
-                "driver_stats:avg_daily_trips",
-                "customer_profile:current_balance",
-                "customer_profile:avg_passenger_count",
-                "customer_profile:lifetime_trip_count",
-                "customer_profile:avg_daily_trips",
-            ],
-            full_feature_names=False,
-        )
-
-    expected_error_message = (
-        "Duplicate features named avg_daily_trips found.\n"
-        "To resolve this collision, either use the full feature name by setting "
-        "'full_feature_names=True', or ensure that the features in question have different names."
+    assert_frame_equal(
+        expected_df, actual_df_from_df_entities, check_dtype=False,
     )
 
-    assert str(error.value) == expected_error_message
-
-    # check when feature names collide and 'full_feature_names=True'
-    with pytest.raises(FeatureNameCollisionError) as error:
-        _validate_feature_refs(
-            feature_refs=[
-                "driver_stats:conv_rate",
-                "driver_stats:avg_daily_trips",
-                "driver_stats:avg_daily_trips",
-                "customer_profile:current_balance",
-                "customer_profile:avg_passenger_count",
-                "customer_profile:lifetime_trip_count",
-                "customer_profile:avg_daily_trips",
-            ],
-            full_feature_names=True,
-        )
-
-    expected_error_message = (
-        "Duplicate features named driver_stats__avg_daily_trips found.\n"
-        "To resolve this collision, please ensure that the features in question "
-        "have different names."
+    table_from_df_entities = job_from_df.to_arrow().to_pandas()
+    table_from_df_entities = (
+        table_from_df_entities[expected_df.columns]
+        .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
+        .drop_duplicates()
+        .reset_index(drop=True)
     )
-    assert str(error.value) == expected_error_message
+    assert_frame_equal(actual_df_from_df_entities, table_from_df_entities)

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -8,17 +8,17 @@ from google.cloud import bigquery
 from pandas.testing import assert_frame_equal
 from pytz import utc
 
-from feast import (
-    errors,
-    utils,
-)
+from feast import errors, utils
 from feast.errors import FeatureNameCollisionError
 from feast.feature_store import _validate_feature_refs
 from feast.feature_view import FeatureView
 from feast.infra.offline_stores.offline_utils import (
     DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,
 )
-from tests.integration.feature_repos.test_repo_configuration import parametrize_offline_retrieval_test, Environment
+from tests.integration.feature_repos.test_repo_configuration import (
+    Environment,
+    parametrize_offline_retrieval_test,
+)
 
 np.random.seed(0)
 
@@ -165,10 +165,8 @@ class BigQueryDataSet:
             )
 
 
-@parametrize_offline_retrieval_test
-def test_historical_features_from_bigquery_sources(
-    environment: Environment
-):
+# @parametrize_offline_retrieval_test
+def test_historical_features_from_bigquery_sources(environment: Environment):
     store = environment.feature_store
 
     try:
@@ -302,22 +300,16 @@ def test_historical_features_from_bigquery_sources(
         actual_df_from_df_entities = job_from_df.to_df()
         end_time = datetime.utcnow()
         print(
-            str(
-                f"Time to execute job_from_df.to_df() = '{(end_time - start_time)}'\n"
-            )
+            str(f"Time to execute job_from_df.to_df() = '{(end_time - start_time)}'\n")
         )
 
-        assert sorted(expected_df.columns) == sorted(
-            actual_df_from_df_entities.columns
-        )
+        assert sorted(expected_df.columns) == sorted(actual_df_from_df_entities.columns)
         assert_frame_equal(
             expected_df.sort_values(
                 by=[event_timestamp, "order_id", "driver_id", "customer_id"]
             ).reset_index(drop=True),
             actual_df_from_df_entities[expected_df.columns]
-            .sort_values(
-                by=[event_timestamp, "order_id", "driver_id", "customer_id"]
-            )
+            .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
             .reset_index(drop=True),
             check_dtype=False,
         )

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -220,47 +220,6 @@ def test_historical_features(environment: Environment):
         )
         assert_frame_equal(actual_df_from_sql_entities, df_from_sql_entities)
 
-    # timestamp_column = (
-    #     "e_ts"
-    #     if environment.test_repo_config.infer_event_timestamp_col
-    #     else DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
-    # )
-
-    # entity_df_query_with_invalid_join_key = (
-    #     f"select order_id, driver_id, customer_id as customer, "
-    #     f"order_is_success, {timestamp_column}, FROM {environment.orders_table()}"
-    # )
-    # # Rename the join key; this should now raise an error.
-    # assertpy.assert_that(store.get_historical_features).raises(
-    #     errors.FeastEntityDFMissingColumnsError
-    # ).when_called_with(
-    #     entity_df=entity_df_query_with_invalid_join_key,
-    #     features=[
-    #         "driver_stats:conv_rate",
-    #         "driver_stats:avg_daily_trips",
-    #         "customer_profile:current_balance",
-    #         "customer_profile:avg_passenger_count",
-    #         "customer_profile:lifetime_trip_count",
-    #     ],
-    # )
-
-    # Rename the join key; this should now raise an error.
-    # orders_df_with_invalid_join_key = orders_df.rename(
-    #     {"customer_id": "customer"}, axis="columns"
-    # )
-    # assertpy.assert_that(store.get_historical_features).raises(
-    #     errors.FeastEntityDFMissingColumnsError
-    # ).when_called_with(
-    #     entity_df=orders_df_with_invalid_join_key,
-    #     features=[
-    #         "driver_stats:conv_rate",
-    #         "driver_stats:avg_daily_trips",
-    #         "customer_profile:current_balance",
-    #         "customer_profile:avg_passenger_count",
-    #         "customer_profile:lifetime_trip_count",
-    #     ],
-    # )
-
     job_from_df = store.get_historical_features(
         entity_df=orders_df,
         features=[


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

We wanna start parameterizing over all the possible combinations when reading feature values from the offline feature store. This PR introduces the decorator needed to set up the underlying tables as needed, updates the historical integration test to operate on an Environment object.

```
$ FEAST_TELEMETRY=False pytest --cov=./ --cov-report=xml --color=yes -s --integration sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py -n 8
======================================================================================= test session starts =======================================================================================
platform darwin -- Python 3.7.11, pytest-6.0.0, py-1.10.0, pluggy-0.13.1
rootdir: /Users/achal/tecton/feast/sdk/python
plugins: cov-2.12.1, xdist-2.3.0, ordering-0.6, mock-1.10.4, timeout-1.4.2, forked-1.3.0, lazy-fixture-0.6.3
gw0 [20] / gw1 [20] / gw2 [20] / gw3 [20] / gw4 [20] / gw5 [20] / gw6 [20] / gw7 [20]
....................

---------- coverage: platform darwin, python 3.7.11-final-0 ----------
Coverage XML written to file coverage.xml

================================================================================= 20 passed in 162.39s (0:02:42) ==================================================================================
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
