### PR TITLE
fix: Remove redis service to prevent more conflicts and add redis node to master_only

### DIFF
--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -65,16 +65,6 @@ jobs:
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
-    services:
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -120,6 +110,11 @@ jobs:
         run: pip install pip-tools
       - name: Install dependencies
         run: make install-python-ci-dependencies
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.4.0
+        with:
+          redis-version: ${{ matrix.redis-version }}
+          redis-port: 12345
       - name: Setup Redis Cluster
         run: |
           docker pull vishnunair/docker-redis-cluster:latest

--- a/sdk/python/tests/integration/registration/test_cli.py
+++ b/sdk/python/tests/integration/registration/test_cli.py
@@ -130,6 +130,11 @@ def make_feature_store_yaml(project, test_repo_config, repo_dir_name: Path):
         repo_path=str(Path(repo_dir_name)),
     )
     config_dict = config.dict()
+    if (
+        isinstance(config_dict["online_store"], dict)
+        and "redis_type" in config_dict["online_store"]
+    ):
+        config_dict["online_store"]["redis_type"] = "redis_cluster"
     config_dict["repo_path"] = str(config_dict["repo_path"])
 
     return yaml.safe_dump(config_dict)

--- a/sdk/python/tests/integration/registration/test_cli.py
+++ b/sdk/python/tests/integration/registration/test_cli.py
@@ -130,11 +130,6 @@ def make_feature_store_yaml(project, test_repo_config, repo_dir_name: Path):
         repo_path=str(Path(repo_dir_name)),
     )
     config_dict = config.dict()
-    if (
-        isinstance(config_dict["online_store"], dict)
-        and "redis_type" in config_dict["online_store"]
-    ):
-        del config_dict["online_store"]["redis_type"]
     config_dict["repo_path"] = str(config_dict["repo_path"])
 
     return yaml.safe_dump(config_dict)

--- a/sdk/python/tests/integration/registration/test_cli.py
+++ b/sdk/python/tests/integration/registration/test_cli.py
@@ -134,9 +134,11 @@ def make_feature_store_yaml(project, test_repo_config, repo_dir_name: Path):
         isinstance(config_dict["online_store"], dict)
         and "redis_type" in config_dict["online_store"]
     ):
-        config_dict["online_store"]["redis_type"] = "redis_cluster"
+        if str(config_dict["online_store"]["redis_type"]) == "RedisType.redis_cluster":
+            config_dict["online_store"]["redis_type"] = "redis_cluster"
+        elif str(config_dict["online_store"]["redis_type"]) == "RedisType.redis":
+            config_dict["online_store"]["redis_type"] = "redis"
     config_dict["repo_path"] = str(config_dict["repo_path"])
-
     return yaml.safe_dump(config_dict)
 
 


### PR DESCRIPTION
Signed-off-by: Kevin Zhang <kzhang@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
There is still redis client of some sort and it may still be because of this random excess client so I'm going to remove it.
It is not used anymore anyway since the current build is stable in master using 12345 as the port. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here:
http://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
