### PR TITLE
fix: Added Redshift and Spark typecheck to data_source event_timestamp_col inference

### DIFF
--- a/sdk/python/feast/inference.py
+++ b/sdk/python/feast/inference.py
@@ -45,7 +45,7 @@ def update_entities_with_inferred_types_from_feature_views(
 
                 # get entity information from information extracted from the view batch source
                 extracted_entity_name_type_pairs = list(
-                    filter(lambda tup: tup[0] == entity.join_key, col_names_and_types,)
+                    filter(lambda tup: tup[0] == entity.join_key,col_names_and_types,)
                 )
                 if len(extracted_entity_name_type_pairs) == 0:
                     # Doesn't mention inference error because would also be an error without inferencing
@@ -54,8 +54,8 @@ def update_entities_with_inferred_types_from_feature_views(
                         its entity's name."""
                     )
 
-                inferred_value_type = view.batch_source.source_datatype_to_feast_value_type()(
-                    extracted_entity_name_type_pairs[0][1]
+                inferred_value_type = (
+                    view.batch_source.source_datatype_to_feast_value_type()(extracted_entity_name_type_pairs[0][1])
                 )
 
                 if (
@@ -111,6 +111,7 @@ def update_data_sources_with_inferred_event_timestamp_col(
             assert (
                 isinstance(data_source, FileSource)
                 or isinstance(data_source, BigQuerySource)
+                or isinstance(data_source, RedshiftSource)
                 or isinstance(data_source, SnowflakeSource)
             )
 

--- a/sdk/python/feast/inference.py
+++ b/sdk/python/feast/inference.py
@@ -45,7 +45,7 @@ def update_entities_with_inferred_types_from_feature_views(
 
                 # get entity information from information extracted from the view batch source
                 extracted_entity_name_type_pairs = list(
-                    filter(lambda tup: tup[0] == entity.join_key,col_names_and_types,)
+                    filter(lambda tup: tup[0] == entity.join_key, col_names_and_types,)
                 )
                 if len(extracted_entity_name_type_pairs) == 0:
                     # Doesn't mention inference error because would also be an error without inferencing
@@ -54,8 +54,8 @@ def update_entities_with_inferred_types_from_feature_views(
                         its entity's name."""
                     )
 
-                inferred_value_type = (
-                    view.batch_source.source_datatype_to_feast_value_type()(extracted_entity_name_type_pairs[0][1])
+                inferred_value_type = view.batch_source.source_datatype_to_feast_value_type()(
+                    extracted_entity_name_type_pairs[0][1]
                 )
 
                 if (

--- a/sdk/python/feast/inference.py
+++ b/sdk/python/feast/inference.py
@@ -113,6 +113,7 @@ def update_data_sources_with_inferred_event_timestamp_col(
                 or isinstance(data_source, BigQuerySource)
                 or isinstance(data_source, RedshiftSource)
                 or isinstance(data_source, SnowflakeSource)
+                or "SparkSource" == data_source.__class__.__name__
             )
 
             # loop through table columns to find singular match

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -203,6 +203,9 @@ class UniversalDataSources:
     global_ds: DataSource
     field_mapping: DataSource
 
+    def values(self):
+        return dataclasses.asdict(self).values()
+
 
 def construct_universal_data_sources(
     datasets: UniversalDatasets, data_source_creator: DataSourceCreator

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import pandas as pd
 import pytest
 
@@ -142,21 +143,23 @@ def test_update_file_data_source_with_inferred_event_timestamp_col(simple_datase
 @pytest.mark.universal
 def test_update_data_sources_with_inferred_event_timestamp_col(universal_data_sources):
     (_, _, data_sources) = universal_data_sources
+    data_sources_copy = deepcopy(data_sources)
 
     # remove defined event_timestamp_column to allow for inference
-    for data_source in data_sources.values():
+    for data_source in data_sources_copy.values():
         data_source.event_timestamp_column = None
 
     update_data_sources_with_inferred_event_timestamp_col(
-        data_sources.values(),
+        data_sources_copy.values(),
         RepoConfig(provider="local", project="test"),
     )
     actual_event_timestamp_cols = [
-        source.event_timestamp_column for source in data_sources.values()
+        source.event_timestamp_column for source in data_sources_copy.values()
     ]
 
-    assert actual_event_timestamp_cols == ["event_timestamp"] * len(data_sources.values())
-
+    assert actual_event_timestamp_cols == ["event_timestamp"] * len(
+        data_sources_copy.values()
+    )
 
 def test_on_demand_features_type_inference():
     # Create Feature Views

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+
 import pandas as pd
 import pytest
 
@@ -150,8 +151,7 @@ def test_update_data_sources_with_inferred_event_timestamp_col(universal_data_so
         data_source.event_timestamp_column = None
 
     update_data_sources_with_inferred_event_timestamp_col(
-        data_sources_copy.values(),
-        RepoConfig(provider="local", project="test"),
+        data_sources_copy.values(), RepoConfig(provider="local", project="test"),
     )
     actual_event_timestamp_cols = [
         source.event_timestamp_column for source in data_sources_copy.values()
@@ -160,6 +160,7 @@ def test_update_data_sources_with_inferred_event_timestamp_col(universal_data_so
     assert actual_event_timestamp_cols == ["event_timestamp"] * len(
         data_sources_copy.values()
     )
+
 
 def test_on_demand_features_type_inference():
     # Create Feature Views

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -142,8 +142,10 @@ def test_update_file_data_source_with_inferred_event_timestamp_col(simple_datase
 @pytest.mark.universal
 def test_update_data_sources_with_inferred_event_timestamp_col(universal_data_sources):
     (_, _, data_sources) = universal_data_sources
+
     update_data_sources_with_inferred_event_timestamp_col(
-        data_sources, RepoConfig(provider="local", project="test")
+        universal_data_sources.asdict().values(),
+        RepoConfig(provider="local", project="test"),
     )
     actual_event_timestamp_cols = [
         source.event_timestamp_column for source in data_sources

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -143,15 +143,19 @@ def test_update_file_data_source_with_inferred_event_timestamp_col(simple_datase
 def test_update_data_sources_with_inferred_event_timestamp_col(universal_data_sources):
     (_, _, data_sources) = universal_data_sources
 
+    # remove defined event_timestamp_column to allow for inference
+    for data_source in data_sources.values():
+        data_source.event_timestamp_column = None
+
     update_data_sources_with_inferred_event_timestamp_col(
-        universal_data_sources.asdict().values(),
+        data_sources.values(),
         RepoConfig(provider="local", project="test"),
     )
     actual_event_timestamp_cols = [
-        source.event_timestamp_column for source in data_sources
+        source.event_timestamp_column for source in data_sources.values()
     ]
 
-    assert actual_event_timestamp_cols == ["event_timestamp" * len(data_sources)]
+    assert actual_event_timestamp_cols == ["event_timestamp"] * len(data_sources.values())
 
 
 def test_on_demand_features_type_inference():

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -111,7 +111,9 @@ def test_infer_datasource_names_dwh():
 
 
 @pytest.mark.integration
-def test_update_data_sources_with_inferred_event_timestamp_col(simple_dataset_1):
+def test_update_data_sources_with_inferred_event_timestamp_col(
+    simple_dataset_1, universal_data_sources
+):
     df_with_two_viable_timestamp_cols = simple_dataset_1.copy(deep=True)
     df_with_two_viable_timestamp_cols["ts_2"] = simple_dataset_1["ts_1"]
 
@@ -136,6 +138,16 @@ def test_update_data_sources_with_inferred_event_timestamp_col(simple_dataset_1)
             update_data_sources_with_inferred_event_timestamp_col(
                 [file_source], RepoConfig(provider="local", project="test")
             )
+
+    (_, _, data_sources) = universal_data_sources
+    update_data_sources_with_inferred_event_timestamp_col(
+        data_sources, RepoConfig(provider="local", project="test")
+    )
+    actual_event_timestamp_cols = [
+        source.event_timestamp_column for source in data_sources
+    ]
+
+    assert actual_event_timestamp_cols == ["event_timestamp" * len(data_sources)]
 
 
 def test_on_demand_features_type_inference():

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -111,9 +111,7 @@ def test_infer_datasource_names_dwh():
 
 
 @pytest.mark.integration
-def test_update_file_data_source_with_inferred_event_timestamp_col(
-    simple_dataset_1
-):
+def test_update_file_data_source_with_inferred_event_timestamp_col(simple_dataset_1):
     df_with_two_viable_timestamp_cols = simple_dataset_1.copy(deep=True)
     df_with_two_viable_timestamp_cols["ts_2"] = simple_dataset_1["ts_1"]
 
@@ -139,6 +137,8 @@ def test_update_file_data_source_with_inferred_event_timestamp_col(
                 [file_source], RepoConfig(provider="local", project="test")
             )
 
+
+@pytest.mark.integration
 @pytest.mark.universal
 def test_update_data_sources_with_inferred_event_timestamp_col(universal_data_sources):
     (_, _, data_sources) = universal_data_sources

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -111,8 +111,8 @@ def test_infer_datasource_names_dwh():
 
 
 @pytest.mark.integration
-def test_update_data_sources_with_inferred_event_timestamp_col(
-    simple_dataset_1, universal_data_sources
+def test_update_file_data_source_with_inferred_event_timestamp_col(
+    simple_dataset_1
 ):
     df_with_two_viable_timestamp_cols = simple_dataset_1.copy(deep=True)
     df_with_two_viable_timestamp_cols["ts_2"] = simple_dataset_1["ts_1"]
@@ -139,6 +139,8 @@ def test_update_data_sources_with_inferred_event_timestamp_col(
                 [file_source], RepoConfig(provider="local", project="test")
             )
 
+@pytest.mark.universal
+def test_update_data_sources_with_inferred_event_timestamp_col(universal_data_sources):
     (_, _, data_sources) = universal_data_sources
     update_data_sources_with_inferred_event_timestamp_col(
         data_sources, RepoConfig(provider="local", project="test")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
`RedshiftSource` is a supported `data_source`, but the `update_data_sources_with_inferred_event_timestamp_col()` method omits it as a valid value in the assertion. This was causing the assertion to fail when using a `RedshiftSource`
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
