### PR TITLE
Add github run id into the integration test projects for debugging

### DIFF
--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -244,7 +244,7 @@ def construct_test_environment(
     _uuid = str(uuid.uuid4()).replace("-", "")[:8]
 
     run_id = os.getenv("GITHUB_RUN_ID", default=None)
-    run_id = f"{run_id}_{_uuid}" if run_id else _uuid
+    run_id = f"gh_run_{run_id}_{_uuid}" if run_id else _uuid
     run_num = os.getenv("GITHUB_RUN_NUMBER", default=1)
 
     project = f"{test_suite_name}_{run_id}_{run_num}"

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -240,7 +240,14 @@ def construct_test_environment(
     test_repo_config: IntegrationTestRepoConfig,
     test_suite_name: str = "integration_test",
 ) -> Environment:
-    project = f"{test_suite_name}_{str(uuid.uuid4()).replace('-', '')[:8]}"
+
+    _uuid = str(uuid.uuid4()).replace("-", "")[:8]
+
+    run_id = os.getenv("GITHUB_RUN_ID", default=None)
+    run_id = f"{run_id}_{_uuid}" if run_id else _uuid
+    run_num = os.getenv("GITHUB_RUN_NUMBER", default=1)
+
+    project = f"{test_suite_name}_{run_id}_{run_num}"
 
     offline_creator: DataSourceCreator = test_repo_config.offline_store_creator(project)
 


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
We have dynamodb resources that are being leaked during integration tests. This should help figure out which runs is causing this.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
