### PR TITLE
feat: Make feast PEP 561 compliant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ format-python:
 	cd ${ROOT_DIR}/sdk/python; python -m black --target-version py37 feast tests
 
 lint-python:
-	cd ${ROOT_DIR}/sdk/python; python -m mypy feast/ tests/
+	cd ${ROOT_DIR}/sdk/python; python -m mypy
 	cd ${ROOT_DIR}/sdk/python; python -m isort feast/ tests/ --check-only
 	cd ${ROOT_DIR}/sdk/python; python -m flake8 feast/ tests/
 	cd ${ROOT_DIR}/sdk/python; python -m black --check feast tests

--- a/sdk/python/MANIFEST.in
+++ b/sdk/python/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include feast/protos/ *.py
 include feast/binaries/*
+recursive-include feast py.typed *.pyi

--- a/sdk/python/feast/go_server.py
+++ b/sdk/python/feast/go_server.py
@@ -25,10 +25,10 @@ from pathlib import Path
 from subprocess import Popen
 from typing import Any, Dict, List, Optional, Union
 
-import grpc
 from tenacity import retry, stop_after_attempt, stop_after_delay, wait_exponential
 
 import feast
+import grpc
 from feast.errors import FeatureNameCollisionError, InvalidFeaturesParameterType
 from feast.feature_service import FeatureService
 from feast.flags_helper import is_test

--- a/sdk/python/feast/go_server.py
+++ b/sdk/python/feast/go_server.py
@@ -25,10 +25,10 @@ from pathlib import Path
 from subprocess import Popen
 from typing import Any, Dict, List, Optional, Union
 
+import grpc
 from tenacity import retry, stop_after_attempt, stop_after_delay, wait_exponential
 
 import feast
-import grpc
 from feast.errors import FeatureNameCollisionError, InvalidFeaturesParameterType
 from feast.feature_service import FeatureService
 from feast.flags_helper import is_test

--- a/sdk/python/feast/transformation_server.py
+++ b/sdk/python/feast/transformation_server.py
@@ -2,10 +2,10 @@ import logging
 import sys
 from concurrent import futures
 
-import grpc
 import pyarrow as pa
 from grpc_reflection.v1alpha import reflection
 
+import grpc
 from feast.errors import OnDemandFeatureViewNotFoundException
 from feast.feature_store import FeatureStore
 from feast.protos.feast.serving.TransformationService_pb2 import (

--- a/sdk/python/feast/transformation_server.py
+++ b/sdk/python/feast/transformation_server.py
@@ -6,7 +6,6 @@ import grpc
 import pyarrow as pa
 from grpc_reflection.v1alpha import reflection
 
-import grpc
 from feast.errors import OnDemandFeatureViewNotFoundException
 from feast.feature_store import FeatureStore
 from feast.protos.feast.serving.TransformationService_pb2 import (

--- a/sdk/python/feast/transformation_server.py
+++ b/sdk/python/feast/transformation_server.py
@@ -2,6 +2,7 @@ import logging
 import sys
 from concurrent import futures
 
+import grpc
 import pyarrow as pa
 from grpc_reflection.v1alpha import reflection
 

--- a/sdk/python/setup.cfg
+++ b/sdk/python/setup.cfg
@@ -1,4 +1,5 @@
 [isort]
+src_paths = feast,tests
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0
@@ -16,5 +17,7 @@ select = B,C,E,F,W,T4
 exclude = .git,__pycache__,docs/conf.py,dist,feast/protos
 
 [mypy]
-files=feast,test
+files=feast,tests
 ignore_missing_imports=true
+# ignore mypy error from generated protos modules
+exclude=feast/protos/*

--- a/sdk/python/setup.cfg
+++ b/sdk/python/setup.cfg
@@ -19,5 +19,3 @@ exclude = .git,__pycache__,docs/conf.py,dist,feast/protos
 [mypy]
 files=feast,tests
 ignore_missing_imports=true
-# ignore mypy error from generated protos modules
-exclude=feast/protos/*


### PR DESCRIPTION
Feast is not PEP 561 compliant which means that mypy won't infer types from feast even though the library is fully typed. This can easily be fixed by including a `py.typed` marker file at the root of the package.

References:
- https://peps.python.org/pep-0561/
- https://mypy.readthedocs.io/en/stable/installed_packages.html#using-installed-packages-with-mypy-pep-561

Signed-off-by: Tomas Pereira de Vasconcelos <tomasvasconcelos1@gmail.com>

