### PR TITLE
Implement diff_infra_protos method for feast plan

### DIFF
--- a/sdk/python/feast/diff/infra_diff.py
+++ b/sdk/python/feast/diff/infra_diff.py
@@ -1,16 +1,30 @@
 from dataclasses import dataclass
-from typing import Any, List
+from typing import Any, Iterable, List, Tuple, TypeVar
 
 from feast.diff.property_diff import PropertyDiff, TransitionType
+from feast.infra.infra_object import (
+    DATASTORE_INFRA_OBJECT_CLASS_TYPE,
+    DYNAMODB_INFRA_OBJECT_CLASS_TYPE,
+    SQLITE_INFRA_OBJECT_CLASS_TYPE,
+    InfraObject,
+)
+from feast.protos.feast.core.DatastoreTable_pb2 import (
+    DatastoreTable as DatastoreTableProto,
+)
+from feast.protos.feast.core.DynamoDBTable_pb2 import (
+    DynamoDBTable as DynamoDBTableProto,
+)
+from feast.protos.feast.core.InfraObject_pb2 import Infra as InfraProto
+from feast.protos.feast.core.SqliteTable_pb2 import SqliteTable as SqliteTableProto
 
 
 @dataclass
 class InfraObjectDiff:
     name: str
     infra_object_type: str
-    current_fco: Any
-    new_fco: Any
-    fco_property_diffs: List[PropertyDiff]
+    current_infra_object: Any
+    new_infra_object: Any
+    infra_object_property_diffs: List[PropertyDiff]
     transition_type: TransitionType
 
 
@@ -26,3 +40,117 @@ class InfraDiff:
 
     def to_string(self):
         pass
+
+
+U = TypeVar("U", DatastoreTableProto, DynamoDBTableProto, SqliteTableProto)
+
+
+def tag_infra_proto_objects_for_keep_delete_add(
+    existing_objs: Iterable[U], desired_objs: Iterable[U]
+) -> Tuple[Iterable[U], Iterable[U], Iterable[U]]:
+    existing_obj_names = {e.name for e in existing_objs}
+    desired_obj_names = {e.name for e in desired_objs}
+
+    objs_to_add = [e for e in desired_objs if e.name not in existing_obj_names]
+    objs_to_keep = [e for e in desired_objs if e.name in existing_obj_names]
+    objs_to_delete = [e for e in existing_objs if e.name not in desired_obj_names]
+
+    return objs_to_keep, objs_to_delete, objs_to_add
+
+
+def diff_infra_protos(
+    current_infra_proto: InfraProto, new_infra_proto: InfraProto
+) -> InfraDiff:
+    infra_diff = InfraDiff()
+
+    infra_object_class_types_to_str = {
+        DATASTORE_INFRA_OBJECT_CLASS_TYPE: "datastore table",
+        DYNAMODB_INFRA_OBJECT_CLASS_TYPE: "dynamodb table",
+        SQLITE_INFRA_OBJECT_CLASS_TYPE: "sqlite table",
+    }
+
+    for infra_object_class_type in infra_object_class_types_to_str:
+        current_infra_objects = get_infra_object_protos_by_type(
+            current_infra_proto, infra_object_class_type
+        )
+        new_infra_objects = get_infra_object_protos_by_type(
+            new_infra_proto, infra_object_class_type
+        )
+        (
+            infra_objects_to_keep,
+            infra_objects_to_delete,
+            infra_objects_to_add,
+        ) = tag_infra_proto_objects_for_keep_delete_add(
+            current_infra_objects, new_infra_objects,
+        )
+
+        for e in infra_objects_to_add:
+            infra_diff.infra_object_diffs.append(
+                InfraObjectDiff(
+                    e.name,
+                    infra_object_class_types_to_str[infra_object_class_type],
+                    None,
+                    e,
+                    [],
+                    TransitionType.CREATE,
+                )
+            )
+        for e in infra_objects_to_delete:
+            infra_diff.infra_object_diffs.append(
+                InfraObjectDiff(
+                    e.name,
+                    infra_object_class_types_to_str[infra_object_class_type],
+                    e,
+                    None,
+                    [],
+                    TransitionType.DELETE,
+                )
+            )
+        for e in infra_objects_to_keep:
+            current_infra_object = [
+                _e for _e in current_infra_objects if _e.name == e.name
+            ][0]
+            infra_diff.infra_object_diffs.append(
+                diff_between(
+                    current_infra_object,
+                    e,
+                    infra_object_class_types_to_str[infra_object_class_type],
+                )
+            )
+
+    return infra_diff
+
+
+def get_infra_object_protos_by_type(
+    infra_proto: InfraProto, infra_object_class_type: str
+) -> List[U]:
+    return [
+        InfraObject.from_infra_object_proto(infra_object).to_proto()
+        for infra_object in infra_proto.infra_objects
+        if infra_object.infra_object_class_type == infra_object_class_type
+    ]
+
+
+FIELDS_TO_IGNORE = {"project"}
+
+
+def diff_between(current: U, new: U, infra_object_type: str) -> InfraObjectDiff:
+    assert current.DESCRIPTOR.full_name == new.DESCRIPTOR.full_name
+    property_diffs = []
+    transition: TransitionType = TransitionType.UNCHANGED
+    if current != new:
+        for _field in current.DESCRIPTOR.fields:
+            if _field.name in FIELDS_TO_IGNORE:
+                continue
+            if getattr(current, _field.name) != getattr(new, _field.name):
+                transition = TransitionType.UPDATE
+                property_diffs.append(
+                    PropertyDiff(
+                        _field.name,
+                        getattr(current, _field.name),
+                        getattr(new, _field.name),
+                    )
+                )
+    return InfraObjectDiff(
+        new.name, infra_object_type, current, new, property_diffs, transition,
+    )

