### PR TITLE
Adding telemetry for on demand feature views and making existing usage calls async

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -56,11 +56,12 @@ from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.registry import Registry
 from feast.repo_config import RepoConfig, load_repo_config
 from feast.type_map import python_value_to_proto_value
-from feast.usage import log_exceptions, log_exceptions_and_usage
+from feast.usage import log_event, log_exceptions, log_exceptions_and_usage
 from feast.value_type import ValueType
 from feast.version import get_version
 
 warnings.simplefilter("once", DeprecationWarning)
+EVENT_APPLY_WITH_ODFV = "apply_with_on_demand_feature_views"
 
 
 class FeatureStore:
@@ -386,6 +387,9 @@ class FeatureStore:
             and len(odfvs_to_update) > 0
         ):
             raise ExperimentalFeatureNotEnabled(flags.FLAG_ON_DEMAND_TRANSFORM_NAME)
+
+        if len(odfvs_to_update) > 0:
+            log_event(EVENT_APPLY_WITH_ODFV)
 
         _validate_feature_views(views_to_update)
         entities_to_update = [ob for ob in objects if isinstance(ob, Entity)]

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -56,13 +56,11 @@ from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.registry import Registry
 from feast.repo_config import RepoConfig, load_repo_config
 from feast.type_map import python_value_to_proto_value
-from feast.usage import log_event, log_exceptions, log_exceptions_and_usage
+from feast.usage import UsageEvent, log_event, log_exceptions, log_exceptions_and_usage
 from feast.value_type import ValueType
 from feast.version import get_version
 
 warnings.simplefilter("once", DeprecationWarning)
-EVENT_APPLY_WITH_ODFV = "apply_with_on_demand_feature_views"
-EVENT_GET_HISTORICAL_FEATURES_WITH_ODFV = "get_historical_features_with_on_demand_feature_views"
 
 
 class FeatureStore:
@@ -390,7 +388,7 @@ class FeatureStore:
             raise ExperimentalFeatureNotEnabled(flags.FLAG_ON_DEMAND_TRANSFORM_NAME)
 
         if len(odfvs_to_update) > 0:
-            log_event(EVENT_APPLY_WITH_ODFV)
+            log_event(UsageEvent.APPLY_WITH_ODFV)
 
         _validate_feature_views(views_to_update)
         entities_to_update = [ob for ob in objects if isinstance(ob, Entity)]
@@ -558,7 +556,7 @@ class FeatureStore:
         feature_views = list(view for view, _ in fvs)
         on_demand_feature_views = list(view for view, _ in odfvs)
         if len(on_demand_feature_views) > 0:
-            log_event(EVENT_GET_HISTORICAL_FEATURES_WITH_ODFV)
+            log_event(UsageEvent.GET_HISTORICAL_FEATURES_WITH_ODFV)
 
         # Check that the right request data is present in the entity_df
         if type(entity_df) == pd.DataFrame:
@@ -817,6 +815,9 @@ class FeatureStore:
         grouped_refs, grouped_odfv_refs = _group_feature_refs(
             _feature_refs, all_feature_views, all_on_demand_feature_views
         )
+        if len(grouped_odfv_refs) > 0:
+            log_event(UsageEvent.GET_ONLINE_FEATURES_WITH_ODFV)
+
         feature_views = list(view for view, _ in grouped_refs)
         entityless_case = DUMMY_ENTITY_NAME in [
             entity_name

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -885,46 +885,16 @@ class FeatureStore:
                     feature_name
                 ] = GetOnlineFeaturesResponse.FieldStatus.PRESENT
 
-        # Note: each "table" is a feature view
         for table, requested_features in grouped_refs:
