### PR TITLE
feat: Allowing password based authentication and SSL for Redis in Java feature server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,9 @@ sdk/go/protos/
 
 #benchmarks
 .benchmarks
+
+# Examples registry
+**/registry.db
+**/*.aof
+**/*.rdb
+**/nodes.conf

--- a/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
+++ b/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
@@ -252,7 +252,7 @@ public class ApplicationProperties {
       String read_from;
       if (!this.config.containsKey("read_from") || this.config.get("read_from") == null) {
         log.info("'read_from' not defined in Redis cluster config, so setting to UPSTREAM");
-         read_from = ReadFrom.UPSTREAM.toString();
+        read_from = ReadFrom.UPSTREAM.toString();
       } else {
         read_from = this.config.get("read_from");
       }

--- a/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
+++ b/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
@@ -27,19 +27,17 @@ import feast.common.logging.config.LoggingProperties;
 import feast.storage.connectors.redis.retriever.RedisClusterStoreConfig;
 import feast.storage.connectors.redis.retriever.RedisStoreConfig;
 import io.lettuce.core.ReadFrom;
-import org.slf4j.Logger;
-
 import java.time.Duration;
 import java.util.*;
 import javax.annotation.PostConstruct;
 import javax.validation.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import org.slf4j.Logger;
 
 /** Feast Serving properties. */
 public class ApplicationProperties {
-  private static final Logger log =
-          org.slf4j.LoggerFactory.getLogger(ApplicationProperties.class);
+  private static final Logger log = org.slf4j.LoggerFactory.getLogger(ApplicationProperties.class);
 
   public static class FeastProperties {
     /* Feast Serving build version */
@@ -272,8 +270,8 @@ public class ApplicationProperties {
       return new RedisClusterStoreConfig(
           this.config.get("connection_string"),
           ReadFrom.valueOf(read_from),
-              timeout,
-              ssl,
+          timeout,
+          ssl,
           this.config.getOrDefault("password", ""));
     }
 

--- a/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
+++ b/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
@@ -257,7 +257,8 @@ public class ApplicationProperties {
       }
 
       if (!this.config.containsKey("timeout") || this.config.get("timeout") == null) {
-        throw new RuntimeException("Redis cluster config does not have 'timeout' specified");
+        throw new IllegalArgumentException(
+            "Redis cluster config does not have 'timeout' specified");
       }
 
       boolean ssl = false;

--- a/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
+++ b/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
@@ -249,9 +249,10 @@ public class ApplicationProperties {
      * @return Returns the store specific configuration
      */
     public RedisClusterStoreConfig getRedisClusterConfig() {
-      String read_from = ReadFrom.UPSTREAM.toString();
+      String read_from;
       if (!this.config.containsKey("read_from") || this.config.get("read_from") == null) {
         log.info("'read_from' not defined in Redis cluster config, so setting to UPSTREAM");
+         read_from = ReadFrom.UPSTREAM.toString();
       } else {
         read_from = this.config.get("read_from");
       }
@@ -261,9 +262,10 @@ public class ApplicationProperties {
             "Redis cluster config does not have 'timeout' specified");
       }
 
-      boolean ssl = false;
+      Boolean ssl = null;
       if (!this.config.containsKey("ssl") || this.config.get("ssl") == null) {
         log.info("'ssl' not defined in Redis cluster config, so setting to false");
+        ssl = false;
       } else {
         ssl = Boolean.parseBoolean(this.config.get("ssl"));
       }

--- a/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
+++ b/java/serving/src/main/java/feast/serving/config/ApplicationProperties.java
@@ -265,7 +265,7 @@ public class ApplicationProperties {
       if (!this.config.containsKey("ssl") || this.config.get("ssl") == null) {
         log.info("'ssl' not defined in Redis cluster config, so setting to false");
       } else {
-        ssl = Boolean.parseBoolean(this.config.getOrDefault("ssl", "false"));
+        ssl = Boolean.parseBoolean(this.config.get("ssl"));
       }
       Duration timeout = Duration.parse(this.config.get("timeout"));
       return new RedisClusterStoreConfig(

--- a/java/serving/src/test/java/feast/serving/it/TestUtils.java
+++ b/java/serving/src/test/java/feast/serving/it/TestUtils.java
@@ -83,7 +83,8 @@ public class TestUtils {
             new ApplicationProperties.Store(
                 "online",
                 "REDIS",
-                ImmutableMap.of("host", redisHost, "port", redisPort.toString()))));
+                ImmutableMap.of(
+                    "host", redisHost, "port", redisPort.toString(), "password", "testpw"))));
 
     return feastProperties;
   }

--- a/java/serving/src/test/resources/docker-compose/docker-compose-redis-it.yml
+++ b/java/serving/src/test/resources/docker-compose/docker-compose-redis-it.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   redis:
     image: redis:6.2
+    command: redis-server --requirepass testpw
     ports:
       - "6379:6379"
   feast:

--- a/java/serving/src/test/resources/docker-compose/feast10/feature_store.yaml
+++ b/java/serving/src/test/resources/docker-compose/feast10/feature_store.yaml
@@ -3,7 +3,7 @@ registry: registry.db
 provider: local
 online_store:
   type: redis
-  connection_string: "redis:6379"
+  connection_string: "redis:6379,password=testpw"
 offline_store: {}
 flags:
   alpha_features: true

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterClient.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterClient.java
@@ -71,7 +71,15 @@ public class RedisClusterClient implements RedisClientAdapter {
             .map(
                 hostPort -> {
                   String[] hostPortSplit = hostPort.trim().split(":");
-                  return RedisURI.create(hostPortSplit[0], Integer.parseInt(hostPortSplit[1]));
+                  RedisURI redisURI =
+                      RedisURI.create(hostPortSplit[0], Integer.parseInt(hostPortSplit[1]));
+                  if (!config.getPassword().isEmpty()) {
+                    redisURI.setPassword(config.getPassword());
+                  }
+                  if (config.getSsl()) {
+                    redisURI.setSsl(true);
+                  }
+                  return redisURI;
                 })
             .collect(Collectors.toList());
 

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterClient.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterClient.java
@@ -79,6 +79,7 @@ public class RedisClusterClient implements RedisClientAdapter {
                   if (config.getSsl()) {
                     redisURI.setSsl(true);
                   }
+                  redisURI.setTimeout(config.getTimeout());
                   return redisURI;
                 })
             .collect(Collectors.toList());

--- a/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterStoreConfig.java
+++ b/java/storage/connectors/redis/src/main/java/feast/storage/connectors/redis/retriever/RedisClusterStoreConfig.java
@@ -23,11 +23,16 @@ public class RedisClusterStoreConfig {
   private final String connectionString;
   private final ReadFrom readFrom;
   private final Duration timeout;
+  private final Boolean ssl;
+  private final String password;
 
-  public RedisClusterStoreConfig(String connectionString, ReadFrom readFrom, Duration timeout) {
+  public RedisClusterStoreConfig(
+      String connectionString, ReadFrom readFrom, Duration timeout, Boolean ssl, String password) {
     this.connectionString = connectionString;
     this.readFrom = readFrom;
     this.timeout = timeout;
+    this.ssl = ssl;
+    this.password = password;
   }
 
   public String getConnectionString() {
@@ -40,5 +45,13 @@ public class RedisClusterStoreConfig {
 
   public Duration getTimeout() {
     return this.timeout;
+  }
+
+  public Boolean getSsl() {
+    return ssl;
+  }
+
+  public String getPassword() {
+    return password;
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This is a partial forward port of https://github.com/feast-dev/feast-java-old/pull/44 to enable auth for Redis in the Java feature server (Python already handles this)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/feast-dev/feast/issues/2285

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Java feature server now supports SSL and password based authentication for Redis
```
