### PR TITLE
Read registry & config from env variables in AWS Lambda feature server

### DIFF
--- a/sdk/python/feast/infra/feature_servers/app.py
+++ b/sdk/python/feast/infra/feature_servers/app.py
@@ -1,13 +1,39 @@
+import base64
+import os
+import tempfile
+from pathlib import Path
+
+import yaml
 from mangum import Mangum
 
-import feast
+from feast import FeatureStore
 from feast.feature_server import get_app
 
-# TODO: replace this with an actual feature repo config deserialized from the env variables
-config = feast.RepoConfig()
+# Load RepoConfig
+config_base64 = os.environ["FEAST_CONFIG_BASE64"]
+config_bytes = base64.b64decode(config_base64)
 
-store = feast.FeatureStore(config=config)
+# Override the registry path
+config_yaml = yaml.safe_load(config_bytes)
+config_yaml["registry"] = "registry.db"
+config_bytes = yaml.safe_dump(config_yaml).encode()
 
+# Load Registry
+registry_base64 = os.environ["FEAST_REGISTRY_BASE64"]
+registry_bytes = base64.b64decode(registry_base64)
+
+# Create a new unique directory for writing feature_store.yaml and registry.db files
+repo_path = Path(tempfile.mkdtemp())
+
+with open(repo_path / "feature_store.yaml", "wb") as f:
+    f.write(config_bytes)
+
+with open(repo_path / "registry.db", "wb") as f:
+    f.write(registry_bytes)
+
+# Initialize the feature store
+store = FeatureStore(repo_path=str(repo_path.resolve()))
+
+# Create the FastAPI app and AWS Lambda handler
 app = get_app(store)
-
 handler = Mangum(app)


### PR DESCRIPTION
Signed-off-by: Tsotne Tabidze <tsotne@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: We want to read registry (binary) and config (feature_store.yaml) via base64-encoded environment variables. They'll be set during `feast apply` when deploying AWS Lambda resource.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
