### PR TITLE
Have apply_total use the repo_config that's passed in as a parameter (makes it more compatible with custom wrapper code)

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -130,7 +130,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     from colorama import Fore, Style
 
     os.chdir(repo_path)
-    store = FeatureStore(repo_path=str(repo_path))
+    store = FeatureStore(repo_config)
     project = store.project
     if not is_valid_name(project):
         print(

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -130,7 +130,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     from colorama import Fore, Style
 
     os.chdir(repo_path)
-    store = FeatureStore(repo_config)
+    store = FeatureStore(config=repo_config)
     project = store.project
     if not is_valid_name(project):
         print(


### PR DESCRIPTION
Signed-off-by: David Y Liu <davidyliuliu@gmail.com>

```release-note
Have apply_total use the repo_config that's passed in as a parameter rather than re-producing the repo config from the repo path. 
```
