### PR TITLE
fix: Fix Spark template to work correctly on feast init -t spark

### DIFF
--- a/sdk/python/feast/templates/spark/example.py
+++ b/sdk/python/feast/templates/spark/example.py
@@ -24,14 +24,14 @@ customer = Entity(
 # Sources
 driver_hourly_stats = SparkSource(
     name="driver_hourly_stats",
-    path=f"{CURRENT_DIR}/data/driver_hourly_stats",
+    path=f"{CURRENT_DIR}/data/driver_hourly_stats.parquet",
     file_format="parquet",
     event_timestamp_column="event_timestamp",
     created_timestamp_column="created",
 )
 customer_daily_profile = SparkSource(
     name="customer_daily_profile",
-    path=f"{CURRENT_DIR}/data/customer_daily_profile",
+    path=f"{CURRENT_DIR}/data/customer_daily_profile.parquet",
     file_format="parquet",
     event_timestamp_column="event_timestamp",
     created_timestamp_column="created",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests scripts here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests or https://github.com/feast-dev/feast/tree/master/sdk/go
4. Make sure documentation is updated for your PR!
5. Make sure you have signed the CLA https://cla.developers.google.com/clas

-->

**What this PR does / why we need it**:
This includes not using SparkSessions to generate the test data (which generates a pickle exception as is) and also dynamically generating timestamps so feature view TTLs don't expire

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
