### PR TITLE
Fix pytest_collection_modifyitems to select benchmark tests only

### DIFF
--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -14,9 +14,11 @@
 import multiprocessing
 from datetime import datetime, timedelta
 from sys import platform
+from typing import List
 
 import pandas as pd
 import pytest
+from _pytest.nodes import Item
 
 from tests.data.data_creator import create_dataset
 from tests.integration.feature_repos.repo_configuration import (
@@ -52,18 +54,27 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config, items: List[Item]):
     should_run_integration = config.getoption("--integration") is True
     should_run_benchmark = config.getoption("--benchmark") is True
-    skip_integration = pytest.mark.skip(
-        reason="not running tests with external dependencies"
-    )
-    skip_benchmark = pytest.mark.skip(reason="not running benchmarks")
-    for item in items:
-        if "integration" in item.keywords and not should_run_integration:
-            item.add_marker(skip_integration)
-        if "benchmark" in item.keywords and not should_run_benchmark:
-            item.add_marker(skip_benchmark)
+
+    integration_tests = {t for t in items if "integration" in t.keywords}
+    if not should_run_integration:
+        for t in integration_tests:
+            items.remove(t)
+    else:
+        items.clear()
+        for t in integration_tests:
+            items.append(t)
+
+    benchmark_tests = {t for t in items if "benchmark" in t.keywords}
+    if not should_run_benchmark:
+        for t in benchmark_tests:
+            items.remove(t)
+    else:
+        items.clear()
+        for t in benchmark_tests:
+            items.append(t)
 
 
 @pytest.fixture

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -58,7 +58,7 @@ def pytest_collection_modifyitems(config, items: List[Item]):
     should_run_integration = config.getoption("--integration") is True
     should_run_benchmark = config.getoption("--benchmark") is True
 
-    integration_tests = {t for t in items if "integration" in t.keywords}
+    integration_tests = [t for t in items if "integration" in t.keywords]
     if not should_run_integration:
         for t in integration_tests:
             items.remove(t)
@@ -67,7 +67,7 @@ def pytest_collection_modifyitems(config, items: List[Item]):
         for t in integration_tests:
             items.append(t)
 
-    benchmark_tests = {t for t in items if "benchmark" in t.keywords}
+    benchmark_tests = [t for t in items if "benchmark" in t.keywords]
     if not should_run_benchmark:
         for t in benchmark_tests:
             items.remove(t)


### PR DESCRIPTION


Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Fixes a bug. Additionally, remove test items instead of skipping them. This makes `--collect-only` more useful, since that flag doesn't filter out skipped flags. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
