### PR TITLE
Fix Redshift query for external tables

### DIFF
--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -426,7 +426,7 @@ WITH entity_dataframe AS (
         {{featureview.name}}__entity_row_unique_id,
         MAX(event_timestamp) AS event_timestamp
         {% if featureview.created_timestamp_column %}
-            ,ANY_VALUE(created_timestamp) AS created_timestamp
+            ,MAX(created_timestamp) AS created_timestamp
         {% endif %}
 
     FROM {{ featureview.name }}__base


### PR DESCRIPTION
Signed-off-by: Willem Pienaar <git@willem.co>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Currently it's not possible to use `ANY_VALUE` with Redshift Spectrum (when querying features on S3). This PR changes `ANY_VALUE` to `MAX`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug in Redshift training dataset generation where queries failed on external tables
```
