### PR TITLE
Properly exclude entities from feature inference

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -46,6 +46,8 @@ from feast.feature_view import (
 from feast.inference import (
     update_data_sources_with_inferred_event_timestamp_col,
     update_entities_with_inferred_types_from_feature_views,
+    update_feature_views_with_inferred_features,
+    update_odfvs_with_inferred_features,
 )
 from feast.infra.provider import Provider, RetrievalJob, get_provider
 from feast.on_demand_feature_view import OnDemandFeatureView
@@ -479,11 +481,11 @@ class FeatureStore:
             [view.batch_source for view in views_to_update], self.config
         )
 
-        for view in views_to_update:
-            view.infer_features_from_batch_source(self.config)
+        update_feature_views_with_inferred_features(
+            views_to_update, entities_to_update, self.config
+        )
 
-        for odfv in odfvs_to_update:
-            odfv.infer_features()
+        update_odfvs_with_inferred_features(odfvs_to_update)
 
         # Handle all entityless feature views by using DUMMY_ENTITY as a placeholder entity.
         DUMMY_ENTITY = Entity(

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -47,7 +47,6 @@ from feast.inference import (
     update_data_sources_with_inferred_event_timestamp_col,
     update_entities_with_inferred_types_from_feature_views,
     update_feature_views_with_inferred_features,
-    update_odfvs_with_inferred_features,
 )
 from feast.infra.provider import Provider, RetrievalJob, get_provider
 from feast.on_demand_feature_view import OnDemandFeatureView
@@ -485,7 +484,8 @@ class FeatureStore:
             views_to_update, entities_to_update, self.config
         )
 
-        update_odfvs_with_inferred_features(odfvs_to_update)
+        for odfv in odfvs_to_update:
+            odfv.infer_features()
 
         # Handle all entityless feature views by using DUMMY_ENTITY as a placeholder entity.
         DUMMY_ENTITY = Entity(

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-import re
 import warnings
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Type, Union
@@ -22,7 +21,6 @@ from google.protobuf.duration_pb2 import Duration
 from feast import utils
 from feast.base_feature_view import BaseFeatureView
 from feast.data_source import DataSource
-from feast.errors import RegistryInferenceFailure
 from feast.feature import Feature
 from feast.feature_view_projection import FeatureViewProjection
 from feast.protos.feast.core.FeatureView_pb2 import FeatureView as FeatureViewProto
@@ -35,7 +33,6 @@ from feast.protos.feast.core.FeatureView_pb2 import (
 from feast.protos.feast.core.FeatureView_pb2 import (
     MaterializationInterval as MaterializationIntervalProto,
 )
-from feast.repo_config import RepoConfig
 from feast.usage import log_exceptions
 from feast.value_type import ValueType
 
@@ -406,69 +403,3 @@ class FeatureView(BaseFeatureView):
         if len(self.materialization_intervals) == 0:
             return None
         return max([interval[1] for interval in self.materialization_intervals])
-
-    def infer_features_from_batch_source(self, config: RepoConfig):
-        """
-        Infers the set of features associated to this feature view from the input source.
-
-        Args:
-            config: Configuration object used to configure the feature store.
-
-        Raises:
-            RegistryInferenceFailure: The set of features could not be inferred.
-        """
-        if not self.features:
-            columns_to_exclude = {
-                self.batch_source.event_timestamp_column,
-                self.batch_source.created_timestamp_column,
-            } | set(self.entities)
-
-            if (
-                self.batch_source.event_timestamp_column
-                in self.batch_source.field_mapping
-            ):
-                columns_to_exclude.add(
-                    self.batch_source.field_mapping[
-                        self.batch_source.event_timestamp_column
-                    ]
-                )
-            if (
-                self.batch_source.created_timestamp_column
-                in self.batch_source.field_mapping
-            ):
-                columns_to_exclude.add(
-                    self.batch_source.field_mapping[
-                        self.batch_source.created_timestamp_column
-                    ]
-                )
-            for e in self.entities:
-                if e in self.batch_source.field_mapping:
-                    columns_to_exclude.add(self.batch_source.field_mapping[e])
-
-            for (
-                col_name,
-                col_datatype,
-            ) in self.batch_source.get_table_column_names_and_types(config):
-                if col_name not in columns_to_exclude and not re.match(
-                    "^__|__$",
-                    col_name,  # double underscores often signal an internal-use column
-                ):
-                    feature_name = (
-                        self.batch_source.field_mapping[col_name]
-                        if col_name in self.batch_source.field_mapping
-                        else col_name
-                    )
-                    self.features.append(
-                        Feature(
-                            feature_name,
-                            self.batch_source.source_datatype_to_feast_value_type()(
-                                col_datatype
-                            ),
-                        )
-                    )
-
-            if not self.features:
-                raise RegistryInferenceFailure(
-                    "FeatureView",
-                    f"Could not infer Features for the FeatureView named {self.name}.",
-                )

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -6,8 +6,10 @@ from typing import Dict, List, Type, Union
 import dill
 import pandas as pd
 
+from feast import errors
 from feast.base_feature_view import BaseFeatureView
 from feast.data_source import RequestDataSource
+from feast.errors import RegistryInferenceFailure
 from feast.feature import Feature
 from feast.feature_view import FeatureView
 from feast.feature_view_projection import FeatureViewProjection
@@ -20,6 +22,10 @@ from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
 )
 from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
     UserDefinedFunction as UserDefinedFunctionProto,
+)
+from feast.type_map import (
+    feast_value_type_to_pandas_type,
+    python_type_to_feast_value_type,
 )
 from feast.usage import log_exceptions
 from feast.value_type import ValueType
