### PR TITLE
Compare Python objects instead of proto objects

### DIFF
--- a/sdk/python/feast/diff/FcoDiff.py
+++ b/sdk/python/feast/diff/FcoDiff.py
@@ -17,22 +17,15 @@ from feast.protos.feast.core.RequestFeatureView_pb2 import (
     RequestFeatureView as RequestFeatureViewProto,
 )
 
-FcoProto = TypeVar(
-    "FcoProto",
-    EntityProto,
-    FeatureViewProto,
-    FeatureServiceProto,
-    OnDemandFeatureViewProto,
-    RequestFeatureViewProto,
-)
+Fco = TypeVar("Fco", Entity, BaseFeatureView, FeatureService)
 
 
 @dataclass
-class FcoDiff(Generic[FcoProto]):
+class FcoDiff(Generic[Fco]):
     name: str
     fco_type: str
-    current_fco: FcoProto
-    new_fco: FcoProto
+    current_fco: Fco
+    new_fco: Fco
     fco_property_diffs: List[PropertyDiff]
     transition_type: TransitionType
 
@@ -48,20 +41,28 @@ class RegistryDiff:
         self.fco_diffs.append(fco_diff)
 
 
-Fco = TypeVar("Fco", Entity, BaseFeatureView, FeatureService)
-
-
-def tag_objects_for_keep_delete_add(
+def tag_objects_for_keep_delete_update_add(
     existing_objs: Iterable[Fco], desired_objs: Iterable[Fco]
-) -> Tuple[Set[Fco], Set[Fco], Set[Fco]]:
+) -> Tuple[Set[Fco], Set[Fco], Set[Fco], Set[Fco]]:
     existing_obj_names = {e.name for e in existing_objs}
     desired_obj_names = {e.name for e in desired_objs}
 
     objs_to_add = {e for e in desired_objs if e.name not in existing_obj_names}
-    objs_to_keep = {e for e in desired_objs if e.name in existing_obj_names}
+    objs_to_update = {e for e in desired_objs if e.name in existing_obj_names}
+    objs_to_keep = {e for e in existing_objs if e.name in desired_obj_names}
     objs_to_delete = {e for e in existing_objs if e.name not in desired_obj_names}
 
