### PR TITLE
Refactor the datastore online_read method to be slightly more efficient

### DIFF
--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -16,7 +16,6 @@ from datetime import datetime
 from multiprocessing.pool import ThreadPool
 from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
-from google.cloud.datastore import Key
 from pydantic import PositiveInt, StrictStr
 from pydantic.typing import Literal
 

--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from multiprocessing.pool import ThreadPool
 from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
+from google.cloud.datastore import Key
 from pydantic import PositiveInt, StrictStr
 from pydantic.typing import Literal
 
@@ -243,22 +244,21 @@ class DatastoreOnlineStore(OnlineStore):
             )
             keys.append(key)
 
+        # NOTE: get_multi doesn't return values in the same order as the keys in the request.
+        # Also, len(values) can be less than len(keys) in the case of missing values.
         values = client.get_multi(keys)
-
-        if values is not None:
-            keys_missing_from_response = set(keys) - set([v.key for v in values])
-            values = sorted(values, key=lambda v: keys.index(v.key))
-            for value in values:
+        values_dict = {v.key: v for v in values} if values is not None else {}
+        for key in keys:
+            if key in values_dict:
+                value = values_dict[key]
                 res = {}
                 for feature_name, value_bin in value["values"].items():
                     val = ValueProto()
                     val.ParseFromString(value_bin)
                     res[feature_name] = val
                 result.append((value["event_ts"], res))
-            for missing_key_idx in sorted(
-                [keys.index(k) for k in keys_missing_from_response]
-            ):
-                result.insert(missing_key_idx, (None, None))
+            else:
+                result.append((None, None))
 
         return result
 


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
