### PR TITLE
Remove old flag warning with the python feature server

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -512,7 +512,7 @@ def init_command(project_directory, minimal: bool, template: str):
 )
 @click.pass_context
 def serve_command(ctx: click.Context, host: str, port: int, no_access_log: bool):
-    """[Experimental] Start a the feature consumption server locally on a given port."""
+    """Start a feature server locally on a given port."""
     repo = ctx.obj["CHDIR"]
     cli_check_repo(repo)
     store = FeatureStore(repo_path=str(repo))

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -66,9 +66,4 @@ def start_server(
     store: "feast.FeatureStore", host: str, port: int, no_access_log: bool
 ):
     app = get_app(store)
-    click.echo(
-        "This is an "
-        + click.style("experimental", fg="yellow", bold=True, underline=True)
-        + " feature. It's intended for early testing and feedback, and could change without warnings in future releases."
-    )
     uvicorn.run(app, host=host, port=port, access_log=(not no_access_log))

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -1,6 +1,5 @@
 import traceback
 
-import click
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.logger import logger


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
We removed the need for a flag, but still have warnings that print when running `feast serve`. This removes those warnings.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