-    return objs_to_keep, objs_to_delete, objs_to_add
+    return objs_to_keep, objs_to_delete, objs_to_update, objs_to_add
+
+
+FcoProto = TypeVar(
+    "FcoProto",
+    EntityProto,
+    FeatureViewProto,
+    FeatureServiceProto,
+    OnDemandFeatureViewProto,
+    RequestFeatureViewProto,
+)
 
 
 def tag_proto_objects_for_keep_delete_add(
@@ -80,23 +81,27 @@ def tag_proto_objects_for_keep_delete_add(
 FIELDS_TO_IGNORE = {"project"}
 
 
-def diff_between(current: FcoProto, new: FcoProto, object_type: str) -> FcoDiff:
-    assert current.DESCRIPTOR.full_name == new.DESCRIPTOR.full_name
+def diff_between(current: Fco, new: Fco, object_type: str) -> FcoDiff:
+    current_proto = current.to_proto()
+    new_proto = new.to_proto()
+    assert current_proto.DESCRIPTOR.full_name == new_proto.DESCRIPTOR.full_name
     property_diffs = []
     transition: TransitionType = TransitionType.UNCHANGED
-    if current.spec != new.spec:
-        for _field in current.spec.DESCRIPTOR.fields:
+    if current_proto.spec != new_proto.spec:
+        for _field in current_proto.spec.DESCRIPTOR.fields:
             if _field.name in FIELDS_TO_IGNORE:
                 continue
-            if getattr(current.spec, _field.name) != getattr(new.spec, _field.name):
+            if getattr(current_proto.spec, _field.name) != getattr(
+                new_proto.spec, _field.name
+            ):
                 transition = TransitionType.UPDATE
                 property_diffs.append(
                     PropertyDiff(
                         _field.name,
-                        getattr(current.spec, _field.name),
-                        getattr(new.spec, _field.name),
+                        getattr(current_proto.spec, _field.name),
+                        getattr(new_proto.spec, _field.name),
                     )
                 )
     return FcoDiff(
-        new.spec.name, object_type, current, new, property_diffs, transition,
+        new_proto.spec.name, object_type, current, new, property_diffs, transition,
     )

--- a/sdk/python/feast/feature_service.py
+++ b/sdk/python/feast/feature_service.py
@@ -30,12 +30,12 @@ class FeatureService:
             Services.
     """
 
-    name: str
-    feature_view_projections: List[FeatureViewProjection]
-    tags: Dict[str, str]
-    description: Optional[str] = None
-    created_timestamp: Optional[datetime] = None
-    last_updated_timestamp: Optional[datetime] = None
+    _name: str
+    _feature_view_projections: List[FeatureViewProjection]
+    _tags: Dict[str, str]
+    _description: Optional[str] = None
+    _created_timestamp: Optional[datetime] = None
+    _last_updated_timestamp: Optional[datetime] = None
 
     @log_exceptions
     def __init__(
@@ -51,22 +51,22 @@ class FeatureService:
         Raises:
             ValueError: If one of the specified features is not a valid type.
         """
-        self.name = name
-        self.feature_view_projections = []
+        self._name = name
+        self._feature_view_projections = []
 
         for feature_grouping in features:
             if isinstance(feature_grouping, BaseFeatureView):
-                self.feature_view_projections.append(feature_grouping.projection)
+                self._feature_view_projections.append(feature_grouping.projection)
             else:
                 raise ValueError(
                     "The FeatureService {fs_name} has been provided with an invalid type"
                     f'{type(feature_grouping)} as part of the "features" argument.)'
                 )
 
-        self.tags = tags or {}
-        self.description = description
-        self.created_timestamp = None
-        self.last_updated_timestamp = None
+        self._tags = tags or {}
+        self._description = description
+        self._created_timestamp = None
+        self._last_updated_timestamp = None
 
     def __repr__(self):
         items = (f"{k} = {v}" for k, v in self.__dict__.items())
@@ -92,6 +92,56 @@ class FeatureService:
             return False
 
         return True
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @name.setter
+    def name(self, name: str):
+        self._name = name
+
+    @property
+    def feature_view_projections(self) -> List[FeatureViewProjection]:
+        return self._feature_view_projections
+
+    @feature_view_projections.setter
+    def feature_view_projections(
+        self, feature_view_projections: List[FeatureViewProjection]
+    ):
+        self._feature_view_projections = feature_view_projections
+
+    @property
+    def tags(self) -> Dict[str, str]:
+        return self._tags
+
+    @tags.setter
+    def tags(self, tags: Dict[str, str]):
+        self._tags = tags
+
+    @property
+    def description(self) -> Optional[str]:
+        return self._description
+
+    @description.setter
+    def description(self, description: str):
+        self._description = description
+
+    @property
+    def created_timestamp(self) -> Optional[datetime]:
+        return self._created_timestamp
+
+    @created_timestamp.setter
+    def created_timestamp(self, created_timestamp: datetime):
+        self._created_timestamp = created_timestamp
+
+    @property
+    def last_updated_timestamp(self) -> Optional[datetime]:
+        return self._last_updated_timestamp
+
+    @last_updated_timestamp.setter
+    def last_updated_timestamp(self, last_updated_timestamp: datetime):
+        self._last_updated_timestamp = last_updated_timestamp
 
     @staticmethod
     def from_proto(feature_service_proto: FeatureServiceProto):

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -24,7 +24,6 @@ from typing import (
     Iterable,
     List,
     Mapping,
-    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -68,14 +67,13 @@ from feast.infra.provider import Provider, RetrievalJob, get_provider
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.online_response import OnlineResponse
 from feast.protos.feast.core.InfraObject_pb2 import Infra as InfraProto
-from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.protos.feast.serving.ServingService_pb2 import (
     FieldStatus,
     GetOnlineFeaturesResponse,
 )
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import RepeatedValue, Value
-from feast.registry import Registry
+from feast.registry import Registry, RepoContents
 from feast.repo_config import RepoConfig, load_repo_config
 from feast.request_feature_view import RequestFeatureView
 from feast.type_map import python_values_to_proto_values
@@ -84,31 +82,6 @@ from feast.value_type import ValueType
 from feast.version import get_version
 
 warnings.simplefilter("once", DeprecationWarning)
-
-
-class RepoContents(NamedTuple):
-    feature_views: Set[FeatureView]
-    on_demand_feature_views: Set[OnDemandFeatureView]
-    request_feature_views: Set[RequestFeatureView]
-    entities: Set[Entity]
-    feature_services: Set[FeatureService]
-
-    def to_registry_proto(self) -> RegistryProto:
-        registry_proto = RegistryProto()
-        registry_proto.entities.extend([e.to_proto() for e in self.entities])
-        registry_proto.feature_views.extend(
-            [fv.to_proto() for fv in self.feature_views]
-        )
-        registry_proto.on_demand_feature_views.extend(
-            [fv.to_proto() for fv in self.on_demand_feature_views]
-        )
-        registry_proto.request_feature_views.extend(
-            [fv.to_proto() for fv in self.request_feature_views]
-        )
-        registry_proto.feature_services.extend(
-            [fs.to_proto() for fs in self.feature_services]
-        )
-        return registry_proto
 
 
 class FeatureStore:
@@ -415,7 +388,7 @@ class FeatureStore:
 
     @log_exceptions_and_usage
     def plan(
-        self, desired_repo_objects: RepoContents
+        self, desired_repo_contents: RepoContents
     ) -> Tuple[RegistryDiff, InfraDiff]:
         """Dry-run registering objects to metadata store.
 
@@ -453,16 +426,9 @@ class FeatureStore:
             ... )
             >>> registry_diff, infra_diff = fs.plan(RepoContents({driver_hourly_stats_view}, set(), set(), {driver}, set())) # register entity and feature view
         """
-
-        current_registry_proto = (
-            self._registry.cached_registry_proto.__deepcopy__()
-            if self._registry.cached_registry_proto
-            else RegistryProto()
-        )
-
-        desired_registry_proto = desired_repo_objects.to_registry_proto()
+        current_repo_contents = self._registry.to_repo_contents(project=self.project)
         registry_diff = Registry.diff_between(
-            current_registry_proto, desired_registry_proto
+            current_repo_contents, desired_repo_contents
         )
 
         current_infra_proto = (
@@ -470,6 +436,7 @@ class FeatureStore:
             if self._registry.cached_registry_proto
             else InfraProto()
         )
+        desired_registry_proto = desired_repo_contents.to_registry_proto()
         new_infra_proto = self._provider.plan_infra(
             self.config, desired_registry_proto
         ).to_proto()
@@ -554,11 +521,7 @@ class FeatureStore:
         if not objects_to_delete:
             objects_to_delete = []
 
-        current_registry_proto = (
-            self._registry.cached_registry_proto.__deepcopy__()
-            if self._registry.cached_registry_proto
-            else RegistryProto()
-        )
+        current_repo_contents = self._registry.to_repo_contents(project=self.project)
 
         # Separate all objects into entities, feature services, and different feature view types.
         entities_to_update = [ob for ob in objects if isinstance(ob, Entity)]
@@ -657,22 +620,6 @@ class FeatureStore:
                     service.name, project=self.project, commit=False
                 )
 
-        new_registry_proto = (
-            self._registry.cached_registry_proto
-            if self._registry.cached_registry_proto
-            else RegistryProto()
-        )
-
-        diffs = Registry.diff_between(current_registry_proto, new_registry_proto)
-
-        entities_to_update = [ob for ob in objects if isinstance(ob, Entity)]
-        views_to_update = [ob for ob in objects if isinstance(ob, FeatureView)]
-
-        entities_to_delete = [ob for ob in objects_to_delete if isinstance(ob, Entity)]
-        views_to_delete = [
-            ob for ob in objects_to_delete if isinstance(ob, FeatureView)
-        ]
-
         self._get_provider().update_infra(
             project=self.project,
             tables_to_delete=views_to_delete if not partial else [],
@@ -684,7 +631,8 @@ class FeatureStore:
 
         self._registry.commit()
 
-        return diffs
+        new_repo_contents = self._registry.to_repo_contents(project=self.project)
+        return Registry.diff_between(current_repo_contents, new_repo_contents)
 
     @log_exceptions_and_usage
     def teardown(self):

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -122,6 +122,7 @@ class FeatureStore:
 
         registry_config = self.config.get_registry_config()
         self._registry = Registry(registry_config, repo_path=self.repo_path)
+        self._registry._initialize_registry()
         self._provider = get_provider(self.config, self.repo_path)
 
     @log_exceptions

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -122,7 +122,6 @@ class FeatureStore:
 
         registry_config = self.config.get_registry_config()
         self._registry = Registry(registry_config, repo_path=self.repo_path)
-        self._registry._initialize_registry()
         self._provider = get_provider(self.config, self.repo_path)
 
     @log_exceptions

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -39,7 +39,7 @@ from tqdm import tqdm
 
 from feast import feature_server, flags, flags_helper, utils
 from feast.base_feature_view import BaseFeatureView
-from feast.diff.FcoDiff import RegistryDiff
+from feast.diff.FcoDiff import RegistryDiff, diff_between
 from feast.diff.infra_diff import InfraDiff, diff_infra_protos
 from feast.entity import Entity
 from feast.errors import (
@@ -73,8 +73,9 @@ from feast.protos.feast.serving.ServingService_pb2 import (
 )
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import RepeatedValue, Value
-from feast.registry import Registry, RepoContents
+from feast.registry import Registry
 from feast.repo_config import RepoConfig, load_repo_config
+from feast.repo_contents import RepoContents
 from feast.request_feature_view import RequestFeatureView
 from feast.type_map import python_values_to_proto_values
 from feast.usage import log_exceptions, log_exceptions_and_usage, set_usage_attribute
@@ -426,7 +427,9 @@ class FeatureStore:
             ... )
             >>> registry_diff, infra_diff = fs.plan(RepoContents({driver_hourly_stats_view}, set(), set(), {driver}, set())) # register entity and feature view
         """
-        registry_diff = self._registry.diff_between(self.project, desired_repo_contents)
+        registry_diff = diff_between(
+            self._registry, self.project, desired_repo_contents
+        )
 
         current_infra_proto = (
             self._registry.cached_registry_proto.infra.__deepcopy__()

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -84,6 +84,7 @@ class RepoContents(NamedTuple):
 
     Equivalently, represents the contents of a registry corresponding to a specific Feas project.
     """
+
     feature_views: Set[FeatureView]
     on_demand_feature_views: Set[OnDemandFeatureView]
     request_feature_views: Set[RequestFeatureView]

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -142,6 +142,8 @@ class Registry:
                 else 0
             )
 
+            self._initialize_registry()
+
     def clone(self) -> "Registry":
         new_registry = Registry(None, None)
         new_registry.cached_registry_proto_ttl = timedelta(seconds=0)

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -134,8 +134,6 @@ class Registry:
                 else 0
             )
 
-            self._initialize_registry()
-
     def clone(self) -> "Registry":
         new_registry = Registry(None, None)
         new_registry.cached_registry_proto_ttl = timedelta(seconds=0)

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -79,6 +79,11 @@ logger = logging.getLogger(__name__)
 
 
 class RepoContents(NamedTuple):
+    """
+    Represents the objects in a Feast feature repo.
+
+    Equivalently, represents the contents of a registry corresponding to a specific Feas project.
+    """
     feature_views: Set[FeatureView]
     on_demand_feature_views: Set[OnDemandFeatureView]
     request_feature_views: Set[RequestFeatureView]

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -102,42 +102,6 @@ class RepoContents(NamedTuple):
         )
         return registry_proto
 
