### PR TITLE
podAnnotations Values in the feature-server chart

### DIFF
--- a/infra/charts/feast/charts/feature-server/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feature-server/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
   template:
     metadata:
       annotations:
+      {{- if .Values.podAnnotations }}
+        {{ toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the possibility of a user passing arbitrary `podAnnotations` Values to the feature-server chart.

