### PR TITLE
Fix bug in feast alpha enable CLI command

### DIFF
--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -277,12 +277,7 @@ class RepoConfig(FeastBaseModel):
         config_path = repo_path / "feature_store.yaml"
         with open(config_path, mode="w") as f:
             yaml.dump(
-                yaml.safe_load(
-                    self.json(
-                        exclude={"repo_path"},
-                        exclude_unset=True,
-                    )
-                ),
+                yaml.safe_load(self.json(exclude={"repo_path"}, exclude_unset=True,)),
                 f,
                 sort_keys=False,
             )


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Previously, `feast alpha enable` could modify the `feature_store.yaml` file in a breaking way; this PR prevents that from happening. Note that non-breaking, but potentially unexpected modifications, are still possible. For example, calling `feast alpha enable python_feature_server` on the following `feature_store.yaml`
```
registry: data/registry.db
project: smooth_fish
provider: local
online_store:
  type: redis
flags:
  alpha_features: true
  python_feature_server: true
```
will still change it to
```
registry: data/registry.db
project: smooth_fish
provider: local
online_store:
  type: redis
offline_store:
  type: file
flags:
  alpha_features: true
  python_feature_server: true
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1938 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The feast alpha enable CLI command is now fixed
```
