### PR TITLE
Fix integration test that is unstable due to incorrect materialization boundaries

### DIFF
--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pyarrow as pa
 from pydantic import StrictStr
 from pydantic.typing import Literal
+from pytz import utc
 
 from feast import OnDemandFeatureView, RedshiftSource
 from feast.data_source import DataSource
@@ -81,6 +82,9 @@ class RedshiftOfflineStore(OfflineStore):
             config.offline_store.region
         )
         s3_resource = aws_utils.get_s3_resource(config.offline_store.region)
+
+        start_date = start_date.astimezone(tz=utc)
+        end_date = end_date.astimezone(tz=utc)
 
         query = f"""
             SELECT


### PR DESCRIPTION
Signed-off-by: pyalex <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

test_universal_e2e::test_e2e_consistency is flaky since test records' timestamps and materialization boundaries (start and end times) are generated independently. So materialization is inconsistent, most of the time it writes 3 rows, but in some moments it could materialize the whole test dataframe (5 rows) in one go, which is not expected behavior.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
