### PR TITLE
Set package long description encoding to UTF-8

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -117,16 +117,23 @@ CI_REQUIRED = [
     "pre-commit",
     "assertpy==1.1",
     "pip-tools",
-] + GCP_REQUIRED + REDIS_REQUIRED + AWS_REQUIRED
+    *GCP_REQUIRED,
+    *REDIS_REQUIRED,
+    *AWS_REQUIRED,
+]
 
-DEV_REQUIRED = ["mypy-protobuf==1.*", "grpcio-testing==1.*"] + CI_REQUIRED
+DEV_REQUIRED = [
+    "mypy-protobuf==1.*",
+    "grpcio-testing==1.*",
+    *CI_REQUIRED,
+]
 
 # Get git repo root directory
 repo_root = str(pathlib.Path(__file__).resolve().parent.parent.parent)
 
 # README file from Feast repo root directory
 README_FILE = os.path.join(repo_root, "README.md")
-with open(README_FILE, "r") as f:
+with open(README_FILE, "r", encoding="utf8") as f:
     LONG_DESCRIPTION = f.read()
 
 # Add Support for parsing tags that have a prefix containing '/' (ie 'sdk/go') to setuptools_scm.

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -119,10 +119,7 @@ CI_REQUIRED = [
     "pip-tools",
 ] + GCP_REQUIRED + REDIS_REQUIRED + AWS_REQUIRED
 
-DEV_REQUIRED = [
-    "mypy-protobuf==1.*",
-    "grpcio-testing==1.*",
-] + CI_REQUIRED
+DEV_REQUIRED = ["mypy-protobuf==1.*", "grpcio-testing==1.*"] + CI_REQUIRED
 
 # Get git repo root directory
 repo_root = str(pathlib.Path(__file__).resolve().parent.parent.parent)

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -117,16 +117,12 @@ CI_REQUIRED = [
     "pre-commit",
     "assertpy==1.1",
     "pip-tools",
-    *GCP_REQUIRED,
-    *REDIS_REQUIRED,
-    *AWS_REQUIRED,
-]
+] + GCP_REQUIRED + REDIS_REQUIRED + AWS_REQUIRED
 
 DEV_REQUIRED = [
     "mypy-protobuf==1.*",
     "grpcio-testing==1.*",
-    *CI_REQUIRED,
-]
+] + CI_REQUIRED
 
 # Get git repo root directory
 repo_root = str(pathlib.Path(__file__).resolve().parent.parent.parent)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Fix feast setup script for Windows.
`README.md` contains emojis resulting character encoding issues in the package long description. This PR sets package long description encoding to UTF-8.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2110

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
