### PR TITLE
chore: Add conversion from ValueTypeProto.Enum to new Feast type system

### DIFF
--- a/sdk/python/tests/unit/test_types.py
+++ b/sdk/python/tests/unit/test_types.py
@@ -1,20 +1,24 @@
 import pytest
 
 from feast.protos.feast.types.Value_pb2 import ValueType as ValueTypeProto
-from feast.types import Array, Float32, String
+from feast.types import Array, Float32, String, from_value_type
 
 
 def test_primitive_feast_type():
-    assert String.to_int() == ValueTypeProto.Enum.Value("STRING")
-    assert Float32.to_int() == ValueTypeProto.Enum.Value("FLOAT")
+    assert String.to_value_type() == ValueTypeProto.Enum.Value("STRING")
+    assert from_value_type(String.to_value_type()) == String
+    assert Float32.to_value_type() == ValueTypeProto.Enum.Value("FLOAT")
+    assert from_value_type(Float32.to_value_type()) == Float32
 
 
 def test_array_feast_type():
     array_float_32 = Array(Float32)
-    assert array_float_32.to_int() == ValueTypeProto.Enum.Value("FLOAT_LIST")
+    assert array_float_32.to_value_type() == ValueTypeProto.Enum.Value("FLOAT_LIST")
+    assert from_value_type(array_float_32.to_value_type()) == array_float_32
 
     array_string = Array(String)
-    assert array_string.to_int() == ValueTypeProto.Enum.Value("STRING_LIST")
+    assert array_string.to_value_type() == ValueTypeProto.Enum.Value("STRING_LIST")
+    assert from_value_type(array_string.to_value_type()) == array_string
 
     with pytest.raises(ValueError):
         _ = Array(Array)

--- a/sdk/python/tests/unit/test_types.py
+++ b/sdk/python/tests/unit/test_types.py
@@ -25,3 +25,11 @@ def test_array_feast_type():
 
     with pytest.raises(ValueError):
         _ = Array(Array(String))
+
+
+def test_all_value_types():
+    values = ValueTypeProto.Enum.values()
+    for value in values:
+        # We do not support the NULL type.
+        if value != ValueTypeProto.Enum.Value("NULL"):
+            assert from_value_type(value).to_value_type() == value


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: #2475 added a new type system but did not include a method to convert from the existing type system enums (`ValueTypeProto.Enum`) to the new type system. This PR adds that conversion method.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
