### PR TITLE
Fix protobuf version conflict in [gcp] and [ci] packages

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -66,8 +66,6 @@ REQUIRED = [
 ]
 
 GCP_REQUIRED = [
-    # proto-plus>=1.19.7 requires protobuf>=3.19.0
-    # which conflicts with the version required by google-api-core[grpc]
     "proto-plus<1.19.7",
     "google-cloud-bigquery>=2.28.1",
     "google-cloud-bigquery-storage >= 2.0.0",
@@ -115,8 +113,6 @@ CI_REQUIRED = [
     "firebase-admin==4.5.2",
     "pre-commit",
     "assertpy==1.1",
-    # proto-plus>=1.19.7 requires protobuf>=3.19.0
-    # which conflicts with the version required by google-api-core[grpc]
     "proto-plus<1.19.7",
     "google-cloud-bigquery>=2.28.1",
     "google-cloud-bigquery-storage >= 2.0.0",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -66,6 +66,9 @@ REQUIRED = [
 ]
 
 GCP_REQUIRED = [
+    # proto-plus>=1.19.7 requires protobuf>=3.19.0
+    # which conflicts with the version required by google-api-core[grpc]
+    "proto-plus<1.19.7",
     "google-cloud-bigquery>=2.28.1",
     "google-cloud-bigquery-storage >= 2.0.0",
     "google-cloud-datastore>=2.1.*",
@@ -112,6 +115,9 @@ CI_REQUIRED = [
     "firebase-admin==4.5.2",
     "pre-commit",
     "assertpy==1.1",
+    # proto-plus>=1.19.7 requires protobuf>=3.19.0
+    # which conflicts with the version required by google-api-core[grpc]
+    "proto-plus<1.19.7",
     "google-cloud-bigquery>=2.28.1",
     "google-cloud-bigquery-storage >= 2.0.0",
     "google-cloud-datastore>=2.1.*",
@@ -231,7 +237,7 @@ setup(
     ],
     entry_points={"console_scripts": ["feast=feast.cli:cli"]},
     use_scm_version=use_scm_version,
-    setup_requires=["setuptools_scm", "grpcio", "grpcio-tools==1.34.0", "mypy-protobuf", "sphinx!=4.0.0"],
+    setup_requires=["setuptools_scm", "grpcio", "grpcio-tools==1.34.0", "mypy-protobuf==1.*", "sphinx!=4.0.0"],
     package_data={
         "": [
             "protos/feast/**/*.proto",


### PR DESCRIPTION
Signed-off-by: Yusuke Nishioka <yusuke.nishioka.0713@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

`proto-plus==1.19.7` requires `protobuf>=3.19.0`, which conflicts with the version required by `google-api-core[grpc]`.
Also, `setup_requires` tries to install the latest version of `mypy-protobuf` because the version is not specified and it requires `protobuf>=3.18.0`.
The error log is like this:

```console
$ pipenv install -e "sdk/python[gcp]"
...
There are incompatible versions in the resolved dependencies:
  protobuf>=3.10 (from -r /tmp/pipenvu4bjkllirequirements/pipenv-sxv104g1-constraints.txt (line 21))
  protobuf<3.18.0,>=3.12.0 (from google-api-core[grpc]==1.31.3->-r /tmp/pipenvu4bjkllirequirements/pipenv-sxv104g1-constraints.txt (line 5))
  protobuf<4.0dev,>=3.5.0.post1 (from grpcio-tools==1.34.0->-r /tmp/pipenvu4bjkllirequirements/pipenv-sxv104g1-constraints.txt (line 13))
  protobuf>=3.12.0 (from google-cloud-bigquery==2.29.0->-r /tmp/pipenvu4bjkllirequirements/pipenv-sxv104g1-constraints.txt (line 26))
  protobuf>=3.18.0 (from mypy-protobuf==3.0.0->-r /tmp/pipenvu4bjkllirequirements/pipenv-sxv104g1-constraints.txt (line 3))
  protobuf>=3.19.0 (from proto-plus==1.19.7->google-cloud-bigquery==2.29.0->-r /tmp/pipenvu4bjkllirequirements/pipenv-sxv104g1-constraints.txt (line 26))
  protobuf>=3.6.0 (from googleapis-common-protos==1.52.0->-r /tmp/pipenvu4bjkllirequirements/pipenv-sxv104g1-constraints.txt (line 25))
  protobuf>=3.6.0 (from grpcio-reflection==1.41.1->-r /tmp/pipenvu4bjkllirequirements/pipenv-sxv104g1-constraints.txt (line 14))
```

So I've fixed `proto-plus` version to `<1.19.7` in `[gcp]` and `[ci]` packages, and `mypy-protobuf` in `setup_requires` to `==1.*`.

We can check the installation succeeds by `pipenv install -e "sdk/python[gcp]"` and `pipenv install -e "sdk/python[ci]"`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
refs https://github.com/feast-dev/feast/issues/1912#issuecomment-958128523

IMO, closing #1912 should be done after the new version is released and we confirms that the installation succeeds.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