-    @classmethod
-    def from_registry_proto(cls, project: str, registry_proto: RegistryProto):
-        repo_contents = cls(
-            entities=set(),
-            feature_views=set(),
-            feature_services=set(),
-            on_demand_feature_views=set(),
-            request_feature_views=set(),
-        )
-
-        for feature_view_proto in registry_proto.feature_views:
-            if feature_view_proto.spec.project == project:
-                repo_contents.feature_views.add(
-                    FeatureView.from_proto(feature_view_proto)
-                )
-        for on_demand_feature_view_proto in registry_proto.on_demand_feature_views:
-            if on_demand_feature_view_proto.spec.project == project:
-                repo_contents.on_demand_feature_views.add(
-                    OnDemandFeatureView.from_proto(on_demand_feature_view_proto)
-                )
-        for request_feature_view_proto in registry_proto.request_feature_views:
-            if request_feature_view_proto.spec.project == project:
-                repo_contents.request_feature_views.add(
-                    RequestFeatureView.from_proto(request_feature_view_proto)
-                )
-        for entity_proto in registry_proto.entities:
-            if entity_proto.spec.project == project:
-                repo_contents.entities.add(Entity.from_proto(entity_proto))
-        for feature_service_proto in registry_proto.feature_services:
-            if feature_service_proto.spec.project == project:
-                repo_contents.feature_services.add(
-                    FeatureService.from_proto(feature_service_proto)
-                )
-
-        return repo_contents
-
 
 def extract_objects_for_keep_delete_update_add(
     current_repo_contents: RepoContents, new_repo_contents: RepoContents

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -14,6 +14,7 @@
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
+from enum import Enum
 from pathlib import Path
 from threading import Lock
 from typing import Any, Dict, List, Optional
@@ -58,15 +59,14 @@ REGISTRY_STORE_CLASS_FOR_SCHEME = {
     "": "LocalRegistryStore",
 }
 
-REGISTRY_OBJECT_TYPE_TO_STR = {
-    "entities": "entity",
-    "feature_views": "feature view",
-    "on_demand_feature_views": "on demand feature view",
-    "request_feature_views": "request feature view",
-    "feature_services": "feature service",
-}
 
-REGISTRY_OBJECT_TYPES = REGISTRY_OBJECT_TYPE_TO_STR.keys()
+class FeastObjectType(Enum):
+    ENTITY = 0
+    FEATURE_VIEW = 1
+    ON_DEMAND_FEATURE_VIEW = 2
+    REQUEST_FEATURE_VIEW = 3
+    FEATURE_SERVICE = 4
+
 
 logger = logging.getLogger(__name__)
 

--- a/sdk/python/feast/repo_contents.py
+++ b/sdk/python/feast/repo_contents.py
@@ -1,0 +1,50 @@
+# Copyright 2022 The Feast Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import NamedTuple, Set
+
+from feast.entity import Entity
+from feast.feature_service import FeatureService
+from feast.feature_view import FeatureView
+from feast.on_demand_feature_view import OnDemandFeatureView
+from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
+from feast.request_feature_view import RequestFeatureView
+
+
+class RepoContents(NamedTuple):
+    """
+    Represents the objects in a Feast feature repo.
+    """
+
+    feature_views: Set[FeatureView]
+    on_demand_feature_views: Set[OnDemandFeatureView]
+    request_feature_views: Set[RequestFeatureView]
+    entities: Set[Entity]
+    feature_services: Set[FeatureService]
+
+    def to_registry_proto(self) -> RegistryProto:
+        registry_proto = RegistryProto()
+        registry_proto.entities.extend([e.to_proto() for e in self.entities])
+        registry_proto.feature_views.extend(
+            [fv.to_proto() for fv in self.feature_views]
+        )
+        registry_proto.on_demand_feature_views.extend(
+            [fv.to_proto() for fv in self.on_demand_feature_views]
+        )
+        registry_proto.request_feature_views.extend(
+            [fv.to_proto() for fv in self.request_feature_views]
+        )
+        registry_proto.feature_services.extend(
+            [fs.to_proto() for fs in self.feature_services]
+        )
+        return registry_proto

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -156,6 +156,7 @@ def _prepare_registry_and_repo(repo_config, repo_path):
         )
         sys.exit(1)
     registry = store.registry
