### PR TITLE
Local feature server implementation (HTTP endpoint)

### DIFF
--- a/protos/feast/serving/ServingService.proto
+++ b/protos/feast/serving/ServingService.proto
@@ -84,21 +84,20 @@ message GetOnlineFeaturesRequestV2 {
     }
 }
 
-message FeatureListConfig {
-    repeated string features = 1;
-    bool full_feature_names = 2;
-}
-
-message EntityRow {
-    map<string,feast.types.Value> fields = 1;
+// In JSON "val" field can be omitted
+message FeatureList {
+    repeated string val = 1;
 }
 
 message GetOnlineFeaturesRequest {
-    oneof features {
-        string feature_service_name = 1;
-        FeatureListConfig feature_list_config = 2;
+    oneof kind {
+        string feature_service = 1;
+        FeatureList features = 2;
     }
-    repeated EntityRow entity_rows = 3;
+    // The entity data is specified in a columnar format
+    // A map of entity name -> list of values
+    map<string, feast.types.RepeatedValue> entities = 3;
+    bool full_feature_names = 4;
 }
 
 message GetOnlineFeaturesResponse {

--- a/protos/feast/serving/ServingService.proto
+++ b/protos/feast/serving/ServingService.proto
@@ -32,9 +32,6 @@ service ServingService {
 
     // Get online features (v2) synchronously.
     rpc GetOnlineFeaturesV2 (GetOnlineFeaturesRequestV2) returns (GetOnlineFeaturesResponse);
-
-    // Get online features synchronously.
-    rpc GetOnlineFeatures (GetOnlineFeaturesRequest) returns (GetOnlineFeaturesResponse);
 }
 
 message GetFeastServingInfoRequest {}

--- a/protos/feast/serving/ServingService.proto
+++ b/protos/feast/serving/ServingService.proto
@@ -32,6 +32,9 @@ service ServingService {
 
     // Get online features (v2) synchronously.
     rpc GetOnlineFeaturesV2 (GetOnlineFeaturesRequestV2) returns (GetOnlineFeaturesResponse);
+
+    // Get online features synchronously.
+    rpc GetOnlineFeatures (GetOnlineFeaturesRequest) returns (GetOnlineFeaturesResponse);
 }
 
 message GetFeastServingInfoRequest {}
@@ -79,6 +82,23 @@ message GetOnlineFeaturesRequestV2 {
         // Map containing mapping of entity name to entity value.
         map<string,feast.types.Value> fields = 2;
     }
+}
+
+message FeatureListConfig {
+    repeated string features = 1;
+    bool full_feature_names = 2;
+}
+
+message EntityRow {
+    map<string,feast.types.Value> fields = 1;
+}
+
+message GetOnlineFeaturesRequest {
+    oneof features {
+        string feature_service_name = 1;
+        FeatureListConfig feature_list_config = 2;
+    }
+    repeated EntityRow entity_rows = 3;
 }
 
 message GetOnlineFeaturesResponse {

--- a/protos/feast/types/Value.proto
+++ b/protos/feast/types/Value.proto
@@ -41,12 +41,14 @@ message ValueType {
     FLOAT_LIST = 16;
     BOOL_LIST = 17;
     UNIX_TIMESTAMP_LIST = 18;
+    NULL = 19;
   }
 }
 
 message Value {
   // ValueType is referenced by the metadata types, FeatureInfo and EntityInfo.
   // The enum values do not have to match the oneof val field ids, but they should.
+  // In JSON "*_val" field can be omitted
   oneof val {
     bytes bytes_val = 1;
     string string_val = 2;
@@ -64,7 +66,12 @@ message Value {
     FloatList float_list_val = 16;
     BoolList bool_list_val = 17;
     Int64List unix_timestamp_list_val = 18;
+    Null null_val = 19;
   }
+}
+
+enum Null {
+  NULL = 0;
 }
 
 message BytesList {
@@ -93,4 +100,10 @@ message FloatList {
 
 message BoolList {
   repeated bool val = 1;
+}
+
+// This is to avoid an issue of being unable to specify `repeated value` in oneofs or maps
+// In JSON "val" field can be omitted
+message RepeatedValue {
+  repeated Value val = 1;
 }

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -357,5 +357,19 @@ def init_command(project_directory, minimal: bool, template: str):
     init_repo(project_directory, template)
 
 
+@cli.command("serve")
+@click.option(
+    "--port", "-p", type=click.INT, default=6566, help="Specify a port for the server"
+)
+@click.pass_context
+def serve_command(ctx: click.Context, port: int):
+    """Start a the feature consumption server locally on a given port."""
+    repo = ctx.obj["CHDIR"]
+    cli_check_repo(repo)
+    store = FeatureStore(repo_path=str(repo))
+
+    store.serve(port)
+
+
 if __name__ == "__main__":
     cli()

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -1,0 +1,57 @@
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.logger import logger
+from google.protobuf.json_format import MessageToDict, Parse
+
+import feast
+from feast.protos.feast.serving.ServingService_pb2 import GetOnlineFeaturesRequest
+from feast.type_map import feast_value_type_to_python_type
+
+
+def get_app(store: "feast.FeatureStore"):
+    app = FastAPI()
+
+    @app.get("/get-online-features/")
+    async def get_online_features(request: Request):
+        try:
+            # Validate and parse the request data into GetOnlineFeaturesRequest Protobuf object
+            body = await request.body()
+            request_proto = GetOnlineFeaturesRequest()
+            Parse(body, request_proto)
+
+            # Initialize parameters for FeatureStore.get_online_features(...) call
+            if request_proto.HasField("feature_service_name"):
+                features = store.get_feature_service(request_proto.feature_service_name)
+                full_feature_names = False
+            else:
+                features = request_proto.feature_list_config.features
+                full_feature_names = (
+                    request_proto.feature_list_config.full_feature_names
+                )
+
+            entity_rows = [
+                {
+                    k: feast_value_type_to_python_type(v)
+                    for k, v in entity_row_proto.fields.items()
+                }
+                for entity_row_proto in request_proto.entity_rows
+            ]
+
+            response_proto = store.get_online_features(
+                features, entity_rows, full_feature_names=full_feature_names
+            ).proto
+
+            # Convert the Protobuf object to JSON and return it
+            return MessageToDict(response_proto, preserving_proto_field_name=True)
+        except Exception as e:
+            # Print the original exception on the server side
+            logger.exception(e)
+            # Raise HTTPException to return the error message to the client
+            raise HTTPException(status_code=500, detail=str(e))
+
+    return app
+
+
+def start_server(store: "feast.FeatureStore", port: int):
+    app = get_app(store)
+    uvicorn.run(app, host="127.0.0.1", port=port)

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -848,7 +848,7 @@ class FeatureStore:
 
     @log_exceptions_and_usage
     def serve(self, port: int) -> None:
-        """Start a the feature consumption server locally on a given port."""
+        """Start the feature consumption server locally on a given port."""
         feature_server.start_server(self, port)
 
 

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -22,7 +22,7 @@ import pandas as pd
 from colorama import Fore, Style
 from tqdm import tqdm
 
-from feast import utils
+from feast import feature_server, utils
 from feast.entity import Entity
 from feast.errors import (
     EntityNotFoundException,
@@ -845,6 +845,11 @@ class FeatureStore:
                             ] = GetOnlineFeaturesResponse.FieldStatus.PRESENT
 
         return OnlineResponse(GetOnlineFeaturesResponse(field_values=result_rows))
+
+    @log_exceptions_and_usage
+    def serve(self, port: int) -> None:
+        """Start a the feature consumption server locally on a given port."""
+        feature_server.start_server(self, port)
 
 
 def _entity_row_to_key(row: GetOnlineFeaturesRequestV2.EntityRow) -> EntityKeyProto:

--- a/sdk/python/feast/proto_json.py
+++ b/sdk/python/feast/proto_json.py
@@ -1,0 +1,196 @@
+import uuid
+from typing import Any, Callable, Type
+
+from google.protobuf.json_format import (  # type: ignore
+    _WKTJSONMETHODS,
+    ParseError,
+    _Parser,
+    _Printer,
+)
+
+from feast.protos.feast.serving.ServingService_pb2 import FeatureList
+from feast.protos.feast.types.Value_pb2 import RepeatedValue, Value
+
+ProtoMessage = Any
+JsonObject = Any
+
+
+def _patch_proto_json_encoding(
+    proto_type: Type[ProtoMessage],
+    to_json_object: Callable[[_Printer, ProtoMessage], JsonObject],
+    from_json_object: Callable[[_Parser, JsonObject, ProtoMessage], None],
+) -> None:
+    """Patch Protobuf JSON Encoder / Decoder for a desired Protobuf type with to_json & from_json methods."""
+    to_json_fn_name = "_" + uuid.uuid4().hex
+    from_json_fn_name = "_" + uuid.uuid4().hex
+    setattr(_Printer, to_json_fn_name, to_json_object)
+    setattr(_Parser, from_json_fn_name, from_json_object)
+    _WKTJSONMETHODS[proto_type.DESCRIPTOR.full_name] = [
+        to_json_fn_name,
+        from_json_fn_name,
+    ]
+
+
+def _patch_feast_value_json_encoding():
+    """Patch Protobuf JSON Encoder / Decoder with a Feast Value type.
+
+    This allows encoding the proto object as a native type, without the dummy structural wrapper.
+
+    Here's a before example:
+
+    {
+        "value_1": {
+            "int64_val": 1
+        },
+        "value_2": {
+            "double_list_val": [1.0, 2.0, 3.0]
+        },
+    }
+
+    And here's an after example:
+
+    {
+        "value_1": 1,
+        "value_2": [1.0, 2.0, 3.0]
+    }
+    """
+
+    def to_json_object(printer: _Printer, message: ProtoMessage) -> JsonObject:
+        which = message.WhichOneof("val")
+        # If the Value message is not set treat as null_value when serialize
+        # to JSON. The parse back result will be different from original message.
+        if which is None or which == "null_val":
+            return None
+        elif "_list_" in which:
+            value = list(getattr(message, which).val)
+        else:
+            value = getattr(message, which)
+        return value
+
+    def from_json_object(
+        parser: _Parser, value: JsonObject, message: ProtoMessage
+    ) -> None:
+        if value is None:
+            message.null_val = 0
+        elif isinstance(value, bool):
+            message.bool_val = value
+        elif isinstance(value, str):
+            message.string_val = value
+        elif isinstance(value, int):
+            message.int64_val = value
+        elif isinstance(value, float):
+            message.double_val = value
+        elif isinstance(value, list):
+            if len(value) == 0:
+                # Clear will mark the struct as modified so it will be created even if there are no values
+                message.int64_list_val.Clear()
+            elif isinstance(value[0], bool):
+                message.bool_list_val.val.extend(value)
+            elif isinstance(value[0], str):
+                message.string_list_val.val.extend(value)
+            elif isinstance(value[0], (float, int, type(None))):
+                # Identify array as ints if all of the elements are ints
+                if all(isinstance(item, int) for item in value):
+                    message.int64_list_val.val.extend(value)
+                # If any of the elements are floats or nulls, then parse it as a float array
+                else:
+                    # Convert each null as NaN.
+                    message.double_list_val.val.extend(
+                        [item if item is not None else float("nan") for item in value]
+                    )
+            else:
+                raise ParseError(
+                    "Value {0} has unexpected type {1}.".format(
+                        value[0], type(value[0])
+                    )
+                )
+        else:
+            raise ParseError(
+                "Value {0} has unexpected type {1}.".format(value, type(value))
+            )
+
+    _patch_proto_json_encoding(Value, to_json_object, from_json_object)
+
+
+def _patch_feast_repeated_value_json_encoding():
+    """Patch Protobuf JSON Encoder / Decoder with a Feast RepeatedValue type.
+
+    This allows list of lists without dummy field name "val".
+
+    Here's a before example:
+
+    {
+        "repeated_value": [
+            {"val": [1,2,3]},
+            {"val": [4,5,6]}
+        ]
+    }
+
+    And here's an after example:
+
+    {
+        "repeated_value": [
+            [1,2,3],
+            [4,5,6]
+        ]
+    }
+    """
+
+    def to_json_object(printer: _Printer, message: ProtoMessage) -> JsonObject:
+        return [printer._MessageToJsonObject(item) for item in message.val]
+
+    def from_json_object(
+        parser: _Parser, value: JsonObject, message: ProtoMessage
+    ) -> None:
+        array = value if isinstance(value, list) else value["val"]
+        for item in array:
+            parser.ConvertMessage(item, message.val.add())
+
+    _patch_proto_json_encoding(RepeatedValue, to_json_object, from_json_object)
+
+
+def _patch_feast_feature_list_json_encoding():
+    """Patch Protobuf JSON Encoder / Decoder with a Feast FeatureList type.
+
+    This allows list of lists without dummy field name "features".
+
+    Here's a before example:
+
+    {
+        "feature_list": {
+            "features": [
+                "feature-1",
+                "feature-2",
+                "feature-3"
+            ]
+        }
+    }
+
+    And here's an after example:
+
+    {
+        "feature_list": [
+            "feature-1",
+            "feature-2",
+            "feature-3"
+        ]
+    }
+    """
+
+    def to_json_object(printer: _Printer, message: ProtoMessage) -> JsonObject:
+        return list(message.val)
+
+    def from_json_object(
+        parser: _Parser, value: JsonObject, message: ProtoMessage
+    ) -> None:
+        array = value if isinstance(value, list) else value["val"]
+        message.val.extend(array)
+
+    _patch_proto_json_encoding(FeatureList, to_json_object, from_json_object)
+
+
+def patch():
+    """Patch Protobuf JSON Encoder / Decoder with all desired Feast types."""
+    _patch_feast_value_json_encoding()
+    _patch_feast_repeated_value_json_encoding()
+    _patch_feast_feature_list_json_encoding()

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -204,7 +204,9 @@ def _python_value_to_proto_value(feast_value_type, value) -> ProtoValue:
             return ProtoValue(
                 int32_list_val=Int32List(
                     val=[
-                        item if type(item) is np.int32 else _type_err(item, np.int32)
+                        item
+                        if type(item) in [np.int32, int]
+                        else _type_err(item, np.int32)
                         for item in value
                     ]
                 )
@@ -215,7 +217,7 @@ def _python_value_to_proto_value(feast_value_type, value) -> ProtoValue:
                 int64_list_val=Int64List(
                     val=[
                         item
-                        if type(item) in [np.int64, np.int32]
+                        if type(item) in [np.int64, np.int32, int]
                         else _type_err(item, np.int64)
                         for item in value
                     ]
@@ -227,7 +229,7 @@ def _python_value_to_proto_value(feast_value_type, value) -> ProtoValue:
                 int64_list_val=Int64List(
                     val=[
                         item
-                        if type(item) in [np.int64, np.int32]
+                        if type(item) in [np.int64, np.int32, int]
                         else _type_err(item, np.int64)
                         for item in value
                     ]
@@ -283,7 +285,7 @@ def _python_value_to_proto_value(feast_value_type, value) -> ProtoValue:
         elif feast_value_type == ValueType.FLOAT:
             return ProtoValue(float_val=float(value))
         elif feast_value_type == ValueType.DOUBLE:
-            assert type(value) is float or np.float64
+            assert type(value) in [float, np.float64]
             return ProtoValue(double_val=value)
         elif feast_value_type == ValueType.STRING:
             return ProtoValue(string_val=str(value))

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -57,6 +57,8 @@ REQUIRED = [
     "tenacity>=7.*",
     "toml==0.10.*",
     "tqdm==4.*",
+    "fastapi>=0.68.0",
+    "uvicorn[standard]>=0.14.0",
 ]
 
 GCP_REQUIRED = [

--- a/sdk/python/tests/unit/test_proto_json.py
+++ b/sdk/python/tests/unit/test_proto_json.py
@@ -1,0 +1,115 @@
+import assertpy
+import pytest
+from google.protobuf.json_format import MessageToDict, Parse
+
+from feast import proto_json
+from feast.protos.feast.serving.ServingService_pb2 import (
+    FeatureList,
+    GetOnlineFeaturesResponse,
+)
+from feast.protos.feast.types.Value_pb2 import RepeatedValue
+
+FieldValues = GetOnlineFeaturesResponse.FieldValues
+
+
+@pytest.fixture(scope="module")
+def proto_json_patch():
+    proto_json.patch()
+
+
+def test_feast_value(proto_json_patch):
+    # FieldValues contains "map<string, feast.types.Value> fields" proto field.
+    # We want to test that feast.types.Value can take different types in JSON
+    # without using additional structure (e.g. 1 instead of {int64_val: 1}).
+    field_values_str = """{
+        "fields": {
+            "a": 1,
+            "b": 2.0,
+            "c": true,
+            "d": "foo",
+            "e": [1, 2, 3],
+            "f": [2.0, 3.0, 4.0, null],
+            "g": [true, false, true],
+            "h": ["foo", "bar", "foobar"],
+            "i": null
+        }
+    }"""
+    field_values_proto = FieldValues()
+    Parse(field_values_str, field_values_proto)
+    assertpy.assert_that(field_values_proto.fields.keys()).is_equal_to(
+        {"a", "b", "c", "d", "e", "f", "g", "h", "i"}
+    )
+    assertpy.assert_that(field_values_proto.fields["a"].int64_val).is_equal_to(1)
+    assertpy.assert_that(field_values_proto.fields["b"].double_val).is_equal_to(2.0)
+    assertpy.assert_that(field_values_proto.fields["c"].bool_val).is_equal_to(True)
+    assertpy.assert_that(field_values_proto.fields["d"].string_val).is_equal_to("foo")
+    assertpy.assert_that(field_values_proto.fields["e"].int64_list_val.val).is_equal_to(
+        [1, 2, 3]
+    )
+    # Can't directly check equality to [2.0, 3.0, 4.0, float("nan")], because float("nan") != float("nan")
+    assertpy.assert_that(
+        field_values_proto.fields["f"].double_list_val.val[:3]
+    ).is_equal_to([2.0, 3.0, 4.0])
+    assertpy.assert_that(field_values_proto.fields["f"].double_list_val.val[3]).is_nan()
+    assertpy.assert_that(field_values_proto.fields["g"].bool_list_val.val).is_equal_to(
+        [True, False, True]
+    )
+    assertpy.assert_that(
+        field_values_proto.fields["h"].string_list_val.val
+    ).is_equal_to(["foo", "bar", "foobar"])
+    assertpy.assert_that(field_values_proto.fields["i"].null_val).is_equal_to(0)
+
+    # Now convert protobuf back to json and check that
+    field_values_json = MessageToDict(field_values_proto)
+    assertpy.assert_that(field_values_json["fields"].keys()).is_equal_to(
+        {"a", "b", "c", "d", "e", "f", "g", "h", "i"}
+    )
+    assertpy.assert_that(field_values_json["fields"]["a"]).is_equal_to(1)
+    assertpy.assert_that(field_values_json["fields"]["b"]).is_equal_to(2.0)
+    assertpy.assert_that(field_values_json["fields"]["c"]).is_equal_to(True)
+    assertpy.assert_that(field_values_json["fields"]["d"]).is_equal_to("foo")
+    assertpy.assert_that(field_values_json["fields"]["e"]).is_equal_to([1, 2, 3])
+    # Can't directly check equality to [2.0, 3.0, 4.0, float("nan")], because float("nan") != float("nan")
+    assertpy.assert_that(field_values_json["fields"]["f"][:3]).is_equal_to(
+        [2.0, 3.0, 4.0]
+    )
+    assertpy.assert_that(field_values_json["fields"]["f"][3]).is_nan()
+    assertpy.assert_that(field_values_json["fields"]["g"]).is_equal_to(
+        [True, False, True]
+    )
+    assertpy.assert_that(field_values_json["fields"]["h"]).is_equal_to(
+        ["foo", "bar", "foobar"]
+    )
+    assertpy.assert_that(field_values_json["fields"]["i"]).is_equal_to(None)
+
+
+def test_feast_repeated_value(proto_json_patch):
+    # Make sure that RepeatedValue in JSON does not need the
+    # additional structure (e.g. [1,2,3] instead of {"val": [1,2,3]})
+    repeated_value_str = "[1,2,3]"
+    repeated_value_proto = RepeatedValue()
+    Parse(repeated_value_str, repeated_value_proto)
+    assertpy.assert_that(len(repeated_value_proto.val)).is_equal_to(3)
+    assertpy.assert_that(repeated_value_proto.val[0].int64_val).is_equal_to(1)
+    assertpy.assert_that(repeated_value_proto.val[1].int64_val).is_equal_to(2)
+    assertpy.assert_that(repeated_value_proto.val[2].int64_val).is_equal_to(3)
+    # Now convert protobuf back to json and check that
+    repeated_value_json = MessageToDict(repeated_value_proto)
+    assertpy.assert_that(repeated_value_json).is_equal_to([1, 2, 3])
+
+
+def test_feature_list(proto_json_patch):
+    # Make sure that FeatureList in JSON does not need the additional structure
+    # (e.g. ["foo", "bar"] instead of {"val": ["foo", "bar"]})
+    feature_list_str = '["feature-a", "feature-b", "feature-c"]'
+    feature_list_proto = FeatureList()
+    Parse(feature_list_str, feature_list_proto)
+    assertpy.assert_that(len(feature_list_proto.val)).is_equal_to(3)
+    assertpy.assert_that(feature_list_proto.val[0]).is_equal_to("feature-a")
+    assertpy.assert_that(feature_list_proto.val[1]).is_equal_to("feature-b")
+    assertpy.assert_that(feature_list_proto.val[2]).is_equal_to("feature-c")
+    # Now convert protobuf back to json and check that
+    feature_list_json = MessageToDict(feature_list_proto)
+    assertpy.assert_that(feature_list_json).is_equal_to(
+        ["feature-a", "feature-b", "feature-c"]
+    )


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Implements the local HTTP feature consumption server.

RFCs for context:
 * [RFC: Feature Consumption Server](https://docs.google.com/document/d/1iXvFhAsJ5jgAhPOpTdB3j-Wj1S9x3Ev_Wr6ZpnLzER4/edit#)
* [RFC: Feast Cloud Architecture](https://docs.google.com/document/d/17TDdtd3GhChfEyah6dppFxD6Ce9fOmIpNdV0b6SEr5o/edit#heading=h.d7e4zxvwrgt1)

From one terminal tab we can run `feast serve`:
```bash
$ feast serve
INFO:     Started server process [13615]
08/12/2021 09:29:36 PM INFO:Started server process [13615]
INFO:     Waiting for application startup.
08/12/2021 09:29:36 PM INFO:Waiting for application startup.
INFO:     Application startup complete.
08/12/2021 09:29:36 PM INFO:Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:6566 (Press CTRL+C to quit)
08/12/2021 09:29:36 PM INFO:Uvicorn running on http://127.0.0.1:6566 (Press CTRL+C to quit)
INFO:     127.0.0.1:52654 - "GET /get-online-features/ HTTP/1.1" 200 OK
INFO:     127.0.0.1:52660 - "GET /get-online-features/ HTTP/1.1" 200 OK
```

From another tab we can run cURL requests:
```bash
$ curl -X GET \
    "http://127.0.0.1:6566/get-online-features/" \
    -H "Content-type: application/json" \
    -H "Accept: application/json" \
    -d '{
        "features": [
            "driver_hourly_stats:conv_rate",
            "driver_hourly_stats:acc_rate",
            "driver_hourly_stats:avg_daily_trips"
        ],
        "entities": {
            "driver_id": [1001, 1002, 1003]
        },
        "full_feature_names": true
    }' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1345  100  1054  100   291   3685   1017 --:--:-- --:--:-- --:--:--  4702
{
  "field_values": [
    {
      "fields": {
        "driver_hourly_stats__conv_rate": 0.5315734148025513,
        "driver_id": 1001,
        "driver_hourly_stats__acc_rate": 0.5842991471290588,
        "driver_hourly_stats__avg_daily_trips": 714
      },
      "statuses": {
        "driver_hourly_stats__conv_rate": "PRESENT",
        "driver_hourly_stats__acc_rate": "PRESENT",
        "driver_hourly_stats__avg_daily_trips": "PRESENT",
        "driver_id": "PRESENT"
      }
    },
    {
      "fields": {
        "driver_id": 1002,
        "driver_hourly_stats__avg_daily_trips": 133,
        "driver_hourly_stats__conv_rate": 0.23269200325012207,
        "driver_hourly_stats__acc_rate": 0.5605814456939697
      },
      "statuses": {
        "driver_hourly_stats__avg_daily_trips": "PRESENT",
        "driver_hourly_stats__acc_rate": "PRESENT",
        "driver_id": "PRESENT",
        "driver_hourly_stats__conv_rate": "PRESENT"
      }
    },
    {
      "fields": {
        "driver_hourly_stats__conv_rate": 0.7948746085166931,
        "driver_hourly_stats__avg_daily_trips": 506,
        "driver_id": 1003,
        "driver_hourly_stats__acc_rate": 0.9278625845909119
      },
      "statuses": {
        "driver_hourly_stats__acc_rate": "PRESENT",
        "driver_hourly_stats__avg_daily_trips": "PRESENT",
        "driver_hourly_stats__conv_rate": "PRESENT",
        "driver_id": "PRESENT"
      }
    }
  ]

```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Implement `feast serve` CLI command that starts a local HTTP feature server
```
