### PR TITLE
feat: Metadata changes & making data sources top level objects to power Feast UI

### DIFF
--- a/protos/feast/core/DataSource.proto
+++ b/protos/feast/core/DataSource.proto
@@ -26,6 +26,7 @@ import "feast/core/DataFormat.proto";
 import "feast/types/Value.proto";
 
 // Defines a Data Source that can be used source Feature data
+// Next available id: 22
 message DataSource {
   // Field indexes should *not* be reused. Not sure if fields 6-10 were used previously or not,
   // but they are going to be reserved for backwards compatibility.
@@ -45,6 +46,13 @@ message DataSource {
     REQUEST_SOURCE = 7;
 
   }
+
+  // Unique name of data source within the project
+  string name = 20;
+
+  // Name of Feast project that this data source belongs to.
+  string project = 21;
+
   SourceType type = 1;
 
   // Defines mapping between fields in the sourced data
@@ -156,9 +164,7 @@ message DataSource {
 
   // Defines options for DataSource that sources features from request data
   message RequestDataOptions {
-    // Name of the request data source
-    string name = 1;
-
+    reserved 1;
     // Mapping of feature name to type
     map<string, feast.types.ValueType.Enum> schema = 2;
   }

--- a/protos/feast/core/OnDemandFeatureView.proto
+++ b/protos/feast/core/OnDemandFeatureView.proto
@@ -48,8 +48,6 @@ message OnDemandFeatureViewSpec {
     map<string, OnDemandInput> inputs = 4;
 
     UserDefinedFunction user_defined_function = 5;
-
-
 }
 
 message OnDemandFeatureViewMeta {

--- a/protos/feast/core/Registry.proto
+++ b/protos/feast/core/Registry.proto
@@ -28,13 +28,16 @@ import "feast/core/FeatureView.proto";
 import "feast/core/InfraObject.proto";
 import "feast/core/OnDemandFeatureView.proto";
 import "feast/core/RequestFeatureView.proto";
+import "feast/core/DataSource.proto";
 import "feast/core/SavedDataset.proto";
 import "google/protobuf/timestamp.proto";
 
+// Next id: 13
 message Registry {
     repeated Entity entities = 1;
     repeated FeatureTable feature_tables = 2;
     repeated FeatureView feature_views = 6;
+    repeated DataSource data_sources = 12;
     repeated OnDemandFeatureView on_demand_feature_views = 8;
     repeated RequestFeatureView request_feature_views = 9;
     repeated FeatureService feature_services = 7;

--- a/protos/feast/core/RequestFeatureView.proto
+++ b/protos/feast/core/RequestFeatureView.proto
@@ -22,8 +22,6 @@ option go_package = "github.com/feast-dev/feast/sdk/go/protos/feast/core";
 option java_outer_classname = "RequestFeatureViewProto";
 option java_package = "feast.proto.core";
 
-import "feast/core/FeatureView.proto";
-import "feast/core/Feature.proto";
 import "feast/core/DataSource.proto";
 
 message RequestFeatureView {

--- a/protos/feast/core/SavedDataset.proto
+++ b/protos/feast/core/SavedDataset.proto
@@ -23,8 +23,8 @@ option java_outer_classname = "SavedDatasetProto";
 option go_package = "github.com/feast-dev/feast/sdk/go/protos/feast/core";
 
 import "google/protobuf/timestamp.proto";
-import "feast/core/FeatureViewProjection.proto";
 import "feast/core/DataSource.proto";
+import "feast/core/FeatureService.proto";
 
 message SavedDatasetSpec {
   // Name of the dataset. Must be unique since it's possible to overwrite dataset by name
@@ -43,6 +43,9 @@ message SavedDatasetSpec {
   bool full_feature_names = 5;
 
   SavedDatasetStorage storage = 6;
+
+  // Optional and only populated if generated from a feature service fetch
+  string feature_service_name = 8;
 
   // User defined metadata
   map<string, string> tags = 7;

--- a/protos/feast/core/ValidationProfile.proto
+++ b/protos/feast/core/ValidationProfile.proto
@@ -22,7 +22,6 @@ option java_package = "feast.proto.core";
 option java_outer_classname = "ValidationProfile";
 option go_package = "github.com/feast-dev/feast/sdk/go/protos/feast/core";
 
-import "google/protobuf/timestamp.proto";
 import "feast/core/SavedDataset.proto";
 
 message GEValidationProfiler {

--- a/protos/feast/storage/Redis.proto
+++ b/protos/feast/storage/Redis.proto
@@ -16,7 +16,6 @@
 
 syntax = "proto3";
 
-import "feast/types/Field.proto";
 import "feast/types/Value.proto";
 
 package feast.storage;

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -126,6 +126,56 @@ def endpoint(ctx: click.Context):
         _logger.info("There is no active feature server.")
 
 
+@cli.group(name="data-sources")
+def data_sources_cmd():
+    """
+    Access data sources
+    """
+    pass
+
+
+@data_sources_cmd.command("describe")
+@click.argument("name", type=click.STRING)
+@click.pass_context
+def data_source_describe(ctx: click.Context, name: str):
+    """
+    Describe a data source
+    """
+    repo = ctx.obj["CHDIR"]
+    cli_check_repo(repo)
+    store = FeatureStore(repo_path=str(repo))
+
+    try:
+        data_source = store.get_data_source(name)
+    except FeastObjectNotFoundException as e:
+        print(e)
+        exit(1)
+
+    print(
+        yaml.dump(
+            yaml.safe_load(str(data_source)), default_flow_style=False, sort_keys=False
+        )
+    )
+
+
+@data_sources_cmd.command(name="list")
+@click.pass_context
+def data_source_list(ctx: click.Context):
+    """
+    List all data sources
+    """
+    repo = ctx.obj["CHDIR"]
+    cli_check_repo(repo)
+    store = FeatureStore(repo_path=str(repo))
+    table = []
+    for datasource in store.list_data_sources():
+        table.append([datasource.name, datasource.__class__])
+
+    from tabulate import tabulate
+
+    print(tabulate(table, headers=["NAME", "CLASS"], tablefmt="plain"))
+
+
 @cli.group(name="entities")
 def entities_cmd():
     """

--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -10,6 +10,13 @@ class DataSourceNotFoundException(Exception):
         )
 
 
+class DataSourceNoNameException(Exception):
+    def __init__(self):
+        super().__init__(
+            "Unable to infer a name for this data source. Either table_ref or name must be specified."
+        )
+
+
 class FeastObjectNotFoundException(Exception):
     pass
 
@@ -62,6 +69,14 @@ class RequestDataNotFoundInEntityRowsException(FeastObjectNotFoundException):
         super().__init__(
             f"Required request data source features {feature_names} not found in the entity rows, but required by feature views"
         )
+
+
+class DataSourceObjectNotFoundException(FeastObjectNotFoundException):
+    def __init__(self, name, project=None):
+        if project:
+            super().__init__(f"Data source {name} does not exist in project {project}")
+        else:
+            super().__init__(f"Data source {name} does not exist")
 
 
 class S3RegistryBucketNotExist(FeastObjectNotFoundException):

--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -13,7 +13,7 @@ class DataSourceNotFoundException(Exception):
 class DataSourceNoNameException(Exception):
     def __init__(self):
         super().__init__(
-            "Unable to infer a name for this data source. Either table_ref or name must be specified."
+            "Unable to infer a name for this data source. Either table or name must be specified."
         )
 
 

--- a/sdk/python/feast/feast_object.py
+++ b/sdk/python/feast/feast_object.py
@@ -1,12 +1,33 @@
 from typing import Union
 
+from .data_source import DataSource
 from .entity import Entity
 from .feature_service import FeatureService
 from .feature_view import FeatureView
 from .on_demand_feature_view import OnDemandFeatureView
+from .protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
+from .protos.feast.core.Entity_pb2 import EntitySpecV2
+from .protos.feast.core.FeatureService_pb2 import FeatureServiceSpec
+from .protos.feast.core.FeatureView_pb2 import FeatureViewSpec
+from .protos.feast.core.OnDemandFeatureView_pb2 import OnDemandFeatureViewSpec
+from .protos.feast.core.RequestFeatureView_pb2 import RequestFeatureViewSpec
 from .request_feature_view import RequestFeatureView
 
 # Convenience type representing all Feast objects
 FeastObject = Union[
-    FeatureView, OnDemandFeatureView, RequestFeatureView, Entity, FeatureService
+    FeatureView,
+    OnDemandFeatureView,
+    RequestFeatureView,
+    Entity,
+    FeatureService,
+    DataSource,
+]
+
+FeastObjectSpecProto = Union[
+    FeatureViewSpec,
+    OnDemandFeatureViewSpec,
+    RequestFeatureViewSpec,
+    EntitySpecV2,
+    FeatureServiceSpec,
+    DataSourceProto,
 ]

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -273,7 +273,7 @@ class FeatureStore:
         Returns:
             A list of data sources.
         """
-        return self._registry.list_data_sources(allow_cache=allow_cache)
+        return self._registry.list_data_sources(self.project, allow_cache=allow_cache)
 
     @log_exceptions_and_usage
     def get_entity(self, name: str) -> Entity:

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -530,6 +530,7 @@ class FeatureStore:
             list(desired_repo_contents.on_demand_feature_views),
             list(desired_repo_contents.request_feature_views),
         )
+        _validate_data_sources(list(desired_repo_contents.data_sources))
         self._make_inferences(
             list(desired_repo_contents.data_sources),
             list(desired_repo_contents.entities),
@@ -1967,3 +1968,18 @@ def _validate_feature_views(feature_views: List[BaseFeatureView]):
             )
         else:
             fv_names.add(case_insensitive_fv_name)
+
+
+def _validate_data_sources(data_sources: List[DataSource]):
+    """ Verify data sources have case-insensitively unique names"""
+    ds_names = set()
+    for fv in data_sources:
+        case_insensitive_ds_name = fv.name.lower()
+        if case_insensitive_ds_name in ds_names:
+            raise ValueError(
+                f"More than one data source with name {case_insensitive_ds_name} found. "
+                f"Please ensure that all data source names are case-insensitively unique. "
+                f"It may be necessary to ignore certain files in your feature repository by using a .feastignore file."
+            )
+        else:
+            ds_names.add(case_insensitive_ds_name)

--- a/sdk/python/feast/inference.py
+++ b/sdk/python/feast/inference.py
@@ -10,7 +10,7 @@ from feast import (
     SnowflakeSource,
     SparkSource,
 )
-from feast.data_source import DataSource
+from feast.data_source import DataSource, RequestDataSource
 from feast.errors import RegistryInferenceFailure
 from feast.feature_view import FeatureView
 from feast.repo_config import RepoConfig
@@ -79,6 +79,8 @@ def update_data_sources_with_inferred_event_timestamp_col(
     ERROR_MSG_PREFIX = "Unable to infer DataSource event_timestamp_column"
 
     for data_source in data_sources:
+        if isinstance(data_source, RequestDataSource):
+            continue
         if (
             data_source.event_timestamp_column is None
             or data_source.event_timestamp_column == ""
@@ -98,9 +100,10 @@ def update_data_sources_with_inferred_event_timestamp_col(
             else:
                 raise RegistryInferenceFailure(
                     "DataSource",
-                    """
+                    f"""
                     DataSource inferencing of event_timestamp_column is currently only supported
-                    for FileSource, SparkSource, BigQuerySource, RedshiftSource, and SnowflakeSource.
+                    for FileSource, SparkSource, BigQuerySource, RedshiftSource, and SnowflakeSource. 
+                    Attempting to infer from {data_source}.
                     """,
                 )
             #  for informing the type checker

--- a/sdk/python/feast/inference.py
+++ b/sdk/python/feast/inference.py
@@ -102,7 +102,7 @@ def update_data_sources_with_inferred_event_timestamp_col(
                     "DataSource",
                     f"""
                     DataSource inferencing of event_timestamp_column is currently only supported
-                    for FileSource, SparkSource, BigQuerySource, RedshiftSource, and SnowflakeSource. 
+                    for FileSource, SparkSource, BigQuerySource, RedshiftSource, and SnowflakeSource.
                     Attempting to infer from {data_source}.
                     """,
                 )

--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -83,7 +83,8 @@ class BigQuerySource(DataSource):
             )
 
         return (
-            self.bigquery_options.table_ref == other.bigquery_options.table_ref
+            self.name == other.name
+            and self.bigquery_options.table_ref == other.bigquery_options.table_ref
             and self.bigquery_options.query == other.bigquery_options.query
             and self.event_timestamp_column == other.event_timestamp_column
             and self.created_timestamp_column == other.created_timestamp_column

--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -44,7 +44,7 @@ class BigQuerySource(DataSource):
          """
         if table is None and table_ref is None and query is None:
             raise ValueError('No "table" argument provided.')
-        if table_ref:
+        if not table and table_ref:
             warnings.warn(
                 (
                     "The argument 'table_ref' is being deprecated. Please use 'table' "
@@ -52,6 +52,7 @@ class BigQuerySource(DataSource):
                 ),
                 DeprecationWarning,
             )
+            table = table_ref
         self.bigquery_options = BigQueryOptions(table_ref=table, query=query)
 
         # If no name, use the table_ref as the default name

--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -2,7 +2,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from feast import type_map
 from feast.data_source import DataSource
-from feast.errors import DataSourceNotFoundException
+from feast.errors import DataSourceNoNameException, DataSourceNotFoundException
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
 from feast.protos.feast.core.SavedDataset_pb2 import (
     SavedDatasetStorage as SavedDatasetStorageProto,
@@ -15,6 +15,7 @@ from feast.value_type import ValueType
 class BigQuerySource(DataSource):
     def __init__(
         self,
+        name: Optional[str] = None,
         event_timestamp_column: Optional[str] = "",
         table_ref: Optional[str] = None,
         created_timestamp_column: Optional[str] = "",
@@ -22,14 +23,45 @@ class BigQuerySource(DataSource):
         date_partition_column: Optional[str] = "",
         query: Optional[str] = None,
     ):
+        """Create a BigQuerySource from an existing table or query.
+
+         Args:
+             name (optional): Name for the source. Defaults to the table_ref if not specified.
+             table_ref (optional): The BigQuery table where features can be found.
+             event_timestamp_column: Event timestamp column used for point in time joins of feature values.
+             created_timestamp_column (optional): Timestamp column when row was created, used for deduplicating rows.
+             field_mapping: A dictionary mapping of column names in this data source to feature names in a feature table
+                 or view. Only used for feature columns, not entities or timestamp columns.
+             date_partition_column (optional): Timestamp column used for partitioning.
+             query (optional): SQL query to execute to generate data for this data source.
+
+         Example:
+             >>> from feast import BigQuerySource
+             >>> my_bigquery_source = BigQuerySource(table_ref="gcp_project:bq_dataset.bq_table")
+         """
+        if table_ref is None and query is None:
+            raise ValueError('No "table_ref" argument provided.')
         self.bigquery_options = BigQueryOptions(table_ref=table_ref, query=query)
 
+        # If no name, use the table_ref as the default name
+        _name = name
+        if not _name:
+            if table_ref:
+                _name = table_ref
+            else:
+                raise DataSourceNoNameException()
+
         super().__init__(
+            _name if _name else "",
             event_timestamp_column,
             created_timestamp_column,
             field_mapping,
             date_partition_column,
         )
+
+    # Note: Python requires redefining hash in child classes that override __eq__
+    def __hash__(self):
+        return super().__hash__()
 
     def __eq__(self, other):
         if not isinstance(other, BigQuerySource):
@@ -59,6 +91,7 @@ class BigQuerySource(DataSource):
         assert data_source.HasField("bigquery_options")
 
         return BigQuerySource(
+            name=data_source.name,
             field_mapping=dict(data_source.field_mapping),
             table_ref=data_source.bigquery_options.table_ref,
             event_timestamp_column=data_source.event_timestamp_column,
@@ -69,6 +102,7 @@ class BigQuerySource(DataSource):
 
     def to_proto(self) -> DataSourceProto:
         data_source_proto = DataSourceProto(
+            name=self.name,
             type=DataSourceProto.BATCH_BIGQUERY,
             field_mapping=self.field_mapping,
             bigquery_options=self.bigquery_options.to_proto(),
@@ -132,7 +166,9 @@ class BigQueryOptions:
     DataSource BigQuery options used to source features from BigQuery query
     """
 
-    def __init__(self, table_ref: Optional[str], query: Optional[str]):
+    def __init__(
+        self, table_ref: Optional[str], query: Optional[str],
+    ):
         self._table_ref = table_ref
         self._query = query
 

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -17,7 +17,6 @@ from feast.value_type import ValueType
 
 
 class FileSource(DataSource):
-
     def __init__(
         self,
         path: str,
@@ -151,6 +150,7 @@ class FileSource(DataSource):
 
     def get_table_query_string(self) -> str:
         pass
+
 
 class FileOptions:
     """

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -74,7 +74,8 @@ class FileSource(DataSource):
             raise TypeError("Comparisons should only involve FileSource class objects.")
 
         return (
-            self.file_options.file_url == other.file_options.file_url
+            self.name == other.name
+            and self.file_options.file_url == other.file_options.file_url
             and self.file_options.file_format == other.file_options.file_format
             and self.event_timestamp_column == other.event_timestamp_column
             and self.created_timestamp_column == other.created_timestamp_column

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -17,13 +17,13 @@ from feast.value_type import ValueType
 
 
 class FileSource(DataSource):
+
     def __init__(
         self,
-        name: str = "",
+        path: str,
+        name: Optional[str] = "",
         event_timestamp_column: Optional[str] = "",
-        file_url: Optional[str] = None,
-        path: Optional[str] = None,
-        file_format: FileFormat = None,
+        file_format: Optional[FileFormat] = None,
         created_timestamp_column: Optional[str] = "",
         field_mapping: Optional[Dict[str, str]] = None,
         date_partition_column: Optional[str] = "",
@@ -149,6 +149,8 @@ class FileSource(DataSource):
         else:
             return None, path
 
+    def get_table_query_string(self) -> str:
+        pass
 
 class FileOptions:
     """

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -97,7 +97,8 @@ class RedshiftSource(DataSource):
             )
 
         return (
-            self.redshift_options.table == other.redshift_options.table
+            self.name == other.name
+            and self.redshift_options.table == other.redshift_options.table
             and self.redshift_options.schema == other.redshift_options.schema
             and self.redshift_options.query == other.redshift_options.query
             and self.event_timestamp_column == other.event_timestamp_column

--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -98,7 +98,8 @@ class SnowflakeSource(DataSource):
             )
 
         return (
-            self.snowflake_options.database == other.snowflake_options.database
+            self.name == other.name
+            and self.snowflake_options.database == other.snowflake_options.database
             and self.snowflake_options.schema == other.snowflake_options.schema
             and self.snowflake_options.table == other.snowflake_options.table
             and self.snowflake_options.query == other.snowflake_options.query

--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -2,6 +2,7 @@ from typing import Callable, Dict, Iterable, Optional, Tuple
 
 from feast import type_map
 from feast.data_source import DataSource
+from feast.errors import DataSourceNoNameException
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
 from feast.protos.feast.core.SavedDataset_pb2 import (
     SavedDatasetStorage as SavedDatasetStorageProto,
@@ -14,6 +15,7 @@ from feast.value_type import ValueType
 class SnowflakeSource(DataSource):
     def __init__(
         self,
+        name: Optional[str] = None,
         database: Optional[str] = None,
         schema: Optional[str] = None,
         table: Optional[str] = None,
@@ -27,6 +29,7 @@ class SnowflakeSource(DataSource):
         Creates a SnowflakeSource object.
 
         Args:
+            name (optional): Name for the source. Defaults to the table if not specified.
             database (optional): Snowflake database where the features are stored.
             schema (optional): Snowflake schema in which the table is located.
             table (optional): Snowflake table where the features are stored.
@@ -40,7 +43,19 @@ class SnowflakeSource(DataSource):
             date_partition_column (optional): Timestamp column used for partitioning.
 
         """
+        if table is None and query is None:
+            raise ValueError('No "table" argument provided.')
+
+        # If no name, use the table as the default name
+        _name = name
+        if not _name:
+            if table:
+                _name = table
+            else:
+                raise DataSourceNoNameException()
+
         super().__init__(
+            _name,
             event_timestamp_column,
             created_timestamp_column,
             field_mapping,

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -21,14 +21,18 @@ from threading import Lock
 from typing import Any, Dict, List, Optional, Set
 from urllib.parse import urlparse
 
+import dill
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
 from google.protobuf.json_format import MessageToJson
 from proto import Message
 
 from feast.base_feature_view import BaseFeatureView
+from feast.data_source import DataSource
 from feast.entity import Entity
 from feast.errors import (
     ConflictingFeatureViewNames,
+    DataSourceNotFoundException,
+    DataSourceObjectNotFoundException,
     EntityNotFoundException,
     FeatureServiceNotFoundException,
     FeatureViewNotFoundException,
@@ -65,6 +69,7 @@ REGISTRY_STORE_CLASS_FOR_SCHEME = {
 
 
 class FeastObjectType(Enum):
+    DATA_SOURCE = "data source"
     ENTITY = "entity"
     FEATURE_VIEW = "feature view"
     ON_DEMAND_FEATURE_VIEW = "on demand feature view"
@@ -76,6 +81,7 @@ class FeastObjectType(Enum):
         registry: "Registry", project: str
     ) -> Dict["FeastObjectType", List[Any]]:
         return {
+            FeastObjectType.DATA_SOURCE: registry.list_data_sources(),
             FeastObjectType.ENTITY: registry.list_entities(project=project),
             FeastObjectType.FEATURE_VIEW: registry.list_feature_views(project=project),
             FeastObjectType.ON_DEMAND_FEATURE_VIEW: registry.list_on_demand_feature_views(
@@ -94,6 +100,7 @@ class FeastObjectType(Enum):
         repo_contents: RepoContents,
     ) -> Dict["FeastObjectType", Set[Any]]:
         return {
+            FeastObjectType.DATA_SOURCE: repo_contents.data_sources,
             FeastObjectType.ENTITY: repo_contents.entities,
             FeastObjectType.FEATURE_VIEW: repo_contents.feature_views,
             FeastObjectType.ON_DEMAND_FEATURE_VIEW: repo_contents.on_demand_feature_views,
@@ -274,6 +281,66 @@ class Registry:
             if entity_proto.spec.project == project:
                 entities.append(Entity.from_proto(entity_proto))
         return entities
+
+    def list_data_sources(self, allow_cache: bool = False) -> List[DataSource]:
+        """
+        Retrieve a list of data sources from the registry
+
+        Args:
+            allow_cache: Whether to allow returning data sources from a cached registry
+
+        Returns:
+            List of data sources
+        """
+        registry_proto = self._get_registry_proto(allow_cache=allow_cache)
+        data_sources = []
+        for data_source_proto in registry_proto.data_sources:
+            data_sources.append(DataSource.from_proto(data_source_proto))
+        return data_sources
+
+    def apply_data_source(
+        self, data_source: DataSource, project: str, commit: bool = True
+    ):
+        """
+        Registers a single data source with Feast
+
+        Args:
+            data_source: A data source that will be registered
+            project: Feast project that this data source belongs to
+            commit: Whether to immediately commit to the registry
+        """
+        registry = self._prepare_registry_for_changes()
+
+        for idx, existing_data_source_proto in enumerate(registry.data_sources):
+            if existing_data_source_proto.name == data_source.name:
+                del registry.data_sources[idx]
+        data_source_proto = data_source.to_proto()
+        data_source_proto.project = project
+        registry.data_sources.append(data_source_proto)
+        if commit:
+            self.commit()
+
+    def delete_data_source(self, name: str, project: str, commit: bool = True):
+        """
+        Deletes a data source or raises an exception if not found.
+
+        Args:
+            name: Name of data source
+            project: Feast project that this data source belongs to
+            commit: Whether the change should be persisted immediately
+        """
+        self._prepare_registry_for_changes()
+        assert self.cached_registry_proto
+
+        for idx, data_source_proto in enumerate(
+            self.cached_registry_proto.data_sources
+        ):
+            if data_source_proto.name == name:
+                del self.cached_registry_proto.data_sources[idx]
+                if commit:
+                    self.commit()
+                return
+        raise DataSourceNotFoundException(name)
 
     def apply_feature_service(
         self, feature_service: FeatureService, project: str, commit: bool = True
@@ -464,7 +531,8 @@ class Registry:
 
         Args:
             name: Name of on demand feature view
-            project: Feast project that this on demand feature  belongs to
+            project: Feast project that this on demand feature view belongs to
+            allow_cache: Whether to allow returning this on demand feature view from a cached registry
 
         Returns:
             Returns either the specified on demand feature view, or raises an exception if
@@ -479,6 +547,27 @@ class Registry:
             ):
                 return OnDemandFeatureView.from_proto(on_demand_feature_view)
         raise OnDemandFeatureViewNotFoundException(name, project=project)
+
+    def get_data_source(
+        self, name: str, project: str, allow_cache: bool = False
+    ) -> DataSource:
+        """
+        Retrieves a data source.
+
+        Args:
+            name: Name of data source
+            project: Feast project that this data source belongs to
+            allow_cache: Whether to allow returning this data source from a cached registry
+
+        Returns:
+            Returns either the specified data source, or raises an exception if none is found
+        """
+        registry = self._get_registry_proto(allow_cache=allow_cache)
+
+        for data_source in registry.data_sources:
+            if data_source.project == project and data_source.name == name:
+                return DataSource.from_proto(data_source)
+        raise DataSourceObjectNotFoundException(name, project=project)
 
     def apply_materialization(
         self,
@@ -693,7 +782,7 @@ class Registry:
         raise EntityNotFoundException(name, project)
 
     def apply_saved_dataset(
-        self, saved_dataset: SavedDataset, project: str, commit: bool = True
+        self, saved_dataset: SavedDataset, project: str, commit: bool = True,
     ):
         """
         Registers a single entity with Feast
@@ -793,8 +882,12 @@ class Registry:
         Args:
             project: Feast project to convert to a dict
         """
-        registry_dict = defaultdict(list)
-
+        registry_dict: Dict[str, Any] = defaultdict(list)
+        registry_dict["project"] = project
+        for data_source in sorted(self.list_data_sources(), key=lambda ds: ds.name,):
+            registry_dict["dataSources"].append(
+                self._message_to_sorted_dict(data_source.to_proto())
+            )
         for entity in sorted(
             self.list_entities(project=project), key=lambda entity: entity.name
         ):
@@ -819,9 +912,11 @@ class Registry:
             self.list_on_demand_feature_views(project=project),
             key=lambda on_demand_feature_view: on_demand_feature_view.name,
         ):
-            registry_dict["onDemandFeatureViews"].append(
-                self._message_to_sorted_dict(on_demand_feature_view.to_proto())
+            odfv_dict = self._message_to_sorted_dict(on_demand_feature_view.to_proto())
+            odfv_dict["spec"]["userDefinedFunction"]["body"] = dill.source.getsource(
+                on_demand_feature_view.udf
             )
+            registry_dict["onDemandFeatureViews"].append(odfv_dict)
         for request_feature_view in sorted(
             self.list_request_feature_views(project=project),
             key=lambda request_feature_view: request_feature_view.name,

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -81,7 +81,7 @@ class FeastObjectType(Enum):
         registry: "Registry", project: str
     ) -> Dict["FeastObjectType", List[Any]]:
         return {
-            FeastObjectType.DATA_SOURCE: registry.list_data_sources(),
+            FeastObjectType.DATA_SOURCE: registry.list_data_sources(project=project),
             FeastObjectType.ENTITY: registry.list_entities(project=project),
             FeastObjectType.FEATURE_VIEW: registry.list_feature_views(project=project),
             FeastObjectType.ON_DEMAND_FEATURE_VIEW: registry.list_on_demand_feature_views(
@@ -888,7 +888,9 @@ class Registry:
         """
         registry_dict: Dict[str, Any] = defaultdict(list)
         registry_dict["project"] = project
-        for data_source in sorted(self.list_data_sources(), key=lambda ds: ds.name,):
+        for data_source in sorted(
+            self.list_data_sources(project=project), key=lambda ds: ds.name
+        ):
             registry_dict["dataSources"].append(
                 self._message_to_sorted_dict(data_source.to_proto())
             )

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -282,11 +282,14 @@ class Registry:
                 entities.append(Entity.from_proto(entity_proto))
         return entities
 
-    def list_data_sources(self, allow_cache: bool = False) -> List[DataSource]:
+    def list_data_sources(
+        self, project: str, allow_cache: bool = False
+    ) -> List[DataSource]:
         """
         Retrieve a list of data sources from the registry
 
         Args:
+            project: Filter data source based on project name
             allow_cache: Whether to allow returning data sources from a cached registry
 
         Returns:
@@ -295,7 +298,8 @@ class Registry:
         registry_proto = self._get_registry_proto(allow_cache=allow_cache)
         data_sources = []
         for data_source_proto in registry_proto.data_sources:
-            data_sources.append(DataSource.from_proto(data_source_proto))
+            if data_source_proto.project == project:
+                data_sources.append(DataSource.from_proto(data_source_proto))
         return data_sources
 
     def apply_data_source(

--- a/sdk/python/feast/repo_contents.py
+++ b/sdk/python/feast/repo_contents.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from typing import NamedTuple, Set
 
+from feast.data_source import DataSource
 from feast.entity import Entity
 from feast.feature_service import FeatureService
 from feast.feature_view import FeatureView
@@ -26,6 +27,7 @@ class RepoContents(NamedTuple):
     Represents the objects in a Feast feature repo.
     """
 
+    data_sources: Set[DataSource]
     feature_views: Set[FeatureView]
     on_demand_feature_views: Set[OnDemandFeatureView]
     request_feature_views: Set[RequestFeatureView]
@@ -34,6 +36,7 @@ class RepoContents(NamedTuple):
 
     def to_registry_proto(self) -> RegistryProto:
         registry_proto = RegistryProto()
+        registry_proto.data_sources.extend([e.to_proto() for e in self.data_sources])
         registry_proto.entities.extend([e.to_proto() for e in self.entities])
         registry_proto.feature_views.extend(
             [fv.to_proto() for fv in self.feature_views]

--- a/sdk/python/feast/saved_dataset.py
+++ b/sdk/python/feast/saved_dataset.py
@@ -54,6 +54,7 @@ class SavedDataset:
     full_feature_names: bool
     storage: SavedDatasetStorage
     tags: Dict[str, str]
+    feature_service_name: Optional[str] = None
 
     created_timestamp: Optional[datetime] = None
     last_updated_timestamp: Optional[datetime] = None
@@ -71,6 +72,7 @@ class SavedDataset:
         storage: SavedDatasetStorage,
         full_feature_names: bool = False,
         tags: Optional[Dict[str, str]] = None,
+        feature_service_name: Optional[str] = None,
     ):
         self.name = name
         self.features = features
@@ -78,6 +80,7 @@ class SavedDataset:
         self.storage = storage
         self.full_feature_names = full_feature_names
         self.tags = tags or {}
+        self.feature_service_name = feature_service_name
 
         self._retrieval_job = None
 
@@ -121,6 +124,9 @@ class SavedDataset:
             tags=dict(saved_dataset_proto.spec.tags.items()),
         )
 
+        if saved_dataset_proto.spec.feature_service_name:
+            ds.feature_service_name = saved_dataset_proto.spec.feature_service_name
+
         if saved_dataset_proto.meta.HasField("created_timestamp"):
             ds.created_timestamp = (
                 saved_dataset_proto.meta.created_timestamp.ToDatetime()
@@ -163,6 +169,8 @@ class SavedDataset:
             storage=self.storage.to_proto(),
             tags=self.tags,
         )
+        if self.feature_service_name:
+            spec.feature_service_name = self.feature_service_name
 
         feature_service_proto = SavedDatasetProto(spec=spec, meta=meta)
         return feature_service_proto

--- a/sdk/python/tests/example_repos/example_feature_repo_1.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_1.py
@@ -10,7 +10,7 @@ from feast import (
 )
 
 driver_locations_source = BigQuerySource(
-    table_ref="feast-oss.public.drivers",
+    table="feast-oss.public.drivers",
     event_timestamp_column="event_timestamp",
     created_timestamp_column="created_timestamp",
 )

--- a/sdk/python/tests/example_repos/example_feature_repo_1.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_1.py
@@ -16,7 +16,9 @@ driver_locations_source = BigQuerySource(
 )
 
 customer_profile_source = BigQuerySource(
-    table_ref="feast-oss.public.customers", event_timestamp_column="event_timestamp",
+    name="customer_profile_source",
+    table_ref="feast-oss.public.customers",
+    event_timestamp_column="event_timestamp",
 )
 
 customer_driver_combined_source = BigQuerySource(

--- a/sdk/python/tests/example_repos/example_repo_duplicate_data_source_names.py
+++ b/sdk/python/tests/example_repos/example_repo_duplicate_data_source_names.py
@@ -1,0 +1,11 @@
+from google.protobuf.duration_pb2 import Duration
+
+from feast import FileSource
+
+driver_hourly_stats = FileSource(
+    path="driver_stats.parquet",  # this parquet is not real and will not be read
+)
+
+driver_hourly_stats_clone = FileSource(
+    path="driver_stats.parquet",  # this parquet is not real and will not be read
+)

--- a/sdk/python/tests/example_repos/example_repo_duplicate_data_source_names.py
+++ b/sdk/python/tests/example_repos/example_repo_duplicate_data_source_names.py
@@ -1,5 +1,3 @@
-from google.protobuf.duration_pb2 import Duration
-
 from feast import FileSource
 
 driver_hourly_stats = FileSource(

--- a/sdk/python/tests/integration/registration/test_cli.py
+++ b/sdk/python/tests/integration/registration/test_cli.py
@@ -69,6 +69,8 @@ def test_universal_cli(environment: Environment):
             assertpy.assert_that(result.returncode).is_equal_to(0)
             result = runner.run(["feature-services", "list"], cwd=repo_path)
             assertpy.assert_that(result.returncode).is_equal_to(0)
+            result = runner.run(["data-sources", "list"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(0)
 
             # entity & feature view describe commands should succeed when objects exist
             result = runner.run(["entities", "describe", "driver"], cwd=repo_path)
@@ -83,6 +85,11 @@ def test_universal_cli(environment: Environment):
             )
             assertpy.assert_that(result.returncode).is_equal_to(0)
             assertpy.assert_that(fs.list_feature_views()).is_length(3)
+            result = runner.run(
+                ["data-sources", "describe", "customer_profile_source"], cwd=repo_path,
+            )
+            assertpy.assert_that(result.returncode).is_equal_to(0)
+            assertpy.assert_that(fs.list_data_sources()).is_length(3)
 
             # entity & feature view describe commands should fail when objects don't exist
             result = runner.run(["entities", "describe", "foo"], cwd=repo_path)
@@ -90,6 +97,8 @@ def test_universal_cli(environment: Environment):
             result = runner.run(["feature-views", "describe", "foo"], cwd=repo_path)
             assertpy.assert_that(result.returncode).is_equal_to(1)
             result = runner.run(["feature-services", "describe", "foo"], cwd=repo_path)
+            assertpy.assert_that(result.returncode).is_equal_to(1)
+            result = runner.run(["data-sources", "describe", "foo"], cwd=repo_path)
             assertpy.assert_that(result.returncode).is_equal_to(1)
 
             # Doing another apply should be a no op, and should not cause errors

--- a/sdk/python/tests/integration/registration/test_cli_apply_duplicates.py
+++ b/sdk/python/tests/integration/registration/test_cli_apply_duplicates.py
@@ -6,10 +6,20 @@ from tests.utils.cli_utils import CliRunner, get_example_repo
 
 
 def test_cli_apply_duplicated_featureview_names() -> None:
-    """
-    Test apply feature views with duplicated names and single py file in a feature repo using CLI
-    """
+    run_simple_apply_test(
+        example_repo_file_name="example_feature_repo_with_duplicated_featureview_names.py",
+        expected_error=b"Please ensure that all feature view names are case-insensitively unique",
+    )
 
+
+def test_cli_apply_duplicate_data_source_names() -> None:
+    run_simple_apply_test(
+        example_repo_file_name="example_repo_duplicate_data_source_names.py",
+        expected_error=b"Please ensure that all data source names are case-insensitively unique",
+    )
+
+
+def run_simple_apply_test(example_repo_file_name: str, expected_error: bytes):
     with tempfile.TemporaryDirectory() as repo_dir_name, tempfile.TemporaryDirectory() as data_dir_name:
         runner = CliRunner()
         # Construct an example repo in a temporary dir
@@ -31,18 +41,10 @@ def test_cli_apply_duplicated_featureview_names() -> None:
         )
 
         repo_example = repo_path / "example.py"
-        repo_example.write_text(
-            get_example_repo(
-                "example_feature_repo_with_duplicated_featureview_names.py"
-            )
-        )
+        repo_example.write_text(get_example_repo(example_repo_file_name))
         rc, output = runner.run_with_output(["apply"], cwd=repo_path)
 
-        assert (
-            rc != 0
-            and b"Please ensure that all feature view names are case-insensitively unique"
-            in output
-        )
+        assert rc != 0 and expected_error in output
 
 
 def test_cli_apply_imported_featureview() -> None:

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -1,9 +1,22 @@
 import pandas as pd
 import pytest
 
-from feast import Entity, Feature, RepoConfig, ValueType, FileSource, BigQuerySource, SnowflakeSource, RedshiftSource
+from feast import (
+    BigQuerySource,
+    Entity,
+    Feature,
+    FileSource,
+    RedshiftSource,
+    RepoConfig,
+    SnowflakeSource,
+    ValueType,
+)
 from feast.data_source import RequestDataSource
-from feast.errors import RegistryInferenceFailure, SpecifiedFeaturesNotPresentError
+from feast.errors import (
+    DataSourceNoNameException,
+    RegistryInferenceFailure,
+    SpecifiedFeaturesNotPresentError,
+)
 from feast.feature_view import FeatureView
 from feast.inference import (
     update_data_sources_with_inferred_event_timestamp_col,
@@ -60,46 +73,34 @@ def test_update_entities_with_inferred_types_from_feature_views(
 
 def test_infer_datasource_names_file():
     file_path = "path/to/test.csv"
-    data_source = FileSource(
-        path=file_path
-    )
+    data_source = FileSource(path=file_path)
     assert data_source.name == file_path
 
     source_name = "my_name"
-    data_source = FileSource(
-        name=source_name,
-        path=file_path
-    )
+    data_source = FileSource(name=source_name, path=file_path)
     assert data_source.name == source_name
 
 
 def test_infer_datasource_names_dwh():
-    table_ref = "project.table"
+    table = "project.table"
     dwh_classes = [BigQuerySource, RedshiftSource, SnowflakeSource]
 
     for dwh_class in dwh_classes:
-        data_source = dwh_class(
-            table_ref=table_ref
-        )
-        assert data_source.name == table_ref
+        data_source = dwh_class(table=table)
+        assert data_source.name == table
 
         source_name = "my_name"
-        data_source_with_table_ref = dwh_class(
-            name=source_name,
-            table_ref=table_ref
-        )
-        assert data_source_with_table_ref.name == source_name
+        data_source_with_table = dwh_class(name=source_name, table=table)
+        assert data_source_with_table.name == source_name
         data_source_with_query = dwh_class(
-            name=source_name,
-            query=f"SELECT * from {table_ref}"
+            name=source_name, query=f"SELECT * from {table}"
         )
         assert data_source_with_query.name == source_name
 
         # If we have a query and no name, throw an error
-        with pytest.raises(ValueError):
-            data_source = dwh_class(
-                query="test_query"
-            )
+        with pytest.raises(DataSourceNoNameException):
+            print(f"Testing dwh {dwh_class}")
+            data_source = dwh_class(query="test_query")
 
 
 @pytest.mark.integration

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from feast import Entity, Feature, RepoConfig, ValueType
+from feast import Entity, Feature, RepoConfig, ValueType, FileSource, BigQuerySource, SnowflakeSource, RedshiftSource
 from feast.data_source import RequestDataSource
 from feast.errors import RegistryInferenceFailure, SpecifiedFeaturesNotPresentError
 from feast.feature_view import FeatureView
@@ -55,6 +55,50 @@ def test_update_entities_with_inferred_types_from_feature_views(
                 [Entity(name="id", join_key="id_join_key")],
                 [fv1, fv2],
                 RepoConfig(provider="local", project="test"),
+            )
+
+
+def test_infer_datasource_names_file():
+    file_path = "path/to/test.csv"
+    data_source = FileSource(
+        path=file_path
+    )
+    assert data_source.name == file_path
+
+    source_name = "my_name"
+    data_source = FileSource(
+        name=source_name,
+        path=file_path
+    )
+    assert data_source.name == source_name
+
+
+def test_infer_datasource_names_dwh():
+    table_ref = "project.table"
+    dwh_classes = [BigQuerySource, RedshiftSource, SnowflakeSource]
+
+    for dwh_class in dwh_classes:
+        data_source = dwh_class(
+            table_ref=table_ref
+        )
+        assert data_source.name == table_ref
+
+        source_name = "my_name"
+        data_source_with_table_ref = dwh_class(
+            name=source_name,
+            table_ref=table_ref
+        )
+        assert data_source_with_table_ref.name == source_name
+        data_source_with_query = dwh_class(
+            name=source_name,
+            query=f"SELECT * from {table_ref}"
+        )
+        assert data_source_with_query.name == source_name
+
+        # If we have a query and no name, throw an error
+        with pytest.raises(ValueError):
+            data_source = dwh_class(
+                query="test_query"
             )
 
 

--- a/sdk/python/tests/integration/registration/test_registry.py
+++ b/sdk/python/tests/integration/registration/test_registry.py
@@ -466,8 +466,10 @@ def test_apply_data_source(test_registry: Registry):
     registry_feature_view = test_registry.list_feature_views(project)[0]
     assert registry_feature_view.batch_source == batch_source
 
+    # Check that change to batch source propagates
     batch_source.event_timestamp_column = "new_ts_col"
-    test_registry.apply_data_source(batch_source, project)
+    test_registry.apply_data_source(batch_source, project, commit=False)
+    test_registry.apply_feature_view(fv1, project, commit=True)
     registry_feature_view = test_registry.list_feature_views(project)[0]
     assert registry_feature_view.batch_source == batch_source
     registry_batch_source = test_registry.list_data_sources(project)[0]

--- a/sdk/python/tests/integration/registration/test_registry.py
+++ b/sdk/python/tests/integration/registration/test_registry.py
@@ -463,14 +463,24 @@ def test_apply_data_source(test_registry: Registry):
     test_registry.apply_data_source(batch_source, project, commit=False)
     test_registry.apply_feature_view(fv1, project, commit=True)
 
-    registry_feature_view = test_registry.list_feature_views(project)[0]
+    registry_feature_views = test_registry.list_feature_views(project)
+    registry_data_sources = test_registry.list_data_sources(project)
+    assert len(registry_feature_views) == 1
+    assert len(registry_data_sources) == 1
+    registry_feature_view = registry_feature_views[0]
     assert registry_feature_view.batch_source == batch_source
+    registry_data_source = registry_data_sources[0]
+    assert registry_data_source == batch_source
 
     # Check that change to batch source propagates
     batch_source.event_timestamp_column = "new_ts_col"
     test_registry.apply_data_source(batch_source, project, commit=False)
     test_registry.apply_feature_view(fv1, project, commit=True)
-    registry_feature_view = test_registry.list_feature_views(project)[0]
+    registry_feature_views = test_registry.list_feature_views(project)
+    registry_data_sources = test_registry.list_data_sources(project)
+    assert len(registry_feature_views) == 1
+    assert len(registry_data_sources) == 1
+    registry_feature_view = registry_feature_views[0]
     assert registry_feature_view.batch_source == batch_source
     registry_batch_source = test_registry.list_data_sources(project)[0]
     assert registry_batch_source == batch_source

--- a/sdk/python/tests/utils/data_source_utils.py
+++ b/sdk/python/tests/utils/data_source_utils.py
@@ -52,6 +52,7 @@ def simple_bq_source_using_query_arg(df, event_timestamp_column=None) -> BigQuer
         df, event_timestamp_column
     )
     return BigQuerySource(
+        name=bq_source_using_table_ref.table_ref,
         query=f"SELECT * FROM {bq_source_using_table_ref.table_ref}",
         event_timestamp_column=event_timestamp_column,
     )


### PR DESCRIPTION
**What this PR does / why we need it**:
Key changes:
- Data sources are now registered in the registry at the top level and can be queried. They need to have names specified (defaulting to the table ref). Note that we move the request data source's name into the top level name instead. They also now have projects attached to them
- Removing unused fields in protos
- `feast registry-dump` becomes more official as a way of dumping data for the Web UI
- Saved datasets can optionally also reference a feature service if they were generated from a feature service.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Data sources are now discoverable from the CLI and are attached to projects.
```
