### PR TITLE
get_online_features on demand transform bug fixes + local integration test mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ test-python:
 test-python-integration:
 	FEAST_USAGE=False IS_TEST=True python -m pytest -n 8 --integration sdk/python/tests
 
+test-python-universal-local:
+	FEAST_USAGE=False IS_TEST=True FEAST_IS_LOCAL_TEST=True python -m pytest -n 8 --integration --universal sdk/python/tests
+
 test-python-universal:
 	FEAST_USAGE=False IS_TEST=True python -m pytest -n 8 --integration --universal sdk/python/tests
 

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1079,13 +1079,13 @@ class FeatureStore:
         return needed_request_data, needed_request_fv_features
 
     def _augment_response_with_on_demand_transforms(
-            self,
-            feature_refs: List[str],
-            requested_result_row_names: Set[str],
-            odfvs: List[OnDemandFeatureView],
-            full_feature_names: bool,
-            initial_response: OnlineResponse,
-            result_rows: List[GetOnlineFeaturesResponse.FieldValues],
+        self,
+        feature_refs: List[str],
+        requested_result_row_names: Set[str],
+        odfvs: List[OnDemandFeatureView],
+        full_feature_names: bool,
+        initial_response: OnlineResponse,
+        result_rows: List[GetOnlineFeaturesResponse.FieldValues],
     ) -> OnlineResponse:
         all_on_demand_feature_views = {view.name: view for view in odfvs}
         all_odfv_feature_names = all_on_demand_feature_views.keys()

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1023,8 +1023,7 @@ class FeatureStore:
     ):
         # Get requested feature values so we can drop odfv dependencies that aren't requested
         requested_result_row_names: Set[str] = set()
-        for row_idx in range(len(result_rows)):
-            result_row = result_rows[row_idx]
+        for result_row in result_rows:
             for feature_name in result_row.fields.keys():
                 requested_result_row_names.add(feature_name)
         # Request feature view values are also request data features that should be in the

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1014,71 +1014,6 @@ class FeatureStore:
             result_rows,
         )
 
