### PR TITLE
Fix bug where using some Pandas dtypes in the output of an ODFV fails

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -114,7 +114,7 @@ def python_type_to_feast_value_type(
     Returns:
         Feast Value Type
     """
-    type_name = type_name or type(value).__name__
+    type_name = (type_name or type(value).__name__).lower()
 
     type_map = {
         "int": ValueType.INT64,
@@ -131,7 +131,7 @@ def python_type_to_feast_value_type(
         "int8": ValueType.INT32,
         "bool": ValueType.BOOL,
         "timedelta": ValueType.UNIX_TIMESTAMP,
-        "Timestamp": ValueType.UNIX_TIMESTAMP,
+        "timestamp": ValueType.UNIX_TIMESTAMP,
         "datetime": ValueType.UNIX_TIMESTAMP,
         "datetime64[ns]": ValueType.UNIX_TIMESTAMP,
         "datetime64[ns, tz]": ValueType.UNIX_TIMESTAMP,

--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -44,6 +44,9 @@ def conv_rate_plus_100(features_df: pd.DataFrame) -> pd.DataFrame:
     df["conv_rate_plus_val_to_add"] = (
         features_df["conv_rate"] + features_df["val_to_add"]
     )
+    df["conv_rate_plus_100_rounded"] = (
+        df["conv_rate_plus_100"].astype("float").round().astype(pd.Int32Dtype())
+    )
     return df
 
 
@@ -55,6 +58,7 @@ def conv_rate_plus_100_feature_view(
     _features = features or [
         Feature("conv_rate_plus_100", ValueType.DOUBLE),
         Feature("conv_rate_plus_val_to_add", ValueType.DOUBLE),
+        Feature("conv_rate_plus_100_rounded", ValueType.INT32),
     ]
     return OnDemandFeatureView(
         name=conv_rate_plus_100.__name__,

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -228,6 +228,12 @@ def get_expected_training_df(
 
     conv_feature_name = "driver_stats__conv_rate" if full_feature_names else "conv_rate"
     expected_df["conv_rate_plus_100"] = expected_df[conv_feature_name] + 100
+    expected_df["conv_rate_plus_100_rounded"] = (
+        expected_df["conv_rate_plus_100"]
+        .astype("float")
+        .round()
+        .astype(pd.Int32Dtype())
+    )
     expected_df["conv_rate_plus_val_to_add"] = (
         expected_df[conv_feature_name] + expected_df["val_to_add"]
     )
@@ -375,6 +381,7 @@ def test_historical_features(environment, universal_data_sources, full_feature_n
         expected_df_query = expected_df.drop(
             columns=[
                 "conv_rate_plus_100",
+                "conv_rate_plus_100_rounded",
                 "val_to_add",
                 "conv_rate_plus_val_to_add",
                 "driver_age",
@@ -426,6 +433,7 @@ def test_historical_features(environment, universal_data_sources, full_feature_n
             "customer_profile:avg_passenger_count",
             "customer_profile:lifetime_trip_count",
             "conv_rate_plus_100:conv_rate_plus_100",
+            "conv_rate_plus_100:conv_rate_plus_100_rounded",
             "conv_rate_plus_100:conv_rate_plus_val_to_add",
             "order:order_is_success",
             "global_stats:num_rides",

--- a/sdk/python/tests/integration/registration/test_universal_odfv_feature_inference.py
+++ b/sdk/python/tests/integration/registration/test_universal_odfv_feature_inference.py
@@ -30,7 +30,7 @@ def test_infer_odfv_features(environment, universal_data_sources, infer_features
     feast_objects = [driver_hourly_stats, driver_odfv, driver(), customer()]
     store.apply(feast_objects)
     odfv = store.get_on_demand_feature_view("conv_rate_plus_100")
-    assert len(odfv.features) == 2
+    assert len(odfv.features) == 3
 
 
 @pytest.mark.integration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
* When the DataFrame returned by an ODFV UDF uses dtypes like `pd.Int64Dtype()` type mapping fails.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
