### PR TITLE
eventtime check before writing features, use pipelines, ttl

### DIFF
--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -252,10 +252,7 @@ class RedisOnlineStore(OnlineStore):
         return result
 
     def _get_features_for_entity(
-            self,
-            values: List[str],
-            feature_view: str,
-            requested_features: List[str],
+        self, values: List[str], feature_view: str, requested_features: List[str],
     ) -> Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]:
         res_val = dict(zip(requested_features, values))
 

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -15,7 +15,7 @@ import json
 import logging
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, ByteString
 
 from google.protobuf.timestamp_pb2 import Timestamp
 from pydantic import StrictStr
@@ -252,7 +252,7 @@ class RedisOnlineStore(OnlineStore):
         return result
 
     def _get_features_for_entity(
-        self, values: List[str], feature_view: str, requested_features: List[str],
+        self, values: List[ByteString], feature_view: str, requested_features: List[str],
     ) -> Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]:
         res_val = dict(zip(requested_features, values))
 

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -21,13 +21,14 @@ import pytest
 from _pytest.nodes import Item
 
 from tests.data.data_creator import create_dataset
+from tests.integration.feature_repos.integration_test_repo_config import IntegrationTestRepoConfig
 from tests.integration.feature_repos.repo_configuration import (
     FULL_REPO_CONFIGS,
     Environment,
     construct_test_environment,
     construct_universal_data_sources,
     construct_universal_datasets,
-    construct_universal_entities,
+    construct_universal_entities, REDIS_CONFIG,
 )
 
 
@@ -135,6 +136,12 @@ def simple_dataset_2() -> pd.DataFrame:
 )
 def environment(request):
     with construct_test_environment(request.param) as e:
+        yield e
+
+
+@pytest.fixture()
+def local_redis_environment():
+    with construct_test_environment(IntegrationTestRepoConfig(online_store=REDIS_CONFIG)) as e:
         yield e
 
 

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -21,14 +21,17 @@ import pytest
 from _pytest.nodes import Item
 
 from tests.data.data_creator import create_dataset
-from tests.integration.feature_repos.integration_test_repo_config import IntegrationTestRepoConfig
+from tests.integration.feature_repos.integration_test_repo_config import (
+    IntegrationTestRepoConfig,
+)
 from tests.integration.feature_repos.repo_configuration import (
     FULL_REPO_CONFIGS,
+    REDIS_CONFIG,
     Environment,
     construct_test_environment,
     construct_universal_data_sources,
     construct_universal_datasets,
-    construct_universal_entities, REDIS_CONFIG,
+    construct_universal_entities,
 )
 
 
@@ -141,7 +144,9 @@ def environment(request):
 
 @pytest.fixture()
 def local_redis_environment():
-    with construct_test_environment(IntegrationTestRepoConfig(online_store=REDIS_CONFIG)) as e:
+    with construct_test_environment(
+        IntegrationTestRepoConfig(online_store=REDIS_CONFIG)
+    ) as e:
         yield e
 
 

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -16,6 +16,7 @@ from tests.integration.feature_repos.universal.feature_views import driver_featu
 @pytest.mark.parametrize("infer_features", [True, False])
 def test_e2e_consistency(environment, e2e_data_sources, infer_features):
     fs = environment.feature_store
+    fs.config.project = fs.config.project + str(infer_features)
     df, data_source = e2e_data_sources
     fv = driver_feature_view(data_source=data_source, infer_features=infer_features)
 

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 from pytest_lazyfixture import lazy_fixture
 
