### PR TITLE
Support Aliyun provider , Add Maxcompute offline store and Hologres o…

### DIFF
--- a/protos/feast/core/DataSource.proto
+++ b/protos/feast/core/DataSource.proto
@@ -39,6 +39,7 @@ message DataSource {
     STREAM_KINESIS = 4;
     BATCH_REDSHIFT = 5;
     CUSTOM_SOURCE = 6;
+    BATCH_MAXCOMPUTE = 8;
   }
   SourceType type = 1;
 
@@ -123,6 +124,16 @@ message DataSource {
     string query = 2;
   }
 
+  // Defines options for DataSource that sources features from a Aliyun Maxcompute Query
+  message MaxcomputeOptions {
+    // Full table reference in the form of [project:table]
+    string table_ref = 1;
+
+    // SQL query that returns a table containing feature data. Must contain an event_timestamp column, and respective
+    // entity columns
+    string query = 2;
+  }
+
   // Defines configuration for custom third-party data sources.
   message CustomSourceOptions {
     // Serialized configuration information for the data source. The implementer of the custom data source is
@@ -138,5 +149,6 @@ message DataSource {
     KinesisOptions kinesis_options = 14;
     RedshiftOptions redshift_options = 15;
     CustomSourceOptions custom_options = 16;
+    MaxcomputeOptions maxcompute_options = 18;
   }
 }

--- a/sdk/python/feast/__init__.py
+++ b/sdk/python/feast/__init__.py
@@ -4,6 +4,7 @@ from pkg_resources import DistributionNotFound, get_distribution
 
 from feast.infra.offline_stores.bigquery_source import BigQuerySource
 from feast.infra.offline_stores.file_source import FileSource
+from feast.infra.offline_stores.maxcompute_source import MaxcomputeSource
 from feast.infra.offline_stores.redshift_source import RedshiftSource
 
 from .data_source import KafkaSource, KinesisSource, SourceType
