### PR TITLE
Don't require `snowflake` to always be installed

### DIFF
--- a/sdk/python/feast/infra/utils/snowflake_utils.py
+++ b/sdk/python/feast/infra/utils/snowflake_utils.py
@@ -7,9 +7,6 @@ from tempfile import TemporaryDirectory
 from typing import Dict, Iterator, List, Optional, Tuple, cast
 
 import pandas as pd
-import snowflake.connector
-from snowflake.connector import ProgrammingError, SnowflakeConnection
-from snowflake.connector.cursor import SnowflakeCursor
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -18,6 +15,16 @@ from tenacity import (
 )
 
 from feast.errors import SnowflakeIncompleteConfig, SnowflakeQueryUnknownError
+
+try:
+    import snowflake.connector
+    from snowflake.connector import ProgrammingError, SnowflakeConnection
+    from snowflake.connector.cursor import SnowflakeCursor
+except ImportError as e:
+    from feast.errors import FeastExtrasDependencyImportError
+
+    raise FeastExtrasDependencyImportError("snowflake", str(e))
+
 
 getLogger("snowflake.connector.cursor").disabled = True
 getLogger("snowflake.connector.connection").disabled = True


### PR DESCRIPTION
Signed-off-by: Judah Rand <17158624+judahrand@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:

The import should be handled like in `aws_utils`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
