### PR TITLE
Return `UNIX_TIMESTAMP` as Python `datetime`

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Set, Sized, Tuple, Type, cast
 
 import numpy as np
@@ -49,8 +50,17 @@ def feast_value_type_to_python_type(field_value_proto: ProtoValue) -> Any:
     if val_attr is None:
         return None
     val = getattr(field_value_proto, val_attr)
+
+    # If it's a _LIST type extract the list.
     if hasattr(val, "val"):
         val = list(val.val)
+
+    # Convert UNIX_TIMESTAMP values to `datetime`
+    if val_attr == "unix_timestamp_list_val":
+        val = [datetime.fromtimestamp(v, tz=timezone.utc) for v in val]
+    elif val_attr == "unix_timestamp_val":
+        val = datetime.fromtimestamp(val, tz=timezone.utc)
+
     return val
 
 

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -271,15 +271,15 @@ def _python_datetime_to_int_timestamp(
         return cast(Sequence[np.int_], values.astype("datetime64[s]").astype(np.int_))
 
     int_timestamps = []
-    for sub_value in values:
-        if isinstance(sub_value, datetime):
-            int_timestamps.append(int(sub_value.timestamp()))
-        elif isinstance(sub_value, Timestamp):
-            int_timestamps.append(int(sub_value.ToSeconds()))
-        elif isinstance(sub_value, np.datetime64):
-            int_timestamps.append(sub_value.astype("datetime64[s]").astype(np.int_))
+    for value in values:
+        if isinstance(value, datetime):
+            int_timestamps.append(int(value.timestamp()))
+        elif isinstance(value, Timestamp):
+            int_timestamps.append(int(value.ToSeconds()))
+        elif isinstance(value, np.datetime64):
+            int_timestamps.append(value.astype("datetime64[s]").astype(np.int_))
         else:
-            int_timestamps.append(int(sub_value))
+            int_timestamps.append(int(value))
     return int_timestamps
 
 

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -234,7 +234,7 @@ def test_feature_get_online_features_types_match(online_types_test_fixtures):
         "float": float,
         "string": str,
         "bool": bool,
-        "datetime": int,
+        "datetime": datetime,
     }
     expected_dtype = feature_list_dtype_to_expected_online_response_value_type[
         config.feature_dtype


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Title is pretty self explanatory. However, it should also be noted that before this PR the `unix_timestamp_val` and `unix_timestamp_list_val` attributes of `Value` were never set. So there was a Proto type which was, as far as I can tell, stored incorrectly.

Because this fixes a bug in how `UNIX_TIMESTAMP` types are represented in the OnlineStore this change could result in a mix of Python types being returned for `UNIX_TIMESTAMP` features in existing OnlineStores.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Return `UNIX_TIMESTAMP` as Python `datetime`
```
