### PR TITLE
Remove  argument `feature_refs`

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -332,12 +332,8 @@ class FeatureStore:
             """
         return self._registry.delete_feature_service(name, self.project)
 
-    def _get_features(
-        self,
-        features: Optional[Union[List[str], FeatureService]],
-        feature_refs: Optional[List[str]],
-    ) -> List[str]:
-        _features = features or feature_refs
+    def _get_features(self, features: Union[List[str], FeatureService],) -> List[str]:
+        _features = features
         if not _features:
             raise ValueError("No features specified for retrieval")
 
@@ -587,8 +583,7 @@ class FeatureStore:
     def get_historical_features(
         self,
         entity_df: Union[pd.DataFrame, str],
-        features: Optional[Union[List[str], FeatureService]] = None,
-        feature_refs: Optional[List[str]] = None,
+        features: Union[List[str], FeatureService],
         full_feature_names: bool = False,
     ) -> RetrievalJob:
         """Enrich an entity dataframe with historical feature values for either training or batch scoring.
@@ -647,23 +642,8 @@ class FeatureStore:
             ... )
             >>> feature_data = retrieval_job.to_df()
         """
-        if (features is not None and feature_refs is not None) or (
-            features is None and feature_refs is None
-        ):
-            raise ValueError(
-                "You must specify exactly one of features and feature_refs."
-            )
 
-        if feature_refs:
-            warnings.warn(
-                (
-                    "The argument 'feature_refs' is being deprecated. Please use 'features' "
-                    "instead. Feast 0.13 and onwards will not support the argument 'feature_refs'."
-                ),
-                DeprecationWarning,
-            )
-
-        _feature_refs = self._get_features(features, feature_refs)
+        _feature_refs = self._get_features(features)
         (
             all_feature_views,
             all_request_feature_views,
@@ -930,7 +910,6 @@ class FeatureStore:
         self,
         features: Union[List[str], FeatureService],
         entity_rows: List[Dict[str, Any]],
-        feature_refs: Optional[List[str]] = None,
         full_feature_names: bool = False,
     ) -> OnlineResponse:
         """
@@ -974,7 +953,7 @@ class FeatureStore:
             ... )
             >>> online_response_dict = online_response.to_dict()
         """
-        _feature_refs = self._get_features(features, feature_refs)
+        _feature_refs = self._get_features(features)
         (
             requested_feature_views,
             requested_request_feature_views,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This argument was scheduled for removal in 0.14 according the
deprecation warning.

Signed-off-by: Judah Rand <17158624+judahrand@users.noreply.github.com>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove `feature_refs` argument from `get_historical_features` and `get_online_features`.
```
