### PR TITLE
Initial scaffolding for on demand feature view

### DIFF
--- a/protos/feast/core/FeatureView.proto
+++ b/protos/feast/core/FeatureView.proto
@@ -35,6 +35,7 @@ message FeatureView {
     FeatureViewMeta meta = 2;
 }
 
+// TODO(adchia): refactor common fields from this and ODFV into separate metadata proto
 message FeatureViewSpec {
     // Name of the feature view. Must be unique. Not updated.
     string name = 1;

--- a/protos/feast/core/OnDemandFeatureView.proto
+++ b/protos/feast/core/OnDemandFeatureView.proto
@@ -1,0 +1,60 @@
+//
+// Copyright 2020 The Feast Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+syntax = "proto3";
+package feast.core;
+
+option go_package = "github.com/feast-dev/feast/sdk/go/protos/feast/core";
+option java_outer_classname = "OnDemandFeatureViewProto";
+option java_package = "feast.proto.core";
+
+import "feast/core/FeatureView.proto";
+import "feast/core/Feature.proto";
+
+message OnDemandFeatureView {
+    // User-specified specifications of this feature view.
+    OnDemandFeatureViewSpec spec = 1;
+}
+
+message OnDemandFeatureViewSpec {
+    // Name of the feature view. Must be unique. Not updated.
+    string name = 1;
+
+    // Name of Feast project that this feature view belongs to.
+    string project = 2;
+
+    // List of features specifications for each feature defined with this feature view.
+    repeated FeatureSpecV2 features = 3;
+
+    // List of features specifications for each feature defined with this feature view.
+    // TODO(adchia): add support for request data
+    map<string, FeatureView> inputs = 4;
+
+    UserDefinedFunction user_defined_function = 5;
+}
+
+// Serialized representation of python function.
+message UserDefinedFunction {
+    // The function name
+    string name = 1;
+
+    // The Python return of of the function, e.g. 'int'
+    string return_type = 2;
+
+    // The python-syntax function body
+    string body = 3;
+}

--- a/protos/feast/core/OnDemandFeatureView.proto
+++ b/protos/feast/core/OnDemandFeatureView.proto
@@ -52,9 +52,6 @@ message UserDefinedFunction {
     // The function name
     string name = 1;
 
-    // The Python return of of the function, e.g. 'int'
-    string return_type = 2;
-
-    // The python-syntax function body
-    string body = 3;
+    // The python-syntax function body (serialized by dill)
+    bytes body = 2;
 }

--- a/protos/feast/core/Registry.proto
+++ b/protos/feast/core/Registry.proto
@@ -25,12 +25,14 @@ import "feast/core/Entity.proto";
 import "feast/core/FeatureService.proto";
 import "feast/core/FeatureTable.proto";
 import "feast/core/FeatureView.proto";
+import "feast/core/OnDemandFeatureView.proto";
 import "google/protobuf/timestamp.proto";
 
 message Registry {
     repeated Entity entities = 1;
     repeated FeatureTable feature_tables = 2;
     repeated FeatureView feature_views = 6;
+    repeated OnDemandFeatureView on_demand_feature_views = 8;
     repeated FeatureService feature_services = 7;
 
     string registry_schema_version = 3; // to support migrations; incremented when schema is changed

--- a/sdk/python/feast/__init__.py
+++ b/sdk/python/feast/__init__.py
@@ -13,6 +13,7 @@ from .feature_service import FeatureService
 from .feature_store import FeatureStore
 from .feature_table import FeatureTable
 from .feature_view import FeatureView
+from .on_demand_feature_view import OnDemandFeatureView
 from .repo_config import RepoConfig
 from .value_type import ValueType
 
@@ -37,6 +38,7 @@ __all__ = [
     "FeatureStore",
     "FeatureTable",
     "FeatureView",
+    "OnDemandFeatureView",
     "RepoConfig",
     "SourceType",
     "ValueType",

--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -200,3 +200,10 @@ class InvalidEntityType(Exception):
             f"The entity dataframe you have provided must be a Pandas DataFrame or a SQL query, "
             f"but we found: {entity_type} "
         )
+
+
+class ConflictingFeatureViewNames(Exception):
+    def __init__(self, feature_view_name: str):
+        super().__init__(
+            f"The feature view name: {feature_view_name} refers to both an on-demand feature view and a feature view"
+        )

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -37,12 +37,14 @@ from feast.inference import (
     update_entities_with_inferred_types_from_feature_views,
 )
 from feast.infra.provider import Provider, RetrievalJob, get_provider
+from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.online_response import OnlineResponse, _infer_online_entity_rows
 from feast.protos.feast.serving.ServingService_pb2 import (
     GetOnlineFeaturesRequestV2,
     GetOnlineFeaturesResponse,
 )
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.registry import Registry
 from feast.repo_config import RepoConfig, load_repo_config
 from feast.usage import log_exceptions, log_exceptions_and_usage
@@ -267,8 +269,9 @@ class FeatureStore:
         objects: Union[
             Entity,
             FeatureView,
+            OnDemandFeatureView,
             FeatureService,
-            List[Union[FeatureView, Entity, FeatureService]],
+            List[Union[FeatureView, OnDemandFeatureView, Entity, FeatureService]],
         ],
         commit: bool = True,
     ):
@@ -314,6 +317,7 @@ class FeatureStore:
         assert isinstance(objects, list)
 
         views_to_update = [ob for ob in objects if isinstance(ob, FeatureView)]
+        odfvs_to_update = [ob for ob in objects if isinstance(ob, OnDemandFeatureView)]
         _validate_feature_views(views_to_update)
         entities_to_update = [ob for ob in objects if isinstance(ob, Entity)]
         services_to_update = [ob for ob in objects if isinstance(ob, FeatureService)]
@@ -332,11 +336,15 @@ class FeatureStore:
 
         if len(views_to_update) + len(entities_to_update) + len(
             services_to_update
-        ) != len(objects):
+        ) + len(odfvs_to_update) != len(objects):
             raise ValueError("Unknown object type provided as part of apply() call")
 
         for view in views_to_update:
             self._registry.apply_feature_view(view, project=self.project, commit=False)