+    registry._initialize_registry()
     sys.dont_write_bytecode = True
     repo = parse_repo(repo_path)
     return project, registry, repo, store

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -6,20 +6,24 @@ import re
 import sys
 from importlib.abc import Loader
 from pathlib import Path
-from typing import List, Set, Union, cast
+from typing import List, Set, Union
 
 import click
 from click.exceptions import BadParameter
 
-from feast.base_feature_view import BaseFeatureView
-from feast.diff.FcoDiff import TransitionType, tag_objects_for_keep_delete_add
+from feast.diff.FcoDiff import TransitionType
 from feast.entity import Entity
 from feast.feature_service import FeatureService
-from feast.feature_store import FeatureStore, RepoContents
+from feast.feature_store import FeatureStore
 from feast.feature_view import DUMMY_ENTITY, DUMMY_ENTITY_NAME, FeatureView
 from feast.names import adjectives, animals
 from feast.on_demand_feature_view import OnDemandFeatureView
-from feast.registry import Registry
+from feast.registry import (
+    REGISTRY_OBJECT_TYPES,
+    Registry,
+    RepoContents,
+    extract_objects_for_keep_delete_update_add,
+)
 from feast.repo_config import RepoConfig
 from feast.request_feature_view import RequestFeatureView
 from feast.usage import log_exceptions_and_usage
