### PR TITLE
requested_features is passed to online_read from passthrough_provider

### DIFF
--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -87,7 +87,9 @@ class PassthroughProvider(Provider):
         requested_features: List[str] = None,
     ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
         set_usage_attribute("provider", self.__class__.__name__)
-        result = self.online_store.online_read(config, table, entity_keys)
+        result = self.online_store.online_read(
+            config, table, entity_keys, requested_features
+        )
 
         return result
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`OnlineStore.online_read()` has a parameter `requested_features`. Similarly, `PassthroughProvider.online_read()` also has a parameter `requested_features`.
`PassthroughProvider.online_read()`  calls `OnlineStore.online_read()` but doesn't pass on the `requested_features` variable.
In this PR, the `requested_features` variable is passed on to `OnlineStore.online_read()`

**Which issue(s) this PR fixes**:
Fixes #2106 

**Does this PR introduce a user-facing change?**:
None

```release-note
requested_features is passed to online_read from passthrough_provider
```
