### PR TITLE
ability to pull all entity rows for specific entities

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1102,6 +1102,12 @@ class FeatureStore:
             grouped_odfv_refs, grouped_request_fv_refs
         )
 
+        if entity_rows is None and flags_helper.enable_get_all_entity_rows(self.config):
+            entity_keys = set()
+            for feature_view in requested_feature_views:
+                entity_keys.update(feature_view.entities)
+            entity_rows = provider.get_entity_rows(self.config, list(entity_keys))
+
         join_key_rows = []
         request_data_features: Dict[str, List[Any]] = {}
         # Entity rows may be either entities or request data.

--- a/sdk/python/feast/flags.py
+++ b/sdk/python/feast/flags.py
@@ -3,6 +3,7 @@ FLAG_ON_DEMAND_TRANSFORM_NAME = "on_demand_transforms"
 FLAG_PYTHON_FEATURE_SERVER_NAME = "python_feature_server"
 FLAG_AWS_LAMBDA_FEATURE_SERVER_NAME = "aws_lambda_feature_server"
 FLAG_DIRECT_INGEST_TO_ONLINE_STORE = "direct_ingest_to_online_store"
+FLAG_GET_ALL_ENTITY_ROWS = "get_all_entity_rows"
 ENV_FLAG_IS_TEST = "IS_TEST"
 
 FLAG_NAMES = {

--- a/sdk/python/feast/flags_helper.py
+++ b/sdk/python/feast/flags_helper.py
@@ -45,3 +45,7 @@ def enable_aws_lambda_feature_server(repo_config: RepoConfig) -> bool:
 
 def enable_direct_ingestion_to_online_store(repo_config: RepoConfig) -> bool:
     return feature_flag_enabled(repo_config, flags.FLAG_DIRECT_INGEST_TO_ONLINE_STORE)
+
+
+def enable_get_all_entity_rows(repo_config: RepoConfig) -> bool:
+    return feature_flag_enabled(repo_config, flags.FLAG_GET_ALL_ENTITY_ROWS)

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -100,3 +100,8 @@ class OnlineStore(ABC):
         entities: Sequence[Entity],
     ):
         ...
+
+    def get_entity_rows(
+        self, config: RepoConfig, entity_keys: List[str]
+    ) -> List[Dict[str, Any]]:
+        raise Exception("get_entity_rows(..) not implemented in this online_store")

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -178,3 +178,10 @@ class PassthroughProvider(Provider):
             full_feature_names=full_feature_names,
         )
         return job
+
+    def get_entity_rows(
+        self, config: RepoConfig, entities: List[str]
+    ) -> List[Dict[str, Any]]:
+        result = self.online_store.get_entity_rows(config, entities)
+
+        return result

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -157,6 +157,14 @@ class Provider(abc.ABC):
         """Returns endpoint for the feature server, if it exists."""
         return None
 
+    def get_entity_rows(
+        self, config: RepoConfig, entity_keys: List[str]
+    ) -> List[Dict[str, Any]]:
+        """
+        get available entity rows for specified entities
+        """
+        pass
+
 
 def get_provider(config: RepoConfig, repo_path: Path) -> Provider:
     if "." not in config.provider:


### PR DESCRIPTION
Signed-off-by: Vitaly Sergeyev <vsergeyev@better.com>

Add default ability to pull all entity_rows for the specified feature view(s) when requesting online features (only implemented for the Redis online store)

So if `entity_rows` are not provided and the feature flag is on then it will pull all relevant entity rows for the specified feature_view(s)

This can be useful for ranking problems where every entity needs to be scored and this way the client doesn't need to keep track of entity id's.
This can also be useful for testing and debugging.

~entity_rows=[{"driver_id": 1001}, {"driver_id": 1002}, {"driver_id": 1003}, {"driver_id": 1004}],~
```
from feast import FeatureStore, RepoConfig
fs = FeatureStore(config=RepoConfig(registry="feature_repo/data/registry.db", project="feature_repo", provider="local"))
online_response = fs.get_online_features(
    features=[
        "driver_hourly_stats:conv_rate",
        "driver_hourly_stats:acc_rate",
        "driver_hourly_stats:avg_daily_trips",
    ],
)
online_response_dict = online_response.to_dict()
# would return all rows 
```