### PR TITLE
feat: Key ttl setting for redis online store

### DIFF
--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -68,6 +68,9 @@ class RedisOnlineStoreConfig(FeastConfigBaseModel):
     """Connection string containing the host, port, and configuration parameters for Redis
      format: host:port,parameter1,parameter2 eg. redis:6379,db=0 """
 
+    key_ttl_seconds: int = None
+    """(Optional) redis key bin ttl (in seconds) for expiring entities"""
+
 
 class RedisOnlineStore(OnlineStore):
     _client: Optional[Union[Redis, RedisCluster]] = None
@@ -227,9 +230,11 @@ class RedisOnlineStore(OnlineStore):
                     entity_hset[f_key] = val.SerializeToString()
 
                 pipe.hset(redis_key_bin, mapping=entity_hset)
-                # TODO: support expiring the entity / features in Redis
-                # otherwise entity features remain in redis until cleaned up in separate process
-                # client.expire redis_key_bin based a ttl setting
+
+                if online_store_config.key_ttl_seconds:
+                    pipe.expire(
+                        name=redis_key_bin, time=online_store_config.key_ttl_seconds
+                    )
             results = pipe.execute()
             if progress:
                 progress(len(results))

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -68,7 +68,7 @@ class RedisOnlineStoreConfig(FeastConfigBaseModel):
     """Connection string containing the host, port, and configuration parameters for Redis
      format: host:port,parameter1,parameter2 eg. redis:6379,db=0 """
 
-    key_ttl_seconds: int = None
+    key_ttl_seconds: Optional[int] = None
     """(Optional) redis key bin ttl (in seconds) for expiring entities"""
 
 


### PR DESCRIPTION
Signed-off-by: Vitaly Sergeyev <vsergeyev@better.com>

TTL feature for Redis online store in order to expire entity keys after some time.

Some thoughts and discussions here:
https://docs.google.com/document/d/1K8k756lgsG-YoIiEyHMOOBEejQerurhfMIABlu8Cir4/edit#heading=h.gjdgxs

Issue:
https://github.com/feast-dev/feast/issues/1988


This implementation is explicitly for the Redis Online store. In the future, this may be better as a `FeatureView` or `Entity` ttl param but it would need some more development to be able to handle across different OnlineStore providers.

```release-note
Python Redis online store allows TTL expiration on entity keys
```