### PR TITLE
Disable Redis cluster tests

### DIFF
--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -30,7 +30,6 @@ from tests.integration.feature_repos.integration_test_repo_config import (
 )
 from tests.integration.feature_repos.repo_configuration import (
     FULL_REPO_CONFIGS,
-    REDIS_CLUSTER_CONFIG,
     REDIS_CONFIG,
     Environment,
     construct_test_environment,
@@ -171,14 +170,10 @@ def environment(request, worker_id: str):
     return e
 
 
-@pytest.fixture(
-    scope="session",
-    params=[REDIS_CONFIG, REDIS_CLUSTER_CONFIG],
-    ids=[str(c) for c in [REDIS_CONFIG, REDIS_CLUSTER_CONFIG]],
-)
+@pytest.fixture()
 def local_redis_environment(request, worker_id):
     e = construct_test_environment(
-        IntegrationTestRepoConfig(online_store=request.param), worker_id=worker_id
+        IntegrationTestRepoConfig(online_store=REDIS_CONFIG), worker_id=worker_id
     )
 
     def cleanup():

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -70,7 +70,6 @@ if os.getenv("FEAST_IS_LOCAL_TEST", "False") != "True":
         [
             # Redis configurations
             IntegrationTestRepoConfig(online_store=REDIS_CONFIG),
-            IntegrationTestRepoConfig(online_store=REDIS_CLUSTER_CONFIG),
             # GCP configurations
             IntegrationTestRepoConfig(
                 provider="gcp",


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**: This PR (temporarily) disables all Redis cluster tests. Recently Redis cluster tests were added in #2311 and #2317, but since the current Redis cluster logic is broken, these tests are failing and blocking other PRs. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