-from feast import FeatureService, Entity, ValueType, FeatureView, Feature
+from feast import Entity, Feature, FeatureService, FeatureView, ValueType
 from feast.errors import (
     FeatureNameCollisionError,
     RequestDataNotFoundInEntityRowsException,
@@ -50,8 +50,12 @@ def test_write_to_online_store_event_check(local_redis_environment, dataframe_so
 
         # write same data points 3 with different timestamps
         now = pd.Timestamp(datetime.datetime.utcnow()).round("ms")
-        hour_ago = pd.Timestamp(datetime.datetime.utcnow() - timedelta(hours=1)).round("ms")
-        latest = pd.Timestamp(datetime.datetime.utcnow() + timedelta(seconds=1)).round("ms")
+        hour_ago = pd.Timestamp(datetime.datetime.utcnow() - timedelta(hours=1)).round(
+            "ms"
+        )
+        latest = pd.Timestamp(datetime.datetime.utcnow() + timedelta(seconds=1)).round(
+            "ms"
+        )
 
         #  data to ingest into Online Store (recent)
         data = {
@@ -65,8 +69,7 @@ def test_write_to_online_store_event_check(local_redis_environment, dataframe_so
         fs.write_to_online_store("feature_view_123", df_data)
 
         df = fs.get_online_features(
-            features=["feature_view_123:string_col"],
-            entity_rows=[{"id": 123}]
+            features=["feature_view_123:string_col"], entity_rows=[{"id": 123}]
         ).to_df()
         assert df["string_col"].iloc[0] == "hi_123"
 
@@ -84,7 +87,7 @@ def test_write_to_online_store_event_check(local_redis_environment, dataframe_so
 
         df = fs.get_online_features(
             features=["feature_view_123:string_col"],
-            entity_rows=[{"id": 123}, {"id": 567}, {"id": 890}]
+            entity_rows=[{"id": 123}, {"id": 567}, {"id": 890}],
         ).to_df()
         assert df["string_col"].iloc[0] == "hi_123"
         assert df["string_col"].iloc[1] == "hello_123"
@@ -102,7 +105,7 @@ def test_write_to_online_store_event_check(local_redis_environment, dataframe_so
 
         df = fs.get_online_features(
             features=["feature_view_123:string_col"],
-            entity_rows=[{"id": 123}, {"id": 567}, {"id": 890}]
+            entity_rows=[{"id": 123}, {"id": 567}, {"id": 890}],
         ).to_df()
         assert df["string_col"].iloc[0] == "LATEST_VALUE"
         assert df["string_col"].iloc[1] == "hello_123"

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -6,8 +6,9 @@ from datetime import timedelta
 import numpy as np
 import pandas as pd
 import pytest
+from pytest_lazyfixture import lazy_fixture
 
-from feast import FeatureService
+from feast import FeatureService, Entity, ValueType, FeatureView, Feature
 from feast.errors import (
     FeatureNameCollisionError,
     RequestDataNotFoundInEntityRowsException,
@@ -23,6 +24,89 @@ from tests.integration.feature_repos.universal.entities import (
 from tests.integration.feature_repos.universal.feature_views import (
     create_driver_hourly_stats_feature_view,
 )
+from tests.utils.data_source_utils import prep_file_source
+
+
+# TODO: make this work with all universal (all online store types)
+@pytest.mark.integration
+@pytest.mark.parametrize("dataframe_source", [lazy_fixture("simple_dataset_1")])
+def test_write_to_online_store_event_check(local_redis_environment, dataframe_source):
+    fs = local_redis_environment.feature_store
+    with prep_file_source(
+        df=dataframe_source, event_timestamp_column="ts_1"
+    ) as file_source:
+        e = Entity(name="id", value_type=ValueType.STRING)
+
+        # Create Feature View
+        fv1 = FeatureView(
+            name="feature_view_123",
+            features=[Feature(name="string_col", dtype=ValueType.STRING)],
+            entities=["id"],
+            batch_source=file_source,
+            ttl=timedelta(minutes=5),
+        )
+        # Register Feature View and Entity
+        fs.apply([fv1, e])
+
+        # write same data points 3 with different timestamps
+        now = pd.Timestamp(datetime.datetime.utcnow()).round("ms")
+        hour_ago = pd.Timestamp(datetime.datetime.utcnow() - timedelta(hours=1)).round("ms")
+        latest = pd.Timestamp(datetime.datetime.utcnow() + timedelta(seconds=1)).round("ms")
+
+        #  data to ingest into Online Store (recent)
+        data = {
+            "id": [123],
+            "string_col": ["hi_123"],
+            "ts_1": [now],
+        }
+        df_data = pd.DataFrame(data)
+
+        # directly ingest data into the Online Store
+        fs.write_to_online_store("feature_view_123", df_data)
+
+        df = fs.get_online_features(
+            features=["feature_view_123:string_col"],
+            entity_rows=[{"id": 123}]
+        ).to_df()
+        assert df["string_col"].iloc[0] == "hi_123"
+
+        # data to ingest into Online Store (1 hour delayed data)
+        # should now overwrite features for id=123 because it's less recent data
+        data = {
+            "id": [123, 567, 890],
+            "string_col": ["bye_321", "hello_123", "greetings_321"],
+            "ts_1": [hour_ago, hour_ago, hour_ago],
+        }
+        df_data = pd.DataFrame(data)
+
+        # directly ingest data into the Online Store
+        fs.write_to_online_store("feature_view_123", df_data)
+
+        df = fs.get_online_features(
+            features=["feature_view_123:string_col"],
+            entity_rows=[{"id": 123}, {"id": 567}, {"id": 890}]
+        ).to_df()
+        assert df["string_col"].iloc[0] == "hi_123"
+        assert df["string_col"].iloc[1] == "hello_123"
+        assert df["string_col"].iloc[2] == "greetings_321"
+
+        # should overwrite string_col for id=123 because it's most recent based on event_timestamp
+        data = {
+            "id": [123],
+            "string_col": ["LATEST_VALUE"],
+            "ts_1": [latest],
+        }
+        df_data = pd.DataFrame(data)
+
+        fs.write_to_online_store("feature_view_123", df_data)
+
+        df = fs.get_online_features(
+            features=["feature_view_123:string_col"],
+            entity_rows=[{"id": 123}, {"id": 567}, {"id": 890}]
+        ).to_df()
+        assert df["string_col"].iloc[0] == "LATEST_VALUE"
+        assert df["string_col"].iloc[1] == "hello_123"
+        assert df["string_col"].iloc[2] == "greetings_321"
 
 
 @pytest.mark.integration

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 import numpy as np
 import pandas as pd
 import pytest
-from pytest_lazyfixture import lazy_fixture
 
 from feast import Entity, Feature, FeatureService, FeatureView, ValueType
 from feast.errors import (
@@ -34,12 +33,8 @@ def test_write_to_online_store_event_check(local_redis_environment):
 
     # write same data points 3 with different timestamps
     now = pd.Timestamp(datetime.datetime.utcnow()).round("ms")
-    hour_ago = pd.Timestamp(datetime.datetime.utcnow() - timedelta(hours=1)).round(
-        "ms"
-    )
-    latest = pd.Timestamp(datetime.datetime.utcnow() + timedelta(seconds=1)).round(
-        "ms"
-    )
+    hour_ago = pd.Timestamp(datetime.datetime.utcnow() - timedelta(hours=1)).round("ms")
+    latest = pd.Timestamp(datetime.datetime.utcnow() + timedelta(seconds=1)).round("ms")
 
     data = {
         "id": [123, 567, 890],
@@ -118,7 +113,10 @@ def test_write_to_online_store_event_check(local_redis_environment):
         assert df["string_col"].iloc[2] == "greetings_321"
 
         # writes to online store via datasource (dataframe_source) materialization
-        fs.materialize(start_date=datetime.datetime.now() - timedelta(hours=12), end_date=datetime.datetime.utcnow())
+        fs.materialize(
+            start_date=datetime.datetime.now() - timedelta(hours=12),
+            end_date=datetime.datetime.utcnow(),
+        )
 
         df = fs.get_online_features(
             features=["feature_view_123:string_col"],

--- a/sdk/python/tests/utils/online_read_write_test.py
+++ b/sdk/python/tests/utils/online_read_write_test.py
@@ -67,16 +67,14 @@ def basic_rw_test(
         event_ts=time_1, created_ts=time_1, write=(1.1, "3.1"), expect_read=(1.1, "3.1")
     )
 
-    # Note: This behavior has changed for performance. We should test that older
-    # value can't overwrite over a newer value once we add the respective flag
+    # We should test that older value can't overwrite over a newer value once we add the respective flag
     # TODO: event_ts check supported by Redis Online Store; add to other Online stores as well
-    """ Values with an older event_ts should overwrite newer ones """
     # time_2 = datetime.utcnow()
     # _driver_rw_test(
     #     event_ts=time_1 - timedelta(hours=1),
     #     created_ts=time_2,
     #     write=(-1000, "OLD"),
-    #     expect_read=(-1000, "OLD"),
+    #     expect_read=(1.1, "3.1"),
     # )
 
     """ Values with an new event_ts should overwrite older ones """
@@ -88,16 +86,14 @@ def basic_rw_test(
         expect_read=(1123, "NEWER"),
     )
 
-    # Note: This behavior has changed for performance. We should test that older
-    # value can't overwrite over a newer value once we add the respective flag
+    # We should test that older value can't overwrite over a newer value once we add the respective flag
     # TODO: add the `created_ts` tie breaker check in the Online stores
-    # TODO: switch order of _driver_rw_test to check that it's tie breaker logic vs. order of write
-    """ created_ts is used as a tie breaker, using older created_ts here, but we still overwrite """
+    """ created_ts is used as a tie breaker, using older created_ts here """
     # _driver_rw_test(
     #     event_ts=time_1 + timedelta(hours=1),
     #     created_ts=time_3 - timedelta(hours=1),
     #     write=(54321, "I HAVE AN OLDER created_ts SO I LOSE"),
-    #     expect_read=(54321, "I HAVE AN OLDER created_ts SO I LOSE"),
+    #     expect_read=(1123, "NEWER"),
     # )
 
     """ created_ts is used as a tie breaker, using newer created_ts here so we should overwrite """

--- a/sdk/python/tests/utils/online_read_write_test.py
+++ b/sdk/python/tests/utils/online_read_write_test.py
@@ -67,16 +67,6 @@ def basic_rw_test(
         event_ts=time_1, created_ts=time_1, write=(1.1, "3.1"), expect_read=(1.1, "3.1")
     )
 
-    # We should test that older value can't overwrite over a newer value once we add the respective flag
-    # TODO: event_ts check supported by Redis Online Store; add to other Online stores as well
-    # time_2 = datetime.utcnow()
-    # _driver_rw_test(
-    #     event_ts=time_1 - timedelta(hours=1),
-    #     created_ts=time_2,
-    #     write=(-1000, "OLD"),
-    #     expect_read=(1.1, "3.1"),
-    # )
-
     """ Values with an new event_ts should overwrite older ones """
     time_3 = datetime.utcnow()
     _driver_rw_test(
@@ -85,21 +75,3 @@ def basic_rw_test(
         write=(1123, "NEWER"),
         expect_read=(1123, "NEWER"),
     )
-
-    # We should test that older value can't overwrite over a newer value once we add the respective flag
-    # TODO: add the `created_ts` tie breaker check in the Online stores
-    """ created_ts is used as a tie breaker, using older created_ts here """
-    # _driver_rw_test(
-    #     event_ts=time_1 + timedelta(hours=1),
-    #     created_ts=time_3 - timedelta(hours=1),
-    #     write=(54321, "I HAVE AN OLDER created_ts SO I LOSE"),
-    #     expect_read=(1123, "NEWER"),
-    # )
-
-    """ created_ts is used as a tie breaker, using newer created_ts here so we should overwrite """
-    # _driver_rw_test(
-    #     event_ts=time_1 + timedelta(hours=1),
-    #     created_ts=time_3 + timedelta(hours=1),
-    #     write=(96864, "I HAVE A NEWER created_ts SO I WIN"),
-    #     expect_read=(96864, "I HAVE A NEWER created_ts SO I WIN"),
-    # )

--- a/sdk/python/tests/utils/online_read_write_test.py
+++ b/sdk/python/tests/utils/online_read_write_test.py
@@ -69,14 +69,15 @@ def basic_rw_test(
 
     # Note: This behavior has changed for performance. We should test that older
     # value can't overwrite over a newer value once we add the respective flag
+    # TODO: event_ts check supported by Redis Online Store; add to other Online stores as well
     """ Values with an older event_ts should overwrite newer ones """
-    time_2 = datetime.utcnow()
-    _driver_rw_test(
-        event_ts=time_1 - timedelta(hours=1),
-        created_ts=time_2,
-        write=(-1000, "OLD"),
-        expect_read=(-1000, "OLD"),
-    )
+    # time_2 = datetime.utcnow()
+    # _driver_rw_test(
+    #     event_ts=time_1 - timedelta(hours=1),
+    #     created_ts=time_2,
+    #     write=(-1000, "OLD"),
+    #     expect_read=(-1000, "OLD"),
+    # )
 
     """ Values with an new event_ts should overwrite older ones """
     time_3 = datetime.utcnow()
@@ -89,18 +90,20 @@ def basic_rw_test(
 
     # Note: This behavior has changed for performance. We should test that older
     # value can't overwrite over a newer value once we add the respective flag
+    # TODO: add the `created_ts` tie breaker check in the Online stores
+    # TODO: switch order of _driver_rw_test to check that it's tie breaker logic vs. order of write
     """ created_ts is used as a tie breaker, using older created_ts here, but we still overwrite """
-    _driver_rw_test(
-        event_ts=time_1 + timedelta(hours=1),
-        created_ts=time_3 - timedelta(hours=1),
-        write=(54321, "I HAVE AN OLDER created_ts SO I LOSE"),
-        expect_read=(54321, "I HAVE AN OLDER created_ts SO I LOSE"),
-    )
+    # _driver_rw_test(
+    #     event_ts=time_1 + timedelta(hours=1),
+    #     created_ts=time_3 - timedelta(hours=1),
+    #     write=(54321, "I HAVE AN OLDER created_ts SO I LOSE"),
+    #     expect_read=(54321, "I HAVE AN OLDER created_ts SO I LOSE"),
+    # )
 
     """ created_ts is used as a tie breaker, using newer created_ts here so we should overwrite """
-    _driver_rw_test(
-        event_ts=time_1 + timedelta(hours=1),
-        created_ts=time_3 + timedelta(hours=1),
-        write=(96864, "I HAVE A NEWER created_ts SO I WIN"),
-        expect_read=(96864, "I HAVE A NEWER created_ts SO I WIN"),
-    )
+    # _driver_rw_test(
+    #     event_ts=time_1 + timedelta(hours=1),
+    #     created_ts=time_3 + timedelta(hours=1),
+    #     write=(96864, "I HAVE A NEWER created_ts SO I WIN"),
+    #     expect_read=(96864, "I HAVE A NEWER created_ts SO I WIN"),
+    # )


### PR DESCRIPTION
Signed-off-by: Vitaly Sergeyev <vsergeyev@better.com>

Several parts here mostly for discussion then can break into smaller PRs:

1. check the event timestamp before writing the features
the use case here comes into play when there are multiple ways to ingest into the OnlineStore (i.e. materialization, direct/streaming ingestion) so timing could be different in different scenarios so we are checking the even timestamp to make sure only the latest features are written

2. using redis pipelines to limit the amount of network calls 
if there are a lot of entities to lookup in Redis then the number of network calls to Redis may be the bottleneck. Tested this with >1000 entities and it's slow without using pipelines.

3. (**removed from this PR**)  support expiring records in the Redis -- probably should be a separate PR for this but putting out there for discussion
entities should be able to be expired otherwise they remain in the store and the feature store continuously grows. 
In many of our use cases an entity has some natural timeline for being relevant so this could be part of the TTL in the OnlineStore.

4. (**removed from this PR**) ability to lookup all entities
use case here is to be able to support ranking models where we are constantly reranking a lot of entities. Works well if entities can be expired as well. 
