### PR TITLE
Don't allow FeatureStore.apply with commit=False

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -190,9 +190,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     all_to_delete.extend(odfvs_to_delete)
     all_to_delete.extend(tables_to_delete)
 
-    store.apply(
-        all_to_apply, objects_to_delete=all_to_delete, partial=False, commit=False
-    )
+    store.apply(all_to_apply, objects_to_delete=all_to_delete, partial=False)
 
     for entity in entities_to_delete:
         click.echo(
@@ -257,9 +255,6 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
             f"Removing infrastructure for {Style.BRIGHT + Fore.GREEN}{name}{Style.RESET_ALL}"
         )
     # TODO: consider echoing also entities being deployed/removed
-
-    # Commit the update to the registry only after successful infra update
-    registry.commit()
 
 
 def _tag_registry_entities_for_keep_delete(


### PR DESCRIPTION
**What this PR does / why we need it**:
The `FeatureStore.apply` method will call `update_infra` for the provider without
offering a dry run, so invoking it without committing should not be
an option. It would make all the infra updates but not update the
registry causing them to be out of sync.

Added `commit=False` to `apply_feature_service` and `apply_feature_table` in the
`apply` method.

**Which issue(s) this PR fixes**:
When calling `feast apply` and adding a feature table or feature service
the registry will get updated even if the update_infra call fails.
This PR makes the only registry commit happen after the call to update_infra
has completed successfully.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