+        for odfv in odfvs_to_update:
+            self._registry.apply_on_demand_feature_view(
+                odfv, project=self.project, commit=False
+            )
         for ent in entities_to_update:
             self._registry.apply_entity(ent, project=self.project, commit=False)
         for feature_service in services_to_update:
@@ -717,7 +725,6 @@ class FeatureStore:
         all_feature_views = self._registry.list_feature_views(
             project=self.project, allow_cache=True
         )
-
         _validate_feature_refs(_feature_refs, full_feature_names)
         grouped_refs = _group_feature_refs(_feature_refs, all_feature_views)
         for table, requested_features in grouped_refs:
@@ -759,6 +766,25 @@ class FeatureStore:
                                 feature_ref
                             ] = GetOnlineFeaturesResponse.FieldStatus.PRESENT
 
+        initial_response_df = OnlineResponse(
+            GetOnlineFeaturesResponse(field_values=result_rows)
+        ).to_df()
+        # Now, we take the on demand transform definitions, reconstruct the python udf in memory,
+        # and run it on the resulting rows.
+        # Ideally, this would only have the feature values from that FV.
+        all_on_demand_feature_views = self._registry.list_on_demand_feature_views(
+            project=self.project, allow_cache=True
+        )
+        for odfv in all_on_demand_feature_views:
+            feature_ref = odfv.name
+            if feature_ref in _feature_refs:
+                ret_value = odfv.udf.__call__(initial_response_df)
+                result_row.fields[odfv.name].CopyFrom(
+                    ValueProto(double_val=ret_value[odfv.features[0].name].values[0])
+                )
+                result_row.statuses[
+                    feature_ref
+                ] = GetOnlineFeaturesResponse.FieldStatus.PRESENT
         return OnlineResponse(GetOnlineFeaturesResponse(field_values=result_rows))
 
     @log_exceptions_and_usage
@@ -791,7 +817,9 @@ def _validate_feature_refs(feature_refs: List[str], full_feature_names: bool = F
             ref for ref, occurrences in Counter(feature_refs).items() if occurrences > 1
         ]
     else:
