### PR TITLE
Use get_multi instead of get for datastore reads

### DIFF
--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -244,17 +244,18 @@ class DatastoreOnlineStore(OnlineStore):
             keys.append(key)
 
         values = client.get_multi(keys)
-
-        for value in values:
-            if value is not None:
-                res = {}
-                for feature_name, value_bin in value["values"].items():
-                    val = ValueProto()
-                    val.ParseFromString(value_bin)
-                    res[feature_name] = val
-                result.append((value["event_ts"], res))
-            else:
-                result.append((None, None))
+        if values is not None:
+            values = sorted(values, key=lambda v: keys.index(v.key))
+            for value in values:
+                if value is not None:
+                    res = {}
+                    for feature_name, value_bin in value["values"].items():
+                        val = ValueProto()
+                        val.ParseFromString(value_bin)
+                        res[feature_name] = val
+                    result.append((value["event_ts"], res))
+                else:
+                    result.append((None, None))
         return result
 
 


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

get is a wrapper around get_multi, and get_multi reduces the network costs involved.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1759 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Use a batch lookup API for Google Datastore. Users should see lower latencies for `get_online_features` when using Datastore as the online store.
```
