### PR TITLE
Add --host as an option for feast serve

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -474,16 +474,27 @@ def init_command(project_directory, minimal: bool, template: str):
 
 @cli.command("serve")
 @click.option(
-    "--port", "-p", type=click.INT, default=6566, help="Specify a port for the server"
+    "--host",
+    "-h",
+    type=click.STRING,
+    default="127.0.0.1",
+    help="Specify a host for the server [default: 127.0.0.1]",
+)
+@click.option(
+    "--port",
+    "-p",
+    type=click.INT,
+    default=6566,
+    help="Specify a port for the server [default: 6566]",
 )
 @click.pass_context
-def serve_command(ctx: click.Context, port: int):
+def serve_command(ctx: click.Context, host: str, port: int):
     """[Experimental] Start a the feature consumption server locally on a given port."""
     repo = ctx.obj["CHDIR"]
     cli_check_repo(repo)
     store = FeatureStore(repo_path=str(repo))
 
-    store.serve(port)
+    store.serve(host, port)
 
 
 @cli.command("serve_transformations")

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -61,11 +61,11 @@ def get_app(store: "feast.FeatureStore"):
     return app
 
 
-def start_server(store: "feast.FeatureStore", port: int):
+def start_server(store: "feast.FeatureStore", host: str, port: int):
     app = get_app(store)
     click.echo(
         "This is an "
         + click.style("experimental", fg="yellow", bold=True, underline=True)
         + " feature. It's intended for early testing and feedback, and could change without warnings in future releases."
     )
-    uvicorn.run(app, host="127.0.0.1", port=port)
+    uvicorn.run(app, host=host, port=port)

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1360,12 +1360,12 @@ class FeatureStore:
         return views_to_use
 
     @log_exceptions_and_usage
-    def serve(self, port: int) -> None:
+    def serve(self, host: str, port: int) -> None:
         """Start the feature consumption server locally on a given port."""
         if not flags_helper.enable_python_feature_server(self.config):
             raise ExperimentalFeatureNotEnabled(flags.FLAG_PYTHON_FEATURE_SERVER_NAME)
 
-        feature_server.start_server(self, port)
+        feature_server.start_server(self, host, port)
 
     @log_exceptions_and_usage
     def get_feature_server_endpoint(self) -> Optional[str]:


### PR DESCRIPTION
Signed-off-by: Gunnar Sv Sigurbjörnsson <gunnar.sigurbjornsson@gmail.com>

**What this PR does / why we need it**:
Today the value is hardcoded to 127.0.0.1. This will enable users to
specify the host that they want to use for feast serve.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
