### PR TITLE
Fix Redshift data creator

### DIFF
--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -243,6 +243,13 @@ class RedshiftQueryError(Exception):
         super().__init__(f"Redshift SQL Query failed to finish. Details: {details}")
 
 
+class RedshiftTableNameTooLong(Exception):
+    def __init__(self, table_name: str):
+        super().__init__(
+            f"Redshift table names have a maximum length of 127 characters, but the table name {table_name} has length {len(table_name)} characters."
+        )
+
+
 class EntityTimestampInferenceException(Exception):
     def __init__(self, expected_column_name: str):
         super().__init__(

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -258,7 +258,7 @@ def construct_test_environment(
     worker_id: str = "worker_id",
 ) -> Environment:
 
-    _uuid = str(uuid.uuid4()).replace("-", "")[:8]
+    _uuid = str(uuid.uuid4()).replace("-", "")[:6]
 
     run_id = os.getenv("GITHUB_RUN_ID", default=None)
     run_id = f"gh_run_{run_id}_{_uuid}" if run_id else _uuid

--- a/sdk/python/tests/integration/registration/test_cli.py
+++ b/sdk/python/tests/integration/registration/test_cli.py
@@ -174,10 +174,10 @@ def test_nullable_online_store(test_nullable_online_store) -> None:
 
     with tempfile.TemporaryDirectory() as repo_dir_name:
         try:
-            feature_store_yaml = make_feature_store_yaml(
-                project, test_nullable_online_store, repo_dir_name
-            )
             repo_path = Path(repo_dir_name)
+            feature_store_yaml = make_feature_store_yaml(
+                project, test_nullable_online_store, repo_path
+            )
 
             repo_config = repo_path / "feature_store.yaml"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: This PR fixes the root cause of several recent failures with AWS integration tests on Github. The issue came from the `test_entity_inference_types_match` test in `test_universal_types.py`, and occurred since the data creator attempted to upload a table to Redshift with a table name of >127 characters. Since Redshift truncates table names to 127 characters, this ensured that subsequent attempts to reference the table would fail, causing the test to fail. Moreover, since PR tests include extra information in the table name, this bug was not reproducible through local testing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
