### PR TITLE
chore: Construct FeatureView with timedelta instead of Duration object

### DIFF
--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -381,10 +381,9 @@ class FeatureView(BaseFeatureView):
             owner=feature_view_proto.spec.owner,
             online=feature_view_proto.spec.online,
             ttl=(
-                None
-                if feature_view_proto.spec.ttl.seconds == 0
-                and feature_view_proto.spec.ttl.nanos == 0
-                else feature_view_proto.spec.ttl
+                timedelta(days=0)
+                if feature_view_proto.spec.ttl.ToNanoseconds() == 0
+                else feature_view_proto.spec.ttl.ToTimedelta()
             ),
             batch_source=batch_source,
             stream_source=stream_source,


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: #2427 deprecated the option to pass in a `Duration` object for the `ttl` parameter during `FeatureView` initialization. This PR ensures that `FeatureView.from_proto` constructs a `FeatureView` using a `timedelta` object instead of a `Duration` object.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
