### PR TITLE
Support multiple application properties files (incl from classpath)

### DIFF
--- a/infra/charts/feast/charts/feature-server/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feature-server/templates/deployment.yaml
@@ -89,8 +89,7 @@ spec:
         - java
         - -jar
         - /opt/feast/feast-serving.jar
-        - --spring.config.location=
-          {{- if index .Values "application.yaml" "enabled" -}}
+        - {{- if index .Values "application.yaml" "enabled" -}}
           classpath:/application.yml
           {{- end }}
           {{- if index .Values "application-generated.yaml" "enabled" -}}

--- a/infra/docker-compose/docker-compose.yml
+++ b/infra/docker-compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - java
       - -jar
       - /opt/feast/feast-core.jar
-      - --spring.config.location=classpath:/application.yml,file:/etc/feast/application.yml
+      - classpath:/application.yml,file:/etc/feast/application.yml
 
   jobservice:
     image: gcr.io/kf-feast/feast-jobservice:${FEAST_VERSION}
@@ -104,7 +104,7 @@ services:
       - java
       - -jar
       - /opt/feast/feast-serving.jar
-      - --spring.config.location=classpath:/application.yml,file:/etc/feast/application.yml
+      - classpath:/application.yml,file:/etc/feast/application.yml
 
   redis:
     image: redis:5-alpine

--- a/java/serving/src/main/java/feast/serving/ServingGuiceApplication.java
+++ b/java/serving/src/main/java/feast/serving/ServingGuiceApplication.java
@@ -27,7 +27,7 @@ public class ServingGuiceApplication {
   public static void main(String[] args) throws InterruptedException, IOException {
     if (args.length == 0) {
       throw new RuntimeException(
-          "Path to application configuration file needs to be specifed via CLI");
+          "Path to application configuration file needs to be specified via CLI");
     }
 
     final Injector i =

--- a/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
+++ b/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
@@ -21,6 +21,8 @@ package feast.serving.config;
 // https://www.baeldung.com/configuration-properties-in-spring-boot
 // https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-typesafe-configuration-properties
 
+import com.fasterxml.jackson.annotation.JsonMerge;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import feast.common.logging.config.LoggingProperties;
 import feast.storage.connectors.redis.retriever.RedisClusterStoreConfig;
 import feast.storage.connectors.redis.retriever.RedisStoreConfig;
@@ -83,6 +85,7 @@ public class ApplicationProperties {
     /**
      * Collection of store configurations. The active store is selected by the "activeStore" field.
      */
+    @JsonMerge(OptBoolean.FALSE)
     private List<Store> stores = new ArrayList<>();
 
     /* Metric tracing properties. */
@@ -177,6 +180,9 @@ public class ApplicationProperties {
 
     private Map<String, String> config = new HashMap<>();
 
+    // empty construct for deserialization
+    public Store() {}
+
     public Store(String name, String type, Map<String, String> config) {
       this.name = name;
       this.type = type;
@@ -210,6 +216,10 @@ public class ApplicationProperties {
       return StoreType.valueOf(this.type);
     }
 
+    public void setType(String type) {
+      this.type = type;
+    }
+
     /**
      * Gets the configuration to this specific store. This is a map of strings. These options are
      * unique to the store. Please see protos/feast/core/Store.proto for the store specific
@@ -217,10 +227,6 @@ public class ApplicationProperties {
      *
      * @return Returns the store specific configuration
      */
-    public Map<String, String> getConfig() {
-      return config;
-    }
-
     public RedisClusterStoreConfig getRedisClusterConfig() {
       return new RedisClusterStoreConfig(
           this.config.get("connection_string"),
@@ -234,6 +240,10 @@ public class ApplicationProperties {
           Integer.valueOf(this.config.get("port")),
           Boolean.valueOf(this.config.getOrDefault("ssl", "false")),
           this.config.getOrDefault("password", ""));
+    }
+
+    public void setConfig(Map<String, String> config) {
+      this.config = config;
     }
   }
 

--- a/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
+++ b/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
@@ -180,7 +180,7 @@ public class ApplicationProperties {
 
     private Map<String, String> config = new HashMap<>();
 
-    // empty construct for deserialization
+    // default construct for deserialization
     public Store() {}
 
     public Store(String name, String type, Map<String, String> config) {

--- a/java/serving/src/main/java/feast/serving/config/ServerModule.java
+++ b/java/serving/src/main/java/feast/serving/config/ServerModule.java
@@ -17,6 +17,7 @@
 package feast.serving.config;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
 import feast.serving.grpc.OnlineServingGrpcServiceV2;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -30,7 +31,7 @@ public class ServerModule extends AbstractModule {
     bind(OnlineServingGrpcServiceV2.class);
   }
 
-  //  @Provides
+  @Provides
   public Server provideGrpcServer(
       ApplicationProperties applicationProperties,
       OnlineServingGrpcServiceV2 onlineServingGrpcServiceV2,


### PR DESCRIPTION
Signed-off-by: pyalex <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

After the recent deletion of Spring in Java feature server we have some functionality degradation:

* Multiple configuration files are not supported
* Default configuration (stored in classpath) cannot be loaded

Also `ApplicationProperties$Store` class cannot be deserialized (bug) due to the absense of the default constructor.

This PR addresses all those issues and returns back the possibility to override configurations.
Also helm chart and docker-compose were updated to new expected CMD format.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