@@ -160,81 +164,38 @@ def _prepare_registry_and_repo(repo_config, repo_path):
 
 
 def extract_objects_for_apply_delete(project, registry, repo):
-    (
-        entities_to_keep,
-        entities_to_delete,
-        entities_to_add,
-    ) = tag_objects_for_keep_delete_add(
-        set(registry.list_entities(project=project)), repo.entities
-    )
     # TODO(achals): This code path should be refactored to handle added & kept entities separately.
-    entities_to_keep = set(entities_to_keep).union(entities_to_add)
-    views = tag_objects_for_keep_delete_add(
-        set(registry.list_feature_views(project=project)), repo.feature_views
-    )
-    views_to_keep, views_to_delete, views_to_add = (
-        cast(Set[FeatureView], views[0]),
-        cast(Set[FeatureView], views[1]),
-        cast(Set[FeatureView], views[2]),
-    )
-    request_views = tag_objects_for_keep_delete_add(
-        set(registry.list_request_feature_views(project=project)),
-        repo.request_feature_views,
-    )
-    request_views_to_keep: Set[RequestFeatureView]
-    request_views_to_delete: Set[RequestFeatureView]
-    request_views_to_add: Set[RequestFeatureView]
-    request_views_to_keep, request_views_to_delete, request_views_to_add = (
-        cast(Set[RequestFeatureView], request_views[0]),
-        cast(Set[RequestFeatureView], request_views[1]),
-        cast(Set[RequestFeatureView], request_views[2]),
-    )
-    base_views_to_keep: Set[Union[RequestFeatureView, FeatureView]] = {
-        *views_to_keep,
-        *views_to_add,
-        *request_views_to_keep,
-        *request_views_to_add,
-    }
-    base_views_to_delete: Set[Union[RequestFeatureView, FeatureView]] = {
-        *views_to_delete,
-        *request_views_to_delete,
-    }
-    odfvs = tag_objects_for_keep_delete_add(
-        set(registry.list_on_demand_feature_views(project=project)),
-        repo.on_demand_feature_views,
-    )
-    odfvs_to_keep, odfvs_to_delete, odfvs_to_add = (
-        cast(Set[OnDemandFeatureView], odfvs[0]),
-        cast(Set[OnDemandFeatureView], odfvs[1]),
-        cast(Set[OnDemandFeatureView], odfvs[2]),
-    )
-    odfvs_to_keep = odfvs_to_keep.union(odfvs_to_add)
+    current_repo_contents = registry.to_repo_contents(project=project)
     (
-        services_to_keep,
-        services_to_delete,
-        services_to_add,
-    ) = tag_objects_for_keep_delete_add(
-        set(registry.list_feature_services(project=project)), repo.feature_services
-    )
-    services_to_keep = services_to_keep.union(services_to_add)
-    sys.dont_write_bytecode = False
-    # Apply all changes to the registry and infrastructure.
-    all_to_apply: List[
-        Union[Entity, BaseFeatureView, FeatureService, OnDemandFeatureView]
-    ] = []
-    all_to_apply.extend(entities_to_keep)
-    all_to_apply.extend(base_views_to_keep)
-    all_to_apply.extend(services_to_keep)
-    all_to_apply.extend(odfvs_to_keep)
-    all_to_delete: List[
-        Union[Entity, BaseFeatureView, FeatureService, OnDemandFeatureView]
-    ] = []
-    all_to_delete.extend(entities_to_delete)
-    all_to_delete.extend(base_views_to_delete)
-    all_to_delete.extend(services_to_delete)
-    all_to_delete.extend(odfvs_to_delete)
+        _,
+        objs_to_delete,
+        objs_to_update,
+        objs_to_add,
+    ) = extract_objects_for_keep_delete_update_add(current_repo_contents, repo)
 
