### PR TITLE
Fix flaky connection to redshift data API

### DIFF
--- a/sdk/python/feast/infra/utils/aws_utils.py
+++ b/sdk/python/feast/infra/utils/aws_utils.py
@@ -51,7 +51,7 @@ def get_bucket_and_key(s3_path: str) -> Tuple[str, str]:
 
 
 @retry(
-    wait=wait_exponential(multiplier=1, max=30),
+    wait=wait_exponential(multiplier=1, max=4),
     retry=retry_if_exception_type(ConnectionClosedError),
 )
 def execute_redshift_statement_async(

--- a/sdk/python/feast/infra/utils/aws_utils.py
+++ b/sdk/python/feast/infra/utils/aws_utils.py
@@ -15,7 +15,7 @@ from feast.type_map import pa_to_redshift_value_type
 try:
     import boto3
     from botocore.config import Config
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import ClientError, ConnectionClosedError
 except ImportError as e:
     from feast.errors import FeastExtrasDependencyImportError
 
@@ -50,6 +50,10 @@ def get_bucket_and_key(s3_path: str) -> Tuple[str, str]:
     return bucket, key
 
 
+@retry(
+    wait=wait_exponential(multiplier=1, max=30),
+    retry=retry_if_exception_type(ConnectionClosedError),
+)
 def execute_redshift_statement_async(
     redshift_data_client, cluster_id: str, database: str, user: str, query: str
 ) -> dict:


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

I've seen this error very often:
```
E           botocore.exceptions.ConnectionClosedError: Connection was closed before we received a valid response from endpoint URL: "https://redshift-data.us-west-2.amazonaws.com/".
```

Examples:
https://github.com/feast-dev/feast/pull/1833/checks?check_run_id=3507137476
https://github.com/feast-dev/feast/runs/3490830039?check_suite_focus=true
https://github.com/feast-dev/feast/runs/3490830012?check_suite_focus=true



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Retry submitting queries to redshift on connection errors.
```
