### PR TITLE
Enable the types test to run on all compatible environments

### DIFF
--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -192,7 +192,10 @@ class SqliteOnlineStore(OnlineStore):
         tables: Sequence[Union[FeatureTable, FeatureView]],
         entities: Sequence[Entity],
     ):
-        os.unlink(self._get_db_path(config))
+        try:
+            os.unlink(self._get_db_path(config))
+        except FileNotFoundError:
+            pass
 
 
 def _table_id(project: str, table: Union[FeatureTable, FeatureView]) -> str:

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -132,9 +132,3 @@ def e2e_data_sources(environment: Environment):
     yield df, data_source
 
     environment.data_source_creator.teardown()
-
-
-@pytest.fixture(params=FULL_REPO_CONFIGS, scope="session")
-def type_test_environment(request):
-    with construct_test_environment(request.param) as e:
-        yield e

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -42,6 +42,7 @@ class BigQueryDataSourceCreator(DataSourceCreator):
             self.dataset_id, delete_contents=True, not_found_ok=True
         )
         print(f"Deleted dataset '{self.dataset_id}'")
+        self.dataset = None
 
     def create_offline_store_config(self):
         return BigQueryOfflineStoreConfig()

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -36,8 +36,7 @@ def populate_test_configs(offline: bool):
                 # For offline tests, don't need to vary for online store
                 if offline and test_repo_config.online_store == REDIS_CONFIG:
                     continue
