### PR TITLE
Fix Azure Terraform installation.

### DIFF
--- a/infra/terraform/azure/helm.tf
+++ b/infra/terraform/azure/helm.tf
@@ -82,7 +82,8 @@ resource "helm_release" "feast" {
 
   name  = var.name_prefix
   namespace = var.aks_namespace
-  chart = "../../charts/feast"
+  repository = "https://feast-helm-charts.storage.googleapis.com"
+  chart = "feast"
 
   values = [
     yamlencode(local.feast_helm_values)


### PR DESCRIPTION
Helm chart for Feast in the Terraform installation changed to
point to the location referenced in the Azure Helm installation
documentation (https://docs.feast.dev/feast-on-kubernetes-1/getting-started/install-feast/kubernetes-azure-aks-with-helm)

**Which issue(s) this PR fixes**:
Fixes #1792 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
