### PR TITLE
Implementing initial on demand transforms for historical retrieval to_df

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timedelta
 from typing import Dict, List, Optional, Union
 
 import numpy as np
-import pandas
+import pandas as pd
 import pyarrow
 from pydantic import StrictStr
 from pydantic.typing import Literal
@@ -19,6 +19,7 @@ from feast.errors import (
 from feast.feature_view import FeatureView
 from feast.infra.offline_stores import offline_utils
 from feast.infra.offline_stores.offline_store import OfflineStore, RetrievalJob
+from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.registry import Registry
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
 
@@ -87,14 +88,21 @@ class BigQueryOfflineStore(OfflineStore):
             WHERE _feast_row = 1
             """
 
-        return BigQueryRetrievalJob(query=query, client=client, config=config)
+        # When materializing a single feature view, we don't need full feature names. On demand transforms aren't materialized
+        return BigQueryRetrievalJob(
+            query=query,
+            client=client,
+            config=config,
+            full_feature_names=False,
+            on_demand_feature_views=None,
+        )
 
     @staticmethod
     def get_historical_features(
         config: RepoConfig,
         feature_views: List[FeatureView],
         feature_refs: List[str],
-        entity_df: Union[pandas.DataFrame, str],
+        entity_df: Union[pd.DataFrame, str],
         registry: Registry,
         project: str,
         full_feature_names: bool = False,
@@ -140,16 +148,41 @@ class BigQueryOfflineStore(OfflineStore):
             full_feature_names=full_feature_names,
         )
 
-        return BigQueryRetrievalJob(query=query, client=client, config=config)
+        return BigQueryRetrievalJob(
+            query=query,
+            client=client,
+            config=config,
+            full_feature_names=full_feature_names,
+            on_demand_feature_views=registry.list_on_demand_feature_views(
+                project, allow_cache=True
+            ),
+        )
 
 
 class BigQueryRetrievalJob(RetrievalJob):
-    def __init__(self, query, client, config):
+    def __init__(
+        self,
+        query: str,
+        client: bigquery.Client,
+        config: RepoConfig,
+        full_feature_names: bool,
+        on_demand_feature_views: Optional[List[OnDemandFeatureView]],
+    ):
         self.query = query
         self.client = client
         self.config = config
+        self._full_feature_names = full_feature_names
+        self._on_demand_feature_views = on_demand_feature_views
 
-    def to_df(self):
+    @property
+    def full_feature_names(self) -> bool:
+        return self._full_feature_names
+
+    @property
+    def on_demand_feature_views(self) -> Optional[List[OnDemandFeatureView]]:
+        return self._on_demand_feature_views
+
+    def to_df_internal(self) -> pd.DataFrame:
         # TODO: Ideally only start this job when the user runs "get_historical_features", not when they run to_df()
         df = self.client.query(self.query).to_dataframe(create_bqstorage_client=True)
         return df
@@ -266,7 +299,7 @@ def _get_table_reference_for_new_entity(
 
 
 def _upload_entity_df_and_get_entity_schema(
-    client: Client, table_name: str, entity_df: Union[pandas.DataFrame, str],
+    client: Client, table_name: str, entity_df: Union[pd.DataFrame, str],
 ) -> Dict[str, np.dtype]:
     """Uploads a Pandas entity dataframe into a BigQuery table and returns the resulting table"""
 
@@ -278,7 +311,7 @@ def _upload_entity_df_and_get_entity_schema(
             client.query(f"SELECT * FROM {table_name} LIMIT 1").result().to_dataframe()
         )
         entity_schema = dict(zip(limited_entity_df.columns, limited_entity_df.dtypes))
-    elif isinstance(entity_df, pandas.DataFrame):
+    elif isinstance(entity_df, pd.DataFrame):
         # Drop the index so that we dont have unnecessary columns
         entity_df.reset_index(drop=True, inplace=True)
 

--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -148,7 +148,7 @@ def build_point_in_time_query(
     entity_df_event_timestamp_col: str,
     query_template: str,
     full_feature_names: bool = False,
-):
+) -> str:
     """Build point-in-time query between each feature view table and the entity dataframe for Bigquery and Redshift"""
     template = Environment(loader=BaseLoader()).from_string(source=query_template)
 

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -177,6 +177,9 @@ def _get_requested_feature_views_to_features_dict(
     feature_views_to_feature_map: Dict[FeatureView, List[str]] = {}
 
     for ref in feature_refs:
+        if ":" not in ref:
+            # ODFV
+            continue
         ref_parts = ref.split(":")
         feature_view_from_ref = ref_parts[0]
         feature_from_ref = ref_parts[1]

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -103,7 +103,7 @@ class OnDemandFeatureView:
 
     def get_transformed_features_df(
         self, full_feature_names: bool, df_with_features: pd.DataFrame
-    ) -> pd.DataFrame:
+    ):
         # Apply on demand transformations
         # TODO(adchia): Include only the feature values from the specified input FVs in the ODFV.
         # Copy over un-prefixed features even if not requested since transform may need it

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -103,7 +103,7 @@ class OnDemandFeatureView:
 
     def get_transformed_features_df(
         self, full_feature_names: bool, df_with_features: pd.DataFrame
-    ):
+    ) -> pd.DataFrame:
         # Apply on demand transformations
         # TODO(adchia): Include only the feature values from the specified input FVs in the ODFV.
         # Copy over un-prefixed features even if not requested since transform may need it


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Sets up a limited on demand transform for historical retrieval for to_df (not to_arrow yet)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
- Add support for row-level on-demand transformations of feature view features in get_offline_features.
- Requires offline store implementations to now also have full_feature_name and on_demand_feature_views properties
```
