### PR TITLE
Fix `BYTES` and `BYTES_LIST` type conversion

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Set, Tuple, Type
@@ -62,7 +63,9 @@ def feast_value_type_to_python_type(field_value_proto: ProtoValue) -> Any:
         if k == "int64Val":
             return int(val)
         if k == "bytesVal":
-            return bytes(val)
+            # MessageToDict converts the bytes object to base64 encoded string:
+            # https://developers.google.com/protocol-buffers/docs/proto3#json
+            return base64.b64decode(val)
         if (k == "int64ListVal") or (k == "int32ListVal"):
             return [int(item) for item in val]
         if (k == "floatListVal") or (k == "doubleListVal"):
@@ -70,7 +73,9 @@ def feast_value_type_to_python_type(field_value_proto: ProtoValue) -> Any:
         if k == "stringListVal":
             return [str(item) for item in val]
         if k == "bytesListVal":
-            return [bytes(item) for item in val]
+            # MessageToDict converts the bytes object to base64 encoded string:
+            # https://developers.google.com/protocol-buffers/docs/proto3#json
+            return [base64.b64decode(val) for item in val]
         if k == "boolListVal":
             return [bool(item) for item in val]
 


### PR DESCRIPTION
Signed-off-by: Judah Rand <17158624+judahrand@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Currently, any `get_online_features` which tries to retrieve a `ValueType.BYTES` Feature will fail due to an incorrect conversion.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix BYTES and BYTES_LIST type conversion
```
