### PR TITLE
ci: Capping the dask dependency since Dask dropped Python 3.7 support

### DIFF
--- a/sdk/python/requirements/py3.7-ci-requirements.txt
+++ b/sdk/python/requirements/py3.7-ci-requirements.txt
@@ -54,7 +54,7 @@ attrs==21.4.0
     #   pytest
 avro==1.10.0
     # via feast (setup.py)
-azure-core==1.21.1
+azure-core==1.22.1
     # via
     #   adlfs
     #   azure-identity
@@ -77,11 +77,11 @@ black==19.10b0
     # via feast (setup.py)
 bleach==4.1.0
     # via nbconvert
-boto3==1.20.46
+boto3==1.21.8
     # via
     #   feast (setup.py)
     #   moto
-botocore==1.23.46
+botocore==1.24.8
     # via
     #   boto3
     #   moto
@@ -104,21 +104,23 @@ cffi==1.15.0
     #   snowflake-connector-python
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==2.0.11
+charset-normalizer==2.0.12
     # via
     #   aiohttp
     #   requests
     #   snowflake-connector-python
-click==8.0.3
+click==8.0.4
     # via
     #   black
     #   feast (setup.py)
     #   great-expectations
     #   pip-tools
     #   uvicorn
+cloudpickle==2.0.0
+    # via dask
 colorama==0.4.4
     # via feast (setup.py)
-coverage[toml]==6.3
+coverage[toml]==6.3.2
     # via pytest-cov
 cryptography==3.3.2
     # via
@@ -131,6 +133,8 @@ cryptography==3.3.2
     #   pyjwt
     #   pyopenssl
     #   snowflake-connector-python
+dask==2022.1.1
+    # via feast (setup.py)
 debugpy==1.5.1
     # via ipykernel
 decorator==5.1.1
@@ -155,20 +159,20 @@ docutils==0.17.1
     # via
     #   sphinx
     #   sphinx-rtd-theme
-entrypoints==0.3
+entrypoints==0.4
     # via
     #   altair
     #   jupyter-client
     #   nbconvert
 execnet==1.9.0
     # via pytest-xdist
-fastapi==0.73.0
+fastapi==0.74.1
     # via feast (setup.py)
 fastavro==1.4.9
     # via
     #   feast (setup.py)
     #   pandavro
-filelock==3.4.2
+filelock==3.6.0
     # via virtualenv
 firebase-admin==4.5.2
     # via feast (setup.py)
@@ -178,11 +182,12 @@ frozenlist==1.3.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2022.1.0
+fsspec==2022.2.0
     # via
     #   adlfs
+    #   dask
     #   gcsfs
-gcsfs==2022.1.0
+gcsfs==2022.2.0
     # via feast (setup.py)
 google-api-core[grpc]==1.31.5
     # via
@@ -194,7 +199,7 @@ google-api-core[grpc]==1.31.5
     #   google-cloud-core
     #   google-cloud-datastore
     #   google-cloud-firestore
-google-api-python-client==2.36.0
+google-api-python-client==2.38.0
     # via firebase-admin
 google-auth==1.35.0
     # via
@@ -207,11 +212,11 @@ google-auth==1.35.0
     #   google-cloud-storage
 google-auth-httplib2==0.1.0
     # via google-api-python-client
-google-auth-oauthlib==0.4.6
+google-auth-oauthlib==0.5.0
     # via gcsfs
-google-cloud-bigquery==2.32.0
+google-cloud-bigquery==2.34.0
     # via feast (setup.py)
-google-cloud-bigquery-storage==2.11.0
+google-cloud-bigquery-storage==2.12.0
     # via feast (setup.py)
 google-cloud-core==1.7.2
     # via
@@ -240,9 +245,9 @@ googleapis-common-protos==1.52.0
     #   feast (setup.py)
     #   google-api-core
     #   tensorflow-metadata
-great-expectations==0.14.4
+great-expectations==0.14.8
     # via feast (setup.py)
-grpcio==1.43.0
+grpcio==1.44.0
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -250,7 +255,7 @@ grpcio==1.43.0
     #   grpcio-reflection
     #   grpcio-testing
     #   grpcio-tools
-grpcio-reflection==1.43.0
+grpcio-reflection==1.44.0
     # via feast (setup.py)
 grpcio-testing==1.34.0
     # via feast (setup.py)