--- a/sdk/python/feast/infra/infra_object.py
+++ b/sdk/python/feast/infra/infra_object.py
@@ -19,6 +19,10 @@ from feast.importer import import_class
 from feast.protos.feast.core.InfraObject_pb2 import Infra as InfraProto
 from feast.protos.feast.core.InfraObject_pb2 import InfraObject as InfraObjectProto
 
+DATASTORE_INFRA_OBJECT_CLASS_TYPE = "feast.infra.online_stores.datastore.DatastoreTable"
+DYNAMODB_INFRA_OBJECT_CLASS_TYPE = "feast.infra.online_stores.dynamodb.DynamoDBTable"
+SQLITE_INFRA_OBJECT_CLASS_TYPE = "feast.infra.online_store.sqlite.SqliteTable"
+
 
 class InfraObject(ABC):
     """
@@ -51,7 +55,7 @@ class InfraObject(ABC):
             cls = _get_infra_object_class_from_type(
                 infra_object_proto.infra_object_class_type
             )
-            return cls.from_proto(infra_object_proto)
+            return cls.from_infra_object_proto(infra_object_proto)
 
         raise ValueError("Could not identify the type of the InfraObject.")
 

--- a/sdk/python/feast/infra/infra_object.py
+++ b/sdk/python/feast/infra/infra_object.py
@@ -26,13 +26,18 @@ class InfraObject(ABC):
     """
 
     @abstractmethod
-    def to_proto(self) -> InfraObjectProto:
+    def to_infra_object_proto(self) -> InfraObjectProto:
+        """Converts an InfraObject to its protobuf representation, wrapped in an InfraObjectProto."""
+        pass
+
+    @abstractmethod
+    def to_proto(self) -> Any:
         """Converts an InfraObject to its protobuf representation."""
         pass
 
     @staticmethod
     @abstractmethod
-    def from_proto(infra_object_proto: InfraObjectProto) -> Any:
+    def from_infra_object_proto(infra_object_proto: InfraObjectProto) -> Any:
         """
         Returns an InfraObject created from a protobuf representation.
 
@@ -97,7 +102,7 @@ class Infra:
         """
         infra = cls()
         cls.infra_objects += [
-            InfraObject.from_proto(infra_object_proto)
+            InfraObject.from_infra_object_proto(infra_object_proto)
             for infra_object_proto in infra_proto.infra_objects
         ]
 

