### PR TITLE
Corrected setup.py BigQuery version that's needed for a contributor's merged PR 1844

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -65,7 +65,7 @@ REQUIRED = [
 ]
 
 GCP_REQUIRED = [
-    "google-cloud-bigquery>=2.0.*",
+    "google-cloud-bigquery>=2.14.0",
     "google-cloud-bigquery-storage >= 2.0.0",
     "google-cloud-datastore>=2.1.*",
     "google-cloud-storage>=1.34.*",
@@ -111,7 +111,7 @@ CI_REQUIRED = [
     "firebase-admin==4.5.2",
     "pre-commit",
     "assertpy==1.1",
-    "google-cloud-bigquery>=2.0.*",
+    "google-cloud-bigquery>=2.14.0",
     "google-cloud-bigquery-storage >= 2.0.0",
     "google-cloud-datastore>=2.1.*",
     "google-cloud-storage>=1.20.*",


### PR DESCRIPTION
Signed-off-by: David Y Liu <davidyliuliu@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->
The following PR by a contributor was merged but it assumes a higher version of google-cloud-bigquery. Passing in job objects to get_job and cancel_job only was supported in 2.14.0. 
https://github.com/feast-dev/feast/pull/1844/files
2.14.0 changes reference - https://newreleases.io/project/pypi/google-cloud-bigquery/release/2.14.0

