### PR TITLE
Update bq_to_feast_value_type with BOOLEAN type as a legacy sql data type

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -402,6 +402,7 @@ def bq_to_feast_value_type(bq_type_as_str: str) -> ValueType:
         "FLOAT64": ValueType.DOUBLE,
         "BYTES": ValueType.BYTES,
         "BOOL": ValueType.BOOL,
+        "BOOLEAN": ValueType.BOOL, # legacy sql data type
         "ARRAY<INT64>": ValueType.INT64_LIST,
         "ARRAY<FLOAT64>": ValueType.DOUBLE_LIST,
         "ARRAY<STRING>": ValueType.STRING_LIST,

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -402,7 +402,7 @@ def bq_to_feast_value_type(bq_type_as_str: str) -> ValueType:
         "FLOAT64": ValueType.DOUBLE,
         "BYTES": ValueType.BYTES,
         "BOOL": ValueType.BOOL,
-        "BOOLEAN": ValueType.BOOL, # legacy sql data type
+        "BOOLEAN": ValueType.BOOL,  # legacy sql data type
         "ARRAY<INT64>": ValueType.INT64_LIST,
         "ARRAY<FLOAT64>": ValueType.DOUBLE_LIST,
         "ARRAY<STRING>": ValueType.STRING_LIST,


### PR DESCRIPTION
Twitter uses this BOOLEAN legacy sql data type for Big Query. 