@@ -45,4 +46,5 @@ __all__ = [
     "BigQuerySource",
     "FileSource",
     "RedshiftSource",
+    "MaxcomputeSource",
 ]

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -394,7 +394,7 @@ def materialize_incremental_command(ctx: click.Context, end_ts: str, views: List
 @click.option(
     "--template",
     "-t",
-    type=click.Choice(["local", "gcp", "aws"], case_sensitive=False),
+    type=click.Choice(["local", "gcp", "aws", "aliyun"], case_sensitive=False),
     help="Specify a template for the created project",
     default="local",
 )

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -361,6 +361,11 @@ class DataSource(ABC):
 
             data_source_obj = RedshiftSource.from_proto(data_source)
         elif (
+            data_source.maxcompute_options.table_ref or data_source.maxcompute_options.query
+        ):
+            from feast.infra.offline_stores.maxcompute_source import MaxcomputeSource
+            data_source_obj = MaxcomputeSource.from_proto(data_source)
+        elif (
             data_source.kafka_options.bootstrap_servers
             and data_source.kafka_options.topic
             and data_source.kafka_options.message_format

--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -197,6 +197,31 @@ class RedshiftQueryError(Exception):
         super().__init__(f"Redshift SQL Query failed to finish. Details: {details}")
 
 
+class MaxcomputeJobStillRunning(Exception):
+    def __init__(self, job_id):
+        super().__init__(f"The Maxcompute job with ID '{job_id}' is still running.")
+
+
+class MaxcomputeCredentialsError(Exception):
+    def __init__(self):
+        super().__init__("Maxcompute API failed due to incorrect credentials")
+
+
+class MaxcomputeJobCancelled(Exception):
+    def __init__(self, job_id):
+        super().__init__(f"The Maxcompute job with ID '{job_id}' was cancelled")
+
+
+class MaxcomputeQueryError(Exception):
+    def __init__(self, details):
+        super().__init__(f"Maxcompute SQL Query failed to finish. Details: {details}")
+
+
+class MaxcomputeUploadError(Exception):
+    def __init__(self, details):
+        super().__init__(f"Maxcompute Upload failed to finish. Details: {details}")
+
+
 class EntityTimestampInferenceException(Exception):
     def __init__(self, expected_column_name: str):
         super().__init__(

--- a/sdk/python/feast/infra/aliyun.py
+++ b/sdk/python/feast/infra/aliyun.py
@@ -1,0 +1,143 @@
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+import pandas
+from tqdm import tqdm
+
+from feast import FeatureTable
+from feast.entity import Entity
+from feast.feature_view import FeatureView
+from feast.infra.offline_stores.offline_utils import get_offline_store_from_config
+from feast.infra.online_stores.helpers import get_online_store_from_config
+from feast.infra.provider import (
+    Provider,
+    RetrievalJob,
+    _convert_arrow_to_proto,
+    _get_column_names,
+    _run_field_mapping,
+)
+from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+from feast.registry import Registry
+from feast.repo_config import RepoConfig
+
+
+class AliyunProvider(Provider):
+    def __init__(self, config: RepoConfig):
+        self.repo_config = config
+        self.offline_store = get_offline_store_from_config(config.offline_store)
+        self.online_store = get_online_store_from_config(config.online_store)
+
+    def update_infra(
+        self,
+        project: str,
+        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
+        tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
+        entities_to_delete: Sequence[Entity],
+        entities_to_keep: Sequence[Entity],
+        partial: bool,
+    ):
+        self.online_store.update(
+            config=self.repo_config,
+            tables_to_delete=tables_to_delete,
+            tables_to_keep=tables_to_keep,
+            entities_to_keep=entities_to_keep,
+            entities_to_delete=entities_to_delete,
+            partial=partial,
+        )
+
+    def teardown_infra(
+        self,
+        project: str,
+        tables: Sequence[Union[FeatureTable, FeatureView]],
+        entities: Sequence[Entity],
+    ) -> None:
+        self.online_store.teardown(self.repo_config, tables, entities)
+
+    def online_write_batch(
+        self,
+        config: RepoConfig,
+        table: Union[FeatureTable, FeatureView],
+        data: List[
+            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+        ],
+        progress: Optional[Callable[[int], Any]],
+    ) -> None:
+        self.online_store.online_write_batch(config, table, data, progress)
+
+    def online_read(
+        self,
+        config: RepoConfig,
+        table: Union[FeatureTable, FeatureView],
+        entity_keys: List[EntityKeyProto],
+        requested_features: List[str] = None,
+    ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
+        result = self.online_store.online_read(config, table, entity_keys)
+
+        return result
+
+    def materialize_single_feature_view(
+        self,
+        config: RepoConfig,
+        feature_view: FeatureView,
+        start_date: datetime,
+        end_date: datetime,
+        registry: Registry,
+        project: str,
+        tqdm_builder: Callable[[int], tqdm],
+    ) -> None:
+        entities = []
+        for entity_name in feature_view.entities:
+            entities.append(registry.get_entity(entity_name, project))
+
+        (
+            join_key_columns,
+            feature_name_columns,
+            event_timestamp_column,
+            created_timestamp_column,
+        ) = _get_column_names(feature_view, entities)
+
+        offline_job = self.offline_store.pull_latest_from_table_or_query(
+            config=config,
+            data_source=feature_view.batch_source,
+            join_key_columns=join_key_columns,
+            feature_name_columns=feature_name_columns,
+            event_timestamp_column=event_timestamp_column,
+            created_timestamp_column=created_timestamp_column,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        table = offline_job.to_arrow()
+
+        if feature_view.batch_source.field_mapping is not None:
+            table = _run_field_mapping(table, feature_view.batch_source.field_mapping)
+
+        join_keys = [entity.join_key for entity in entities]
+        rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
+
+        with tqdm_builder(len(rows_to_write)) as pbar:
+            self.online_write_batch(
+                self.repo_config, feature_view, rows_to_write, lambda x: pbar.update(x)
+            )
+
+    def get_historical_features(
+        self,
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_df: Union[pandas.DataFrame, str],
+        registry: Registry,
+        project: str,
+        full_feature_names: bool,
+    ) -> RetrievalJob:
+        job = self.offline_store.get_historical_features(
+            config=config,
+            feature_views=feature_views,
+            feature_refs=feature_refs,
+            entity_df=entity_df,
+            registry=registry,
+            project=project,
+            full_feature_names=full_feature_names,
+        )
+        return job

--- a/sdk/python/feast/infra/offline_stores/maxcompute.py
+++ b/sdk/python/feast/infra/offline_stores/maxcompute.py
@@ -1,0 +1,470 @@
+import uuid
+from datetime import date, datetime, timedelta
+from typing import Dict, List, Optional, Union
+
+import numpy as np
+import pandas as pd
+import pyarrow
+from pydantic import StrictStr
+from pydantic.typing import Literal
+from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
+
+from feast.data_source import DataSource
+from feast.errors import (
+    FeastProviderLoginError,
+    InvalidEntityType,
+    MaxcomputeJobCancelled,
+    MaxcomputeJobStillRunning,
+    MaxcomputeQueryError,
+    MaxcomputeUploadError,
+)
+from feast.feature_view import FeatureView
+from feast.infra.offline_stores import offline_utils
+from feast.infra.offline_stores.offline_store import OfflineStore, RetrievalJob
+from feast.infra.utils import aliyun_utils
+from feast.on_demand_feature_view import OnDemandFeatureView
+from feast.registry import Registry
+from feast.repo_config import FeastConfigBaseModel, RepoConfig
+
+from .maxcompute_source import MaxcomputeSource
+
+try:
+    import odps
+    from odps import ODPS, options
+
+    options.sql.use_odps2_extension = True
+    options.tunnel.use_instance_tunnel = True
+    options.tunnel.limit_instance_tunnel = False
+
+except ImportError as e:
+    from feast.errors import FeastExtrasDependencyImportError
+
+    raise FeastExtrasDependencyImportError("aliyun", str(e))
+
+
+class MaxcomputeOfflineStoreConfig(FeastConfigBaseModel):
+    """ Offline store config for Aliyun Maxcompute """
+
+    type: Literal["maxcompute"] = "maxcompute"
+    """ Offline store type selector"""
+
+    region: Optional[StrictStr] = None
+    """ (optional)Macompute region name"""
+
+    project: StrictStr
+    """ Maxcompute project name"""
+
+    access_key: StrictStr
+    """ Maxcompute access key"""
+
+    secret_access_key: StrictStr
+    """ Maxcompute secret access key"""
+
+    end_point: Optional[StrictStr] = None
+    """ (optional)Maxcompute endpoint"""
+
+
+class MaxcomputeOfflineStore(OfflineStore):
+    @staticmethod
+    def pull_latest_from_table_or_query(
+        config: RepoConfig,
+        data_source: DataSource,
+        join_key_columns: List[str],
+        feature_name_columns: List[str],
+        event_timestamp_column: str,
+        created_timestamp_column: Optional[str],
+        start_date: datetime,
+        end_date: datetime,
+    ) -> RetrievalJob:
+        assert isinstance(data_source, MaxcomputeSource)
+        from_expression = data_source.get_table_query_string()
+
+        partition_by_join_key_string = ", ".join(join_key_columns)
+        if partition_by_join_key_string != "":
+            partition_by_join_key_string = (
+                "PARTITION BY " + partition_by_join_key_string
+            )
+        timestamps = [event_timestamp_column]
+        if created_timestamp_column:
+            timestamps.append(created_timestamp_column)
+        timestamp_desc_string = " DESC, ".join(timestamps) + " DESC"
+        field_string = ", ".join(join_key_columns + feature_name_columns + timestamps)
+
+        # client = aliyun_utils.get_maxcompute_client(project=config.offline_store.project)
+        client = aliyun_utils.get_maxcompute_client(
+            ak=config.offline_store.access_key,
+            sk=config.offline_store.secret_access_key,
+            project=config.offline_store.project,
+            region=config.offline_store.region,
+            endpoint=config.offline_store.end_point,
+        )
+
+        query = f"""
+            SELECT {field_string}
+            FROM (
+                SELECT {field_string},
+                ROW_NUMBER() OVER({partition_by_join_key_string} ORDER BY {timestamp_desc_string}) AS _feast_row
+                FROM {from_expression}
+                WHERE cast({event_timestamp_column} as TIMESTAMP) BETWEEN TIMESTAMP('{start_date}') AND TIMESTAMP('{end_date}')
+            )
+            WHERE _feast_row = 1
+            """
+
+        # When materializing a single feature view, we don't need full feature names. On demand transforms aren't materialized
+        return MaxcomputeRetrievalJob(
+            query=query,
+            client=client,
+            config=config,
+            full_feature_names=False,
+            on_demand_feature_views=None,
+        )
+
+    @staticmethod
+    def get_historical_features(
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_df: Union[pd.DataFrame, odps.df.DataFrame, str],
+        registry: Registry,
+        project: str,
+        full_feature_names: bool = False,
+    ) -> RetrievalJob:
+        # TODO: Add entity_df validation in order to fail before interacting with Maxcompute
+        assert isinstance(config.offline_store, MaxcomputeOfflineStoreConfig)
+
+        client = aliyun_utils.get_maxcompute_client(
+            ak=config.offline_store.access_key,
+            sk=config.offline_store.secret_access_key,
+            project=config.offline_store.project,
+            region=config.offline_store.region,
+            endpoint=config.offline_store.end_point,
+        )
+
+        assert isinstance(config.offline_store, MaxcomputeOfflineStoreConfig)
+
+        # local pandas data frame need upload
+        if isinstance(entity_df, str):
+            table_reference = entity_df
+        else:
+            table_reference = _get_table_reference_for_new_entity(
+                client, config.offline_store.project
+            )
+
+        entity_schema = _upload_entity_df_and_get_entity_schema(
+            client=client, table_name=table_reference, entity_df=entity_df
+        )
+
+        entity_df_event_timestamp_col = offline_utils.infer_event_timestamp_from_entity_df(
+            entity_schema
+        )
+
+        expected_join_keys = offline_utils.get_expected_join_keys(
+            project, feature_views, registry
+        )
+
+        offline_utils.assert_expected_columns_in_entity_df(
+            entity_schema, expected_join_keys, entity_df_event_timestamp_col
+        )
+
+        # Build a query context containing all information required to template the Maxcompute SQL query
+        query_context = offline_utils.get_feature_view_query_context(
+            feature_refs, feature_views, registry, project
+        )
+
+        # Generate the Maxcompute SQL query from the query context
+        query = offline_utils.build_point_in_time_query(
+            query_context,
+            left_table_query_string=table_reference,
+            entity_df_event_timestamp_col=entity_df_event_timestamp_col,
+            query_template=MULTIPLE_FEATURE_VIEW_POINT_IN_TIME_JOIN,
+            full_feature_names=full_feature_names,
+        )
+
+        return MaxcomputeRetrievalJob(
+            query=query,
+            client=client,
+            config=config,
+            full_feature_names=full_feature_names,
+            on_demand_feature_views=registry.list_on_demand_feature_views(
+                project, allow_cache=True
+            ),
+        )
+
+
+class MaxcomputeRetrievalJob(RetrievalJob):
+    def __init__(
+        self,
+        query: str,
+        client: ODPS,
+        config: RepoConfig,
+        full_feature_names: bool,
+        on_demand_feature_views: Optional[List[OnDemandFeatureView]],
+    ):
+        self.query = query
+        self.client = client
+        self.config = config
+        self._full_feature_names = full_feature_names
+        self._on_demand_feature_views = on_demand_feature_views
+
+    @property
+    def full_feature_names(self) -> bool:
+        return self._full_feature_names
+
+    @property
+    def on_demand_feature_views(self) -> Optional[List[OnDemandFeatureView]]:
+        return self._on_demand_feature_views
+
+    def to_df_internal(self) -> pd.DataFrame:
+        # TODO: Ideally only start this job when the user runs "get_historical_features", not when they run to_df()
+        df = self._to_df()
+        return df
+
+    def to_sql(self) -> str:
+        """
+        Returns the SQL query that will be executed in Maxcompute to build the historical feature table.
+        """
+        return self.query
+
+    def to_maxcompute(self, table_name: str,overwrite:bool = True) -> None:
+        """
+        Triggers the execution of a historical feature retrieval query and exports the results to a Maxcompute table.
+        Args:
+            table_name: specify name of destination table
+
+        """
+
+        if overwrite:
+            sql = f"DROP TABLE IF EXISTS {table_name}"
+            job = self.client.run_sql(sql)
+            print("logview url:", job.get_logview_address())
+        query = self.query
+        sql = f"CREATE TABLE {table_name} LIFECYCLE 1 AS {query}"
+        job = self.client.run_sql(sql)
+        print("logview url:", job.get_logview_address())
+        job.wait_for_success()
+
+    def _to_df(self) -> pd.DataFrame:
+        table_reference = _get_table_reference_for_new_entity(
+            self.client, self.config.offline_store.project
+        )
+        query = self.query
+        sql = f"CREATE TABLE {table_reference} LIFECYCLE 1 AS {query}"
+        job = self.client.run_sql(sql)
+        print("logview url:", job.get_logview_address())
+        job.wait_for_success()
+
+        table = odps.df.DataFrame(self.client.get_table(table_reference))
+        return table.to_pandas()
+
+    def to_arrow(self) -> pyarrow.Table:
+        df = self._to_df()
+        return pyarrow.Table.from_pandas(df)
+
+
+def _get_table_reference_for_new_entity(client: ODPS, dataset_project: str) -> str:
+    """Gets the table_id for the new entity to be uploaded."""
+
+    table_name = offline_utils.get_temp_entity_table_name()
+
+    return f"{dataset_project}.{table_name}"
+
+
+def _upload_entity_df_and_get_entity_schema(
+    client: ODPS,
+    table_name: str,
+    entity_df: Union[pd.DataFrame, odps.df.DataFrame, str],
+) -> Dict[str, np.dtype]:
+    """Uploads a Pandas entity dataframe into a Maxcompute table and returns the resulting table"""
+
+    if type(entity_df) is str:
+        limited_entity_df = (
+            odps.df.DataFrame(client.get_table(table_name)).limit(1).execute()
+        )
+        entity_schema = dict(
+            zip(limited_entity_df.schema.names, limited_entity_df.schema.types)
+        )
+    elif isinstance(entity_df, pd.DataFrame):
+        # Drop the index so that we dont have unnecessary columns
+        entity_df.reset_index(drop=True, inplace=True)
+
+        # Upload the dataframe into Maxcompute, creating a temporary table
+        upload_df = odps.df.DataFrame(entity_df)
+        try:
+            upload_df.persist(table_name, odps=client, lifecycle=1)
+        except Exception as e:
+            raise MaxcomputeUploadError(e)
+
+        entity_schema = dict(zip(upload_df.dtypes.names, upload_df.dtypes.types))
+    elif isinstance(entity_df, odps.df.DataFrame):
+        # Just return the Maxcompute schema
+        entity_schema = dict(zip(entity_df.dtypes.names, entity_df.dtypes.types))
+    else:
+        raise InvalidEntityType(type(entity_df))
+
+    return entity_schema
+
+
+# TODO: Optimizations
+#   * Use GENERATE_UUID() instead of ROW_NUMBER(), or join on entity columns directly
+#   * Precompute ROW_NUMBER() so that it doesn't have to be recomputed for every query on entity_dataframe
+#   * Create temporary tables instead of keeping all tables in memory
+
+# Note: Keep this in sync with sdk/python/feast/infra/offline_stores/redshift.py:MULTIPLE_FEATURE_VIEW_POINT_IN_TIME_JOIN
+
+MULTIPLE_FEATURE_VIEW_POINT_IN_TIME_JOIN = """
+--Compute a deterministic hash for the `left_table_query_string` that will be used throughout
+--all the logic as the field to GROUP BY the data
+WITH entity_dataframe AS (
+    SELECT *,
+        CAST({{entity_df_event_timestamp_col}} AS TIMESTAMP) AS entity_timestamp
+        {% for featureview in featureviews %}
+            ,CONCAT(
+                {% for entity in featureview.entities %}
+                    CAST({{entity}} AS STRING),
+                {% endfor %}
+                CAST({{entity_df_event_timestamp_col}} AS STRING)
+            ) AS {{featureview.name}}__entity_row_unique_id
+        {% endfor %}
+    FROM {{ left_table_query_string }}
+),
+
+{% for featureview in featureviews %}
+
+{{ featureview.name }}__entity_dataframe AS (
+    SELECT
+        {{ featureview.entities | join(', ')}},
+        cast(entity_timestamp as TIMESTAMP),
+        {{featureview.name}}__entity_row_unique_id
+    FROM entity_dataframe
+    GROUP BY {{ featureview.entities | join(', ')}}, entity_timestamp, {{featureview.name}}__entity_row_unique_id
+),
+
+
+-- This query template performs the point-in-time correctness join for a single feature set table
+-- to the provided entity table.
+--
+-- 1. We first join the current feature_view to the entity dataframe that has been passed.
+-- This JOIN has the following logic:
+--    - For each row of the entity dataframe, only keep the rows where the `event_timestamp_column`
+--    is less than the one provided in the entity dataframe
+--    - If there a TTL for the current feature_view, also keep the rows where the `event_timestamp_column`
+--    is higher the the one provided minus the TTL
+--    - For each row, Join on the entity key and retrieve the `entity_row_unique_id` that has been
+--    computed previously
+--
+-- The output of this CTE will contain all the necessary information and already filtered out most
+-- of the data that is not relevant.
+
+{{ featureview.name }}__subquery AS (
+    SELECT
+        cast({{ featureview.event_timestamp_column }} as TIMESTAMP) as event_timestamp,
+        {{ featureview.created_timestamp_column ~ ' as created_timestamp,' if featureview.created_timestamp_column else '' }}
+        {{ featureview.entity_selections | join(', ')}},
+        {% for feature in featureview.features %}
+            {{ feature }} as {% if full_feature_names %}{{ featureview.name }}__{{feature}}{% else %}{{ feature }}{% endif %}{% if loop.last %}{% else %}, {% endif %}
+        {% endfor %}
+    FROM {{ featureview.table_subquery }}
+    WHERE cast({{ featureview.event_timestamp_column }} as TIMESTAMP) <= (SELECT MAX(entity_timestamp) FROM entity_dataframe)
+    {% if featureview.ttl == 0 %}{% else %}
+    AND cast({{ featureview.event_timestamp_column }} as TIMESTAMP) >= DATEADD((SELECT MIN(entity_timestamp) FROM entity_dataframe), -{{ featureview.ttl }}, "ss")
+    {% endif %}
+),
+
+{{ featureview.name }}__base AS (
+    SELECT
+        /*+ mapjoin({{ featureview.name }}__entity_dataframe)*/ subquery.*,
+        entity_dataframe.entity_timestamp,
+        entity_dataframe.{{featureview.name}}__entity_row_unique_id
+    FROM {{ featureview.name }}__subquery AS subquery
+    JOIN {{ featureview.name }}__entity_dataframe AS entity_dataframe
+    ON TRUE
+        AND subquery.event_timestamp <= entity_dataframe.entity_timestamp
+
+        {% if featureview.ttl == 0 %}{% else %}
+        AND subquery.event_timestamp >= DATEADD(entity_dataframe.entity_timestamp, -{{ featureview.ttl }}, "ss")
+        {% endif %}
+
+        {% for entity in featureview.entities %}
+        AND subquery.{{ entity }} = entity_dataframe.{{ entity }}
+        {% endfor %}
+),
+
+
+-- 2. If the `created_timestamp_column` has been set, we need to
+-- deduplicate the data first. This is done by calculating the
+-- `MAX(created_at_timestamp)` for each event_timestamp.
+-- We then join the data on the next CTE
+
+{% if featureview.created_timestamp_column %}
+{{ featureview.name }}__dedup AS (
+    SELECT
+        {{featureview.name}}__entity_row_unique_id,
+        event_timestamp,
+        MAX(created_timestamp) as created_timestamp
+    FROM {{ featureview.name }}__base
+    GROUP BY {{featureview.name}}__entity_row_unique_id, event_timestamp
+),
+{% endif %}
+
+
+-- 3. The data has been filtered during the first CTE "*__base"
+-- Thus we only need to compute the latest timestamp of each feature.
+
+{{ featureview.name }}__latest AS (
+    SELECT 
+        {{featureview.name}}__entity_row_unique_id,
+        event_timestamp,
+        created_timestamp
+    FROM
+    (
+        SELECT *,
+            ROW_NUMBER() OVER(
+                PARTITION BY {{featureview.name}}__entity_row_unique_id
+                ORDER BY event_timestamp DESC{% if featureview.created_timestamp_column %},created_timestamp DESC{% endif %}
+            ) AS row_number
+        FROM {{ featureview.name }}__base
+        {% if featureview.created_timestamp_column %}
+            JOIN {{ featureview.name }}__dedup
+            USING ({{featureview.name}}__entity_row_unique_id, event_timestamp, created_timestamp)
+        {% endif %}
+    )
+    WHERE row_number = 1
+),
+
+
+-- 4. Once we know the latest value of each feature for a given timestamp,
+-- we can join again the data back to the original "base" dataset
+
+{{ featureview.name }}__cleaned AS (
+    SELECT base.*,
+        {{featureview.name}}__entity_row_unique_id
+    FROM {{ featureview.name }}__base as base
+    JOIN {{ featureview.name }}__latest
+    USING(
+        {{featureview.name}}__entity_row_unique_id,
+        event_timestamp
+        {% if featureview.created_timestamp_column %}
+            ,created_timestamp
+        {% endif %}
+    )
+){% if loop.last %}{% else %}, {% endif %}
+
+
+{% endfor %}
+
+-- Joins the outputs of multiple time travel joins to a single table.
+-- The entity_dataframe dataset being our source of truth here.
+
+SELECT * 
+FROM entity_dataframe
+{% for featureview in featureviews %}
+LEFT JOIN (
+    SELECT
+        {{featureview.name}}__entity_row_unique_id
+        {% for feature in featureview.features %}
+            ,{% if full_feature_names %}{{ featureview.name }}__{{feature}}{% else %}{{ feature }}{% endif %}
+        {% endfor %}
+    FROM {{ featureview.name }}__cleaned
+) {{ featureview.name }}__u USING ({{featureview.name}}__entity_row_unique_id)
+{% endfor %}
+"""

--- a/sdk/python/feast/infra/offline_stores/maxcompute_source.py
+++ b/sdk/python/feast/infra/offline_stores/maxcompute_source.py
@@ -1,0 +1,222 @@
+from typing import Callable, Dict, Iterable, Optional, Tuple
+
+from feast import type_map
+from feast.data_source import DataSource
+from feast.errors import DataSourceNotFoundException
+from feast.infra.utils import aliyun_utils
+from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
+from feast.repo_config import RepoConfig
+from feast.value_type import ValueType
+
+
+class MaxcomputeSource(DataSource):
+    def __init__(
+        self,
+        event_timestamp_column: Optional[str] = "",
+        table_ref: Optional[str] = None,
+        created_timestamp_column: Optional[str] = "",
+        field_mapping: Optional[Dict[str, str]] = None,
+        date_partition_column: Optional[str] = "",
+        query: Optional[str] = None,
+    ):
+        self._maxcompute_options = MaxcomputeOptions(table_ref=table_ref, query=query)
+
+        super().__init__(
+            event_timestamp_column,
+            created_timestamp_column,
+            field_mapping,
+            date_partition_column,
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, MaxcomputeSource):
+            raise TypeError(
+                "Comparisons should only involve MaxcomputeSource class objects."
+            )
+
+        return (
+            self.maxcompute_options.table_ref == other.maxcompute_options.table_ref
+            and self.maxcompute_options.query == other.maxcompute_options.query
+            and self.event_timestamp_column == other.event_timestamp_column
+            and self.created_timestamp_column == other.created_timestamp_column
+            and self.field_mapping == other.field_mapping
+        )
+
+    @property
+    def table_ref(self):
+        return self._maxcompute_options.table_ref
+
+    @property
+    def query(self):
+        return self._maxcompute_options.query
+
+    @property
+    def maxcompute_options(self):
+        """
+        Returns the maxcompute options of this data source
+        """
+        return self._maxcompute_options
+
+    @maxcompute_options.setter
+    def maxcompute_options(self, maxcompute_options):
+        """
+        Sets the maxcompute options of this data source
+        """
+        self._maxcompute_options = maxcompute_options
+
+    @staticmethod
+    def from_proto(data_source: DataSourceProto):
+
+        assert data_source.HasField("maxcompute_options")
+
+        return MaxcomputeSource(
+            field_mapping=dict(data_source.field_mapping),
+            table_ref=data_source.maxcompute_options.table_ref,
+            event_timestamp_column=data_source.event_timestamp_column,
+            created_timestamp_column=data_source.created_timestamp_column,
+            date_partition_column=data_source.date_partition_column,
+            query=data_source.maxcompute_options.query,
+        )
+
+    def to_proto(self) -> DataSourceProto:
+        data_source_proto = DataSourceProto(
+            type=DataSourceProto.BATCH_BIGQUERY,
+            field_mapping=self.field_mapping,
+            maxcompute_options=self.maxcompute_options.to_proto(),
+        )
+
+        data_source_proto.event_timestamp_column = self.event_timestamp_column
+        data_source_proto.created_timestamp_column = self.created_timestamp_column
+        data_source_proto.date_partition_column = self.date_partition_column
+
+        return data_source_proto
+
+    def validate(self, config: RepoConfig):
+        from odps.errors import NoSuchObject as NoSuchObject
+
+        if not self.query:
+            client = aliyun_utils.get_maxcompute_client(
+                ak=config.offline_store.access_key,
+                sk=config.offline_store.secret_access_key,
+                project=config.offline_store.project,
+                region=config.offline_store.region,
+                endpoint=config.offline_store.end_point,
+            )
+
+            try:
+                client.get_table(self.table_ref)
+            except NoSuchObject:
+                raise DataSourceNotFoundException(self.table_ref)
+
+    def get_table_query_string(self) -> str:
+        """Returns a string that can directly be used to reference this table in SQL"""
+        if self.table_ref:
+            return f"`{self.table_ref}`"
+        else:
+            return f"({self.query})"
+
+    @staticmethod
+    def source_datatype_to_feast_value_type() -> Callable[[str], ValueType]:
+        return type_map.mc_to_feast_value_type
+
+    def get_table_column_names_and_types(
+        self, config: RepoConfig
+    ) -> Iterable[Tuple[str, str]]:
+        client = aliyun_utils.get_maxcompute_client(
+            ak=config.offline_store.access_key,
+            sk=config.offline_store.secret_access_key,
+            project=config.offline_store.project,
+            region=config.offline_store.region,
+            endpoint=config.offline_store.end_point,
+        )
+
+        if self.table_ref is not None:
+            table_schema = client.get_table(self.table_ref).schema
+            if not isinstance(
+                table_schema[0], odps.models.table.TableSchema.TableColumn
+            ):
+                raise TypeError("Could not parse Maxcompute table schema.")
+
+            name_type_pairs = [(field.name, field.type) for field in schema]
+        else:
+            mc_columns_query = f"SELECT * FROM ({self.query}) LIMIT 1"
+            queryRes = client.execute_sql(mc_columns_query)
+            with queryRes.open_reader() as reader:
+                for row in reader:
+                    name_type_pairs = [
+                        (schema.name, schema.type) for schema in row._columns
+                    ]
+                    break
+
+        return name_type_pairs
+
+
+class MaxcomputeOptions:
+    """
+    DataSource Maxcompute options used to source features from Aliyun Maxcompute query
+    """
+
+    def __init__(self, table_ref: Optional[str], query: Optional[str]):
+        self._table_ref = table_ref
+        self._query = query
+
+    @property
+    def query(self):
+        """
+        Returns the Maxcompute SQL query referenced by this source
+        """
+        return self._query
+
+    @query.setter
+    def query(self, query):
+        """
+        Sets the Maxcompute SQL query referenced by this source
+        """
+        self._query = query
+
+    @property
+    def table_ref(self):
+        """
+        Returns the table ref of this BQ table
+        """
+        return self._table_ref
+
+    @table_ref.setter
+    def table_ref(self, table_ref):
+        """
+        Sets the table ref of this BQ table
+        """
+        self._table_ref = table_ref
+
+    @classmethod
+    def from_proto(cls, maxcompute_options_proto: DataSourceProto.MaxcomputeOptions):
+        """
+        Creates a MaxcomputeOptions from a protobuf representation of a Maxcompute option
+
+        Args:
+            maxcompute_options_proto: A protobuf representation of a DataSource
+
+        Returns:
+            Returns a MaxcomputeOptions object based on the maxcompute_options protobuf
+        """
+
+        maxcompute_options = cls(
+            table_ref=maxcompute_options_proto.table_ref,
+            query=maxcompute_options_proto.query,
+        )
+
+        return maxcompute_options
+
+    def to_proto(self) -> DataSourceProto.MaxcomputeOptions:
+        """
+        Converts an MaxcomputeOptionsProto object to its protobuf representation.
+
+        Returns:
+            MaxcomputeOptionsProto protobuf
+        """
+
+        maxcompute_options_proto = DataSourceProto.MaxcomputeOptions(
+            table_ref=self.table_ref, query=self.query
+        )
+
+        return maxcompute_options_proto

--- a/sdk/python/feast/infra/online_stores/hologres.py
+++ b/sdk/python/feast/infra/online_stores/hologres.py
@@ -1,0 +1,223 @@
+# Copyright 2021 The Feast Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+import psycopg2
+import pytz
+from pydantic import PositiveInt, StrictStr
+from pydantic.schema import Literal
+
+from feast import Entity, FeatureTable
+from feast.feature_view import FeatureView
+from feast.infra.key_encoding_utils import serialize_entity_key
+from feast.infra.online_stores.online_store import OnlineStore
+from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+from feast.repo_config import FeastConfigBaseModel, RepoConfig
+
+
+class HologresOnlineStoreConfig(FeastConfigBaseModel):
+    """ Online store config for local (SQLite-based) store """
+
+    type: Literal[
+        "hologres", "feast.infra.online_stores.hologres.HologresOnlineStore"
+    ] = "sqlite"
+    """ Online store type selector"""
+
+    host: StrictStr = None
+    """ host to hologres db """
+
+    port: PositiveInt = 1
+    """ port to hologres db"""
+
+    dbname: StrictStr = None
+    """ db name to hologres db"""
+
+    user: StrictStr = None
+    """ user name to hologres db"""
+
+    password: StrictStr = None
+    """ passwrod to hologres db"""
+
+
+class HologresOnlineStore(OnlineStore):
+    """
+    OnlineStore is an object used for all interaction between Feast and the service used for offline storage of
+    features.
+    """
+
+    _conn: Optional[psycopg2.extensions.connection] = None
+
+    @staticmethod
+    def _get_db_connect_param(config: RepoConfig) -> str:
+        assert (
+            config.online_store.type == "hologres"
+            or config.online_store.type.endswith("HologresOnlineStore")
+        )
+
+        host = config.online_store.host
+        port = config.online_store.port
+        dbname = config.online_store.dbname
+        user = config.online_store.user
+        password = config.online_store.password
+        return host, port, dbname, user, password
+
+    def _get_conn(self, config: RepoConfig):
+        if not self._conn:
+            host, port, dbname, user, password = self._get_db_connect_param(config)
+            self._conn = psycopg2.connect(
+                host=host, port=port, dbname=dbname, user=user, password=password
+            )
+        return self._conn
+
+    def online_write_batch(
+        self,
+        config: RepoConfig,
+        table: Union[FeatureTable, FeatureView],
+        data: List[
+            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+        ],
+        progress: Optional[Callable[[int], Any]],
+    ) -> None:
+
+        conn = self._get_conn(config)
+
+        project = config.project
+
+        with conn:
+            cur = conn.cursor()
+            for entity_key, values, timestamp, created_ts in data:
+                entity_key_bin = serialize_entity_key(entity_key)
+                timestamp = _to_naive_utc(timestamp)
+                if created_ts is not None:
+                    created_ts = _to_naive_utc(created_ts)
+
+                for feature_name, val in values.items():
+                    cur.execute(
+                        f"""
+                            UPDATE {_table_id(project, table)}
+                            SET value = %s, event_ts = %s, created_ts = %s
+                            WHERE (entity_key = %s AND feature_name = %s)
+                        """,
+                        (
+                            # SET
+                            val.SerializeToString(),
+                            timestamp,
+                            created_ts,
+                            # WHERE
+                            entity_key_bin,
+                            feature_name,
+                        ),
+                    )
+
+                    cur.execute(
+                        f"""INSERT INTO {_table_id(project, table)}
+                            (entity_key, feature_name, value, event_ts, created_ts)
+                            VALUES (%s, %s, %s, %s, %s)
+                            ON CONFLICT(entity_key, feature_name) DO UPDATE SET 
+                            (entity_key, feature_name, value, event_ts, created_ts) = ROW(excluded.*);
+                            """,
+                        (
+                            entity_key_bin,
+                            feature_name,
+                            val.SerializeToString(),
+                            timestamp,
+                            created_ts,
+                        ),
+                    )
+                if progress:
+                    progress(1)
+
+    def online_read(
+        self,
+        config: RepoConfig,
+        table: Union[FeatureTable, FeatureView],
+        entity_keys: List[EntityKeyProto],
+        requested_features: Optional[List[str]] = None,
+    ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
+        conn = self._get_conn(config)
+        cur = conn.cursor()
+
+        result: List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]] = []
+
+        project = config.project
+        for entity_key in entity_keys:
+            entity_key_bin = serialize_entity_key(entity_key)
+
+            cur.execute(
+                f"SELECT feature_name, value, event_ts FROM {_table_id(project, table)} WHERE entity_key = %%s",
+                (entity_key_bin,),
+            )
+
+            res = {}
+            res_ts = None
+            for feature_name, val_bin, ts in cur.fetchall():
+                val = ValueProto()
+                val.ParseFromString(val_bin)
+                res[feature_name] = val
+                res_ts = ts
+
+            if not res:
+                result.append((None, None))
+            else:
+                result.append((res_ts, res))
+        return result
+
+    def update(
+        self,
+        config: RepoConfig,
+        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
+        tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
+        entities_to_delete: Sequence[Entity],
+        entities_to_keep: Sequence[Entity],
+        partial: bool,
+    ):
+        conn = self._get_conn(config)
+        cur = conn.cursor()
+        project = config.project
+
+        # create feast schema
+        cur.execute("CREATE SCHEMA IF NOT EXISTS feast")
+        for table in tables_to_keep:
+            sql = f"CREATE TABLE IF NOT EXISTS {_table_id(project, table)} (entity_key BYTEA, feature_name TEXT, value BYTEA, event_ts timestamp, created_ts timestamp,  PRIMARY KEY(entity_key, feature_name))"
+            cur.execute(sql)
+            conn.commit()
+
+        for table in tables_to_delete:
+            cur.execute(f"DROP TABLE IF EXISTS {_table_id(project, table)}")
+            conn.commit()
+
+    def teardown(
+        self,
+        config: RepoConfig,
+        tables: Sequence[Union[FeatureTable, FeatureView]],
+        entities: Sequence[Entity],
+    ):
+        conn = self._get_conn(config)
+        conn.close()
+
+
+def _table_id(project: str, table: Union[FeatureTable, FeatureView]) -> str:
+    return f"feast.{project}_{table.name}"
+
+
+def _to_naive_utc(ts: datetime):
+    if ts.tzinfo is None:
+        return ts
+    else:
+        return ts.astimezone(pytz.utc).replace(tzinfo=None)

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -152,6 +152,10 @@ def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
             from feast.infra.aws import AwsProvider
 
             return AwsProvider(config)
+        elif config.provider == "aliyun":
+            from feast.infra.aliyun import AliyunProvider
+
+            return AliyunProvider(config)
         elif config.provider == "local":
             from feast.infra.local import LocalProvider
 

--- a/sdk/python/feast/infra/utils/aliyun_utils.py
+++ b/sdk/python/feast/infra/utils/aliyun_utils.py
@@ -1,0 +1,33 @@
+import os
+from typing import Callable, Dict, Iterable, Optional, Tuple
+
+import pandas as pd
+
+from feast.errors import MaxcomputeCredentialsError, MaxcomputeQueryError
+from feast.type_map import pa_to_redshift_value_type
+
+try:
+    import odps
+except ImportError as e:
+    from odps.errors import NoSuchObject as NoSuchObject
+
+    from feast.errors import FeastExtrasDependencyImportError
+
+    raise FeastExtrasDependencyImportError("aliyun", str(e))
+
+
+def get_maxcompute_client(
+    ak: str, sk: str, project: str, region: str, endpoint: Optional[str] = ""
+):
+    try:
+        o = odps.ODPS(
+            access_id=ak, secret_access_key=sk, project=project, endpoint=endpoint
+        )
+    except:
+        raise FeastProviderLoginError(
+            "Aliyun error: "
+            + str(e)
+            + "\nIt may be necessary to set a default Aliyun project by running "
+            '"gcloud config set project your-project"'
+        )
+    return o

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -24,12 +24,14 @@ ONLINE_STORE_CLASS_FOR_TYPE = {
     "datastore": "feast.infra.online_stores.datastore.DatastoreOnlineStore",
     "redis": "feast.infra.online_stores.redis.RedisOnlineStore",
     "dynamodb": "feast.infra.online_stores.dynamodb.DynamoDBOnlineStore",
+    "hologres": "feast.infra.online_stores.hologres.HologresOnlineStore",
 }
 
 OFFLINE_STORE_CLASS_FOR_TYPE = {
     "file": "feast.infra.offline_stores.file.FileOfflineStore",
     "bigquery": "feast.infra.offline_stores.bigquery.BigQueryOfflineStore",
     "redshift": "feast.infra.offline_stores.redshift.RedshiftOfflineStore",
+    "maxcompute": "feast.infra.offline_stores.maxcompute.MaxcomputeOfflineStore",
 }
 
 
@@ -138,6 +140,8 @@ class RepoConfig(FeastBaseModel):
                 values["online_store"]["type"] = "datastore"
             elif values["provider"] == "aws":
                 values["online_store"]["type"] = "dynamodb"
+            elif values["provider"] == "aliyun":
+                values["online_store"]["type"] = "hologres"
 
         online_store_type = values["online_store"]["type"]
 
@@ -173,6 +177,8 @@ class RepoConfig(FeastBaseModel):
                 values["offline_store"]["type"] = "bigquery"
             elif values["provider"] == "aws":
                 values["offline_store"]["type"] = "redshift"
+            elif values["provider"] == "aliyun":
+                values["offline_store"]["type"] = "maxcompute"
 
         offline_store_type = values["offline_store"]["type"]
 

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -245,7 +245,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     all_to_delete.extend(views_to_delete)
     all_to_keep: List[Union[FeatureTable, FeatureView]] = []
     all_to_keep.extend(tables_to_keep)
-    all_to_keep.extend(views_to_delete)
+    all_to_keep.extend(views_to_keep)
     infra_provider.update_infra(
         project,
         tables_to_delete=all_to_delete,

--- a/sdk/python/feast/templates/aliyun/bootstrap.py
+++ b/sdk/python/feast/templates/aliyun/bootstrap.py
@@ -1,0 +1,97 @@
+# Copy from aws template
+import click
+
+import odps 
+from feast.infra.utils import aliyun_utils
+import pandas as pd
+import time
+
+def replace_str_in_file(file_path, match_str, sub_str):
+    with open(file_path, "r") as f:
+        contents = f.read()
+    contents = contents.replace(match_str, sub_str)
+    with open(file_path, "wt") as f:
+        f.write(contents)
+
+
+def bootstrap():
+    # Bootstrap() will automatically be called from the init_repo() during `feast init`
+
+    import pathlib
+    from datetime import datetime, timedelta
+
+    from feast.driver_test_data import create_driver_hourly_stats_df
+
+    end_date = datetime.now().replace(microsecond=0, second=0, minute=0)
+    start_date = end_date - timedelta(days=15)
+
+    driver_entities = [1001, 1002, 1003, 1004, 1005]
+    driver_df = create_driver_hourly_stats_df(driver_entities, start_date, end_date)
+
+    ak = click.prompt("Aliyun access key")
+    sk = click.prompt("Aliyun sercet key")
+    p = click.prompt("Maxcompute project")
+    region = click.prompt("Maxcompute region")
+    endpoint = click.prompt("Maxcompute endpoint")
+    
+    holo_host = click.prompt("Aliyun Hologres host")
+    holo_port = click.prompt("Aliyun Hologres port")
+    holo_db = click.prompt("Aliyun Hologres db")
+
+    client = client = aliyun_utils.get_maxcompute_client(
+            ak=ak,
+            sk=sk,
+            project=p,
+            region=region,
+            endpoint=endpoint,
+        )
+
+    if click.confirm(
+        "Should I upload example data to Maxcompute (overwriting 'feast_driver_hourly_stats' table)?",
+        default=True,
+    ):
+        
+        upload_df = odps.df.DataFrame(driver_df)
+        upload_df.persist("feast_driver_hourly_stats", odps=client, lifecycle=1)
+        print("upload `feast_driver_hourly_stats` succ!")
+    
+    if click.confirm(
+        "Should I upload entity data to Maxcompute (overwriting 'feast_driver_entity_table' table)?",
+        default=True,
+    ):
+        entity_df = pd.DataFrame(
+		{
+		    "event_timestamp": [
+			pd.Timestamp(dt, unit="ms", tz="UTC").round("ms")
+			for dt in pd.date_range(
+			    start=datetime.now() - timedelta(days=2),
+			    end=datetime.now(),
+			    periods=2,
+			)
+		    ],
+		    "driver_id": [1004, 1005],
+		}
+	    )
+
+       
+
+        upload_df = odps.df.DataFrame(entity_df)
+        upload_df.persist("feast_driver_entity_table", odps=client, lifecycle=1)
+        print("upload `feast_driver_entity_table` succ!")
+
+    repo_path = pathlib.Path(__file__).parent.absolute()
+    config_file = repo_path / "feature_store.yaml"
+
+    replace_str_in_file(config_file, "%ALIYUN_REGION%", region)
+    replace_str_in_file(config_file, "%ALIYUN_ACCESS_KEY%", ak)
+    replace_str_in_file(config_file, "%ALIYUN_SECRET_KEY%", sk)
+    replace_str_in_file(config_file, "%MAXCOMPUTE_PROJECT%", p)
+    replace_str_in_file(config_file, "%MAXCOMPUTE_ENDPOINT%", endpoint) 
+    replace_str_in_file(config_file, "%HOLOGRES_HOST%", holo_host)
+    replace_str_in_file(config_file, "%HOLOGRES_PORT%", holo_port)
+    replace_str_in_file(config_file, "%HOLOGRES_DB%", holo_db)
+
+
+
+if __name__ == "__main__":
+    bootstrap()

--- a/sdk/python/feast/templates/aliyun/feature_declare.py
+++ b/sdk/python/feast/templates/aliyun/feature_declare.py
@@ -1,0 +1,34 @@
+# Copy from aws template
+# This is an example feature definition file
+
+from google.protobuf.duration_pb2 import Duration
+
+from feast import Entity, Feature, FeatureView, FileSource, ValueType
+from feast import MaxcomputeSource
+
+driver_stats_source = MaxcomputeSource(
+    # The maxcompute table where features can be found
+    table_ref = "feast_driver_stats_source",
+    # The event timestamp is used for point-in-time joins
+    event_timestamp_column="event_timestamp",
+    # The create timestamp, recommand as a partition column
+    created_timestamp_column="created",
+)
+
+driver = Entity(name="driver_id", join_key="driver_id", value_type=ValueType.INT64, description="driver id",)
+
+# Feature views are a grouping based on how features are stored in either the
+# online or offline store.
+test_view = FeatureView(
+    name="driver_hourly_stats",
+    entities=["driver_id"],
+    ttl=Duration(seconds=86400 * 15),
+    features=[
+        Feature(name="conv_rate", dtype=ValueType.FLOAT),
+        Feature(name="acc_rate", dtype=ValueType.FLOAT),
+        Feature(name="avg_daily_trips", dtype=ValueType.INT64),
+    ],
+    online=True,
+    batch_source=driver_stats_source,
+    tags={},
+)

--- a/sdk/python/feast/templates/aliyun/feature_store.yaml
+++ b/sdk/python/feast/templates/aliyun/feature_store.yaml
@@ -1,0 +1,17 @@
+project: fond_tomcat
+registry: data/registry.db
+provider: aliyun
+offline_store:
+    type: maxcompute
+    access_key: %ALIYUN_ACCESS_KEY% 
+    secret_access_key: %ALIYUN_SECRET_KEY%
+    end_point: %MAXCOMPUTE_ENDPOINT%
+    region: %ALIYUN_REGION%
+    project: %MAXCOMPUTE_PROJECT%
+online_store:
+    type: hologres
+    host: %HOLOGRES_HOST%
+    port: %HOLOGRES_PORT%
+    dbname: %HOLOGRES_DB% 
+    user: %ALIYUN_ACCESS_KEY%
+    password: %ALIYUN_SECRET_KEY%

--- a/sdk/python/feast/templates/aliyun/test.py
+++ b/sdk/python/feast/templates/aliyun/test.py
@@ -1,0 +1,47 @@
+# Copy from aws template
+from google.protobuf.duration_pb2 import Duration
+
+from feast import Entity, Feature, FeatureView, FileSource, ValueType, FeatureService, FeatureStore
+from feature_declare import driver_stats_source, driver, test_view
+import pandas as pd
+from datetime import datetime,timedelta
+import time
+
+fs = FeatureStore(repo_path=".")
+# Deploy the feature store
+fs.apply([driver, test_view])
+
+# Create an entity dataframe. This is the dataframe that will be enriched with historical features
+entity_df = pd.DataFrame(
+        {
+            "event_timestamp": [
+                pd.Timestamp(dt, unit="ms", tz="UTC").round("ms")
+                for dt in pd.date_range(
+                    start=datetime.now() - timedelta(days=3),
+                    end=datetime.now(),
+                    periods=3,
+                )
+            ],
+            "driver_id": [1001, 1002, 1003],
+        }
+    )
+# Select features
+features = ["driver_hourly_stats:conv_rate", "driver_hourly_stats:acc_rate"]
+
+training_df = fs.get_historical_features(
+        entity_df=entity_df,
+        features=features,
+)
+
+print(training_df.to_df())
+
+# Export historical features to maxcompute
+print(training_df.to_maxcompute("my_samples"))
+
+training_df = fs.get_historical_features(
+        entity_df="feast_driver_entity_table",
+        features=features,
+)
+
+print("Loading features into the online store...")
+fs.materialize_incremental(end_date=datetime.now())

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -339,6 +339,29 @@ def bq_to_feast_value_type(bq_type_as_str):
     return type_map[bq_type_as_str]
 
 
+def mc_to_feast_value_type(mc_type_as_str):
+    # Type names from https://www.alibabacloud.com/help/doc-detail/159541.htm?spm=a2c63.l28256.b99.156.56307cfcDOy8Y2
+    type_map: Dict[ValueType, Union[str, Dict[str, Any]]] = {
+       "TINYINT": ValueType.INT64, 
+       "SMALLINT": ValueType.INT64, 
+       "INT": ValueType.INT64, 
+       "BIGINT": ValueType.INT64, 
+       "BINARY": ValueType.BYTES, 
+       "FLOAT": ValueType.DOUBLE, 
+       "DOUBLE": ValueType.DOUBLE, 
+       "DECIMAL": ValueType.DOUBLE, 
+       "VARCHAR": ValueType.STRING, 
+       "CHAR": ValueType.STRING, 
+       "STRING": ValueType.STRING, 
+       "DATE": ValueType.STRING, 
+       "DATETIME": ValueType.STRING, 
+       "TIMESTAMP": ValueType.UNIX_TIMESTAMP, 
+       "BOOLEAN": ValueType.UNIX_TIMESTAMP 
+    }
+
+    return type_map[mc_type_as_str]
+
+
 def redshift_to_feast_value_type(redshift_type_as_str: str) -> ValueType:
     # Type names from https://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
     type_map = {


### PR DESCRIPTION
Support Aliyun provider , Add Maxcompute offline store and Hologres onlie store (#1860)


**What this PR does / why we need it**:
Support Aliyun provider , Add Maxcompute offline store and Hologres onlie store
**Which issue(s) this PR fixes**:
No

**Does this PR introduce a user-facing change?**:

add `aliyun` template

    feast init -t aliyun

the config example:

    project: fond_tomcat
    registry: data/registry.db
    provider: aliyun
    offline_store:
        type: maxcompute
        access_key: %ALIYUN_ACCESS_KEY% 
        secret_access_key: %ALIYUN_SECRET_KEY%
        end_point: %MAXCOMPUTE_ENDPOINT%
        region: %ALIYUN_REGION%
        project: %MAXCOMPUTE_PROJECT%
    online_store:
        type: hologres
        host: %HOLOGRES_HOST%
        port: %HOLOGRES_PORT%
        dbname: %HOLOGRES_DB% 
        user: %ALIYUN_ACCESS_KEY%
        password: %ALIYUN_SECRET_KEY%

-->
```release-note

```