-                # TODO(adchia): Fix BQ materialization of list features, which fail to_arrow conversion because the
-                #  value is a dict type like {'list': [{'item': 3}, {'item': 3}]}
+                # TODO(https://github.com/feast-dev/feast/issues/1839): Fix BQ materialization of list features
                 if (
                     not offline
                     and test_repo_config.provider == "gcp"

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -1,4 +1,6 @@
+from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import List
 
 import pandas as pd
 import pytest
@@ -10,9 +12,6 @@ from tests.data.data_creator import create_dataset, get_feature_values_for_dtype
 from tests.integration.feature_repos.repo_configuration import (
     IntegrationTestRepoConfig,
     construct_test_environment,
-)
-from tests.integration.feature_repos.universal.data_sources.bigquery import (
-    BigQueryDataSourceCreator,
 )
 from tests.integration.feature_repos.universal.entities import driver
 from tests.integration.feature_repos.universal.feature_views import driver_feature_view
@@ -28,56 +27,81 @@ entity_type_feature_dtypes = [
     (ValueType.STRING, "float"),
     (ValueType.STRING, "bool"),
 ]
-GCP_CONFIG = IntegrationTestRepoConfig(
-    provider="gcp",
-    offline_store_creator=BigQueryDataSourceCreator,
-    online_store="datastore",
+
+
+@dataclass(frozen=True, repr=True)
+class TypeTestConfig:
+    entity_type: ValueType
+    feature_dtype: str
+    feature_is_list: bool
+
+
+FULL_TYPE_TEST_CONFIGS: List[TypeTestConfig] = []
+for entity_type, feature_dtype in entity_type_feature_dtypes:
+    for feature_is_list in [True, False]:
+        FULL_TYPE_TEST_CONFIGS.append(
+            TypeTestConfig(
+                entity_type=entity_type,
+                feature_dtype=feature_dtype,
+                feature_is_list=feature_is_list,
+            )
+        )
+
+
+@pytest.fixture(
+    params=FULL_TYPE_TEST_CONFIGS,
+    scope="session",
+    ids=[str(c) for c in FULL_TYPE_TEST_CONFIGS],
 )
+def types_fixtures(environment, request):
+    config = request.param
+    test_project_id = f"{config.entity_type}{config.feature_dtype}{config.feature_is_list}".replace(
+        ".", ""
+    )
+    with construct_test_environment(
+        test_repo_config=environment.test_repo_config,
+        test_suite_name=f"integration_test_{test_project_id}",
+    ) as type_test_environment:
+        config = request.param
+        df = create_dataset(
+            config.entity_type, config.feature_dtype, config.feature_is_list
+        )
+        data_source = type_test_environment.data_source_creator.create_data_source(
+            df,
+            destination_name=type_test_environment.feature_store.project,
+            field_mapping={"ts_1": "ts"},
+        )
+        fv = create_feature_view(
+            config.feature_dtype, config.feature_is_list, data_source
+        )
+        try:
+            yield type_test_environment, config, data_source, fv
+        finally:
+            type_test_environment.data_source_creator.teardown()
 
 
 # TODO: change parametrization to allow for other providers aside from gcp
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    "entity_type,feature_dtype",
-    entity_type_feature_dtypes,
-    ids=[
-        entity_feature_types_ids(entity_type, feature_dtype)
-        for entity_type, feature_dtype in entity_type_feature_dtypes
-    ],
-)
-@pytest.mark.parametrize(
-    "feature_is_list", [False], ids=lambda v: f"feature_is_list:{str(v)}"
-)
-def test_entity_inference_types_match(entity_type, feature_dtype, feature_is_list):
-    with construct_test_environment(GCP_CONFIG) as environment:
-        df = create_dataset(entity_type, feature_dtype, feature_is_list)
-        data_source = environment.data_source_creator.create_data_source(
-            df,
-            destination_name=environment.feature_store.project,
-            field_mapping={"ts_1": "ts"},
+def test_entity_inference_types_match(types_fixtures):
+    environment, config, data_source, fv = types_fixtures
+    fs = environment.feature_store
+
+    # Don't specify value type in entity to force inference
+    entity = driver(value_type=ValueType.UNKNOWN)
+    fs.apply([fv, entity])
+
+    entities = fs.list_entities()
+    entity_type_to_expected_inferred_entity_type = {
+        ValueType.INT32: ValueType.INT64,
+        ValueType.INT64: ValueType.INT64,
+        ValueType.FLOAT: ValueType.DOUBLE,
+        ValueType.STRING: ValueType.STRING,
+    }
+    for entity in entities:
+        assert (
+            entity.value_type
+            == entity_type_to_expected_inferred_entity_type[config.entity_type]
         )
-        fv = create_feature_view(feature_dtype, feature_is_list, data_source)
-        fs = environment.feature_store
-
-        try:
-            # Don't specify value type in entity to force inference
-            entity = driver(value_type=ValueType.UNKNOWN)
-            fs.apply([fv, entity])
-
-            entities = fs.list_entities()
-            entity_type_to_expected_inferred_entity_type = {
-                ValueType.INT32: ValueType.INT64,
-                ValueType.INT64: ValueType.INT64,
-                ValueType.FLOAT: ValueType.DOUBLE,
-                ValueType.STRING: ValueType.STRING,
-            }
-            for entity in entities:
-                assert (
-                    entity.value_type
-                    == entity_type_to_expected_inferred_entity_type[entity_type]
-                )
-        finally:
-            environment.data_source_creator.teardown()
 
 
 @pytest.mark.integration
@@ -95,7 +119,7 @@ def test_entity_inference_types_match(entity_type, feature_dtype, feature_is_lis
 def test_feature_get_historical_features_types_match(
     entity_type, feature_dtype, feature_is_list
 ):
-    with construct_test_environment(GCP_CONFIG) as environment:
+    with construct_test_environment(IntegrationTestRepoConfig()) as environment:
         df = create_dataset(entity_type, feature_dtype, feature_is_list)
         data_source = environment.data_source_creator.create_data_source(
             df,
@@ -109,29 +133,38 @@ def test_feature_get_historical_features_types_match(
             fs.apply([fv, entity])
 
             features = [f"{fv.name}:value"]
-            df = pd.DataFrame()
-            df["driver_id"] = ["1", "3"] if entity_type == ValueType.STRING else [1, 3]
+            entity_df = pd.DataFrame()
+            entity_df["driver_id"] = (
+                ["1", "3"] if entity_type == ValueType.STRING else [1, 3]
+            )
             now = datetime.utcnow()
             ts = pd.Timestamp(now).round("ms")
-            df["ts"] = [
+            entity_df["ts"] = [
                 ts - timedelta(hours=4),
                 ts - timedelta(hours=2),
             ]
             historical_features = fs.get_historical_features(
-                entity_df=df, features=features,
+                entity_df=entity_df, features=features,
             )
 
             # TODO(adchia): pandas doesn't play well with nan values in ints. BQ will also coerce to floats if there are NaNs
             historical_features_df = historical_features.to_df()
             print(historical_features_df)
             if feature_is_list:
-                assert_feature_list_types(feature_dtype, historical_features_df)
+                assert_feature_list_types(
+                    environment.test_repo_config.provider,
+                    feature_dtype,
+                    historical_features_df,
+                )
             else:
                 assert_expected_historical_feature_types(
                     feature_dtype, historical_features_df
                 )
             assert_expected_arrow_types(
-                feature_dtype, feature_is_list, historical_features
+                environment.test_repo_config.provider,
+                feature_dtype,
+                feature_is_list,
+                historical_features,
             )
         finally:
             environment.data_source_creator.teardown()
@@ -152,7 +185,7 @@ def test_feature_get_historical_features_types_match(
 def test_feature_get_online_features_types_match(
     entity_type, feature_dtype, feature_is_list
 ):
-    with construct_test_environment(GCP_CONFIG) as environment:
+    with construct_test_environment(IntegrationTestRepoConfig()) as environment:
         df = create_dataset(entity_type, feature_dtype, feature_is_list)
         data_source = environment.data_source_creator.create_data_source(
             df,
@@ -208,16 +241,18 @@ def assert_expected_historical_feature_types(
         "int32": "int64",
         "int64": "int64",
         "float": "float64",
-        "string": "object",
-        "bool": "bool",
+        "string": {"string", "object"},
+        "bool": {"bool", "object"},
     }
     assert (
         str(historical_features_df.dtypes["value"])
-        == feature_dtype_to_expected_historical_feature_dtype[feature_dtype]
+        in feature_dtype_to_expected_historical_feature_dtype[feature_dtype]
     )
 
 
-def assert_feature_list_types(feature_dtype: str, historical_features_df: pd.DataFrame):
+def assert_feature_list_types(
+    provider: str, feature_dtype: str, historical_features_df: pd.DataFrame
+):
     print("Asserting historical feature list types")
     # Note, these expected values only hold for BQ
     feature_list_dtype_to_expected_historical_feature_list_dtype = {
@@ -229,14 +264,23 @@ def assert_feature_list_types(feature_dtype: str, historical_features_df: pd.Dat
     }
     assert str(historical_features_df.dtypes["value"]) == "object"
     # Note, this struct schema is only true for BQ and not for other stores
-    assert (
-        type(historical_features_df.value[0]["list"][0]["item"]).__name__
-        == feature_list_dtype_to_expected_historical_feature_list_dtype[feature_dtype]
-    )
+    if str == "gcp":
+        assert (
+            feature_list_dtype_to_expected_historical_feature_list_dtype[feature_dtype]
+            in type(historical_features_df.value[0]["list"][0]["item"]).__name__
+        )
+    else:
+        assert (
+            feature_list_dtype_to_expected_historical_feature_list_dtype[feature_dtype]
+            in type(historical_features_df.value[0][0]).__name__
+        )
 
 
 def assert_expected_arrow_types(
-    feature_dtype: str, feature_is_list: bool, historical_features: RetrievalJob
+    provider: str,
+    feature_dtype: str,
+    feature_is_list: bool,
+    historical_features: RetrievalJob,
 ):
     print("Asserting historical feature arrow types")
     historical_features_arrow = historical_features.to_arrow()
@@ -252,10 +296,16 @@ def assert_expected_arrow_types(
         feature_dtype
     ]
     if feature_is_list:
-        assert (
-            str(historical_features_arrow.schema.field_by_name("value").type)
-            == f"struct<list: list<item: struct<item: {arrow_type}>> not null>"
-        )
+        if provider == "gcp":
+            assert (
+                str(historical_features_arrow.schema.field_by_name("value").type)
+                == f"struct<list: list<item: struct<item: {arrow_type}>> not null>"
+            )
+        else:
+            assert (
+                str(historical_features_arrow.schema.field_by_name("value").type)
+                == f"list<item: {arrow_type}>"
+            )
     else:
         assert (
             str(historical_features_arrow.schema.field_by_name("value").type)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Enables the types test to test feature types across compatible offline / online stores (but e.g. not using list features on Redshift since Redshift doesn't support those). This also doesn't fully enable testing materializing list features for BQ because of https://github.com/feast-dev/feast/issues/1839.

This also fixes some missing teardown functionality, which caused tests to fail because the same "project" across different environments that used the same offline store caused issues (e.g. inability to create a new dataset)

This surfaced a bug where we can't materialize list features in BQ. There's a J
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
