### PR TITLE
Refactor providers to remove duplicate implementations

### DIFF
--- a/sdk/python/feast/infra/aws.py
+++ b/sdk/python/feast/infra/aws.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryFile
 from urllib.parse import urlparse
 
 from feast.errors import S3RegistryBucketForbiddenAccess, S3RegistryBucketNotExist
-from feast.infra.provider import PassthroughProvider
+from feast.infra.passthrough_provider import PassthroughProvider
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.registry_store import RegistryStore
 from feast.repo_config import RegistryConfig

--- a/sdk/python/feast/infra/aws.py
+++ b/sdk/python/feast/infra/aws.py
@@ -3,152 +3,21 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryFile
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 from urllib.parse import urlparse
 
-import pandas
-from tqdm import tqdm
-
-from feast import FeatureTable
-from feast.entity import Entity
 from feast.errors import S3RegistryBucketForbiddenAccess, S3RegistryBucketNotExist
-from feast.feature_view import FeatureView
-from feast.infra.offline_stores.offline_utils import get_offline_store_from_config
-from feast.infra.online_stores.helpers import get_online_store_from_config
-from feast.infra.provider import (
-    Provider,
-    RetrievalJob,
-    _convert_arrow_to_proto,
-    _get_column_names,
-    _run_field_mapping,
-)
+from feast.infra.provider import PassthroughProvider
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
-from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
-from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.registry import Registry
 from feast.registry_store import RegistryStore
-from feast.repo_config import RegistryConfig, RepoConfig
+from feast.repo_config import RegistryConfig
 
 
-class AwsProvider(Provider):
-    def __init__(self, config: RepoConfig):
-        self.repo_config = config
-        self.offline_store = get_offline_store_from_config(config.offline_store)
-        self.online_store = get_online_store_from_config(config.online_store)
+class AwsProvider(PassthroughProvider):
+    """
+    This class only exists for backwards compatibility.
+    """
 
