### PR TITLE
Solve package conflict in [gcp] and [ci]

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -69,7 +69,7 @@ GCP_REQUIRED = [
     "google-cloud-bigquery>=2.28.1",
     "google-cloud-bigquery-storage >= 2.0.0",
     "google-cloud-datastore>=2.1.*",
-    "google-cloud-storage>=1.34.*",
+    "google-cloud-storage>=1.34.*,<1.41",
     "google-cloud-core==1.4.*",
 ]
 
@@ -115,7 +115,7 @@ CI_REQUIRED = [
     "google-cloud-bigquery>=2.28.1",
     "google-cloud-bigquery-storage >= 2.0.0",
     "google-cloud-datastore>=2.1.*",
-    "google-cloud-storage>=1.20.*",
+    "google-cloud-storage>=1.20.*,<1.41",
     "google-cloud-core==1.4.*",
     "redis-py-cluster==2.1.2",
     "boto3==1.17.*",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR fixes Installing `feast[gcp]` and `feast[ci]` fails due to package conflict.
Both extra packages try to install `google-cloud-core==1.4.*` but the latest version of `google-cloud-storage` (the latest version is `1.42.3` for now) tries to install `google-cloud-core<3.0dev,>=1.6.0` .

Steps to reproduce are as follows:

```console
$ cat Pipfile
[[source]]
url = "https://pypi.org/simple"
verify_ssl = true
name = "pypi"

[packages]
feast = {extras = ["gcp"], version = "*"}

[dev-packages]

[requires]
python_version = "3.9"
$ pipenv install 
...
ERROR: Could not find a version that matches google-cloud-core<3.0.0dev,<3.0dev,==1.4.*,>=1.4.0,>=1.4.1,>=1.6.0 (from feast[gcp]==0.14.0->-r /var/folders/rv/h226tqmj72xbpjyjjf2hr5xc0000gp/T/pipenv3doi2g2zrequirements/pipenv-u9o2xijh-constraints.txt (line 4))
Tried: 0.20.0, 0.20.0, 0.21.0, 0.21.0, 0.22.0, 0.22.0, 0.22.1, 0.22.1, 0.23.0, 0.23.0, 0.23.1, 0.23.1, 0.24.0, 0.24.0, 0.24.1, 0.24.1, 0.25.0, 0.25.0, 0.26.0, 0.26.0, 0.27.0, 0.27.0, 0.27.1, 0.27.1, 0.28.0, 0.28.0, 0.28.1, 0.28.1, 0.29.0, 0.29.0, 0.29.1, 0.29.1, 1.0.0, 1.0.0, 1.0.1, 1.0.1, 1.0.2, 1.0.2, 1.0.3, 1.0.3, 1.1.0, 1.1.0, 1.2.0, 1.2.0, 1.3.0, 1.3.0, 1.4.0, 1.4.0, 1.4.1, 1.4.1, 1.4.2, 1.4.2, 1.4.3, 1.4.3, 1.4.4, 1.4.4, 1.5.0, 1.5.0, 1.6.0, 1.6.0, 1.7.0, 1.7.0, 1.7.1, 1.7.1, 1.7.2, 1.7.2, 2.0.0, 2.0.0, 2.1.0, 2.1.0
Tried pre-versions: 1.4.2rc1, 1.4.2rc1, 1.4.2rc2, 1.4.2rc2, 2.0.0b1, 2.0.0b1
There are incompatible versions in the resolved dependencies:
  google-cloud-core<3.0.0dev,>=1.4.0 (from google-cloud-datastore==2.2.0->feast[gcp]==0.14.0->-r /var/folders/rv/h226tqmj72xbpjyjjf2hr5xc0000gp/T/pipenv3doi2g2zrequirements/pipenv-u9o2xijh-constraints.txt (line 4))
  google-cloud-core<3.0.0dev,>=1.4.1 (from google-cloud-bigquery==2.28.1->feast[gcp]==0.14.0->-r /var/folders/rv/h226tqmj72xbpjyjjf2hr5xc0000gp/T/pipenv3doi2g2zrequirements/pipenv-u9o2xijh-constraints.txt (line 4))
  google-cloud-core<3.0dev,>=1.6.0 (from google-cloud-storage==1.42.3->feast[gcp]==0.14.0->-r /var/folders/rv/h226tqmj72xbpjyjjf2hr5xc0000gp/T/pipenv3doi2g2zrequirements/pipenv-u9o2xijh-constraints.txt (line 4))
  google-cloud-core==1.4.* (from feast[gcp]==0.14.0->-r /var/folders/rv/h226tqmj72xbpjyjjf2hr5xc0000gp/T/pipenv3doi2g2zrequirements/pipenv-u9o2xijh-constraints.txt (line 4))
```

`google-cloud-storage==1.40.0` requires `google-cloud-core >= 1.4.1, < 2.0dev` (see [here](https://github.com/googleapis/python-storage/blob/v1.40.0/setup.py#L32)) and `google-cloud-storage>=1.41.0` requires `google-cloud-core >= 1.6.0` (see [here](https://github.com/googleapis/python-storage/blob/v1.41.0/setup.py#L32)). So I decided to constrain the version under `1.41`.

Another way to fix this problem is to install `google-cloud-core >= 1.4.*` , but I didn't choose this because I'm not sure it's OK...

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1912

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
