### PR TITLE
duplicate columns from the offline redshift select sql query

### DIFF
--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -516,7 +516,7 @@ WITH entity_dataframe AS (
 /*
  Joins the outputs of multiple time travel joins to a single table.
  The entity_dataframe dataset being our source of truth here.
- */
+*/
 
 SELECT entity_dataframe.*
 FROM entity_dataframe

--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -518,7 +518,7 @@ WITH entity_dataframe AS (
  The entity_dataframe dataset being our source of truth here.
  */
 
-SELECT *
+SELECT entity_dataframe.*
 FROM entity_dataframe
 {% for featureview in featureviews %}
 LEFT JOIN (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Calling https://github.com/feast-dev/feast/blob/v0.13-branch/sdk/python/feast/feature_store.py#L464 created the redshift query using https://github.com/feast-dev/feast/blob/v0.13-branch/sdk/python/feast/feature_store.py#L464. This redshift query is being generated as to `select *` at https://github.com/feast-dev/feast/blob/v0.13-branch/sdk/python/feast/infra/offline_stores/redshift.py#L520, which is causing duplicated columns (except entity columns, entity_timestamp & zipcode_features__entity_row_unique_id) being selected in the query.
Note: zipcode_features__entity_row_unique_id is taken as reference from https://github.com/feast-dev/real-time-credit-scoring-on-aws-tutorial

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes 1917

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```Fixes the issue of duplicates columns for the get_historical_features data pull from offline redshift. Entity columns, entity_timestamp & zipcode_features__entity_row_unique_id are already not coming as duplicated, but rest all columns are getting duplicated in the result of the select query, which is being fixed by this release.
Note: zipcode_features__entity_row_unique_id is taken as reference from https://github.com/feast-dev/real-time-credit-scoring-on-aws-tutorial

```