-    return all_to_apply, all_to_delete, views_to_delete, views_to_keep
+    all_to_apply: List[
+        Union[
+            Entity, FeatureView, RequestFeatureView, OnDemandFeatureView, FeatureService
+        ]
+    ] = []
+    for object_type in REGISTRY_OBJECT_TYPES:
+        to_apply = set(objs_to_add[object_type]).union(objs_to_update[object_type])
+        all_to_apply.extend(to_apply)
+
+    all_to_delete: List[
+        Union[
+            Entity, FeatureView, RequestFeatureView, OnDemandFeatureView, FeatureService
+        ]
+    ] = []
+    for object_type in REGISTRY_OBJECT_TYPES:
+        all_to_delete.extend(objs_to_delete[object_type])
+
+    return (
+        all_to_apply,
+        all_to_delete,
+        set(objs_to_add["feature_views"].union(objs_to_update["feature_views"])),
+        objs_to_delete["feature_views"],
+    )
 
 
 def apply_total_with_repo_instance(

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -12,16 +12,17 @@ import click
 from click.exceptions import BadParameter
 
 from feast.diff.FcoDiff import (
-    TransitionType,
+    FEAST_OBJECT_TYPES,
     extract_objects_for_keep_delete_update_add,
 )
+from feast.diff.property_diff import TransitionType
 from feast.entity import Entity
 from feast.feature_service import FeatureService
 from feast.feature_store import FeatureStore
 from feast.feature_view import DUMMY_ENTITY, DUMMY_ENTITY_NAME, FeatureView
 from feast.names import adjectives, animals
 from feast.on_demand_feature_view import OnDemandFeatureView
-from feast.registry import REGISTRY_OBJECT_TYPES, Registry
+from feast.registry import FeastObjectType, Registry
 from feast.repo_config import RepoConfig
 from feast.repo_contents import RepoContents
 from feast.request_feature_view import RequestFeatureView
@@ -176,7 +177,7 @@ def extract_objects_for_apply_delete(project, registry, repo):
             Entity, FeatureView, RequestFeatureView, OnDemandFeatureView, FeatureService
         ]
     ] = []
-    for object_type in REGISTRY_OBJECT_TYPES:
+    for object_type in FEAST_OBJECT_TYPES:
         to_apply = set(objs_to_add[object_type]).union(objs_to_update[object_type])
         all_to_apply.extend(to_apply)
 
@@ -185,14 +186,18 @@ def extract_objects_for_apply_delete(project, registry, repo):
             Entity, FeatureView, RequestFeatureView, OnDemandFeatureView, FeatureService
         ]
     ] = []
-    for object_type in REGISTRY_OBJECT_TYPES:
+    for object_type in FEAST_OBJECT_TYPES:
         all_to_delete.extend(objs_to_delete[object_type])
 
     return (
         all_to_apply,
         all_to_delete,
-        set(objs_to_add["feature_views"].union(objs_to_update["feature_views"])),
-        objs_to_delete["feature_views"],
+        set(
+            objs_to_add[FeastObjectType.FEATURE_VIEW].union(
+                objs_to_update[FeastObjectType.FEATURE_VIEW]
+            )
+        ),
+        objs_to_delete[FeastObjectType.FEATURE_VIEW],
     )
 
 

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -11,7 +11,10 @@ from typing import List, Set, Union
 import click
 from click.exceptions import BadParameter
 
