### PR TITLE
Correct cleanup after usage e2e tests

### DIFF
--- a/sdk/python/tests/integration/e2e/test_usage_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_usage_e2e.py
@@ -37,6 +37,9 @@ def enabling_toggle():
         p.__bool__.return_value = True
         yield p
 
+    # return to initial state
+    _reload_feast()
+
 
 @pytest.mark.integration
 def test_usage_on(dummy_exporter, enabling_toggle):

--- a/sdk/python/tests/integration/e2e/test_usage_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_usage_e2e.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 
 import pytest
 
-from feast import Entity, RepoConfig, ValueType, usage
+from feast import Entity, RepoConfig, ValueType
 from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 
 
@@ -114,8 +114,8 @@ def test_exception_usage_on(dummy_exporter, enabling_toggle):
 
 
 @pytest.mark.integration
-def test_exception_usage_off(dummy_exporter):
-    usage._is_enabled = False
+def test_exception_usage_off(dummy_exporter, enabling_toggle):
+    enabling_toggle.__bool__.return_value = False
 
     _reload_feast()
     from feast.feature_store import FeatureStore

--- a/sdk/python/tests/integration/e2e/test_usage_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_usage_e2e.py
@@ -31,10 +31,15 @@ def dummy_exporter():
         yield event_log
 
 
-@pytest.mark.integration
-def test_usage_on(dummy_exporter):
-    usage._is_enabled = True
+@pytest.fixture(scope="function")
+def enabling_toggle():
+    with patch("feast.usage._is_enabled") as p:
+        p.__bool__.return_value = True
+        yield p
 
+
+@pytest.mark.integration
+def test_usage_on(dummy_exporter, enabling_toggle):
     _reload_feast()
     from feast.feature_store import FeatureStore
 
@@ -65,8 +70,8 @@ def test_usage_on(dummy_exporter):
 
 
 @pytest.mark.integration
-def test_usage_off(dummy_exporter):
-    usage._is_enabled = False
+def test_usage_off(dummy_exporter, enabling_toggle):
+    enabling_toggle.__bool__.return_value = False
 
     _reload_feast()
     from feast.feature_store import FeatureStore
@@ -94,9 +99,7 @@ def test_usage_off(dummy_exporter):
 
 
 @pytest.mark.integration
-def test_exception_usage_on(dummy_exporter):
-    usage._is_enabled = True
-
+def test_exception_usage_on(dummy_exporter, enabling_toggle):
     _reload_feast()
     from feast.feature_store import FeatureStore
 


### PR DESCRIPTION
Signed-off-by: pyalex <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR fixes flaky e2e tests for usage module.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
