### PR TITLE
Changed FVProjection 'name_to_use' field to 'name_alias' and changed '.set_projection' in FeatureView to ".with_projection". Also adjustments for some edge cases

### DIFF
--- a/protos/feast/core/FeatureViewProjection.proto
+++ b/protos/feast/core/FeatureViewProjection.proto
@@ -15,7 +15,7 @@ message FeatureViewProjection {
   string feature_view_name = 1;
 
   // Alias for feature view name
-  string feature_view_name_to_use = 3;
+  string feature_view_name_alias = 3;
 
   // The features of the feature view that are a part of the feature reference.
   repeated FeatureSpecV2 feature_columns = 2;

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -155,6 +155,21 @@ class FeatureView:
     def __hash__(self):
         return hash((id(self), self.name))
 
+    def __copy__(self):
+        fv = FeatureView(
+            name=self.name,
+            entities=self.entities,
+            ttl=self.ttl,
+            input=self.input,
+            batch_source=self.batch_source,
+            stream_source=self.stream_source,
+            features=self.features,
+            tags=self.tags,
+            online=self.online,
+        )
+        fv.projection = copy.copy(self.projection)
+        return fv
+
     def __getitem__(self, item):
         assert isinstance(item, list)
 
@@ -163,7 +178,8 @@ class FeatureView:
             if feature.name in item:
                 referenced_features.append(feature)
 
-        self.projection.features = referenced_features
+        cp = self.__copy__()
+        cp.projection.features = referenced_features
 
         return self
 
@@ -207,7 +223,9 @@ class FeatureView:
 
     def with_name(self, name: str):
         """
-        Produces a copy of this FeatureView with the passed name.
+        Renames this feature view by returning a copy of this feature view with an alias
+        set for the feature view name. This rename operation is only used as part of query
+        operations and will not modify the underlying FeatureView.
 
         Args:
             name: Name to assign to the FeatureView copy.
@@ -215,22 +233,44 @@ class FeatureView:
         Returns:
             A copy of this FeatureView with the name replaced with the 'name' input.
         """
-        fv = FeatureView(
-            name=self.name,
-            entities=self.entities,
-            ttl=self.ttl,
-            input=self.input,
-            batch_source=self.batch_source,
-            stream_source=self.stream_source,
-            features=self.features,
-            tags=self.tags,
-            online=self.online,
-        )
+        cp = self.__copy__()
+        cp.projection.name_alias = name
 
-        fv.set_projection(copy.copy(self.projection))
-        fv.projection.name_to_use = name
+        return cp
 
-        return fv
+    def with_projection(self, feature_view_projection: FeatureViewProjection):
+        """
+        Sets the feature view projection by returning a copy of this feature view
+        with its projection set to the given projection. A projection is an
+        object that stores the modifications to a feature view that is used during
+        query operations.
+
+        Args:
+            feature_view_projection: The FeatureViewProjection object to link to this
+                OnDemandFeatureView.
+
+        Returns:
+            A copy of this FeatureView with its projection replaced with the 'feature_view_projection'
+            argument.
+        """
+        if feature_view_projection.name != self.name:
+            raise ValueError(
+                f"The projection for the {self.name} FeatureView cannot be applied because it differs in name. "
+                f"The projection is named {feature_view_projection.name} and the name indicates which "
+                "FeatureView the projection is for."
+            )
+
+        for feature in feature_view_projection.features:
+            if feature not in self.features:
+                raise ValueError(
+                    f"The projection for {self.name} cannot be applied because it contains {feature.name} which the "
+                    "FeatureView doesn't have."
+                )
+
+        cp = self.__copy__()
+        cp.projection = feature_view_projection
+
+        return cp
 
     def to_proto(self) -> FeatureViewProto:
         """
@@ -416,31 +456,3 @@ class FeatureView:
                     "FeatureView",
                     f"Could not infer Features for the FeatureView named {self.name}.",
                 )
-
-    def set_projection(self, feature_view_projection: FeatureViewProjection) -> None:
-        """
-        Setter for the projection object held by this FeatureView. A projection is an
-        object that stores the modifications to a FeatureView that is applied to the FeatureView
-        when the FeatureView is used such as during feature_store.get_historical_features.
-        This method also performs checks to ensure the projection is consistent with this
-        FeatureView before doing the set.
-
-        Args:
-            feature_view_projection: The FeatureViewProjection object to set this FeatureView's
-                'projection' field to.
-        """
-        if feature_view_projection.name != self.name:
-            raise ValueError(
-                f"The projection for the {self.name} FeatureView cannot be applied because it differs in name. "
-                f"The projection is named {feature_view_projection.name} and the name indicates which "
-                "FeatureView the projection is for."
-            )
-
-        for feature in feature_view_projection.features:
-            if feature not in self.features:
-                raise ValueError(
-                    f"The projection for {self.name} cannot be applied because it contains {feature.name} which the "
-                    "FeatureView doesn't have."
-                )
-
-        self.projection = feature_view_projection

--- a/sdk/python/feast/feature_view_projection.py
+++ b/sdk/python/feast/feature_view_projection.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from attr import dataclass
 
@@ -11,12 +11,15 @@ from feast.protos.feast.core.FeatureViewProjection_pb2 import (
 @dataclass
 class FeatureViewProjection:
     name: str
-    name_to_use: str
+    name_alias: Optional[str]
     features: List[Feature]
+
+    def name_to_use(self):
+        return self.name_alias or self.name
 
     def to_proto(self):
         feature_reference_proto = FeatureViewProjectionProto(
-            feature_view_name=self.name, feature_view_name_to_use=self.name_to_use
+            feature_view_name=self.name, feature_view_name_alias=self.name_alias
         )
         for feature in self.features:
             feature_reference_proto.feature_columns.append(feature.to_proto())
@@ -27,7 +30,7 @@ class FeatureViewProjection:
     def from_proto(proto: FeatureViewProjectionProto):
         ref = FeatureViewProjection(
             name=proto.feature_view_name,
-            name_to_use=proto.feature_view_name_to_use,
+            name_alias=proto.feature_view_name_alias,
             features=[],
         )
         for feature_column in proto.feature_columns:
@@ -39,6 +42,6 @@ class FeatureViewProjection:
     def from_definition(feature_grouping):
         return FeatureViewProjection(
             name=feature_grouping.name,
-            name_to_use=feature_grouping.name,
+            name_alias=None,
             features=feature_grouping.features,
         )

--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -128,7 +128,7 @@ def get_feature_view_query_context(
         created_timestamp_column = feature_view.input.created_timestamp_column
 
         context = FeatureViewQueryContext(
-            name=feature_view.projection.name_to_use,
+            name=feature_view.projection.name_to_use(),
             ttl=ttl_seconds,
             entities=join_keys,
             features=features,

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -191,11 +191,11 @@ def _get_requested_feature_views_to_features_dict(
 
         found = False
         for fv in feature_views:
-            if fv.projection.name_to_use == feature_view_from_ref:
+            if fv.projection.name_to_use() == feature_view_from_ref:
                 found = True
                 feature_views_to_feature_map[fv].append(feature_from_ref)
         for odfv in on_demand_feature_views:
-            if odfv.projection.name_to_use == feature_view_from_ref:
+            if odfv.projection.name_to_use() == feature_view_from_ref:
                 found = True
                 on_demand_feature_views_to_feature_map[odfv].append(feature_from_ref)
 


### PR DESCRIPTION
Signed-off-by: David Y Liu <davidyliuliu@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Better style and the change to "with_projection" makes it harder to make mistakes. Adjustments for some edge cases like the following:

```
FeatureService(
    ...
    features=[
        my_fv[[feature_a]],
        my_fv[[feature_b]].with_name("fv_2")
   ]  
    ...
)
```
won't work unless __get_items__() returns a copy of the FV rather than just editing the projection. In this example, when my_fv[[feature_b]] is invoked, it overrides the feature subset in the projection for my_fv[[feature_a]]. 
