### PR TITLE
fix: Properly close threadpool resources

### DIFF
--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -159,11 +159,13 @@ class DatastoreOnlineStore(OnlineStore):
         write_batch_size = online_config.write_batch_size
         feast_project = config.project
 
-        pool = ThreadPool(processes=write_concurrency)
-        pool.map(
-            lambda b: self._write_minibatch(client, feast_project, table, b, progress),
-            self._to_minibatches(data, batch_size=write_batch_size),
-        )
+        with ThreadPool(processes=write_concurrency) as pool:
+            pool.map(
+                lambda b: self._write_minibatch(
+                    client, feast_project, table, b, progress
+                ),
+                self._to_minibatches(data, batch_size=write_batch_size),
+            )
 
     @staticmethod
     def _to_minibatches(data: ProtoBatch, batch_size) -> Iterator[ProtoBatch]:


### PR DESCRIPTION
**What this PR does / why we need it**:
Properly closes threadpool resources.

Without this PR, large materializations produce `RuntimeError: can't start new thread`, because `threading.active_count()` infinitely increases toward system limit.  With properly closed resources, `threading.active_count()` stays low.

**Which issue(s) this PR fixes**:
No open issue.
