### PR TITLE
Add feature server configuration for AWS lambda

### DIFF
--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -93,6 +93,25 @@ class FeastProviderNotImplementedError(Exception):
         super().__init__(f"Provider '{provider_name}' is not implemented")
 
 
+class FeastProviderNotSetError(Exception):
+    def __init__(self):
+        super().__init__("Provider is not set, but is required")
+
+
+class FeastFeatureServerTypeSetError(Exception):
+    def __init__(self, feature_server_type: str):
+        super().__init__(
+            f"Feature server type was set to {feature_server_type}, but the type should be determined by the provider"
+        )
+
+
+class FeastFeatureServerTypeInvalidError(Exception):
+    def __init__(self, feature_server_type: str):
+        super().__init__(
+            f"Feature server type was set to {feature_server_type}, but this type is invalid"
+        )
+
+
 class FeastModuleImportError(Exception):
     def __init__(self, module_name: str, module_type: str):
         super().__init__(f"Could not import {module_type} module '{module_name}'")

--- a/sdk/python/feast/infra/feature_servers/aws_lambda/app.py
+++ b/sdk/python/feast/infra/feature_servers/aws_lambda/app.py
@@ -1,0 +1,23 @@
+from pydantic import StrictBool, StrictStr
+from pydantic.typing import Literal
+
+from feast.repo_config import FeastConfigBaseModel
+
+
+class AwsLambdaFeatureServerConfig(FeastConfigBaseModel):
+    """Feature server config for AWS Lambda."""
+
+    type: Literal["aws_lambda"] = "aws_lambda"
+    """Feature server type selector."""
+
+    enabled: StrictBool
+    """Whether the feature server should be launched."""
+
+    public: StrictBool
+    """Whether the endpoint should be publicly accessible."""
+
+    auth: StrictStr
+    """Authentication method for the endpoint."""
+
+    execution_role_name: StrictStr
+    """The execution role for the AWS Lambda function."""

--- a/sdk/python/feast/infra/feature_servers/aws_lambda/config.py
+++ b/sdk/python/feast/infra/feature_servers/aws_lambda/config.py
@@ -10,13 +10,13 @@ class AwsLambdaFeatureServerConfig(FeastConfigBaseModel):
     type: Literal["aws_lambda"] = "aws_lambda"
     """Feature server type selector."""
 
-    enabled: StrictBool
+    enabled: StrictBool = False
     """Whether the feature server should be launched."""
 
-    public: StrictBool
+    public: StrictBool = True
     """Whether the endpoint should be publicly accessible."""
 
-    auth: StrictStr
+    auth: Literal["none", "api-key"] = "none"
     """Authentication method for the endpoint."""
 
     execution_role_name: StrictStr

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -213,6 +213,10 @@ class RepoConfig(FeastBaseModel):
         if "feature_server" not in values:
             return values
 
+        # Skip if we aren't creating the configuration from a dict
+        if not isinstance(values["feature_server"], Dict):
+            return values
+
         # Make sure that the provider configuration is set. We need it to set the defaults
         if "provider" not in values:
             raise FeastProviderNotSetError()

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -33,7 +33,7 @@ OFFLINE_STORE_CLASS_FOR_TYPE = {
 }
 
 FEATURE_SERVER_CONFIG_CLASS_FOR_TYPE = {
-    "aws_lambda": "feast.infra.feature_servers.aws_lambda.app.AwsLambdaFeatureServerConfig",
+    "aws_lambda": "feast.infra.feature_servers.aws_lambda.config.AwsLambdaFeatureServerConfig",
 }
 
 

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -95,6 +95,9 @@ class RepoConfig(FeastBaseModel):
     offline_store: Any
     """ OfflineStoreConfig: Offline store configuration (optional depending on provider) """
 
+    feature_server: Any
+    """ FeatureServerConfig: Feature server configuration (optional depending on provider) """
+
     repo_path: Optional[Path] = None
 
     def __init__(self, **data: Any):
@@ -113,6 +116,11 @@ class RepoConfig(FeastBaseModel):
             )(**self.offline_store)
         elif isinstance(self.offline_store, str):
             self.offline_store = get_offline_config_from_type(self.offline_store)()
+
+        if isinstance(self.feature_server, Dict):
+            self.feature_server = get_feature_server_config_from_type(
+                self.feature_server["type"]
+            )(**self.feature_server)
 
     def get_registry_config(self):
         if isinstance(self.registry, str):
@@ -203,6 +211,7 @@ class RepoConfig(FeastBaseModel):
     def _validate_feature_server_config(cls, values):
         # Having no feature server is the default.
         if "feature_server" not in values:
+            values["feature_server"] = dict()
             return values
 
         # Make sure that the provider configuration is set. We need it to set the defaults

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -95,7 +95,7 @@ class RepoConfig(FeastBaseModel):
     offline_store: Any
     """ OfflineStoreConfig: Offline store configuration (optional depending on provider) """
 
-    feature_server: Any
+    feature_server: Optional[Any]
     """ FeatureServerConfig: Feature server configuration (optional depending on provider) """
 
     repo_path: Optional[Path] = None
@@ -211,7 +211,6 @@ class RepoConfig(FeastBaseModel):
     def _validate_feature_server_config(cls, values):
         # Having no feature server is the default.
         if "feature_server" not in values:
-            values["feature_server"] = dict()
             return values
 
         # Make sure that the provider configuration is set. We need it to set the defaults


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: This PR adds the option to add a feature server configuration to `feature_store.yaml`. Right now, only AWS lambda is supported.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The user can now define a feature server in `feature_store.yaml`.
```
