### PR TITLE
Fix unexpected feature view deletion when applying edited odfv

### DIFF
--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -341,7 +341,7 @@ class Registry:
                 ):
                     return
                 else:
-                    del self.cached_registry_proto.feature_views[idx]
+                    del existing_feature_views_of_same_type[idx]
                     break
 
         existing_feature_views_of_same_type.append(feature_view_proto)


### PR DESCRIPTION
**What this PR does / why we need it**:
When changing existing on-demand-feature-views, the existing proto in the registry needs to be replaced by the new one. In this step, the existing proto has been deleted from the wrong container. The existing implementation always deletes the proto of the given index from the REGULAR feature-view container, not the odfv container.

This leads to:
1. **Unexpected deletion** of feature views
2. Index error when there are more odfv than regular feature views.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
