### PR TITLE
Reducing wait interval for BQ integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: make install-python-ci-dependencies
       - name: Test python
-        run: FEAST_USAGE=False pytest -n 8 --cov=./ --cov-report=xml --verbose --color=yes sdk/python/tests --integration
+        run: FEAST_USAGE=False IS_TEST=True pytest -n 8 --cov=./ --cov-report=xml --verbose --color=yes sdk/python/tests --integration
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install dependencies
         run: make install-python-ci-dependencies
       - name: Test python
-        run: FEAST_USAGE=False pytest -n 8 --cov=./ --cov-report=xml --verbose --color=yes sdk/python/tests --integration
+        run: FEAST_USAGE=False IS_TEST=True pytest -n 8 --cov=./ --cov-report=xml --verbose --color=yes sdk/python/tests --integration
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test-python:
 	FEAST_USAGE=False pytest -n 8 sdk/python/tests
 
 test-python-integration:
-	FEAST_USAGE=False pytest -n 8 --integration sdk/python/tests
+	FEAST_USAGE=False IS_TEST=True pytest -n 8 --integration sdk/python/tests
 
 format-python:
 	# Sort

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -207,7 +207,7 @@ def block_until_done(
     client: Client,
     bq_job: Union[bigquery.job.query.QueryJob, bigquery.job.load.LoadJob],
     timeout: int = 1800,
-    retry_cadence: int = 10,
+    retry_cadence: float = 1,
 ):
     """
     Waits for bq_job to finish running, up to a maximum amount of time specified by the timeout parameter (defaulting to 30 minutes).
@@ -226,7 +226,7 @@ def block_until_done(
     # For test environments, retry more aggressively
     is_test = os.getenv("IS_TEST", default="False") == "True"
     if is_test:
-        retry_cadence = 1
+        retry_cadence = 0.1
 
     def _wait_until_done(job_id):
         if client.get_job(job_id).state in ["PENDING", "RUNNING"]:

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from datetime import date, datetime, timedelta
 from typing import Dict, List, Optional, Union
@@ -221,6 +222,11 @@ def block_until_done(
         BigQueryJobStillRunning exception if the function has blocked longer than 30 minutes.
         BigQueryJobCancelled exception to signify when that the job has been cancelled (i.e. from timeout or KeyboardInterrupt).
     """
+
+    # For test environments, retry more aggressively
+    is_test = os.getenv("IS_TEST", default=None) == "TRUE"
+    if is_test:
+        retry_cadence = 1
 
     def _wait_until_done(job_id):
         if client.get_job(job_id).state in ["PENDING", "RUNNING"]:

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -224,7 +224,7 @@ def block_until_done(
     """
 
     # For test environments, retry more aggressively
-    is_test = os.getenv("IS_TEST", default=None) == "TRUE"
+    is_test = os.getenv("IS_TEST", default="False") == "True"
     if is_test:
         retry_cadence = 1
 

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import uuid
 from contextlib import contextmanager
@@ -162,6 +163,7 @@ def construct_test_environment(
     test_repo_config: IntegrationTestRepoConfig,
     test_suite_name: str = "integration_test",
 ) -> Environment:
+    os.environ["IS_TEST"] = "TRUE"
     project = f"{test_suite_name}_{str(uuid.uuid4()).replace('-', '')[:8]}"
 
     offline_creator: DataSourceCreator = test_repo_config.offline_store_creator(project)

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import uuid
 from contextlib import contextmanager
@@ -163,7 +162,6 @@ def construct_test_environment(
     test_repo_config: IntegrationTestRepoConfig,
     test_suite_name: str = "integration_test",
 ) -> Environment:
-    os.environ["IS_TEST"] = "TRUE"
     project = f"{test_suite_name}_{str(uuid.uuid4()).replace('-', '')[:8]}"
 
     offline_creator: DataSourceCreator = test_repo_config.offline_store_creator(project)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
From some quick logging, a hotspot when running integration tests lies in uploading entity_df for BQ related tests. This reduces the polling interval from 10 seconds to 0.1 seconds in test environments (and also reduce the prod environment interval to 1s since the main cost is catching a raised Exception, but there's nothing else happening on this thread)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
