### PR TITLE
Don't materialize FeatureViews where `online is False`

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -758,9 +758,16 @@ class FeatureStore:
             feature_views_to_materialize = self._list_feature_views(
                 hide_dummy_entity=False
             )
+            feature_views_to_materialize = [
+                fv for fv in feature_views_to_materialize if fv.online
+            ]
         else:
             for name in feature_views:
                 feature_view = self._get_feature_view(name, hide_dummy_entity=False)
+                if not feature_view.online:
+                    raise ValueError(
+                        f"FeatureView {feature_view.name} is not configured to be served online."
+                    )
                 feature_views_to_materialize.append(feature_view)
 
         _print_materialization_log(
@@ -850,9 +857,16 @@ class FeatureStore:
             feature_views_to_materialize = self._list_feature_views(
                 hide_dummy_entity=False
             )
+            feature_views_to_materialize = [
+                fv for fv in feature_views_to_materialize if fv.online
+            ]
         else:
             for name in feature_views:
                 feature_view = self._get_feature_view(name, hide_dummy_entity=False)
+                if not feature_view.online:
+                    raise ValueError(
+                        f"FeatureView {feature_view.name} is not configured to be served online."
+                    )
                 feature_views_to_materialize.append(feature_view)
 
         _print_materialization_log(


### PR DESCRIPTION
Signed-off-by: Judah Rand <17158624+judahrand@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, even if `online=False` is set on a FeatureView `feast materialize` will try to materialize the FeatureView.

This PR prevents this.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Correct behavior of non-online FeatureViews.
```