@@ -260,13 +265,13 @@ h11==0.13.0
     # via uvicorn
 hiredis==2.0.0
     # via feast (setup.py)
-httplib2==0.20.2
+httplib2==0.20.4
     # via
     #   google-api-python-client
     #   google-auth-httplib2
 httptools==0.3.0
     # via uvicorn
-identify==2.4.7
+identify==2.4.11
     # via pre-commit
 idna==3.3
     # via
@@ -293,11 +298,11 @@ importlib-resources==5.4.0
     # via jsonschema
 iniconfig==1.1.1
     # via pytest
-ipykernel==6.7.0
+ipykernel==6.9.1
     # via
     #   ipywidgets
     #   notebook
-ipython==7.31.1
+ipython==7.32.0
     # via
     #   ipykernel
     #   ipywidgets
@@ -342,7 +347,7 @@ jupyter-client==7.1.2
     #   ipykernel
     #   nbclient
     #   notebook
-jupyter-core==4.9.1
+jupyter-core==4.9.2
     # via
     #   jupyter-client
     #   nbconvert
@@ -353,10 +358,10 @@ jupyterlab-pygments==0.1.2
 jupyterlab-widgets==1.0.2
     # via ipywidgets
 libcst==0.4.1
-    # via
-    #   google-cloud-bigquery-storage
-    #   google-cloud-datastore
-markupsafe==2.0.1
+    # via google-cloud-datastore
+locket==0.2.1
+    # via partd
+markupsafe==2.1.0
     # via
     #   jinja2
     #   moto
@@ -376,9 +381,9 @@ mmh3==3.0.0
     # via feast (setup.py)
 mock==2.0.0
     # via feast (setup.py)
-moto==3.0.2
+moto==3.0.5
     # via feast (setup.py)
-msal==1.16.0
+msal==1.17.0
     # via
     #   azure-identity
     #   msal-extensions
@@ -404,9 +409,9 @@ mypy-extensions==0.4.3
     #   typing-inspect
 mypy-protobuf==3.1.0
     # via feast (setup.py)
-nbclient==0.5.10
+nbclient==0.5.11
     # via nbconvert
-nbconvert==6.4.1
+nbconvert==6.4.2
     # via notebook
 nbformat==5.1.3
     # via
@@ -439,6 +444,7 @@ oscrypto==1.2.1
 packaging==21.3
     # via
     #   bleach
+    #   dask
     #   deprecation
     #   google-api-core
     #   google-cloud-bigquery
@@ -459,9 +465,11 @@ pandocfilters==1.5.0
     # via nbconvert
 parso==0.8.3
     # via jedi
+partd==1.2.0
+    # via dask
 pathspec==0.9.0
     # via black
-pbr==5.8.0
+pbr==5.8.1
     # via mock
 pep517==0.12.0
     # via pip-tools
@@ -469,19 +477,19 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.4.0
+pip-tools==6.5.1
     # via feast (setup.py)
-platformdirs==2.4.1
+platformdirs==2.5.1
     # via virtualenv
 pluggy==1.0.0
     # via pytest
-portalocker==2.3.2
+portalocker==2.4.0
     # via msal-extensions
 pre-commit==2.17.0
     # via feast (setup.py)
 prometheus-client==0.13.1
     # via notebook
-prompt-toolkit==3.0.26
+prompt-toolkit==3.0.28
     # via ipython
 proto-plus==1.19.6
     # via
@@ -526,7 +534,7 @@ pycodestyle==2.8.0
     # via flake8
 pycparser==2.21
     # via cffi
-pycryptodomex==3.14.0
+pycryptodomex==3.14.1
     # via snowflake-connector-python
 pydantic==1.9.0
     # via
@@ -554,7 +562,7 @@ pyparsing==2.4.7
     #   packaging
 pyrsistent==0.18.1
     # via jsonschema
-pytest==6.2.5
+pytest==7.0.1
     # via
     #   feast (setup.py)
     #   pytest-benchmark
@@ -604,6 +612,7 @@ pytz-deprecation-shim==0.1.0.post0
     # via tzlocal
 pyyaml==6.0
     # via
+    #   dask
     #   feast (setup.py)
     #   libcst
     #   pre-commit
@@ -612,7 +621,7 @@ pyzmq==22.3.0
     # via
     #   jupyter-client
     #   notebook
