### PR TITLE
Split apply total parse repo

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -237,7 +237,7 @@ def extract_objects_for_apply_delete(project, registry, repo):
     return all_to_apply, all_to_delete, views_to_delete, views_to_keep
 
 
-def apply_total_with_repo_instance(repo_contents: RepoContents):
+def apply_total_with_repo_instance(repo_contents: RepoContents, repo_path: Path):
     pass
 
 

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -240,6 +240,7 @@ def extract_objects_for_apply_delete(project, registry, repo):
 def apply_total_with_repo_instance(repo_contents: RepoContents):
     pass
 
+
 @log_exceptions_and_usage
 def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool):
 

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -268,7 +268,9 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
 
     os.chdir(repo_path)
     project, registry, repo, store = _prepare_registry_and_repo(repo_config, repo_path)
-    apply_total_with_repo_instance(store, project, registry, repo, skip_source_validation)
+    apply_total_with_repo_instance(
+        store, project, registry, repo, skip_source_validation
+    )
 
 
 def log_cli_output(diff, views_to_delete, views_to_keep):

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -237,6 +237,8 @@ def extract_objects_for_apply_delete(project, registry, repo):
     return all_to_apply, all_to_delete, views_to_delete, views_to_keep
 
 
+def apply_total_with_repo_instance(repo_contents: RepoContents, )
+
 @log_exceptions_and_usage
 def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool):
 

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -237,12 +237,12 @@ def extract_objects_for_apply_delete(project, registry, repo):
     return all_to_apply, all_to_delete, views_to_delete, views_to_keep
 
 
-def _apply_total(
-    project: str,
-    registry: Registry,
-    repo: RepoContents,
-    store: FeatureStore,
-    skip_source_validation: bool,
+def apply_total_with_repo_instance(
+  store: FeatureStore,
+  project: str,
+  registry: Registry,
+  repo: RepoContents,
+  skip_source_validation: bool,
 ):
     if not skip_source_validation:
         data_sources = [t.batch_source for t in repo.feature_views]
@@ -264,23 +264,11 @@ def _apply_total(
 
 
 @log_exceptions_and_usage
-def apply_total_with_repo_instance(
-    repo_contents: RepoContents,
-    repo_config: RepoConfig,
-    repo_path: Path,
-    skip_source_validation: bool,
-):
-    os.chdir(repo_path)
-    project, registry, _, store = _prepare_registry_and_repo(repo_config, repo_path)
-    _apply_total(project, registry, repo_contents, store, skip_source_validation)
-
-
-@log_exceptions_and_usage
 def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool):
 
     os.chdir(repo_path)
     project, registry, repo, store = _prepare_registry_and_repo(repo_config, repo_path)
-    _apply_total(project, registry, repo, store, skip_source_validation)
+    apply_total_with_repo_instance(repo, registry, repo, store, skip_source_validation)
 
 
 def log_cli_output(diff, views_to_delete, views_to_keep):

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -238,11 +238,11 @@ def extract_objects_for_apply_delete(project, registry, repo):
 
 
 def apply_total_with_repo_instance(
-  store: FeatureStore,
-  project: str,
-  registry: Registry,
-  repo: RepoContents,
-  skip_source_validation: bool,
+    store: FeatureStore,
+    project: str,
+    registry: Registry,
+    repo: RepoContents,
+    skip_source_validation: bool,
 ):
     if not skip_source_validation:
         data_sources = [t.batch_source for t in repo.feature_views]
@@ -268,7 +268,7 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
 
     os.chdir(repo_path)
     project, registry, repo, store = _prepare_registry_and_repo(repo_config, repo_path)
-    apply_total_with_repo_instance(repo, registry, repo, store, skip_source_validation)
+    apply_total_with_repo_instance(store, project, registry, repo, skip_source_validation)
 
 
 def log_cli_output(diff, views_to_delete, views_to_keep):

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -237,16 +237,13 @@ def extract_objects_for_apply_delete(project, registry, repo):
     return all_to_apply, all_to_delete, views_to_delete, views_to_keep
 
 
-def apply_total_with_repo_instance(repo_contents: RepoContents, repo_path: Path):
-    pass
-
-
-@log_exceptions_and_usage
-def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool):
-
-    os.chdir(repo_path)
-    project, registry, repo, store = _prepare_registry_and_repo(repo_config, repo_path)
-
+def _apply_total(
+    project: str,
+    registry: Registry,
+    repo: RepoContents,
+    store: FeatureStore,
+    skip_source_validation: bool,
+):
     if not skip_source_validation:
         data_sources = [t.batch_source for t in repo.feature_views]
         # Make sure the data source used by this feature view is supported by Feast
@@ -264,6 +261,26 @@ def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation
     diff = store.apply(all_to_apply, objects_to_delete=all_to_delete, partial=False)
 
     log_cli_output(diff, views_to_delete, views_to_keep)
+
+
+@log_exceptions_and_usage
+def apply_total_with_repo_instance(
+    repo_contents: RepoContents,
+    repo_config: RepoConfig,
+    repo_path: Path,
+    skip_source_validation: bool,
+):
+    os.chdir(repo_path)
+    project, registry, _, store = _prepare_registry_and_repo(repo_config, repo_path)
+    _apply_total(project, registry, repo_contents, store, skip_source_validation)
+
+
+@log_exceptions_and_usage
+def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool):
+
+    os.chdir(repo_path)
+    project, registry, repo, store = _prepare_registry_and_repo(repo_config, repo_path)
+    _apply_total(project, registry, repo, store, skip_source_validation)
 
 
 def log_cli_output(diff, views_to_delete, views_to_keep):

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -237,7 +237,8 @@ def extract_objects_for_apply_delete(project, registry, repo):
     return all_to_apply, all_to_delete, views_to_delete, views_to_keep
 
 
-def apply_total_with_repo_instance(repo_contents: RepoContents, )
+def apply_total_with_repo_instance(repo_contents: RepoContents):
+    pass
 
 @log_exceptions_and_usage
 def apply_total(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool):


### PR DESCRIPTION
**What this PR does / why we need it**:
Need a way to pass a user-defined repo to the apply_total method. Added a new method which `apply_total` will now call that takes a RepoContents arg

**Which issue(s) this PR fixes**:
Fixes #2128

**Does this PR introduce a user-facing change?**:
```release-note
1. Added functionality
2. No User action required
3. added method: apply_total_with_repo_instance()
4. See #2128 
```