### PR TITLE
resolve environment variables in repo config

### DIFF
--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Any
 
@@ -345,7 +346,7 @@ def load_repo_config(repo_path: Path) -> RepoConfig:
     config_path = repo_path / "feature_store.yaml"
 
     with open(config_path) as f:
-        raw_config = yaml.safe_load(f)
+        raw_config = yaml.safe_load(os.path.expandvars(f.read()))
         try:
             c = RepoConfig(**raw_config)
             c.repo_path = repo_path


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
The feature_store.yaml file allows Feast users to enter connection strings for offline and online stores. For example:

```yaml
registry:
  path: ./registry.db
project: production
provider: local
online_store:
  type: redis
  connection_string: my-secret-connection-string
```
This means that a connection string can sit in a plain text file, which makes CI/CD impossible.

This PR allows Feast users to hide the connection string in the YAML file by using environment variables. For example:

```yaml
registry:
  path: ./registry.db
project: production
provider: local
online_store:
  type: redis
  connection_string: ${CONN_STRING_ENV_VAR}
```
Here the environment variable `CONN_STRING_ENV_VAR` is resolved in repo_config.load_repo_config method. This aids CI/CD flows (e.g. using secrets in GitHub actions).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
