### PR TITLE
Rerun failed python integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test-python:
 	FEAST_USAGE=False pytest -n 8 sdk/python/tests
 
 test-python-integration:
-	FEAST_USAGE=False pytest -n 8 --integration sdk/python/tests
+	FEAST_USAGE=False pytest -n 8 --integration --reruns 3 sdk/python/tests
 
 format-python:
 	# Sort

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -93,6 +93,7 @@ CI_REQUIRED = [
     "pytest-cov",
     "pytest-xdist",
     "pytest-lazy-fixture==0.6.3",
+    "pytest-rerunfailures==10.1",
     "pytest-timeout==1.4.2",
     "pytest-ordering==0.6.*",
     "pytest-mock==1.10.4",


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

With our working on increasing out integration test coverage, we are at higher risk of test failures because of flakes. To address this, this PR introduces a pytest-rerunfailures to try and alleviate the issue with failed tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
