### PR TITLE
Allow using cached registry when writing to the online store

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -891,7 +891,7 @@ class FeatureStore:
         self,
         feature_view_name: str,
         df: pd.DataFrame,
-        allow_registry_cache: bool = False,
+        allow_registry_cache: bool = True,
     ):
         """
         ingests data directly into the Online store

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -888,7 +888,10 @@ class FeatureStore:
 
     @log_exceptions_and_usage
     def write_to_online_store(
-        self, feature_view_name: str, df: pd.DataFrame,
+        self,
+        feature_view_name: str,
+        df: pd.DataFrame,
+        allow_registry_cache: bool = False,
     ):
         """
         ingests data directly into the Online store
@@ -899,7 +902,9 @@ class FeatureStore:
             )
 
         # TODO: restrict this to work with online StreamFeatureViews and validate the FeatureView type
-        feature_view = self._registry.get_feature_view(feature_view_name, self.project)
+        feature_view = self._registry.get_feature_view(
+            feature_view_name, self.project, allow_cache=allow_registry_cache
+        )
         entities = []
         for entity_name in feature_view.entities:
             entities.append(self._registry.get_entity(entity_name, self.project))

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -519,19 +519,22 @@ class Registry:
                 return FeatureTable.from_proto(feature_table_proto)
         raise FeatureTableNotFoundException(name, project)
 
-    def get_feature_view(self, name: str, project: str) -> FeatureView:
+    def get_feature_view(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> FeatureView:
         """
         Retrieves a feature view.
 
         Args:
             name: Name of feature view
             project: Feast project that this feature view belongs to
+            allow_cache: Allow returning feature view from the cached registry
 
         Returns:
             Returns either the specified feature view, or raises an exception if
             none is found
         """
-        registry_proto = self._get_registry_proto()
+        registry_proto = self._get_registry_proto(allow_cache=allow_cache)
         for feature_view_proto in registry_proto.feature_views:
             if (
                 feature_view_proto.spec.name == name


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2051 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Use cached registry to speed up direct writes to the online store
```
