### PR TITLE
Implement feature_store._apply_diffs to handle registry and infra diffs

### DIFF
--- a/sdk/python/feast/diff/FcoDiff.py
+++ b/sdk/python/feast/diff/FcoDiff.py
@@ -17,18 +17,8 @@ from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
 from feast.protos.feast.core.RequestFeatureView_pb2 import (
     RequestFeatureView as RequestFeatureViewProto,
 )
-from feast.registry import FeastObjectType, Registry
+from feast.registry import FEAST_OBJECT_TYPES, FeastObjectType, Registry
 from feast.repo_contents import RepoContents
-
-FEAST_OBJECT_TYPE_TO_STR = {
-    FeastObjectType.ENTITY: "entity",
-    FeastObjectType.FEATURE_VIEW: "feature view",
-    FeastObjectType.ON_DEMAND_FEATURE_VIEW: "on demand feature view",
-    FeastObjectType.REQUEST_FEATURE_VIEW: "request feature view",
-    FeastObjectType.FEATURE_SERVICE: "feature service",
-}
-
-FEAST_OBJECT_TYPES = FEAST_OBJECT_TYPE_TO_STR.keys()
 
 Fco = TypeVar("Fco", Entity, BaseFeatureView, FeatureService)
 
@@ -68,7 +58,7 @@ class RegistryDiff:
             if fco_diff.name == DUMMY_ENTITY_NAME:
                 continue
             action, color = message_action_map[fco_diff.transition_type]
-            log_string += f"{action} {FEAST_OBJECT_TYPE_TO_STR[fco_diff.fco_type]} {Style.BRIGHT + color}{fco_diff.name}{Style.RESET_ALL}\n"
+            log_string += f"{action} {fco_diff.fco_type.value} {Style.BRIGHT + color}{fco_diff.name}{Style.RESET_ALL}\n"
             if fco_diff.transition_type == TransitionType.UPDATE:
                 for _p in fco_diff.fco_property_diffs:
                     log_string += f"\t{_p.property_name}: {Style.BRIGHT + color}{_p.val_existing}{Style.RESET_ALL} -> {Style.BRIGHT + Fore.LIGHTGREEN_EX}{_p.val_declared}{Style.RESET_ALL}\n"

