### PR TITLE
feat: Add support for fetching features using multiple feature views with different entities in the Java feature server

### DIFF
--- a/java/serving/src/main/java/feast/serving/registry/Registry.java
+++ b/java/serving/src/main/java/feast/serving/registry/Registry.java
@@ -112,4 +112,8 @@ public class Registry {
     }
     return spec;
   }
+
+  public List<EntityProto.Entity> getEntities() {
+    return registry.getEntitiesList();
+  }
 }

--- a/java/serving/src/main/java/feast/serving/registry/Registry.java
+++ b/java/serving/src/main/java/feast/serving/registry/Registry.java
@@ -66,6 +66,10 @@ public class Registry {
   public FeatureViewProto.FeatureViewSpec getFeatureViewSpec(
       ServingAPIProto.FeatureReferenceV2 featureReference) {
     String featureViewName = featureReference.getFeatureViewName();
+    return this.getFeatureViewSpecByName(featureViewName);
+  }
+
+  public FeatureViewProto.FeatureViewSpec getFeatureViewSpecByName(String featureViewName) {
     if (featureViewNameToSpec.containsKey(featureViewName)) {
       return featureViewNameToSpec.get(featureViewName);
     }

--- a/java/serving/src/main/java/feast/serving/registry/RegistryRepository.java
+++ b/java/serving/src/main/java/feast/serving/registry/RegistryRepository.java
@@ -105,6 +105,6 @@ public class RegistryRepository {
   }
 
   public List<EntityProto.Entity> getEntities() {
-    return this.registry.getRegistry().getEntitiesList();
+    return this.registry.getEntities();
   }
 }

--- a/java/serving/src/main/java/feast/serving/registry/RegistryRepository.java
+++ b/java/serving/src/main/java/feast/serving/registry/RegistryRepository.java
@@ -78,6 +78,10 @@ public class RegistryRepository {
     return this.registry.getFeatureViewSpec(featureReference);
   }
 
+  public FeatureViewProto.FeatureViewSpec getFeatureViewSpecByName(String featureViewName) {
+    return this.registry.getFeatureViewSpecByName(featureViewName);
+  }
+
   public FeatureProto.FeatureSpecV2 getFeatureSpec(
       ServingAPIProto.FeatureReferenceV2 featureReference) {
     return this.registry.getFeatureSpec(featureReference);

--- a/java/serving/src/main/java/feast/serving/registry/RegistryRepository.java
+++ b/java/serving/src/main/java/feast/serving/registry/RegistryRepository.java
@@ -17,6 +17,7 @@
 package feast.serving.registry;
 
 import com.google.protobuf.Duration;
+import feast.proto.core.EntityProto;
 import feast.proto.core.FeatureProto;
 import feast.proto.core.FeatureServiceProto;
 import feast.proto.core.FeatureViewProto;
@@ -101,5 +102,9 @@ public class RegistryRepository {
 
   public List<String> getEntitiesList(ServingAPIProto.FeatureReferenceV2 featureReference) {
     return getFeatureViewSpec(featureReference).getEntitiesList();
+  }
+
+  public List<EntityProto.Entity> getEntities() {
+    return this.registry.getRegistry().getEntitiesList();
   }
 }

--- a/java/serving/src/main/java/feast/serving/registry/RegistryRepository.java
+++ b/java/serving/src/main/java/feast/serving/registry/RegistryRepository.java
@@ -17,7 +17,6 @@
 package feast.serving.registry;
 
 import com.google.protobuf.Duration;
-import feast.proto.core.EntityProto;
 import feast.proto.core.FeatureProto;
 import feast.proto.core.FeatureServiceProto;
 import feast.proto.core.FeatureViewProto;
@@ -25,9 +24,11 @@ import feast.proto.core.OnDemandFeatureViewProto;
 import feast.proto.core.RegistryProto;
 import feast.proto.serving.ServingAPIProto;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /*
  *
@@ -108,7 +109,8 @@ public class RegistryRepository {
     return getFeatureViewSpec(featureReference).getEntitiesList();
   }
 
-  public List<EntityProto.Entity> getEntities() {
-    return this.registry.getEntities();
+  public Map<String, String> getEntityJoinKeyLookup() {
+    return this.registry.getEntities().stream()
+        .collect(Collectors.toMap(e -> e.getSpec().getName(), e -> e.getSpec().getJoinKey()));
   }
 }

--- a/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -136,7 +136,7 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
     }
     List<List<feast.storage.api.retriever.Feature>> features =
         retriever.getOnlineFeatures(
-            entityRows, retrievedFeatureReferences, entityNames, entityNamesPerFeatureView);
+            entityRows, retrievedFeatureReferences, entityNamesPerFeatureView);
 
     if (storageRetrievalSpan != null) {
       storageRetrievalSpan.finish();

--- a/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -23,6 +23,7 @@ import com.google.protobuf.Timestamp;
 import feast.common.models.Feature;
 import feast.proto.core.EntityProto;
 import feast.proto.core.FeatureServiceProto;
+import feast.proto.core.FeatureViewProto;
 import feast.proto.core.FeatureViewProto.FeatureViewSpec;
 import feast.proto.serving.ServingAPIProto;
 import feast.proto.serving.ServingAPIProto.FeatureReferenceV2;
@@ -112,11 +113,15 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
       throw new RuntimeException("Requested features list must not be empty");
     }
 
+    List<FeatureViewProto.FeatureViewSpec> featureViewSpecs =
+        retrievedFeatureReferences.stream()
+            .map(FeatureReferenceV2::getFeatureViewName)
+            .distinct()
+            .map(this.registryRepository::getFeatureViewSpecByName)
+            .collect(Collectors.toList());
     List<EntityProto.Entity> entities = this.registryRepository.getEntities();
     Map<String, List<String>> entityNamesPerFeatureView =
-        retrievedFeatureReferences.stream()
-            .map(this.registryRepository::getFeatureViewSpec)
-            .distinct()
+        featureViewSpecs.stream()
             .collect(
                 Collectors.toMap(
                     FeatureViewSpec::getName,

--- a/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -113,19 +113,23 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
     }
 
     List<EntityProto.Entity> entities = this.registryRepository.getEntities();
-    Map<String, List<String>> entityNamesPerFeatureView = retrievedFeatureReferences.stream()
-        .map(this.registryRepository::getFeatureViewSpec)
-        .distinct()
-        .collect(Collectors.toMap(
-            FeatureViewSpec::getName,
-            spec -> spec.getEntitiesList().stream().map(name ->
-                entities.stream()
-                    .filter(e -> e.getSpec().getName().equals(name))
-                    .findFirst()
-                    .get()).map(e -> e.getSpec().getJoinKey())
-                .collect(Collectors.toList())
-            )
-        );
+    Map<String, List<String>> entityNamesPerFeatureView =
+        retrievedFeatureReferences.stream()
+            .map(this.registryRepository::getFeatureViewSpec)
+            .distinct()
+            .collect(
+                Collectors.toMap(
+                    FeatureViewSpec::getName,
+                    spec ->
+                        spec.getEntitiesList().stream()
+                            .map(
+                                name ->
+                                    entities.stream()
+                                        .filter(e -> e.getSpec().getName().equals(name))
+                                        .findFirst()
+                                        .get())
+                            .map(e -> e.getSpec().getJoinKey())
+                            .collect(Collectors.toList())));
 
     Span storageRetrievalSpan = tracer.buildSpan("storageRetrieval").start();
     if (storageRetrievalSpan != null) {
@@ -133,8 +137,8 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
       storageRetrievalSpan.setTag("features", retrievedFeatureReferences.size());
     }
     List<List<feast.storage.api.retriever.Feature>> features =
-        retriever.getOnlineFeatures(entityRows, retrievedFeatureReferences, entityNames,
-            entityNamesPerFeatureView);
+        retriever.getOnlineFeatures(
+            entityRows, retrievedFeatureReferences, entityNames, entityNamesPerFeatureView);
 
     if (storageRetrievalSpan != null) {
       storageRetrievalSpan.finish();

--- a/java/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
+++ b/java/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
@@ -172,7 +172,7 @@ public class OnlineServingServiceTest {
             List.of(mockedFeatureRows.get(0), mockedFeatureRows.get(1)),
             List.of(mockedFeatureRows.get(2), mockedFeatureRows.get(3)));
 
-    when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
+    when(retrieverV2.getOnlineFeatures(any(), any(), any())).thenReturn(featureRows);
     when(registry.getFeatureViewSpec(any())).thenReturn(getFeatureViewSpec());
     when(registry.getFeatureViewSpecByName(any())).thenReturn(getFeatureViewSpec());
     when(registry.getFeatureSpec(mockedFeatureRows.get(0).getFeatureReference()))
@@ -245,7 +245,7 @@ public class OnlineServingServiceTest {
             List.of(mockedFeatureRows.get(0), mockedFeatureRows.get(1)),
             Arrays.asList(null, mockedFeatureRows.get(4)));
 
-    when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
+    when(retrieverV2.getOnlineFeatures(any(), any(), any())).thenReturn(featureRows);
     when(registry.getFeatureViewSpec(any())).thenReturn(getFeatureViewSpec());
     when(registry.getFeatureViewSpecByName(any())).thenReturn(getFeatureViewSpec());
     when(registry.getFeatureSpec(mockedFeatureRows.get(0).getFeatureReference()))
@@ -307,7 +307,7 @@ public class OnlineServingServiceTest {
             List.of(mockedFeatureRows.get(5), mockedFeatureRows.get(1)),
             List.of(mockedFeatureRows.get(5), mockedFeatureRows.get(1)));
 
-    when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
+    when(retrieverV2.getOnlineFeatures(any(), any(), any())).thenReturn(featureRows);
     when(registry.getFeatureViewSpec(any())).thenReturn(getFeatureViewSpec(3600));
     when(registry.getFeatureViewSpecByName(any())).thenReturn(getFeatureViewSpec(3600));
     when(registry.getFeatureSpec(mockedFeatureRows.get(1).getFeatureReference()))

--- a/java/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
+++ b/java/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
+import feast.proto.core.EntityProto;
 import feast.proto.core.FeatureProto;
 import feast.proto.core.FeatureViewProto;
 import feast.proto.serving.ServingAPIProto;
@@ -60,6 +61,7 @@ public class OnlineServingServiceTest {
 
   List<Feature> mockedFeatureRows;
   List<FeatureProto.FeatureSpecV2> featureSpecs;
+  List<EntityProto.Entity> entities;
 
   Timestamp now = Timestamp.newBuilder().setSeconds(System.currentTimeMillis() / 1000).build();
 
@@ -136,6 +138,16 @@ public class OnlineServingServiceTest {
             .setName("feature_2")
             .setValueType(ValueProto.ValueType.Enum.STRING)
             .build());
+
+    entities = new ArrayList<>();
+    entities.add(
+        EntityProto.Entity.newBuilder()
+            .setSpec(EntityProto.EntitySpecV2.newBuilder().setName("entity1").build())
+            .build());
+    entities.add(
+        EntityProto.Entity.newBuilder()
+            .setSpec(EntityProto.EntitySpecV2.newBuilder().setName("entity2").build())
+            .build());
   }
 
   @Test
@@ -160,7 +172,7 @@ public class OnlineServingServiceTest {
             List.of(mockedFeatureRows.get(0), mockedFeatureRows.get(1)),
             List.of(mockedFeatureRows.get(2), mockedFeatureRows.get(3)));
 
-    when(retrieverV2.getOnlineFeatures(any(), any(), any())).thenReturn(featureRows);
+    when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
     when(registry.getFeatureViewSpec(any())).thenReturn(getFeatureViewSpec());
     when(registry.getFeatureSpec(mockedFeatureRows.get(0).getFeatureReference()))
         .thenReturn(featureSpecs.get(0));
@@ -170,6 +182,7 @@ public class OnlineServingServiceTest {
         .thenReturn(featureSpecs.get(0));
     when(registry.getFeatureSpec(mockedFeatureRows.get(3).getFeatureReference()))
         .thenReturn(featureSpecs.get(1));
+    when(registry.getEntities()).thenReturn(entities);
 
     when(tracer.buildSpan(ArgumentMatchers.any())).thenReturn(Mockito.mock(SpanBuilder.class));
 
@@ -231,12 +244,13 @@ public class OnlineServingServiceTest {
             List.of(mockedFeatureRows.get(0), mockedFeatureRows.get(1)),
             Arrays.asList(null, mockedFeatureRows.get(4)));
 
-    when(retrieverV2.getOnlineFeatures(any(), any(), any())).thenReturn(featureRows);
+    when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
     when(registry.getFeatureViewSpec(any())).thenReturn(getFeatureViewSpec());
     when(registry.getFeatureSpec(mockedFeatureRows.get(0).getFeatureReference()))
         .thenReturn(featureSpecs.get(0));
     when(registry.getFeatureSpec(mockedFeatureRows.get(1).getFeatureReference()))
         .thenReturn(featureSpecs.get(1));
+    when(registry.getEntities()).thenReturn(entities);
 
     when(tracer.buildSpan(ArgumentMatchers.any())).thenReturn(Mockito.mock(SpanBuilder.class));
 
@@ -291,7 +305,7 @@ public class OnlineServingServiceTest {
             List.of(mockedFeatureRows.get(5), mockedFeatureRows.get(1)),
             List.of(mockedFeatureRows.get(5), mockedFeatureRows.get(1)));
 
-    when(retrieverV2.getOnlineFeatures(any(), any(), any())).thenReturn(featureRows);
+    when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
     when(registry.getFeatureViewSpec(any()))
         .thenReturn(
             FeatureViewProto.FeatureViewSpec.newBuilder()
@@ -314,6 +328,7 @@ public class OnlineServingServiceTest {
         .thenReturn(featureSpecs.get(1));
     when(registry.getFeatureSpec(mockedFeatureRows.get(5).getFeatureReference()))
         .thenReturn(featureSpecs.get(0));
+    when(registry.getEntities()).thenReturn(entities);
 
     when(tracer.buildSpan(ArgumentMatchers.any())).thenReturn(Mockito.mock(SpanBuilder.class));
 

--- a/java/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
+++ b/java/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
@@ -174,6 +174,7 @@ public class OnlineServingServiceTest {
 
     when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
     when(registry.getFeatureViewSpec(any())).thenReturn(getFeatureViewSpec());
+    when(registry.getFeatureViewSpecByName(any())).thenReturn(getFeatureViewSpec());
     when(registry.getFeatureSpec(mockedFeatureRows.get(0).getFeatureReference()))
         .thenReturn(featureSpecs.get(0));
     when(registry.getFeatureSpec(mockedFeatureRows.get(1).getFeatureReference()))
@@ -246,6 +247,7 @@ public class OnlineServingServiceTest {
 
     when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
     when(registry.getFeatureViewSpec(any())).thenReturn(getFeatureViewSpec());
+    when(registry.getFeatureViewSpecByName(any())).thenReturn(getFeatureViewSpec());
     when(registry.getFeatureSpec(mockedFeatureRows.get(0).getFeatureReference()))
         .thenReturn(featureSpecs.get(0));
     when(registry.getFeatureSpec(mockedFeatureRows.get(1).getFeatureReference()))
@@ -306,24 +308,8 @@ public class OnlineServingServiceTest {
             List.of(mockedFeatureRows.get(5), mockedFeatureRows.get(1)));
 
     when(retrieverV2.getOnlineFeatures(any(), any(), any(), any())).thenReturn(featureRows);
-    when(registry.getFeatureViewSpec(any()))
-        .thenReturn(
-            FeatureViewProto.FeatureViewSpec.newBuilder()
-                .setName("featureview_1")
-                .addEntities("entity1")
-                .addEntities("entity2")
-                .addFeatures(
-                    FeatureProto.FeatureSpecV2.newBuilder()
-                        .setName("feature_1")
-                        .setValueType(ValueProto.ValueType.Enum.STRING)
-                        .build())
-                .addFeatures(
-                    FeatureProto.FeatureSpecV2.newBuilder()
-                        .setName("feature_2")
-                        .setValueType(ValueProto.ValueType.Enum.STRING)
-                        .build())
-                .setTtl(Duration.newBuilder().setSeconds(3600))
-                .build());
+    when(registry.getFeatureViewSpec(any())).thenReturn(getFeatureViewSpec(3600));
+    when(registry.getFeatureViewSpecByName(any())).thenReturn(getFeatureViewSpec(3600));
     when(registry.getFeatureSpec(mockedFeatureRows.get(1).getFeatureReference()))
         .thenReturn(featureSpecs.get(1));
     when(registry.getFeatureSpec(mockedFeatureRows.get(5).getFeatureReference()))
@@ -362,6 +348,10 @@ public class OnlineServingServiceTest {
   }
 
   private FeatureViewProto.FeatureViewSpec getFeatureViewSpec() {
+    return getFeatureViewSpec(120);
+  }
+
+  private FeatureViewProto.FeatureViewSpec getFeatureViewSpec(int ttlSeconds) {
     return FeatureViewProto.FeatureViewSpec.newBuilder()
         .setName("featureview_1")
         .addEntities("entity1")
@@ -376,7 +366,7 @@ public class OnlineServingServiceTest {
                 .setName("feature_2")
                 .setValueType(ValueProto.ValueType.Enum.STRING)
                 .build())
-        .setTtl(Duration.newBuilder().setSeconds(120))
+        .setTtl(Duration.newBuilder().setSeconds(ttlSeconds))
         .build();
   }
 

--- a/java/storage/api/src/main/java/feast/storage/api/retriever/OnlineRetrieverV2.java
+++ b/java/storage/api/src/main/java/feast/storage/api/retriever/OnlineRetrieverV2.java
@@ -34,13 +34,12 @@ public interface OnlineRetrieverV2 {
    *
    * @param entityRows list of entity rows to request features for.
    * @param featureReferences specifies the FeatureTable to retrieve data from
-   * @param entityNames name of entities
+   * @param entityNamesPerFeatureView map from feature view name to list of entity join keys
    * @return list of {@link Feature}s corresponding to data retrieved for each entity row from
    *     FeatureTable specified in FeatureTable request.
    */
   List<List<Feature>> getOnlineFeatures(
       List<Map<String, ValueProto.Value>> entityRows,
       List<ServingAPIProto.FeatureReferenceV2> featureReferences,
-      List<String> entityNames,
       Map<String, List<String>> entityNamesPerFeatureView);
 }

--- a/java/storage/api/src/main/java/feast/storage/api/retriever/OnlineRetrieverV2.java
+++ b/java/storage/api/src/main/java/feast/storage/api/retriever/OnlineRetrieverV2.java
@@ -41,5 +41,6 @@ public interface OnlineRetrieverV2 {
   List<List<Feature>> getOnlineFeatures(
       List<Map<String, ValueProto.Value>> entityRows,
       List<ServingAPIProto.FeatureReferenceV2> featureReferences,
-      List<String> entityNames);
+      List<String> entityNames,
+      Map<String, List<String>> entityNamesPerFeatureView);
 }

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
@@ -59,7 +59,6 @@ public class OnlineRetriever implements OnlineRetrieverV2 {
   public List<List<Feature>> getOnlineFeatures(
       List<Map<String, ValueProto.Value>> entityRows,
       List<ServingAPIProto.FeatureReferenceV2> featureReferences,
-      List<String> entityNames,
       Map<String, List<String>> entityNamesPerFeatureView) {
 
     List<String> featureViewNames =

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/OnlineRetriever.java
@@ -18,7 +18,6 @@ package feast.storage.connectors.redis.retriever;
 
 import com.google.common.collect.Lists;
 import feast.proto.serving.ServingAPIProto;
-import feast.proto.serving.ServingAPIProto.FeatureReferenceV2;
 import feast.proto.storage.RedisProto;
 import feast.proto.types.ValueProto;
 import feast.proto.types.ValueProto.Value;
@@ -61,11 +60,7 @@ public class OnlineRetriever implements OnlineRetrieverV2 {
       List<ServingAPIProto.FeatureReferenceV2> featureReferences,
       Map<String, List<String>> entityNamesPerFeatureView) {
 
-    List<String> featureViewNames =
-        featureReferences.stream()
-            .map(FeatureReferenceV2::getFeatureViewName)
-            .distinct()
-            .collect(Collectors.toList());
+    Set<String> featureViewNames = entityNamesPerFeatureView.keySet();
 
     Set<List<String>> uniqueEntityKeyCombinations =
         featureViewNames.stream().map(entityNamesPerFeatureView::get).collect(Collectors.toSet());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
When fetching features from multiple features views using different entities, the feature server returns `NOT_FOUND` for all of the features instead of properly using the available information to get all feature values. This PR fixes this issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2302

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Java feature server supports fetching from multiple feature views with different entities
```
