### PR TITLE
Fix get_online_features telemetry to only log every 10000 times

### DIFF
--- a/sdk/python/feast/usage.py
+++ b/sdk/python/feast/usage.py
@@ -77,8 +77,8 @@ class Usage:
         self.check_env_and_configure()
         if self._usage_enabled and self.usage_id:
             if function_name == "get_online_features":
+                self._usage_counter["get_online_features"] += 1
                 if self._usage_counter["get_online_features"] % 10000 != 0:
-                    self._usage_counter["get_online_features"] += 1
                     return
 
             json = {

--- a/sdk/python/feast/usage.py
+++ b/sdk/python/feast/usage.py
@@ -78,9 +78,9 @@ class Usage:
         if self._usage_enabled and self.usage_id:
             if function_name == "get_online_features":
                 self._usage_counter["get_online_features"] += 1
-                if self._usage_counter["get_online_features"] % 10000 != 0:
+                if self._usage_counter["get_online_features"] % 10000 != 2:
                     return
-                self._usage_counter["get_online_features"] = 0  # avoid overflow
+                self._usage_counter["get_online_features"] = 2  # avoid overflow
             json = {
                 "function_name": function_name,
                 "telemetry_id": self.usage_id,

--- a/sdk/python/feast/usage.py
+++ b/sdk/python/feast/usage.py
@@ -80,7 +80,7 @@ class Usage:
                 self._usage_counter["get_online_features"] += 1
                 if self._usage_counter["get_online_features"] % 10000 != 0:
                     return
-
+                self._usage_counter["get_online_features"] = 0  # avoid overflow
             json = {
                 "function_name": function_name,
                 "telemetry_id": self.usage_id,


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Telemetry for `get_online_features` currently has a bug where telemetry is being logged during every call to `get_online_features`, instead of every 10000 calls. This PR fixes that bug. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
