### PR TITLE
Rename telemetry to usage

### DIFF
--- a/sdk/python/feast/usage.py
+++ b/sdk/python/feast/usage.py
@@ -25,7 +25,7 @@ import requests
 
 from feast.version import get_version
 
-USAGE_ENDPOINT = "https://us-central1-kf-feast.cloudfunctions.net/bq_telemetry_logger"
+USAGE_ENDPOINT = "https://usage.feast.dev"
 _logger = logging.getLogger(__name__)
 
 
@@ -83,7 +83,7 @@ class Usage:
                 self._usage_counter["get_online_features"] = 2  # avoid overflow
             json = {
                 "function_name": function_name,
-                "telemetry_id": self.usage_id,
+                "usage_id": self.usage_id,
                 "timestamp": datetime.utcnow().isoformat(),
                 "version": get_version(),
                 "os": sys.platform,
@@ -104,7 +104,7 @@ class Usage:
             json = {
                 "error_type": error_type,
                 "traceback": traceback,
-                "telemetry_id": self.usage_id,
+                "usage_id": self.usage_id,
                 "version": get_version(),
                 "os": sys.platform,
                 "is_test": self._is_test,

--- a/sdk/python/usage_tests/test_usage.py
+++ b/sdk/python/usage_tests/test_usage.py
@@ -142,16 +142,16 @@ def read_bigquery_usage_id(usage_id):
     bq_client = bigquery.Client()
     query = f"""
                 SELECT
-                  telemetry_id
+                  usage_id
                 FROM (
                   SELECT
-                    JSON_EXTRACT(textPayload, '$.telemetry_id') AS telemetry_id
+                    JSON_EXTRACT(textPayload, '$.usage_id') AS usage_id
                   FROM
                     `{USAGE_BIGQUERY_TABLE}`
                   WHERE
                     timestamp >= TIMESTAMP(\"{datetime.utcnow().date().isoformat()}\"))
                 WHERE
-                  telemetry_id = '\"{usage_id}\"'
+                  usage_id = '\"{usage_id}\"'
             """
     query_job = bq_client.query(query)
     return query_job.result()


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: A few places in the codebase still refer to telemetry. This PR renames "telemetry" to "usage".

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
