### PR TITLE
Fix Makefile to properly create the ECR_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,14 +149,14 @@ build-ci-docker:
 # Note, we use underscores instead of periods in the version name since ECR doesn't support periods. We automatically
 # pull from Docker Hub and push to ECR.
 push-feature-server-aws-docker:
-	ECR_VERSION=`echo "$(VERSION)" | sed 's/[.]/_/g'`
-	docker push $(REGISTRY)/feature-server-aws:$(ECR_VERSION)
+	ECR_VERSION=$(shell echo "$(VERSION)" | sed 's/[.]/_/g'); \
+		docker push $(REGISTRY)/feature-server-aws:$$ECR_VERSION
 
 build-feature-server-aws-docker:
-	ECR_VERSION=`echo "$(VERSION)" | sed 's/[.]/_/g'`
-	docker build --build-arg VERSION=${ECR_VERSION} \
-		-t $(REGISTRY)/feature-server-aws:${ECR_VERSION} \
-		-f sdk/python/feast/infra/feature_servers/aws_lambda/Dockerfile .
+	ECR_VERSION=$(shell echo "$(VERSION)" | sed 's/[.]/_/g'); \
+		docker build --build-arg VERSION=$$ECR_VERSION \
+			-t $(REGISTRY)/feature-server-aws:$$ECR_VERSION \
+			-f sdk/python/feast/infra/feature_servers/aws_lambda/Dockerfile .
 
 push-feature-transformation-server-docker:
 	docker push $(REGISTRY)/feature-transformation-server:$(VERSION)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
For the lambda feature server makefile commands, the ECR_VERSION variable was not properly being generated. This fixes that so the workflows should work properly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
