### PR TITLE
Install redis extra in AWS Lambda feature server & add hiredis depend…

### DIFF
--- a/sdk/python/feast/infra/feature_servers/aws_lambda/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/aws_lambda/Dockerfile
@@ -9,7 +9,7 @@ COPY protos protos
 COPY README.md README.md
 
 # Install Feast for AWS with Lambda dependencies
-RUN pip3 install -e 'sdk/python[aws]'
+RUN pip3 install -e 'sdk/python[aws,redis]'
 RUN pip3 install -r sdk/python/feast/infra/feature_servers/aws_lambda/requirements.txt --target "${LAMBDA_TASK_ROOT}"
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -78,6 +78,7 @@ GCP_REQUIRED = [
 
 REDIS_REQUIRED = [
     "redis-py-cluster==2.1.2",
+    "hiredis>=2.0.0",
 ]
 
 AWS_REQUIRED = [


### PR DESCRIPTION
…ency

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
1. Re-introduce installing redis extra in AWS lambda-based feature server. This makes it possible to use public Redis endpoints with lambda (e.g. Redis Enterprise).
2. Install hiredis library, which is a C-based client and allows the default redis client to perform better (https://github.com/redis/redis-py/blob/1a41cfd95a53a95b078084d8627be6b6fba3bb71/redis/utils.py#L4).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow using Redis online store in AWS Lambda feature server
```