-redis==4.1.2
+redis==4.1.4
     # via feast (setup.py)
 regex==2022.1.18
     # via black
@@ -640,7 +649,7 @@ requests-oauthlib==1.3.1
     # via
     #   google-auth-oauthlib
     #   msrest
-responses==0.17.0
+responses==0.18.0
     # via moto
 rsa==4.8
     # via google-auth
@@ -648,7 +657,7 @@ ruamel.yaml==0.17.17
     # via great-expectations
 ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
-s3transfer==0.5.0
+s3transfer==0.5.2
     # via boto3
 scipy==1.7.3
     # via great-expectations
@@ -673,13 +682,12 @@ six==1.16.0
     #   pandavro
     #   pyopenssl
     #   python-dateutil
-    #   responses
     #   virtualenv
 sniffio==1.2.0
     # via anyio
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python[pandas]==2.7.3
+snowflake-connector-python[pandas]==2.7.4
     # via feast (setup.py)
 sphinx==4.3.2
     # via
@@ -713,21 +721,24 @@ terminado==0.13.1
     # via notebook
 testcontainers==3.4.2
     # via feast (setup.py)
-testpath==0.5.0
+testpath==0.6.0
     # via nbconvert
 toml==0.10.2
     # via
     #   black
     #   feast (setup.py)
     #   pre-commit
-    #   pytest
-tomli==2.0.0
+tomli==2.0.1
     # via
     #   coverage
     #   mypy
     #   pep517
+    #   pytest
 toolz==0.11.2
-    # via altair
+    # via
+    #   altair
+    #   dask
+    #   partd
 tornado==6.1
     # via
     #   ipykernel
@@ -754,29 +765,27 @@ typed-ast==1.5.2
     # via
     #   black
     #   mypy
-types-futures==3.3.8
-    # via types-protobuf
-types-protobuf==3.19.7
+types-protobuf==3.19.12
     # via
     #   feast (setup.py)
     #   mypy-protobuf
 types-python-dateutil==2.8.9
     # via feast (setup.py)
-types-pytz==2021.3.4
+types-pytz==2021.3.5
     # via feast (setup.py)
 types-pyyaml==6.0.4
     # via feast (setup.py)
-types-redis==4.1.13
+types-redis==4.1.17
     # via feast (setup.py)
-types-requests==2.27.8
+types-requests==2.27.11
     # via feast (setup.py)
-types-setuptools==57.4.8
+types-setuptools==57.4.9
     # via feast (setup.py)
 types-tabulate==0.8.5
     # via feast (setup.py)
-types-urllib3==1.26.8
+types-urllib3==1.26.9
     # via types-requests
-typing-extensions==4.0.1
+typing-extensions==4.1.1
     # via
     #   aiohttp
     #   anyio
@@ -809,11 +818,11 @@ urllib3==1.26.8
     #   minio
     #   requests
     #   responses
-uvicorn[standard]==0.17.1
+uvicorn[standard]==0.17.5
     # via feast (setup.py)
 uvloop==0.16.0
     # via uvicorn
-virtualenv==20.13.0
+virtualenv==20.13.2
     # via pre-commit
 watchgod==0.7
     # via uvicorn
@@ -821,11 +830,11 @@ wcwidth==0.2.5
     # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
-websocket-client==1.2.3
+websocket-client==1.3.1
     # via docker
-websockets==10.1
+websockets==10.2
     # via uvicorn
-werkzeug==2.0.2
+werkzeug==2.0.3
     # via moto
 wheel==0.37.1
     # via pip-tools

--- a/sdk/python/requirements/py3.7-requirements.txt
+++ b/sdk/python/requirements/py3.7-requirements.txt
@@ -8,44 +8,50 @@ absl-py==1.0.0
     # via tensorflow-metadata
 anyio==3.5.0
     # via starlette
-asgiref==3.4.1
+asgiref==3.5.0
     # via uvicorn
 attrs==21.4.0
     # via jsonschema
-cachetools==4.2.4
+cachetools==5.0.0
     # via google-auth
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.10
+charset-normalizer==2.0.12
     # via requests
-click==8.0.3
+click==8.0.4
     # via
     #   feast (setup.py)
     #   uvicorn
+cloudpickle==2.0.0
+    # via dask
 colorama==0.4.4
+    # via feast (setup.py)
+dask==2022.1.1
     # via feast (setup.py)
 dill==0.3.4
     # via feast (setup.py)
