### PR TITLE
Add DatastoreTable infra object

### DIFF
--- a/protos/feast/core/DatastoreTable.proto
+++ b/protos/feast/core/DatastoreTable.proto
@@ -18,32 +18,26 @@ syntax = "proto3";
 
 package feast.core;
 option java_package = "feast.proto.core";
-option java_outer_classname = "InfraObjectProto";
+option java_outer_classname = "DatastoreTableProto";
 option go_package = "github.com/feast-dev/feast/sdk/go/protos/feast/core";
 
-import "feast/core/DynamoDBTable.proto";
-import "feast/core/DatastoreTable.proto";
+// Represents a Datastore table
+message DatastoreTable {
+    // Feast project of the table
+    string project = 1;
 
-// Represents a set of infrastructure objects managed by Feast
-message Infra {
-    // List of infrastructure objects managed by Feast
-    repeated InfraObject infra_objects = 1;
-}
+    // Name of the table
+    string name = 2;
 
-// Represents a single infrastructure object managed by Feast
-message InfraObject {
-    // Represents the Python class for the infrastructure object
-    string infra_object_class_type = 1;
-
-    // The infrastructure object
-    oneof infra_object {
-        DynamoDBTable dynamodb_table = 2;
-        DatastoreTable datastore_table = 3;
-        CustomInfra custom_infra = 100;
+    // GCP project id, which can be null
+    oneof project_id {
+        bool project_id_null = 3;
+        string project_id_value = 4;
     }
 
-    // Allows for custom infra objects to be added
-    message CustomInfra {
-        bytes field = 1;
+    // Datastore namespace, which can be null
+    oneof namespace {
+        bool namespace_null = 5;
+        string namespace_value = 6;
     }
 }

--- a/protos/feast/core/DatastoreTable.proto
+++ b/protos/feast/core/DatastoreTable.proto
@@ -21,6 +21,8 @@ option java_package = "feast.proto.core";
 option java_outer_classname = "DatastoreTableProto";
 option go_package = "github.com/feast-dev/feast/sdk/go/protos/feast/core";
 
+import "google/protobuf/wrappers.proto";
+
 // Represents a Datastore table
 message DatastoreTable {
     // Feast project of the table
@@ -29,15 +31,9 @@ message DatastoreTable {
     // Name of the table
     string name = 2;
 
-    // GCP project id, which can be null
-    oneof project_id {
-        bool project_id_null = 3;
-        string project_id_value = 4;
-    }
+    // GCP project id
+    google.protobuf.StringValue project_id = 3;
 
-    // Datastore namespace, which can be null
-    oneof namespace {
-        bool namespace_null = 5;
-        string namespace_value = 6;
-    }
+    // Datastore namespace
+    google.protobuf.StringValue namespace = 4;
 }


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: This PR adds an `InfraObject` for Datastore tables, as part of the `feast plan` implementation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
