### PR TITLE
Use `datetime.utcnow()` to avoid timezone issues

### DIFF
--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -374,7 +374,7 @@ class Registry:
         """
         feature_view.ensure_valid()
         if not feature_view.created_timestamp:
-            feature_view.created_timestamp = datetime.now()
+            feature_view.created_timestamp = datetime.utcnow()
         feature_view_proto = feature_view.to_proto()
         feature_view_proto.spec.project = project
         self._prepare_registry_for_changes()
@@ -819,7 +819,7 @@ class Registry:
             registry_proto = RegistryProto()
             registry_proto.registry_schema_version = REGISTRY_SCHEMA_VERSION
             self.cached_registry_proto = registry_proto
-            self.cached_registry_proto_created = datetime.now()
+            self.cached_registry_proto_created = datetime.utcnow()
         return self.cached_registry_proto
 
     def _get_registry_proto(self, allow_cache: bool = False) -> RegistryProto:
@@ -838,7 +838,7 @@ class Registry:
                 self.cached_registry_proto_ttl.total_seconds()
                 > 0  # 0 ttl means infinity
                 and (
-                    datetime.now()
+                    datetime.utcnow()
                     > (
                         self.cached_registry_proto_created
                         + self.cached_registry_proto_ttl
@@ -852,7 +852,7 @@ class Registry:
 
             registry_proto = self._registry_store.get_registry_proto()
             self.cached_registry_proto = registry_proto
-            self.cached_registry_proto_created = datetime.now()
+            self.cached_registry_proto_created = datetime.utcnow()
 
             return registry_proto
 


### PR DESCRIPTION
Signed-off-by: Judah Rand <17158624+judahrand@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Use `datetime.now` has the potential for timezone issues, especially when persisting the data to the Registry. 

**Which issue(s) this PR fixes**:

Use `datetime.utcnow`instead.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
