### PR TITLE
[Java Feature Server] Use hgetall in redis connector when number of retrieved fields is big enough

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -565,6 +565,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <source>11</source>
+                    <target>11</target>
                     <release>11</release>
                     <annotationProcessorPaths>
                         <path>

--- a/java/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
+++ b/java/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
@@ -73,8 +73,6 @@ public class ServingServiceGRpcController extends ServingServiceImplBase {
   public void getOnlineFeaturesV2(
       ServingAPIProto.GetOnlineFeaturesRequestV2 request,
       StreamObserver<GetOnlineFeaturesResponse> responseObserver) {
-    long start = System.currentTimeMillis();
-
     try {
       // authorize for the project in request object.
       if (request.getProject() != null && !request.getProject().isEmpty()) {
@@ -90,8 +88,6 @@ public class ServingServiceGRpcController extends ServingServiceImplBase {
 
       responseObserver.onNext(onlineFeatures);
       responseObserver.onCompleted();
-      System.out.printf("Total %d\n", System.currentTimeMillis() - start);
-
     } catch (SpecRetrievalException e) {
       log.error("Failed to retrieve specs from Registry", e);
       responseObserver.onError(

--- a/java/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
+++ b/java/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
@@ -73,6 +73,8 @@ public class ServingServiceGRpcController extends ServingServiceImplBase {
   public void getOnlineFeaturesV2(
       ServingAPIProto.GetOnlineFeaturesRequestV2 request,
       StreamObserver<GetOnlineFeaturesResponse> responseObserver) {
+    long start = System.currentTimeMillis();
+
     try {
       // authorize for the project in request object.
       if (request.getProject() != null && !request.getProject().isEmpty()) {
@@ -85,8 +87,11 @@ public class ServingServiceGRpcController extends ServingServiceImplBase {
       if (span != null) {
         span.finish();
       }
+
       responseObserver.onNext(onlineFeatures);
       responseObserver.onCompleted();
+      System.out.printf("Total %d\n", System.currentTimeMillis() - start);
+
     } catch (SpecRetrievalException e) {
       log.error("Failed to retrieve specs from Registry", e);
       responseObserver.onError(

--- a/java/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
+++ b/java/serving/src/main/java/feast/serving/controller/ServingServiceGRpcController.java
@@ -85,7 +85,6 @@ public class ServingServiceGRpcController extends ServingServiceImplBase {
       if (span != null) {
         span.finish();
       }
-
       responseObserver.onNext(onlineFeatures);
       responseObserver.onCompleted();
     } catch (SpecRetrievalException e) {

--- a/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -80,7 +80,7 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
     if (projectName.isEmpty()) {
       projectName = "default";
     }
-    
+
     // Split all feature references into non-ODFV (e.g. batch and stream) references and ODFV.
     List<FeatureReferenceV2> allFeatureReferences = request.getFeaturesList();
     List<FeatureReferenceV2> featureReferences =

--- a/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -165,11 +165,8 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
       storageRetrievalSpan.setTag("entities", entityRows.size());
       storageRetrievalSpan.setTag("features", featureReferences.size());
     }
-    long s = System.currentTimeMillis();
     List<Map<FeatureReferenceV2, Feature>> features =
         retriever.getOnlineFeatures(projectName, entityRows, featureReferences, entityNames);
-    System.out.printf("GetOnlineFeatures %d\n", System.currentTimeMillis() - s);
-
     if (storageRetrievalSpan != null) {
       storageRetrievalSpan.finish();
     }

--- a/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -80,6 +80,7 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
     if (projectName.isEmpty()) {
       projectName = "default";
     }
+    
     // Split all feature references into non-ODFV (e.g. batch and stream) references and ODFV.
     List<FeatureReferenceV2> allFeatureReferences = request.getFeaturesList();
     List<FeatureReferenceV2> featureReferences =

--- a/java/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
+++ b/java/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
 import feast.proto.core.FeatureProto;
@@ -42,6 +43,7 @@ import io.opentracing.Tracer;
 import io.opentracing.Tracer.SpanBuilder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
@@ -151,14 +153,14 @@ public class OnlineServingServiceTest {
         List.of(featureReference1, featureReference2);
     GetOnlineFeaturesRequestV2 request = getOnlineFeaturesRequestV2(projectName, featureReferences);
 
-    List<Feature> entityKeyList1 = new ArrayList<>();
-    List<Feature> entityKeyList2 = new ArrayList<>();
-    entityKeyList1.add(mockedFeatureRows.get(0));
-    entityKeyList1.add(mockedFeatureRows.get(1));
-    entityKeyList2.add(mockedFeatureRows.get(2));
-    entityKeyList2.add(mockedFeatureRows.get(3));
-
-    List<List<Feature>> featureRows = List.of(entityKeyList1, entityKeyList2);
+    List<Map<ServingAPIProto.FeatureReferenceV2, Feature>> featureRows =
+        List.of(
+            ImmutableMap.of(
+                mockedFeatureRows.get(0).getFeatureReference(), mockedFeatureRows.get(0),
+                mockedFeatureRows.get(1).getFeatureReference(), mockedFeatureRows.get(1)),
+            ImmutableMap.of(
+                mockedFeatureRows.get(2).getFeatureReference(), mockedFeatureRows.get(2),
+                mockedFeatureRows.get(3).getFeatureReference(), mockedFeatureRows.get(3)));
 
     when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
     when(registry.getFeatureViewSpec(any(), any())).thenReturn(getFeatureViewSpec());
@@ -225,7 +227,13 @@ public class OnlineServingServiceTest {
     entityKeyList1.add(mockedFeatureRows.get(1));
     entityKeyList2.add(mockedFeatureRows.get(4));
 
-    List<List<Feature>> featureRows = List.of(entityKeyList1, entityKeyList2);
+    List<Map<ServingAPIProto.FeatureReferenceV2, Feature>> featureRows =
+        List.of(
+            ImmutableMap.of(
+                mockedFeatureRows.get(0).getFeatureReference(), mockedFeatureRows.get(0),
+                mockedFeatureRows.get(1).getFeatureReference(), mockedFeatureRows.get(1)),
+            ImmutableMap.of(
+                mockedFeatureRows.get(4).getFeatureReference(), mockedFeatureRows.get(4)));
 
     when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
     when(registry.getFeatureViewSpec(any(), any())).thenReturn(getFeatureViewSpec());
@@ -282,14 +290,14 @@ public class OnlineServingServiceTest {
         List.of(featureReference1, featureReference2);
     GetOnlineFeaturesRequestV2 request = getOnlineFeaturesRequestV2(projectName, featureReferences);
 
-    List<Feature> entityKeyList1 = new ArrayList<>();
-    List<Feature> entityKeyList2 = new ArrayList<>();
-    entityKeyList1.add(mockedFeatureRows.get(5));
-    entityKeyList1.add(mockedFeatureRows.get(1));
-    entityKeyList2.add(mockedFeatureRows.get(5));
-    entityKeyList2.add(mockedFeatureRows.get(1));
-
-    List<List<Feature>> featureRows = List.of(entityKeyList1, entityKeyList2);
+    List<Map<ServingAPIProto.FeatureReferenceV2, Feature>> featureRows =
+        List.of(
+            ImmutableMap.of(
+                mockedFeatureRows.get(5).getFeatureReference(), mockedFeatureRows.get(5),
+                mockedFeatureRows.get(1).getFeatureReference(), mockedFeatureRows.get(1)),
+            ImmutableMap.of(
+                mockedFeatureRows.get(5).getFeatureReference(), mockedFeatureRows.get(5),
+                mockedFeatureRows.get(1).getFeatureReference(), mockedFeatureRows.get(1)));
 
     when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
     when(registry.getFeatureViewSpec(any(), any()))

--- a/java/storage/api/src/main/java/feast/storage/api/retriever/OnlineRetrieverV2.java
+++ b/java/storage/api/src/main/java/feast/storage/api/retriever/OnlineRetrieverV2.java
@@ -18,6 +18,7 @@ package feast.storage.api.retriever;
 
 import feast.proto.serving.ServingAPIProto;
 import java.util.List;
+import java.util.Map;
 
 public interface OnlineRetrieverV2 {
   /**
@@ -37,7 +38,7 @@ public interface OnlineRetrieverV2 {
    * @return list of {@link Feature}s corresponding to data retrieved for each entity row from
    *     FeatureTable specified in FeatureTable request.
    */
-  List<List<Feature>> getOnlineFeatures(
+  List<Map<ServingAPIProto.FeatureReferenceV2, Feature>> getOnlineFeatures(
       String project,
       List<ServingAPIProto.GetOnlineFeaturesRequestV2.EntityRow> entityRows,
       List<ServingAPIProto.FeatureReferenceV2> featureReferences,

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/common/RedisHashDecoder.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/common/RedisHashDecoder.java
@@ -16,6 +16,7 @@
  */
 package feast.storage.connectors.redis.common;
 
+import com.google.common.collect.Maps;
 import com.google.common.hash.Hashing;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
@@ -57,7 +58,7 @@ public class RedisHashDecoder {
                       }
                     }));
     Map<ServingAPIProto.FeatureReferenceV2, Feature> results =
-        new HashMap<>(byteToFeatureReferenceMap.size(), 1);
+        Maps.newHashMapWithExpectedSize(byteToFeatureReferenceMap.size());
 
     redisHashValues.entrySet().stream()
         .filter(e -> !(new String(e.getKey()).startsWith(timestampPrefix)))

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
@@ -125,7 +125,7 @@ public class OnlineRetriever implements OnlineRetrieverV2 {
         results.add(
             RedisHashDecoder.retrieveFeature(f.get(), byteToFeatureReferenceMap, timestampPrefix));
       } catch (InterruptedException | ExecutionException e) {
-        throw new RuntimeException();
+        throw new RuntimeException("Unexpected error when pulling data from Redis");
       }
     }
 

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
@@ -27,93 +27,134 @@ import feast.storage.connectors.redis.common.RedisKeyGenerator;
 import io.grpc.Status;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.RedisFuture;
+
+import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+
+import io.lettuce.core.Value;
 import org.slf4j.Logger;
 
 public class OnlineRetriever implements OnlineRetrieverV2 {
 
-  private static final Logger log = org.slf4j.LoggerFactory.getLogger(OnlineRetriever.class);
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(OnlineRetriever.class);
 
-  private static final String timestampPrefix = "_ts";
-  private final RedisClientAdapter redisClientAdapter;
-  private final EntityKeySerializer keySerializer;
+    private static final String timestampPrefix = "_ts";
+    private final RedisClientAdapter redisClientAdapter;
+    private final EntityKeySerializer keySerializer;
 
-  public OnlineRetriever(RedisClientAdapter redisClientAdapter, EntityKeySerializer keySerializer) {
-    this.redisClientAdapter = redisClientAdapter;
-    this.keySerializer = keySerializer;
-  }
-
-  @Override
-  public List<List<Feature>> getOnlineFeatures(
-      String project,
-      List<ServingAPIProto.GetOnlineFeaturesRequestV2.EntityRow> entityRows,
-      List<ServingAPIProto.FeatureReferenceV2> featureReferences,
-      List<String> entityNames) {
-
-    List<RedisProto.RedisKeyV2> redisKeys = RedisKeyGenerator.buildRedisKeys(project, entityRows);
-    List<List<Feature>> features = getFeaturesFromRedis(redisKeys, featureReferences);
-
-    return features;
-  }
-
-  private List<List<Feature>> getFeaturesFromRedis(
-      List<RedisProto.RedisKeyV2> redisKeys,
-      List<ServingAPIProto.FeatureReferenceV2> featureReferences) {
-    List<List<Feature>> features = new ArrayList<>();
-    // To decode bytes back to Feature Reference
-    Map<byte[], ServingAPIProto.FeatureReferenceV2> byteToFeatureReferenceMap = new HashMap<>();
-
-    // Serialize using proto
-    List<byte[]> binaryRedisKeys =
-        redisKeys.stream().map(this.keySerializer::serialize).collect(Collectors.toList());
-
-    List<byte[]> featureReferenceWithTsByteList = new ArrayList<>();
-    featureReferences.stream()
-        .forEach(
-            featureReference -> {
-
-              // eg. murmur(<featuretable_name:feature_name>)
-              byte[] featureReferenceBytes =
-                  RedisHashDecoder.getFeatureReferenceRedisHashKeyBytes(featureReference);
-              featureReferenceWithTsByteList.add(featureReferenceBytes);
-              byteToFeatureReferenceMap.put(featureReferenceBytes, featureReference);
-
-              // eg. <_ts:featuretable_name>
-              byte[] featureTableTsBytes =
-                  RedisHashDecoder.getTimestampRedisHashKeyBytes(featureReference, timestampPrefix);
-              featureReferenceWithTsByteList.add(featureTableTsBytes);
-            });
-
-    // Perform a series of independent calls
-    List<RedisFuture<List<KeyValue<byte[], byte[]>>>> futures = Lists.newArrayList();
-    for (byte[] binaryRedisKey : binaryRedisKeys) {
-      byte[][] featureReferenceWithTsByteArrays =
-          featureReferenceWithTsByteList.toArray(new byte[0][]);
-      // Access redis keys and extract features
-      futures.add(redisClientAdapter.hmget(binaryRedisKey, featureReferenceWithTsByteArrays));
+    public OnlineRetriever(RedisClientAdapter redisClientAdapter, EntityKeySerializer keySerializer) {
+        this.redisClientAdapter = redisClientAdapter;
+        this.keySerializer = keySerializer;
     }
 
-    // Write all commands to the transport layer
-    redisClientAdapter.flushCommands();
+    @Override
+    public List<List<Feature>> getOnlineFeatures(
+        String project,
+        List<ServingAPIProto.GetOnlineFeaturesRequestV2.EntityRow> entityRows,
+        List<ServingAPIProto.FeatureReferenceV2> featureReferences,
+        List<String> entityNames) {
 
-    futures.forEach(
-        future -> {
-          try {
-            List<KeyValue<byte[], byte[]>> redisValuesList = future.get();
+        List<RedisProto.RedisKeyV2> redisKeys = RedisKeyGenerator.buildRedisKeys(project, entityRows);
+        List<List<Feature>> features = getFeaturesFromRedis(redisKeys, featureReferences);
 
-            List<Feature> curRedisKeyFeatures =
-                RedisHashDecoder.retrieveFeature(
-                    redisValuesList, byteToFeatureReferenceMap, timestampPrefix);
-            features.add(curRedisKeyFeatures);
-          } catch (InterruptedException | ExecutionException | InvalidProtocolBufferException e) {
-            throw Status.UNKNOWN
-                .withDescription("Unexpected error when pulling data from from Redis.")
-                .withCause(e)
-                .asRuntimeException();
-          }
-        });
-    return features;
-  }
+        return features;
+    }
+
+    private List<List<Feature>> getFeaturesFromRedis(
+        List<RedisProto.RedisKeyV2> redisKeys,
+        List<ServingAPIProto.FeatureReferenceV2> featureReferences) {
+        List<List<Feature>> features = new ArrayList<>();
+        // To decode bytes back to Feature Reference
+        Map<ByteBuffer, ServingAPIProto.FeatureReferenceV2> byteToFeatureReferenceMap = new HashMap<>();
+
+        // Serialize using proto
+        List<byte[]> binaryRedisKeys =
+            redisKeys.stream().map(this.keySerializer::serialize).collect(Collectors.toList());
+
+        List<byte[]> retrieveFields = new ArrayList<>();
+        featureReferences.stream()
+            .forEach(
+                featureReference -> {
+
+                    // eg. murmur(<featuretable_name:feature_name>)
+                    byte[] featureReferenceBytes =
+                        RedisHashDecoder.getFeatureReferenceRedisHashKeyBytes(featureReference);
+                    retrieveFields.add(featureReferenceBytes);
+                    byteToFeatureReferenceMap.put(
+                        ByteBuffer.wrap(featureReferenceBytes), featureReference);
+                });
+
+        featureReferences.stream()
+            .map(ServingAPIProto.FeatureReferenceV2::getFeatureTable)
+            .distinct()
+            .forEach(
+                table -> {
+                    // eg. <_ts:featuretable_name>
+                    byte[] featureTableTsBytes =
+                        RedisHashDecoder.getTimestampRedisHashKeyBytes(table, timestampPrefix);
+
+                    retrieveFields.add(featureTableTsBytes);
+                }
+            );
+
+        List<Map<byte[], byte[]>> results;
+
+        long start = System.currentTimeMillis();
+        // Perform a series of independent calls
+        if (retrieveFields.size() < 20) {
+            byte[][] retrieveFieldsByteArray =
+                retrieveFields.toArray(new byte[0][]);
+
+            List<RedisFuture<List<KeyValue<byte[], byte[]>>>> futures = Lists.newArrayList();
+            for (byte[] binaryRedisKey : binaryRedisKeys) {
+                // Access redis keys and extract features
+                futures.add(redisClientAdapter.hmget(binaryRedisKey, retrieveFieldsByteArray));
+            }
+
+            // Write all commands to the transport layer
+            //redisClientAdapter.flushCommands();
+
+            results = futures.stream().map(f -> {
+                try {
+                    return f.get().stream()
+                        .filter(Value::hasValue)
+                        .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException();
+                }
+            }).collect(Collectors.toList());
+        } else {
+            List<RedisFuture<Map<byte[], byte[]>>> futures = Lists.newArrayList();
+            for (byte[] binaryRedisKey : binaryRedisKeys) {
+                futures.add(redisClientAdapter.hgetall(binaryRedisKey));
+            }
+
+            results = futures.stream().map(f -> {
+                try {
+                    return f.get();
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new RuntimeException();
+                }
+            }).collect(Collectors.toList());
+        }
+        System.out.printf("Redis %d\n", System.currentTimeMillis() - start);
+
+        results.forEach(
+            redisValuesList -> {
+                try {
+                    List<Feature> curRedisKeyFeatures =
+                        RedisHashDecoder.retrieveFeature(
+                            redisValuesList, byteToFeatureReferenceMap, timestampPrefix);
+                    features.add(curRedisKeyFeatures);
+                } catch (InvalidProtocolBufferException e) {
+                    throw Status.UNKNOWN
+                        .withDescription("Unexpected error when pulling data from from Redis.")
+                        .withCause(e)
+                        .asRuntimeException();
+                }
+            });
+        return features;
+    }
 }

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
@@ -39,6 +39,9 @@ public class OnlineRetriever implements OnlineRetrieverV2 {
   private final RedisClientAdapter redisClientAdapter;
   private final EntityKeySerializer keySerializer;
 
+  // Number of fields in request to Redis which requires using HGETALL instead of HMGET
+  public static final int HGETALL_NUMBER_OF_FIELDS_THRESHOLD = 50;
+
   public OnlineRetriever(RedisClientAdapter redisClientAdapter, EntityKeySerializer keySerializer) {
     this.redisClientAdapter = redisClientAdapter;
     this.keySerializer = keySerializer;
@@ -96,7 +99,7 @@ public class OnlineRetriever implements OnlineRetrieverV2 {
 
     // Number of fields that controls whether to use hmget or hgetall was discovered empirically
     // Could be potentially tuned further
-    if (retrieveFields.size() < 50) {
+    if (retrieveFields.size() < HGETALL_NUMBER_OF_FIELDS_THRESHOLD) {
       byte[][] retrieveFieldsByteArray = retrieveFields.toArray(new byte[0][]);
 
       for (byte[] binaryRedisKey : binaryRedisKeys) {

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
@@ -17,144 +17,116 @@
 package feast.storage.connectors.redis.retriever;
 
 import com.google.common.collect.Lists;
-import com.google.protobuf.InvalidProtocolBufferException;
 import feast.proto.serving.ServingAPIProto;
 import feast.proto.storage.RedisProto;
 import feast.storage.api.retriever.Feature;
 import feast.storage.api.retriever.OnlineRetrieverV2;
 import feast.storage.connectors.redis.common.RedisHashDecoder;
 import feast.storage.connectors.redis.common.RedisKeyGenerator;
-import io.grpc.Status;
 import io.lettuce.core.KeyValue;
-import io.lettuce.core.RedisFuture;
-
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
-
-import io.lettuce.core.Value;
 import org.slf4j.Logger;
 
 public class OnlineRetriever implements OnlineRetrieverV2 {
 
-    private static final Logger log = org.slf4j.LoggerFactory.getLogger(OnlineRetriever.class);
+  private static final Logger log = org.slf4j.LoggerFactory.getLogger(OnlineRetriever.class);
 
-    private static final String timestampPrefix = "_ts";
-    private final RedisClientAdapter redisClientAdapter;
-    private final EntityKeySerializer keySerializer;
+  private static final String timestampPrefix = "_ts";
+  private final RedisClientAdapter redisClientAdapter;
+  private final EntityKeySerializer keySerializer;
 
-    public OnlineRetriever(RedisClientAdapter redisClientAdapter, EntityKeySerializer keySerializer) {
-        this.redisClientAdapter = redisClientAdapter;
-        this.keySerializer = keySerializer;
-    }
+  public OnlineRetriever(RedisClientAdapter redisClientAdapter, EntityKeySerializer keySerializer) {
+    this.redisClientAdapter = redisClientAdapter;
+    this.keySerializer = keySerializer;
+  }
 
-    @Override
-    public List<List<Feature>> getOnlineFeatures(
-        String project,
-        List<ServingAPIProto.GetOnlineFeaturesRequestV2.EntityRow> entityRows,
-        List<ServingAPIProto.FeatureReferenceV2> featureReferences,
-        List<String> entityNames) {
+  @Override
+  public List<Map<ServingAPIProto.FeatureReferenceV2, Feature>> getOnlineFeatures(
+      String project,
+      List<ServingAPIProto.GetOnlineFeaturesRequestV2.EntityRow> entityRows,
+      List<ServingAPIProto.FeatureReferenceV2> featureReferences,
+      List<String> entityNames) {
 
-        List<RedisProto.RedisKeyV2> redisKeys = RedisKeyGenerator.buildRedisKeys(project, entityRows);
-        List<List<Feature>> features = getFeaturesFromRedis(redisKeys, featureReferences);
+    List<RedisProto.RedisKeyV2> redisKeys = RedisKeyGenerator.buildRedisKeys(project, entityRows);
+    return getFeaturesFromRedis(redisKeys, featureReferences);
+  }
 
-        return features;
-    }
+  private List<Map<ServingAPIProto.FeatureReferenceV2, Feature>> getFeaturesFromRedis(
+      List<RedisProto.RedisKeyV2> redisKeys,
+      List<ServingAPIProto.FeatureReferenceV2> featureReferences) {
+    List<List<Feature>> features = new ArrayList<>();
+    // To decode bytes back to Feature Reference
+    Map<ByteBuffer, ServingAPIProto.FeatureReferenceV2> byteToFeatureReferenceMap = new HashMap<>();
 
-    private List<List<Feature>> getFeaturesFromRedis(
-        List<RedisProto.RedisKeyV2> redisKeys,
-        List<ServingAPIProto.FeatureReferenceV2> featureReferences) {
-        List<List<Feature>> features = new ArrayList<>();
-        // To decode bytes back to Feature Reference
-        Map<ByteBuffer, ServingAPIProto.FeatureReferenceV2> byteToFeatureReferenceMap = new HashMap<>();
+    // Serialize using proto
+    List<byte[]> binaryRedisKeys =
+        redisKeys.stream().map(this.keySerializer::serialize).collect(Collectors.toList());
 
-        // Serialize using proto
-        List<byte[]> binaryRedisKeys =
-            redisKeys.stream().map(this.keySerializer::serialize).collect(Collectors.toList());
+    List<byte[]> retrieveFields = new ArrayList<>();
+    featureReferences.stream()
+        .forEach(
+            featureReference -> {
 
-        List<byte[]> retrieveFields = new ArrayList<>();
-        featureReferences.stream()
-            .forEach(
-                featureReference -> {
-
-                    // eg. murmur(<featuretable_name:feature_name>)
-                    byte[] featureReferenceBytes =
-                        RedisHashDecoder.getFeatureReferenceRedisHashKeyBytes(featureReference);
-                    retrieveFields.add(featureReferenceBytes);
-                    byteToFeatureReferenceMap.put(
-                        ByteBuffer.wrap(featureReferenceBytes), featureReference);
-                });
-
-        featureReferences.stream()
-            .map(ServingAPIProto.FeatureReferenceV2::getFeatureTable)
-            .distinct()
-            .forEach(
-                table -> {
-                    // eg. <_ts:featuretable_name>
-                    byte[] featureTableTsBytes =
-                        RedisHashDecoder.getTimestampRedisHashKeyBytes(table, timestampPrefix);
-
-                    retrieveFields.add(featureTableTsBytes);
-                }
-            );
-
-        List<Map<byte[], byte[]>> results;
-
-        long start = System.currentTimeMillis();
-        // Perform a series of independent calls
-        if (retrieveFields.size() < 20) {
-            byte[][] retrieveFieldsByteArray =
-                retrieveFields.toArray(new byte[0][]);
-
-            List<RedisFuture<List<KeyValue<byte[], byte[]>>>> futures = Lists.newArrayList();
-            for (byte[] binaryRedisKey : binaryRedisKeys) {
-                // Access redis keys and extract features
-                futures.add(redisClientAdapter.hmget(binaryRedisKey, retrieveFieldsByteArray));
-            }
-
-            // Write all commands to the transport layer
-            //redisClientAdapter.flushCommands();
-
-            results = futures.stream().map(f -> {
-                try {
-                    return f.get().stream()
-                        .filter(Value::hasValue)
-                        .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
-                } catch (InterruptedException | ExecutionException e) {
-                    throw new RuntimeException();
-                }
-            }).collect(Collectors.toList());
-        } else {
-            List<RedisFuture<Map<byte[], byte[]>>> futures = Lists.newArrayList();
-            for (byte[] binaryRedisKey : binaryRedisKeys) {
-                futures.add(redisClientAdapter.hgetall(binaryRedisKey));
-            }
-
-            results = futures.stream().map(f -> {
-                try {
-                    return f.get();
-                } catch (InterruptedException | ExecutionException e) {
-                    throw new RuntimeException();
-                }
-            }).collect(Collectors.toList());
-        }
-        System.out.printf("Redis %d\n", System.currentTimeMillis() - start);
-
-        results.forEach(
-            redisValuesList -> {
-                try {
-                    List<Feature> curRedisKeyFeatures =
-                        RedisHashDecoder.retrieveFeature(
-                            redisValuesList, byteToFeatureReferenceMap, timestampPrefix);
-                    features.add(curRedisKeyFeatures);
-                } catch (InvalidProtocolBufferException e) {
-                    throw Status.UNKNOWN
-                        .withDescription("Unexpected error when pulling data from from Redis.")
-                        .withCause(e)
-                        .asRuntimeException();
-                }
+              // eg. murmur(<featuretable_name:feature_name>)
+              byte[] featureReferenceBytes =
+                  RedisHashDecoder.getFeatureReferenceRedisHashKeyBytes(featureReference);
+              retrieveFields.add(featureReferenceBytes);
+              byteToFeatureReferenceMap.put(
+                  ByteBuffer.wrap(featureReferenceBytes), featureReference);
             });
-        return features;
+
+    featureReferences.stream()
+        .map(ServingAPIProto.FeatureReferenceV2::getFeatureTable)
+        .distinct()
+        .forEach(
+            table -> {
+              // eg. <_ts:featuretable_name>
+              byte[] featureTableTsBytes =
+                  RedisHashDecoder.getTimestampRedisHashKeyBytes(table, timestampPrefix);
+
+              retrieveFields.add(featureTableTsBytes);
+            });
+
+    List<Future<Map<byte[], byte[]>>> futures = Lists.newArrayList();
+
+    // Number of fields that controls whether to use hmget or hgetall was discovered empirically
+    // Could be potentially tuned further
+    if (retrieveFields.size() < 50) {
+      byte[][] retrieveFieldsByteArray = retrieveFields.toArray(new byte[0][]);
+
+      for (byte[] binaryRedisKey : binaryRedisKeys) {
+        // Access redis keys and extract features
+        futures.add(
+            redisClientAdapter
+                .hmget(binaryRedisKey, retrieveFieldsByteArray)
+                .thenApply(
+                    list ->
+                        list.stream()
+                            .filter(KeyValue::hasValue)
+                            .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue)))
+                .toCompletableFuture());
+      }
+
+    } else {
+      for (byte[] binaryRedisKey : binaryRedisKeys) {
+        futures.add(redisClientAdapter.hgetall(binaryRedisKey));
+      }
     }
+
+    return futures.stream()
+        .map(
+            f -> {
+              try {
+                return RedisHashDecoder.retrieveFeature(
+                    f.get(), byteToFeatureReferenceMap, timestampPrefix);
+              } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException();
+              }
+            })
+        .collect(Collectors.toList());
+  }
 }

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClient.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClient.java
@@ -21,7 +21,6 @@ import io.lettuce.core.RedisFuture;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
-import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +48,7 @@ public class RedisClient implements RedisClientAdapter {
     this.asyncCommands = connection.async();
 
     // Disable auto-flushing
-    //this.asyncCommands.setAutoFlushCommands(false);
+    // this.asyncCommands.setAutoFlushCommands(false);
   }
 
   public static RedisClientAdapter create(RedisStoreConfig config) {

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClient.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClient.java
@@ -46,9 +46,6 @@ public class RedisClient implements RedisClientAdapter {
 
   private RedisClient(StatefulRedisConnection<byte[], byte[]> connection) {
     this.asyncCommands = connection.async();
-
-    // Disable auto-flushing
-    // this.asyncCommands.setAutoFlushCommands(false);
   }
 
   public static RedisClientAdapter create(RedisStoreConfig config) {

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClient.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClient.java
@@ -21,8 +21,10 @@ import io.lettuce.core.RedisFuture;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import java.util.List;
+import java.util.Map;
 
 public class RedisClient implements RedisClientAdapter {
 
@@ -34,6 +36,11 @@ public class RedisClient implements RedisClientAdapter {
   }
 
   @Override
+  public RedisFuture<Map<byte[], byte[]>> hgetall(byte[] key) {
+    return asyncCommands.hgetall(key);
+  }
+
+  @Override
   public void flushCommands() {
     asyncCommands.flushCommands();
   }
@@ -42,7 +49,7 @@ public class RedisClient implements RedisClientAdapter {
     this.asyncCommands = connection.async();
 
     // Disable auto-flushing
-    this.asyncCommands.setAutoFlushCommands(false);
+    //this.asyncCommands.setAutoFlushCommands(false);
   }
 
   public static RedisClientAdapter create(RedisStoreConfig config) {

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClientAdapter.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClientAdapter.java
@@ -18,9 +18,11 @@ package feast.storage.connectors.redis.retriever;
 
 import io.lettuce.core.*;
 import java.util.List;
+import java.util.Map;
 
 public interface RedisClientAdapter {
   RedisFuture<List<KeyValue<byte[], byte[]>>> hmget(byte[] key, byte[]... fields);
+  RedisFuture<Map<byte[], byte[]>> hgetall(byte[] key);
 
   void flushCommands();
 }

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClientAdapter.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClientAdapter.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 public interface RedisClientAdapter {
   RedisFuture<List<KeyValue<byte[], byte[]>>> hmget(byte[] key, byte[]... fields);
+
   RedisFuture<Map<byte[], byte[]>> hgetall(byte[] key);
 
   void flushCommands();

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterClient.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterClient.java
@@ -24,6 +24,7 @@ import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import io.lettuce.core.codec.ByteArrayCodec;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class RedisClusterClient implements RedisClientAdapter {
@@ -33,6 +34,11 @@ public class RedisClusterClient implements RedisClientAdapter {
   @Override
   public RedisFuture<List<KeyValue<byte[], byte[]>>> hmget(byte[] key, byte[]... fields) {
     return asyncCommands.hmget(key, fields);
+  }
+
+  @Override
+  public RedisFuture<Map<byte[], byte[]>> hgetall(byte[] key) {
+    return asyncCommands.hgetall(key);
   }
 
   @Override

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterClient.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterClient.java
@@ -63,9 +63,6 @@ public class RedisClusterClient implements RedisClientAdapter {
 
     // allows reading from replicas
     this.asyncCommands.readOnly();
-
-    // Disable auto-flushing
-    this.asyncCommands.setAutoFlushCommands(false);
   }
 
   public static RedisClientAdapter create(RedisClusterStoreConfig config) {


### PR DESCRIPTION
Signed-off-by: pyalex <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

According to my analysis after the number of fields passed to `hmget` surpasses some value (roughly 50) - `hgetall` becomes a much more efficient way to retrieve the same data. With 250 fields - `hgetall` is 5x faster then `hmget`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