-            entity_keys = _get_table_entity_keys(
-                table, union_of_entity_keys, entity_name_to_join_key_map
+            self._populate_result_rows_from_feature_view(
+                entity_name_to_join_key_map,
+                full_feature_names,
+                provider,
+                requested_features,
+                result_rows,
+                table,
+                union_of_entity_keys,
             )
-            read_rows = provider.online_read(
-                config=self.config,
-                table=table,
-                entity_keys=entity_keys,
-                requested_features=requested_features,
-            )
-            # Each row is a set of features for a given entity key
-            for row_idx, read_row in enumerate(read_rows):
-                row_ts, feature_data = read_row
-                result_row = result_rows[row_idx]
-
-                if feature_data is None:
-                    for feature_name in requested_features:
-                        feature_ref = (
-                            f"{table.name}__{feature_name}"
-                            if full_feature_names
-                            else feature_name
-                        )
-                        result_row.statuses[
-                            feature_ref
-                        ] = GetOnlineFeaturesResponse.FieldStatus.NOT_FOUND
-                else:
-                    for feature_name in feature_data:
-                        feature_ref = (
-                            f"{table.name}__{feature_name}"
-                            if full_feature_names
-                            else feature_name
-                        )
-                        if feature_name in requested_features:
-                            result_row.fields[feature_ref].CopyFrom(
-                                feature_data[feature_name]
-                            )
-                            result_row.statuses[
-                                feature_ref
-                            ] = GetOnlineFeaturesResponse.FieldStatus.PRESENT
 
         initial_response = OnlineResponse(
             GetOnlineFeaturesResponse(field_values=result_rows)
@@ -932,6 +902,55 @@ class FeatureStore:
         return self._augment_response_with_on_demand_transforms(
             _feature_refs, full_feature_names, initial_response, result_rows
         )
+
+    def _populate_result_rows_from_feature_view(
+        self,
+        entity_name_to_join_key_map: Dict[str, str],
+        full_feature_names: bool,
+        provider: Provider,
+        requested_features: List[str],
+        result_rows: List[GetOnlineFeaturesResponse.FieldValues],
+        table: FeatureView,
+        union_of_entity_keys: List[EntityKeyProto],
+    ):
+        entity_keys = _get_table_entity_keys(
+            table, union_of_entity_keys, entity_name_to_join_key_map
+        )
+        read_rows = provider.online_read(
+            config=self.config,
+            table=table,
+            entity_keys=entity_keys,
+            requested_features=requested_features,
+        )
+        # Each row is a set of features for a given entity key
+        for row_idx, read_row in enumerate(read_rows):
+            row_ts, feature_data = read_row
+            result_row = result_rows[row_idx]
+
+            if feature_data is None:
+                for feature_name in requested_features:
+                    feature_ref = (
+                        f"{table.name}__{feature_name}"
+                        if full_feature_names
+                        else feature_name
+                    )
+                    result_row.statuses[
+                        feature_ref
+                    ] = GetOnlineFeaturesResponse.FieldStatus.NOT_FOUND
+            else:
+                for feature_name in feature_data:
+                    feature_ref = (
+                        f"{table.name}__{feature_name}"
+                        if full_feature_names
+                        else feature_name
+                    )
+                    if feature_name in requested_features:
+                        result_row.fields[feature_ref].CopyFrom(
+                            feature_data[feature_name]
+                        )
+                        result_row.statuses[
+                            feature_ref
+                        ] = GetOnlineFeaturesResponse.FieldStatus.PRESENT
 
     def _get_needed_request_data_features(self, grouped_odfv_refs) -> Set[str]:
         needed_request_data_features = set()

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -62,6 +62,7 @@ from feast.version import get_version
 
 warnings.simplefilter("once", DeprecationWarning)
 EVENT_APPLY_WITH_ODFV = "apply_with_on_demand_feature_views"
+EVENT_GET_HISTORICAL_FEATURES_WITH_ODFV = "get_historical_features_with_on_demand_feature_views"
 
 
 class FeatureStore:
@@ -556,6 +557,8 @@ class FeatureStore:
         )
         feature_views = list(view for view, _ in fvs)
         on_demand_feature_views = list(view for view, _ in odfvs)
+        if len(on_demand_feature_views) > 0:
+            log_event(EVENT_GET_HISTORICAL_FEATURES_WITH_ODFV)
 
         # Check that the right request data is present in the entity_df
         if type(entity_df) == pd.DataFrame:

--- a/sdk/python/feast/usage.py
+++ b/sdk/python/feast/usage.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import enum
 import logging
 import os
 import sys
@@ -28,6 +29,21 @@ from feast.version import get_version
 
 USAGE_ENDPOINT = "https://usage.feast.dev"
 _logger = logging.getLogger(__name__)
+
+
+@enum.unique
+class UsageEvent(enum.Enum):
+    """
+    An event meant to be logged
+    """
+
+    UNKNOWN = 0
+    APPLY_WITH_ODFV = 1
+    GET_HISTORICAL_FEATURES_WITH_ODFV = 2
+    GET_ONLINE_FEATURES_WITH_ODFV = 3
+
+    def __str__(self):
+        return self.name.lower()
 
 
 class Usage:
@@ -51,7 +67,7 @@ class Usage:
                     usage_filepath = join(feast_home_dir, "usage")
 
                     self._is_test = os.getenv("FEAST_IS_USAGE_TEST", "False") == "True"
-                    self._usage_counter = {"get_online_features": 0}
+                    self._usage_counter = {}
 
                     if os.path.exists(usage_filepath):
                         with open(usage_filepath, "r") as f:
@@ -91,11 +107,11 @@ class Usage:
     def log_function(self, function_name: str):
         self.check_env_and_configure()
         if self._usage_enabled and self.usage_id:
-            if function_name == "get_online_features":
-                self._usage_counter["get_online_features"] += 1
-                if self._usage_counter["get_online_features"] % 10000 != 2:
-                    return
-                self._usage_counter["get_online_features"] = 2  # avoid overflow
+            if (
+                function_name == "get_online_features"
+                and not self.should_log_for_get_online_features_event(function_name)
+            ):
+                return
             json = {
                 "function_name": function_name,
                 "usage_id": self.usage_id,
@@ -105,13 +121,25 @@ class Usage:
                 "is_test": self._is_test,
             }
             asyncio.run(self._send_usage_request(json))
-            return
 
-    def log_event(self, function_name: str):
+    def should_log_for_get_online_features_event(self, event_name: str):
+        if event_name not in self._usage_counter:
+            self._usage_counter[event_name] = 0
+        self._usage_counter[event_name] += 1
+        if self._usage_counter[event_name] % 10000 != 2:
+            return False
+        self._usage_counter[event_name] = 2  # avoid overflow
+        return True
+
+    def log_event(self, event: UsageEvent):
         self.check_env_and_configure()
         if self._usage_enabled and self.usage_id:
+            event_name = str(event)
+            if event == UsageEvent.GET_ONLINE_FEATURES_WITH_ODFV:
+                if not self.should_log_for_get_online_features_event(event_name):
+                    return
             json = {
-                "event_name": function_name,
+                "event_name": event_name,
                 "usage_id": self.usage_id,
                 "timestamp": datetime.utcnow().isoformat(),
                 "version": get_version(),
@@ -119,7 +147,6 @@ class Usage:
                 "is_test": self._is_test,
             }
             asyncio.run(self._send_usage_request(json))
-            return
 
     def log_exception(self, error_type: str, traceback: List[Tuple[str, int, str]]):
         self.check_env_and_configure()
@@ -193,8 +220,8 @@ def log_exceptions_and_usage(func):
     return exception_logging_wrapper
 
 
-def log_event(event_name: str):
-    usage.log_event(event_name)
+def log_event(event: UsageEvent):
+    usage.log_event(event)
 
 
 def _trim_filename(filename: str) -> str:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Adding telemetry for on demand feature views and making existing usage calls async

Tested this locally to ensure the events are logged correctly and that the get_online_features logs only trigger once every 10k requests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
