### PR TITLE
Change the feast serve endpoint to be sync rather than async.

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -508,14 +508,17 @@ def init_command(project_directory, minimal: bool, template: str):
     default=6566,
     help="Specify a port for the server [default: 6566]",
 )
+@click.option(
+    "--no-access-log", is_flag=True, help="Disable the Uvicorn access log.",
+)
 @click.pass_context
-def serve_command(ctx: click.Context, host: str, port: int):
+def serve_command(ctx: click.Context, host: str, port: int, no_access_log: bool):
     """[Experimental] Start a the feature consumption server locally on a given port."""
     repo = ctx.obj["CHDIR"]
     cli_check_repo(repo)
     store = FeatureStore(repo_path=str(repo))
 
-    store.serve(host, port)
+    store.serve(host, port, no_access_log)
 
 
 @cli.command("serve_transformations")


### PR DESCRIPTION
Signed-off-by: Gunnar Sv Sigurbjörnsson <gunnar.sigurbjornsson@gmail.com>

**What this PR does / why we need it**:
When an endpoint is async, everything happens on the event loop thread.
This is great for functionality that is IO heavy since the job can be
awaited and other requests processed in the meantime. But if there are
no awaits, then everything happens synchronously on one thread which
means that while we're waiting for a response from a DB or API call,
nothing else gets processed.
To address this I've removed the async keyword from the endpoint.
This makes FastAPI process each request on a thread in a thread pool.

Testing this with postgres as the online store, running everything locally,
and 1 worker, req/sec went from 200 to 800.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
