### PR TITLE
Updating lambda docker image to feature-server-python-aws

### DIFF
--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        component: [ feature-server-aws, feature-server-java, feature-transformation-server ]
+        component: [ feature-server-python-aws, feature-server-java, feature-transformation-server ]
     env:
       MAVEN_CACHE: gs://feast-templocation-kf-feast/.m2.2020-08-19.tar
       REGISTRY: gcr.io/kf-feast

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
     needs: get-version
     strategy:
       matrix:
-        component: [feature-server-aws, feature-server-java, feature-transformation-server]
+        component: [feature-server-python-aws, feature-server-java, feature-transformation-server]
     env:
       MAVEN_CACHE: gs://feast-templocation-kf-feast/.m2.2020-08-19.tar
       REGISTRY: feastdev

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ lint-go:
 
 # Docker
 
-build-docker: build-ci-docker build-feature-server-aws-docker build-feature-transformation-server-docker build-feature-server-java-docker
+build-docker: build-ci-docker build-feature-server-python-aws-docker build-feature-transformation-server-docker build-feature-server-java-docker
 
 push-ci-docker:
 	docker push $(REGISTRY)/feast-ci:$(VERSION)
@@ -148,14 +148,14 @@ build-ci-docker:
 
 # Note, we use underscores instead of periods in the version name since ECR doesn't support periods. We automatically
 # pull from Docker Hub and push to ECR.
-push-feature-server-aws-docker:
+push-feature-server-python-aws-docker:
 	ECR_VERSION=$(shell echo "$(VERSION)" | sed 's/[.]/_/g'); \
-		docker push $(REGISTRY)/feature-server-aws:$$ECR_VERSION
+		docker push $(REGISTRY)/feature-server-python-aws:$$ECR_VERSION
 
-build-feature-server-aws-docker:
+build-feature-server-python-aws-docker:
 	ECR_VERSION=$(shell echo "$(VERSION)" | sed 's/[.]/_/g'); \
 		docker build --build-arg VERSION=$$ECR_VERSION \
-			-t $(REGISTRY)/feature-server-aws:$$ECR_VERSION \
+			-t $(REGISTRY)/feature-server-python-aws:$$ECR_VERSION \
 			-f sdk/python/feast/infra/feature_servers/aws_lambda/Dockerfile .
 
 push-feature-transformation-server-docker:

--- a/docs/reference/alpha-aws-lambda-feature-server.md
+++ b/docs/reference/alpha-aws-lambda-feature-server.md
@@ -114,7 +114,7 @@ After `feature_store.yaml` has been modified as described in the previous sectio
 
 ```bash
 $ feast apply
-10/07/2021 03:57:26 PM INFO:Pulling remote image feastdev/feature-server-aws:aws:
+10/07/2021 03:57:26 PM INFO:Pulling remote image feastdev/feature-server-python-aws:aws:
 10/07/2021 03:57:28 PM INFO:Creating remote ECR repository feast-python-server-key_shark-0_13_1_dev23_gb3c08320:
 10/07/2021 03:57:29 PM INFO:Pushing local image to remote 402087665549.dkr.ecr.us-west-2.amazonaws.com/feast-python-server-key_shark-0_13_1_dev23_gb3c08320:0_13_1_dev23_gb3c08320:
 10/07/2021 03:58:44 PM INFO:Deploying feature server...

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -17,7 +17,7 @@
 # Maximum interval(secs) to wait between retries for retry function
 MAX_WAIT_INTERVAL: str = "60"
 
-AWS_LAMBDA_FEATURE_SERVER_IMAGE = "feastdev/feature-server-aws"
+AWS_LAMBDA_FEATURE_SERVER_IMAGE = "feastdev/feature-server-python-aws"
 AWS_LAMBDA_FEATURE_SERVER_REPOSITORY = "feast-python-server"
 
 # feature_store.yaml environment variable name for remote feature server


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This updates the lambda image to be feastdev/feature-server-python-aws instead of feastdev/feature-server-aws for more consistent naming with feature-server-java

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
