### PR TITLE
Respect specified ValueTypes for features during materialization

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -325,7 +325,11 @@ def python_value_to_proto_value(
                 else python_type_to_feast_value_type("", value)
             )
         else:
-            value_type = python_type_to_feast_value_type("", value)
+            value_type = (
+                feature_type
+                if feature_type is ValueType.FLOAT
+                else python_type_to_feast_value_type("", value)
+            )
     return _python_value_to_proto_value(value_type, value)
 
 

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -245,7 +245,13 @@ PYTHON_SCALAR_VALUE_TYPE_TO_PROTO_VALUE: Dict[
     ValueType, Tuple[str, Any, Optional[Set[Type]]]
 ] = {
     ValueType.INT32: ("int32_val", lambda x: int(x), None),
-    ValueType.INT64: ("int64_val", lambda x: int(x.timestamp()) if isinstance(x, pd._libs.tslibs.timestamps.Timestamp) else int(x), None),
+    ValueType.INT64: (
+        "int64_val",
+        lambda x: int(x.timestamp())
+        if isinstance(x, pd._libs.tslibs.timestamps.Timestamp)
+        else int(x),
+        None,
+    ),
     ValueType.FLOAT: ("float_val", lambda x: float(x), None),
     ValueType.DOUBLE: ("double_val", lambda x: x, {float, np.float64}),
     ValueType.STRING: ("string_val", lambda x: str(x), None),

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -19,9 +19,9 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Type
 import numpy as np
 import pandas as pd
 import pyarrow
+from google.protobuf.internal.well_known_types import Timestamp
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType
-from google.protobuf.timestamp_pb2 import Timestamp
 
 from feast.protos.feast.types.Value_pb2 import (
     BoolList,
@@ -245,7 +245,7 @@ PYTHON_SCALAR_VALUE_TYPE_TO_PROTO_VALUE: Dict[
     ValueType, Tuple[str, Any, Optional[Set[Type]]]
 ] = {
     ValueType.INT32: ("int32_val", lambda x: int(x), None),
-    ValueType.INT64: ("int64_val", lambda x: int(x), None),
+    ValueType.INT64: ("int64_val", lambda x: int(x.timestamp()) if isinstance(x, pd._libs.tslibs.timestamps.Timestamp) else int(x), None),
     ValueType.FLOAT: ("float_val", lambda x: float(x), None),
     ValueType.DOUBLE: ("double_val", lambda x: x, {float, np.float64}),
     ValueType.STRING: ("string_val", lambda x: str(x), None),

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -19,9 +19,9 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Type
 import numpy as np
 import pandas as pd
 import pyarrow
-from google.protobuf.internal.well_known_types import Timestamp
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType
+from google.protobuf.timestamp_pb2 import Timestamp
 
 from feast.protos.feast.types.Value_pb2 import (
     BoolList,

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -317,7 +317,7 @@ def python_value_to_proto_value(
     value: Any, feature_type: ValueType = ValueType.UNKNOWN
 ) -> ProtoValue:
     value_type = feature_type
-    if value is not None:
+    if value is not None and feature_type == ValueType.UNKNOWN:
         if isinstance(value, (list, np.ndarray)):
             value_type = (
                 feature_type
@@ -325,11 +325,7 @@ def python_value_to_proto_value(
                 else python_type_to_feast_value_type("", value)
             )
         else:
-            value_type = (
-                feature_type
-                if feature_type is ValueType.FLOAT
-                else python_type_to_feast_value_type("", value)
-            )
+            value_type = python_type_to_feast_value_type("", value)
     return _python_value_to_proto_value(value_type, value)
 
 

--- a/sdk/python/tests/integration/online_store/test_e2e_local.py
+++ b/sdk/python/tests/integration/online_store/test_e2e_local.py
@@ -27,7 +27,7 @@ def _assert_online_features(
 ):
     """Assert that features in online store are up to date with `max_date` date."""
     # Read features back
-    result = store.get_online_features(
+    response = store.get_online_features(
         features=[
             "driver_hourly_stats:conv_rate",
             "driver_hourly_stats:avg_daily_trips",
@@ -36,8 +36,14 @@ def _assert_online_features(
         ],
         entity_rows=[{"driver_id": 1001}],
         full_feature_names=True,
-    ).to_dict()
+    )
 
+    # Float features should still be floats from the online store...
+    assert (
+        response.field_values[0].fields["driver_hourly_stats__conv_rate"].float_val > 0
+    )
+
+    result = response.to_dict()
     assert len(result) == 5
     assert "driver_hourly_stats__avg_daily_trips" in result
     assert "driver_hourly_stats__conv_rate" in result

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -115,21 +115,22 @@ def test_online_retrieval(environment, universal_data_sources, full_feature_name
                 response_feature_name("conv_rate_plus_100", full_feature_names)
             ][i],
             df_features["conv_rate"] + 100,
-            delta=0.0001
+            delta=0.0001,
         )
         tc.assertAlmostEqual(
             online_features_dict[
                 response_feature_name("conv_rate_plus_val_to_add", full_feature_names)
             ][i],
             df_features["conv_rate"] + df_features["val_to_add"],
-            delta=0.0001)
+            delta=0.0001,
+        )
         for unprefixed_feature_ref in unprefixed_feature_refs:
             tc.assertAlmostEqual(
                 df_features[unprefixed_feature_ref],
                 online_features_dict[
                     response_feature_name(unprefixed_feature_ref, full_feature_names)
                 ][i],
-                delta=0.0001
+                delta=0.0001,
             )
 
     # Check what happens for missing values
@@ -266,5 +267,5 @@ def assert_feature_service_correctness(
                 response_feature_name("conv_rate_plus_100", full_feature_names)
             ][i],
             df_features["conv_rate"] + 100,
-            delta=0.0001
+            delta=0.0001,
         )

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -110,24 +110,26 @@ def test_online_retrieval(environment, universal_data_sources, full_feature_name
 
         assert df_features["customer_id"] == online_features_dict["customer_id"][i]
         assert df_features["driver_id"] == online_features_dict["driver_id"][i]
-        assert (
+        tc.assertAlmostEqual(
             online_features_dict[
                 response_feature_name("conv_rate_plus_100", full_feature_names)
-            ][i]
-            == df_features["conv_rate"] + 100
+            ][i],
+            df_features["conv_rate"] + 100,
+            delta=0.0001
         )
-        assert (
+        tc.assertAlmostEqual(
             online_features_dict[
                 response_feature_name("conv_rate_plus_val_to_add", full_feature_names)
-            ][i]
-            == df_features["conv_rate"] + df_features["val_to_add"]
-        )
+            ][i],
+            df_features["conv_rate"] + df_features["val_to_add"],
+            delta=0.0001)
         for unprefixed_feature_ref in unprefixed_feature_refs:
-            tc.assertEqual(
+            tc.assertAlmostEqual(
                 df_features[unprefixed_feature_ref],
                 online_features_dict[
                     response_feature_name(unprefixed_feature_ref, full_feature_names)
                 ][i],
+                delta=0.0001
             )
 
     # Check what happens for missing values
@@ -254,13 +256,15 @@ def assert_feature_service_correctness(
         + 3
     )  # Add two for the driver id and the customer id entity keys and val_to_add request data
 
+    tc = unittest.TestCase()
     for i, entity_row in enumerate(entity_rows):
         df_features = get_latest_feature_values_from_dataframes(
             drivers_df, customers_df, orders_df, global_df, entity_row
         )
-        assert (
+        tc.assertAlmostEqual(
             feature_service_online_features_dict[
                 response_feature_name("conv_rate_plus_100", full_feature_names)
-            ][i]
-            == df_features["conv_rate"] + 100
+            ][i],
+            df_features["conv_rate"] + 100,
+            delta=0.0001
         )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Float features are erroneously materialized to online stores as doubles. This bug could drastically affect the memory and  storage usage of online stores.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1904

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
