### PR TITLE
fix: Fix default feast apply path without any extras

### DIFF
--- a/docs/reference/data-sources/spark.md
+++ b/docs/reference/data-sources/spark.md
@@ -13,7 +13,9 @@ The spark data source API allows for the retrieval of historical feature values 
 Using a table reference from SparkSession(for example, either in memory or a Hive Metastore)
 
 ```python
-from feast import SparkSource
+from feast.infra.offline_stores.contrib.spark_offline_store.spark_source import (
+    SparkSource,
+)
 
 my_spark_source = SparkSource(
     table="FEATURE_TABLE",
@@ -23,7 +25,9 @@ my_spark_source = SparkSource(
 Using a query
 
 ```python
-from feast import SparkSource
+from feast.infra.offline_stores.contrib.spark_offline_store.spark_source import (
+    SparkSource,
+)
 
 my_spark_source = SparkSource(
     query="SELECT timestamp as ts, created, f1, f2 "
@@ -34,7 +38,9 @@ my_spark_source = SparkSource(
 Using a file reference
 
 ```python
-from feast import SparkSource
+from feast.infra.offline_stores.contrib.spark_offline_store.spark_source import (
+    SparkSource,
+)
 
 my_spark_source = SparkSource(
     path=f"{CURRENT_DIR}/data/driver_hourly_stats",

--- a/sdk/python/feast/__init__.py
+++ b/sdk/python/feast/__init__.py
@@ -3,9 +3,6 @@ import logging
 from pkg_resources import DistributionNotFound, get_distribution
 
 from feast.infra.offline_stores.bigquery_source import BigQuerySource
-from feast.infra.offline_stores.contrib.spark_offline_store.spark_source import (
-    SparkSource,
-)
 from feast.infra.offline_stores.file_source import FileSource
 from feast.infra.offline_stores.redshift_source import RedshiftSource
 from feast.infra.offline_stores.snowflake_source import SnowflakeSource
@@ -50,5 +47,4 @@ __all__ = [
     "RedshiftSource",
     "RequestFeatureView",
     "SnowflakeSource",
-    "SparkSource",
 ]

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -42,7 +42,6 @@ from feast.base_feature_view import BaseFeatureView
 from feast.data_source import DataSource
 from feast.diff.infra_diff import InfraDiff, diff_infra_protos
 from feast.diff.registry_diff import RegistryDiff, apply_diff_to_registry, diff_between
-from feast.dqm.profilers.ge_profiler import GEProfiler
 from feast.entity import Entity
 from feast.errors import (
     EntityNotFoundException,
@@ -881,7 +880,6 @@ class FeatureStore:
         storage: SavedDatasetStorage,
         tags: Optional[Dict[str, str]] = None,
         feature_service: Optional[FeatureService] = None,
-        profiler: Optional[GEProfiler] = None,
     ) -> SavedDataset:
         """
             Execute provided retrieval job and persist its outcome in given storage.

--- a/sdk/python/feast/inference.py
+++ b/sdk/python/feast/inference.py
@@ -8,7 +8,6 @@ from feast import (
     FileSource,
     RedshiftSource,
     SnowflakeSource,
-    SparkSource,
 )
 from feast.data_source import DataSource, RequestDataSource
 from feast.errors import RegistryInferenceFailure
@@ -87,8 +86,10 @@ def update_data_sources_with_inferred_event_timestamp_col(
         ):
             # prepare right match pattern for data source
             ts_column_type_regex_pattern = ""
-            if isinstance(data_source, FileSource) or isinstance(
-                data_source, SparkSource
+            # TODO(adchia): Move Spark source inference out of this logic
+            if (
+                isinstance(data_source, FileSource)
+                or "SparkSource" == data_source.__class__.__name__
             ):
                 ts_column_type_regex_pattern = r"^timestamp"
             elif isinstance(data_source, BigQuerySource):

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -46,7 +46,6 @@ REQUIRED = [
     "fastavro>=1.1.0",
     "google-api-core>=1.23.0",
     "googleapis-common-protos==1.52.*",
-    "great_expectations>=0.14.0,<0.15.0",
     "grpcio>=1.34.0",
     "grpcio-reflection>=1.34.0",
     "Jinja2>=2.0.0",
@@ -97,6 +96,10 @@ SPARK_REQUIRED = [
     "pyspark>=3.0.0",
 ]
 
+GE_REQUIRED = [
+    "great_expectations>=0.14.0,<0.15.0"
+]
+
 CI_REQUIRED = (
         [
         "cryptography==3.3.2",
@@ -143,6 +146,7 @@ CI_REQUIRED = (
         + AWS_REQUIRED
         + SNOWFLAKE_REQUIRED
         + SPARK_REQUIRED
+        + GE_REQUIRED
 )
 
 DEV_REQUIRED = ["mypy-protobuf>=3.1.0", "grpcio-testing==1.*"] + CI_REQUIRED
@@ -246,6 +250,7 @@ setup(
         "redis": REDIS_REQUIRED,
         "snowflake": SNOWFLAKE_REQUIRED,
         "spark": SPARK_REQUIRED,
+        "ge": GE_REQUIRED,
     },
     include_package_data=True,
     license="Apache",

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -46,6 +46,7 @@ REQUIRED = [
     "fastavro>=1.1.0",
     "google-api-core>=1.23.0",
     "googleapis-common-protos==1.52.*",
+    "great_expectations>=0.14.0,<0.15.0",
     "grpcio>=1.34.0",
     "grpcio-reflection>=1.34.0",
     "Jinja2>=2.0.0",
@@ -96,10 +97,6 @@ SPARK_REQUIRED = [
     "pyspark>=3.0.0",
 ]
 
-GE_REQUIRED = [
-    "great_expectations>=0.14.0,<0.15.0"
-]
-
 CI_REQUIRED = (
         [
         "cryptography==3.3.2",
@@ -146,7 +143,6 @@ CI_REQUIRED = (
         + AWS_REQUIRED
         + SNOWFLAKE_REQUIRED
         + SPARK_REQUIRED
-        + GE_REQUIRED
 )
 
 DEV_REQUIRED = ["mypy-protobuf>=3.1.0", "grpcio-testing==1.*"] + CI_REQUIRED
@@ -250,7 +246,6 @@ setup(
         "redis": REDIS_REQUIRED,
         "snowflake": SNOWFLAKE_REQUIRED,
         "spark": SPARK_REQUIRED,
-        "ge": GE_REQUIRED,
     },
     include_package_data=True,
     license="Apache",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
There were two issues introduced related to dependencies:
1. Great expectations was being force imported in feature_store.py, which makes a default feast installation fail to run methods like feast apply
2. Similarly, the feast __init__.py referenced a SparkSource, which imported pyspark, which isn't included unless the user installs the spark extra.

This PR removes both of those dependencies (one was an unused arg).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