-    def _augment_response_with_on_demand_transforms(
-        self,
-        feature_refs: List[str],
-        requested_result_row_names: Set[str],
-        odfvs: List[OnDemandFeatureView],
-        full_feature_names: bool,
-        initial_response: OnlineResponse,
-        result_rows: List[GetOnlineFeaturesResponse.FieldValues],
-    ) -> OnlineResponse:
-        all_on_demand_feature_views = {view.name: view for view in odfvs}
-        all_odfv_feature_names = all_on_demand_feature_views.keys()
-
-        if len(all_on_demand_feature_views) == 0:
-            return initial_response
-        initial_response_df = initial_response.to_df()
-
-        odfv_feature_refs = defaultdict(list)
-        for feature_ref in feature_refs:
-            view_name, feature_name = feature_ref.split(":")
-            if view_name in all_odfv_feature_names:
-                odfv_feature_refs[view_name].append(feature_name)
-
-        # Apply on demand transformations
-        odfv_result_names = set()
-        for odfv_name, _feature_refs in odfv_feature_refs.items():
-            odfv = all_on_demand_feature_views[odfv_name]
-            transformed_features_df = odfv.get_transformed_features_df(
-                full_feature_names, initial_response_df
-            )
-            for row_idx in range(len(result_rows)):
-                result_row = result_rows[row_idx]
-
-                selected_subset = [
-                    f for f in transformed_features_df.columns if f in _feature_refs
-                ]
-
-                for transformed_feature in selected_subset:
-                    transformed_feature_name = (
-                        f"{odfv.projection.name_to_use()}__{transformed_feature}"
-                        if full_feature_names
-                        else transformed_feature
-                    )
-                    odfv_result_names.add(transformed_feature_name)
-                    proto_value = python_value_to_proto_value(
-                        transformed_features_df[transformed_feature].values[row_idx]
-                    )
-                    result_row.fields[transformed_feature_name].CopyFrom(proto_value)
-                    result_row.statuses[
-                        transformed_feature_name
-                    ] = GetOnlineFeaturesResponse.FieldStatus.PRESENT
-
-        # Drop values that aren't needed
-        unneeded_features = [
-            val
-            for val in result_rows[0].fields
-            if val not in requested_result_row_names and val not in odfv_result_names
-        ]
-        for row_idx in range(len(result_rows)):
-            result_row = result_rows[row_idx]
-            for unneeded_feature in unneeded_features:
-                result_row.fields.pop(unneeded_feature)
-                result_row.statuses.pop(unneeded_feature)
-
-        return OnlineResponse(GetOnlineFeaturesResponse(field_values=result_rows))
-
     def _get_requested_result_fields_and_populate_odfv_dependencies(
         self,
         entity_name_to_join_key_map: Dict[str, str],
@@ -1142,6 +1077,71 @@ class FeatureStore:
             for feature in request_fv.features:
                 needed_request_fv_features.add(feature.name)
         return needed_request_data, needed_request_fv_features
+
+    def _augment_response_with_on_demand_transforms(
+            self,
+            feature_refs: List[str],
+            requested_result_row_names: Set[str],
+            odfvs: List[OnDemandFeatureView],
+            full_feature_names: bool,
+            initial_response: OnlineResponse,
+            result_rows: List[GetOnlineFeaturesResponse.FieldValues],
+    ) -> OnlineResponse:
+        all_on_demand_feature_views = {view.name: view for view in odfvs}
+        all_odfv_feature_names = all_on_demand_feature_views.keys()
+
+        if len(all_on_demand_feature_views) == 0:
+            return initial_response
+        initial_response_df = initial_response.to_df()
+
+        odfv_feature_refs = defaultdict(list)
+        for feature_ref in feature_refs:
+            view_name, feature_name = feature_ref.split(":")
+            if view_name in all_odfv_feature_names:
+                odfv_feature_refs[view_name].append(feature_name)
+
+        # Apply on demand transformations
+        odfv_result_names = set()
+        for odfv_name, _feature_refs in odfv_feature_refs.items():
+            odfv = all_on_demand_feature_views[odfv_name]
+            transformed_features_df = odfv.get_transformed_features_df(
+                full_feature_names, initial_response_df
+            )
+            for row_idx in range(len(result_rows)):
+                result_row = result_rows[row_idx]
+
+                selected_subset = [
+                    f for f in transformed_features_df.columns if f in _feature_refs
+                ]
+
+                for transformed_feature in selected_subset:
+                    transformed_feature_name = (
+                        f"{odfv.projection.name_to_use()}__{transformed_feature}"
+                        if full_feature_names
+                        else transformed_feature
+                    )
+                    odfv_result_names.add(transformed_feature_name)
+                    proto_value = python_value_to_proto_value(
+                        transformed_features_df[transformed_feature].values[row_idx]
+                    )
+                    result_row.fields[transformed_feature_name].CopyFrom(proto_value)
+                    result_row.statuses[
+                        transformed_feature_name
+                    ] = GetOnlineFeaturesResponse.FieldStatus.PRESENT
+
+        # Drop values that aren't needed
+        unneeded_features = [
+            val
+            for val in result_rows[0].fields
+            if val not in requested_result_row_names and val not in odfv_result_names
+        ]
+        for row_idx in range(len(result_rows)):
+            result_row = result_rows[row_idx]
+            for unneeded_feature in unneeded_features:
+                result_row.fields.pop(unneeded_feature)
+                result_row.statuses.pop(unneeded_feature)
+
+        return OnlineResponse(GetOnlineFeaturesResponse(field_values=result_rows))
 
     def ensure_request_data_values_exist(
         self,

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -49,30 +49,35 @@ REDIS_CONFIG = {"type": "redis", "connection_string": "localhost:6379,db=0"}
 DEFAULT_FULL_REPO_CONFIGS: List[IntegrationTestRepoConfig] = [
     # Local configurations
     IntegrationTestRepoConfig(),
+]
+if os.getenv("FEAST_IS_LOCAL_TEST", "False") != "True":
     IntegrationTestRepoConfig(online_store=REDIS_CONFIG),
     # GCP configurations
-    IntegrationTestRepoConfig(
-        provider="gcp",
-        offline_store_creator=BigQueryDataSourceCreator,
-        online_store="datastore",
-    ),
-    IntegrationTestRepoConfig(
-        provider="gcp",
-        offline_store_creator=BigQueryDataSourceCreator,
-        online_store=REDIS_CONFIG,
-    ),
-    # AWS configurations
-    IntegrationTestRepoConfig(
-        provider="aws",
-        offline_store_creator=RedshiftDataSourceCreator,
-        online_store=DYNAMO_CONFIG,
-    ),
-    IntegrationTestRepoConfig(
-        provider="aws",
-        offline_store_creator=RedshiftDataSourceCreator,
-        online_store=REDIS_CONFIG,
-    ),
-]
+    DEFAULT_FULL_REPO_CONFIGS.extend(
+        [
+            IntegrationTestRepoConfig(
+                provider="gcp",
+                offline_store_creator=BigQueryDataSourceCreator,
+                online_store="datastore",
+            ),
+            IntegrationTestRepoConfig(
+                provider="gcp",
+                offline_store_creator=BigQueryDataSourceCreator,
+                online_store=REDIS_CONFIG,
+            ),
+            # AWS configurations
+            IntegrationTestRepoConfig(
+                provider="aws",
+                offline_store_creator=RedshiftDataSourceCreator,
+                online_store=DYNAMO_CONFIG,
+            ),
+            IntegrationTestRepoConfig(
+                provider="aws",
+                offline_store_creator=RedshiftDataSourceCreator,
+                online_store=REDIS_CONFIG,
+            ),
+        ]
+    )
 full_repo_configs_module = os.environ.get(FULL_REPO_CONFIGS_MODULE_ENV_NAME)
 if full_repo_configs_module is not None:
     try:

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -1,5 +1,6 @@
 import datetime
 import itertools
+import os
 import unittest
 from datetime import timedelta
 
@@ -29,6 +30,8 @@ from tests.utils.data_source_utils import prep_file_source
 # TODO: make this work with all universal (all online store types)
 @pytest.mark.integration
 def test_write_to_online_store_event_check(local_redis_environment):
+    if os.getenv("FEAST_IS_LOCAL_TEST", "False") == "True":
+        return
     fs = local_redis_environment.feature_store
 
     # write same data points 3 with different timestamps
@@ -274,11 +277,19 @@ def test_online_retrieval(environment, universal_data_sources, full_feature_name
     )
     assert online_features is not None
 
+    # Test if the dependent conv_rate feature isn't present for odfv
+    online_features_no_conv_rate = fs.get_online_features(
+        features=[ref for ref in feature_refs if ref != "driver_stats:conv_rate"],
+        entity_rows=entity_rows,
+        full_feature_names=full_feature_names,
+    )
+    assert online_features_no_conv_rate is not None
+
     online_features_dict = online_features.to_dict()
     keys = online_features_dict.keys()
     assert (
-        len(keys) == len(feature_refs) + 3
-    )  # Add three for the driver id and the customer id entity keys + val_to_add request data.
+        len(keys) == len(feature_refs) + 2
+    )  # Add two for the driver id and the customer id entity keys
     for feature in feature_refs:
         # full_feature_names does not apply to request feature views
         if full_feature_names and feature != "driver_age:driver_age":