-        feature_names = [ref.split(":")[1] for ref in feature_refs]
+        feature_names = [
+            ref.split(":")[1] if ":" in ref else ref for ref in feature_refs
+        ]
         collided_feature_names = [
             ref
             for ref, occurrences in Counter(feature_names).items()
@@ -820,6 +848,9 @@ def _group_feature_refs(
 
     if isinstance(features, list) and isinstance(features[0], str):
         for ref in features:
+            if ":" not in ref:
+                # This is an on demand feature view ref
+                continue
             view_name, feat_name = ref.split(":")
             if view_name not in view_index:
                 raise FeatureViewNotFoundException(view_name)

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -770,7 +770,7 @@ class FeatureStore:
             GetOnlineFeaturesResponse(field_values=result_rows)
         ).to_df()
         # Apply on demand transformations
-        # TODO(adchia): Ideally, this would only have the feature values from that FV.
+        # TODO(adchia): Ideally, this would only have the feature values from the specified input FVs in the ODFV.
         all_on_demand_feature_views = self._registry.list_on_demand_feature_views(
             project=self.project, allow_cache=True
         )

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -769,9 +769,8 @@ class FeatureStore:
         initial_response_df = OnlineResponse(
             GetOnlineFeaturesResponse(field_values=result_rows)
         ).to_df()
-        # Now, we take the on demand transform definitions, reconstruct the python udf in memory,
-        # and run it on the resulting rows.
-        # Ideally, this would only have the feature values from that FV.
+        # Apply on demand transformations
+        # TODO(adchia): Ideally, this would only have the feature values from that FV.
         all_on_demand_feature_views = self._registry.list_on_demand_feature_views(
             project=self.project, allow_cache=True
         )

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -1,0 +1,248 @@
+import functools
+import inspect
+from collections import defaultdict
+from types import FunctionType, MethodType, ModuleType
+from typing import Dict, List
+
+from dill.detect import freevars, globalvars
+
+from feast.feature import Feature
+from feast.feature_view import FeatureView
+from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
+    OnDemandFeatureView as OnDemandFeatureViewProto,
+)
+from feast.protos.feast.core.OnDemandFeatureView_pb2 import OnDemandFeatureViewSpec
+from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
+    UserDefinedFunction as UserDefinedFunctionProto,
+)
+from feast.usage import log_exceptions
+from feast.value_type import ValueType
+
+
+class OnDemandFeatureView:
+    """
+    Declare an OnDemandFeatureView.
+    """
+
+    name: str
+    features: List[Feature]
+    inputs: Dict[str, FeatureView]
+    udf: MethodType
+
+    @log_exceptions
+    def __init__(
+        self,
+        name: str,
+        features: List[Feature],
+        inputs: Dict[str, FeatureView],
+        udf: MethodType,
+    ):
+        """
+        Instantiates a new OnDemandFeatureView.
+
+        :param name: Unique, human friendly name that identifies the FeatureView.
+        """
+
+        self.name = name
+        self.features = features
+        self.inputs = inputs
+        self.udf = udf
+
+    def to_proto(self) -> OnDemandFeatureViewProto:
+        """
+        Converts a feature view object to its protobuf representation.
+
+        Returns:
+            A OnDemandFeatureViewProto protobuf.
+        """
+        spec = OnDemandFeatureViewSpec(
+            name=self.name,
+            features=[feature.to_proto() for feature in self.features],
+            inputs={k: fv.to_proto() for k, fv in self.inputs.items()},
+            user_defined_function=UserDefinedFunctionProto(
+                name=self.udf.__name__,
+                return_type="double",  # TODO: fix
+                body=_getsource(self.udf),
+            ),
+        )
+
+        return OnDemandFeatureViewProto(spec=spec)
+
+    @classmethod
+    def from_proto(cls, on_demand_feature_view_proto: OnDemandFeatureViewProto):
+        """
+        Creates a feature view from a protobuf representation of a feature view.
+
+        Args:
+            on_demand_feature_view_proto: A protobuf representation of an on-demand feature view.
+
+        Returns:
+            A OnDemandFeatureView object based on the on-demand feature view protobuf.
+        """
+        on_demand_feature_view_obj = cls(
+            name=on_demand_feature_view_proto.spec.name,
+            features=[
+                Feature(
+                    name=feature.name,
+                    dtype=ValueType(feature.value_type),
+                    labels=dict(feature.labels),
+                )
+                for feature in on_demand_feature_view_proto.spec.features
+            ],
+            inputs={
+                feature_view_name: FeatureView.from_proto(feature_view_proto)
+                for feature_view_name, feature_view_proto in on_demand_feature_view_proto.spec.inputs.items()
+            },
+            udf=udf_from_proto(on_demand_feature_view_proto.spec.user_defined_function),
+        )
+
+        return on_demand_feature_view_obj
+
+
+def on_demand_feature_view(features: List[Feature], inputs: Dict[str, FeatureView]):
+    """
+    Declare an on-demand feature view
+
+    :param features: Output schema with feature names
+    :param inputs: The inputs passed into the transform.
+    :return: An On Demand Feature View.
+    """
+
+    def decorator(user_function):
+        on_demand_feature_view_obj = OnDemandFeatureView(
+            name=user_function.__name__,
+            inputs=inputs,
+            features=features,
+            udf=user_function,
+        )
+        functools.update_wrapper(
+            wrapper=on_demand_feature_view_obj, wrapped=user_function
+        )
+        return on_demand_feature_view_obj
+
+    return decorator
+
+
+def udf_from_proto(serialized_transform: UserDefinedFunctionProto, scope=None):
+    """
+    deserialize into global scope by default. if a scope if provided, deserialize into provided scope
+    """
+
+    if scope is None:
+        scope = __import__("__main__").__dict__
+        import pandas as pd
+
+        scope["pd"] = pd
+
+    exec(serialized_transform.body, scope)
+
+    # Return function pointer
+    try:
+        fn = eval(serialized_transform.name, scope)
+        fn._code = serialized_transform.body
+        return fn
+    except Exception as e:
+        raise ValueError("Invalid transform") from e
+
+
+def _getsource(func):
+    imports = defaultdict(set)
+    modules = set()
+    code_lines = []
+    seen_args = {}
+
+    def process_functiontype(name, obj, imports, modules, code_lines, seen_args):
+        # if this is user-defined or otherwise unavailable to import at deserialization time
+        # including anything without a module, with module of __main__, defined as @inlined method,
+        # or anything with a qualified name containing characters invalid for an import path, like foo.<locals>.bar
+        objs = globalvars(obj, recurse=False)
+        objs.update(freevars(obj))
+        default_objs = {}
+        for param in inspect.signature(obj).parameters.values():
+            if param.default != inspect.Parameter.empty:
+                default_objs[param.name] = param.default
+                # these defaults shadow over obj
+                objs.pop(param.name, None)
+        # need to sort the keys since globalvars ordering is non-deterministic
+        for dependency, dep_obj in sorted(objs.items()):
+            recurse(
+                dependency,
+                dep_obj,
+                imports,
+                modules,
+                code_lines,
+                seen_args,
+                write_codelines=True,
+            )
+        for dependency, dep_obj in sorted(default_objs.items()):
+            # we dont re-write defaults at top-level since the `def` lines should have the declarations
+            recurse(
+                dependency,
+                dep_obj,
+                imports,
+                modules,
+                code_lines,
+                seen_args,
+                write_codelines=False,
+            )
+        fdef = inspect.getsource(obj)
+        fdef = fdef[fdef.find("def ") :]
+        code_lines.append(fdef)
+
+    def recurse(name, obj, imports, modules, code_lines, seen_args, write_codelines):
+        def _add_codeline(line):
+            if write_codelines:
+                code_lines.append(line)
+
+        # prevent processing same dependency object multiple times, even if
+        # multiple dependent objects exist in the tree from the original
+        # func
+        seen_key = str(name) + str(obj)
+        if seen_args.get(seen_key) is True:
+            return
+        seen_args[seen_key] = True
+
+        # Confusingly classes are subtypes of 'type'; non-classes are not
+        if isinstance(obj, type):
+            if obj.__module__ == "__main__":
+                raise Exception(
+                    f"Cannot serialize class {obj.__name__} from module __main__"
+                )
+            imports[obj.__module__].add(obj.__name__)
+
+        elif isinstance(obj, FunctionType):
+            process_functiontype(name, obj, imports, modules, code_lines, seen_args)
+        elif isinstance(obj, ModuleType):
+            if f"{obj.__package__}.{name}" == obj.__name__:
+                imports[obj.__package__].add(name)
+            else:
+                modules.add(obj.__name__)
+        else:
+            try:
+                repr_str = f"{name}={repr(obj)}"
+                exec(repr_str)
+                _add_codeline(repr_str)
+            except Exception:
+                raise Exception(
+                    f"Cannot evaluate object {obj} of type '{type(obj)}' for serialization"
+                )
+
+    recurse(
+        func.__name__,
+        func,
+        imports,
+        modules,
+        code_lines,
+        seen_args,
+        write_codelines=True,
+    )
+
+    for module in sorted(imports):
+        import_line = f"from {module} import "
+        import_line += ", ".join(sorted(imports[module]))
+        code_lines.insert(0, import_line)
+
+    for module in sorted(modules):
+        code_lines.insert(0, f"import {module}")
+
+    return "\n".join(code_lines)

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -3,6 +3,7 @@ from types import MethodType
 from typing import Dict, List
 
 import dill
