### PR TITLE
fix: Use the correct dockerhub image tag when building feature servers

### DIFF
--- a/sdk/python/feast/infra/aws.py
+++ b/sdk/python/feast/infra/aws.py
@@ -262,7 +262,9 @@ class AwsProvider(PassthroughProvider):
         _logger.info(
             f"Pulling remote image {Style.BRIGHT + Fore.GREEN}{dockerhub_image}{Style.RESET_ALL}"
         )
-        for line in docker_client.api.pull(dockerhub_image, stream=True, decode=True):
+        for line in docker_client.api.pull(
+            dockerhub_image.replace("_", "."), stream=True, decode=True
+        ):
             _logger.debug(f"  {line}")
 
         auth_token = ecr_client.get_authorization_token()["authorizationData"][0][

--- a/sdk/python/feast/infra/aws.py
+++ b/sdk/python/feast/infra/aws.py
@@ -119,6 +119,8 @@ class AwsProvider(PassthroughProvider):
         lambda_client = boto3.client("lambda")
         api_gateway_client = boto3.client("apigatewayv2")
         function = aws_utils.get_lambda_function(lambda_client, resource_name)
+        _logger.info("Using function name: %s", resource_name)
+        _logger.info("Found function: %s", function)
 
         if function is None:
             # If the Lambda function does not exist, create it.

--- a/sdk/python/feast/infra/aws.py
+++ b/sdk/python/feast/infra/aws.py
@@ -288,7 +288,7 @@ class AwsProvider(PassthroughProvider):
         _logger.info(
             f"Pushing local image to remote {Style.BRIGHT + Fore.GREEN}{image_remote_name}{Style.RESET_ALL}"
         )
-        image.tag(image_remote_name)
+        image.tag(image_remote_name.replace('_', '.'))
         for line in docker_client.api.push(
             repository_uri, tag=docker_image_version, stream=True, decode=True
         ):

--- a/sdk/python/feast/infra/aws.py
+++ b/sdk/python/feast/infra/aws.py
@@ -283,7 +283,7 @@ class AwsProvider(PassthroughProvider):
         )
         _logger.debug(f"  {login_status}")
 
-        image = docker_client.images.get(dockerhub_image)
+        image = docker_client.images.get(dockerhub_image.replace("_", "."))
         image_remote_name = f"{repository_uri}:{docker_image_version}"
         _logger.info(
             f"Pushing local image to remote {Style.BRIGHT + Fore.GREEN}{image_remote_name}{Style.RESET_ALL}"

--- a/sdk/python/feast/infra/aws.py
+++ b/sdk/python/feast/infra/aws.py
@@ -119,8 +119,8 @@ class AwsProvider(PassthroughProvider):
         lambda_client = boto3.client("lambda")
         api_gateway_client = boto3.client("apigatewayv2")
         function = aws_utils.get_lambda_function(lambda_client, resource_name)
-        _logger.info("Using function name: %s", resource_name)
-        _logger.info("Found function: %s", function)
+        _logger.debug("Using function name: %s", resource_name)
+        _logger.debug("Found function: %s", function)
 
         if function is None:
             # If the Lambda function does not exist, create it.

--- a/sdk/python/feast/infra/aws.py
+++ b/sdk/python/feast/infra/aws.py
@@ -349,8 +349,6 @@ def _get_docker_image_version() -> str:
                 "> git fetch --all --tags\n"
                 "> pip install -e sdk/python"
             )
