### PR TITLE
Use contextvars to maintain a call stack during the usage calls

### DIFF
--- a/sdk/python/feast/usage.py
+++ b/sdk/python/feast/usage.py
@@ -108,9 +108,7 @@ class Usage:
     def log_function(self, function_name: str):
         self.check_env_and_configure()
         if self._usage_enabled and self.usage_id:
-            if "get_online_features" in call_stack.get(
-                []
-            ) and not self.should_log_for_get_online_features_event(
+            if "get_online_features" in call_stack.get() and not self.should_log_for_get_online_features_event(
                 "get_online_features"
             ):
                 return
@@ -195,8 +193,8 @@ def log_exceptions(func):
             usage.log_exception(error_type, trace_to_log)
             raise
         finally:
-            if len(call_stack.get([])) > 0:
-                call_stack.set(call_stack.get([])[:-1])
+            if len(call_stack.get()) > 0:
+                call_stack.set(call_stack.get()[:-1])
         return result
 
     return exception_logging_wrapper
@@ -226,8 +224,8 @@ def log_exceptions_and_usage(func):
             usage.log_exception(error_type, trace_to_log)
             raise
         finally:
-            if len(call_stack.get([])) > 0:
-                call_stack.set(call_stack.get([])[:-1])
+            if len(call_stack.get()) > 0:
+                call_stack.set(call_stack.get()[:-1])
         return result
 
     return exception_logging_wrapper

--- a/sdk/python/feast/usage.py
+++ b/sdk/python/feast/usage.py
@@ -54,6 +54,8 @@ class UsageEvent(enum.Enum):
 class Usage:
     def __init__(self):
         self._usage_enabled: bool = False
+        self._is_test = os.getenv("FEAST_IS_USAGE_TEST", "False") == "True"
+        self._usage_counter = defaultdict(lambda: 0)
         self.check_env_and_configure()
 
     def check_env_and_configure(self):
@@ -70,9 +72,6 @@ class Usage:
                     feast_home_dir = join(expanduser("~"), ".feast")
                     Path(feast_home_dir).mkdir(exist_ok=True)
                     usage_filepath = join(feast_home_dir, "usage")
-
-                    self._is_test = os.getenv("FEAST_IS_USAGE_TEST", "False") == "True"
-                    self._usage_counter = defaultdict(lambda: 0)
 
                     if os.path.exists(usage_filepath):
                         with open(usage_filepath, "r") as f:

--- a/sdk/python/feast/usage.py
+++ b/sdk/python/feast/usage.py
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import concurrent.futures
+import contextvars
 import enum
 import logging
 import os
 import sys
 import uuid
+from collections import defaultdict
 from datetime import datetime
 from functools import wraps
 from os.path import expanduser, join
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import requests
 
@@ -31,6 +33,7 @@ USAGE_ENDPOINT = "https://usage.feast.dev"
 _logger = logging.getLogger(__name__)
 
 executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+call_stack: contextvars.ContextVar = contextvars.ContextVar("call_stack", default=[])
 
 
 @enum.unique
@@ -69,7 +72,7 @@ class Usage:
                     usage_filepath = join(feast_home_dir, "usage")
 
                     self._is_test = os.getenv("FEAST_IS_USAGE_TEST", "False") == "True"
-                    self._usage_counter = {}
+                    self._usage_counter = defaultdict(lambda: 0)
 
                     if os.path.exists(usage_filepath):
                         with open(usage_filepath, "r") as f:
@@ -106,9 +109,10 @@ class Usage:
     def log_function(self, function_name: str):
         self.check_env_and_configure()
         if self._usage_enabled and self.usage_id:
-            if (
-                function_name == "get_online_features"
-                and not self.should_log_for_get_online_features_event(function_name)
+            if "get_online_features" in call_stack.get(
+                []
+            ) and not self.should_log_for_get_online_features_event(
+                "get_online_features"
             ):
                 return
             json = {
@@ -121,10 +125,10 @@ class Usage:
             }
             self._send_usage_request(json)
 
-    def should_log_for_get_online_features_event(self, event_name: str):
-        if event_name not in self._usage_counter:
-            self._usage_counter[event_name] = 0
+    def increment_event_count(self, event_name: Union[UsageEvent, str]):
         self._usage_counter[event_name] += 1
+
+    def should_log_for_get_online_features_event(self, event_name: str):
         if self._usage_counter[event_name] % 10000 != 2:
             return False
         self._usage_counter[event_name] = 2  # avoid overflow
@@ -174,6 +178,7 @@ def log_exceptions(func):
     @wraps(func)
     def exception_logging_wrapper(*args, **kwargs):
         try:
+            call_stack.set(call_stack.get() + [func.__name__])
             result = func(*args, **kwargs)
         except Exception as e:
             error_type = type(e).__name__
@@ -190,6 +195,9 @@ def log_exceptions(func):
                 tb = tb.tb_next
             usage.log_exception(error_type, trace_to_log)
             raise
+        finally:
+            if len(call_stack.get([])) > 0:
+                call_stack.set(call_stack.get([])[:-1])
         return result
 
     return exception_logging_wrapper
@@ -199,6 +207,8 @@ def log_exceptions_and_usage(func):
     @wraps(func)
     def exception_logging_wrapper(*args, **kwargs):
         try:
+            call_stack.set(call_stack.get() + [func.__name__])
+            usage.increment_event_count(func.__name__)
             result = func(*args, **kwargs)
             usage.log_function(func.__name__)
         except Exception as e:
@@ -216,12 +226,16 @@ def log_exceptions_and_usage(func):
                 tb = tb.tb_next
             usage.log_exception(error_type, trace_to_log)
             raise
+        finally:
+            if len(call_stack.get([])) > 0:
+                call_stack.set(call_stack.get([])[:-1])
         return result
 
     return exception_logging_wrapper
 
 
 def log_event(event: UsageEvent):
+    usage.increment_event_count(event)
     usage.log_event(event)
 
 


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Our usage handling doesn't handle calls to `usage` annotated events *within* the implementation of `get_online_features`. So, e.g., calling `get_feature_views` within `get_online_features` would always get called, which would result in bad performance. 

This fixes that by maintaining the call stack and making sure any call path that includes `get_online_features` is only sampled.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
