### PR TITLE
Optimize memory usage during materialization

### DIFF
--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -285,7 +285,9 @@ def _run_field_mapping(
 
 
 def _convert_arrow_to_proto(
-    table: pyarrow.Table, feature_view: FeatureView, join_keys: List[str],
+    table: Union[pyarrow.Table, pyarrow.RecordBatch],
+    feature_view: FeatureView,
+    join_keys: List[str],
 ) -> List[Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]]:
     rows_to_write = []
 
@@ -305,7 +307,7 @@ def _convert_arrow_to_proto(
         else:
             return ts
 
-    column_names_idx = {k: i for i, k in enumerate(table.column_names)}
+    column_names_idx = {field.name: i for i, field in enumerate(table.schema)}
     for row in zip(*table.to_pydict().values()):
         entity_key = EntityKeyProto()
         for join_key in join_keys:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
I have run memory usage into issues on initial materialization of a large FeatureView with approaching 10 million rows and 30 columns. Acquiring the Arrow table succeeds but the conversion to Protobuf seems to require duplicating the whole dataset in memory which is not practical.

This initial improvement batches the table returned by `to_arrow` into RecordBatches which improves the situation. Looking forward I think that there should be the option (or requirement?) for RetrievalJobs to yield these RecordBatches directly to further reduce memory requirements.

This PR improves the situation from #2071 but I do not believe is enough to close it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
