### PR TITLE
podAnnotations Values in the feature-server chart

### DIFF
--- a/infra/charts/feast/charts/feature-server/README.md
+++ b/infra/charts/feast/charts/feature-server/README.md
@@ -45,6 +45,7 @@ Feast Feature Server: Online feature serving service for Feast
 | logLevel | string | `"WARN"` | Default log level, use either one of `DEBUG`, `INFO`, `WARN` or `ERROR` |
 | logType | string | `"Console"` | Log format, either `JSON` or `Console` |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
+| podAnnotations | object | `{}` | Annotations to be added to Feast Serving pods |
 | podLabels | object | `{}` | Labels to be added to Feast Serving pods |
 | readinessProbe.enabled | bool | `true` | Flag to enabled the probe |
 | readinessProbe.failureThreshold | int | `5` | Min consecutive failures for the probe to be considered failed |

--- a/infra/charts/feast/charts/feature-server/templates/deployment.yaml
+++ b/infra/charts/feast/charts/feature-server/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      {{- if .Values.podAnnotations }}
+        {{ toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ template "feature-server.name" . }}
         component: serving

--- a/infra/charts/feast/charts/feature-server/values.yaml
+++ b/infra/charts/feast/charts/feature-server/values.yaml
@@ -140,5 +140,8 @@ envOverrides: {}
 # secrets -- List of Kubernetes secrets to be mounted. These secrets will be mounted on /etc/secrets/<secret name>.
 secrets: []
 
+# podAnnotations -- Annotations to be added to Feast Serving pods
+podAnnotations: {}
+
 # podLabels -- Labels to be added to Feast Serving pods
 podLabels: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the possibility of a user passing arbitrary `podAnnotations` Values to the feature-server chart.

Reference: https://tectonfeast.slack.com/archives/C01MSKCMB37/p1644600405847739