### PR TITLE
Add `ValueType.NULL`

### DIFF
--- a/sdk/python/feast/infra/utils/aws_utils.py
+++ b/sdk/python/feast/infra/utils/aws_utils.py
@@ -216,7 +216,7 @@ def upload_df_to_redshift(
     column_names, column_types = [], []
     for field in table.schema:
         column_names.append(field.name)
-        column_types.append(pa_to_redshift_value_type(str(field.type)))
+        column_types.append(pa_to_redshift_value_type(field.type))
     column_query_list = ", ".join(
         [
             f"{column_name} {column_type}"

--- a/sdk/python/feast/online_response.py
+++ b/sdk/python/feast/online_response.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, cast
 
 import pandas as pd
 
@@ -24,7 +24,7 @@ from feast.protos.feast.serving.ServingService_pb2 import (
 )
 from feast.protos.feast.types.Value_pb2 import Value as Value
 from feast.type_map import (
-    _proto_str_to_value_type,
+    _proto_value_to_value_type,
     _python_value_to_proto_value,
     feast_value_type_to_python_type,
     python_values_to_feast_value_type,
@@ -96,14 +96,14 @@ def _infer_online_entity_rows(
 
     entity_rows_dicts = cast(List[Dict[str, Any]], entity_rows)
     entity_row_list = []
-    entity_type_map: Dict[str, Optional[ValueType]] = dict()
+    entity_type_map: Dict[str, ValueType] = dict()
     entity_python_values_map = defaultdict(list)
 
     # Flatten keys-value dicts into lists for type inference
     for entity in entity_rows_dicts:
         for key, value in entity.items():
             if isinstance(value, Value):
-                inferred_type = _proto_str_to_value_type(str(value.WhichOneof("val")))
+                inferred_type = _proto_value_to_value_type(value)
                 # If any ProtoValues were present their types must all be the same
                 if key in entity_type_map and entity_type_map.get(key) != inferred_type:
                     raise TypeError(

--- a/sdk/python/feast/value_type.py
+++ b/sdk/python/feast/value_type.py
@@ -38,6 +38,7 @@ class ValueType(enum.Enum):
     FLOAT_LIST = 16
     BOOL_LIST = 17
     UNIX_TIMESTAMP_LIST = 18
+    NULL = 19
 
     def to_tfx_schema_feature_type(self):
         if self.value in [


### PR DESCRIPTION
Signed-off-by: Judah Rand <17158624+judahrand@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This PR fixes this simple case:

```python
from datetime import datetime, timedelta
from feast import Entity, Feature, FeatureStore, FeatureView, FileSource, ValueType
import numpy as np
import pandas as pd
from pathlib import Path

df = pd.DataFrame(columns=["device_type", "encoding", "datetime"])
df["device_type"] = ["A", "B", "C", "D"]
df["encoding"] = [[0, 1, 0], [1, 0, 0], None, [0, 0, 0]]
df["rank"] = np.array([1, None, 3, 4], dtype=np.float64)
df["datetime"] = pd.to_datetime([datetime.now()] * 4)
device_encodings_path_str = "data/device_encodings.parquet"
device_encodings_path = Path(device_encodings_path_str)
device_encodings_abs_path_str = str(device_encodings_path.absolute())
df.to_parquet(device_encodings_abs_path_str)
device_encodings = FileSource(
    path=device_encodings_abs_path_str, event_timestamp_column="datetime"
)
device_type = Entity("device_type", value_type=ValueType.STRING, description="")
device_encoding_view = FeatureView(
    name="device_encoding",
    entities=["device_type"],
    ttl=timedelta(minutes=60),
    input=device_encodings,
    online=True,
)
fm = FeatureStore(repo_path=".")
fm.apply([device_type, device_encoding_view])
fm.materialize(start_date=datetime(2021, 1, 1), end_date=datetime.now())

res = fm.get_online_features(
    [
        "device_encoding:encoding",
        "device_encoding:rank",
    ],
    entity_rows=df["device_type"].to_frame().to_dict("record"),
).to_df()
print(res)
```


(Okay, I might have sneaked quite a lot of tidy up in here too...)
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes issues with NULL values
```
