### PR TITLE
fix: Update Makefile to cd into python dir before running commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ package-protos:
 	cp -r ${ROOT_DIR}/protos ${ROOT_DIR}/sdk/python/feast/protos
 
 compile-protos-python:
-	python sdk/python/setup.py build_python_protos
+	cd sdk/python && python setup.py build_python_protos
 
 install-python:
 	cd sdk/python && python -m piptools sync requirements/py$(PYTHON)-requirements.txt
@@ -133,7 +133,7 @@ install-protoc-dependencies:
 	pip install grpcio-tools==1.34.0
 
 compile-protos-go: install-go-proto-dependencies install-protoc-dependencies
-	python sdk/python/setup.py build_go_protos
+	cd sdk/python && python setup.py build_go_protos
 
 compile-go-feature-server: compile-protos-go
 	go mod tidy


### PR DESCRIPTION

Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Without the `cd`, the makefile commands generates the python/proto code with the wrong path since we rely on `os.getcwd()`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
