### PR TITLE
Improve serialization performance

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -207,7 +207,7 @@ PYTHON_LIST_VALUE_TYPE_TO_PROTO_VALUE: Dict[
         "double_list_val",
         [np.float64, np.float32, float],
     ),
-    ValueType.INT32_LIST: (Int32List, "int32_list_val", [np.int32, int]),
+    ValueType.INT32_LIST: (Int32List, "int32_list_val", [np.int64, np.int32, int]),
     ValueType.INT64_LIST: (Int64List, "int64_list_val", [np.int64, np.int32, int]),
     ValueType.UNIX_TIMESTAMP_LIST: (
         Int64List,
@@ -234,7 +234,7 @@ PYTHON_SCALAR_VALUE_TYPE_TO_PROTO_VALUE: Dict[
     ValueType.DOUBLE: ("double_val", lambda x: x, {float, np.float64}),
     ValueType.STRING: ("string_val", lambda x: str(x), None),
     ValueType.BYTES: ("bytes_val", lambda x: x, {bytes}),
-    ValueType.BOOL: ("bool_val", lambda x: x, {bool}),
+    ValueType.BOOL: ("bool_val", lambda x: x, {bool, np.bool_}),
 }
 
 


### PR DESCRIPTION
Signed-off-by: Judah Rand <17158624+judahrand@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
Similar quick pass as the deserialize PR (#2164). A definite improvement but not as drastic as the other one. Looks like between 20-30% improvement. This is achieved by avoiding memory copies as much as possible by using Numpy and allowing Protobuf to handle that more sensibly than copying to convert to Python object then copying back again to create Protobuf Message.

Same benchmark as the deserialize PR:

On `master`:
![image](https://user-images.githubusercontent.com/17158624/146930655-7ea15685-8ba1-495a-88e9-d5aa620fbbee.png)

With changes:
![image](https://user-images.githubusercontent.com/17158624/146930689-29ac9cf4-59e7-49d9-aacc-943ac90dc123.png)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
