### PR TITLE
Move IntegrationTestRepoConfig class to another module

### DIFF
--- a/sdk/python/tests/integration/feature_repos/integration_test_repo_config.py
+++ b/sdk/python/tests/integration/feature_repos/integration_test_repo_config.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Dict, Type, Union
+
+from tests.integration.feature_repos.universal.data_source_creator import (
+    DataSourceCreator,
+)
+from tests.integration.feature_repos.universal.data_sources.file import (
+    FileDataSourceCreator,
+)
+
+
+@dataclass(frozen=True)
+class IntegrationTestRepoConfig:
+    """
+    This class should hold all possible parameters that may need to be varied by individual tests.
+    """
+
+    provider: str = "local"
+    online_store: Union[str, Dict] = "sqlite"
+
+    offline_store_creator: Type[DataSourceCreator] = FileDataSourceCreator
+
+    full_feature_names: bool = True
+    infer_features: bool = False
+
+    def __repr__(self) -> str:
+        return "-".join(
+            [
+                f"Provider: {self.provider}",
+                f"{self.offline_store_creator.__name__.split('.')[-1].rstrip('DataSourceCreator')}",
+                self.online_store
+                if isinstance(self.online_store, str)
+                else self.online_store["type"],
+            ]
+        )

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -6,21 +6,21 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
 from feast import FeatureStore, FeatureView, RepoConfig, driver_test_data
 from feast.constants import FULL_REPO_CONFIGS_MODULE_ENV_NAME
 from feast.data_source import DataSource
+from tests.integration.feature_repos.integration_test_repo_config import (
+    IntegrationTestRepoConfig,
+)
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
 )
 from tests.integration.feature_repos.universal.data_sources.bigquery import (
     BigQueryDataSourceCreator,
-)
-from tests.integration.feature_repos.universal.data_sources.file import (
-    FileDataSourceCreator,
 )
 from tests.integration.feature_repos.universal.data_sources.redshift import (
     RedshiftDataSourceCreator,
@@ -35,33 +35,6 @@ from tests.integration.feature_repos.universal.feature_views import (
     create_location_stats_feature_view,
     create_order_feature_view,
 )
-
-
-@dataclass(frozen=True)
-class IntegrationTestRepoConfig:
-    """
-    This class should hold all possible parameters that may need to be varied by individual tests.
-    """
-
-    provider: str = "local"
-    online_store: Union[str, Dict] = "sqlite"
-
-    offline_store_creator: Type[DataSourceCreator] = FileDataSourceCreator
-
-    full_feature_names: bool = True
-    infer_features: bool = False
-
-    def __repr__(self) -> str:
-        return "-".join(
-            [
-                f"Provider: {self.provider}",
-                f"{self.offline_store_creator.__name__.split('.')[-1].rstrip('DataSourceCreator')}",
-                self.online_store
-                if isinstance(self.online_store, str)
-                else self.online_store["type"],
-            ]
-        )
-
 
 DYNAMO_CONFIG = {"type": "dynamodb", "region": "us-west-2"}
 REDIS_CONFIG = {"type": "redis", "connection_string": "localhost:6379,db=0"}


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: In order for plugin repos to override `FULL_REPO_CONFIGS`, they must import the `IntegrationTestRepoConfig` class. However, if the class remains in `repo_configuration.py`, it will automatically trigger `FULL_REPO_CONFIGS` to be computed. By moving the class to another file, we avoid this circular logic.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
