### PR TITLE
Fix duplicate update infra

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -378,6 +378,7 @@ class FeatureStore:
                 ]
             ],
         ],
+        update_infra: bool = True,
         commit: bool = True,
     ):
         """Register objects to metadata store and update related infrastructure.
@@ -389,6 +390,7 @@ class FeatureStore:
 
         Args:
             objects: A single object, or a list of objects that should be registered with the Feature Store.
+            update_infra: If True, update online store infra to reflect the newly applied objects.
             commit: whether to commit changes to the registry
 
         Raises:
@@ -478,14 +480,15 @@ class FeatureStore:
         for feature_service in services_to_update:
             self._registry.apply_feature_service(feature_service, project=self.project)
 
-        self._get_provider().update_infra(
-            project=self.project,
-            tables_to_delete=[],
-            tables_to_keep=views_to_update,
-            entities_to_delete=[],
-            entities_to_keep=entities_to_update,
-            partial=True,
-        )
+        if update_infra:
+            self._get_provider().update_infra(
+                project=self.project,
+                tables_to_delete=[],
+                tables_to_keep=views_to_update,
+                entities_to_delete=[],
+                entities_to_keep=entities_to_update,
+                partial=True,
+            )
 
         if commit:
             self._registry.commit()

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -368,6 +368,7 @@ class FeatureStore:
             OnDemandFeatureView,
             RequestFeatureView,
             FeatureService,
+            FeatureTable,
             List[
                 Union[
                     FeatureView,
@@ -375,10 +376,21 @@ class FeatureStore:
                     RequestFeatureView,
                     Entity,
                     FeatureService,
+                    FeatureTable,
                 ]
             ],
         ],
-        update_infra: bool = True,
+        objects_to_delete: List[
+            Union[
+                FeatureView,
+                OnDemandFeatureView,
+                RequestFeatureView,
+                Entity,
+                FeatureService,
+                FeatureTable,
+            ]
+        ] = [],
+        partial: bool = True,
         commit: bool = True,
     ):
         """Register objects to metadata store and update related infrastructure.
@@ -390,7 +402,10 @@ class FeatureStore:
 
         Args:
             objects: A single object, or a list of objects that should be registered with the Feature Store.
-            update_infra: If True, update online store infra to reflect the newly applied objects.
+            objects_to_delete: A list of objects to be deleted from the registry and removed from the
+                provider's infrastructure. This deletion will only be performed if partial is set to False.
+            partial: If True, apply will only handle the specified objects; if False, apply will also delete
+                all the objects in objects_to_delete, and tear down any associated cloud resources.
             commit: whether to commit changes to the registry
 
         Raises:
@@ -423,11 +438,26 @@ class FeatureStore:
 
         assert isinstance(objects, list)
 
+        # Separate all objects into entities, feature services, and different feature view types.
+        entities_to_update = [ob for ob in objects if isinstance(ob, Entity)]
         views_to_update = [ob for ob in objects if isinstance(ob, FeatureView)]
         request_views_to_update = [
             ob for ob in objects if isinstance(ob, RequestFeatureView)
         ]
         odfvs_to_update = [ob for ob in objects if isinstance(ob, OnDemandFeatureView)]
