### PR TITLE
Remove duplicates in setup.py and run rudimentary verifications

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -41,6 +41,8 @@ jobs:
         run: make install-python-ci-dependencies
       - name: Test Python
         run: FEAST_USAGE=False pytest -n 8 --cov=./ --cov-report=xml --verbose --color=yes sdk/python/tests
+      - name: Ensure conflict-free dependencies
+        run: FEAST_USAGE=False pip-compile --dry-run sdk/python/setup.py --extra ci
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ pip install --upgrade pip
 
 4. Install development dependencies for Feast Python SDK / CLI
 ```sh
-pip install -e "sdk/python[ci]"
+pip install -e "sdk/python[dev]"
 ```
 
 ### Code Style & Linting

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The list below contains the functionality that contributors are planning to deve
   * [x] [Synapse source (community plugin)](https://github.com/Azure/feast-azure)
   * [x] [Hive (community plugin)](https://github.com/baineng/feast-hive)
   * [x] [Postgres (community plugin)](https://github.com/nossrannug/feast-postgres)
-  * [ ] Kafka source (Planned for Q4 2021)
+  * [x] Kafka source (with [push support into the online store](reference/alpha-stream-ingestion.md))
   * [ ] Snowflake source (Planned for Q4 2021)
   * [ ] HTTP source
 * **Offline Stores**
@@ -165,7 +165,8 @@ The list below contains the functionality that contributors are planning to deve
   * [ ] Cassandra
 * **Streaming**
   * [x] [Custom streaming ingestion job support](https://docs.feast.dev/how-to-guides/creating-a-custom-provider)
-  * [ ] Streaming ingestion on AWS (Planned for Q4 2021)
+  * [x] [Push based streaming data ingestion](reference/alpha-stream-ingestion.md)
+  * [ ] Streaming ingestion on AWS
   * [ ] Streaming ingestion on GCP
 * **Feature Engineering**
   * [x] On-demand Transformations (Alpha release. See [RFC](https://docs.google.com/document/d/1lgfIw0Drc65LpaxbUu49RCeJgMew547meSJttnUqz7c/edit#))
@@ -180,9 +181,9 @@ The list below contains the functionality that contributors are planning to deve
   * [x] Python Client
   * [x] REST Feature Server (Python) (Alpha release. See [RFC](https://docs.google.com/document/d/1iXvFhAsJ5jgAhPOpTdB3j-Wj1S9x3Ev\_Wr6ZpnLzER4/edit))
   * [x] gRPC Feature Server (Java) (See [#1497](https://github.com/feast-dev/feast/issues/1497))
+  * [x] Push API
   * [ ] Java Client
   * [ ] Go Client
-  * [ ] Push API
   * [ ] Delete API
   * [ ] Feature Logging (for training)
 * **Data Quality Management**

--- a/README.md
+++ b/README.md
@@ -137,28 +137,32 @@ The list below contains the functionality that contributors are planning to deve
   * [x] [Redshift source](https://docs.feast.dev/reference/data-sources/redshift)
   * [x] [BigQuery source](https://docs.feast.dev/reference/data-sources/bigquery)
   * [x] [Parquet file source](https://docs.feast.dev/reference/data-sources/file)
+  * [x] [Synapse source (community plugin)](https://github.com/Azure/feast-azure)
+  * [x] [Hive (community plugin)](https://github.com/baineng/feast-hive)
+  * [x] [Postgres (community plugin)](https://github.com/nossrannug/feast-postgres)
   * [ ] Kafka source (Planned for Q4 2021)
-  * [ ] Synapse source (Planned for Q4 2021)
   * [ ] Snowflake source (Planned for Q4 2021)
   * [ ] HTTP source
 * **Offline Stores**
   * [x] [Redshift](https://docs.feast.dev/reference/offline-stores/redshift)
   * [x] [BigQuery](https://docs.feast.dev/reference/offline-stores/bigquery)
+  * [x] [Synapse (community plugin)](https://github.com/Azure/feast-azure)
+  * [x] [Hive (community plugin)](https://github.com/baineng/feast-hive)
+  * [x] [Postgres (community plugin)](https://github.com/nossrannug/feast-postgres)
   * [x] [In-memory / Pandas](https://docs.feast.dev/reference/offline-stores/file)
   * [x] [Custom offline store support](https://docs.feast.dev/how-to-guides/adding-a-new-offline-store)
-  * [x] [Hive (community maintained)](https://github.com/baineng/feast-hive)
-  * [x] [Postgres (community maintained)](https://github.com/nossrannug/feast-postgres)
   * [ ] Snowflake (Planned for Q4 2021)
-  * [ ] Synapse (Planned for Q4 2021)
+  * [ ] Trino (Planned for Q4 2021)
 * **Online Stores**
   * [x] [DynamoDB](https://docs.feast.dev/reference/online-stores/dynamodb)
   * [x] [Redis](https://docs.feast.dev/reference/online-stores/redis)
   * [x] [Datastore](https://docs.feast.dev/reference/online-stores/datastore)
   * [x] [SQLite](https://docs.feast.dev/reference/online-stores/sqlite)
+  * [x] [Azure Cache for Redis (community plugin)](https://github.com/Azure/feast-azure)
+  * [x] [Postgres (community plugin)](https://github.com/nossrannug/feast-postgres)
   * [x] [Custom online store support](https://docs.feast.dev/how-to-guides/adding-support-for-a-new-online-store)
-  * [x] [Postgres (community maintained)](https://github.com/nossrannug/feast-postgres)
   * [ ] Bigtable
-  * [ ] Cassandra\\
+  * [ ] Cassandra
 * **Streaming**
   * [x] [Custom streaming ingestion job support](https://docs.feast.dev/how-to-guides/creating-a-custom-provider)
   * [ ] Streaming ingestion on AWS (Planned for Q4 2021)
@@ -171,7 +175,7 @@ The list below contains the functionality that contributors are planning to deve
   * [x] AWS Lambda (Alpha release. See [RFC](https://docs.google.com/document/d/1eZWKWzfBif66LDN32IajpaG-j82LSHCCOzY6R7Ax7MI/edit))
   * [ ] Cloud Run
   * [ ] Kubernetes
-  * [ ] KNative\\
+  * [ ] KNative
 * **Feature Serving**
   * [x] Python Client
   * [x] REST Feature Server (Python) (Alpha release. See [RFC](https://docs.google.com/document/d/1iXvFhAsJ5jgAhPOpTdB3j-Wj1S9x3Ev\_Wr6ZpnLzER4/edit))

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -113,6 +113,7 @@ CI_REQUIRED = [
     "firebase-admin==4.5.2",
     "pre-commit",
     "assertpy==1.1",
+    "pip-tools~=6"
 ] + GCP_REQUIRED + REDIS_REQUIRED + AWS_REQUIRED
 
 # Get git repo root directory
@@ -207,7 +208,7 @@ setup(
     # https://stackoverflow.com/questions/28509965/setuptools-development-requirements
     # Install dev requirements with: pip install -e .[dev]
     extras_require={
-        "dev": ["mypy-protobuf==1.*", "grpcio-testing==1.*", "pip-tools"] + CI_REQUIRED,
+        "dev": ["mypy-protobuf==1.*", "grpcio-testing==1.*"] + CI_REQUIRED,
         "ci": CI_REQUIRED,
         "gcp": GCP_REQUIRED,
         "aws": AWS_REQUIRED,

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -116,6 +116,8 @@ CI_REQUIRED = [
     "pip-tools"
 ] + GCP_REQUIRED + REDIS_REQUIRED + AWS_REQUIRED
 
+DEV_REQUIRED = ["mypy-protobuf==1.*", "grpcio-testing==1.*"] + CI_REQUIRED
+
 # Get git repo root directory
 repo_root = str(pathlib.Path(__file__).resolve().parent.parent.parent)
 
@@ -208,7 +210,7 @@ setup(
     # https://stackoverflow.com/questions/28509965/setuptools-development-requirements
     # Install dev requirements with: pip install -e .[dev]
     extras_require={
-        "dev": ["mypy-protobuf==1.*", "grpcio-testing==1.*"].extend(CI_REQUIRED),
+        "dev": DEV_REQUIRED,
         "ci": CI_REQUIRED,
         "gcp": GCP_REQUIRED,
         "aws": AWS_REQUIRED,

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -208,7 +208,7 @@ setup(
     # https://stackoverflow.com/questions/28509965/setuptools-development-requirements
     # Install dev requirements with: pip install -e .[dev]
     extras_require={
-        "dev": ["mypy-protobuf==1.*", "grpcio-testing==1.*"] + CI_REQUIRED,
+        "dev": ["mypy-protobuf==1.*", "grpcio-testing==1.*"].extend(CI_REQUIRED),
         "ci": CI_REQUIRED,
         "gcp": GCP_REQUIRED,
         "aws": AWS_REQUIRED,

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -113,7 +113,7 @@ CI_REQUIRED = [
     "firebase-admin==4.5.2",
     "pre-commit",
     "assertpy==1.1",
-    "pip-tools~=6"
+    "pip-tools"
 ] + GCP_REQUIRED + REDIS_REQUIRED + AWS_REQUIRED
 
 # Get git repo root directory

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -46,7 +46,7 @@ REQUIRED = [
     "fastavro>=1.1.0",
     "google-api-core>=1.23.0",
     "googleapis-common-protos==1.52.*",
-    "grpcio>=1.34.0",
+    "grpcio>=1.34.0,<1.40",
     "grpcio-reflection>=1.34.0"
     "Jinja2>=2.0.0",
     "jsonschema",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -46,7 +46,7 @@ REQUIRED = [
     "fastavro>=1.1.0",
     "google-api-core>=1.23.0",
     "googleapis-common-protos==1.52.*",
-    "grpcio>=1.34.0,<1.40",
+    "grpcio>=1.34.0",
     "grpcio-reflection>=1.34.0"
     "Jinja2>=2.0.0",
     "jsonschema",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -113,15 +113,7 @@ CI_REQUIRED = [
     "firebase-admin==4.5.2",
     "pre-commit",
     "assertpy==1.1",
-    "proto-plus<1.19.7",
-    "google-cloud-bigquery>=2.28.1",
-    "google-cloud-bigquery-storage >= 2.0.0",
-    "google-cloud-datastore>=2.1.*",
-    "google-cloud-storage>=1.20.*,<1.41",
-    "google-cloud-core==1.4.*",
-    "redis-py-cluster==2.1.2",
-    "boto3==1.17.*",
-]
+] + GCP_REQUIRED + REDIS_REQUIRED + AWS_REQUIRED
 
 # Get git repo root directory
 repo_root = str(pathlib.Path(__file__).resolve().parent.parent.parent)
@@ -215,7 +207,7 @@ setup(
     # https://stackoverflow.com/questions/28509965/setuptools-development-requirements
     # Install dev requirements with: pip install -e .[dev]
     extras_require={
-        "dev": ["mypy-protobuf==1.*", "grpcio-testing==1.*"],
+        "dev": ["mypy-protobuf==1.*", "grpcio-testing==1.*", "pip-tools"] + CI_REQUIRED,
         "ci": CI_REQUIRED,
         "gcp": GCP_REQUIRED,
         "aws": AWS_REQUIRED,

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -54,6 +54,7 @@ REQUIRED = [
     "pandas>=1.0.0",
     "pandavro==1.5.*",
     "protobuf>=3.10",
+    "proto-plus",
     "pyarrow>=4.0.0",
     "pydantic>=1.0.0",
     "PyYAML>=5.4.*",


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This removes some of the duplicates of packages in the setup.py, to make sure we use consistent versions.

Additionally, when packages are not compatible we should an error like this:

```
$ pip-compile --dry-run sdk/python/setup.py --extra dev
ERROR: ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
ERROR: grpcio-reflection 1.42.0rc1 requires grpcio>=1.42.0rc1, but you have grpcio 1.41.1 which is incompatible.
Could not find a version that matches grpcio<1.40,<2.0dev,>=1.34.0,>=1.38.1,>=1.41.1 (from feast (sdk/python/setup.py))
Tried: 0.13.0, 0.13.1, 0.14.0, 0.15.0, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.1.0, 1.1.3, 1.2.0, 1.2.1, 1.3.0, 1.3.5, 1.4.0, 1.6.0, 1.6.3, 1.7.0, 1.7.3, 1.8.1, 1.8.2, 1.8.3, 1.8.4, 1.8.6, 1.9.0, 1.9.1, 1.10.0, 1.10.1, 1.11.0, 1.11.1, 1.12.0, 1.12.1, 1.13.0, 1.13.0, 1.14.0, 1.14.0, 1.14.1, 1.14.1, 1.14.2, 1.14.2, 1.15.0, 1.15.0, 1.16.0, 1.16.0, 1.16.1, 1.16.1, 1.17.0, 1.17.0, 1.17.1, 1.17.1, 1.18.0, 1.18.0, 1.19.0, 1.19.0, 1.20.0, 1.20.0, 1.20.1, 1.20.1, 1.21.1, 1.21.1, 1.22.0, 1.22.0, 1.22.1, 1.22.1, 1.23.0, 1.23.0, 1.23.1, 1.23.1, 1.24.0, 1.24.0, 1.24.1, 1.24.1, 1.24.3, 1.24.3, 1.25.0, 1.25.0, 1.26.0, 1.26.0, 1.27.1, 1.27.1, 1.27.2, 1.27.2, 1.28.1, 1.28.1, 1.29.0, 1.29.0, 1.30.0, 1.30.0, 1.31.0, 1.31.0, 1.32.0, 1.32.0, 1.33.1, 1.33.1, 1.33.2, 1.33.2, 1.34.0, 1.34.0, 1.34.1, 1.34.1, 1.35.0, 1.35.0, 1.36.0, 1.36.0, 1.36.1, 1.36.1, 1.37.0, 1.37.0, 1.37.1, 1.37.1, 1.38.0, 1.38.0, 1.38.1, 1.38.1, 1.39.0, 1.39.0, 1.40.0, 1.40.0, 1.41.0, 1.41.0, 1.41.1, 1.41.1
Skipped pre-versions: 0.4.0a0, 0.4.0a1, 0.4.0a2, 0.4.0a3, 0.4.0a4, 0.4.0a5, 0.4.0a6, 0.4.0a7, 0.4.0a8, 0.4.0a13, 0.4.0a14, 0.5.0a0, 0.5.0a1, 0.5.0a2, 0.9.0a0, 0.9.0a1, 0.10.0a0, 0.11.0b0, 0.11.0b1, 0.12.0b0, 0.13.1rc1, 0.14.0rc1, 1.0.0rc1, 1.0.0rc2, 1.0.1rc1, 1.9.0rc1, 1.9.0rc2, 1.9.0rc3, 1.10.0rc1, 1.10.0rc2, 1.10.1rc1, 1.10.1rc2, 1.11.0rc1, 1.11.0rc2, 1.11.1rc1, 1.12.0rc1, 1.13.0rc1, 1.13.0rc2, 1.13.0rc3, 1.14.0rc1, 1.14.0rc1, 1.14.0rc2, 1.14.0rc2, 1.14.2rc1, 1.14.2rc1, 1.15.0rc1, 1.15.0rc1, 1.16.0rc1, 1.16.0rc1, 1.16.1rc1, 1.16.1rc1, 1.17.0rc1, 1.17.0rc1, 1.17.1rc1, 1.17.1rc1, 1.18.0rc1, 1.18.0rc1, 1.19.0rc1, 1.19.0rc1, 1.20.0rc1, 1.20.0rc1, 1.20.0rc2, 1.20.0rc2, 1.20.0rc3, 1.20.0rc3, 1.21.0rc1, 1.21.0rc1, 1.21.1rc1, 1.21.1rc1, 1.22.0rc1, 1.22.0rc1, 1.23.0rc1, 1.23.0rc1, 1.24.0rc1, 1.24.0rc1, 1.25.0rc1, 1.25.0rc1, 1.26.0rc1, 1.26.0rc1, 1.27.0rc1, 1.27.0rc1, 1.27.0rc2, 1.27.0rc2, 1.28.0.dev0, 1.28.0.dev0, 1.28.0rc1, 1.28.0rc1, 1.28.0rc2, 1.28.0rc2, 1.28.0rc3, 1.28.0rc3, 1.30.0rc1, 1.30.0rc1, 1.31.0rc1, 1.31.0rc1, 1.31.0rc2, 1.31.0rc2, 1.32.0rc1, 1.32.0rc1, 1.33.0rc1, 1.33.0rc1, 1.33.0rc2, 1.33.0rc2, 1.34.0rc1, 1.34.0rc1, 1.35.0rc1, 1.35.0rc1, 1.36.0rc1, 1.36.0rc1, 1.37.0rc1, 1.37.0rc1, 1.38.0rc1, 1.38.0rc1, 1.39.0rc1, 1.39.0rc1, 1.40.0rc1, 1.41.0rc2, 1.41.0rc2, 1.42.0rc1, 1.42.0rc1
There are incompatible versions in the resolved dependencies:
  grpcio<1.40,>=1.34.0 (from feast (sdk/python/setup.py))
  grpcio<2.0dev,>=1.38.1 (from google-cloud-bigquery==2.30.1->feast (sdk/python/setup.py))
  grpcio>=1.34.0 (from grpcio-testing==1.34.0->feast (sdk/python/setup.py))
  grpcio>=1.41.1 (from grpcio-reflection==1.41.1->feast (sdk/python/setup.py))
  grpcio>=1.34.0 (from grpcio-tools==1.34.0->feast (sdk/python/setup.py))
[10/11/21 2:55:39] (python-3.7.12) ~/tecton/feast   achal/simplify-setup-py ● 
$ echo $?

2
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2009 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
