### PR TITLE
Publish alternative python package with FEAST_USAGE=False by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,27 @@ jobs:
           python3 setup.py sdist bdist_wheel
           python3 -m twine upload --verbose dist/*
 
+  publish-python-sdk-no-telemetry:
+    runs-on: ubuntu-latest
+    env:
+      TWINE_USERNAME: __token__
+      TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    container: python:3.7
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install pip-tools
+        run: pip install pip-tools
+      - name: Install dependencies
+        run: make install-python-ci-dependencies PYTHON=3.7
+      - name: Publish Python Package
+        run: |
+          cd sdk/python
+          sed -i 's/DEFAULT_FEAST_USAGE_VALUE = "True"/DEFAULT_FEAST_USAGE_VALUE = "False"/g' feast/constants.py
+          sed -i 's/NAME = "feast"/NAME = "feast-no-telemetry"/g' setup.py
+          python3 -m pip install --user --upgrade setuptools wheel twine
+          python3 setup.py sdist bdist_wheel
+          python3 -m twine upload --verbose dist/*
+
   publish-java-sdk:
     container: maven:3.6-jdk-11
     runs-on: ubuntu-latest

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -29,6 +29,9 @@ REGISTRY_ENV_NAME: str = "REGISTRY_BASE64"
 # Environment variable for toggling usage
 FEAST_USAGE = "FEAST_USAGE"
 
+# Default value for FEAST_USAGE when environment variable is not set
+DEFAULT_FEAST_USAGE_VALUE = "True"
+
 # Environment variable for the path for overwriting universal test configs
 FULL_REPO_CONFIGS_MODULE_ENV_NAME: str = "FULL_REPO_CONFIGS_MODULE"
 

--- a/sdk/python/feast/usage.py
+++ b/sdk/python/feast/usage.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 import requests
 
-from feast.constants import FEAST_USAGE
+from feast.constants import DEFAULT_FEAST_USAGE_VALUE, FEAST_USAGE
 from feast.version import get_version
 
 USAGE_ENDPOINT = "https://usage.feast.dev"
@@ -37,7 +37,7 @@ USAGE_ENDPOINT = "https://usage.feast.dev"
 _logger = logging.getLogger(__name__)
 _executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
-_is_enabled = os.getenv(FEAST_USAGE, default="True") == "True"
+_is_enabled = os.getenv(FEAST_USAGE, default=DEFAULT_FEAST_USAGE_VALUE) == "True"
 
 _constant_attributes = {
     "session_id": str(uuid.uuid4()),


### PR DESCRIPTION
Signed-off-by: pyalex <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

There will be two python packages `feast` and `feast-no-telemetry`. The last one will have `FEAST_USAGE` set to False by default.
To minimize maintenance costs as much as possible I solved this issue on the last possible stage - GH workflow job.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2235 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
