### PR TITLE
Reducing size of universal repo to decrease integration test time

### DIFF
--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -76,7 +76,7 @@ FULL_REPO_CONFIGS: List[IntegrationTestRepoConfig] = [
 
 
 def construct_universal_entities() -> Dict[str, List[Any]]:
-    return {"customer": list(range(1001, 1110)), "driver": list(range(5001, 5110))}
+    return {"customer": list(range(1001, 1020)), "driver": list(range(5001, 5020))}
 
 
 def construct_universal_datasets(
@@ -91,9 +91,9 @@ def construct_universal_datasets(
     orders_df = driver_test_data.create_orders_df(
         customers=entities["customer"],
         drivers=entities["driver"],
-        start_date=end_time - timedelta(days=365),
-        end_date=end_time + timedelta(days=365),
-        order_count=1000,
+        start_date=end_time - timedelta(days=3),
+        end_date=end_time + timedelta(days=3),
+        order_count=20,
     )
 
     return {"customer": customer_df, "driver": driver_df, "orders": orders_df}
@@ -146,7 +146,7 @@ class Environment:
     )
 
     def __post_init__(self):
-        self.start_date: datetime = self.end_date - timedelta(days=7)
+        self.start_date: datetime = self.end_date - timedelta(days=3)
 
 
 def table_name_from_data_source(ds: DataSource) -> Optional[str]:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Reducing the size of the universal repo datasets, shaving 45 seconds off of integration tests (down from 6 minutes)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