-    def update_infra(
-        self,
-        project: str,
-        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
-        tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
-        entities_to_delete: Sequence[Entity],
-        entities_to_keep: Sequence[Entity],
-        partial: bool,
-    ):
-        self.online_store.update(
-            config=self.repo_config,
-            tables_to_delete=tables_to_delete,
-            tables_to_keep=tables_to_keep,
-            entities_to_keep=entities_to_keep,
-            entities_to_delete=entities_to_delete,
-            partial=partial,
-        )
-
-    def teardown_infra(
-        self,
-        project: str,
-        tables: Sequence[Union[FeatureTable, FeatureView]],
-        entities: Sequence[Entity],
-    ) -> None:
-        self.online_store.teardown(self.repo_config, tables, entities)
-
-    def online_write_batch(
-        self,
-        config: RepoConfig,
-        table: Union[FeatureTable, FeatureView],
-        data: List[
-            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
-        ],
-        progress: Optional[Callable[[int], Any]],
-    ) -> None:
-        self.online_store.online_write_batch(config, table, data, progress)
-
-    def online_read(
-        self,
-        config: RepoConfig,
-        table: Union[FeatureTable, FeatureView],
-        entity_keys: List[EntityKeyProto],
-        requested_features: List[str] = None,
-    ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
-        result = self.online_store.online_read(config, table, entity_keys)
-
-        return result
-
-    def materialize_single_feature_view(
-        self,
-        config: RepoConfig,
-        feature_view: FeatureView,
-        start_date: datetime,
-        end_date: datetime,
-        registry: Registry,
-        project: str,
-        tqdm_builder: Callable[[int], tqdm],
-    ) -> None:
-        entities = []
-        for entity_name in feature_view.entities:
-            entities.append(registry.get_entity(entity_name, project))
-
-        (
-            join_key_columns,
-            feature_name_columns,
-            event_timestamp_column,
-            created_timestamp_column,
-        ) = _get_column_names(feature_view, entities)
-
-        offline_job = self.offline_store.pull_latest_from_table_or_query(
-            config=config,
-            data_source=feature_view.batch_source,
-            join_key_columns=join_key_columns,
-            feature_name_columns=feature_name_columns,
-            event_timestamp_column=event_timestamp_column,
-            created_timestamp_column=created_timestamp_column,
-            start_date=start_date,
-            end_date=end_date,
-        )
-
-        table = offline_job.to_arrow()
-
-        if feature_view.batch_source.field_mapping is not None:
-            table = _run_field_mapping(table, feature_view.batch_source.field_mapping)
-
-        join_keys = [entity.join_key for entity in entities]
-        rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
-
-        with tqdm_builder(len(rows_to_write)) as pbar:
-            self.online_write_batch(
-                self.repo_config, feature_view, rows_to_write, lambda x: pbar.update(x)
-            )
-
-    def get_historical_features(
-        self,
-        config: RepoConfig,
-        feature_views: List[FeatureView],
-        feature_refs: List[str],
-        entity_df: Union[pandas.DataFrame, str],
-        registry: Registry,
-        project: str,
-        full_feature_names: bool,
-    ) -> RetrievalJob:
-        job = self.offline_store.get_historical_features(
-            config=config,
-            feature_views=feature_views,
-            feature_refs=feature_refs,
-            entity_df=entity_df,
-            registry=registry,
-            project=project,
-            full_feature_names=full_feature_names,
-        )
-        return job
+    pass
 
 
 class S3RegistryStore(RegistryStore):

--- a/sdk/python/feast/infra/gcp.py
+++ b/sdk/python/feast/infra/gcp.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from tempfile import TemporaryFile
 from urllib.parse import urlparse
 
-from feast.infra.provider import PassthroughProvider
+from feast.infra.passthrough_provider import PassthroughProvider
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.registry_store import RegistryStore
 from feast.repo_config import RegistryConfig

--- a/sdk/python/feast/infra/gcp.py
+++ b/sdk/python/feast/infra/gcp.py
@@ -2,153 +2,20 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryFile
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 from urllib.parse import urlparse
 
-import pandas
-from tqdm import tqdm
-
-from feast import FeatureTable
-from feast.entity import Entity
-from feast.feature_view import FeatureView
-from feast.infra.offline_stores.offline_utils import get_offline_store_from_config
-from feast.infra.online_stores.helpers import get_online_store_from_config
-from feast.infra.provider import (
-    Provider,
-    RetrievalJob,
-    _convert_arrow_to_proto,
-    _get_column_names,
-    _run_field_mapping,
-)
+from feast.infra.provider import PassthroughProvider
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
-from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
-from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.registry import Registry
 from feast.registry_store import RegistryStore
-from feast.repo_config import RegistryConfig, RepoConfig
+from feast.repo_config import RegistryConfig
 
 
-class GcpProvider(Provider):
-    _gcp_project_id: Optional[str]
-    _namespace: Optional[str]
+class GcpProvider(PassthroughProvider):
+    """
+    This class only exists for backwards compatibility.
+    """
 
-    def __init__(self, config: RepoConfig):
-        self.repo_config = config
-        self.offline_store = get_offline_store_from_config(config.offline_store)
-        self.online_store = get_online_store_from_config(config.online_store)
-
-    def update_infra(
-        self,
-        project: str,
-        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
-        tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
-        entities_to_delete: Sequence[Entity],
-        entities_to_keep: Sequence[Entity],
-        partial: bool,
-    ):
-        self.online_store.update(
-            config=self.repo_config,
-            tables_to_delete=tables_to_delete,
-            tables_to_keep=tables_to_keep,
-            entities_to_keep=entities_to_keep,
-            entities_to_delete=entities_to_delete,
-            partial=partial,
-        )
-
-    def teardown_infra(
-        self,
-        project: str,
-        tables: Sequence[Union[FeatureTable, FeatureView]],
-        entities: Sequence[Entity],
-    ) -> None:
-        self.online_store.teardown(self.repo_config, tables, entities)
-
-    def online_write_batch(
-        self,
-        config: RepoConfig,
-        table: Union[FeatureTable, FeatureView],
-        data: List[
-            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
-        ],
-        progress: Optional[Callable[[int], Any]],
-    ) -> None:
-        self.online_store.online_write_batch(config, table, data, progress)
-
-    def online_read(
-        self,
-        config: RepoConfig,
-        table: Union[FeatureTable, FeatureView],
-        entity_keys: List[EntityKeyProto],
-        requested_features: List[str] = None,
-    ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
-        result = self.online_store.online_read(config, table, entity_keys)
-
-        return result
-
-    def materialize_single_feature_view(
-        self,
-        config: RepoConfig,
-        feature_view: FeatureView,
-        start_date: datetime,
-        end_date: datetime,
-        registry: Registry,
-        project: str,
-        tqdm_builder: Callable[[int], tqdm],
-    ) -> None:
-        entities = []
-        for entity_name in feature_view.entities:
-            entities.append(registry.get_entity(entity_name, project))
-
-        (
-            join_key_columns,
-            feature_name_columns,
-            event_timestamp_column,
-            created_timestamp_column,
-        ) = _get_column_names(feature_view, entities)
-
-        offline_job = self.offline_store.pull_latest_from_table_or_query(
-            config=config,
-            data_source=feature_view.batch_source,
-            join_key_columns=join_key_columns,
-            feature_name_columns=feature_name_columns,
-            event_timestamp_column=event_timestamp_column,
-            created_timestamp_column=created_timestamp_column,
-            start_date=start_date,
-            end_date=end_date,
-        )
-        table = offline_job.to_arrow()
-
-        if feature_view.batch_source.field_mapping is not None:
-            table = _run_field_mapping(table, feature_view.batch_source.field_mapping)
-
-        join_keys = [entity.join_key for entity in entities]
-        rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
-
-        with tqdm_builder(len(rows_to_write)) as pbar:
-            self.online_write_batch(
-                self.repo_config, feature_view, rows_to_write, lambda x: pbar.update(x)
-            )
-
-    def get_historical_features(
-        self,
-        config: RepoConfig,
-        feature_views: List[FeatureView],
-        feature_refs: List[str],
-        entity_df: Union[pandas.DataFrame, str],
-        registry: Registry,
-        project: str,
-        full_feature_names: bool,
-    ) -> RetrievalJob:
-        job = self.offline_store.get_historical_features(
-            config=config,
-            feature_views=feature_views,
-            feature_refs=feature_refs,
-            entity_df=entity_df,
-            registry=registry,
-            project=project,
-            full_feature_names=full_feature_names,
-        )
-        return job
+    pass
 
 
 class GCSRegistryStore(RegistryStore):

--- a/sdk/python/feast/infra/local.py
+++ b/sdk/python/feast/infra/local.py
@@ -7,7 +7,7 @@ import pytz
 
 from feast import FeatureTable
 from feast.feature_view import FeatureView
-from feast.infra.provider import PassthroughProvider
+from feast.infra.passthrough_provider import PassthroughProvider
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.registry_store import RegistryStore
 from feast.repo_config import RegistryConfig

--- a/sdk/python/feast/infra/local.py
+++ b/sdk/python/feast/infra/local.py
@@ -1,150 +1,24 @@
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Union
 
-import pandas as pd
 import pytz
-from tqdm import tqdm
 
 from feast import FeatureTable
-from feast.entity import Entity
 from feast.feature_view import FeatureView
-from feast.infra.offline_stores.offline_utils import get_offline_store_from_config
-from feast.infra.online_stores.helpers import get_online_store_from_config
-from feast.infra.provider import (
-    Provider,
-    RetrievalJob,
-    _convert_arrow_to_proto,
-    _get_column_names,
-    _run_field_mapping,
-)
+from feast.infra.provider import PassthroughProvider
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
-from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
-from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.registry import Registry
 from feast.registry_store import RegistryStore
-from feast.repo_config import RegistryConfig, RepoConfig
+from feast.repo_config import RegistryConfig
 
 
-class LocalProvider(Provider):
-    def __init__(self, config: RepoConfig):
-        assert config is not None
-        self.config = config
-        self.offline_store = get_offline_store_from_config(config.offline_store)
-        self.online_store = get_online_store_from_config(config.online_store)
+class LocalProvider(PassthroughProvider):
+    """
+    This class only exists for backwards compatibility.
+    """
 
-    def update_infra(
-        self,
-        project: str,
-        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
-        tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
-        entities_to_delete: Sequence[Entity],
-        entities_to_keep: Sequence[Entity],
-        partial: bool,
-    ):
-        self.online_store.update(
-            self.config,
-            tables_to_delete,
-            tables_to_keep,
-            entities_to_delete,
-            entities_to_keep,
-            partial,
-        )
-
-    def teardown_infra(
-        self,
-        project: str,
-        tables: Sequence[Union[FeatureTable, FeatureView]],
-        entities: Sequence[Entity],
-    ) -> None:
-        self.online_store.teardown(self.config, tables, entities)
-
-    def online_write_batch(
-        self,
-        config: RepoConfig,
-        table: Union[FeatureTable, FeatureView],
-        data: List[
-            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
-        ],
-        progress: Optional[Callable[[int], Any]],
-    ) -> None:
-        self.online_store.online_write_batch(config, table, data, progress)
-
-    def online_read(
-        self,
-        config: RepoConfig,
-        table: Union[FeatureTable, FeatureView],
-        entity_keys: List[EntityKeyProto],
-        requested_features: List[str] = None,
-    ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
-        result = self.online_store.online_read(config, table, entity_keys)
-
-        return result
-
-    def materialize_single_feature_view(
-        self,
-        config: RepoConfig,
-        feature_view: FeatureView,
-        start_date: datetime,
-        end_date: datetime,
-        registry: Registry,
-        project: str,
-        tqdm_builder: Callable[[int], tqdm],
-    ) -> None:
-        entities = []
-        for entity_name in feature_view.entities:
-            entities.append(registry.get_entity(entity_name, project))
-
-        (
-            join_key_columns,
-            feature_name_columns,
-            event_timestamp_column,
-            created_timestamp_column,
-        ) = _get_column_names(feature_view, entities)
-
-        offline_job = self.offline_store.pull_latest_from_table_or_query(
-            data_source=feature_view.batch_source,
-            join_key_columns=join_key_columns,
-            feature_name_columns=feature_name_columns,
-            event_timestamp_column=event_timestamp_column,
-            created_timestamp_column=created_timestamp_column,
-            start_date=start_date,
-            end_date=end_date,
-            config=config,
-        )
-        table = offline_job.to_arrow()
-
-        if feature_view.batch_source.field_mapping is not None:
-            table = _run_field_mapping(table, feature_view.batch_source.field_mapping)
-
-        join_keys = [entity.join_key for entity in entities]
-        rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
-
-        with tqdm_builder(len(rows_to_write)) as pbar:
-            self.online_write_batch(
-                self.config, feature_view, rows_to_write, lambda x: pbar.update(x)
-            )
-
-    def get_historical_features(
-        self,
-        config: RepoConfig,
-        feature_views: List[FeatureView],
-        feature_refs: List[str],
-        entity_df: Union[pd.DataFrame, str],
-        registry: Registry,
-        project: str,
-        full_feature_names: bool,
-    ) -> RetrievalJob:
-        return self.offline_store.get_historical_features(
-            config=config,
-            feature_views=feature_views,
-            feature_refs=feature_refs,
-            entity_df=entity_df,
-            registry=registry,
-            project=project,
-            full_feature_names=full_feature_names,
-        )
+    pass
 
 
 def _table_id(project: str, table: Union[FeatureTable, FeatureView]) -> str:

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -1,0 +1,146 @@
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+import pandas
+from tqdm import tqdm
+
+from feast import Entity, FeatureTable, FeatureView, RepoConfig
+from feast.infra.offline_stores.offline_store import RetrievalJob
+from feast.infra.offline_stores.offline_utils import get_offline_store_from_config
+from feast.infra.online_stores.helpers import get_online_store_from_config
+from feast.infra.provider import (
+    Provider,
+    _convert_arrow_to_proto,
+    _get_column_names,
+    _run_field_mapping,
+)
+from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+from feast.registry import Registry
+
+
+class PassthroughProvider(Provider):
+    """
+    The Passthrough provider delegates all operations to the underlying online and offline stores.
+    """
+
+    def __init__(self, config: RepoConfig):
+        super().__init__(config)
+
+        self.repo_config = config
+        self.offline_store = get_offline_store_from_config(config.offline_store)
+        self.online_store = get_online_store_from_config(config.online_store)
+
+    def update_infra(
+        self,
+        project: str,
+        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
+        tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
+        entities_to_delete: Sequence[Entity],
+        entities_to_keep: Sequence[Entity],
+        partial: bool,
+    ):
+        self.online_store.update(
+            config=self.repo_config,
+            tables_to_delete=tables_to_delete,
+            tables_to_keep=tables_to_keep,
+            entities_to_keep=entities_to_keep,
+            entities_to_delete=entities_to_delete,
+            partial=partial,
+        )
+
+    def teardown_infra(
+        self,
+        project: str,
+        tables: Sequence[Union[FeatureTable, FeatureView]],
+        entities: Sequence[Entity],
+    ) -> None:
+        self.online_store.teardown(self.repo_config, tables, entities)
+
+    def online_write_batch(
+        self,
+        config: RepoConfig,
+        table: Union[FeatureTable, FeatureView],
+        data: List[
+            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+        ],
+        progress: Optional[Callable[[int], Any]],
+    ) -> None:
+        self.online_store.online_write_batch(config, table, data, progress)
+
+    def online_read(
+        self,
+        config: RepoConfig,
+        table: Union[FeatureTable, FeatureView],
+        entity_keys: List[EntityKeyProto],
+        requested_features: List[str] = None,
+    ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
+        result = self.online_store.online_read(config, table, entity_keys)
+
+        return result
+
+    def materialize_single_feature_view(
+        self,
+        config: RepoConfig,
+        feature_view: FeatureView,
+        start_date: datetime,
+        end_date: datetime,
+        registry: Registry,
+        project: str,
+        tqdm_builder: Callable[[int], tqdm],
+    ) -> None:
+        entities = []
+        for entity_name in feature_view.entities:
+            entities.append(registry.get_entity(entity_name, project))
+
+        (
+            join_key_columns,
+            feature_name_columns,
+            event_timestamp_column,
+            created_timestamp_column,
+        ) = _get_column_names(feature_view, entities)
+
+        offline_job = self.offline_store.pull_latest_from_table_or_query(
+            config=config,
+            data_source=feature_view.batch_source,
+            join_key_columns=join_key_columns,
+            feature_name_columns=feature_name_columns,
+            event_timestamp_column=event_timestamp_column,
+            created_timestamp_column=created_timestamp_column,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        table = offline_job.to_arrow()
+
+        if feature_view.batch_source.field_mapping is not None:
+            table = _run_field_mapping(table, feature_view.batch_source.field_mapping)
+
+        join_keys = [entity.join_key for entity in entities]
+        rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
+
+        with tqdm_builder(len(rows_to_write)) as pbar:
+            self.online_write_batch(
+                self.repo_config, feature_view, rows_to_write, lambda x: pbar.update(x)
+            )
+
+    def get_historical_features(
+        self,
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_df: Union[pandas.DataFrame, str],
+        registry: Registry,
+        project: str,
+        full_feature_names: bool,
+    ) -> RetrievalJob:
+        job = self.offline_store.get_historical_features(
+            config=config,
+            feature_views=feature_views,
+            feature_refs=feature_refs,
+            entity_df=entity_df,
+            registry=registry,
+            project=project,
+            full_feature_names=full_feature_names,
+        )
+        return job

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -4,7 +4,9 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 import pandas
 from tqdm import tqdm
 
-from feast import Entity, FeatureTable, FeatureView, RepoConfig
+from feast.entity import Entity
+from feast.feature_table import FeatureTable
+from feast.feature_view import FeatureView
 from feast.infra.offline_stores.offline_store import RetrievalJob
 from feast.infra.offline_stores.offline_utils import get_offline_store_from_config
 from feast.infra.online_stores.helpers import get_online_store_from_config
@@ -17,6 +19,7 @@ from feast.infra.provider import (
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.registry import Registry
+from feast.repo_config import RepoConfig
 
 
 class PassthroughProvider(Provider):

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -148,6 +148,7 @@ def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
     if "." not in config.provider:
         if config.provider in {"gcp", "aws", "local"}:
             from feast.infra.passthrough_provider import PassthroughProvider
+
             return PassthroughProvider(config)
         else:
             raise errors.FeastProviderNotImplementedError(config.provider)

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -13,8 +13,6 @@ from feast.entity import Entity
 from feast.feature_table import FeatureTable
 from feast.feature_view import DUMMY_ENTITY_ID, FeatureView
 from feast.infra.offline_stores.offline_store import RetrievalJob
-from feast.infra.offline_stores.offline_utils import get_offline_store_from_config
-from feast.infra.online_stores.helpers import get_online_store_from_config
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
@@ -153,6 +151,11 @@ class PassthroughProvider(Provider):
 
     def __init__(self, config: RepoConfig):
         super().__init__(config)
+        from feast.infra.offline_stores.offline_utils import (
+            get_offline_store_from_config,
+        )
+        from feast.infra.online_stores.helpers import get_online_store_from_config
+
         self.repo_config = config
         self.offline_store = get_offline_store_from_config(config.offline_store)
         self.online_store = get_online_store_from_config(config.online_store)

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -13,6 +13,8 @@ from feast.entity import Entity
 from feast.feature_table import FeatureTable
 from feast.feature_view import DUMMY_ENTITY_ID, FeatureView
 from feast.infra.offline_stores.offline_store import RetrievalJob
+from feast.infra.offline_stores.offline_utils import get_offline_store_from_config
+from feast.infra.online_stores.helpers import get_online_store_from_config
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
@@ -142,6 +144,132 @@ class Provider(abc.ABC):
             Values are returned as Value proto message.
         """
         ...
+
+
+class PassthroughProvider(Provider):
+    """
+    The Passthrough provider delegates all operations to the underlying online and offline stores.
+    """
+
+    def __init__(self, config: RepoConfig):
+        super().__init__(config)
+        self.repo_config = config
+        self.offline_store = get_offline_store_from_config(config.offline_store)
+        self.online_store = get_online_store_from_config(config.online_store)
+
+    def update_infra(
+        self,
+        project: str,
+        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
+        tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
+        entities_to_delete: Sequence[Entity],
+        entities_to_keep: Sequence[Entity],
+        partial: bool,
+    ):
+        self.online_store.update(
+            config=self.repo_config,
+            tables_to_delete=tables_to_delete,
+            tables_to_keep=tables_to_keep,
+            entities_to_keep=entities_to_keep,
+            entities_to_delete=entities_to_delete,
+            partial=partial,
+        )
+
+    def teardown_infra(
+        self,
+        project: str,
+        tables: Sequence[Union[FeatureTable, FeatureView]],
+        entities: Sequence[Entity],
+    ) -> None:
+        self.online_store.teardown(self.repo_config, tables, entities)
+
+    def online_write_batch(
+        self,
+        config: RepoConfig,
+        table: Union[FeatureTable, FeatureView],
+        data: List[
+            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
+        ],
+        progress: Optional[Callable[[int], Any]],
+    ) -> None:
+        self.online_store.online_write_batch(config, table, data, progress)
+
+    def online_read(
+        self,
+        config: RepoConfig,
+        table: Union[FeatureTable, FeatureView],
+        entity_keys: List[EntityKeyProto],
+        requested_features: List[str] = None,
+    ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
+        result = self.online_store.online_read(config, table, entity_keys)
+
+        return result
+
+    def materialize_single_feature_view(
+        self,
+        config: RepoConfig,
+        feature_view: FeatureView,
+        start_date: datetime,
+        end_date: datetime,
+        registry: Registry,
+        project: str,
+        tqdm_builder: Callable[[int], tqdm],
+    ) -> None:
+        entities = []
+        for entity_name in feature_view.entities:
+            entities.append(registry.get_entity(entity_name, project))
+
+        (
+            join_key_columns,
+            feature_name_columns,
+            event_timestamp_column,
+            created_timestamp_column,
+        ) = _get_column_names(feature_view, entities)
+
+        offline_job = self.offline_store.pull_latest_from_table_or_query(
+            config=config,
+            data_source=feature_view.batch_source,
+            join_key_columns=join_key_columns,
+            feature_name_columns=feature_name_columns,
+            event_timestamp_column=event_timestamp_column,
+            created_timestamp_column=created_timestamp_column,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        table = offline_job.to_arrow()
+
+        if feature_view.batch_source.field_mapping is not None:
+            table = _run_field_mapping(table, feature_view.batch_source.field_mapping)
+
+        join_keys = [entity.join_key for entity in entities]
+        rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
+
+        with tqdm_builder(len(rows_to_write)) as pbar:
+            self.online_write_batch(
+                self.repo_config, feature_view, rows_to_write, lambda x: pbar.update(x)
+            )
+
+    def get_historical_features(
+        self,
+        config: RepoConfig,
+        feature_views: List[FeatureView],
+        feature_refs: List[str],
+        entity_df: Union[pandas.DataFrame, str],
+        registry: Registry,
+        project: str,
+        full_feature_names: bool,
+    ) -> RetrievalJob:
+        job = self.offline_store.get_historical_features(
+            config=config,
+            feature_views=feature_views,
+            feature_refs=feature_refs,
+            entity_df=entity_df,
+            registry=registry,
+            project=project,
+            full_feature_names=full_feature_names,
+        )
+        return job
 
 
 def get_provider(config: RepoConfig, repo_path: Path) -> Provider:

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -274,18 +274,8 @@ class PassthroughProvider(Provider):
 
 def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
     if "." not in config.provider:
-        if config.provider == "gcp":
-            from feast.infra.gcp import GcpProvider
-
-            return GcpProvider(config)
-        elif config.provider == "aws":
-            from feast.infra.aws import AwsProvider
-
-            return AwsProvider(config)
-        elif config.provider == "local":
-            from feast.infra.local import LocalProvider
-
-            return LocalProvider(config)
+        if config.provider in {"gcp", "aws", "local"}:
+            return PassthroughProvider(config)
         else:
             raise errors.FeastProviderNotImplementedError(config.provider)
     else:

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -13,7 +13,6 @@ from feast.entity import Entity
 from feast.feature_table import FeatureTable
 from feast.feature_view import DUMMY_ENTITY_ID, FeatureView
 from feast.infra.offline_stores.offline_store import RetrievalJob
-from feast.infra.passthrough_provider import PassthroughProvider
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
@@ -148,6 +147,7 @@ class Provider(abc.ABC):
 def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
     if "." not in config.provider:
         if config.provider in {"gcp", "aws", "local"}:
+            from feast.infra.passthrough_provider import PassthroughProvider
             return PassthroughProvider(config)
         else:
             raise errors.FeastProviderNotImplementedError(config.provider)

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -13,6 +13,7 @@ from feast.entity import Entity
 from feast.feature_table import FeatureTable
 from feast.feature_view import DUMMY_ENTITY_ID, FeatureView
 from feast.infra.offline_stores.offline_store import RetrievalJob
+from feast.infra.passthrough_provider import PassthroughProvider
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
@@ -142,137 +143,6 @@ class Provider(abc.ABC):
             Values are returned as Value proto message.
         """
         ...
-
-
-class PassthroughProvider(Provider):
-    """
-    The Passthrough provider delegates all operations to the underlying online and offline stores.
-    """
-
-    def __init__(self, config: RepoConfig):
-        super().__init__(config)
-        from feast.infra.offline_stores.offline_utils import (
-            get_offline_store_from_config,
-        )
-        from feast.infra.online_stores.helpers import get_online_store_from_config
-
-        self.repo_config = config
-        self.offline_store = get_offline_store_from_config(config.offline_store)
-        self.online_store = get_online_store_from_config(config.online_store)
-
-    def update_infra(
-        self,
-        project: str,
-        tables_to_delete: Sequence[Union[FeatureTable, FeatureView]],
-        tables_to_keep: Sequence[Union[FeatureTable, FeatureView]],
-        entities_to_delete: Sequence[Entity],
-        entities_to_keep: Sequence[Entity],
-        partial: bool,
-    ):
-        self.online_store.update(
-            config=self.repo_config,
-            tables_to_delete=tables_to_delete,
-            tables_to_keep=tables_to_keep,
-            entities_to_keep=entities_to_keep,
-            entities_to_delete=entities_to_delete,
-            partial=partial,
-        )
-
-    def teardown_infra(
-        self,
-        project: str,
-        tables: Sequence[Union[FeatureTable, FeatureView]],
-        entities: Sequence[Entity],
-    ) -> None:
-        self.online_store.teardown(self.repo_config, tables, entities)
-
-    def online_write_batch(
-        self,
-        config: RepoConfig,
-        table: Union[FeatureTable, FeatureView],
-        data: List[
-            Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]
-        ],
-        progress: Optional[Callable[[int], Any]],
-    ) -> None:
-        self.online_store.online_write_batch(config, table, data, progress)
-
-    def online_read(
-        self,
-        config: RepoConfig,
-        table: Union[FeatureTable, FeatureView],
-        entity_keys: List[EntityKeyProto],
-        requested_features: List[str] = None,
-    ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
-        result = self.online_store.online_read(config, table, entity_keys)
-
-        return result
-
-    def materialize_single_feature_view(
-        self,
-        config: RepoConfig,
-        feature_view: FeatureView,
-        start_date: datetime,
-        end_date: datetime,
-        registry: Registry,
-        project: str,
-        tqdm_builder: Callable[[int], tqdm],
-    ) -> None:
-        entities = []
-        for entity_name in feature_view.entities:
-            entities.append(registry.get_entity(entity_name, project))
-
-        (
-            join_key_columns,
-            feature_name_columns,
-            event_timestamp_column,
-            created_timestamp_column,
-        ) = _get_column_names(feature_view, entities)
-
-        offline_job = self.offline_store.pull_latest_from_table_or_query(
-            config=config,
-            data_source=feature_view.batch_source,
-            join_key_columns=join_key_columns,
-            feature_name_columns=feature_name_columns,
-            event_timestamp_column=event_timestamp_column,
-            created_timestamp_column=created_timestamp_column,
-            start_date=start_date,
-            end_date=end_date,
-        )
-
-        table = offline_job.to_arrow()
-
-        if feature_view.batch_source.field_mapping is not None:
-            table = _run_field_mapping(table, feature_view.batch_source.field_mapping)
-
-        join_keys = [entity.join_key for entity in entities]
-        rows_to_write = _convert_arrow_to_proto(table, feature_view, join_keys)
-
-        with tqdm_builder(len(rows_to_write)) as pbar:
-            self.online_write_batch(
-                self.repo_config, feature_view, rows_to_write, lambda x: pbar.update(x)
-            )
-
-    def get_historical_features(
-        self,
-        config: RepoConfig,
-        feature_views: List[FeatureView],
-        feature_refs: List[str],
-        entity_df: Union[pandas.DataFrame, str],
-        registry: Registry,
-        project: str,
-        full_feature_names: bool,
-    ) -> RetrievalJob:
-        job = self.offline_store.get_historical_features(
-            config=config,
-            feature_views=feature_views,
-            feature_refs=feature_refs,
-            entity_df=entity_df,
-            registry=registry,
-            project=project,
-            full_feature_names=full_feature_names,
-        )
-        return job
 
 
 def get_provider(config: RepoConfig, repo_path: Path) -> Provider:


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Currently, the AWS, GCP and Local providers have the exact same implementation - and the implementation only defers actual business logic of setting up infrastructure and materializing data to the offline/online store interfaces.

This is confusing for users, and is unnecessary code to maintain. Instead, this PR refactors the implementations into a single implementation, with a dummy subclass for the 3 existing providers for backwards compatibility.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
