### PR TITLE
check the variable not the function

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -256,7 +256,7 @@ class BigQueryRetrievalJob(RetrievalJob):
                 path = f"{self.client.project}.{self.config.offline_store.dataset}.historical_{today}_{rand_id}"
                 job_config = bigquery.QueryJobConfig(destination=path)
 
-            if not job_config.dry_run and self.on_demand_feature_views:
+            if not job_config.dry_run and self._on_demand_feature_views:
                 job = self.client.load_table_from_dataframe(
                     self.to_df(), job_config.destination
                 )


### PR DESCRIPTION
**What this PR does / why we need it**:
During a BigQueryRetrievalJob, the method `to_bigquery()` will check if `self.on_demand_feature_views` contains something rather than checking the variable `self._on_demand_feature_views`

And because `on_demand_feature_views()` is also a property, then the following logic was always true an executed
```python
if not job_config.dry_run and self._on_demand_feature_views:
    job = self.client.load_table_from_dataframe(
        self.to_df(), job_config.destination
    )
    job.result()
    print(f"Done writing to '{job_config.destination}'.")
    return str(job_config.destination)
```

This bug just means that the `job.result()` is executed twice in a row 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