-        else:
-            version = version
         return version
 
 

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -47,7 +47,7 @@ from tests.integration.feature_repos.universal.feature_views import (
 
 DYNAMO_CONFIG = {"type": "dynamodb", "region": "us-west-2"}
 # Port 12345 will chosen as default for redis node configuration because Redis Cluster is started off of nodes 6379 -> 6384. This causes conflicts in cli integration tests so we manually keep them separate.
-REDIS_CONFIG = {"type": "redis", "connection_string": "localhost:6379,db=0"}
+REDIS_CONFIG = {"type": "redis", "connection_string": "localhost:12345,db=0"}
 REDIS_CLUSTER_CONFIG = {
     "type": "redis",
     "redis_type": "redis_cluster",
@@ -71,6 +71,7 @@ if os.getenv("FEAST_IS_LOCAL_TEST", "False") != "True":
     DEFAULT_FULL_REPO_CONFIGS.extend(
         [
             IntegrationTestRepoConfig(online_store=REDIS_CONFIG),
+            IntegrationTestRepoConfig(online_store=REDIS_CLUSTER_CONFIG),
             # GCP configurations
             IntegrationTestRepoConfig(
                 provider="gcp",

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -1,5 +1,6 @@
 import datetime
 import itertools
+import logging
 import os
 import time
 import unittest
@@ -34,6 +35,8 @@ from tests.integration.feature_repos.universal.feature_views import (
     driver_feature_view,
 )
 from tests.utils.data_source_utils import prep_file_source
+
+_logger = logging.getLogger(__name__)
 
 
 @pytest.mark.integration
@@ -267,12 +270,12 @@ def _get_online_features_dict_remotely(
         response = requests.post(
             f"{endpoint}/get-online-features", json=request, timeout=30
         ).json()
-        print(f"Attempt: {attempt}, {response}")
+        _logger.info(f"Attempt: {attempt}, {response}")
         # Retry if the response is internal server error, which can happen when lambda is being restarted
         if response.get("message") != "Internal Server Error":
             break
         # Sleep between retries to give the server some time to start
-        time.sleep(1)
+        time.sleep(5)
     else:
         raise Exception("Failed to get online features from remote feature server")
     if "metadata" not in response:

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -275,7 +275,7 @@ def _get_online_features_dict_remotely(
         if response.get("message") != "Internal Server Error":
             break
         # Sleep between retries to give the server some time to start
-        time.sleep(5)
+        time.sleep(15)
     else:
         raise Exception("Failed to get online features from remote feature server")
     if "metadata" not in response:

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -36,8 +36,6 @@ from tests.integration.feature_repos.universal.feature_views import (
 )
 from tests.utils.data_source_utils import prep_file_source
 
-_logger = logging.getLogger(__name__)
-
 
 @pytest.mark.integration
 def test_entity_ttl_online_store(local_redis_environment, redis_universal_data_sources):
@@ -270,7 +268,6 @@ def _get_online_features_dict_remotely(
         response = requests.post(
             f"{endpoint}/get-online-features", json=request, timeout=30
         ).json()
-        _logger.info(f"Attempt: {attempt}, {response}")
         # Retry if the response is internal server error, which can happen when lambda is being restarted
         if response.get("message") != "Internal Server Error":
             break

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -1,6 +1,5 @@
 import datetime
 import itertools
-import logging
 import os
 import time
 import unittest

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -262,7 +262,7 @@ def _get_online_features_dict_remotely(
         request["features"] = features
     else:
         request["feature_service"] = features.name
-    for attempt in range(25):
+    for _ in range(25):
         # Send the request to the remote feature server and get the response in JSON format
         response = requests.post(
             f"{endpoint}/get-online-features", json=request, timeout=30

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -262,11 +262,12 @@ def _get_online_features_dict_remotely(
         request["features"] = features
     else:
         request["feature_service"] = features.name
-    for _ in range(25):
+    for attempt in range(25):
         # Send the request to the remote feature server and get the response in JSON format
         response = requests.post(
             f"{endpoint}/get-online-features", json=request, timeout=30
         ).json()
+        print(f"Attempt: {attempt}, {response}")
         # Retry if the response is internal server error, which can happen when lambda is being restarted
         if response.get("message") != "Internal Server Error":
             break


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
`sdk/python/tests/integration/online_store/test_universal_online.py::test_online_retrieval` has been failling consistently for a few PRs now. This PR should address the underlying issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
