### PR TITLE
fix: Method _should_use_plan only returns true for local sqlite provider

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -392,8 +392,10 @@ class FeatureStore:
 
     def _should_use_plan(self):
         """Returns True if _plan and _apply_diffs should be used, False otherwise."""
-        # Currently only the local provider supports _plan and _apply_diffs.
-        return self.config.provider == "local"
+        # Currently only the local provider with sqlite online store supports _plan and _apply_diffs.
+        return self.config.provider == "local" and (
+            self.config.online_store and self.config.online_store.type == "sqlite"
+        )
 
     def _validate_all_feature_views(
         self,


### PR DESCRIPTION
Only the SQLite local provider supports _plan and _apply_diffs. Updated
the _should_use_plan method to only return true for that setup so that other local providers don't need to implement these methods right now.

Signed-off-by: Gunnar Sv Sigurbjörnsson <gunnar.sigurbjornsson@gmail.com>

**What this PR does / why we need it**:
Only the SQLite provider supports _plan and _apply_diffs today. Before this can be added to other providers there needs to be some discussion around the InfraObject and how the update and teardown is performed.

My main worry at the moment is that the InfraObject can be constructed from a proto and then the update method can be called. This requires all the connection information and credentials to be present in the infra object proto.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
