### PR TITLE
Fixes large payload runtime exception in Datastore (issue 1633)

### DIFF
--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -196,13 +196,17 @@ class DatastoreOnlineStore(OnlineStore):
                 key=key, exclude_from_indexes=("created_ts", "event_ts", "values")
             )
 
-            content_entity = datastore.Entity(exclude_from_indexes=tuple(features.keys()))
+            content_entity = datastore.Entity(
+                exclude_from_indexes=tuple(features.keys())
+            )
             for k, v in features.items():
                 content_entity[k] = v.SerializeToString()
             entity["key"] = entity_key.SerializeToString()
             entity["values"] = content_entity
-            entity['event_ts'] = utils.make_tzaware(timestamp)
-            entity['created_ts'] = utils.make_tzaware(created_ts) if created_ts is not None else None
+            entity["event_ts"] = utils.make_tzaware(timestamp)
+            entity["created_ts"] = (
+                utils.make_tzaware(created_ts) if created_ts is not None else None
+            )
 
             entities.append(entity)
         with client.transaction():

--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -196,18 +196,14 @@ class DatastoreOnlineStore(OnlineStore):
                 key=key, exclude_from_indexes=("created_ts", "event_ts", "values")
             )
 
-            entity.update(
-                dict(
-                    key=entity_key.SerializeToString(),
-                    values={k: v.SerializeToString() for k, v in features.items()},
-                    event_ts=utils.make_tzaware(timestamp),
-                    created_ts=(
-                        utils.make_tzaware(created_ts)
-                        if created_ts is not None
-                        else None
-                    ),
-                )
-            )
+            content_entity = datastore.Entity(exclude_from_indexes=tuple(features.keys()))
+            for k, v in features.items():
+                content_entity[k] = v.SerializeToString()
+            entity["key"] = entity_key.SerializeToString()
+            entity["values"] = content_entity
+            entity['event_ts'] = utils.make_tzaware(timestamp)
+            entity['created_ts'] = utils.make_tzaware(created_ts) if created_ts is not None else None
+
             entities.append(entity)
         with client.transaction():
             client.put_multi(entities)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes runtime exception when feature values are larger than 1500 bytes in Datastore.

Datastore indexes values as well as keys so by default it disallows large payloads (error: `google.api_core.exceptions.InvalidArgument: 400 The value of property _ is longer than 1500 bytes.`). This PR ensures that values will not be indexed, which seems to be the intent of the original code.

**Which issue(s) this PR fixes**:
Fixes #1633 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
**Testing**
There is not yet a test harness for changes of this sort. The issue is demonstratable in master & fixed in this branch with the following steps (you'll want to change some of them):

`echo '{"entity": "entity1", "event_timestamp": "2021-12-01T01:01:01.123456", "big_feature": ["A", "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB", "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"]}' > data.json
gsutil cp data.json gs://$MY_PATH/issue1633/long-list-data.json`

```
from google.cloud import bigquery
client = bigquery.Client(project=$MY_PROJECT)

gcs_uri = 'gs://$MY_PATH/issue1633/long-list-data.json'

dataset = client.create_dataset('feast_development', exists_ok=True)
table = dataset.table('issue1633_example')

job_config = bigquery.job.LoadJobConfig()
job_config.schema = [
    bigquery.SchemaField('entity', 'STRING'),
    bigquery.SchemaField('big_feature', 'STRING', 'REPEATED'),
    bigquery.SchemaField('event_timestamp', 'TIMESTAMP'),
]
job_config.source_format = bigquery.SourceFormat.NEWLINE_DELIMITED_JSON
job_config.write_disposition = "WRITE_TRUNCATE"

load_job = client.load_table_from_uri(gcs_uri, table, job_config=job_config)
```

```
from feast import FeatureStore, Entity, Feature, FeatureView, ValueType, RepoConfig, BigQuerySource
from feast.repo_config import RegistryConfig
from feast.infra.online_stores.datastore import DatastoreOnlineStoreConfig
from feast.infra.offline_stores.bigquery import BigQueryOfflineStoreConfig

import datetime
from datetime import timedelta

repo_config = RepoConfig(
    project="new_project",
    registry="gs://$MY_PATH/issue1633/registry.db",
    provider="gcp",
    online_store=DatastoreOnlineStoreConfig(project_id=$MY_PROJECT),
    offline_store=BigQueryOfflineStoreConfig(project_id=$MY_PROJECT)
)

entity = Entity(
    name="entity",
    value_type=ValueType.STRING
)
big_feature = FeatureView(
    name="big_feature",
    entities=["entity"],
    ttl=timedelta(days=180),
    features=[
        Feature(name="big_feature", dtype=ValueType.STRING_LIST)
    ],
    batch_source=BigQuerySource(
        table_ref="$MY_PROJECT.feast_development.issue1633_example",
        event_timestamp_column="event_timestamp"
    )
)

feature_store = FeatureStore(config=repo_config)
feature_store.registry._initialize_registry()
feature_store.apply([entity, big_feature])

start_time = datetime.datetime(2021, 11, 15, tzinfo=datetime.timezone.utc)
end_time = datetime.datetime(2021, 12, 31, tzinfo=datetime.timezone.utc)
feature_store.materialize(start_time, end_time) # WAS: google.api_core.exceptions.InvalidArgument: 400 The value of property "big_feature" is longer than 1500 bytes.

feature_store.get_online_features(
    features=["big_feature:big_feature"],
    entity_rows=[
        {"entity": "entity1"}
    ]
).to_df()

feature_store.teardown()
```