### PR TITLE
Clean up references to core in github workflow

### DIFF
--- a/.github/workflows/java_master_only.yml
+++ b/.github/workflows/java_master_only.yml
@@ -10,9 +10,6 @@ on:
 jobs:
   build-docker-images:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        component: [core, serving]
     env:
       MAVEN_CACHE: gs://feast-templocation-kf-feast/.m2.2020-08-19.tar
     steps:
@@ -34,12 +31,12 @@ jobs:
       - name: Get version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Build image
-        run: make build-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
+        run: make build-serving-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
       - name: Push image
-        run: make push-${{ matrix.component }}-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
+        run: make push-serving-docker REGISTRY=gcr.io/kf-feast VERSION=${GITHUB_SHA}
       - name: Push development Docker image
         run: |
           if [ ${GITHUB_REF#refs/*/} == "master" ]; then
-            docker tag gcr.io/kf-feast/feast-${{ matrix.component }}:${GITHUB_SHA} gcr.io/kf-feast/feast-${{ matrix.component }}:develop
-            docker push gcr.io/kf-feast/feast-${{ matrix.component }}:develop
+            docker tag gcr.io/kf-feast/feast-serving:${GITHUB_SHA} gcr.io/kf-feast/feast-serving:develop
+            docker push gcr.io/kf-feast/feast-serving:develop
           fi

--- a/.github/workflows/java_release.yml
+++ b/.github/workflows/java_release.yml
@@ -46,9 +46,6 @@ jobs:
   build-publish-docker-images:
     runs-on: [ubuntu-latest]
     needs: get-version
-    strategy:
-      matrix:
-        component: [core, serving]
     env:
       MAVEN_CACHE: gs://feast-templocation-kf-feast/.m2.2020-08-19.tar
     steps:
@@ -83,20 +80,20 @@ jobs:
           HIGHEST_SEMVER_TAG: ${{ needs.get-version.outputs.highest_semver_tag }}
         run: |
           docker build --build-arg VERSION=$RELEASE_VERSION \
-            -t gcr.io/kf-feast/feast-${{ matrix.component }}:${GITHUB_SHA} \
-            -t gcr.io/kf-feast/feast-${{ matrix.component }}:${VERSION_WITHOUT_PREFIX} \
-            -t feastdev/feast-${{ matrix.component }}:${VERSION_WITHOUT_PREFIX} \
-            -f infra/docker/${{ matrix.component }}/Dockerfile .
-          docker push gcr.io/kf-feast/feast-${{ matrix.component }}:${VERSION_WITHOUT_PREFIX}
-          docker push feastdev/feast-${{ matrix.component }}:${VERSION_WITHOUT_PREFIX}
+            -t gcr.io/kf-feast/feast-serving:${GITHUB_SHA} \
+            -t gcr.io/kf-feast/feast-serving:${VERSION_WITHOUT_PREFIX} \
+            -t feastdev/feast-serving:${VERSION_WITHOUT_PREFIX} \
+            -f java/infra/docker/serving/Dockerfile .
+          docker push gcr.io/kf-feast/feast-serving:${VERSION_WITHOUT_PREFIX}
+          docker push feastdev/feast-serving:${VERSION_WITHOUT_PREFIX}
 
           echo "Only push to latest tag if tag is the highest semver version $HIGHEST_SEMVER_TAG"
           if [ "${VERSION_WITHOUT_PREFIX}" = "${HIGHEST_SEMVER_TAG:1}" ]
           then
-            docker tag feastdev/feast-${{ matrix.component }}:${VERSION_WITHOUT_PREFIX} feastdev/feast-${{ matrix.component }}:latest
-            docker tag gcr.io/kf-feast/feast-${{ matrix.component }}:${VERSION_WITHOUT_PREFIX} gcr.io/kf-feast/feast-${{ matrix.component }}:latest
-            docker push feastdev/feast-${{ matrix.component }}:latest
-            docker push gcr.io/kf-feast/feast-${{ matrix.component }}:latest
+            docker tag feastdev/feast-serving:${VERSION_WITHOUT_PREFIX} feastdev/feast-serving:latest
+            docker tag gcr.io/kf-feast/feast-serving:${VERSION_WITHOUT_PREFIX} gcr.io/kf-feast/feast-serving:latest
+            docker push feastdev/feast-serving:latest
+            docker push gcr.io/kf-feast/feast-serving:latest
           fi
 
   publish-java-sdk:


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

There's some references to core (which has been removed in #2029) in github actions which causes them to fail. The old references need to be cleaned up.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
