### PR TITLE
ci: Use testcontainers to spin up redis and datastore instances 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,11 +128,14 @@ There are two sets of tests you can run:
 2. Full integration tests (requires cloud environment setups)
 
 #### Local integration tests
-To get local integration tests running, you'll need to have Redis setup:
+To get local integration tests running, you'll need to have Redis and Docker setup:
 
 Redis
 1. Install Redis: [Quickstart](https://redis.io/topics/quickstart)
 2. Run `redis-server`
+
+Docker:
+1. Install Docker: [Get Docker](https://docs.docker.com/get-docker/)
 
 Now run `make test-python-universal-local`
 
@@ -160,6 +163,19 @@ To test across clouds, on top of setting up Redis, you also need GCP / AWS / Sno
 - See https://signup.snowflake.com/
 
 Then run `make test-python-integration`. Note that for Snowflake / GCP / AWS, this will create new temporary tables / datasets.
+
+#### (Experimental) Run full integration tests against containerized services
+Test across clouds requires existing accounts on GCP / AWS / Snowflake, and may incur costs when using these services.
+
+It's possible to run some integration tests against emulated local versions of these services, using ephemeral containers. 
+These tests create new temporary tables / datasets locally only, and they are cleaned up. when the containers are torn down.
+
+The services with containerized replacements currently implemented are:
+- Datastore
+- Redis
+
+You can run `make test-python-integration-container` to run tests against the containerized versions of dependencies.
+
 
 ## Feast Java Serving
 See [Java contributing guide](java/CONTRIBUTING.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,14 +128,11 @@ There are two sets of tests you can run:
 2. Full integration tests (requires cloud environment setups)
 
 #### Local integration tests
-To get local integration tests running, you'll need to have Redis and Docker setup:
+To get local integration tests running, you'll need to have Redis setup:
 
 Redis
 1. Install Redis: [Quickstart](https://redis.io/topics/quickstart)
 2. Run `redis-server`
-
-Docker:
-1. Install Docker: [Get Docker](https://docs.docker.com/get-docker/)
 
 Now run `make test-python-universal-local`
 
@@ -166,6 +163,8 @@ Then run `make test-python-integration`. Note that for Snowflake / GCP / AWS, th
 
 #### (Experimental) Run full integration tests against containerized services
 Test across clouds requires existing accounts on GCP / AWS / Snowflake, and may incur costs when using these services.
+
+For this approach of running tests, you'll need to have docker set up locally: [Get Docker](https://docs.docker.com/get-docker/)
 
 It's possible to run some integration tests against emulated local versions of these services, using ephemeral containers. 
 These tests create new temporary tables / datasets locally only, and they are cleaned up. when the containers are torn down.

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ test-python:
 test-python-integration:
 	FEAST_USAGE=False IS_TEST=True python -m pytest -n 8 --integration sdk/python/tests
 
+test-python-integration-container:
+	FEAST_USAGE=False IS_TEST=True FEAST_LOCAL_ONLINE_CONTAINER=True python -m pytest -n 8 --integration sdk/python/tests
+
 test-python-universal-contrib:
 	PYTHONPATH='.' FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.contrib_repo_configuration FEAST_USAGE=False IS_TEST=True python -m pytest -n 8 --integration --universal sdk/python/tests
 

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -126,7 +126,7 @@ CI_REQUIRED = (
         "pytest-mock==1.10.4",
         "Sphinx!=4.0.0,<4.4.0",
         "sphinx-rtd-theme",
-        "testcontainers==3.4.2",
+        "testcontainers>=3.5",
         "adlfs==0.5.9",
         "firebase-admin==4.5.2",
         "pre-commit",

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -24,7 +24,6 @@ import pytest
 from _pytest.nodes import Item
 
 from feast import FeatureStore
-from feast.infra.online_stores.redis import RedisOnlineStoreConfig
 from tests.data.data_creator import create_dataset
 from tests.integration.feature_repos.integration_test_repo_config import (
     IntegrationTestRepoConfig,
@@ -33,6 +32,7 @@ from tests.integration.feature_repos.repo_configuration import (
     FULL_REPO_CONFIGS,
     GO_REPO_CONFIGS,
     REDIS_CLUSTER_CONFIG,
+    REDIS_CONFIG,
     Environment,
     TestData,
     construct_test_environment,
@@ -206,9 +206,9 @@ def go_environment(request, worker_id: str):
 
 
 @pytest.fixture(
-    params=[RedisOnlineStoreConfig, REDIS_CLUSTER_CONFIG],
+    params=[REDIS_CONFIG, REDIS_CLUSTER_CONFIG],
     scope="session",
-    ids=[str(c) for c in [RedisOnlineStoreConfig, REDIS_CLUSTER_CONFIG]],
+    ids=[str(c) for c in [REDIS_CONFIG, REDIS_CLUSTER_CONFIG]],
 )
 def local_redis_environment(request, worker_id):
     e = construct_test_environment(

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -24,6 +24,7 @@ import pytest
 from _pytest.nodes import Item
 
 from feast import FeatureStore
+from feast.infra.online_stores.redis import RedisOnlineStoreConfig
 from tests.data.data_creator import create_dataset
 from tests.integration.feature_repos.integration_test_repo_config import (
     IntegrationTestRepoConfig,
@@ -32,7 +33,6 @@ from tests.integration.feature_repos.repo_configuration import (
     FULL_REPO_CONFIGS,
     GO_REPO_CONFIGS,
     REDIS_CLUSTER_CONFIG,
-    REDIS_CONFIG,
     Environment,
     TestData,
     construct_test_environment,
@@ -206,9 +206,9 @@ def go_environment(request, worker_id: str):
 
 
 @pytest.fixture(
-    params=[REDIS_CONFIG, REDIS_CLUSTER_CONFIG],
+    params=[RedisOnlineStoreConfig, REDIS_CLUSTER_CONFIG],
     scope="session",
-    ids=[str(c) for c in [REDIS_CONFIG, REDIS_CLUSTER_CONFIG]],
+    ids=[str(c) for c in [RedisOnlineStoreConfig, REDIS_CLUSTER_CONFIG]],
 )
 def local_redis_environment(request, worker_id):
     e = construct_test_environment(

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -184,6 +184,8 @@ def environment(request, worker_id: str):
         e.feature_store.teardown()
         if proc.is_alive():
             proc.kill()
+        if e.online_store_creator:
+            e.online_store_creator.teardown()
 
     request.addfinalizer(cleanup)
 
@@ -245,6 +247,8 @@ def go_data_sources(request, go_environment):
     def cleanup():
         # logger.info("Running cleanup in %s, Request: %s", worker_id, request.param)
         go_environment.data_source_creator.teardown()
+        if environment.online_store_creator:
+            environment.online_store_creator.teardown()
 
     request.addfinalizer(cleanup)
     return construct_universal_test_data(go_environment)
@@ -259,6 +263,8 @@ def e2e_data_sources(environment: Environment, request):
 
     def cleanup():
         environment.data_source_creator.teardown()
+        if environment.online_store_creator:
+            environment.online_store_creator.teardown()
 
     request.addfinalizer(cleanup)
 

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -247,8 +247,8 @@ def go_data_sources(request, go_environment):
     def cleanup():
         # logger.info("Running cleanup in %s, Request: %s", worker_id, request.param)
         go_environment.data_source_creator.teardown()
-        if environment.online_store_creator:
-            environment.online_store_creator.teardown()
+        if go_environment.online_store_creator:
+            go_environment.online_store_creator.teardown()
 
     request.addfinalizer(cleanup)
     return construct_universal_test_data(go_environment)

--- a/sdk/python/tests/integration/feature_repos/integration_test_repo_config.py
+++ b/sdk/python/tests/integration/feature_repos/integration_test_repo_config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, Dict, Type, Union
+from typing import Dict, Optional, Type, Union
 
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
@@ -7,18 +7,22 @@ from tests.integration.feature_repos.universal.data_source_creator import (
 from tests.integration.feature_repos.universal.data_sources.file import (
     FileDataSourceCreator,
 )
+from tests.integration.feature_repos.universal.online_store_creator import (
+    OnlineStoreCreator,
+)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=False)
 class IntegrationTestRepoConfig:
     """
     This class should hold all possible parameters that may need to be varied by individual tests.
     """
 
     provider: str = "local"
-    online_store: Union[str, Dict, Callable] = "sqlite"
+    online_store: Union[str, Dict] = "sqlite"
 
     offline_store_creator: Type[DataSourceCreator] = FileDataSourceCreator
+    online_store_creator: Optional[Type[OnlineStoreCreator]] = None
 
     full_feature_names: bool = True
     infer_features: bool = False

--- a/sdk/python/tests/integration/feature_repos/integration_test_repo_config.py
+++ b/sdk/python/tests/integration/feature_repos/integration_test_repo_config.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Type, Union
+from typing import Callable, Dict, Type, Union
 
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
@@ -16,7 +16,7 @@ class IntegrationTestRepoConfig:
     """
 
     provider: str = "local"
-    online_store: Union[str, Dict] = "sqlite"
+    online_store: Union[str, Dict, Callable] = "sqlite"
 
     offline_store_creator: Type[DataSourceCreator] = FileDataSourceCreator
 
@@ -28,10 +28,13 @@ class IntegrationTestRepoConfig:
     def __repr__(self) -> str:
         if isinstance(self.online_store, str):
             online_store_type = self.online_store
-        elif self.online_store["type"] == "redis":
-            online_store_type = self.online_store.get("redis_type", "redis")
+        elif isinstance(self.online_store, dict):
+            if self.online_store["type"] == "redis":
+                online_store_type = self.online_store.get("redis_type", "redis")
+            else:
+                online_store_type = self.online_store["type"]
         else:
-            online_store_type = self.online_store["type"]
+            online_store_type = self.online_store.__name__
 
         return ":".join(
             [

--- a/sdk/python/tests/integration/feature_repos/integration_test_repo_config.py
+++ b/sdk/python/tests/integration/feature_repos/integration_test_repo_config.py
@@ -30,15 +30,18 @@ class IntegrationTestRepoConfig:
     go_feature_server: bool = False
 
     def __repr__(self) -> str:
-        if isinstance(self.online_store, str):
-            online_store_type = self.online_store
-        elif isinstance(self.online_store, dict):
-            if self.online_store["type"] == "redis":
-                online_store_type = self.online_store.get("redis_type", "redis")
+        if not self.online_store_creator:
+            if isinstance(self.online_store, str):
+                online_store_type = self.online_store
+            elif isinstance(self.online_store, dict):
+                if self.online_store["type"] == "redis":
+                    online_store_type = self.online_store.get("redis_type", "redis")
+                else:
+                    online_store_type = self.online_store["type"]
             else:
-                online_store_type = self.online_store["type"]
+                online_store_type = self.online_store.__name__
         else:
-            online_store_type = self.online_store.__name__
+            online_store_type = self.online_store_creator.__name__
 
         return ":".join(
             [

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -44,6 +44,9 @@ from tests.integration.feature_repos.universal.feature_views import (
     create_order_feature_view,
     create_pushable_feature_view,
 )
+from tests.integration.feature_repos.universal.online_store.datastore import (
+    DatastoreOnlineStoreCreator,
+)
 from tests.integration.feature_repos.universal.online_store.redis import (
     RedisOnlineStoreCreator,
 )
@@ -83,7 +86,7 @@ if os.getenv("FEAST_IS_LOCAL_TEST", "False") != "True":
             IntegrationTestRepoConfig(
                 provider="gcp",
                 offline_store_creator=BigQueryDataSourceCreator,
-                online_store="datastore",
+                online_store_creator=DatastoreOnlineStoreCreator,
             ),
             IntegrationTestRepoConfig(
                 provider="gcp",

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -54,6 +54,7 @@ from tests.integration.feature_repos.universal.online_store_creator import (
 DYNAMO_CONFIG = {"type": "dynamodb", "region": "us-west-2"}
 # Port 12345 will chosen as default for redis node configuration because Redis Cluster is started off of nodes
 # 6379 -> 6384. This causes conflicts in cli integration tests so we manually keep them separate.
+REDIS_CONFIG = {"type": "redis", "connection_string": "localhost:6379,db=0"}
 REDIS_CLUSTER_CONFIG = {
     "type": "redis",
     "redis_type": "redis_cluster",

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -374,8 +374,6 @@ def construct_test_environment(
         online_creator = None
         online_store = test_repo_config.online_store
 
-    print(f"Online Store creator: {online_creator}, online store: {online_store}")
-
     repo_dir_name = tempfile.mkdtemp()
 
     if test_repo_config.python_feature_server and test_repo_config.provider == "aws":

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -352,7 +352,7 @@ def construct_test_environment(
     offline_creator: DataSourceCreator = test_repo_config.offline_store_creator(project)
     offline_store_config = offline_creator.create_offline_store_config()
 
-    if isinstance(test_repo_config.online_store, Callable):  # type: ignore
+    if isinstance(test_repo_config.online_store, Callable):
         online_creator = test_repo_config.online_store(project)
         online_store = online_creator.create_online_store()
     else:

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -78,6 +78,7 @@ if os.getenv("FEAST_IS_LOCAL_TEST", "False") != "True":
     DEFAULT_FULL_REPO_CONFIGS.extend(
         [
             IntegrationTestRepoConfig(online_store_creator=RedisOnlineStoreCreator),
+            IntegrationTestRepoConfig(online_store=REDIS_CONFIG),
             # GCP configurations
             IntegrationTestRepoConfig(
                 provider="gcp",
@@ -354,7 +355,9 @@ def construct_test_environment(
 
     if test_repo_config.online_store_creator:
         online_creator = test_repo_config.online_store_creator(project)
-        test_repo_config.online_store = online_creator.create_online_store()
+        online_store = (
+            test_repo_config.online_store
+        ) = online_creator.create_online_store()
     else:
         online_creator = None
         online_store = test_repo_config.online_store

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -9,6 +9,9 @@ from feast.saved_dataset import SavedDatasetStorage
 
 
 class DataSourceCreator(ABC):
+    def __init__(self, project_name: str):
+        self.project_name = project_name
+
     @abstractmethod
     def create_data_source(
         self,

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -18,8 +18,8 @@ class BigQueryDataSourceCreator(DataSourceCreator):
     dataset: Optional[Dataset] = None
 
     def __init__(self, project_name: str):
+        super().__init__(project_name)
         self.client = bigquery.Client()
-        self.project_name = project_name
         self.gcp_project = self.client.project
         self.dataset_id = f"{self.gcp_project}.{project_name}"
 

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -22,7 +22,7 @@ class FileDataSourceCreator(DataSourceCreator):
     files: List[Any]
 
     def __init__(self, project_name: str):
-        self.project_name = project_name
+        super().__init__(project_name)
         self.files = []
 
     def create_data_source(

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
@@ -19,8 +19,7 @@ class RedshiftDataSourceCreator(DataSourceCreator):
     tables: List[str] = []
 
     def __init__(self, project_name: str):
-        super().__init__()
-        self.project_name = project_name
+        super().__init__(project_name)
         self.client = aws_utils.get_redshift_data_client("us-west-2")
         self.s3 = aws_utils.get_s3_resource("us-west-2")
 

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/snowflake.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/snowflake.py
@@ -20,8 +20,7 @@ class SnowflakeDataSourceCreator(DataSourceCreator):
     tables: List[str] = []
 
     def __init__(self, project_name: str):
-        super().__init__()
-        self.project_name = project_name
+        super().__init__(project_name)
         self.offline_store_config = SnowflakeOfflineStoreConfig(
             type="snowflake.offline",
             account=os.environ["SNOWFLAKE_CI_DEPLOYMENT"],

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/spark_data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/spark_data_source_creator.py
@@ -24,6 +24,7 @@ class SparkDataSourceCreator(DataSourceCreator):
     spark_session = None
 
     def __init__(self, project_name: str):
+        super().__init__(project_name)
         self.spark_conf = {
             "master": "local[*]",
             "spark.ui.enabled": "false",
@@ -31,7 +32,6 @@ class SparkDataSourceCreator(DataSourceCreator):
             "spark.sql.parser.quotedRegexColumnNames": "true",
             "spark.sql.session.timeZone": "UTC",
         }
-        self.project_name = project_name
         if not self.spark_offline_store_config:
             self.create_offline_store_config()
         if not self.spark_session:

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/datastore.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/datastore.py
@@ -1,5 +1,5 @@
 import os
-import typing
+from typing import Dict
 
 from google.cloud import datastore
 from testcontainers.core.container import DockerContainer
@@ -23,7 +23,7 @@ class DatastoreOnlineStoreCreator(OnlineStoreCreator):
             .with_exposed_ports("8081")
         )
 
-    def create_online_store(self) -> typing.Dict[str, str]:
+    def create_online_store(self) -> Dict[str, str]:
         self.container.start()
         log_string_to_wait_for = r"\[datastore\] Dev App Server is now running"
         wait_for_logs(

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/datastore.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/datastore.py
@@ -1,0 +1,38 @@
+import os
+import typing
+
+from google.cloud import datastore
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+from tests.integration.feature_repos.universal.online_store_creator import (
+    OnlineStoreCreator,
+)
+
+
+class DatastoreOnlineStoreCreator(OnlineStoreCreator):
+    def __init__(self, project_name: str):
+        super().__init__(project_name)
+        self.container = (
+            DockerContainer(
+                "gcr.io/google.com/cloudsdktool/cloud-sdk:380.0.0-emulators"
+            )
+            .with_command(
+                "gcloud beta emulators datastore start --project test-project --host-port 0.0.0.0:8081"
+            )
+            .with_exposed_ports("8081")
+        )
+
+    def create_online_store(self) -> typing.Dict[str, str]:
+        self.container.start()
+        log_string_to_wait_for = r"\[datastore\] Dev App Server is now running"
+        wait_for_logs(
+            container=self.container, predicate=log_string_to_wait_for, timeout=5
+        )
+        exposed_port = self.container.get_exposed_port("8081")
+        os.environ[datastore.client.DATASTORE_EMULATOR_HOST] = f"0.0.0.0:{exposed_port}"
+        return {"type": "datastore", "project_id": "test-project"}
+
+    def teardown(self):
+        del os.environ[datastore.client.DATASTORE_EMULATOR_HOST]
+        self.container.stop()

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/redis.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/redis.py
@@ -1,4 +1,4 @@
-import typing
+from typing import Dict
 
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
@@ -13,7 +13,7 @@ class RedisOnlineStoreCreator(OnlineStoreCreator):
         super().__init__(project_name)
         self.container = DockerContainer("redis").with_exposed_ports("6379")
 
-    def create_online_store(self) -> typing.Dict[str, str]:
+    def create_online_store(self) -> Dict[str, str]:
         self.container.start()
         log_string_to_wait_for = "Ready to accept connections"
         wait_for_logs(

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/redis.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/redis.py
@@ -1,0 +1,26 @@
+import typing
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+from tests.integration.feature_repos.universal.online_store_creator import (
+    OnlineStoreCreator,
+)
+
+
+class RedisOnlineStoreCreator(OnlineStoreCreator):
+    def __init__(self, project_name: str):
+        super().__init__(project_name)
+        self.container = DockerContainer("redis").with_exposed_ports("6379")
+
+    def create_online_store(self) -> typing.Dict[str, str]:
+        self.container.start()
+        log_string_to_wait_for = "Ready to accept connections"
+        wait_for_logs(
+            container=self.container, predicate=log_string_to_wait_for, timeout=5
+        )
+        exposed_port = self.container.get_exposed_port("6379")
+        return {"type": "redis", "connection_string": f"localhost:{exposed_port},db=0"}
+
+    def teardown(self):
+        self.container.stop()

--- a/sdk/python/tests/integration/feature_repos/universal/online_store_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store_creator.py
@@ -1,0 +1,14 @@
+from abc import ABC
+
+from feast.repo_config import FeastConfigBaseModel
+
+
+class OnlineStoreCreator(ABC):
+    def __init__(self, project_name: str):
+        self.project_name = project_name
+
+    def create_online_store(self) -> FeastConfigBaseModel:
+        ...
+
+    def teardown(self):
+        ...


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Running integration tests for contributors has been challenging since they don't always have access to GCP or AWS. This makes development or contributions harder than they need to be.

Additionally, there's some infrastructure that's needed to run tests locally - such as redis. This shouldn't have to be installed by contributors explicitly if it's not necessary.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
