### PR TITLE
fix: Making a name for data sources not a breaking change

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -3,7 +3,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from feast import type_map
 from feast.data_source import DataSource
-from feast.errors import DataSourceNoNameException, DataSourceNotFoundException
+from feast.errors import DataSourceNotFoundException
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
 from feast.protos.feast.core.SavedDataset_pb2 import (
     SavedDatasetStorage as SavedDatasetStorageProto,
@@ -16,7 +16,6 @@ from feast.value_type import ValueType
 class BigQuerySource(DataSource):
     def __init__(
         self,
-        name: Optional[str] = None,
         event_timestamp_column: Optional[str] = "",
         table: Optional[str] = None,
         table_ref: Optional[str] = None,
@@ -24,11 +23,11 @@ class BigQuerySource(DataSource):
         field_mapping: Optional[Dict[str, str]] = None,
         date_partition_column: Optional[str] = "",
         query: Optional[str] = None,
+        name: Optional[str] = None,
     ):
         """Create a BigQuerySource from an existing table or query.
 
          Args:
-             name (optional): Name for the source. Defaults to the table_ref if not specified.
              table (optional): The BigQuery table where features can be found.
              table_ref (optional): (Deprecated) The BigQuery table where features can be found.
              event_timestamp_column: Event timestamp column used for point in time joins of feature values.
@@ -37,13 +36,13 @@ class BigQuerySource(DataSource):
                  or view. Only used for feature columns, not entities or timestamp columns.
              date_partition_column (optional): Timestamp column used for partitioning.
              query (optional): SQL query to execute to generate data for this data source.
-
+             name (optional): Name for the source. Defaults to the table_ref if not specified.
          Example:
              >>> from feast import BigQuerySource
              >>> my_bigquery_source = BigQuerySource(table="gcp_project:bq_dataset.bq_table")
          """
         if table is None and table_ref is None and query is None:
-            raise ValueError('No "table" argument provided.')
+            raise ValueError('No "table" or "query" argument provided.')
         if not table and table_ref:
             warnings.warn(
                 (
@@ -63,7 +62,12 @@ class BigQuerySource(DataSource):
             elif table_ref:
                 _name = table_ref
             else:
-                raise DataSourceNoNameException()
+                warnings.warn(
+                    (
+                        "Starting in Feast 0.21, Feast will require either a name for a data source (if using query) or `table`."
+                    ),
+                    DeprecationWarning,
+                )
 
         super().__init__(
             _name if _name else "",

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -20,19 +20,18 @@ class FileSource(DataSource):
     def __init__(
         self,
         path: str,
-        name: Optional[str] = "",
         event_timestamp_column: Optional[str] = "",
         file_format: Optional[FileFormat] = None,
         created_timestamp_column: Optional[str] = "",
         field_mapping: Optional[Dict[str, str]] = None,
         date_partition_column: Optional[str] = "",
         s3_endpoint_override: Optional[str] = None,
+        name: Optional[str] = "",
     ):
         """Create a FileSource from a file containing feature data. Only Parquet format supported.
 
         Args:
 
-            name (optional): Name for the file source. Defaults to the path.
             path: File path to file containing feature data. Must contain an event_timestamp column, entity columns and
                 feature columns.
             event_timestamp_column: Event timestamp column used for point in time joins of feature values.
@@ -42,6 +41,7 @@ class FileSource(DataSource):
                 or view. Only used for feature columns, not entities or timestamp columns.
             date_partition_column (optional): Timestamp column used for partitioning.
             s3_endpoint_override (optional): Overrides AWS S3 enpoint with custom S3 storage
+            name (optional): Name for the file source. Defaults to the path.
 
         Examples:
             >>> from feast import FileSource

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -1,12 +1,9 @@
+import warnings
 from typing import Callable, Dict, Iterable, Optional, Tuple
 
 from feast import type_map
 from feast.data_source import DataSource
-from feast.errors import (
-    DataSourceNoNameException,
-    DataSourceNotFoundException,
-    RedshiftCredentialsError,
-)
+from feast.errors import DataSourceNotFoundException, RedshiftCredentialsError
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
 from feast.protos.feast.core.SavedDataset_pb2 import (
     SavedDatasetStorage as SavedDatasetStorageProto,
@@ -19,7 +16,6 @@ from feast.value_type import ValueType
 class RedshiftSource(DataSource):
     def __init__(
         self,
-        name: Optional[str] = None,
         event_timestamp_column: Optional[str] = "",
         table: Optional[str] = None,
         schema: Optional[str] = None,
@@ -27,12 +23,12 @@ class RedshiftSource(DataSource):
         field_mapping: Optional[Dict[str, str]] = None,
         date_partition_column: Optional[str] = "",
         query: Optional[str] = None,
+        name: Optional[str] = None,
     ):
         """
         Creates a RedshiftSource object.
 
         Args:
-            name (optional): Name for the source. Defaults to the table_ref if not specified.
             event_timestamp_column (optional): Event timestamp column used for point in
                 time joins of feature values.
             table (optional): Redshift table where the features are stored.
@@ -43,6 +39,7 @@ class RedshiftSource(DataSource):
                 source to column names in a feature table or view.
             date_partition_column (optional): Timestamp column used for partitioning.
             query (optional): The query to be executed to obtain the features.
+            name (optional): Name for the source. Defaults to the table_ref if not specified.
         """
         if table is None and query is None:
             raise ValueError('No "table" argument provided.')
@@ -51,11 +48,15 @@ class RedshiftSource(DataSource):
             if table:
                 _name = table
             else:
-                raise DataSourceNoNameException()
+                warnings.warn(
+                    (
+                        "Starting in Feast 0.21, Feast will require either a name for a data source (if using query) or `table`."
+                    ),
+                    DeprecationWarning,
+                )
 
-        # TODO(adchia): figure out what to do if user uses the query to start
         super().__init__(
-            _name,
+            _name if _name else "",
             event_timestamp_column,
             created_timestamp_column,
             field_mapping,

--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -1,8 +1,8 @@
+import warnings
 from typing import Callable, Dict, Iterable, Optional, Tuple
 
 from feast import type_map
 from feast.data_source import DataSource
-from feast.errors import DataSourceNoNameException
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
 from feast.protos.feast.core.SavedDataset_pb2 import (
     SavedDatasetStorage as SavedDatasetStorageProto,
@@ -15,7 +15,6 @@ from feast.value_type import ValueType
 class SnowflakeSource(DataSource):
     def __init__(
         self,
-        name: Optional[str] = None,
         database: Optional[str] = None,
         schema: Optional[str] = None,
         table: Optional[str] = None,
@@ -24,12 +23,12 @@ class SnowflakeSource(DataSource):
         created_timestamp_column: Optional[str] = "",
         field_mapping: Optional[Dict[str, str]] = None,
         date_partition_column: Optional[str] = "",
+        name: Optional[str] = None,
     ):
         """
         Creates a SnowflakeSource object.
 
         Args:
-            name (optional): Name for the source. Defaults to the table if not specified.
             database (optional): Snowflake database where the features are stored.
             schema (optional): Snowflake schema in which the table is located.
             table (optional): Snowflake table where the features are stored.
@@ -41,7 +40,7 @@ class SnowflakeSource(DataSource):
             field_mapping (optional): A dictionary mapping of column names in this data
                 source to column names in a feature table or view.
             date_partition_column (optional): Timestamp column used for partitioning.
-
+            name (optional): Name for the source. Defaults to the table if not specified.
         """
         if table is None and query is None:
             raise ValueError('No "table" argument provided.')
@@ -52,10 +51,15 @@ class SnowflakeSource(DataSource):
             if table:
                 _name = table
             else:
-                raise DataSourceNoNameException()
+                warnings.warn(
+                    (
+                        "Starting in Feast 0.21, Feast will require either a name for a data source (if using query) or `table`."
+                    ),
+                    DeprecationWarning,
+                )
 
         super().__init__(
-            _name,
+            _name if _name else "",
             event_timestamp_column,
             created_timestamp_column,
             field_mapping,


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
https://github.com/feast-dev/feast/pull/2336 introduced a change that would be breaking (forcing the first parameter of a DataSource to be a name). This pushes that to the end as an optional parameter and also outputs a warning for a future version where we require a name if users use a query in a data source.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
