### PR TITLE
chore: Switch new type system to use ValueType instead of ValueTypeProto.Enum

### DIFF
--- a/sdk/python/feast/field.py
+++ b/sdk/python/feast/field.py
@@ -15,6 +15,7 @@
 from feast.feature import Feature
 from feast.protos.feast.core.Feature_pb2 import FeatureSpecV2 as FieldProto
 from feast.types import FeastType, from_value_type
+from feast.value_type import ValueType
 
 
 class Field:
@@ -61,7 +62,8 @@ class Field:
 
     def to_proto(self) -> FieldProto:
         """Converts a Field object to its protobuf representation."""
-        return FieldProto(name=self.name, value_type=self.dtype.to_value_type())
+        value_type = self.dtype.to_value_type()
+        return FieldProto(name=self.name, value_type=value_type.value)
 
     @classmethod
     def from_proto(cls, field_proto: FieldProto):
@@ -71,7 +73,8 @@ class Field:
         Args:
             field_proto: FieldProto protobuf object
         """
-        return cls(name=field_proto.name, dtype=from_value_type(field_proto.value_type))
+        value_type = ValueType(field_proto.value_type)
+        return cls(name=field_proto.name, dtype=from_value_type(value_type))
 
     @classmethod
     def from_feature(cls, feature: Feature):
@@ -81,4 +84,4 @@ class Field:
         Args:
             feature: Feature object to convert.
         """
-        return cls(name=feature.name, dtype=from_value_type(feature.dtype.value))
+        return cls(name=feature.name, dtype=from_value_type(feature.dtype))

--- a/sdk/python/tests/unit/test_types.py
+++ b/sdk/python/tests/unit/test_types.py
@@ -1,24 +1,24 @@
 import pytest
 
-from feast.protos.feast.types.Value_pb2 import ValueType as ValueTypeProto
 from feast.types import Array, Float32, String, from_value_type
+from feast.value_type import ValueType
 
 
 def test_primitive_feast_type():
-    assert String.to_value_type() == ValueTypeProto.Enum.Value("STRING")
+    assert String.to_value_type() == ValueType.STRING
     assert from_value_type(String.to_value_type()) == String
-    assert Float32.to_value_type() == ValueTypeProto.Enum.Value("FLOAT")
+    assert Float32.to_value_type() == ValueType.FLOAT
     assert from_value_type(Float32.to_value_type()) == Float32
 
 
 def test_array_feast_type():
-    array_float_32 = Array(Float32)
-    assert array_float_32.to_value_type() == ValueTypeProto.Enum.Value("FLOAT_LIST")
-    assert from_value_type(array_float_32.to_value_type()) == array_float_32
-
     array_string = Array(String)
-    assert array_string.to_value_type() == ValueTypeProto.Enum.Value("STRING_LIST")
+    assert array_string.to_value_type() == ValueType.STRING_LIST
     assert from_value_type(array_string.to_value_type()) == array_string
+
+    array_float_32 = Array(Float32)
+    assert array_float_32.to_value_type() == ValueType.FLOAT_LIST
+    assert from_value_type(array_float_32.to_value_type()) == array_float_32
 
     with pytest.raises(ValueError):
         _ = Array(Array)
@@ -28,8 +28,7 @@ def test_array_feast_type():
 
 
 def test_all_value_types():
-    values = ValueTypeProto.Enum.values()
-    for value in values:
+    for value in ValueType:
         # We do not support the NULL type.
-        if value != ValueTypeProto.Enum.Value("NULL"):
+        if value != ValueType.NULL:
             assert from_value_type(value).to_value_type() == value


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: #2489 added a conversion method from the new `FeastType`s to to `ValueTypeProto.Enum`. This conversion method is slightly awkward since it relies on a proto class, `ValueTypeProto.Enum`, instead of `ValueType`, the corresponding Python enum. This PR switches the conversion method to rely on `ValueType` instead of `ValueTypeProto.Enum`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
