### PR TITLE
Fix conditional statements for if OnDemandFVs exist

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -255,7 +255,7 @@ class BigQueryRetrievalJob(RetrievalJob):
                 path = f"{self.client.project}.{self.config.offline_store.dataset}.historical_{today}_{rand_id}"
                 job_config = bigquery.QueryJobConfig(destination=path)
 
-            if not job_config.dry_run and self.on_demand_feature_views is not None:
+            if not job_config.dry_run and self.on_demand_feature_views:
                 job = _write_pyarrow_table_to_bq(
                     self.client, self.to_arrow(), job_config.destination
                 )

--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -265,7 +265,7 @@ class RedshiftRetrievalJob(RetrievalJob):
 
     def to_s3(self) -> str:
         """ Export dataset to S3 in Parquet format and return path """
-        if self.on_demand_feature_views is not None:
+        if self.on_demand_feature_views:
             transformed_df = self.to_df()
             aws_utils.upload_df_to_s3(self._s3_resource, self._s3_path, transformed_df)
             return self._s3_path
@@ -285,7 +285,7 @@ class RedshiftRetrievalJob(RetrievalJob):
 
     def to_redshift(self, table_name: str) -> None:
         """ Save dataset as a new Redshift table """
-        if self.on_demand_feature_views is not None:
+        if self.on_demand_feature_views:
             transformed_df = self.to_df()
             aws_utils.upload_df_to_redshift(
                 self._redshift_client,


### PR DESCRIPTION
Signed-off-by: Cody Lin <codyl@twitter.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
There's an inconsistency for checking whether there are `self.on_demand_feature_views` - if this value is an empty list `[]` as returned by [`on_demand_feature_view.get_requested_odfvs`](https://github.com/feast-dev/feast/blob/156d004672e73d27ddaa2408fff49d7e5f642a63/sdk/python/feast/on_demand_feature_view.py#L298-L308) ([like here](https://github.com/feast-dev/feast/blob/156d004672e73d27ddaa2408fff49d7e5f642a63/sdk/python/feast/infra/offline_stores/bigquery.py#L183)), then the old conditional statements are wrong.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Small bugfix, no issue

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