-from feast.diff.FcoDiff import TransitionType
+from feast.diff.FcoDiff import (
+    TransitionType,
+    extract_objects_for_keep_delete_update_add,
+)
 from feast.entity import Entity
 from feast.feature_service import FeatureService
 from feast.feature_store import FeatureStore
@@ -165,7 +168,7 @@ def extract_objects_for_apply_delete(project, registry, repo):
         objs_to_delete,
         objs_to_update,
         objs_to_add,
-    ) = registry.extract_objects_for_keep_delete_update_add(project, repo)
+    ) = extract_objects_for_keep_delete_update_add(registry, project, repo)
 
     all_to_apply: List[
         Union[

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -153,7 +153,6 @@ def _prepare_registry_and_repo(repo_config, repo_path):
         )
         sys.exit(1)
     registry = store.registry
-    registry._initialize_registry()
     sys.dont_write_bytecode = True
     repo = parse_repo(repo_path)
     return project, registry, repo, store

--- a/sdk/python/tests/integration/e2e/test_usage_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_usage_e2e.py
@@ -66,10 +66,16 @@ def test_usage_on(dummy_exporter, enabling_toggle):
 
         test_feature_store.apply([entity])
 
-        assert len(dummy_exporter) == 1
+        assert len(dummy_exporter) == 3
+        assert {
+            "entrypoint": "feast.infra.local.LocalRegistryStore.get_registry_proto"
+        }.items() <= dummy_exporter[0].items()
+        assert {
+            "entrypoint": "feast.infra.local.LocalRegistryStore.update_registry_proto"
+        }.items() <= dummy_exporter[1].items()
         assert {
             "entrypoint": "feast.feature_store.FeatureStore.apply"
-        }.items() <= dummy_exporter[0].items()
+        }.items() <= dummy_exporter[2].items()
 
 
 @pytest.mark.integration

--- a/sdk/python/tests/integration/e2e/test_usage_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_usage_e2e.py
@@ -66,16 +66,10 @@ def test_usage_on(dummy_exporter, enabling_toggle):
 
         test_feature_store.apply([entity])
 
-        assert len(dummy_exporter) == 3
-        assert {
-            "entrypoint": "feast.infra.local.LocalRegistryStore.get_registry_proto"
-        }.items() <= dummy_exporter[0].items()
-        assert {
-            "entrypoint": "feast.infra.local.LocalRegistryStore.update_registry_proto"
-        }.items() <= dummy_exporter[1].items()
+        assert len(dummy_exporter) == 1
         assert {
             "entrypoint": "feast.feature_store.FeatureStore.apply"
-        }.items() <= dummy_exporter[2].items()
+        }.items() <= dummy_exporter[0].items()
 
 
 @pytest.mark.integration

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -12,10 +12,11 @@ from typing import Any, Dict, List, Optional
 import pandas as pd
 import yaml
 
-from feast import FeatureStore, FeatureView, RepoConfig, driver_test_data
+from feast import FeatureStore, FeatureView, driver_test_data
 from feast.constants import FULL_REPO_CONFIGS_MODULE_ENV_NAME
 from feast.data_source import DataSource
 from feast.errors import FeastModuleImportError
+from feast.repo_config import RepoConfig, RegistryConfig
 from tests.integration.feature_repos.integration_test_repo_config import (
     IntegrationTestRepoConfig,
 )
