### PR TITLE
fix: Building of go extension fails

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -324,7 +324,7 @@ class BuildGoProtosCommand(Command):
             self._generate_go_protos(f"feast/{sub_folder}/*.proto")
 
 
-class BuildGoEmbeddedCommand(build_py):
+class BuildGoEmbeddedCommand(Command):
     description = "Builds Go embedded library"
     user_options = []
 


### PR DESCRIPTION
Signed-off-by: pyalex <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Calling `python setup.py build_go_lib` fails with error
```
distutils.errors.DistutilsGetoptError: invalid negative alias 'no-compile': option 'no-compile' not defined
make: *** [compile-go-lib] Error 1
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
