### PR TITLE
Docker build fails for java feature server

### DIFF
--- a/java/infra/docker/feature-server/Dockerfile
+++ b/java/infra/docker/feature-server/Dockerfile
@@ -7,14 +7,14 @@ FROM maven:3.6-jdk-11 as builder
 WORKDIR /build
 
 COPY java/pom.xml .
-COPY java/datatypes/java/pom.xml datatypes/java/pom.xml
+COPY java/datatypes/pom.xml datatypes/pom.xml
 COPY java/common/pom.xml common/pom.xml
 COPY java/serving/pom.xml serving/pom.xml
 COPY java/storage/api/pom.xml storage/api/pom.xml
 COPY java/storage/connectors/pom.xml storage/connectors/pom.xml
 COPY java/storage/connectors/redis/pom.xml storage/connectors/redis/pom.xml
-COPY java/sdk/java/pom.xml sdk/java/pom.xml
-COPY java/docs/coverage/java/pom.xml docs/coverage/java/pom.xml
+COPY java/sdk/pom.xml sdk/pom.xml
+COPY java/docs/coverage/pom.xml docs/coverage/pom.xml
 
 # Setting Maven repository .m2 directory relative to /build folder gives the
 # user to optionally use cached repository when building the image by copying
@@ -24,7 +24,7 @@ COPY java/pom.xml .m2/* .m2/
 RUN mvn dependency:go-offline -DexcludeGroupIds:dev.feast 2>/dev/null || true
 
 COPY java/ .
-COPY protos/feast datatypes/java/src/main/proto/feast
+COPY protos/feast datatypes/src/main/proto/feast
 
 ARG VERSION=dev
 RUN mvn --also-make --projects serving -Drevision=$VERSION \


### PR DESCRIPTION
Signed-off-by: pyalex <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Fixes docker file for Java feature server.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
