### PR TITLE
Compare only specs in integration tests

### DIFF
--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -708,7 +708,7 @@ class Registry:
         """Tears down (removes) the registry."""
         self._registry_store.teardown()
 
-    def to_dict(self, project: str) -> Dict[str, List[Any]]:
+    def to_dict(self, project: str, spec_only: bool = False) -> Dict[str, List[Any]]:
         """Returns a dictionary representation of the registry contents for the specified project.
 
         For each list in the dictionary, the elements are sorted by name, so this
@@ -716,38 +716,61 @@ class Registry:
 
         Args:
             project: Feast project to convert to a dict
+            spec_only: If True, return only specs, and exclude metadata.
         """
         registry_dict = defaultdict(list)
 
         for entity in sorted(
             self.list_entities(project=project), key=lambda entity: entity.name
         ):
-            registry_dict["entities"].append(MessageToDict(entity.to_proto()))
+            registry_dict["entities"].append(
+                MessageToDict(
+                    entity.to_proto().spec if spec_only else entity.to_proto()
+                )
+            )
         for feature_view in sorted(
             self.list_feature_views(project=project),
             key=lambda feature_view: feature_view.name,
         ):
-            registry_dict["featureViews"].append(MessageToDict(feature_view.to_proto()))
+            registry_dict["featureViews"].append(
+                MessageToDict(
+                    feature_view.to_proto().spec
+                    if spec_only
+                    else feature_view.to_proto()
+                )
+            )
         for feature_service in sorted(
             self.list_feature_services(project=project),
             key=lambda feature_service: feature_service.name,
         ):
             registry_dict["featureServices"].append(
-                MessageToDict(feature_service.to_proto())
+                MessageToDict(
+                    feature_service.to_proto().spec
+                    if spec_only
+                    else feature_service.to_proto()
+                )
             )
         for on_demand_feature_view in sorted(
             self.list_on_demand_feature_views(project=project),
             key=lambda on_demand_feature_view: on_demand_feature_view.name,
         ):
             registry_dict["onDemandFeatureViews"].append(
-                MessageToDict(on_demand_feature_view.to_proto())
+                MessageToDict(
+                    on_demand_feature_view.to_proto().spec
+                    if spec_only
+                    else on_demand_feature_view.to_proto()
+                )
             )
         for request_feature_view in sorted(
             self.list_request_feature_views(project=project),
             key=lambda request_feature_view: request_feature_view.name,
         ):
             registry_dict["requestFeatureViews"].append(
-                MessageToDict(request_feature_view.to_proto())
+                MessageToDict(
+                    request_feature_view.to_proto().spec
+                    if spec_only
+                    else request_feature_view.to_proto()
+                )
             )
         return registry_dict
 

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -708,7 +708,7 @@ class Registry:
         """Tears down (removes) the registry."""
         self._registry_store.teardown()
 
-    def to_dict(self, project: str, spec_only: bool = False) -> Dict[str, List[Any]]:
+    def to_dict(self, project: str) -> Dict[str, List[Any]]:
         """Returns a dictionary representation of the registry contents for the specified project.
 
         For each list in the dictionary, the elements are sorted by name, so this
@@ -716,61 +716,38 @@ class Registry:
 
         Args:
             project: Feast project to convert to a dict
-            spec_only: If True, return only specs, and exclude metadata.
         """
         registry_dict = defaultdict(list)
 
         for entity in sorted(
             self.list_entities(project=project), key=lambda entity: entity.name
         ):
-            registry_dict["entities"].append(
-                MessageToDict(
-                    entity.to_proto().spec if spec_only else entity.to_proto()
-                )
-            )
+            registry_dict["entities"].append(MessageToDict(entity.to_proto()))
         for feature_view in sorted(
             self.list_feature_views(project=project),
             key=lambda feature_view: feature_view.name,
         ):
