### PR TITLE
Persisting results of historical retrieval

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -16,6 +16,7 @@
   * [Feature service](getting-started/concepts/feature-service.md)
   * [Feature retrieval](getting-started/concepts/feature-retrieval.md)
   * [Point-in-time joins](getting-started/concepts/point-in-time-joins.md)
+  * [Dataset](getting-started/concepts/dataset.md)
 * [Architecture](getting-started/architecture-and-components/README.md)
   * [Overview](getting-started/architecture-and-components/overview.md)
   * [Feature repository](getting-started/architecture-and-components/feature-repository.md)

--- a/docs/getting-started/concepts/README.md
+++ b/docs/getting-started/concepts/README.md
@@ -14,3 +14,4 @@
 
 {% page-ref page="point-in-time-joins.md" %}
 
+{% page-ref page="dataset.md" %}

--- a/docs/getting-started/concepts/dataset.md
+++ b/docs/getting-started/concepts/dataset.md
@@ -1,0 +1,46 @@
+# Dataset
+
+Feast datasets allow for conveniently saving dataframes that include both features and entities to be subsequently used for data analysis and model training.
+[Data Quality Monitoring](https://docs.google.com/document/d/110F72d4NTv80p35wDSONxhhPBqWRwbZXG4f9mNEMd98) was the primary motivation for creating dataset concept.
+
+Dataset's metadata is stored in the Feast registry and raw data (features, entities, additional input keys and timestamp) is stored in the [offline store](../architecture-and-components/offline-store.md).
+
+Dataset can be created from:
+1. Results of historical retrieval
+2. [planned] Logging request (including input for [on demand transformation](../../reference/alpha-on-demand-feature-view.md)) and response during feature serving
+3. [planned] Logging features during writing to online store (from batch source or stream)
+
+
+### Creating Saved Dataset from Historical Retrieval
+
+To create a saved dataset from historical features for later retrieval or analysis, a user needs to call `get_historical_features` method first and then pass the returned retrieval job to `create_saved_dataset` method.
+`create_saved_dataset` will trigger provided retrieval job (by calling `.persist()` on it) to store the data using specified `storage`.
+Storage type must be the same as globally configured offline store (eg, it's impossible to persist data to Redshift with BigQuery source).
+`create_saved_dataset` will also create SavedDataset object with all related metadata and will write it to the registry.
+
+```python
+from feast import FeatureStore
+from feast.infra.offline_stores.bigquery_source import SavedDatasetBigQueryStorage
+
+store = FeatureStore()
+
+historical_job = store.get_historical_features(
+    features=["driver:avg_trip"],
+    entity_df=...,
+)
+
+dataset = store.create_saved_dataset(
+    from_=historical_job,
+    name='my_training_dataset',
+    storage=SavedDatasetBigQueryStorage(table_ref='<gcp-project>.<gcp-dataset>.my_training_dataset'),
+    tags={'author': 'oleksii'}
+)
+
+dataset.to_df()
+```
+
+Saved dataset can be later retrieved using `get_saved_dataset` method:
+```python
+dataset = store.get_saved_dataset('my_training_dataset')
+dataset.to_df()
+```

--- a/protos/feast/core/Registry.proto
+++ b/protos/feast/core/Registry.proto
@@ -28,6 +28,7 @@ import "feast/core/FeatureView.proto";
 import "feast/core/InfraObject.proto";
 import "feast/core/OnDemandFeatureView.proto";
 import "feast/core/RequestFeatureView.proto";
+import "feast/core/SavedDataset.proto";
 import "google/protobuf/timestamp.proto";
 
 message Registry {
@@ -37,6 +38,7 @@ message Registry {
     repeated OnDemandFeatureView on_demand_feature_views = 8;
     repeated RequestFeatureView request_feature_views = 9;
     repeated FeatureService feature_services = 7;
+    repeated SavedDataset saved_datasets = 11;
     Infra infra = 10;
 
     string registry_schema_version = 3; // to support migrations; incremented when schema is changed

--- a/protos/feast/core/SavedDataset.proto
+++ b/protos/feast/core/SavedDataset.proto
@@ -1,0 +1,76 @@
+//
+// Copyright 2021 The Feast Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+syntax = "proto3";
+
+package feast.core;
+option java_package = "feast.proto.core";
+option java_outer_classname = "SavedDatasetProto";
+option go_package = "github.com/feast-dev/feast/sdk/go/protos/feast/core";
+
+import "google/protobuf/timestamp.proto";
+import "feast/core/FeatureViewProjection.proto";
+import "feast/core/DataSource.proto";
+
+message SavedDatasetSpec {
+  // Name of the dataset. Must be unique since it's possible to overwrite dataset by name
+  string name = 1;
+
+  // Name of Feast project that this Dataset belongs to.
+  string project = 2;
+
+  // list of feature references with format "<view name>:<feature name>"
+  repeated string features = 3;
+
+  // entity columns + request columns from all feature views used during retrieval
+  repeated string join_keys = 4;
+
+  // Whether full feature names are used in stored data
+  bool full_feature_names = 5;
+
+  SavedDatasetStorage storage = 6;
+
+  // User defined metadata
+  map<string, string> tags = 7;
+}
+
+message SavedDatasetStorage {
+  oneof kind {
+    DataSource.FileOptions file_storage = 4;
+    DataSource.BigQueryOptions bigquery_storage = 5;
+    DataSource.RedshiftOptions redshift_storage = 6;
+  }
+}
+
+message SavedDatasetMeta {
+  // Time when this saved dataset is created
+  google.protobuf.Timestamp created_timestamp = 1;
+
+  // Time when this saved dataset is last updated
+  google.protobuf.Timestamp last_updated_timestamp = 2;
+
+  // Min timestamp in the dataset (needed for retrieval)
+  google.protobuf.Timestamp min_event_timestamp = 3;
+
+  // Max timestamp in the dataset (needed for retrieval)
+  google.protobuf.Timestamp max_event_timestamp = 4;
+}
+
+message SavedDataset {
+  SavedDatasetSpec spec = 1;
+  SavedDatasetMeta meta = 2;
+}

--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -74,6 +74,11 @@ class S3RegistryBucketForbiddenAccess(FeastObjectNotFoundException):
         super().__init__(f"S3 bucket {bucket} for the Feast registry can't be accessed")
 
 
+class SavedDatasetNotFound(FeastObjectNotFoundException):
+    def __init__(self, name: str, project: str):
+        super().__init__(f"Saved dataset {name} does not exist in project {project}")
+
+
 class FeastProviderLoginError(Exception):
     """Error class that indicates a user has not authenticated with their provider."""
 

--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -4,7 +4,11 @@ from feast import type_map
 from feast.data_source import DataSource
 from feast.errors import DataSourceNotFoundException
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
+from feast.protos.feast.core.SavedDataset_pb2 import (
+    SavedDatasetStorage as SavedDatasetStorageProto,
+)
 from feast.repo_config import RepoConfig
+from feast.saved_dataset import SavedDatasetStorage
 from feast.value_type import ValueType
 
 
@@ -204,3 +208,28 @@ class BigQueryOptions:
         )
 
         return bigquery_options_proto
+
+
+class SavedDatasetBigQueryStorage(SavedDatasetStorage):
+    _proto_attr_name = "bigquery_storage"
+
+    bigquery_options: BigQueryOptions
+
+    def __init__(self, table_ref: str):
+        self.bigquery_options = BigQueryOptions(table_ref=table_ref, query=None)
+
+    @staticmethod
+    def from_proto(storage_proto: SavedDatasetStorageProto) -> SavedDatasetStorage:
+        return SavedDatasetBigQueryStorage(
+            table_ref=BigQueryOptions.from_proto(
+                storage_proto.bigquery_storage
+            ).table_ref
+        )
+
+    def to_proto(self) -> SavedDatasetStorageProto:
+        return SavedDatasetStorageProto(
+            bigquery_storage=self.bigquery_options.to_proto()
+        )
+
+    def to_data_source(self) -> DataSource:
+        return BigQuerySource(table_ref=self.bigquery_options.table_ref)

--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import pandas as pd
 import pyarrow
@@ -10,7 +10,12 @@ from feast import FileSource, OnDemandFeatureView
 from feast.data_source import DataSource
 from feast.errors import FeastJoinKeysDuringMaterialization
 from feast.feature_view import DUMMY_ENTITY_ID, DUMMY_ENTITY_VAL, FeatureView
-from feast.infra.offline_stores.offline_store import OfflineStore, RetrievalJob
+from feast.infra.offline_stores.file_source import SavedDatasetFileStorage
+from feast.infra.offline_stores.offline_store import (
+    OfflineStore,
+    RetrievalJob,
+    RetrievalMetadata,
+)
 from feast.infra.offline_stores.offline_utils import (
     DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,
 )
@@ -20,6 +25,7 @@ from feast.infra.provider import (
 )
 from feast.registry import Registry
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
+from feast.saved_dataset import SavedDatasetStorage
 from feast.usage import log_exceptions_and_usage
 
 
@@ -36,6 +42,7 @@ class FileRetrievalJob(RetrievalJob):
         evaluation_function: Callable,
         full_feature_names: bool,
         on_demand_feature_views: Optional[List[OnDemandFeatureView]] = None,
+        metadata: Optional[RetrievalMetadata] = None,
     ):
         """Initialize a lazy historical retrieval job"""
 
@@ -45,6 +52,7 @@ class FileRetrievalJob(RetrievalJob):
         self._on_demand_feature_views = (
             on_demand_feature_views if on_demand_feature_views else []
         )
+        self._metadata = metadata
 
     @property
     def full_feature_names(self) -> bool:
@@ -65,6 +73,27 @@ class FileRetrievalJob(RetrievalJob):
         # Only execute the evaluation function to build the final historical retrieval dataframe at the last moment.
         df = self.evaluation_function()
         return pyarrow.Table.from_pandas(df)
+
+    def persist(self, storage: SavedDatasetStorage):
+        assert isinstance(storage, SavedDatasetFileStorage)
+
+        filesystem, path = FileSource.create_filesystem_and_path(
+            storage.file_options.file_url, storage.file_options.s3_endpoint_override,
+        )
+
+        if path.endswith(".parquet"):
+            pyarrow.parquet.write_table(
+                self._to_arrow_internal(), where=path, filesystem=filesystem
+            )
+        else:
+            # otherwise assume destination is directory
+            pyarrow.parquet.write_to_dataset(
+                self._to_arrow_internal(), root_path=path, filesystem=filesystem
+            )
+
+    @property
+    def metadata(self) -> Optional[RetrievalMetadata]:
+        return self._metadata
 
 
 class FileOfflineStore(OfflineStore):
@@ -104,6 +133,10 @@ class FileOfflineStore(OfflineStore):
             feature_refs,
             feature_views,
             registry.list_on_demand_feature_views(config.project),
+        )
+
+        entity_df_event_timestamp_range = _get_entity_df_event_timestamp_range(
+            entity_df, entity_df_event_timestamp_col
         )
 
         # Create lazy function that is only called from the RetrievalJob object
@@ -266,6 +299,12 @@ class FileOfflineStore(OfflineStore):
             on_demand_feature_views=OnDemandFeatureView.get_requested_odfvs(
                 feature_refs, project, registry
             ),
+            metadata=RetrievalMetadata(
+                features=feature_refs,
+                keys=list(set(entity_df.columns) - {entity_df_event_timestamp_col}),
+                min_event_timestamp=entity_df_event_timestamp_range[0],
+                max_event_timestamp=entity_df_event_timestamp_range[1],
+            ),
         )
         return job
 
