### PR TITLE
Move apply(dummy_entity) to apply time to ensure it persists in FeatureStore

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -100,12 +100,6 @@ class FeatureStore:
             repo_path=self.repo_path,
             cache_ttl=timedelta(seconds=registry_config.cache_ttl_seconds),
         )
-        DUMMY_ENTITY = Entity(
-            name=DUMMY_ENTITY_NAME,
-            join_key=DUMMY_ENTITY_ID,
-            value_type=ValueType.INT32,
-        )
-        self.apply(DUMMY_ENTITY)
 
     @log_exceptions
     def version(self) -> str:
@@ -411,6 +405,14 @@ class FeatureStore:
             services_to_update
         ) + len(odfvs_to_update) != len(objects):
             raise ValueError("Unknown object type provided as part of apply() call")
+
+        # DUMMY_ENTITY is a placeholder entity used in entityless FeatureViews
+        DUMMY_ENTITY = Entity(
+            name=DUMMY_ENTITY_NAME,
+            join_key=DUMMY_ENTITY_ID,
+            value_type=ValueType.INT32,
+        )
+        entities_to_update.append(DUMMY_ENTITY)
 
         for view in views_to_update:
             self._registry.apply_feature_view(view, project=self.project, commit=False)


### PR DESCRIPTION
Signed-off-by: Cody Lin <codyl@twitter.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This is a follow up of https://github.com/feast-dev/feast/pull/1804/ and addresses changes from this comment: https://github.com/feast-dev/feast/pull/1804/files/b767eb7d42a4ae3d244693fee5fafe7ea9e4143c#r705519160

Basically, if we only apply the dummy_id at FeatureStore.init time, it might get erased in future apply calls by the user. It would be persisted by moving it to `apply` time.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Small bug fix for #1737

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
