### PR TITLE
Broaden google-cloud-core dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,14 +25,16 @@ pre-commit install --hook-type pre-commit --hook-type pre-push
 ```
 3. On push, the pre-commit hook will run. This runs `make format` and `make lint`.
 
-### Signing commits
-Use git signing to sign your commits. See 
+### Signing off commits
+Use git signoffs to sign your commits. See 
 https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification for details
 
-Then, you can sign commits with the `-s` flag:
+Then, you can sign off commits with the `-s` flag:
 ```
 git commit -s -m "My first commit"
 ```
+
+GPG-signing commits with `-S` is optional.
 
 ### Incorporating upstream changes from master
 Our preference is the use of `git rebase [master]` instead of `git merge` : `git pull -r`.

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Feast Authors
+  # Copyright 2019 The Feast Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ GCP_REQUIRED = [
     "google-cloud-bigquery-storage >= 2.0.0",
     "google-cloud-datastore>=2.1.*",
     "google-cloud-storage>=1.34.*,<1.41",
-    "google-cloud-core==1.4.*",
+    "google-cloud-core>=1.4.0,<2.0.0",
 ]
 
 REDIS_REQUIRED = [

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -1,4 +1,4 @@
-  # Copyright 2019 The Feast Authors
+# Copyright 2019 The Feast Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
Broadens dependency on google-cloud-core. The limitation to 1.4.* seems tighter than it needs to be. The version 1.7.2 (which is the latest before 2.0.0) passes unit tests and makes feast more interoperable as a library with other systems.

**Which issue(s) this PR fixes**:
Relates to https://github.com/feast-dev/feast/issues/928

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```