### PR TITLE
Ensure that universal CLI test tears down infrastructure

### DIFF
--- a/sdk/python/tests/integration/registration/test_cli.py
+++ b/sdk/python/tests/integration/registration/test_cli.py
@@ -60,7 +60,8 @@ def test_universal_cli(test_repo_config) -> None:
             )
             assertpy.assert_that(result.returncode).is_equal_to(0)
             result = runner.run(
-                ["feature-services", "describe", "driver_locations_service"], cwd=repo_path
+                ["feature-services", "describe", "driver_locations_service"],
+                cwd=repo_path,
             )
             assertpy.assert_that(result.returncode).is_equal_to(0)
             assertpy.assert_that(fs.list_feature_views()).is_length(3)

--- a/sdk/python/tests/integration/registration/test_cli.py
+++ b/sdk/python/tests/integration/registration/test_cli.py
@@ -25,68 +25,71 @@ def test_universal_cli(test_repo_config) -> None:
     runner = CliRunner()
 
     with tempfile.TemporaryDirectory() as repo_dir_name:
-        feature_store_yaml = make_feature_store_yaml(
-            project, test_repo_config, repo_dir_name
-        )
-        repo_path = Path(repo_dir_name)
+        try:
+            feature_store_yaml = make_feature_store_yaml(
+                project, test_repo_config, repo_dir_name
+            )
+            repo_path = Path(repo_dir_name)
 
-        repo_config = repo_path / "feature_store.yaml"
+            repo_config = repo_path / "feature_store.yaml"
 
-        repo_config.write_text(dedent(feature_store_yaml))
+            repo_config.write_text(dedent(feature_store_yaml))
 
-        repo_example = repo_path / "example.py"
-        repo_example.write_text(get_example_repo("example_feature_repo_1.py"))
-        result = runner.run(["apply"], cwd=repo_path)
-        assertpy.assert_that(result.returncode).is_equal_to(0)
+            repo_example = repo_path / "example.py"
+            repo_example.write_text(get_example_repo("example_feature_repo_1.py"))
+            result = runner.run(["apply"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(0)
 
-        # Store registry contents, to be compared later.
-        fs = FeatureStore(repo_path=str(repo_path))
-        registry_dict = fs.registry.to_dict(project=project)
+            # Store registry contents, to be compared later.
+            fs = FeatureStore(repo_path=str(repo_path))
+            registry_dict = fs.registry.to_dict(project=project)
 
-        # entity & feature view list commands should succeed
-        result = runner.run(["entities", "list"], cwd=repo_path)
-        assertpy.assert_that(result.returncode).is_equal_to(0)
-        result = runner.run(["feature-views", "list"], cwd=repo_path)
-        assertpy.assert_that(result.returncode).is_equal_to(0)
-        result = runner.run(["feature-services", "list"], cwd=repo_path)
-        assertpy.assert_that(result.returncode).is_equal_to(0)
+            # entity & feature view list commands should succeed
+            result = runner.run(["entities", "list"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(0)
+            result = runner.run(["feature-views", "list"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(0)
+            result = runner.run(["feature-services", "list"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(0)
 
-        # entity & feature view describe commands should succeed when objects exist
-        result = runner.run(["entities", "describe", "driver"], cwd=repo_path)
-        assertpy.assert_that(result.returncode).is_equal_to(0)
-        result = runner.run(
-            ["feature-views", "describe", "driver_locations"], cwd=repo_path
-        )
-        assertpy.assert_that(result.returncode).is_equal_to(0)
-        result = runner.run(
-            ["feature-services", "describe", "driver_locations_service"], cwd=repo_path
-        )
-        assertpy.assert_that(result.returncode).is_equal_to(0)
-        assertpy.assert_that(fs.list_feature_views()).is_length(3)
+            # entity & feature view describe commands should succeed when objects exist
+            result = runner.run(["entities", "describe", "driver"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(0)
+            result = runner.run(
+                ["feature-views", "describe", "driver_locations"], cwd=repo_path
+            )
+            assertpy.assert_that(result.returncode).is_equal_to(0)
+            result = runner.run(
+                ["feature-services", "describe", "driver_locations_service"], cwd=repo_path
+            )
+            assertpy.assert_that(result.returncode).is_equal_to(0)
+            assertpy.assert_that(fs.list_feature_views()).is_length(3)
 
-        # entity & feature view describe commands should fail when objects don't exist
-        result = runner.run(["entities", "describe", "foo"], cwd=repo_path)
-        assertpy.assert_that(result.returncode).is_equal_to(1)
-        result = runner.run(["feature-views", "describe", "foo"], cwd=repo_path)
-        assertpy.assert_that(result.returncode).is_equal_to(1)
-        result = runner.run(["feature-services", "describe", "foo"], cwd=repo_path)
-        assertpy.assert_that(result.returncode).is_equal_to(1)
+            # entity & feature view describe commands should fail when objects don't exist
+            result = runner.run(["entities", "describe", "foo"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(1)
+            result = runner.run(["feature-views", "describe", "foo"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(1)
+            result = runner.run(["feature-services", "describe", "foo"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(1)
 
-        # Doing another apply should be a no op, and should not cause errors
-        result = runner.run(["apply"], cwd=repo_path)
-        assertpy.assert_that(result.returncode).is_equal_to(0)
-        basic_rw_test(
-            FeatureStore(repo_path=str(repo_path), config=None),
-            view_name="driver_locations",
-        )
+            # Doing another apply should be a no op, and should not cause errors
+            result = runner.run(["apply"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(0)
+            basic_rw_test(
+                FeatureStore(repo_path=str(repo_path), config=None),
+                view_name="driver_locations",
+            )
 
-        # Confirm that registry contents have not changed.
-        assertpy.assert_that(registry_dict).is_equal_to(
-            fs.registry.to_dict(project=project)
-        )
+            # Confirm that registry contents have not changed.
+            assertpy.assert_that(registry_dict).is_equal_to(
+                fs.registry.to_dict(project=project)
+            )
 
-        result = runner.run(["teardown"], cwd=repo_path)
-        assertpy.assert_that(result.returncode).is_equal_to(0)
+            result = runner.run(["teardown"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(0)
+        finally:
+            runner.run(["teardown"], cwd=repo_path)
 
 
 def make_feature_store_yaml(project, test_repo_config, repo_dir_name: PosixPath):


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: Recently we have been leaking DynamoDB tables. Upon closer inspection, I noticed that tests often leak `test_universal_cli` tables. This PR aims to ensure that those tables are always torn down.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