+import pandas as pd
 
 from feast.feature import Feature
 from feast.feature_view import FeatureView
@@ -99,6 +100,30 @@ class OnDemandFeatureView:
         )
 
         return on_demand_feature_view_obj
+
+    def get_transformed_features_df(
+        self, full_feature_names: bool, df_with_features: pd.DataFrame
+    ) -> pd.DataFrame:
+        # Apply on demand transformations
+        # TODO(adchia): Include only the feature values from the specified input FVs in the ODFV.
+        # Copy over un-prefixed features even if not requested since transform may need it
+        columns_to_cleanup = []
+        if full_feature_names:
+            for input_fv in self.inputs.values():
+                for feature in input_fv.features:
+                    full_feature_ref = f"{input_fv.name}__{feature.name}"
+                    if full_feature_ref in df_with_features.keys():
+                        df_with_features[feature.name] = df_with_features[
+                            full_feature_ref
+                        ]
+                        columns_to_cleanup.append(feature.name)
+
+        # Compute transformed values and apply to each result row
+        df_with_transformed_features = self.udf.__call__(df_with_features)
+
+        # Cleanup extra columns used for transformation
+        df_with_features.drop(columns=columns_to_cleanup, inplace=True)
+        return df_with_transformed_features
 
 
 def on_demand_feature_view(features: List[Feature], inputs: Dict[str, FeatureView]):

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -1,10 +1,8 @@
 import functools
