### PR TITLE
Fixing typo enabling on_demand_transforms

### DIFF
--- a/docs/reference/alpha-on-demand-feature-view.md
+++ b/docs/reference/alpha-on-demand-feature-view.md
@@ -3,7 +3,7 @@
 **Warning**: This is an _experimental_ feature. It's intended for early testing and feedback, and could change without warnings in future releases.
 
 {% hint style="info" %}
-To enable this feature, run **`feast alpha enable enable_on_demand_transforms`**
+To enable this feature, run **`feast alpha enable on_demand_transforms`**
 {% endhint %}
 
 ## Overview


### PR DESCRIPTION
Fixing typo: The correct CLI command is 'feast alpha enable on_demand_transforms' - not 'feast alpha enable enable_on_demand_transforms'

**What this PR does / why we need it**:
Fixes a typo in the docs.

**Does this PR introduce a user-facing change?**:
NONE