### PR TITLE
Raise import error when repo configs module cannot be imported

### DIFF
--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -15,6 +15,7 @@ import yaml
 from feast import FeatureStore, FeatureView, RepoConfig, driver_test_data
 from feast.constants import FULL_REPO_CONFIGS_MODULE_ENV_NAME
 from feast.data_source import DataSource
+from feast.errors import FeastModuleImportError
 from tests.integration.feature_repos.integration_test_repo_config import (
     IntegrationTestRepoConfig,
 )
@@ -86,8 +87,10 @@ if full_repo_configs_module is not None:
     try:
         module = importlib.import_module(full_repo_configs_module)
         FULL_REPO_CONFIGS = getattr(module, "FULL_REPO_CONFIGS")
-    except Exception:
-        FULL_REPO_CONFIGS = DEFAULT_FULL_REPO_CONFIGS
+    except Exception as e:
+        raise FeastModuleImportError(
+            "FULL_REPO_CONFIGS", full_repo_configs_module
+        ) from e
 else:
     FULL_REPO_CONFIGS = DEFAULT_FULL_REPO_CONFIGS
 


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Previously when the full repo configs module could not be imported, the error was suppressed and the integration tests continued with the default repo configs. This makes it difficult for users who are trying to extend the test suite to realize the issue is an import error.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