@@ -286,7 +287,10 @@ def construct_test_environment(
     else:
         # Note: even if it's a local feature server, the repo config does not have this configured
         feature_server = None
-        registry = str(Path(repo_dir_name) / "registry.db")
+        registry = RegistryConfig(
+            path=str(Path(repo_dir_name) / "registry.db"),
+            cache_ttl_seconds=1,
+        )
 
     config = RepoConfig(
         registry=registry,

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -16,7 +16,7 @@ from feast import FeatureStore, FeatureView, driver_test_data
 from feast.constants import FULL_REPO_CONFIGS_MODULE_ENV_NAME
 from feast.data_source import DataSource
 from feast.errors import FeastModuleImportError
-from feast.repo_config import RepoConfig, RegistryConfig
+from feast.repo_config import RegistryConfig, RepoConfig
 from tests.integration.feature_repos.integration_test_repo_config import (
     IntegrationTestRepoConfig,
 )
@@ -288,8 +288,7 @@ def construct_test_environment(
         # Note: even if it's a local feature server, the repo config does not have this configured
         feature_server = None
         registry = RegistryConfig(
-            path=str(Path(repo_dir_name) / "registry.db"),
-            cache_ttl_seconds=1,
+            path=str(Path(repo_dir_name) / "registry.db"), cache_ttl_seconds=1,
         )
 
     config = RepoConfig(

--- a/sdk/python/tests/unit/diff/test_fco_diff.py
+++ b/sdk/python/tests/unit/diff/test_fco_diff.py
@@ -1,4 +1,8 @@
-from feast.diff.FcoDiff import diff_between, tag_proto_objects_for_keep_delete_add
+from feast.diff.FcoDiff import (
+    diff_between,
+    tag_objects_for_keep_delete_update_add,
+    tag_proto_objects_for_keep_delete_add,
+)
 from feast.feature_view import FeatureView
 from tests.utils.data_source_utils import prep_file_source
 
@@ -41,6 +45,52 @@ def test_tag_proto_objects_for_keep_delete_add(simple_dataset_1):
         assert pre_changed not in keep
         assert len(list(delete)) == 1
         assert to_delete in delete
+        assert len(list(add)) == 1
+        assert to_add in add
+
+
+def test_tag_objects_for_keep_delete_update_add(simple_dataset_1):
+    with prep_file_source(
+        df=simple_dataset_1, event_timestamp_column="ts_1"
+    ) as file_source:
+        to_delete = FeatureView(
+            name="to_delete", entities=["id"], batch_source=file_source, ttl=None,
+        )
+        unchanged_fv = FeatureView(
+            name="fv1", entities=["id"], batch_source=file_source, ttl=None,
+        )
+        pre_changed = FeatureView(
+            name="fv2",
+            entities=["id"],
+            batch_source=file_source,
+            ttl=None,
+            tags={"when": "before"},
+        )
+        post_changed = FeatureView(
+            name="fv2",
+            entities=["id"],
+            batch_source=file_source,
+            ttl=None,
+            tags={"when": "after"},
+        )
+        to_add = FeatureView(
+            name="to_add", entities=["id"], batch_source=file_source, ttl=None,
+        )
+
+        keep, delete, update, add = tag_objects_for_keep_delete_update_add(
+            [unchanged_fv, pre_changed, to_delete], [unchanged_fv, post_changed, to_add]
+        )
+
+        assert len(list(keep)) == 2
+        assert unchanged_fv in keep
+        assert pre_changed in keep
+        assert post_changed not in keep
+        assert len(list(delete)) == 1
+        assert to_delete in delete
+        assert len(list(update)) == 2
+        assert unchanged_fv in update
+        assert post_changed in update
+        assert pre_changed not in update
         assert len(list(add)) == 1
         assert to_add in add
 

--- a/sdk/python/tests/unit/diff/test_fco_diff.py
+++ b/sdk/python/tests/unit/diff/test_fco_diff.py
@@ -1,5 +1,5 @@
 from feast.diff.FcoDiff import (
-    diff_between,
+    diff_registry_objects,
     tag_objects_for_keep_delete_update_add,
     tag_proto_objects_for_keep_delete_add,
 )
@@ -95,7 +95,7 @@ def test_tag_objects_for_keep_delete_update_add(simple_dataset_1):
         assert to_add in add
 
 
-def test_diff_between_feature_views(simple_dataset_1):
+def test_diff_registry_objects_feature_views(simple_dataset_1):
     with prep_file_source(
         df=simple_dataset_1, event_timestamp_column="ts_1"
     ) as file_source:
@@ -114,10 +114,10 @@ def test_diff_between_feature_views(simple_dataset_1):
             tags={"when": "after"},
         )
 
-        fco_diffs = diff_between(pre_changed, pre_changed, "feature view")
+        fco_diffs = diff_registry_objects(pre_changed, pre_changed, "feature view")
         assert len(fco_diffs.fco_property_diffs) == 0
 
-        fco_diffs = diff_between(pre_changed, post_changed, "feature view")
+        fco_diffs = diff_registry_objects(pre_changed, post_changed, "feature view")
         assert len(fco_diffs.fco_property_diffs) == 1
 
         assert fco_diffs.fco_property_diffs[0].property_name == "tags"

--- a/sdk/python/tests/unit/diff/test_fco_diff.py
+++ b/sdk/python/tests/unit/diff/test_fco_diff.py
@@ -55,14 +55,14 @@ def test_diff_between_feature_views(simple_dataset_1):
             batch_source=file_source,
             ttl=None,
             tags={"when": "before"},
-        ).to_proto()
+        )
         post_changed = FeatureView(
             name="fv2",
             entities=["id"],
             batch_source=file_source,
             ttl=None,
             tags={"when": "after"},
-        ).to_proto()
+        )
 
         fco_diffs = diff_between(pre_changed, pre_changed, "feature view")
         assert len(fco_diffs.fco_property_diffs) == 0


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: This PR switches `Registry.diff_between` and other helper methods to compare registry objects as Python objects instead of proto objects.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
