### PR TITLE
Fix flaky tests (test_online_store_cleanup & test_feature_get_online_features_types_match)

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -300,9 +300,6 @@ def _python_value_to_proto_value(
     """
     # ToDo: make a better sample for type checks (more than one element)
     sample = next(filter(_non_empty_value, values), None)  # first not empty value
-    if sample is None:
-        # all input values are None or empty lists
-        return [ProtoValue()] * len(values)
 
     # Detect list type and handle separately
     if "list" in feast_value_type.name.lower():
@@ -312,7 +309,9 @@ def _python_value_to_proto_value(
                 feast_value_type
             ]
 
-            if not all(type(item) in valid_types for item in sample):
+            if sample is not None and not all(
+                type(item) in valid_types for item in sample
+            ):
                 first_invalid = next(
                     item for item in sample if type(item) not in valid_types
                 )
@@ -337,6 +336,10 @@ def _python_value_to_proto_value(
 
     # Handle scalar types below
     else:
+        if sample is None:
+            # all input values are None
+            return [ProtoValue()] * len(values)
+
         if feast_value_type == ValueType.UNIX_TIMESTAMP:
             int_timestamps = _python_datetime_to_int_timestamp(values)
             # ProtoValue does actually accept `np.int_` but the typing complains.

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -4,7 +4,7 @@ import os
 import re
 import tempfile
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
@@ -245,11 +245,8 @@ class Environment:
     python_feature_server: bool
     worker_id: str
 
-    end_date: datetime = field(
-        default=datetime.utcnow().replace(microsecond=0, second=0, minute=0)
-    )
-
     def __post_init__(self):
+        self.end_date = datetime.utcnow().replace(microsecond=0, second=0, minute=0)
         self.start_date: datetime = self.end_date - timedelta(days=3)
 
     def get_feature_server_endpoint(self) -> str:

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -4,19 +4,21 @@ import os
 import time
 import unittest
 from datetime import timedelta
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import assertpy
 import numpy as np
 import pandas as pd
 import pytest
 import requests
+from botocore.exceptions import BotoCoreError
 
 from feast import Entity, Feature, FeatureService, FeatureView, ValueType
 from feast.errors import (
     FeatureNameCollisionError,
     RequestDataNotFoundInEntityRowsException,
 )
+from feast.wait import wait_retry_backoff
 from tests.integration.feature_repos.repo_configuration import (
     Environment,
     construct_universal_feature_views,
@@ -569,8 +571,18 @@ def test_online_store_cleanup(environment, universal_data_sources):
     assert np.allclose(expected_values["value"], online_features["value"])
 
     fs.apply(objects=[], objects_to_delete=[simple_driver_fv], partial=False)
-    time.sleep(1)  # some online stores have eventual consistency of schema
-    fs.apply([simple_driver_fv])
+
+    def eventually_apply() -> Tuple[None, bool]:
+        try:
+            fs.apply([simple_driver_fv])
+        except BotoCoreError:
+            return None, False
+
+        return None, True
+
+    # Online store backend might have eventual consistency in schema update
+    # So recreating table that was just deleted might need some retries
+    wait_retry_backoff(eventually_apply, timeout_secs=60)
 
     online_features = fs.get_online_features(
         features=features, entity_rows=entity_rows

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -569,6 +569,7 @@ def test_online_store_cleanup(environment, universal_data_sources):
     assert np.allclose(expected_values["value"], online_features["value"])
 
     fs.apply(objects=[], objects_to_delete=[simple_driver_fv], partial=False)
+    time.sleep(1)  # some online stores have eventual consistency of schema
     fs.apply([simple_driver_fv])
 
     online_features = fs.get_online_features(

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -226,7 +226,9 @@ def test_feature_get_online_features_types_match(online_types_test_fixtures):
     driver_id_value = "1" if config.entity_type == ValueType.STRING else 1
     online_features = fs.get_online_features(
         features=features, entity_rows=[{"driver": driver_id_value}],
-    ).to_dict()
+    )
+    print(online_features.proto)  # will be in the logs when test fails
+    online_features = online_features.to_dict()
 
     feature_list_dtype_to_expected_online_response_value_type = {
         "int32": int,
@@ -241,7 +243,10 @@ def test_feature_get_online_features_types_match(online_types_test_fixtures):
     ]
     if config.feature_is_list:
         for feature in online_features["value"]:
-            assert isinstance(feature, list)
+            assert isinstance(feature, list), "Feature value should be a list"
+            assert (
+                config.has_empty_list or len(feature) > 0
+            ), "List of values should not be empty"
             for element in feature:
                 assert isinstance(element, expected_dtype)
     else:

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -241,6 +241,9 @@ def test_feature_get_online_features_types_match(online_types_test_fixtures):
     expected_dtype = feature_list_dtype_to_expected_online_response_value_type[
         config.feature_dtype
     ]
+
+    assert len(online_features["value"]) == 1
+
     if config.feature_is_list:
         for feature in online_features["value"]:
             assert isinstance(feature, list), "Feature value should be a list"

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -221,14 +221,17 @@ def test_feature_get_online_features_types_match(online_types_test_fixtures):
     features = [fv.name + ":value"]
     entity = driver(value_type=config.entity_type)
     fs.apply([fv, entity])
-    fs.materialize(environment.start_date, environment.end_date)
+    fs.materialize(
+        environment.start_date,
+        environment.end_date
+        - timedelta(hours=1)  # throwing out last record to make sure
+        # we can successfully infer type even from all empty values
+    )
 
     driver_id_value = "1" if config.entity_type == ValueType.STRING else 1
     online_features = fs.get_online_features(
         features=features, entity_rows=[{"driver": driver_id_value}],
-    )
-    print(online_features.proto)  # will be in the logs when test fails
-    online_features = online_features.to_dict()
+    ).to_dict()
 
     feature_list_dtype_to_expected_online_response_value_type = {
         "int32": int,


### PR DESCRIPTION
Signed-off-by: pyalex <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

Several issues addressed in this PR:
1. Test environment time range (start and end dates) was instantiated once on tests start. Which could be an issue when tests are started at the end of the hour and then continued to the next hour. So there will be difference between generated datasets boundaries and environment start and end timestamps.
2. In `test_online_store_cleanup` some online stores (like dynamo) can have eventual consistency of schema. So when table was deleted it might need some time before it can be recreated.
3. Bug with inferring feature type when all values are empty list.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