-fastapi==0.72.0
+fastapi==0.74.1
     # via feast (setup.py)
 fastavro==1.4.9
     # via
     #   feast (setup.py)
     #   pandavro
-google-api-core==2.4.0
+fsspec==2022.2.0
+    # via dask
+google-api-core==2.5.0
     # via feast (setup.py)
-google-auth==2.3.3
+google-auth==2.6.0
     # via google-api-core
 googleapis-common-protos==1.52.0
     # via
     #   feast (setup.py)
     #   google-api-core
     #   tensorflow-metadata
-grpcio==1.43.0
+grpcio==1.44.0
     # via
     #   feast (setup.py)
     #   grpcio-reflection
-grpcio-reflection==1.43.0
+grpcio-reflection==1.44.0
     # via feast (setup.py)
 h11==0.13.0
     # via uvicorn
@@ -55,7 +61,7 @@ idna==3.3
     # via
     #   anyio
     #   requests
-importlib-metadata==4.10.1
+importlib-metadata==4.11.1
     # via
     #   click
     #   jsonschema
@@ -65,7 +71,9 @@ jinja2==3.0.3
     # via feast (setup.py)
 jsonschema==4.4.0
     # via feast (setup.py)
-markupsafe==2.0.1
+locket==0.2.1
+    # via partd
+markupsafe==2.1.0
     # via jinja2
 mmh3==3.0.0
     # via feast (setup.py)
@@ -74,15 +82,19 @@ numpy==1.21.5
     #   pandas
     #   pandavro
     #   pyarrow
+packaging==21.3
+    # via dask
 pandas==1.3.5
     # via
     #   feast (setup.py)
     #   pandavro
 pandavro==1.5.2
     # via feast (setup.py)
+partd==1.2.0
+    # via dask
 proto-plus==1.19.6
     # via feast (setup.py)
-protobuf==3.19.3
+protobuf==3.19.4
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -90,7 +102,7 @@ protobuf==3.19.3
     #   grpcio-reflection
     #   proto-plus
     #   tensorflow-metadata
-pyarrow==6.0.1
+pyarrow==7.0.0
     # via feast (setup.py)
 pyasn1==0.4.8
     # via
@@ -102,6 +114,8 @@ pydantic==1.9.0
     # via
     #   fastapi
     #   feast (setup.py)
+pyparsing==3.0.7
+    # via packaging
 pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
@@ -112,6 +126,7 @@ pytz==2021.3
     # via pandas
 pyyaml==6.0
     # via
+    #   dask
     #   feast (setup.py)
     #   uvicorn
 requests==2.27.1
@@ -137,9 +152,13 @@ tensorflow-metadata==1.6.0
     # via feast (setup.py)
 toml==0.10.2
     # via feast (setup.py)
+toolz==0.11.2
+    # via
+    #   dask
+    #   partd
 tqdm==4.62.3
     # via feast (setup.py)
-typing-extensions==4.0.1
+typing-extensions==4.1.1
     # via
     #   anyio
     #   asgiref
@@ -151,18 +170,15 @@ typing-extensions==4.0.1
     #   uvicorn
 urllib3==1.26.8
     # via requests
-uvicorn[standard]==0.17.0
+uvicorn[standard]==0.17.5
     # via feast (setup.py)
 uvloop==0.16.0
     # via uvicorn
 watchgod==0.7
     # via uvicorn
-websockets==10.1
+websockets==10.2
     # via uvicorn
 zipp==3.7.0
     # via
     #   importlib-metadata
     #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -40,7 +40,7 @@ AUTHOR = "Feast"
 REQUIRES_PYTHON = ">=3.7.0"
 
 REQUIRED = [
-    "Click==8.*",
+    "Click>=7.*",
     "colorama>=0.3.9",
     "dill==0.3.*",
     "fastavro>=1.1.0",
@@ -66,7 +66,7 @@ REQUIRED = [
     "uvicorn[standard]>=0.14.0",
     "proto-plus<1.19.7",
     "tensorflow-metadata>=1.0.0,<2.0.0",
-    "dask>=2021.*",
+    "dask>=2021.*,<2022.02.0",
 ]
 
 GCP_REQUIRED = [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
See https://github.com/dask/dask/pull/8572 which dropped Python 3.7 support in Dask for the last 2 releases.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
