### PR TITLE
Do not attempt to compute ODFVs when there are no ODFVs

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -107,11 +107,7 @@ class BigQueryOfflineStore(OfflineStore):
 
         # When materializing a single feature view, we don't need full feature names. On demand transforms aren't materialized
         return BigQueryRetrievalJob(
-            query=query,
-            client=client,
-            config=config,
-            full_feature_names=False,
-            on_demand_feature_views=None,
+            query=query, client=client, config=config, full_feature_names=False,
         )
 
     @staticmethod
@@ -200,7 +196,7 @@ class BigQueryRetrievalJob(RetrievalJob):
         client: bigquery.Client,
         config: RepoConfig,
         full_feature_names: bool,
-        on_demand_feature_views: Optional[List[OnDemandFeatureView]],
+        on_demand_feature_views: Optional[List[OnDemandFeatureView]] = None,
     ):
         if not isinstance(query, str):
             self._query_generator = query
@@ -215,7 +211,9 @@ class BigQueryRetrievalJob(RetrievalJob):
         self.client = client
         self.config = config
         self._full_feature_names = full_feature_names
-        self._on_demand_feature_views = on_demand_feature_views
+        self._on_demand_feature_views = (
+            on_demand_feature_views if on_demand_feature_views else []
+        )
 
     @property
     def full_feature_names(self) -> bool:

--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -35,14 +35,16 @@ class FileRetrievalJob(RetrievalJob):
         self,
         evaluation_function: Callable,
         full_feature_names: bool,
-        on_demand_feature_views: Optional[List[OnDemandFeatureView]],
+        on_demand_feature_views: Optional[List[OnDemandFeatureView]] = None,
     ):
         """Initialize a lazy historical retrieval job"""
 
         # The evaluation function executes a stored procedure to compute a historical retrieval.
         self.evaluation_function = evaluation_function
         self._full_feature_names = full_feature_names
-        self._on_demand_feature_views = on_demand_feature_views
+        self._on_demand_feature_views = (
+            on_demand_feature_views if on_demand_feature_views else []
+        )
 
     @property
     def full_feature_names(self) -> bool:
@@ -333,7 +335,5 @@ class FileOfflineStore(OfflineStore):
 
         # When materializing a single feature view, we don't need full feature names. On demand transforms aren't materialized
         return FileRetrievalJob(
-            evaluation_function=evaluate_offline_job,
-            full_feature_names=False,
-            on_demand_feature_views=None,
+            evaluation_function=evaluate_offline_job, full_feature_names=False,
         )

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -41,7 +41,7 @@ class RetrievalJob(ABC):
     def to_df(self) -> pd.DataFrame:
         """Return dataset as Pandas DataFrame synchronously including on demand transforms"""
         features_df = self._to_df_internal()
-        if self.on_demand_feature_views is None:
+        if not self.on_demand_feature_views:
             return features_df
 
         # TODO(adchia): Fix requirement to specify dependent feature views in feature_refs
@@ -63,7 +63,7 @@ class RetrievalJob(ABC):
 
     def to_arrow(self) -> pyarrow.Table:
         """Return dataset as pyarrow Table synchronously"""
-        if self.on_demand_feature_views is None:
+        if not self.on_demand_feature_views:
             return self._to_arrow_internal()
 
         features_df = self._to_df_internal()

--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -101,7 +101,6 @@ class RedshiftOfflineStore(OfflineStore):
             s3_resource=s3_resource,
             config=config,
             full_feature_names=False,
-            on_demand_feature_views=None,
         )
 
     @staticmethod
@@ -189,7 +188,7 @@ class RedshiftRetrievalJob(RetrievalJob):
         s3_resource,
         config: RepoConfig,
         full_feature_names: bool,
-        on_demand_feature_views: Optional[List[OnDemandFeatureView]],
+        on_demand_feature_views: Optional[List[OnDemandFeatureView]] = None,
     ):
         """Initialize RedshiftRetrievalJob object.
 
@@ -199,7 +198,7 @@ class RedshiftRetrievalJob(RetrievalJob):
             s3_resource: boto3 s3 resource object
             config: Feast repo config
             full_feature_names: Whether to add the feature view prefixes to the feature names
-            on_demand_feature_views: A list of on demand transforms to apply at retrieval time
+            on_demand_feature_views (optional): A list of on demand transforms to apply at retrieval time
         """
         if not isinstance(query, str):
             self._query_generator = query
@@ -220,7 +219,9 @@ class RedshiftRetrievalJob(RetrievalJob):
             + str(uuid.uuid4())
         )
         self._full_feature_names = full_feature_names
-        self._on_demand_feature_views = on_demand_feature_views
+        self._on_demand_feature_views = (
+            on_demand_feature_views if on_demand_feature_views else []
+        )
 
     @property
     def full_feature_names(self) -> bool:
@@ -346,7 +347,6 @@ def _upload_entity_df_and_get_entity_schema(
             s3_resource,
             config,
             full_feature_names=False,
-            on_demand_feature_views=None,
         ).to_df()
         return dict(zip(limited_entity_df.columns, limited_entity_df.dtypes))
     else:


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: This PR ensures that we do not attempt to compute ODFVs in `RetrievalJobs` when there are no ODFVs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2072

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
