### PR TITLE
fix: Relax click python requirement to >=7

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -39,7 +39,7 @@ AUTHOR = "Feast"
 REQUIRES_PYTHON = ">=3.7.0"
 
 REQUIRED = [
-    "Click>=7.*",
+    "click>=7.0.0",
     "colorama>=0.3.9",
     "dill==0.3.*",
     "fastavro>=1.1.0",


### PR DESCRIPTION
Solving typo from https://github.com/feast-dev/feast/pull/2342. See https://github.com/feast-dev/feast/pull/2342#discussion_r816177367