-import inspect
-from collections import defaultdict
-from types import FunctionType, MethodType, ModuleType
+from types import MethodType
 from typing import Dict, List
 
-from dill.detect import freevars, globalvars
+import dill
 
 from feast.feature import Feature
 from feast.feature_view import FeatureView
@@ -64,9 +62,7 @@ class OnDemandFeatureView:
             features=[feature.to_proto() for feature in self.features],
             inputs={k: fv.to_proto() for k, fv in self.inputs.items()},
             user_defined_function=UserDefinedFunctionProto(
-                name=self.udf.__name__,
-                return_type="double",  # TODO: fix
-                body=_getsource(self.udf),
+                name=self.udf.__name__, body=dill.dumps(self.udf, recurse=True),
             ),
         )
 
@@ -97,7 +93,9 @@ class OnDemandFeatureView:
                 feature_view_name: FeatureView.from_proto(feature_view_proto)
                 for feature_view_name, feature_view_proto in on_demand_feature_view_proto.spec.inputs.items()
             },
-            udf=udf_from_proto(on_demand_feature_view_proto.spec.user_defined_function),
+            udf=dill.loads(
+                on_demand_feature_view_proto.spec.user_defined_function.body
+            ),
         )
 
         return on_demand_feature_view_obj
@@ -125,128 +123,3 @@ def on_demand_feature_view(features: List[Feature], inputs: Dict[str, FeatureVie
         return on_demand_feature_view_obj
 
     return decorator
-
-
-def udf_from_proto(serialized_transform: UserDefinedFunctionProto, scope=None):
-    """
-    deserialize into global scope with pandas by default. if a scope if provided, deserialize into provided scope
-    """
-
-    if scope is None:
-        scope = __import__("__main__").__dict__
-        import pandas as pd
-
-        scope["pd"] = pd
-
-    exec(serialized_transform.body, scope)
-
-    # Return function pointer
-    try:
-        fn = eval(serialized_transform.name, scope)
-        fn._code = serialized_transform.body
-        return fn
-    except Exception as e:
-        raise ValueError("Invalid transform") from e
-
-
-def _getsource(func):
-    imports = defaultdict(set)
-    modules = set()
-    code_lines = []
-    seen_args = {}
-
-    def process_functiontype(name, obj, imports, modules, code_lines, seen_args):
-        # if this is user-defined or otherwise unavailable to import at deserialization time
-        # including anything without a module, with module of __main__, defined as @inlined method,
-        # or anything with a qualified name containing characters invalid for an import path, like foo.<locals>.bar
-        objs = globalvars(obj, recurse=False)
-        objs.update(freevars(obj))
-        default_objs = {}
-        for param in inspect.signature(obj).parameters.values():
-            if param.default != inspect.Parameter.empty:
-                default_objs[param.name] = param.default
-                # these defaults shadow over obj
-                objs.pop(param.name, None)
-        # need to sort the keys since globalvars ordering is non-deterministic
-        for dependency, dep_obj in sorted(objs.items()):
-            recurse(
-                dependency,
-                dep_obj,
-                imports,
-                modules,
-                code_lines,
-                seen_args,
-                write_codelines=True,
-            )
-        for dependency, dep_obj in sorted(default_objs.items()):
-            # we dont re-write defaults at top-level since the `def` lines should have the declarations
-            recurse(
-                dependency,
-                dep_obj,
-                imports,
-                modules,
-                code_lines,
-                seen_args,
-                write_codelines=False,
-            )
-        fdef = inspect.getsource(obj)
-        fdef = fdef[fdef.find("def ") :]
-        code_lines.append(fdef)
-
-    def recurse(name, obj, imports, modules, code_lines, seen_args, write_codelines):
-        def _add_codeline(line):
-            if write_codelines:
-                code_lines.append(line)
-
-        # prevent processing same dependency object multiple times, even if
-        # multiple dependent objects exist in the tree from the original
-        # func
-        seen_key = str(name) + str(obj)
-        if seen_args.get(seen_key) is True:
-            return
-        seen_args[seen_key] = True
-
-        # Confusingly classes are subtypes of 'type'; non-classes are not
-        if isinstance(obj, type):
-            if obj.__module__ == "__main__":
-                raise Exception(
-                    f"Cannot serialize class {obj.__name__} from module __main__"
-                )
-            imports[obj.__module__].add(obj.__name__)
-
-        elif isinstance(obj, FunctionType):
-            process_functiontype(name, obj, imports, modules, code_lines, seen_args)
-        elif isinstance(obj, ModuleType):
-            if f"{obj.__package__}.{name}" == obj.__name__:
-                imports[obj.__package__].add(name)
-            else:
-                modules.add(obj.__name__)
-        else:
-            try:
-                repr_str = f"{name}={repr(obj)}"
-                exec(repr_str)
-                _add_codeline(repr_str)
-            except Exception:
-                raise Exception(
-                    f"Cannot evaluate object {obj} of type '{type(obj)}' for serialization"
-                )
-
-    recurse(
-        func.__name__,
-        func,
-        imports,
-        modules,
-        code_lines,
-        seen_args,
-        write_codelines=True,
-    )
-
-    for module in sorted(imports):
-        import_line = f"from {module} import "
-        import_line += ", ".join(sorted(imports[module]))
-        code_lines.insert(0, import_line)
-
-    for module in sorted(modules):
-        code_lines.insert(0, f"import {module}")
-
-    return "\n".join(code_lines)

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -21,7 +21,13 @@ from feast.value_type import ValueType
 
 class OnDemandFeatureView:
     """
-    Declare an OnDemandFeatureView.
+    An OnDemandFeatureView defines on demand transformations on existing feature view values and request data.
+
+    Args:
+        name: Name of the group of features.
+        features: Output schema of transformation with feature names
+        inputs: The input feature views passed into the transform.
+        udf: User defined transformation function that takes as input pandas dataframes
     """
 
     name: str
@@ -38,9 +44,7 @@ class OnDemandFeatureView:
         udf: MethodType,
     ):
         """
-        Instantiates a new OnDemandFeatureView.
-
-        :param name: Unique, human friendly name that identifies the FeatureView.
+        Creates an OnDemandFeatureView object.
         """
 
         self.name = name
@@ -50,7 +54,7 @@ class OnDemandFeatureView:
 
     def to_proto(self) -> OnDemandFeatureViewProto:
         """
-        Converts a feature view object to its protobuf representation.
+        Converts an on demand feature view object to its protobuf representation.
 
         Returns:
             A OnDemandFeatureViewProto protobuf.
@@ -71,7 +75,7 @@ class OnDemandFeatureView:
     @classmethod
     def from_proto(cls, on_demand_feature_view_proto: OnDemandFeatureViewProto):
         """
-        Creates a feature view from a protobuf representation of a feature view.
+        Creates an on demand feature view from a protobuf representation.
 
         Args:
             on_demand_feature_view_proto: A protobuf representation of an on-demand feature view.
@@ -125,7 +129,7 @@ def on_demand_feature_view(features: List[Feature], inputs: Dict[str, FeatureVie
 
 def udf_from_proto(serialized_transform: UserDefinedFunctionProto, scope=None):
     """
-    deserialize into global scope by default. if a scope if provided, deserialize into provided scope
+    deserialize into global scope with pandas by default. if a scope if provided, deserialize into provided scope
     """
 
     if scope is None:

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -620,12 +620,15 @@ class Registry:
 
     def _get_existing_feature_view_names(self) -> Set[str]:
         assert self.cached_registry_proto
-        return set([fv.name for fv in self.cached_registry_proto.feature_views])
+        return set([fv.spec.name for fv in self.cached_registry_proto.feature_views])
 
     def _get_existing_on_demand_feature_view_names(self) -> Set[str]:
         assert self.cached_registry_proto
         return set(
-            [odfv.name for odfv in self.cached_registry_proto.on_demand_feature_views]
+            [
+                odfv.spec.name
+                for odfv in self.cached_registry_proto.on_demand_feature_views
+            ]
         )
 
 

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -33,6 +33,7 @@ from feast.errors import (
 from feast.feature_service import FeatureService
 from feast.feature_table import FeatureTable
 from feast.feature_view import FeatureView
+from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 
 REGISTRY_SCHEMA_VERSION = "1"
@@ -289,6 +290,48 @@ class Registry:
         if commit:
             self.commit()
 
+    def apply_on_demand_feature_view(
+        self,
+        on_demand_feature_view: OnDemandFeatureView,
+        project: str,
+        commit: bool = True,
+    ):
+        """
+        Registers a single on demand feature view with Feast
+
+        Args:
+            on_demand_feature_view: Feature view that will be registered
+            project: Feast project that this feature view belongs to
+            commit: Whether the change should be persisted immediately
+        """
+        on_demand_feature_view_proto = on_demand_feature_view.to_proto()
+        on_demand_feature_view_proto.spec.project = project
+        self._prepare_registry_for_changes()
+        assert self.cached_registry_proto
+
+        for idx, existing_feature_view_proto in enumerate(
+            self.cached_registry_proto.on_demand_feature_views
+        ):
+            if (
+                existing_feature_view_proto.spec.name
+                == on_demand_feature_view_proto.spec.name
+                and existing_feature_view_proto.spec.project == project
+            ):
+                if (
+                    OnDemandFeatureView.from_proto(existing_feature_view_proto)
+                    == on_demand_feature_view
+                ):
+                    return
+                else:
+                    del self.cached_registry_proto.on_demand_feature_views[idx]
+                    break
+
+        self.cached_registry_proto.on_demand_feature_views.append(
+            on_demand_feature_view_proto
+        )
+        if commit:
+            self.commit()
+
     def apply_materialization(
         self,
         feature_view: FeatureView,
@@ -369,6 +412,28 @@ class Registry:
             if feature_view_proto.spec.project == project:
                 feature_views.append(FeatureView.from_proto(feature_view_proto))
         return feature_views
+
+    def list_on_demand_feature_views(
+        self, project: str, allow_cache: bool = False
+    ) -> List[OnDemandFeatureView]:
+        """
+        Retrieve a list of on demand feature views from the registry
+
+        Args:
+            allow_cache: Allow returning feature views from the cached registry
+            project: Filter feature tables based on project name
+
+        Returns:
+            List of on demand feature views
+        """
+        registry_proto = self._get_registry_proto(allow_cache=allow_cache)
+        on_demand_feature_views = []
+        for on_demand_feature_view_proto in registry_proto.on_demand_feature_views:
+            if on_demand_feature_view_proto.spec.project == project:
+                on_demand_feature_views.append(
+                    OnDemandFeatureView.from_proto(on_demand_feature_view_proto)
+                )
+        return on_demand_feature_views
 
     def get_feature_table(self, name: str, project: str) -> FeatureTable:
         """

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -113,6 +113,7 @@ CI_REQUIRED = [
     "google-cloud-core==1.4.*",
     "redis-py-cluster==2.1.2",
     "boto3==1.17.*",
+    "dill==0.3.0"
 ]
 
 

--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -21,6 +21,7 @@ def driver_feature_view(
         input=data_source,
     )
 
+
 def conv_rate_plus_100(driver_hourly_stats: pd.DataFrame) -> pd.DataFrame:
     df = pd.DataFrame()
     df["conv_rate_plus_100"] = driver_hourly_stats["conv_rate"] + 100
@@ -28,7 +29,7 @@ def conv_rate_plus_100(driver_hourly_stats: pd.DataFrame) -> pd.DataFrame:
 
 
 def conv_rate_plus_100_feature_view(
-        inputs: Dict[str, FeatureView]
+    inputs: Dict[str, FeatureView]
 ) -> OnDemandFeatureView:
     return OnDemandFeatureView(
         name=conv_rate_plus_100.__name__,

--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -1,6 +1,9 @@
 from datetime import timedelta
+from typing import Dict
 
-from feast import Feature, FeatureView, ValueType
+import pandas as pd
+
+from feast import Feature, FeatureView, OnDemandFeatureView, ValueType
 from feast.data_source import DataSource
 
 
@@ -16,6 +19,22 @@ def driver_feature_view(
         features=None if infer_features else [Feature("value", value_type)],
         ttl=timedelta(days=5),
         input=data_source,
+    )
+
+def conv_rate_plus_100(driver_hourly_stats: pd.DataFrame) -> pd.DataFrame:
+    df = pd.DataFrame()
+    df["conv_rate_plus_100"] = driver_hourly_stats["conv_rate"] + 100
+    return df
+
+
+def conv_rate_plus_100_feature_view(
+        inputs: Dict[str, FeatureView]
+) -> OnDemandFeatureView:
+    return OnDemandFeatureView(
+        name=conv_rate_plus_100.__name__,
+        inputs=inputs,
+        features=[Feature("conv_rate_plus_100", ValueType.FLOAT)],
+        udf=conv_rate_plus_100,
     )
 
 

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -20,9 +20,7 @@ def test_online_retrieval(environment, universal_data_sources, full_feature_name
     fs = environment.feature_store
     entities, datasets, data_sources = universal_data_sources
     feature_views = construct_universal_feature_views(data_sources)
-    odfv = conv_rate_plus_100_feature_view(
-        inputs={"driver": feature_views["driver_stats"]}
-    )
+    odfv = conv_rate_plus_100_feature_view(inputs={"driver": feature_views["driver"]})
     feast_objects = []
     feast_objects.extend(feature_views.values())
     feast_objects.extend([odfv, driver(), customer()])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Sets up initial storage and scaffolding for on demand feature view, and supports online fetching. This does not yet support offline feature fetching or request data.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add support for row-level on-demand transformations of feature view features in get_online_features
```