--- a/sdk/python/feast/diff/FcoDiff.py
+++ b/sdk/python/feast/diff/FcoDiff.py
@@ -160,30 +160,12 @@ def extract_objects_for_keep_delete_update_add(
     objs_to_update = {}
     objs_to_add = {}
 
-    registry_object_type_to_objects: Dict[FeastObjectType, List[Any]]
-    registry_object_type_to_objects = {
-        FeastObjectType.ENTITY: registry.list_entities(project=current_project),
-        FeastObjectType.FEATURE_VIEW: registry.list_feature_views(
-            project=current_project
-        ),
-        FeastObjectType.ON_DEMAND_FEATURE_VIEW: registry.list_on_demand_feature_views(
-            project=current_project
-        ),
-        FeastObjectType.REQUEST_FEATURE_VIEW: registry.list_request_feature_views(
-            project=current_project
-        ),
-        FeastObjectType.FEATURE_SERVICE: registry.list_feature_services(
-            project=current_project
-        ),
-    }
-    registry_object_type_to_repo_contents: Dict[FeastObjectType, Set[Any]]
-    registry_object_type_to_repo_contents = {
-        FeastObjectType.ENTITY: desired_repo_contents.entities,
-        FeastObjectType.FEATURE_VIEW: desired_repo_contents.feature_views,
-        FeastObjectType.ON_DEMAND_FEATURE_VIEW: desired_repo_contents.on_demand_feature_views,
-        FeastObjectType.REQUEST_FEATURE_VIEW: desired_repo_contents.request_feature_views,
-        FeastObjectType.FEATURE_SERVICE: desired_repo_contents.feature_services,
-    }
+    registry_object_type_to_objects: Dict[
+        FeastObjectType, List[Any]
+    ] = FeastObjectType.get_objects_from_registry(registry, current_project)
+    registry_object_type_to_repo_contents: Dict[
+        FeastObjectType, Set[Any]
+    ] = FeastObjectType.get_objects_from_repo_contents(desired_repo_contents)
 
     for object_type in FEAST_OBJECT_TYPES:
         (

--- a/sdk/python/feast/diff/FcoDiff.py
+++ b/sdk/python/feast/diff/FcoDiff.py
@@ -260,10 +260,10 @@ def apply_diff_to_registry(
         # will automatically delete the existing FCO.
         if fco_diff.transition_type == TransitionType.DELETE:
             if fco_diff.fco_type == FeastObjectType.ENTITY:
-                registry.delete_entity(fco_diff.current_fco.name, project, False)
+                registry.delete_entity(fco_diff.current_fco.name, project, commit=False)
             elif fco_diff.fco_type == FeastObjectType.FEATURE_SERVICE:
                 registry.delete_feature_service(
-                    fco_diff.current_fco.name, project, False
+                    fco_diff.current_fco.name, project, commit=False
                 )
             elif fco_diff.fco_type in [
                 FeastObjectType.FEATURE_VIEW,
@@ -271,7 +271,7 @@ def apply_diff_to_registry(
                 FeastObjectType.REQUEST_FEATURE_VIEW,
             ]:
                 registry.delete_feature_view(
-                    fco_diff.current_fco.name, project, False,
+                    fco_diff.current_fco.name, project, commit=False,
                 )
 
         if fco_diff.transition_type in [
@@ -279,15 +279,15 @@ def apply_diff_to_registry(
             TransitionType.UPDATE,
         ]:
             if fco_diff.fco_type == FeastObjectType.ENTITY:
-                registry.apply_entity(fco_diff.new_fco, project, False)
+                registry.apply_entity(fco_diff.new_fco, project, commit=False)
             elif fco_diff.fco_type == FeastObjectType.FEATURE_SERVICE:
-                registry.apply_feature_service(fco_diff.new_fco, project, False)
+                registry.apply_feature_service(fco_diff.new_fco, project, commit=False)
             elif fco_diff.fco_type in [
                 FeastObjectType.FEATURE_VIEW,
                 FeastObjectType.ON_DEMAND_FEATURE_VIEW,
                 FeastObjectType.REQUEST_FEATURE_VIEW,
             ]:
-                registry.apply_feature_view(fco_diff.new_fco, project, False)
+                registry.apply_feature_view(fco_diff.new_fco, project, commit=False)
 
     if commit:
         registry.commit()

--- a/sdk/python/feast/diff/infra_diff.py
+++ b/sdk/python/feast/diff/infra_diff.py
@@ -60,7 +60,24 @@ class InfraDiff:
                 infra_object.update()
 
     def to_string(self):
-        pass
+        from colorama import Fore, Style
+
+        log_string = ""
+
+        message_action_map = {
+            TransitionType.CREATE: ("Created", Fore.GREEN),
+            TransitionType.DELETE: ("Deleted", Fore.RED),
+            TransitionType.UNCHANGED: ("Unchanged", Fore.LIGHTBLUE_EX),
+            TransitionType.UPDATE: ("Updated", Fore.YELLOW),
+        }
+        for infra_object_diff in self.infra_object_diffs:
+            action, color = message_action_map[infra_object_diff.transition_type]
+            log_string += f"{action} {infra_object_diff.infra_object_type} {Style.BRIGHT + color}{infra_object_diff.name}{Style.RESET_ALL}\n"
+            if infra_object_diff.transition_type == TransitionType.UPDATE:
+                for _p in infra_object_diff.infra_object_property_diffs:
+                    log_string += f"\t{_p.property_name}: {Style.BRIGHT + color}{_p.val_existing}{Style.RESET_ALL} -> {Style.BRIGHT + Fore.LIGHTGREEN_EX}{_p.val_declared}{Style.RESET_ALL}\n"
+
+        return log_string
 
 
 def tag_infra_proto_objects_for_keep_delete_add(

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -533,6 +533,7 @@ class FeatureStore:
             in [TransitionType.CREATE, TransitionType.UPDATE]
         ]
 
+        # TODO(felixwang9817): move validation logic into _plan.
         # Validate all feature views and make inferences.
         self._validate_all_feature_views(
             views_to_update, odfvs_to_update, request_views_to_update

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
 from threading import Lock
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 from urllib.parse import urlparse
 
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
@@ -42,6 +42,7 @@ from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.registry_store import NoopRegistryStore
 from feast.repo_config import RegistryConfig
+from feast.repo_contents import RepoContents
 from feast.request_feature_view import RequestFeatureView
 from feast.saved_dataset import SavedDataset
 
@@ -68,6 +69,36 @@ class FeastObjectType(Enum):
     ON_DEMAND_FEATURE_VIEW = "on demand feature view"
     REQUEST_FEATURE_VIEW = "request feature view"
     FEATURE_SERVICE = "feature service"
+
+    @staticmethod
+    def get_objects_from_registry(
+        registry: "Registry", project: str
+    ) -> Dict["FeastObjectType", List[Any]]:
+        return {
+            FeastObjectType.ENTITY: registry.list_entities(project=project),
+            FeastObjectType.FEATURE_VIEW: registry.list_feature_views(project=project),
+            FeastObjectType.ON_DEMAND_FEATURE_VIEW: registry.list_on_demand_feature_views(
+                project=project
+            ),
+            FeastObjectType.REQUEST_FEATURE_VIEW: registry.list_request_feature_views(
+                project=project
+            ),
+            FeastObjectType.FEATURE_SERVICE: registry.list_feature_services(
+                project=project
+            ),
+        }
+
+    @staticmethod
+    def get_objects_from_repo_contents(
+        repo_contents: RepoContents,
+    ) -> Dict["FeastObjectType", Set[Any]]:
+        return {
+            FeastObjectType.ENTITY: repo_contents.entities,
+            FeastObjectType.FEATURE_VIEW: repo_contents.feature_views,
+            FeastObjectType.ON_DEMAND_FEATURE_VIEW: repo_contents.on_demand_feature_views,
+            FeastObjectType.REQUEST_FEATURE_VIEW: repo_contents.request_feature_views,
+            FeastObjectType.FEATURE_SERVICE: repo_contents.feature_services,
+        }
 
 
 FEAST_OBJECT_TYPES = [feast_object_type for feast_object_type in FeastObjectType]

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -63,11 +63,14 @@ REGISTRY_STORE_CLASS_FOR_SCHEME = {
 
 
 class FeastObjectType(Enum):
-    ENTITY = 0
-    FEATURE_VIEW = 1
-    ON_DEMAND_FEATURE_VIEW = 2
-    REQUEST_FEATURE_VIEW = 3
-    FEATURE_SERVICE = 4
+    ENTITY = "entity"
+    FEATURE_VIEW = "feature view"
+    ON_DEMAND_FEATURE_VIEW = "on demand feature view"
+    REQUEST_FEATURE_VIEW = "request feature view"
+    FEATURE_SERVICE = "feature service"
+
+
+FEAST_OBJECT_TYPES = [feast_object_type for feast_object_type in FeastObjectType]
 
 
 logger = logging.getLogger(__name__)

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -12,17 +12,14 @@ from typing import List, Set, Union
 import click
 from click.exceptions import BadParameter
 
-from feast.diff.FcoDiff import (
-    FEAST_OBJECT_TYPES,
-    extract_objects_for_keep_delete_update_add,
-)
+from feast.diff.FcoDiff import extract_objects_for_keep_delete_update_add
 from feast.entity import Entity
 from feast.feature_service import FeatureService
 from feast.feature_store import FeatureStore
 from feast.feature_view import DUMMY_ENTITY, FeatureView
 from feast.names import adjectives, animals
 from feast.on_demand_feature_view import OnDemandFeatureView
-from feast.registry import FeastObjectType, Registry
+from feast.registry import FEAST_OBJECT_TYPES, FeastObjectType, Registry
 from feast.repo_config import RepoConfig
 from feast.repo_contents import RepoContents
 from feast.request_feature_view import RequestFeatureView


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: This PR modifies `FeatureStore` to execute `feast apply` logic by applying the appropriate `RegistryDiff` and `InfraDiff` generated from `FeatureStore._plan`. Right now, this logic is only activated for the local provider.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
feast plan works:
$ feast plan
Unchanged entity driver_id
Unchanged feature view driver_hourly_stats

Unchanged sqlite table adjusted_raven_driver_hourly_stats
```
