### PR TITLE
Ensure docstring tests always teardown

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -291,7 +291,7 @@ class FeatureStore:
 
             >>> from feast import FeatureStore, Entity, FeatureView, Feature, ValueType, FileSource, RepoConfig
             >>> from datetime import timedelta
-            >>> fs = FeatureStore(config=RepoConfig(registry="feature_repo/data/registry.db", project="feature_repo", provider="local"))
+            >>> fs = FeatureStore(repo_path="feature_repo")
             >>> driver = Entity(name="driver_id", value_type=ValueType.INT64, description="driver id")
             >>> driver_hourly_stats = FileSource(
             ...     path="feature_repo/data/driver_stats.parquet",
@@ -413,7 +413,7 @@ class FeatureStore:
 
             >>> from feast import FeatureStore, RepoConfig
             >>> import pandas as pd
-            >>> fs = FeatureStore(config=RepoConfig(registry="feature_repo/data/registry.db", project="feature_repo", provider="local"))
+            >>> fs = FeatureStore(repo_path="feature_repo")
             >>> entity_df = pd.DataFrame.from_dict(
             ...     {
             ...         "driver_id": [1001, 1002],
@@ -498,7 +498,7 @@ class FeatureStore:
 
             >>> from feast import FeatureStore, RepoConfig
             >>> from datetime import datetime, timedelta
-            >>> fs = FeatureStore(config=RepoConfig(registry="feature_repo/data/registry.db", project="feature_repo", provider="local"))
+            >>> fs = FeatureStore(repo_path="feature_repo")
             >>> fs.materialize_incremental(end_date=datetime.utcnow() - timedelta(minutes=5))
             Materializing...
             <BLANKLINE>
@@ -583,7 +583,7 @@ class FeatureStore:
 
             >>> from feast import FeatureStore, RepoConfig
             >>> from datetime import datetime, timedelta
-            >>> fs = FeatureStore(config=RepoConfig(registry="feature_repo/data/registry.db", project="feature_repo", provider="local"))
+            >>> fs = FeatureStore(repo_path="feature_repo")
             >>> fs.materialize(
             ...     start_date=datetime.utcnow() - timedelta(hours=3), end_date=datetime.utcnow() - timedelta(minutes=10)
             ... )
@@ -675,7 +675,7 @@ class FeatureStore:
             from 3 hours ago to 10 minutes ago, and then retrieve these online features.
 
             >>> from feast import FeatureStore, RepoConfig
-            >>> fs = FeatureStore(config=RepoConfig(registry="feature_repo/data/registry.db", project="feature_repo", provider="local"))
+            >>> fs = FeatureStore(repo_path="feature_repo")
             >>> online_response = fs.get_online_features(
             ...     features=[
             ...         "driver_hourly_stats:conv_rate",

--- a/sdk/python/tests/doctest/test_all.py
+++ b/sdk/python/tests/doctest/test_all.py
@@ -11,21 +11,11 @@ def setup_feature_store():
     """Prepares the local environment for a FeatureStore docstring test."""
     from datetime import datetime, timedelta
 
-    from feast import (
-        Entity,
-        Feature,
-        FeatureStore,
-        FeatureView,
-        FileSource,
-        RepoConfig,
-        ValueType,
-    )
+    from feast import Entity, Feature, FeatureStore, FeatureView, FileSource, ValueType
     from feast.repo_operations import init_repo
 
     init_repo("feature_repo", "local")
-    fs = FeatureStore(
-        repo_path="feature_repo"
-    )
+    fs = FeatureStore(repo_path="feature_repo")
     driver = Entity(
         name="driver_id", value_type=ValueType.INT64, description="driver id",
     )
@@ -98,14 +88,13 @@ def test_docstrings():
                         setup_function()
 
                     test_suite = doctest.DocTestSuite(
-                        temp_module,
-                        optionflags=doctest.ELLIPSIS,
+                        temp_module, optionflags=doctest.ELLIPSIS,
                     )
                     if test_suite.countTestCases() > 0:
                         result = unittest.TextTestRunner(sys.stdout).run(test_suite)
                         if not result.wasSuccessful():
                             successful = False
-                except:
+                except Exception:
                     successful = False
                 finally:
                     if teardown_function:

--- a/sdk/python/tests/doctest/test_all.py
+++ b/sdk/python/tests/doctest/test_all.py
@@ -7,7 +7,7 @@ import unittest
 import feast
 
 
-def setup_feature_store(docstring_tests):
+def setup_feature_store():
     """Prepares the local environment for a FeatureStore docstring test."""
     from datetime import datetime, timedelta
 
@@ -24,11 +24,7 @@ def setup_feature_store(docstring_tests):
 
     init_repo("feature_repo", "local")
     fs = FeatureStore(
-        config=RepoConfig(
-            registry="feature_repo/data/registry.db",
-            project="feature_repo",
-            provider="local",
-        )
+        repo_path="feature_repo"
     )
     driver = Entity(
         name="driver_id", value_type=ValueType.INT64, description="driver id",
@@ -56,12 +52,11 @@ def setup_feature_store(docstring_tests):
     )
 
 
-def teardown_feature_store(docstring_tests):
+def teardown_feature_store():
     """Cleans up the local environment after a FeatureStore docstring test."""
     import shutil
 
     shutil.rmtree("feature_repo", ignore_errors=True)
-    shutil.rmtree("data", ignore_errors=True)
 
 
 def test_docstrings():
@@ -84,28 +79,37 @@ def test_docstrings():
 
                 try:
                     temp_module = importlib.import_module(full_name)
-                    relative_path_from_feast = full_name.split(".", 1)[1]
-                    function_suffix = relative_path_from_feast.replace(".", "_")
-                    setup_function_name = "setup_" + function_suffix
-                    teardown_function_name = "teardown_" + function_suffix
-                    setup_function = globals().get(setup_function_name)
-                    teardown_function = globals().get(teardown_function_name)
+                    if is_pkg:
+                        next_packages.append(temp_module)
+                except ModuleNotFoundError:
+                    pass
+
+                # Retrieve the setup and teardown functions defined in this file.
+                relative_path_from_feast = full_name.split(".", 1)[1]
+                function_suffix = relative_path_from_feast.replace(".", "_")
+                setup_function_name = "setup_" + function_suffix
+                teardown_function_name = "teardown_" + function_suffix
+                setup_function = globals().get(setup_function_name)
+                teardown_function = globals().get(teardown_function_name)
+
+                # Execute the test with setup and teardown functions.
+                try:
+                    if setup_function:
+                        setup_function()
 
                     test_suite = doctest.DocTestSuite(
                         temp_module,
-                        setUp=setup_function,
-                        tearDown=teardown_function,
                         optionflags=doctest.ELLIPSIS,
                     )
                     if test_suite.countTestCases() > 0:
                         result = unittest.TextTestRunner(sys.stdout).run(test_suite)
                         if not result.wasSuccessful():
                             successful = False
-
-                    if is_pkg:
-                        next_packages.append(temp_module)
-                except ModuleNotFoundError:
-                    pass
+                except:
+                    successful = False
+                finally:
+                    if teardown_function:
+                        teardown_function()
 
         current_packages = next_packages
 


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Occasionally docstring tests are not cleaned up properly. This test ensures they always teardown correctly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