--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -354,7 +354,14 @@ class DatastoreTable(InfraObject):
         self.namespace = namespace
         self.client = _initialize_client(self.project_id, self.namespace)
 
-    def to_proto(self) -> InfraObjectProto:
+    def to_infra_object_proto(self) -> InfraObjectProto:
+        datastore_table_proto = self.to_proto()
+        return InfraObjectProto(
+            infra_object_class_type="feast.infra.online_stores.datastore.DatastoreTable",
+            datastore_table=datastore_table_proto,
+        )
+
+    def to_proto(self) -> Any:
         datastore_table_proto = DatastoreTableProto()
         datastore_table_proto.project = self.project
         datastore_table_proto.name = self.name
@@ -362,14 +369,10 @@ class DatastoreTable(InfraObject):
             datastore_table_proto.project_id.FromString(bytes(self.project_id, "utf-8"))
         if self.namespace:
             datastore_table_proto.namespace.FromString(bytes(self.namespace, "utf-8"))
-
-        return InfraObjectProto(
-            infra_object_class_type="feast.infra.online_stores.datastore.DatastoreTable",
-            datastore_table=datastore_table_proto,
-        )
+        return datastore_table_proto
 
     @staticmethod
-    def from_proto(infra_object_proto: InfraObjectProto) -> Any:
+    def from_infra_object_proto(infra_object_proto: InfraObjectProto) -> DatastoreTable:
         datastore_table = DatastoreTable(
             project=infra_object_proto.datastore_table.project,
             name=infra_object_proto.datastore_table.name,

--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -24,7 +24,7 @@ from pydantic.typing import Literal
 
 from feast import Entity, utils
 from feast.feature_view import FeatureView
-from feast.infra.infra_object import InfraObject
+from feast.infra.infra_object import DATASTORE_INFRA_OBJECT_CLASS_TYPE, InfraObject
 from feast.infra.online_stores.helpers import compute_entity_id
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.core.DatastoreTable_pb2 import (
@@ -357,7 +357,7 @@ class DatastoreTable(InfraObject):
     def to_infra_object_proto(self) -> InfraObjectProto:
         datastore_table_proto = self.to_proto()
         return InfraObjectProto(
-            infra_object_class_type="feast.infra.online_stores.datastore.DatastoreTable",
+            infra_object_class_type=DATASTORE_INFRA_OBJECT_CLASS_TYPE,
             datastore_table=datastore_table_proto,
         )
 
@@ -366,13 +366,13 @@ class DatastoreTable(InfraObject):
         datastore_table_proto.project = self.project
         datastore_table_proto.name = self.name
         if self.project_id:
-            datastore_table_proto.project_id.FromString(bytes(self.project_id, "utf-8"))
+            datastore_table_proto.project_id.value = self.project_id
         if self.namespace:
-            datastore_table_proto.namespace.FromString(bytes(self.namespace, "utf-8"))
+            datastore_table_proto.namespace.value = self.namespace
         return datastore_table_proto
 
     @staticmethod
-    def from_infra_object_proto(infra_object_proto: InfraObjectProto) -> DatastoreTable:
+    def from_infra_object_proto(infra_object_proto: InfraObjectProto) -> Any:
         datastore_table = DatastoreTable(
             project=infra_object_proto.datastore_table.project,
             name=infra_object_proto.datastore_table.name,
@@ -380,12 +380,12 @@ class DatastoreTable(InfraObject):
 
         if infra_object_proto.datastore_table.HasField("project_id"):
             datastore_table.project_id = (
-                infra_object_proto.datastore_table.project_id.SerializeToString()
-            ).decode("utf-8")
+                infra_object_proto.datastore_table.project_id.value
+            )
         if infra_object_proto.datastore_table.HasField("namespace"):
             datastore_table.namespace = (
-                infra_object_proto.datastore_table.namespace.SerializeToString()
-            ).decode("utf-8")
+                infra_object_proto.datastore_table.namespace.value
+            )
 
         return datastore_table
 

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -19,7 +19,7 @@ from pydantic import StrictStr
 from pydantic.typing import Literal
 
 from feast import Entity, FeatureView, utils
-from feast.infra.infra_object import InfraObject
+from feast.infra.infra_object import DYNAMODB_INFRA_OBJECT_CLASS_TYPE, InfraObject
 from feast.infra.online_stores.helpers import compute_entity_id
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.core.DynamoDBTable_pb2 import (
@@ -237,7 +237,7 @@ class DynamoDBTable(InfraObject):
     def to_infra_object_proto(self) -> InfraObjectProto:
         dynamodb_table_proto = self.to_proto()
         return InfraObjectProto(
-            infra_object_class_type="feast.infra.online_stores.dynamodb.DynamoDBTable",
+            infra_object_class_type=DYNAMODB_INFRA_OBJECT_CLASS_TYPE,
             dynamodb_table=dynamodb_table_proto,
         )
 
@@ -248,7 +248,7 @@ class DynamoDBTable(InfraObject):
         return dynamodb_table_proto
 
     @staticmethod
-    def from_infra_object_proto(infra_object_proto: InfraObjectProto) -> DynamoDBTable:
+    def from_infra_object_proto(infra_object_proto: InfraObjectProto) -> Any:
         return DynamoDBTable(
             name=infra_object_proto.dynamodb_table.name,
             region=infra_object_proto.dynamodb_table.region,

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -234,18 +234,21 @@ class DynamoDBTable(InfraObject):
         self.name = name
         self.region = region
 
-    def to_proto(self) -> InfraObjectProto:
-        dynamodb_table_proto = DynamoDBTableProto()
-        dynamodb_table_proto.name = self.name
-        dynamodb_table_proto.region = self.region
-
+    def to_infra_object_proto(self) -> InfraObjectProto:
+        dynamodb_table_proto = self.to_proto()
         return InfraObjectProto(
             infra_object_class_type="feast.infra.online_stores.dynamodb.DynamoDBTable",
             dynamodb_table=dynamodb_table_proto,
         )
 
+    def to_proto(self) -> Any:
+        dynamodb_table_proto = DynamoDBTableProto()
+        dynamodb_table_proto.name = self.name
+        dynamodb_table_proto.region = self.region
+        return dynamodb_table_proto
+
     @staticmethod
-    def from_proto(infra_object_proto: InfraObjectProto) -> Any:
+    def from_infra_object_proto(infra_object_proto: InfraObjectProto) -> DynamoDBTable:
         return DynamoDBTable(
             name=infra_object_proto.dynamodb_table.name,
             region=infra_object_proto.dynamodb_table.region,

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -23,7 +23,7 @@ from pydantic.schema import Literal
 
 from feast import Entity
 from feast.feature_view import FeatureView
-from feast.infra.infra_object import InfraObject
+from feast.infra.infra_object import SQLITE_INFRA_OBJECT_CLASS_TYPE, InfraObject
 from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.core.InfraObject_pb2 import InfraObject as InfraObjectProto
@@ -244,7 +244,7 @@ class SqliteTable(InfraObject):
     def to_infra_object_proto(self) -> InfraObjectProto:
         sqlite_table_proto = self.to_proto()
         return InfraObjectProto(
-            infra_object_class_type="feast.infra.online_store.sqlite.SqliteTable",
+            infra_object_class_type=SQLITE_INFRA_OBJECT_CLASS_TYPE,
             sqlite_table=sqlite_table_proto,
         )
 
@@ -255,7 +255,7 @@ class SqliteTable(InfraObject):
         return sqlite_table_proto
 
     @staticmethod
-    def from_infra_object_proto(infra_object_proto: InfraObjectProto) -> SqliteTable:
+    def from_infra_object_proto(infra_object_proto: InfraObjectProto) -> Any:
         return SqliteTable(
             path=infra_object_proto.sqlite_table.path,
             name=infra_object_proto.sqlite_table.name,

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -241,18 +241,21 @@ class SqliteTable(InfraObject):
         self.name = name
         self.conn = _initialize_conn(path)
 
-    def to_proto(self) -> InfraObjectProto:
-        sqlite_table_proto = SqliteTableProto()
-        sqlite_table_proto.path = self.path
-        sqlite_table_proto.name = self.name
-
+    def to_infra_object_proto(self) -> InfraObjectProto:
+        sqlite_table_proto = self.to_proto()
         return InfraObjectProto(
             infra_object_class_type="feast.infra.online_store.sqlite.SqliteTable",
             sqlite_table=sqlite_table_proto,
         )
 
+    def to_proto(self) -> Any:
+        sqlite_table_proto = SqliteTableProto()
+        sqlite_table_proto.path = self.path
+        sqlite_table_proto.name = self.name
+        return sqlite_table_proto
+
     @staticmethod
-    def from_proto(infra_object_proto: InfraObjectProto) -> Any:
+    def from_infra_object_proto(infra_object_proto: InfraObjectProto) -> SqliteTable:
         return SqliteTable(
             path=infra_object_proto.sqlite_table.path,
             name=infra_object_proto.sqlite_table.name,

--- a/sdk/python/tests/unit/diff/test_infra_diff.py
+++ b/sdk/python/tests/unit/diff/test_infra_diff.py
@@ -1,0 +1,154 @@
+from google.protobuf import wrappers_pb2 as wrappers
+
+from feast.diff.infra_diff import (
+    diff_between,
+    diff_infra_protos,
+    tag_infra_proto_objects_for_keep_delete_add,
+)
+from feast.diff.property_diff import TransitionType
+from feast.infra.online_stores.datastore import DatastoreTable
+from feast.infra.online_stores.dynamodb import DynamoDBTable
+from feast.protos.feast.core.InfraObject_pb2 import Infra as InfraProto
+
+
+def test_tag_infra_proto_objects_for_keep_delete_add():
+    to_delete = DynamoDBTable(name="to_delete", region="us-west-2").to_proto()
+    to_add = DynamoDBTable(name="to_add", region="us-west-2").to_proto()
+    unchanged_table = DynamoDBTable(name="unchanged", region="us-west-2").to_proto()
+    pre_changed = DynamoDBTable(name="table", region="us-west-2").to_proto()
+    post_changed = DynamoDBTable(name="table", region="us-east-2").to_proto()
+
+    keep, delete, add = tag_infra_proto_objects_for_keep_delete_add(
+        [to_delete, unchanged_table, pre_changed],
+        [to_add, unchanged_table, post_changed],
+    )
+
+    assert len(list(keep)) == 2
+    assert unchanged_table in keep
+    assert post_changed in keep
+    assert to_add not in keep
+    assert len(list(delete)) == 1
+    assert to_delete in delete
+    assert unchanged_table not in delete
+    assert pre_changed not in delete
+    assert len(list(add)) == 1
+    assert to_add in add
+    assert unchanged_table not in add
+    assert post_changed not in add
+
+
+def test_diff_between_datastore_tables():
+    pre_changed = DatastoreTable(
+        project="test", name="table", project_id="pre", namespace="pre"
+    ).to_proto()
+    post_changed = DatastoreTable(
+        project="test", name="table", project_id="post", namespace="post"
+    ).to_proto()
+
+    infra_object_diff = diff_between(pre_changed, pre_changed, "datastore table")
+    infra_object_property_diffs = infra_object_diff.infra_object_property_diffs
+    assert len(infra_object_property_diffs) == 0
+
+    infra_object_diff = diff_between(pre_changed, post_changed, "datastore table")
+    infra_object_property_diffs = infra_object_diff.infra_object_property_diffs
+    assert len(infra_object_property_diffs) == 2
+
+    assert infra_object_property_diffs[0].property_name == "project_id"
+    assert infra_object_property_diffs[0].val_existing == wrappers.StringValue(
+        value="pre"
+    )
+    assert infra_object_property_diffs[0].val_declared == wrappers.StringValue(
+        value="post"
+    )
+    assert infra_object_property_diffs[1].property_name == "namespace"
+    assert infra_object_property_diffs[1].val_existing == wrappers.StringValue(
+        value="pre"
+    )
+    assert infra_object_property_diffs[1].val_declared == wrappers.StringValue(
+        value="post"
+    )
+
+
+def test_diff_infra_protos():
+    to_delete = DynamoDBTable(name="to_delete", region="us-west-2")
+    to_add = DynamoDBTable(name="to_add", region="us-west-2")
+    unchanged_table = DynamoDBTable(name="unchanged", region="us-west-2")
+    pre_changed = DatastoreTable(
+        project="test", name="table", project_id="pre", namespace="pre"
+    )
+    post_changed = DatastoreTable(
+        project="test", name="table", project_id="post", namespace="post"
+    )
+
+    infra_objects_before = [to_delete, unchanged_table, pre_changed]
+    infra_objects_after = [to_add, unchanged_table, post_changed]
+
+    infra_proto_before = InfraProto()
+    infra_proto_before.infra_objects.extend(
+        [obj.to_infra_object_proto() for obj in infra_objects_before]
+    )
+
+    infra_proto_after = InfraProto()
+    infra_proto_after.infra_objects.extend(
+        [obj.to_infra_object_proto() for obj in infra_objects_after]
+    )
+
+    infra_diff = diff_infra_protos(infra_proto_before, infra_proto_after)
+    infra_object_diffs = infra_diff.infra_object_diffs
+
+    # There should be one addition, one deletion, one unchanged, and one changed.
+    assert len(infra_object_diffs) == 4
+
+    additions = [
+        infra_object_diff
+        for infra_object_diff in infra_object_diffs
+        if infra_object_diff.transition_type == TransitionType.CREATE
+    ]
+    assert len(additions) == 1
+    assert not additions[0].current_infra_object
+    assert additions[0].new_infra_object == to_add.to_proto()
+    assert len(additions[0].infra_object_property_diffs) == 0
+
+    deletions = [
+        infra_object_diff
+        for infra_object_diff in infra_object_diffs
+        if infra_object_diff.transition_type == TransitionType.DELETE
+    ]
+    assert len(deletions) == 1
+    assert deletions[0].current_infra_object == to_delete.to_proto()
+    assert not deletions[0].new_infra_object
+    assert len(deletions[0].infra_object_property_diffs) == 0
+
+    unchanged = [
+        infra_object_diff
+        for infra_object_diff in infra_object_diffs
+        if infra_object_diff.transition_type == TransitionType.UNCHANGED
+    ]
+    assert len(unchanged) == 1
+    assert unchanged[0].current_infra_object == unchanged_table.to_proto()
+    assert unchanged[0].new_infra_object == unchanged_table.to_proto()
+    assert len(unchanged[0].infra_object_property_diffs) == 0
+
+    updates = [
+        infra_object_diff
+        for infra_object_diff in infra_object_diffs
+        if infra_object_diff.transition_type == TransitionType.UPDATE
+    ]
+    assert len(updates) == 1
+    assert updates[0].current_infra_object == pre_changed.to_proto()
+    assert updates[0].new_infra_object == post_changed.to_proto()
+    assert len(updates[0].infra_object_property_diffs) == 2
+    assert updates[0].infra_object_property_diffs[0].property_name == "project_id"
+    assert updates[0].infra_object_property_diffs[
+        0
+    ].val_existing == wrappers.StringValue(value="pre")
+    assert updates[0].infra_object_property_diffs[
+        0
+    ].val_declared == wrappers.StringValue(value="post")
+    assert updates[0].infra_object_property_diffs[1].property_name == "namespace"
+    assert updates[0].infra_object_property_diffs[
+        1
+    ].val_existing == wrappers.StringValue(value="pre")
+    assert updates[0].infra_object_property_diffs[
+        1
+    ].val_declared == wrappers.StringValue(value="post")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: This PR implements the `diff_infra_protos`, which will compute the difference between two `InfraProto` objects, for `feast plan`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
