### PR TITLE
fix: Update some fields optional in UI parser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,12 +20,12 @@ A quick list of things to keep in mind as you're making changes:
 - When you make the PR
   - Make a pull request from the forked repo you made
   - Ensure you add a GitHub **label** (i.e. a kind tag to the PR (e.g. `kind/bug` or `kind/housekeeping`)) or else checks will fail.
-  - Ensure you leave a release note for any user facing changes in the PR. There is a field automatically generated in the PR request. You can write `NONE` in that field if there are no user facing changes. 
+  - Ensure you leave a release note for any user facing changes in the PR. There is a field automatically generated in the PR request. You can write `NONE` in that field if there are no user facing changes.
   - Please run tests locally before submitting a PR (e.g. for Python, the [local integration tests](#local-integration-tests))
   - Try to keep PRs smaller. This makes them easier to review.
 
 ### Forking the repo
-Fork the Feast Github repo and clone your fork locally. Then make changes to a local branch to the fork. 
+Fork the Feast Github repo and clone your fork locally. Then make changes to a local branch to the fork.
 
 See [Creating a pull request from a fork](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
 
@@ -40,10 +40,10 @@ pre-commit install --hook-type pre-commit --hook-type pre-push
 3. On push, the pre-commit hook will run. This runs `make format` and `make lint`.
 
 ### Signing off commits
-> :warning: Warning: using the default integrations with IDEs like VSCode or IntelliJ will not sign commits. 
+> :warning: Warning: using the default integrations with IDEs like VSCode or IntelliJ will not sign commits.
 > When you submit a PR, you'll have to re-sign commits to pass the DCO check.
 
-Use git signoffs to sign your commits. See 
+Use git signoffs to sign your commits. See
 https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification for details
 
 Then, you can sign off commits with the `-s` flag:
@@ -121,15 +121,15 @@ There are two sets of tests you can run:
 To get local integration tests running, you'll need to have Redis setup:
 
 Redis
-1. Install Redis: [Quickstart](https://redis.io/topics/quickstart) 
-2. Run `redis-server` 
+1. Install Redis: [Quickstart](https://redis.io/topics/quickstart)
+2. Run `redis-server`
 
 Now run `make test-python-universal-local`
 
 #### Full integration tests
 To test across clouds, on top of setting up Redis, you also need GCP / AWS / Snowflake setup.
 
-> Note: you can manually control what tests are run today by inspecting 
+> Note: you can manually control what tests are run today by inspecting
 > [RepoConfiguration](https://github.com/feast-dev/feast/blob/master/sdk/python/tests/integration/feature_repos/repo_configuration.py)
 > and commenting out tests that are added to `DEFAULT_FULL_REPO_CONFIGS`
 
@@ -188,3 +188,18 @@ Unit tests for the Feast Go Client can be run as follows:
 ```sh
 go test
 ```
+
+### Testing with Github Actions workflows
+* Update your current master on your forked branch and make a pull request against your own forked master.
+* Enable workflows by going to actions and clicking `Enable Workflows`.
+    * Pushes will now run your edited workflow yaml file against your test code.
+    * Unfortunately, in order to test any github workflow changes, you must push the code to the branch and see the output in the actions tab.
+
+## Issues
+* pr-integration-tests workflow is skipped
+    * Add `ok-to-test` github label.
+* pr-integration-tests errors out with `Error: fatal: invalid refspec '+refs/pull//merge:refs/remotes/pull//merge'`
+    * This is because github actions cannot pull the branch version for some reason so just find your PR number in your pull request header and hard code it into the `uses: actions/checkout@v2` section (i.e replace `refs/pull/${{ github.event.pull_request.number }}/merge` with `refs/pull/<pr number>/merge`)
+* AWS/GCP workflow
+    * Currently still cannot test GCP/AWS workflow without setting up secrets in a forked repository.
+

--- a/docs/how-to-guides/adding-or-reusing-tests.md
+++ b/docs/how-to-guides/adding-or-reusing-tests.md
@@ -202,4 +202,3 @@ Starting 6006
 * You should be able to run the integration tests and have the redis cluster tests pass.
 * If you would like to run your own redis cluster, you can run the above commands with your own specified ports and connect to the newly configured cluster.
 * To stop the cluster, run `./create-cluster stop` and then `./create-cluster clean`.
-

--- a/ui/src/pages/entities/EntityOverviewTab.tsx
+++ b/ui/src/pages/entities/EntityOverviewTab.tsx
@@ -9,6 +9,7 @@ import {
   EuiText,
   EuiFlexItem,
   EuiSpacer,
+  EuiStat,
   EuiDescriptionList,
   EuiDescriptionListTitle,
   EuiDescriptionListDescription,
@@ -71,12 +72,20 @@ const EntityOverviewTab = () => {
                 <EuiDescriptionList>
                   <EuiDescriptionListTitle>Created</EuiDescriptionListTitle>
                   <EuiDescriptionListDescription>
-                    {data.meta.createdTimestamp.toLocaleDateString("en-CA")}
+                    {data.meta.createdTimestamp ? (
+                      data.meta.createdTimestamp.toLocaleDateString("en-CA")
+                    ) : (
+                      <EuiText>No createdTimestamp specified on this entity.</EuiText>
+                    )}
                   </EuiDescriptionListDescription>
 
                   <EuiDescriptionListTitle>Updated</EuiDescriptionListTitle>
                   <EuiDescriptionListDescription>
-                    {data.meta.lastUpdatedTimestamp.toLocaleDateString("en-CA")}
+                    {data.meta.lastUpdatedTimestamp ? (
+                      data.meta.lastUpdatedTimestamp.toLocaleDateString("en-CA")
+                    ) : (
+                      <EuiText>No lastUpdatedTimestamp specified on this entity.</EuiText>
+                    )}
                   </EuiDescriptionListDescription>
                 </EuiDescriptionList>
               </EuiPanel>

--- a/ui/src/pages/feature-views/RegularFeatureViewOverviewTab.tsx
+++ b/ui/src/pages/feature-views/RegularFeatureViewOverviewTab.tsx
@@ -60,7 +60,7 @@ const RegularFeatureViewOverviewTab = ({
         <EuiFlexItem>
           <EuiStat title={`${numOfFs}`} description="Consuming Services" />
         </EuiFlexItem>
-        {data.spec.batchSource.meta && (
+        {data.spec.batchSource.meta ? (
           <EuiFlexItem>
             <EuiStat
               title={data.spec.batchSource.meta.latestEventTimestamp.toLocaleDateString(
@@ -70,8 +70,9 @@ const RegularFeatureViewOverviewTab = ({
               titleColor="subdued"
             />
           </EuiFlexItem>
+        ) : (
+          <EuiText>No batchSource specified on this feature view.</EuiText>
         )}
-
         {data.meta.lastUpdatedTimestamp && (
           <EuiFlexItem>
             <EuiStat

--- a/ui/src/parsers/feastEntities.ts
+++ b/ui/src/parsers/feastEntities.ts
@@ -10,8 +10,8 @@ const FeastEntitySchema = z.object({
     labels: z.record(z.string()).optional(),
   }),
   meta: z.object({
-    createdTimestamp: z.string().transform((val) => new Date(val)),
-    lastUpdatedTimestamp: z.string().transform((val) => new Date(val)),
+    createdTimestamp: z.string().transform((val) => new Date(val)).optional(),
+    lastUpdatedTimestamp: z.string().transform((val) => new Date(val)).optional(),
   }),
 });
 

--- a/ui/src/parsers/feastFeatureViews.ts
+++ b/ui/src/parsers/feastFeatureViews.ts
@@ -13,7 +13,7 @@ const FeastBatchSourceSchema = z.object({
   fileOptions: z.object({
     fileUrl: z.string().optional(),
   }).optional(),
-  name: z.string(),
+  name: z.string().optional(),
   meta: z.object({
     earliestEventTimestamp: z.string().transform((val) => new Date(val)),
     latestEventTimestamp: z.string().transform((val) => new Date(val)),
@@ -39,8 +39,8 @@ const FeastFeatureViewSchema = z.object({
     tags: z.record(z.string()).optional(),
   }),
   meta: z.object({
-    createdTimestamp: z.string().transform((val) => new Date(val)),
-    lastUpdatedTimestamp: z.string().transform((val) => new Date(val)),
+    createdTimestamp: z.string().transform((val) => new Date(val)).optional(),
+    lastUpdatedTimestamp: z.string().transform((val) => new Date(val)).optional(),
     materializationIntervals: z
       .array(
         z.object({

--- a/ui/src/parsers/parseEntityRelationships.ts
+++ b/ui/src/parsers/parseEntityRelationships.ts
@@ -46,7 +46,7 @@ const parseEntityRelationships = (objects: FeastRegistryType) => {
       links.push({
         source: {
           type: FEAST_FCO_TYPES["dataSource"],
-          name: fv.spec.batchSource.name
+          name: fv.spec.batchSource.name || ''
         },
         target: {
           type: FEAST_FCO_TYPES["featureView"],
@@ -77,7 +77,7 @@ const parseEntityRelationships = (objects: FeastRegistryType) => {
           links.push({
              source: {
                type: FEAST_FCO_TYPES["dataSource"],
-               name: source_fv?.spec.batchSource.name,
+               name: source_fv?.spec.batchSource.name || '',
              },
              target: {
                type: FEAST_FCO_TYPES["featureView"],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
The UI parser expects some fields to be mandatory even though the feast source api's do not, this PR makes the following fields optional:

- featureViews.meta.lastUpdatedTimestamp
- featureViews.meta.createdTimestamp
- featureViews.spec.batchSource.name
- entities.meta.createdTimestamp
- entities.meta.lastUpdatedTimestamp

Screenshots for how the UI looks when the above fields are missing vs when present

<img width="1444" alt="Screen Shot 2022-03-04 at 3 05 56 PM" src="https://user-images.githubusercontent.com/4226516/156854012-efb87140-cfb8-44c1-8f9d-4b8de50cc806.png">
<img width="1505" alt="Screen Shot 2022-03-04 at 3 05 50 PM" src="https://user-images.githubusercontent.com/4226516/156854013-da810a6a-0ee4-4ea5-96af-269acdd86e7c.png">
<img width="1529" alt="Screen Shot 2022-03-04 at 3 05 40 PM" src="https://user-images.githubusercontent.com/4226516/156854015-a2ce0ae0-4e58-4b23-9665-ca71ba0d3832.png">
<img width="1520" alt="Screen Shot 2022-03-04 at 3 05 32 PM" src="https://user-images.githubusercontent.com/4226516/156854016-e65f25fc-8bd8-4284-84d4-226f53597ced.png">


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
None
-->
```release-note
None
```
