### PR TITLE
Feature server helm chart produces invalid YAML

### DIFF
--- a/infra/charts/feast/charts/feature-server/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feature-server/templates/deployment.yaml
@@ -84,12 +84,11 @@ spec:
           value: {{ $value | quote }}
           {{- end }}
         {{- end }}
-
         command:
         - java
         - -jar
         - /opt/feast/feast-serving.jar
-        - {{- if index .Values "application.yaml" "enabled" -}}
+        - {{ if index .Values "application.yaml" "enabled" -}}
           classpath:/application.yml
           {{- end }}
           {{- if index .Values "application-generated.yaml" "enabled" -}}

--- a/infra/charts/feast/charts/feature-server/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feature-server/templates/deployment.yaml
@@ -84,6 +84,7 @@ spec:
           value: {{ $value | quote }}
           {{- end }}
         {{- end }}
+
         command:
         - java
         - -jar


### PR DESCRIPTION
Signed-off-by: pyalex <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Helm install fails on feature-server helm chart.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2232 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```