-            registry_dict["featureViews"].append(
-                MessageToDict(
-                    feature_view.to_proto().spec
-                    if spec_only
-                    else feature_view.to_proto()
-                )
-            )
+            registry_dict["featureViews"].append(MessageToDict(feature_view.to_proto()))
         for feature_service in sorted(
             self.list_feature_services(project=project),
             key=lambda feature_service: feature_service.name,
         ):
             registry_dict["featureServices"].append(
-                MessageToDict(
-                    feature_service.to_proto().spec
-                    if spec_only
-                    else feature_service.to_proto()
-                )
+                MessageToDict(feature_service.to_proto())
             )
         for on_demand_feature_view in sorted(
             self.list_on_demand_feature_views(project=project),
             key=lambda on_demand_feature_view: on_demand_feature_view.name,
         ):
             registry_dict["onDemandFeatureViews"].append(
-                MessageToDict(
-                    on_demand_feature_view.to_proto().spec
-                    if spec_only
-                    else on_demand_feature_view.to_proto()
-                )
+                MessageToDict(on_demand_feature_view.to_proto())
             )
         for request_feature_view in sorted(
             self.list_request_feature_views(project=project),
             key=lambda request_feature_view: request_feature_view.name,
         ):
             registry_dict["requestFeatureViews"].append(
-                MessageToDict(
-                    request_feature_view.to_proto().spec
-                    if spec_only
-                    else request_feature_view.to_proto()
-                )
+                MessageToDict(request_feature_view.to_proto())
             )
         return registry_dict
 

--- a/sdk/python/tests/integration/registration/test_cli.py
+++ b/sdk/python/tests/integration/registration/test_cli.py
@@ -42,7 +42,7 @@ def test_universal_cli(test_repo_config) -> None:
 
             # Store registry contents, to be compared later.
             fs = FeatureStore(repo_path=str(repo_path))
-            registry_dict = fs.registry.to_dict(project=project)
+            registry_dict = fs.registry.to_dict(project=project, spec_only=True)
 
             # entity & feature view list commands should succeed
             result = runner.run(["entities", "list"], cwd=repo_path)
@@ -84,7 +84,7 @@ def test_universal_cli(test_repo_config) -> None:
 
             # Confirm that registry contents have not changed.
             assertpy.assert_that(registry_dict).is_equal_to(
-                fs.registry.to_dict(project=project)
+                fs.registry.to_dict(project=project, spec_only=True)
             )
 
             result = runner.run(["teardown"], cwd=repo_path)

--- a/sdk/python/tests/integration/registration/test_cli.py
+++ b/sdk/python/tests/integration/registration/test_cli.py
@@ -42,7 +42,13 @@ def test_universal_cli(test_repo_config) -> None:
 
             # Store registry contents, to be compared later.
             fs = FeatureStore(repo_path=str(repo_path))
-            registry_dict = fs.registry.to_dict(project=project, spec_only=True)
+            registry_dict = fs.registry.to_dict(project=project)
+
+            # Save only the specs, not the metadata.
+            registry_specs = {
+                key: [fco["spec"] for fco in value]
+                for key, value in registry_dict.items()
+            }
 
             # entity & feature view list commands should succeed
             result = runner.run(["entities", "list"], cwd=repo_path)
@@ -83,8 +89,12 @@ def test_universal_cli(test_repo_config) -> None:
             )
 
             # Confirm that registry contents have not changed.
-            assertpy.assert_that(registry_dict).is_equal_to(
-                fs.registry.to_dict(project=project, spec_only=True)
+            registry_dict = fs.registry.to_dict(project=project)
+            assertpy.assert_that(registry_specs).is_equal_to(
+                {
+                    key: [fco["spec"] for fco in value]
+                    for key, value in registry_dict.items()
+                }
             )
 
             result = runner.run(["teardown"], cwd=repo_path)


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: #1952 was recently merged and is currently breaking integration tests on master. Specifically, by setting `created_timestamp` for feature views, the `test_universal_cli` test breaks because the second `feast apply` changes FV metadata, causing the registry to be changed. This PR ensures that when registry contents are compared after the first and second calls to `feast plan`, only specs of the FCOs are compared, and metadata is excluded. This allows the test to pass.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
