### PR TITLE
Fix bug causing OnDemandFeatureView.infer_features() to fail when the…

### DIFF
--- a/sdk/python/feast/feature.py
+++ b/sdk/python/feast/feature.py
@@ -48,11 +48,7 @@ class Feature:
             self._labels = labels
 
     def __eq__(self, other):
-        if (
-            self.name != other.name
-            or self.dtype != other.dtype
-            or self.labels != other.labels
-        ):
+        if self.name != other.name or self.dtype != other.dtype:
             return False
         return True
 

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -215,7 +215,8 @@ class OnDemandFeatureView(BaseFeatureView):
 
         if self.features:
             missing_features = []
-            for specified_features in self.features:
+            delabeled_features = [Feature(name=f.name, dtype=f.dtype) for f in self.features]
+            for specified_features in delabeled_features:
                 if specified_features not in inferred_features:
                     missing_features.append(specified_features)
             if missing_features:

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -215,7 +215,9 @@ class OnDemandFeatureView(BaseFeatureView):
 
         if self.features:
             missing_features = []
-            delabeled_features = [Feature(name=f.name, dtype=f.dtype) for f in self.features]
+            delabeled_features = [
+                Feature(name=f.name, dtype=f.dtype) for f in self.features
+            ]
             for specified_features in delabeled_features:
                 if specified_features not in inferred_features:
                     missing_features.append(specified_features)

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -215,10 +215,7 @@ class OnDemandFeatureView(BaseFeatureView):
 
         if self.features:
             missing_features = []
-            delabeled_features = [
-                Feature(name=f.name, dtype=f.dtype) for f in self.features
-            ]
-            for specified_features in delabeled_features:
+            for specified_features in self.features:
                 if specified_features not in inferred_features:
                     missing_features.append(specified_features)
             if missing_features:


### PR DESCRIPTION
**What this PR does / why we need it**:
Problem:
When running OnDemandFeatureView.infer_features() and there are features registered with labels, an RegistryInferenceFailure is raised. 

Currently, this will work as-is:

``` python
import feast
import pandas as pd

@feast.on_demand_feature_view.on_demand_feature_view(
    inputs={},
    features=[
        feast.Feature(name="not_labeled", dtype=feast.ValueType.DOUBLE)
    ],
)
def not_labeled_view(feature_df: pd.DataFrame) -> pd.DataFrame:
    df = pd.DataFrame(dtype="float", columns=["not_labeled"])
    return df

not_labeled_view.infer_features()
```

While this won't:

``` python
import feast
import pandas as pd

@feast.on_demand_feature_view.on_demand_feature_view(
    inputs={},
    features=[
        feast.Feature(name="not_labeled", dtype=feast.ValueType.DOUBLE, labels={"test": "label"})
    ],
)
def labeled_view(feature_df: pd.DataFrame) -> pd.DataFrame:
    df = pd.DataFrame(dtype="float", columns=["labeled"])
    return df

labeled_view.infer_features()
```


Suggested Fix:
~To allow features with labels in the OnDemandFeatureView definition, remove labels from the registered features when comparing infered features with registered ones.~

Do not include labels when checking equality of Features.


**Does this PR introduce a user-facing change?**:
```
None
```