### PR TITLE
Always pass full and partial feature names to ODFV

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1210,7 +1210,7 @@ class FeatureStore:
         for odfv_name, _feature_refs in odfv_feature_refs.items():
             odfv = all_on_demand_feature_views[odfv_name]
             transformed_features_df = odfv.get_transformed_features_df(
-                full_feature_names, initial_response_df
+                initial_response_df
             )
             for row_idx in range(len(result_rows)):
                 result_row = result_rows[row_idx]

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -47,7 +47,7 @@ class RetrievalJob(ABC):
         # TODO(adchia): Fix requirement to specify dependent feature views in feature_refs
         for odfv in self.on_demand_feature_views:
             features_df = features_df.join(
-                odfv.get_transformed_features_df(self.full_feature_names, features_df)
+                odfv.get_transformed_features_df(features_df)
             )
         return features_df
 
@@ -69,7 +69,7 @@ class RetrievalJob(ABC):
         features_df = self._to_df_internal()
         for odfv in self.on_demand_feature_views:
             features_df = features_df.join(
-                odfv.get_transformed_features_df(self.full_feature_names, features_df)
+                odfv.get_transformed_features_df(features_df)
             )
         return pyarrow.Table.from_pandas(features_df)
 

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -164,21 +164,21 @@ class OnDemandFeatureView(BaseFeatureView):
         return schema
 
     def get_transformed_features_df(
-        self, full_feature_names: bool, df_with_features: pd.DataFrame
+        self, df_with_features: pd.DataFrame
     ) -> pd.DataFrame:
         # Apply on demand transformations
-        # TODO(adchia): Include only the feature values from the specified input FVs in the ODFV.
-        # Copy over un-prefixed features even if not requested since transform may need it
         columns_to_cleanup = []
-        if full_feature_names:
-            for input_fv in self.input_feature_views.values():
-                for feature in input_fv.features:
-                    full_feature_ref = f"{input_fv.name}__{feature.name}"
-                    if full_feature_ref in df_with_features.keys():
-                        df_with_features[feature.name] = df_with_features[
-                            full_feature_ref
-                        ]
-                        columns_to_cleanup.append(feature.name)
+        for input_fv in self.input_feature_views.values():
+            for feature in input_fv.features:
+                full_feature_ref = f"{input_fv.name}__{feature.name}"
+                if full_feature_ref in df_with_features.keys():
+                    # Make sure the partial feature name is always present
+                    df_with_features[feature.name] = df_with_features[full_feature_ref]
+                    columns_to_cleanup.append(feature.name)
+                elif feature.name in df_with_features.keys():
+                    # Make sure the full feature name is always present
+                    df_with_features[full_feature_ref] = df_with_features[feature.name]
+                    columns_to_cleanup.append(full_feature_ref)
 
         # Compute transformed values and apply to each result row
         df_with_transformed_features = self.udf.__call__(df_with_features)

--- a/sdk/python/feast/transformation_server.py
+++ b/sdk/python/feast/transformation_server.py
@@ -47,7 +47,7 @@ class TransformationServer(TransformationServiceServicer):
 
         df = pa.ipc.open_file(request.transformation_input.arrow_value).read_pandas()
 
-        result_df = odfv.get_transformed_features_df(True, df)
+        result_df = odfv.get_transformed_features_df(df)
         result_arrow = pa.Table.from_pandas(result_df)
         sink = pa.BufferOutputStream()
         writer = pa.ipc.new_file(sink, result_arrow.schema)


### PR DESCRIPTION
Signed-off-by: Judah Rand <17158624+judahrand@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

I've run into a problem where when an ODFV depends on two FV which have colliding feature names the ODFV will always want the full feature names. However, it only gets them when `full_feature_names` is set when requesting the features.

This PR ensures that both full and partial feature names are always passed to ODFVs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Always pass full and partial feature names to ODFV.
```
