### PR TITLE
fix: Ensure that __init__ files exist in proto dirs

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -224,6 +224,11 @@ class BuildPythonProtosCommand(Command):
             with open(f"{self.python_folder}/feast/{sub_folder}/__init__.py", 'w'):
                 pass
 
+        with open(f"{self.python_folder}/__init__.py", 'w'):
+            pass
+        with open(f"{self.python_folder}/feast/__init__.py", 'w'):
+            pass
+
         for path in Path("feast/protos").rglob("*.py"):
             for folder in self.sub_folders:
                 # Read in the file


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
This should unblock the issue when mypy is typechecking our code in python 3.7. https://github.com/feast-dev/feast/pull/2405#discussion_r831751241


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
