### PR TITLE
Enforce case-insensitively unique feature view names

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -982,12 +982,13 @@ def _print_materialization_log(
 
 
 def _validate_feature_views(feature_views: List[FeatureView]):
-    """ Verify feature views have unique names"""
-    name_to_fv_dict = {}
+    """ Verify feature views have case-insensitively unique names"""
+    fv_names = set()
     for fv in feature_views:
-        if fv.name in name_to_fv_dict:
+        case_insensitive_fv_name = fv.name.lower()
+        if case_insensitive_fv_name in fv_names:
             raise ValueError(
-                f"More than one feature view with name {fv.name} found. Please ensure that all feature view names are unique. It may be necessary to ignore certain files in your feature repository by using a .feastignore file."
+                f"More than one feature view with name {case_insensitive_fv_name} found. Please ensure that all feature view names are case-insensitively unique. It may be necessary to ignore certain files in your feature repository by using a .feastignore file."
             )
         else:
-            name_to_fv_dict[fv.name] = fv
+            fv_names.add(case_insensitive_fv_name)

--- a/sdk/python/tests/integration/registration/test_cli_apply_duplicated_featureview_names.py
+++ b/sdk/python/tests/integration/registration/test_cli_apply_duplicated_featureview_names.py
@@ -40,7 +40,8 @@ def test_cli_apply_duplicated_featureview_names() -> None:
 
         assert (
             rc != 0
-            and b"Please ensure that all feature view names are unique" in output
+            and b"Please ensure that all feature view names are case-insensitively unique"
+            in output
         )
 
 
@@ -76,5 +77,6 @@ def test_cli_apply_duplicated_featureview_names_multiple_py_files() -> None:
 
         assert (
             rc != 0
-            and b"Please ensure that all feature view names are unique" in output
+            and b"Please ensure that all feature view names are case-insensitively unique"
+            in output
         )

--- a/sdk/python/tests/integration/registration/test_feature_store.py
+++ b/sdk/python/tests/integration/registration/test_feature_store.py
@@ -482,8 +482,8 @@ def test_reapply_feature_view_success(test_feature_store, dataframe_source):
         test_feature_store.teardown()
 
 
-def test_apply_duplicated_featureview_names(feature_store_with_local_registry):
-    """ Test applying feature views with duplicated names"""
+def test_apply_conflicting_featureview_names(feature_store_with_local_registry):
+    """ Test applying feature views with non-case-insensitively unique names"""
 
     driver_stats = FeatureView(
         name="driver_hourly_stats",
@@ -495,7 +495,7 @@ def test_apply_duplicated_featureview_names(feature_store_with_local_registry):
     )
 
     customer_stats = FeatureView(
-        name="driver_hourly_stats",
+        name="DRIVER_HOURLY_STATS",
         entities=["id"],
         ttl=timedelta(seconds=10),
         online=False,
@@ -509,7 +509,8 @@ def test_apply_duplicated_featureview_names(feature_store_with_local_registry):
         error = e
     assert (
         isinstance(error, ValueError)
-        and "Please ensure that all feature view names are unique" in error.args[0]
+        and "Please ensure that all feature view names are case-insensitively unique"
+        in error.args[0]
     )
 
     feature_store_with_local_registry.teardown()


### PR DESCRIPTION
Signed-off-by: Cody Lin <codyl@twitter.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
CockroachDB's table names and the materialization jobs using dataflow need feature view names to be lowercase. (CRDB is an online store we're trying to use.) We can transform the names downstream / on our end, but we would like the collision check to happen at `feast apply` time.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
It's such a small change that no issue created.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
FeatureView names must now be *case-insensitively* unique
```
