### PR TITLE
Add init to Provider contract

### DIFF
--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -21,6 +21,10 @@ from feast.type_map import python_value_to_proto_value
 
 class Provider(abc.ABC):
     @abc.abstractmethod
+    def __init__(self, config: RepoConfig):
+        ...
+
+    @abc.abstractmethod
     def update_infra(
         self,
         project: str,

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -165,7 +165,7 @@ def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
 
         cls = importer.get_class_from_type(module_name, class_name, "Provider")
 
-        return cls(config, repo_path)
+        return cls(config)
 
 
 def _get_requested_feature_views_to_features_dict(

--- a/sdk/python/tests/foo_provider.py
+++ b/sdk/python/tests/foo_provider.py
@@ -13,6 +13,9 @@ from feast.registry import Registry
 
 
 class FooProvider(Provider):
+    def __init__(self, config: RepoConfig):
+        pass
+
     def update_infra(
         self,
         project: str,
@@ -74,7 +77,4 @@ class FooProvider(Provider):
         entity_keys: List[EntityKeyProto],
         requested_features: List[str] = None,
     ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
-        pass
-
-    def __init__(self, config, repo_path):
         pass


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR adds an abstract `__init__` as part of the base class for Providers. Currently no such method exists which has led to custom providers and built in providers having different initialization contracts.
https://github.com/feast-dev/feast/blob/745a1b43d20c0169b675b1f28039854205fb8180/sdk/python/feast/infra/provider.py#L146
vs 
https://github.com/feast-dev/feast/blob/745a1b43d20c0169b675b1f28039854205fb8180/sdk/python/feast/infra/provider.py#L164

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
All custom providers must now provide an initialization method and won't receive a repo_path argument
```