@@ -180,6 +186,50 @@ class OnDemandFeatureView(BaseFeatureView):
         # Cleanup extra columns used for transformation
         df_with_features.drop(columns=columns_to_cleanup, inplace=True)
         return df_with_transformed_features
+
+    def infer_features(self):
+        """
+        Infers the set of features associated to this feature view from the input source.
+
+        Raises:
+            RegistryInferenceFailure: The set of features could not be inferred.
+        """
+        df = pd.DataFrame()
+        for feature_view in self.input_feature_views.values():
+            for feature in feature_view.features:
+                dtype = feast_value_type_to_pandas_type(feature.dtype)
+                df[f"{feature_view.name}__{feature.name}"] = pd.Series(dtype=dtype)
+                df[f"{feature.name}"] = pd.Series(dtype=dtype)
+        for request_data in self.input_request_data_sources.values():
+            for feature_name, feature_type in request_data.schema.items():
+                dtype = feast_value_type_to_pandas_type(feature_type)
+                df[f"{feature_name}"] = pd.Series(dtype=dtype)
+        output_df: pd.DataFrame = self.udf.__call__(df)
+        inferred_features = []
+        for f, dt in zip(output_df.columns, output_df.dtypes):
+            inferred_features.append(
+                Feature(
+                    name=f, dtype=python_type_to_feast_value_type(f, type_name=str(dt))
+                )
+            )
+
+        if self.features:
+            missing_features = []
+            for specified_features in self.features:
+                if specified_features not in inferred_features:
+                    missing_features.append(specified_features)
+            if missing_features:
+                raise errors.SpecifiedFeaturesNotPresentError(
+                    [f.name for f in missing_features], self.name
+                )
+        else:
+            self.features = inferred_features
+
+        if not self.features:
+            raise RegistryInferenceFailure(
+                "OnDemandFeatureView",
+                f"Could not infer Features for the feature view '{self.name}'.",
+            )
 
     @staticmethod
     def get_requested_odfvs(feature_refs, project, registry):

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -99,7 +99,7 @@ def simple_dataset_1() -> pd.DataFrame:
     now = datetime.utcnow()
     ts = pd.Timestamp(now).round("ms")
     data = {
-        "id": [1, 2, 1, 3, 3],
+        "id_join_key": [1, 2, 1, 3, 3],
         "float_col": [0.1, 0.2, 0.3, 4, 5],
         "int64_col": [1, 2, 3, 4, 5],
         "string_col": ["a", "b", "c", "d", "e"],
@@ -119,7 +119,7 @@ def simple_dataset_2() -> pd.DataFrame:
     now = datetime.utcnow()
     ts = pd.Timestamp(now).round("ms")
     data = {
-        "id": ["a", "b", "c", "d", "e"],
+        "id_join_key": ["a", "b", "c", "d", "e"],
         "float_col": [0.1, 0.2, 0.3, 4, 5],
         "int64_col": [1, 2, 3, 4, 5],
         "string_col": ["a", "b", "c", "d", "e"],

--- a/sdk/python/tests/integration/registration/test_feature_store.py
+++ b/sdk/python/tests/integration/registration/test_feature_store.py
@@ -218,6 +218,8 @@ def test_feature_view_inference_success(test_feature_store, dataframe_source):
     with prep_file_source(
         df=dataframe_source, event_timestamp_column="ts_1"
     ) as file_source:
+        entity = Entity(name="id", join_key="id_join_key", value_type=ValueType.INT64)
+
         fv1 = FeatureView(
             name="fv1",
             entities=["id"],
@@ -245,7 +247,7 @@ def test_feature_view_inference_success(test_feature_store, dataframe_source):
             tags={},
         )
 
-        test_feature_store.apply([fv1, fv2, fv3])  # Register Feature Views
+        test_feature_store.apply([entity, fv1, fv2, fv3])  # Register Feature Views
         feature_view_1 = test_feature_store.list_feature_views()[0]
         feature_view_2 = test_feature_store.list_feature_views()[1]
         feature_view_3 = test_feature_store.list_feature_views()[2]
@@ -433,7 +435,7 @@ def test_reapply_feature_view_success(test_feature_store, dataframe_source):
         df=dataframe_source, event_timestamp_column="ts_1"
     ) as file_source:
 
-        e = Entity(name="id", value_type=ValueType.STRING)
+        e = Entity(name="id", join_key="id_join_key", value_type=ValueType.STRING)
 
         # Create Feature View
         fv1 = FeatureView(

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -30,8 +30,8 @@ def test_update_entities_with_inferred_types_from_feature_views(
             name="fv2", entities=["id"], batch_source=file_source_2, ttl=None,
         )
 
-        actual_1 = Entity(name="id")
-        actual_2 = Entity(name="id")
+        actual_1 = Entity(name="id", join_key="id_join_key")
+        actual_2 = Entity(name="id", join_key="id_join_key")
 
         update_entities_with_inferred_types_from_feature_views(
             [actual_1], [fv1], RepoConfig(provider="local", project="test")
@@ -39,13 +39,17 @@ def test_update_entities_with_inferred_types_from_feature_views(
         update_entities_with_inferred_types_from_feature_views(
             [actual_2], [fv2], RepoConfig(provider="local", project="test")
         )
-        assert actual_1 == Entity(name="id", value_type=ValueType.INT64)
-        assert actual_2 == Entity(name="id", value_type=ValueType.STRING)
+        assert actual_1 == Entity(
+            name="id", join_key="id_join_key", value_type=ValueType.INT64
+        )
+        assert actual_2 == Entity(
+            name="id", join_key="id_join_key", value_type=ValueType.STRING
+        )
 
         with pytest.raises(RegistryInferenceFailure):
             # two viable data types
             update_entities_with_inferred_types_from_feature_views(
-                [Entity(name="id")],
+                [Entity(name="id", join_key="id_join_key")],
                 [fv1, fv2],
                 RepoConfig(provider="local", project="test"),
             )


### PR DESCRIPTION
```release-note
Fix to correctly exclude entity columns from being considered features when using feature inference during registration.
```