@@ -337,3 +376,46 @@ class FileOfflineStore(OfflineStore):
         return FileRetrievalJob(
             evaluation_function=evaluate_offline_job, full_feature_names=False,
         )
+
+    @staticmethod
+    @log_exceptions_and_usage(offline_store="file")
+    def pull_all_from_table_or_query(
+        config: RepoConfig,
+        data_source: DataSource,
+        join_key_columns: List[str],
+        feature_name_columns: List[str],
+        event_timestamp_column: str,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> RetrievalJob:
+        return FileOfflineStore.pull_latest_from_table_or_query(
+            config=config,
+            data_source=data_source,
+            join_key_columns=join_key_columns
+            + [event_timestamp_column],  # avoid deduplication
+            feature_name_columns=feature_name_columns,
+            event_timestamp_column=event_timestamp_column,
+            created_timestamp_column=None,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+
+def _get_entity_df_event_timestamp_range(
+    entity_df: Union[pd.DataFrame, str], entity_df_event_timestamp_col: str,
+) -> Tuple[datetime, datetime]:
+    if not isinstance(entity_df, pd.DataFrame):
+        raise ValueError(
+            f"Please provide an entity_df of type {type(pd.DataFrame)} instead of type {type(entity_df)}"
+        )
+
+    entity_df_event_timestamp = entity_df.loc[
+        :, entity_df_event_timestamp_col
+    ].infer_objects()
+    if pd.api.types.is_string_dtype(entity_df_event_timestamp):
+        entity_df_event_timestamp = pd.to_datetime(entity_df_event_timestamp, utc=True)
+
+    return (
+        entity_df_event_timestamp.min().to_pydatetime(),
+        entity_df_event_timestamp.max().to_pydatetime(),
+    )

--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -25,10 +25,16 @@ from feast.data_source import DataSource
 from feast.errors import InvalidEntityType
 from feast.feature_view import DUMMY_ENTITY_ID, DUMMY_ENTITY_VAL, FeatureView
 from feast.infra.offline_stores import offline_utils
-from feast.infra.offline_stores.offline_store import OfflineStore, RetrievalJob
+from feast.infra.offline_stores.offline_store import (
+    OfflineStore,
+    RetrievalJob,
+    RetrievalMetadata,
+)
+from feast.infra.offline_stores.redshift_source import SavedDatasetRedshiftStorage
 from feast.infra.utils import aws_utils
 from feast.registry import Registry
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
+from feast.saved_dataset import SavedDatasetStorage
 from feast.usage import log_exceptions_and_usage
 
 
@@ -119,6 +125,46 @@ class RedshiftOfflineStore(OfflineStore):
 
     @staticmethod
     @log_exceptions_and_usage(offline_store="redshift")
+    def pull_all_from_table_or_query(
+        config: RepoConfig,
+        data_source: DataSource,
+        join_key_columns: List[str],
+        feature_name_columns: List[str],
+        event_timestamp_column: str,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> RetrievalJob:
+        assert isinstance(data_source, RedshiftSource)
+        from_expression = data_source.get_table_query_string()
+
+        field_string = ", ".join(
+            join_key_columns + feature_name_columns + [event_timestamp_column]
+        )
+
+        redshift_client = aws_utils.get_redshift_data_client(
+            config.offline_store.region
+        )
+        s3_resource = aws_utils.get_s3_resource(config.offline_store.region)
+
+        start_date = start_date.astimezone(tz=utc)
+        end_date = end_date.astimezone(tz=utc)
+
+        query = f"""
+            SELECT {field_string}
+            FROM {from_expression}
+            WHERE {event_timestamp_column} BETWEEN TIMESTAMP '{start_date}' AND TIMESTAMP '{end_date}'
+        """
+
+        return RedshiftRetrievalJob(
+            query=query,
+            redshift_client=redshift_client,
+            s3_resource=s3_resource,
+            config=config,
+            full_feature_names=False,
+        )
+
+    @staticmethod
+    @log_exceptions_and_usage(offline_store="redshift")
     def get_historical_features(
         config: RepoConfig,
         feature_views: List[FeatureView],
@@ -135,16 +181,24 @@ class RedshiftOfflineStore(OfflineStore):
         )
         s3_resource = aws_utils.get_s3_resource(config.offline_store.region)
 
+        entity_schema = _get_entity_schema(
+            entity_df, redshift_client, config, s3_resource
+        )
+
+        entity_df_event_timestamp_col = offline_utils.infer_event_timestamp_from_entity_df(
+            entity_schema
+        )
+
+        entity_df_event_timestamp_range = _get_entity_df_event_timestamp_range(
+            entity_df, entity_df_event_timestamp_col, redshift_client, config,
+        )
+
         @contextlib.contextmanager
         def query_generator() -> Iterator[str]:
             table_name = offline_utils.get_temp_entity_table_name()
 
-            entity_schema = _upload_entity_df_and_get_entity_schema(
+            _upload_entity_df(
                 entity_df, redshift_client, config, s3_resource, table_name
-            )
-
-            entity_df_event_timestamp_col = offline_utils.infer_event_timestamp_from_entity_df(
-                entity_schema
             )
 
             expected_join_keys = offline_utils.get_expected_join_keys(
@@ -153,14 +207,6 @@ class RedshiftOfflineStore(OfflineStore):
 
             offline_utils.assert_expected_columns_in_entity_df(
                 entity_schema, expected_join_keys, entity_df_event_timestamp_col
-            )
-
-            entity_df_event_timestamp_range = _get_entity_df_event_timestamp_range(
-                entity_df,
-                entity_df_event_timestamp_col,
-                redshift_client,
-                config,
-                table_name,
             )
 
             # Build a query context containing all information required to template the Redshift SQL query
@@ -203,6 +249,12 @@ class RedshiftOfflineStore(OfflineStore):
             on_demand_feature_views=OnDemandFeatureView.get_requested_odfvs(
                 feature_refs, project, registry
             ),
+            metadata=RetrievalMetadata(
+                features=feature_refs,
+                keys=list(entity_schema.keys() - {entity_df_event_timestamp_col}),
+                min_event_timestamp=entity_df_event_timestamp_range[0],
+                max_event_timestamp=entity_df_event_timestamp_range[1],
+            ),
         )
 
 
@@ -215,6 +267,7 @@ class RedshiftRetrievalJob(RetrievalJob):
         config: RepoConfig,
         full_feature_names: bool,
         on_demand_feature_views: Optional[List[OnDemandFeatureView]] = None,
+        metadata: Optional[RetrievalMetadata] = None,
     ):
         """Initialize RedshiftRetrievalJob object.
 
@@ -248,6 +301,7 @@ class RedshiftRetrievalJob(RetrievalJob):
         self._on_demand_feature_views = (
             on_demand_feature_views if on_demand_feature_views else []
         )
+        self._metadata = metadata
 
     @property
     def full_feature_names(self) -> bool:
@@ -334,17 +388,24 @@ class RedshiftRetrievalJob(RetrievalJob):
                 query,
             )
 
+    def persist(self, storage: SavedDatasetStorage):
+        assert isinstance(storage, SavedDatasetRedshiftStorage)
+        self.to_redshift(table_name=storage.redshift_options.table)
 
-def _upload_entity_df_and_get_entity_schema(
+    @property
+    def metadata(self) -> Optional[RetrievalMetadata]:
+        return self._metadata
+
+
+def _upload_entity_df(
     entity_df: Union[pd.DataFrame, str],
     redshift_client,
     config: RepoConfig,
     s3_resource,
     table_name: str,
-) -> Dict[str, np.dtype]:
+):
     if isinstance(entity_df, pd.DataFrame):
         # If the entity_df is a pandas dataframe, upload it to Redshift
-        # and construct the schema from the original entity_df dataframe
         aws_utils.upload_df_to_redshift(
             redshift_client,
             config.offline_store.cluster_id,
@@ -356,10 +417,8 @@ def _upload_entity_df_and_get_entity_schema(
             table_name,
             entity_df,
         )
-        return dict(zip(entity_df.columns, entity_df.dtypes))
     elif isinstance(entity_df, str):
-        # If the entity_df is a string (SQL query), create a Redshift table out of it,
-        # get pandas dataframe consisting of 1 row (LIMIT 1) and generate the schema out of it
+        # If the entity_df is a string (SQL query), create a Redshift table out of it
         aws_utils.execute_redshift_statement(
             redshift_client,
             config.offline_store.cluster_id,
@@ -367,14 +426,29 @@ def _upload_entity_df_and_get_entity_schema(
             config.offline_store.user,
             f"CREATE TABLE {table_name} AS ({entity_df})",
         )
-        limited_entity_df = RedshiftRetrievalJob(
-            f"SELECT * FROM {table_name} LIMIT 1",
+    else:
+        raise InvalidEntityType(type(entity_df))
+
+
+def _get_entity_schema(
+    entity_df: Union[pd.DataFrame, str],
+    redshift_client,
+    config: RepoConfig,
+    s3_resource,
+) -> Dict[str, np.dtype]:
+    if isinstance(entity_df, pd.DataFrame):
+        return dict(zip(entity_df.columns, entity_df.dtypes))
+
+    elif isinstance(entity_df, str):
+        # get pandas dataframe consisting of 1 row (LIMIT 1) and generate the schema out of it
+        entity_df_sample = RedshiftRetrievalJob(
+            f"SELECT * FROM ({entity_df}) LIMIT 1",
             redshift_client,
             s3_resource,
             config,
             full_feature_names=False,
         ).to_df()
-        return dict(zip(limited_entity_df.columns, limited_entity_df.dtypes))
+        return dict(zip(entity_df_sample.columns, entity_df_sample.dtypes))
     else:
         raise InvalidEntityType(type(entity_df))
 
@@ -384,7 +458,6 @@ def _get_entity_df_event_timestamp_range(
     entity_df_event_timestamp_col: str,
     redshift_client,
     config: RepoConfig,
-    table_name: str,
 ) -> Tuple[datetime, datetime]:
     if isinstance(entity_df, pd.DataFrame):
         entity_df_event_timestamp = entity_df.loc[
@@ -395,8 +468,8 @@ def _get_entity_df_event_timestamp_range(
                 entity_df_event_timestamp, utc=True
             )
         entity_df_event_timestamp_range = (
-            entity_df_event_timestamp.min(),
-            entity_df_event_timestamp.max(),
+            entity_df_event_timestamp.min().to_pydatetime(),
+            entity_df_event_timestamp.max().to_pydatetime(),
         )
     elif isinstance(entity_df, str):
         # If the entity_df is a string (SQL query), determine range
@@ -406,7 +479,8 @@ def _get_entity_df_event_timestamp_range(
             config.offline_store.cluster_id,
             config.offline_store.database,
             config.offline_store.user,
-            f"SELECT MIN({entity_df_event_timestamp_col}) AS min, MAX({entity_df_event_timestamp_col}) AS max FROM {table_name}",
+            f"SELECT MIN({entity_df_event_timestamp_col}) AS min, MAX({entity_df_event_timestamp_col}) AS max "
+            f"FROM ({entity_df})",
         )
         res = aws_utils.get_redshift_statement_result(redshift_client, statement_id)[
             "Records"

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -4,7 +4,11 @@ from feast import type_map
 from feast.data_source import DataSource
 from feast.errors import DataSourceNotFoundException, RedshiftCredentialsError
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
+from feast.protos.feast.core.SavedDataset_pb2 import (
+    SavedDatasetStorage as SavedDatasetStorageProto,
+)
 from feast.repo_config import RepoConfig
+from feast.saved_dataset import SavedDatasetStorage
 from feast.value_type import ValueType
 
 
@@ -269,3 +273,29 @@ class RedshiftOptions:
         )
 
         return redshift_options_proto
+
+
+class SavedDatasetRedshiftStorage(SavedDatasetStorage):
+    _proto_attr_name = "redshift_storage"
+
+    redshift_options: RedshiftOptions
+
+    def __init__(self, table_ref: str):
+        self.redshift_options = RedshiftOptions(
+            table=table_ref, schema=None, query=None
+        )
+
+    @staticmethod
+    def from_proto(storage_proto: SavedDatasetStorageProto) -> SavedDatasetStorage:
+
+        return SavedDatasetRedshiftStorage(
+            table_ref=RedshiftOptions.from_proto(storage_proto.redshift_storage).table
+        )
+
+    def to_proto(self) -> SavedDatasetStorageProto:
+        return SavedDatasetStorageProto(
+            redshift_storage=self.redshift_options.to_proto()
+        )
+
+    def to_data_source(self) -> DataSource:
+        return RedshiftSource(table=self.redshift_options.table)

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import pandas
@@ -20,7 +20,9 @@ from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.registry import Registry
 from feast.repo_config import RepoConfig
+from feast.saved_dataset import SavedDataset
 from feast.usage import RatioSampler, log_exceptions_and_usage, set_usage_attribute
+from feast.utils import make_tzaware
 
 DEFAULT_BATCH_SIZE = 10_000
 
@@ -177,4 +179,28 @@ class PassthroughProvider(Provider):
             project=project,
             full_feature_names=full_feature_names,
         )
+
         return job
+
+    def retrieve_saved_dataset(
+        self, config: RepoConfig, dataset: SavedDataset
+    ) -> RetrievalJob:
+        set_usage_attribute("provider", self.__class__.__name__)
+
+        feature_name_columns = [
+            ref.replace(":", "__") if dataset.full_feature_names else ref.split(":")[1]
+            for ref in dataset.features
+        ]
+
+        # ToDo: replace hardcoded value
+        event_ts_column = "event_timestamp"
+
+        return self.offline_store.pull_all_from_table_or_query(
+            config=config,
+            data_source=dataset.storage.to_data_source(),
+            join_key_columns=dataset.join_keys,
+            feature_name_columns=feature_name_columns,
+            event_timestamp_column=event_ts_column,
+            start_date=make_tzaware(dataset.min_event_timestamp),  # type: ignore
+            end_date=make_tzaware(dataset.max_event_timestamp + timedelta(seconds=1)),  # type: ignore
+        )

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -20,6 +20,7 @@ from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.registry import Registry
 from feast.repo_config import RepoConfig
+from feast.saved_dataset import SavedDataset
 from feast.type_map import python_values_to_proto_values
 from feast.value_type import ValueType
 
@@ -167,6 +168,21 @@ class Provider(abc.ABC):
             of event_ts for the row, and the feature data as a dict from feature names to values.
             Values are returned as Value proto message.
         """
+        ...
+
+    @abc.abstractmethod
+    def retrieve_saved_dataset(
+        self, config: RepoConfig, dataset: SavedDataset
+    ) -> RetrievalJob:
+        """
+        Read saved dataset from offline store.
+        All parameters for retrieval (like path, datetime boundaries, column names for both keys and features, etc)
+        are determined from SavedDataset object.
+
+        Returns:
+             RetrievalJob object, which is lazy wrapper for actual query performed under the hood.
+
+         """
         ...
 
     def get_feature_server_endpoint(self) -> Optional[str]:

--- a/sdk/python/feast/saved_dataset.py
+++ b/sdk/python/feast/saved_dataset.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from datetime import datetime
-from typing import TYPE_CHECKING, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Dict, List, Optional, Type, cast
 
 import pandas as pd
 import pyarrow
@@ -32,7 +32,7 @@ class SavedDatasetStorage(metaclass=_StorageRegistry):
 
     @staticmethod
     def from_proto(storage_proto: SavedDatasetStorageProto) -> "SavedDatasetStorage":
-        proto_attr_name = storage_proto.WhichOneof("kind")
+        proto_attr_name = cast(str, storage_proto.WhichOneof("kind"))
         return _StorageRegistry.classes_by_proto_attr_name[proto_attr_name].from_proto(
             storage_proto
         )

--- a/sdk/python/feast/saved_dataset.py
+++ b/sdk/python/feast/saved_dataset.py
@@ -1,0 +1,185 @@
+from abc import abstractmethod
+from datetime import datetime
+from typing import TYPE_CHECKING, Dict, List, Optional, Type
+
+import pandas as pd
+import pyarrow
+from google.protobuf.json_format import MessageToJson
+
+from feast.data_source import DataSource
+from feast.protos.feast.core.SavedDataset_pb2 import SavedDataset as SavedDatasetProto
+from feast.protos.feast.core.SavedDataset_pb2 import SavedDatasetMeta, SavedDatasetSpec
+from feast.protos.feast.core.SavedDataset_pb2 import (
+    SavedDatasetStorage as SavedDatasetStorageProto,
+)
+
+if TYPE_CHECKING:
+    from feast.infra.offline_stores.offline_store import RetrievalJob
+
+
+class _StorageRegistry(type):
+    classes_by_proto_attr_name: Dict[str, Type["SavedDatasetStorage"]] = {}
+
+    def __new__(cls, name, bases, dct):
+        kls = type.__new__(cls, name, bases, dct)
+        if dct.get("_proto_attr_name"):
+            cls.classes_by_proto_attr_name[dct["_proto_attr_name"]] = kls
+        return kls
+
+
+class SavedDatasetStorage(metaclass=_StorageRegistry):
+    _proto_attr_name: str
+
+    @staticmethod
+    def from_proto(storage_proto: SavedDatasetStorageProto) -> "SavedDatasetStorage":
+        proto_attr_name = storage_proto.WhichOneof("kind")
+        return _StorageRegistry.classes_by_proto_attr_name[proto_attr_name].from_proto(
+            storage_proto
+        )
+
+    @abstractmethod
+    def to_proto(self) -> SavedDatasetStorageProto:
+        ...
+
+    @abstractmethod
+    def to_data_source(self) -> DataSource:
+        ...
+
+
+class SavedDataset:
+    name: str
+    features: List[str]
+    join_keys: List[str]
+    full_feature_names: bool
+    storage: SavedDatasetStorage
+    tags: Dict[str, str]
+
+    created_timestamp: Optional[datetime] = None
+    last_updated_timestamp: Optional[datetime] = None
+
+    min_event_timestamp: Optional[datetime] = None
+    max_event_timestamp: Optional[datetime] = None
+
+    def __init__(
+        self,
+        name: str,
+        features: List[str],
+        join_keys: List[str],
+        storage: SavedDatasetStorage,
+        full_feature_names: bool = False,
+        tags: Optional[Dict[str, str]] = None,
+    ):
+        self.name = name
+        self.features = features
+        self.join_keys = join_keys
+        self.storage = storage
+        self.full_feature_names = full_feature_names
+        self.tags = tags or {}
+
+    def __repr__(self):
+        items = (f"{k} = {v}" for k, v in self.__dict__.items())
+        return f"<{self.__class__.__name__}({', '.join(items)})>"
+
+    def __str__(self):
+        return str(MessageToJson(self.to_proto()))
+
+    def __hash__(self):
+        return hash((id(self), self.name))
+
+    def __eq__(self, other):
+        if not isinstance(other, SavedDataset):
+            raise TypeError(
+                "Comparisons should only involve FeatureService class objects."
+            )
+        if self.name != other.name:
+            return False
+
+        if sorted(self.features) != sorted(other.features):
+            return False
+
+        return True
+
+    @staticmethod
+    def from_proto(saved_dataset_proto: SavedDatasetProto):
+        """
+        Converts a SavedDatasetProto to a SavedDataset object.
+
+        Args:
+            saved_dataset_proto: A protobuf representation of a SavedDataset.
+        """
+        ds = SavedDataset(
+            name=saved_dataset_proto.spec.name,
+            features=list(saved_dataset_proto.spec.features),
+            join_keys=list(saved_dataset_proto.spec.join_keys),
+            full_feature_names=saved_dataset_proto.spec.full_feature_names,
+            storage=SavedDatasetStorage.from_proto(saved_dataset_proto.spec.storage),
+            tags=dict(saved_dataset_proto.spec.tags.items()),
+        )
+
+        if saved_dataset_proto.meta.HasField("created_timestamp"):
+            ds.created_timestamp = (
+                saved_dataset_proto.meta.created_timestamp.ToDatetime()
+            )
+        if saved_dataset_proto.meta.HasField("last_updated_timestamp"):
+            ds.last_updated_timestamp = (
+                saved_dataset_proto.meta.last_updated_timestamp.ToDatetime()
+            )
+        if saved_dataset_proto.meta.HasField("min_event_timestamp"):
+            ds.min_event_timestamp = (
+                saved_dataset_proto.meta.min_event_timestamp.ToDatetime()
+            )
+        if saved_dataset_proto.meta.HasField("max_event_timestamp"):
+            ds.max_event_timestamp = (
+                saved_dataset_proto.meta.max_event_timestamp.ToDatetime()
+            )
+
+        return ds
+
+    def to_proto(self) -> SavedDatasetProto:
+        """
+        Converts a SavedDataset to its protobuf representation.
+
+        Returns:
+            A SavedDatasetProto protobuf.
+        """
+        meta = SavedDatasetMeta()
+        if self.created_timestamp:
+            meta.created_timestamp.FromDatetime(self.created_timestamp)
+        if self.min_event_timestamp:
+            meta.min_event_timestamp.FromDatetime(self.min_event_timestamp)
+        if self.max_event_timestamp:
+            meta.max_event_timestamp.FromDatetime(self.max_event_timestamp)
+
+        spec = SavedDatasetSpec(
+            name=self.name,
+            features=self.features,
+            join_keys=self.join_keys,
+            full_feature_names=self.full_feature_names,
+            storage=self.storage.to_proto(),
+            tags=self.tags,
+        )
+
+        feature_service_proto = SavedDatasetProto(spec=spec, meta=meta)
+        return feature_service_proto
+
+    def with_retrieval_job(self, retrieval_job: "RetrievalJob") -> "SavedDataset":
+        self._retrieval_job = retrieval_job
+        return self
+
+    def to_df(self) -> pd.DataFrame:
+        if not self._retrieval_job:
+            raise RuntimeError(
+                "To load this dataset use FeatureStore.get_saved_dataset() "
+                "instead of instantiating it directly."
+            )
+
+        return self._retrieval_job.to_df()
+
+    def to_arrow(self) -> pyarrow.Table:
+        if not self._retrieval_job:
+            raise RuntimeError(
+                "To load this dataset use FeatureStore.get_saved_dataset() "
+                "instead of instantiating it directly."
+            )
+
+        return self._retrieval_job.to_arrow()

--- a/sdk/python/tests/foo_provider.py
+++ b/sdk/python/tests/foo_provider.py
@@ -10,6 +10,7 @@ from feast.infra.provider import Provider
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.registry import Registry
+from feast.saved_dataset import SavedDataset
 
 
 class FooProvider(Provider):
@@ -74,4 +75,7 @@ class FooProvider(Provider):
         entity_keys: List[EntityKeyProto],
         requested_features: List[str] = None,
     ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
+        pass
+
+    def retrieve_saved_dataset(self, config: RepoConfig, dataset: SavedDataset):
         pass

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -7,7 +7,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 import yaml
@@ -283,7 +283,9 @@ def construct_test_environment(
             execution_role_name="arn:aws:iam::402087665549:role/lambda_execution_role",
         )
 
-        registry = f"s3://feast-integration-tests/registries/{project}/registry.db"
+        registry = (
+            f"s3://feast-integration-tests/registries/{project}/registry.db"
+        )  # type: Union[str, RegistryConfig]
     else:
         # Note: even if it's a local feature server, the repo config does not have this configured
         feature_server = None

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from feast.data_source import DataSource
 from feast.repo_config import FeastConfigBaseModel
+from feast.saved_dataset import SavedDatasetStorage
 
 
 class DataSourceCreator(ABC):
@@ -38,6 +39,10 @@ class DataSourceCreator(ABC):
 
     @abstractmethod
     def create_offline_store_config(self) -> FeastConfigBaseModel:
+        ...
+
+    @abstractmethod
+    def create_saved_dataset_destination(self) -> SavedDatasetStorage:
         ...
 
     @abstractmethod

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Dict, List, Optional
 
 import pandas as pd
@@ -7,6 +8,7 @@ from google.cloud.bigquery import Dataset
 from feast import BigQuerySource
 from feast.data_source import DataSource
 from feast.infra.offline_stores.bigquery import BigQueryOfflineStoreConfig
+from feast.infra.offline_stores.bigquery_source import SavedDatasetBigQueryStorage
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
 )
@@ -78,6 +80,12 @@ class BigQueryDataSourceCreator(DataSourceCreator):
             date_partition_column="",
             field_mapping=field_mapping or {"ts_1": "ts"},
         )
+
+    def create_saved_dataset_destination(self) -> SavedDatasetBigQueryStorage:
+        table = self.get_prefixed_table_name(
+            f"persisted_{str(uuid.uuid4()).replace('-', '_')}"
+        )
+        return SavedDatasetBigQueryStorage(table_ref=table)
 
     def get_prefixed_table_name(self, suffix: str) -> str:
         return f"{self.client.project}.{self.project_name}.{suffix}"

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Dict, List, Optional
 
 import pandas as pd
@@ -5,6 +6,7 @@ import pandas as pd
 from feast import RedshiftSource
 from feast.data_source import DataSource
 from feast.infra.offline_stores.redshift import RedshiftOfflineStoreConfig
+from feast.infra.offline_stores.redshift_source import SavedDatasetRedshiftStorage
 from feast.infra.utils import aws_utils
 from feast.repo_config import FeastConfigBaseModel
 from tests.integration.feature_repos.universal.data_source_creator import (
@@ -64,6 +66,14 @@ class RedshiftDataSourceCreator(DataSourceCreator):
             date_partition_column="",
             field_mapping=field_mapping or {"ts_1": "ts"},
         )
+
+    def create_saved_dataset_destination(self) -> SavedDatasetRedshiftStorage:
+        table = self.get_prefixed_table_name(
+            f"persisted_ds_{str(uuid.uuid4()).replace('-', '_')}"
+        )
+        self.tables.append(table)
+
+        return SavedDatasetRedshiftStorage(table_ref=table)
 
     def create_offline_store_config(self) -> FeastConfigBaseModel:
         return self.offline_store_config

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal as pd_assert_frame_equal
 from pytz import utc
 
 from feast import utils
@@ -239,9 +239,10 @@ def get_expected_training_df(
         .round()
         .astype(pd.Int32Dtype())
     )
-    expected_df[
-        response_feature_name("conv_rate_plus_val_to_add", full_feature_names)
-    ] = (expected_df[conv_feature_name] + expected_df["val_to_add"])
+    if "val_to_add" in expected_df.columns:
+        expected_df[
+            response_feature_name("conv_rate_plus_val_to_add", full_feature_names)
+        ] = (expected_df[conv_feature_name] + expected_df["val_to_add"])
 
     return expected_df
 
@@ -255,15 +256,7 @@ def test_historical_features(environment, universal_data_sources, full_feature_n
     (entities, datasets, data_sources) = universal_data_sources
     feature_views = construct_universal_feature_views(data_sources)
 
-    customer_df, driver_df, location_df, orders_df, global_df, entity_df = (
-        datasets["customer"],
-        datasets["driver"],
-        datasets["location"],
-        datasets["orders"],
-        datasets["global"],
-        datasets["entity"],
-    )
-    entity_df_with_request_data = entity_df.copy(deep=True)
+    entity_df_with_request_data = datasets["entity"].copy(deep=True)
     entity_df_with_request_data["val_to_add"] = [
         i for i in range(len(entity_df_with_request_data))
     ]
@@ -271,84 +264,53 @@ def test_historical_features(environment, universal_data_sources, full_feature_n
         i + 100 for i in range(len(entity_df_with_request_data))
     ]
 
-    (
-        customer_fv,
-        driver_fv,
-        driver_odfv,
-        location_fv,
-        order_fv,
-        global_fv,
-        driver_age_request_fv,
-    ) = (
-        feature_views["customer"],
-        feature_views["driver"],
-        feature_views["driver_odfv"],
-        feature_views["location"],
-        feature_views["order"],
-        feature_views["global"],
-        feature_views["driver_age_request_fv"],
-    )
-
     feature_service = FeatureService(
         name="convrate_plus100",
         features=[
             feature_views["driver"][["conv_rate"]],
-            driver_odfv,
-            driver_age_request_fv,
+            feature_views["driver_odfv"],
+            feature_views["driver_age_request_fv"],
         ],
     )
     feature_service_entity_mapping = FeatureService(
         name="entity_mapping",
         features=[
-            location_fv.with_name("origin").with_join_key_map(
-                {"location_id": "origin_id"}
-            ),
-            location_fv.with_name("destination").with_join_key_map(
-                {"location_id": "destination_id"}
-            ),
+            feature_views["location"]
+            .with_name("origin")
+            .with_join_key_map({"location_id": "origin_id"}),
+            feature_views["location"]
+            .with_name("destination")
+            .with_join_key_map({"location_id": "destination_id"}),
         ],
     )
 
-    feast_objects = []
-    feast_objects.extend(
+    store.apply(
         [
-            customer_fv,
-            driver_fv,
-            driver_odfv,
-            location_fv,
-            order_fv,
-            global_fv,
-            driver_age_request_fv,
             driver(),
             customer(),
             location(),
             feature_service,
             feature_service_entity_mapping,
+            *feature_views.values(),
         ]
     )
-    store.apply(feast_objects)
-
-    entity_df_query = None
-    orders_table = table_name_from_data_source(data_sources["orders"])
-    if orders_table:
-        entity_df_query = f"SELECT customer_id, driver_id, order_id, origin_id, destination_id, event_timestamp FROM {orders_table}"
 
     event_timestamp = (
         DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
-        if DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL in orders_df.columns
+        if DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL in datasets["orders"].columns
         else "e_ts"
     )
     full_expected_df = get_expected_training_df(
-        customer_df,
-        customer_fv,
-        driver_df,
-        driver_fv,
-        orders_df,
-        order_fv,
-        location_df,
-        location_fv,
-        global_df,
-        global_fv,
+        datasets["customer"],
+        feature_views["customer"],
+        datasets["driver"],
+        feature_views["driver"],
+        datasets["orders"],
+        feature_views["order"],
+        datasets["location"],
+        feature_views["location"],
+        datasets["global"],
+        feature_views["global"],
         entity_df_with_request_data,
         event_timestamp,
         full_feature_names,
@@ -358,76 +320,6 @@ def test_historical_features(environment, universal_data_sources, full_feature_n
     expected_df = full_expected_df.drop(
         columns=["origin__temperature", "destination__temperature"],
     )
-
-    if entity_df_query:
-        job_from_sql = store.get_historical_features(
-            entity_df=entity_df_query,
-            features=[
-                "driver_stats:conv_rate",
-                "driver_stats:avg_daily_trips",
-                "customer_profile:current_balance",
-                "customer_profile:avg_passenger_count",
-                "customer_profile:lifetime_trip_count",
-                "order:order_is_success",
-                "global_stats:num_rides",
-                "global_stats:avg_ride_length",
-            ],
-            full_feature_names=full_feature_names,
-        )
-
-        start_time = datetime.utcnow()
-        actual_df_from_sql_entities = job_from_sql.to_df()
-        end_time = datetime.utcnow()
-        print(
-            str(f"\nTime to execute job_from_sql.to_df() = '{(end_time - start_time)}'")
-        )
-
-        # Not requesting the on demand transform with an entity_df query (can't add request data in them)
-        expected_df_query = expected_df.drop(
-            columns=[
-                response_feature_name("conv_rate_plus_100", full_feature_names),
-                response_feature_name("conv_rate_plus_100_rounded", full_feature_names),
-                response_feature_name("conv_rate_plus_val_to_add", full_feature_names),
-                "val_to_add",
-                "driver_age",
-            ]
-        )
-        assert sorted(expected_df_query.columns) == sorted(
-            actual_df_from_sql_entities.columns
-        )
-
-        actual_df_from_sql_entities = (
-            actual_df_from_sql_entities[expected_df_query.columns]
-            .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
-            .drop_duplicates()
-            .reset_index(drop=True)
-        )
-        expected_df_query = (
-            expected_df_query.sort_values(
-                by=[event_timestamp, "order_id", "driver_id", "customer_id"]
-            )
-            .drop_duplicates()
-            .reset_index(drop=True)
-        )
-
-        assert_frame_equal(
-            actual_df_from_sql_entities, expected_df_query, check_dtype=False,
-        )
-
-        table_from_sql_entities = job_from_sql.to_arrow()
-        df_from_sql_entities = (
-            table_from_sql_entities.to_pandas()[expected_df_query.columns]
-            .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
-            .drop_duplicates()
-            .reset_index(drop=True)
-        )
-
-        for col in df_from_sql_entities.columns:
-            expected_df_query[col] = expected_df_query[col].astype(
-                df_from_sql_entities[col].dtype
-            )
-
-        assert_frame_equal(expected_df_query, df_from_sql_entities)
 
     job_from_df = store.get_historical_features(
         entity_df=entity_df_with_request_data,
@@ -456,23 +348,12 @@ def test_historical_features(environment, universal_data_sources, full_feature_n
     print(str(f"Time to execute job_from_df.to_df() = '{(end_time - start_time)}'\n"))
 
     assert sorted(expected_df.columns) == sorted(actual_df_from_df_entities.columns)
-    expected_df: pd.DataFrame = (
-        expected_df.sort_values(
-            by=[event_timestamp, "order_id", "driver_id", "customer_id"]
-        )
-        .drop_duplicates()
-        .reset_index(drop=True)
-    )
-    actual_df_from_df_entities = (
-        actual_df_from_df_entities[expected_df.columns]
-        .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
-        .drop_duplicates()
-        .reset_index(drop=True)
+    assert_frame_equal(
+        expected_df,
+        actual_df_from_df_entities,
+        keys=[event_timestamp, "order_id", "driver_id", "customer_id"],
     )
 
-    assert_frame_equal(
-        expected_df, actual_df_from_df_entities, check_dtype=False,
-    )
     assert_feature_service_correctness(
         store,
         feature_service,
@@ -489,26 +370,33 @@ def test_historical_features(environment, universal_data_sources, full_feature_n
         full_expected_df,
         event_timestamp,
     )
-
     table_from_df_entities: pd.DataFrame = job_from_df.to_arrow().to_pandas()
 
-    columns_expected_in_table = expected_df.columns.tolist()
-
-    table_from_df_entities = (
-        table_from_df_entities[columns_expected_in_table]
-        .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
-        .drop_duplicates()
-        .reset_index(drop=True)
+    assert_frame_equal(
+        expected_df,
+        table_from_df_entities,
+        keys=[event_timestamp, "order_id", "driver_id", "customer_id"],
     )
-    assert_frame_equal(actual_df_from_df_entities, table_from_df_entities)
+
+
+@pytest.mark.integration
+@pytest.mark.universal
+@pytest.mark.parametrize("full_feature_names", [True, False], ids=lambda v: str(v))
+def test_historical_features_with_missing_request_data(
+    environment, universal_data_sources, full_feature_names
+):
+    store = environment.feature_store
+
+    (_, datasets, data_sources) = universal_data_sources
+    feature_views = construct_universal_feature_views(data_sources)
+
+    store.apply([driver(), customer(), location(), *feature_views.values()])
 
     # If request data is missing that's needed for on demand transform, throw an error
     with pytest.raises(RequestDataNotFoundInEntityDfException):
         store.get_historical_features(
-            entity_df=entity_df,
+            entity_df=datasets["entity"],
             features=[
-                "driver_stats:conv_rate",
-                "driver_stats:avg_daily_trips",
                 "customer_profile:current_balance",
                 "customer_profile:avg_passenger_count",
                 "customer_profile:lifetime_trip_count",
@@ -519,13 +407,12 @@ def test_historical_features(environment, universal_data_sources, full_feature_n
             ],
             full_feature_names=full_feature_names,
         )
+
     # If request data is missing that's needed for a request feature view, throw an error
     with pytest.raises(RequestDataNotFoundInEntityDfException):
         store.get_historical_features(
-            entity_df=entity_df,
+            entity_df=datasets["entity"],
             features=[
-                "driver_stats:conv_rate",
-                "driver_stats:avg_daily_trips",
                 "customer_profile:current_balance",
                 "customer_profile:avg_passenger_count",
                 "customer_profile:lifetime_trip_count",
@@ -535,6 +422,170 @@ def test_historical_features(environment, universal_data_sources, full_feature_n
             ],
             full_feature_names=full_feature_names,
         )
+
+
+@pytest.mark.integration
+@pytest.mark.universal
+@pytest.mark.parametrize("full_feature_names", [True, False], ids=lambda v: str(v))
+def test_historical_features_with_entities_from_query(
+    environment, universal_data_sources, full_feature_names
+):
+    store = environment.feature_store
+
+    (entities, datasets, data_sources) = universal_data_sources
+    feature_views = construct_universal_feature_views(data_sources)
+
+    orders_table = table_name_from_data_source(data_sources["orders"])
+    if not orders_table:
+        raise pytest.skip("Offline source is not sql-based")
+
+    entity_df_query = f"SELECT customer_id, driver_id, order_id, origin_id, destination_id, event_timestamp FROM {orders_table}"
+
+    store.apply([driver(), customer(), location(), *feature_views.values()])
+
+    job_from_sql = store.get_historical_features(
+        entity_df=entity_df_query,
+        features=[
+            "customer_profile:current_balance",
+            "customer_profile:avg_passenger_count",
+            "customer_profile:lifetime_trip_count",
+            "order:order_is_success",
+            "global_stats:num_rides",
+            "global_stats:avg_ride_length",
+        ],
+        full_feature_names=full_feature_names,
+    )
+
+    start_time = datetime.utcnow()
+    actual_df_from_sql_entities = job_from_sql.to_df()
+    end_time = datetime.utcnow()
+    print(str(f"\nTime to execute job_from_sql.to_df() = '{(end_time - start_time)}'"))
+
+    event_timestamp = (
+        DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
+        if DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL in datasets["orders"].columns
+        else "e_ts"
+    )
+    full_expected_df = get_expected_training_df(
+        datasets["customer"],
+        feature_views["customer"],
+        datasets["driver"],
+        feature_views["driver"],
+        datasets["orders"],
+        feature_views["order"],
+        datasets["location"],
+        feature_views["location"],
+        datasets["global"],
+        feature_views["global"],
+        datasets["entity"],
+        event_timestamp,
+        full_feature_names,
+    )
+
+    # Not requesting the on demand transform with an entity_df query (can't add request data in them)
+    expected_df_query = full_expected_df.drop(
+        columns=[
+            response_feature_name("conv_rate_plus_100", full_feature_names),
+            response_feature_name("conv_rate_plus_100_rounded", full_feature_names),
+            response_feature_name("avg_daily_trips", full_feature_names),
+            response_feature_name("conv_rate", full_feature_names),
+            "origin__temperature",
+            "destination__temperature",
+        ]
+    )
+    assert_frame_equal(
+        expected_df_query,
+        actual_df_from_sql_entities,
+        keys=[event_timestamp, "order_id", "driver_id", "customer_id"],
+    )
+
+    table_from_sql_entities = job_from_sql.to_arrow().to_pandas()
+    for col in table_from_sql_entities.columns:
+        expected_df_query[col] = expected_df_query[col].astype(
+            table_from_sql_entities[col].dtype
+        )
+
+    assert_frame_equal(
+        expected_df_query,
+        table_from_sql_entities,
+        keys=[event_timestamp, "order_id", "driver_id", "customer_id"],
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.universal
+@pytest.mark.parametrize("full_feature_names", [True, False], ids=lambda v: str(v))
+def test_historical_features_persisting(
+    environment, universal_data_sources, full_feature_names
+):
+    store = environment.feature_store
+
+    (entities, datasets, data_sources) = universal_data_sources
+    feature_views = construct_universal_feature_views(data_sources)
+
+    store.apply([driver(), customer(), location(), *feature_views.values()])
+
+    entity_df = datasets["entity"].drop(
+        columns=["order_id", "origin_id", "destination_id"]
+    )
+
+    job = store.get_historical_features(
+        entity_df=entity_df,
+        features=[
+            "customer_profile:current_balance",
+            "customer_profile:avg_passenger_count",
+            "customer_profile:lifetime_trip_count",
+            "order:order_is_success",
+            "global_stats:num_rides",
+            "global_stats:avg_ride_length",
+        ],
+        full_feature_names=full_feature_names,
+    )
+
+    saved_dataset = store.create_saved_dataset(
+        from_=job,
+        name="saved_dataset",
+        storage=environment.data_source_creator.create_saved_dataset_destination(),
+        tags={"env": "test"},
+    )
+
+    event_timestamp = DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL
+    expected_df = get_expected_training_df(
+        datasets["customer"],
+        feature_views["customer"],
+        datasets["driver"],
+        feature_views["driver"],
+        datasets["orders"],
+        feature_views["order"],
+        datasets["location"],
+        feature_views["location"],
+        datasets["global"],
+        feature_views["global"],
+        entity_df,
+        event_timestamp,
+        full_feature_names,
+    ).drop(
+        columns=[
+            response_feature_name("conv_rate_plus_100", full_feature_names),
+            response_feature_name("conv_rate_plus_100_rounded", full_feature_names),
+            response_feature_name("avg_daily_trips", full_feature_names),
+            response_feature_name("conv_rate", full_feature_names),
+            "origin__temperature",
+            "destination__temperature",
+        ]
+    )
+
+    assert_frame_equal(
+        expected_df,
+        saved_dataset.to_df(),
+        keys=[event_timestamp, "driver_id", "customer_id"],
+    )
+
+    assert_frame_equal(
+        job.to_df(),
+        saved_dataset.to_df(),
+        keys=[event_timestamp, "driver_id", "customer_id"],
+    )
 
 
 @pytest.mark.integration
@@ -630,13 +681,7 @@ def test_historical_features_from_bigquery_sources_containing_backfills(environm
     print(str(f"Time to execute job_from_df.to_df() = '{(end_time - start_time)}'\n"))
 
     assert sorted(expected_df.columns) == sorted(actual_df.columns)
-    assert_frame_equal(
-        expected_df.sort_values(by=["driver_id"]).reset_index(drop=True),
-        actual_df[expected_df.columns]
-        .sort_values(by=["driver_id"])
-        .reset_index(drop=True),
-        check_dtype=False,
-    )
+    assert_frame_equal(expected_df, actual_df, keys=["driver_id"])
 
 
 def response_feature_name(feature: str, full_feature_names: bool) -> str:
@@ -669,13 +714,6 @@ def assert_feature_service_correctness(
 
     actual_df_from_df_entities = job_from_df.to_df()
 
-    expected_df: pd.DataFrame = (
-        expected_df.sort_values(
-            by=[event_timestamp, "order_id", "driver_id", "customer_id"]
-        )
-        .drop_duplicates()
-        .reset_index(drop=True)
-    )
     expected_df = expected_df[
         [
             event_timestamp,
@@ -687,15 +725,11 @@ def assert_feature_service_correctness(
             "driver_age",
         ]
     ]
-    actual_df_from_df_entities = (
-        actual_df_from_df_entities[expected_df.columns]
-        .sort_values(by=[event_timestamp, "order_id", "driver_id", "customer_id"])
-        .drop_duplicates()
-        .reset_index(drop=True)
-    )
 
     assert_frame_equal(
-        expected_df, actual_df_from_df_entities, check_dtype=False,
+        expected_df,
+        actual_df_from_df_entities,
+        keys=[event_timestamp, "order_id", "driver_id", "customer_id"],
     )
 
 
@@ -736,24 +770,18 @@ def assert_feature_service_entity_mapping_correctness(
                 "destination__temperature",
             ]
         ]
-        actual_df_from_df_entities = (
-            actual_df_from_df_entities[expected_df.columns]
-            .sort_values(
-                by=[
-                    event_timestamp,
-                    "order_id",
-                    "driver_id",
-                    "customer_id",
-                    "origin_id",
-                    "destination_id",
-                ]
-            )
-            .drop_duplicates()
-            .reset_index(drop=True)
-        )
 
         assert_frame_equal(
-            expected_df, actual_df_from_df_entities, check_dtype=False,
+            expected_df,
+            actual_df_from_df_entities,
+            keys=[
+                event_timestamp,
+                "order_id",
+                "driver_id",
+                "customer_id",
+                "origin_id",
+                "destination_id",
+            ],
         )
     else:
         # using 2 of the same FeatureView without full_feature_names=True will result in collision
@@ -763,3 +791,20 @@ def assert_feature_service_entity_mapping_correctness(
                 features=feature_service,
                 full_feature_names=full_feature_names,
             )
+
+
+def assert_frame_equal(expected_df, actual_df, keys):
+    expected_df: pd.DataFrame = (
+        expected_df.sort_values(by=keys).drop_duplicates().reset_index(drop=True)
+    )
+
+    actual_df = (
+        actual_df[expected_df.columns]
+        .sort_values(by=keys)
+        .drop_duplicates()
+        .reset_index(drop=True)
+    )
+
+    pd_assert_frame_equal(
+        expected_df, actual_df, check_dtype=False,
+    )


### PR DESCRIPTION
Signed-off-by: pyalex <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

This PR introduces persisting results of historical retrieval. This feature is required by Data Quality Monitoring and described in the [DQM RFC](https://docs.google.com/document/d/110F72d4NTv80p35wDSONxhhPBqWRwbZXG4f9mNEMd98/edit#heading=h.9gaqqtox9jg6). The difference with RFC, though, is that this PR proposes to persist datasets in configured offline store (currently supported Redshift / BigQuery / File) instead of always writing it to cloud storage as parquet files.

Example of usage:
```
from feast.infra.offline_stores.bigquery_source import SavedDatasetBigQueryStorage

job = store.get_historical_features(...)

ds = store.create_saved_dataset(
   from_=job,
   name='my_persisted_ds',
   storage=SavedDatasetBigQueryStorage(table_ref='project.dataset.table_name'),
   tags={'key': 'value'}
)

ds = store.get_saved_dataset(name='my_persisted_ds')
ds.to_df()
```

`get_saved_dataset(name)` returns `SavedDataset` object which provides access to dataset metadata. Data can be retrieved by calling `.to_df()` or `.to_arrow()` on this object.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Two new methods in FeatureStore class
create_saved_dataset - create dataset from historical retrieval job; persist it in offline store and write metadata to the registry
get_saved_dataset - retrieve metadata from registry and data from offline store
```