+        services_to_update = [ob for ob in objects if isinstance(ob, FeatureService)]
+        tables_to_update = [ob for ob in objects if isinstance(ob, FeatureTable)]
+
+        if len(entities_to_update) + len(views_to_update) + len(
+            request_views_to_update
+        ) + len(odfvs_to_update) + len(services_to_update) + len(
+            tables_to_update
+        ) != len(
+            objects
+        ):
+            raise ValueError("Unknown object type provided as part of apply() call")
+
+        # Validate all types of feature views.
         if (
             not flags_helper.enable_on_demand_feature_views(self.config)
             and len(odfvs_to_update) > 0
@@ -440,8 +470,6 @@ class FeatureStore:
         _validate_feature_views(
             [*views_to_update, *odfvs_to_update, *request_views_to_update]
         )
-        entities_to_update = [ob for ob in objects if isinstance(ob, Entity)]
-        services_to_update = [ob for ob in objects if isinstance(ob, FeatureService)]
 
         # Make inferences
         update_entities_with_inferred_types_from_feature_views(
@@ -458,12 +486,7 @@ class FeatureStore:
         for odfv in odfvs_to_update:
             odfv.infer_features()
 
-        if len(views_to_update) + len(entities_to_update) + len(
-            services_to_update
-        ) + len(odfvs_to_update) + len(request_views_to_update) != len(objects):
-            raise ValueError("Unknown object type provided as part of apply() call")
-
-        # DUMMY_ENTITY is a placeholder entity used in entityless FeatureViews
+        # Handle all entityless feature views by using DUMMY_ENTITY as a placeholder entity.
         DUMMY_ENTITY = Entity(
             name=DUMMY_ENTITY_NAME,
             join_key=DUMMY_ENTITY_ID,
@@ -471,6 +494,7 @@ class FeatureStore:
         )
         entities_to_update.append(DUMMY_ENTITY)
 
+        # Add all objects to the registry and update the provider's infrastructure.
         for view in itertools.chain(
             views_to_update, odfvs_to_update, request_views_to_update
         ):
@@ -479,16 +503,63 @@ class FeatureStore:
             self._registry.apply_entity(ent, project=self.project, commit=False)
         for feature_service in services_to_update:
             self._registry.apply_feature_service(feature_service, project=self.project)
+        for table in tables_to_update:
+            self._registry.apply_feature_table(table, project=self.project)
 
-        if update_infra:
-            self._get_provider().update_infra(
-                project=self.project,
-                tables_to_delete=[],
-                tables_to_keep=views_to_update,
-                entities_to_delete=[],
-                entities_to_keep=entities_to_update,
-                partial=True,
-            )
+        if not partial:
+            # Delete all registry objects that should not exist.
+            entities_to_delete = [
+                ob for ob in objects_to_delete if isinstance(ob, Entity)
+            ]
+            views_to_delete = [
+                ob for ob in objects_to_delete if isinstance(ob, FeatureView)
+            ]
+            request_views_to_delete = [
+                ob for ob in objects_to_delete if isinstance(ob, RequestFeatureView)
+            ]
+            odfvs_to_delete = [
+                ob for ob in objects_to_delete if isinstance(ob, OnDemandFeatureView)
+            ]
+            services_to_delete = [
+                ob for ob in objects_to_delete if isinstance(ob, FeatureService)
+            ]
+            tables_to_delete = [
+                ob for ob in objects_to_delete if isinstance(ob, FeatureTable)
+            ]
+
+            for entity in entities_to_delete:
+                self._registry.delete_entity(
+                    entity.name, project=self.project, commit=False
+                )
+            for view in views_to_delete:
+                self._registry.delete_feature_view(
+                    view.name, project=self.project, commit=False
+                )
+            for request_view in request_views_to_delete:
+                self._registry.delete_feature_view(
+                    request_view.name, project=self.project, commit=False
+                )
+            for odfv in odfvs_to_delete:
+                self._registry.delete_feature_view(
+                    odfv.name, project=self.project, commit=False
+                )
+            for service in services_to_delete:
+                self._registry.delete_feature_service(
+                    service.name, project=self.project, commit=False
+                )
+            for table in tables_to_delete:
+                self._registry.delete_feature_table(
+                    table.name, project=self.project, commit=False
+                )
+
+        self._get_provider().update_infra(
+            project=self.project,
+            tables_to_delete=views_to_delete + tables_to_delete if not partial else [],
+            tables_to_keep=views_to_update + tables_to_update,
+            entities_to_delete=entities_to_delete if not partial else [],
+            entities_to_keep=entities_to_update,
+            partial=partial,
+        )
 
         if commit:
             self._registry.commit()

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -629,6 +629,32 @@ class Registry:
 
         raise FeatureViewNotFoundException(name, project)
 
+    def delete_entity(self, name: str, project: str, commit: bool = True):
+        """
+        Deletes an entity or raises an exception if not found.
+
+        Args:
+            name: Name of entity
+            project: Feast project that this entity belongs to
+            commit: Whether the change should be persisted immediately
+        """
+        self._prepare_registry_for_changes()
+        assert self.cached_registry_proto
+
+        for idx, existing_entity_proto in enumerate(
+            self.cached_registry_proto.entities
+        ):
+            if (
+                existing_entity_proto.spec.name == name
+                and existing_entity_proto.spec.project == project
+            ):
+                del self.cached_registry_proto.entities[idx]
+                if commit:
+                    self.commit()
+                return
+
+        raise EntityNotFoundException(name, project)
+
     def commit(self):
         """Commits the state of the registry cache to the remote registry store."""
         if self.cached_registry_proto:

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -212,7 +212,8 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     all_to_apply.extend(services_to_keep)
     all_to_apply.extend(odfvs_to_keep)
     # TODO: delete odfvs
-    store.apply(all_to_apply, commit=False)
+
+    store.apply(all_to_apply, update_infra=False, commit=False)
     for entity in entities_to_keep:
         click.echo(
             f"Registered entity {Style.BRIGHT + Fore.GREEN}{entity.name}{Style.RESET_ALL}"

--- a/sdk/python/tests/integration/registration/test_registry.py
+++ b/sdk/python/tests/integration/registration/test_registry.py
@@ -101,6 +101,10 @@ def test_apply_entity_success(test_registry):
         and entity.labels["team"] == "matchmaking"
     )
 
+    test_registry.delete_entity("driver_car_id", project)
+    entities = test_registry.list_entities(project)
+    assert len(entities) == 0
+
     test_registry.teardown()
 
     # Will try to reload registry, which will fail because the file has been deleted


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: This PR removes the duplicate `update_infra` call in `feast apply`. It also cleans up `apply_total`, by ensuring that entities and ODFVs are also being deleted.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1795 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
feast apply only calls update_infra once
```
