### PR TITLE
Add on demand feature views deletion

### DIFF
--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -667,6 +667,18 @@ class Registry:
                     self.commit()
                 return
 
+        for idx, existing_on_demand_feature_view_proto in enumerate(
+            self.cached_registry_proto.on_demand_feature_views
+        ):
+            if (
+                existing_on_demand_feature_view_proto.spec.name == name
+                and existing_on_demand_feature_view_proto.spec.project == project
+            ):
+                del self.cached_registry_proto.on_demand_feature_views[idx]
+                if commit:
+                    self.commit()
+                return
+
         raise FeatureViewNotFoundException(name, project)
 
     def delete_entity(self, name: str, project: str, commit: bool = True):


### PR DESCRIPTION
The deletion of on demand feature views is broken as it is not covered in `registry.delete_feature_view`. 
This is a small fix to cover deletion of odfv the same way it is done for standard or request feature views. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```