### PR TITLE
Make `feast registry-dump` print the whole registry as one json

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -339,6 +339,8 @@ def teardown(repo_config: RepoConfig, repo_path: Path):
 @log_exceptions_and_usage
 def registry_dump(repo_config: RepoConfig, repo_path: Path):
     """ For debugging only: output contents of the metadata registry """
+    from colorama import Fore, Style
+
     registry_config = repo_config.get_registry_config()
     project = repo_config.project
     registry = Registry(registry_config=registry_config, repo_path=repo_path)
@@ -364,8 +366,12 @@ def registry_dump(repo_config: RepoConfig, repo_path: Path):
         registry_dict["requestFeatureViews"].append(
             MessageToDict(request_feature_view.to_proto())
         )
-
-    print(json.dumps(registry_dict, indent=2))
+    warning = (
+        "Warning: The registry-dump command is for debugging only and may contain "
+        "breaking changes in the future. No guarantees are made on this interface."
+    )
+    click.echo(f"{Style.BRIGHT}{Fore.YELLOW}{warning}{Style.RESET_ALL}")
+    click.echo(json.dumps(registry_dict, indent=2))
 
 
 def cli_check_repo(repo_path: Path):

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -1,14 +1,17 @@
 import importlib
+import json
 import os
 import random
 import re
 import sys
+from collections import defaultdict
 from importlib.abc import Loader
 from pathlib import Path
 from typing import List, NamedTuple, Set, Tuple, Union, cast
 
 import click
 from click.exceptions import BadParameter
+from google.protobuf.json_format import MessageToDict
 
 from feast import Entity, FeatureTable
 from feast.base_feature_view import BaseFeatureView
@@ -339,11 +342,30 @@ def registry_dump(repo_config: RepoConfig, repo_path: Path):
     registry_config = repo_config.get_registry_config()
     project = repo_config.project
     registry = Registry(registry_config=registry_config, repo_path=repo_path)
+    registry_dict = defaultdict(list)
 
     for entity in registry.list_entities(project=project):
-        print(entity)
+        registry_dict["entities"].append(MessageToDict(entity.to_proto()))
     for feature_view in registry.list_feature_views(project=project):
-        print(feature_view)
+        registry_dict["featureViews"].append(MessageToDict(feature_view.to_proto()))
+    for feature_table in registry.list_feature_tables(project=project):
+        registry_dict["featureTables"].append(MessageToDict(feature_table.to_proto()))
+    for feature_service in registry.list_feature_services(project=project):
+        registry_dict["featureServices"].append(
+            MessageToDict(feature_service.to_proto())
+        )
+    for on_demand_feature_view in registry.list_on_demand_feature_views(
+        project=project
+    ):
+        registry_dict["onDemandFeatureViews"].append(
+            MessageToDict(on_demand_feature_view.to_proto())
+        )
+    for request_feature_view in registry.list_request_feature_views(project=project):
+        registry_dict["requestFeatureViews"].append(
+            MessageToDict(request_feature_view.to_proto())
+        )
+
+    print(json.dumps(registry_dict, indent=2))
 
 
 def cli_check_repo(repo_path: Path):


### PR DESCRIPTION
**What this PR does / why we need it**:
When running `feast registry-dump`, the whole registry is printed as one json.

I intentionally kept all the logic in repo_operations.py instead of adding a method to the Registry class since this is for debugging only.

**Changes**

The current implementation will print the json representation of each entity and feature view but none of the other objects such as feature services and on demand feature views. It is also not obvious which type each json represents.
```json
{
  "spec": {
    "name": "driver_id",
    "valueType": "INT64",
    "description": "driver id",
    "joinKey": "driver_id"
  },
  "meta": {}
}
{
  "spec": {
    "name": "driver_hourly_stats",
    "entities": [
      "driver_id"
    ],
    "features": [
      {
        "name": "conv_rate",
        "valueType": "FLOAT"
      },
      {
        "name": "acc_rate",
        "valueType": "FLOAT"
      },
      {
        "name": "avg_daily_trips",
        "valueType": "INT64"
      }
    ],
    "ttl": "86400s",
    "batchSource": {
      "type": "BATCH_FILE",
      "eventTimestampColumn": "event_timestamp",
      "createdTimestampColumn": "created",
      "fileOptions": {
        "fileUrl": "/content/feature_repo/data/driver_stats.parquet"
      },
      "dataSourceClassType": "feast.infra.offline_stores.file_source.FileSource"
    },
    "online": true
  },
  "meta": {}
}
```
The change in this PR would print one json object containing a list of all objects of the registry.
```json
Warning: The registry-dump command is for debugging only and may contain breaking changes in the future. No guarantees are made on this interface.
{
  "entities": [
    {
      "spec": {
        "name": "driver_id",
        "valueType": "INT64",
        "description": "driver id",
        "joinKey": "driver_id"
      },
      "meta": {}
    }
  ],
  "featureViews": [
    {
      "spec": {
        "name": "driver_hourly_stats",
        "entities": [
          "driver_id"
        ],
        "features": [
          {
            "name": "conv_rate",
            "valueType": "FLOAT"
          },
          {
            "name": "acc_rate",
            "valueType": "FLOAT"
          },
          {
            "name": "avg_daily_trips",
            "valueType": "INT64"
          }
        ],
        "ttl": "86400s",
        "batchSource": {
          "type": "BATCH_FILE",
          "eventTimestampColumn": "event_timestamp",
          "createdTimestampColumn": "created",
          "fileOptions": {
            "fileUrl": "/content/feature_repo/data/driver_stats.parquet"
          },
          "dataSourceClassType": "feast.infra.offline_stores.file_source.FileSource"
        },
        "online": true
      },
      "meta": {}
    }
  ],
  "featureServices": [
    {
      "spec": {
        "name": "driver_activity",
        "features": [
          {
            "featureViewName": "driver_hourly_stats",
            "featureColumns": [
              {
                "name": "avg_daily_trips",
                "valueType": "INT64"
              }
            ]
          },
          {
            "featureViewName": "driver_hourly_stats",
            "featureColumns": [
              {
                "name": "conv_rate",
                "valueType": "FLOAT"
              }
            ]
          }
        ]
      },
      "meta": {}
    }
  ]
}

```
The json object will contain entities, featureViews, featureTables, featureServices, onDemandFeatureViews, and requestFeatureViews.

```release-note
NONE
```