@@ -526,8 +537,8 @@ def assert_feature_service_correctness(
                 for projection in feature_service.feature_view_projections
             ]
         )
-        + 3
-    )  # Add two for the driver id and the customer id entity keys and val_to_add request data
+        + 2
+    )  # Add two for the driver id and the customer id entity keys
 
     tc = unittest.TestCase()
     for i, entity_row in enumerate(entity_rows):

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -277,7 +277,8 @@ def test_online_retrieval(environment, universal_data_sources, full_feature_name
     )
     assert online_features is not None
 
-    # Test if the dependent conv_rate feature isn't present for odfv
+    # Test that the on demand feature views compute properly even if the dependent conv_rate
+    # feature isn't requested.
     online_features_no_conv_rate = fs.get_online_features(
         features=[ref for ref in feature_refs if ref != "driver_stats:conv_rate"],
         entity_rows=entity_rows,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
For get_online_features, removing request data (that isn't specified by a request feature view) and odfv dependencies (that aren't otherwise requested) from the online response. It also adds in dependent feature views when specified in odfvs, so users no longer need to specify dependencies in the get_online_features request.

This also adds a rule (make test-python-universal-local) that will run local only integration tests for convenience for devs.

Related issues: #1999  and #1998 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Removes need to specify on demand feature view dependencies in get_online_features
```
