### PR TITLE
Add location to BigQueryOfflineStoreConfig

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -52,6 +52,9 @@ class BigQueryOfflineStoreConfig(FeastConfigBaseModel):
     project_id: Optional[StrictStr] = None
     """ (optional) GCP project name used for the BigQuery offline store """
 
+    location: Optional[StrictStr] = None
+    """ (optional) GCP location name used for the BigQuery offline store """
+
 
 class BigQueryOfflineStore(OfflineStore):
     @staticmethod
@@ -79,7 +82,10 @@ class BigQueryOfflineStore(OfflineStore):
         timestamp_desc_string = " DESC, ".join(timestamps) + " DESC"
         field_string = ", ".join(join_key_columns + feature_name_columns + timestamps)
 
-        client = _get_bigquery_client(project=config.offline_store.project_id)
+        client = _get_bigquery_client(
+            project=config.offline_store.project_id,
+            location=config.offline_store.location,
+        )
         query = f"""
             SELECT
                 {field_string}
@@ -115,7 +121,10 @@ class BigQueryOfflineStore(OfflineStore):
         # TODO: Add entity_df validation in order to fail before interacting with BigQuery
         assert isinstance(config.offline_store, BigQueryOfflineStoreConfig)
 
-        client = _get_bigquery_client(project=config.offline_store.project_id)
+        client = _get_bigquery_client(
+            project=config.offline_store.project_id,
+            location=config.offline_store.location,
+        )
 
         assert isinstance(config.offline_store, BigQueryOfflineStoreConfig)
 
@@ -367,9 +376,9 @@ def _upload_entity_df_and_get_entity_schema(
     return entity_schema
 
 
-def _get_bigquery_client(project: Optional[str] = None):
+def _get_bigquery_client(project: Optional[str] = None, location: Optional[str] = None):
     try:
-        client = bigquery.Client(project=project)
+        client = bigquery.Client(project=project, location=location)
     except DefaultCredentialsError as e:
         raise FeastProviderLoginError(
             str(e)

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -53,7 +53,11 @@ class BigQueryOfflineStoreConfig(FeastConfigBaseModel):
     """ (optional) GCP project name used for the BigQuery offline store """
 
     location: Optional[StrictStr] = None
-    """ (optional) GCP location name used for the BigQuery offline store """
+    """ (optional) GCP location name used for the BigQuery offline store.
+    Examples of location names include ``US``, ``EU``, ``us-central1``, ``us-west4``.
+    If a location is not specified, the location defaults to the ``US`` multi-regional location.
+    For more information on BigQuery data locations see: https://cloud.google.com/bigquery/docs/locations
+    """
 
 
 class BigQueryOfflineStore(OfflineStore):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Currently, the BigQueryOfflineStore default to the 'us' GCP region and does provide a configuration to change the region. This PR adds a config to BigQueryOfflineStoreConfig that allows defining a GCP region for a BigQueryOfflineStore.

The default behavior (defaulting to region 'us') is maintained (ie. no location/region specified in the offline store configuration).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1728 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add location configuration to BigQueryOfflineStore
```
