### PR TITLE
fix: Dynamodb deduplicate batch write request by partition keys

### DIFF
--- a/sdk/python/tests/utils/online_store_utils.py
+++ b/sdk/python/tests/utils/online_store_utils.py
@@ -19,6 +19,8 @@ def _create_n_customer_test_samples(n=10):
                 "name": ValueProto(string_val="John"),
                 "age": ValueProto(int64_val=3),
             },
+            datetime.utcnow(),
+            None,
         )
         for i in range(n)
     ]
@@ -42,13 +44,13 @@ def _delete_test_table(project, tbl_name, region):
 def _insert_data_test_table(data, project, tbl_name, region):
     dynamodb_resource = boto3.resource("dynamodb", region_name=region)
     table_instance = dynamodb_resource.Table(f"{project}.{tbl_name}")
-    for entity_key, features in data:
+    for entity_key, features, timestamp, created_ts in data:
         entity_id = compute_entity_id(entity_key)
         with table_instance.batch_writer() as batch:
             batch.put_item(
                 Item={
                     "entity_id": entity_id,
-                    "event_ts": str(utils.make_tzaware(datetime.utcnow())),
+                    "event_ts": str(utils.make_tzaware(timestamp)),
                     "values": {k: v.SerializeToString() for k, v in features.items()},
                 }
             )


### PR DESCRIPTION
Signed-off-by: Miguel Trejo <armando.trejo.marrufo@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

The `DynamoDBOnlineStore` batch writer can raise the following error if duplicate primary keys `entity_id` appear 
> BatchWriteItem operation: Provided list of item keys contains duplicates

This Merge Request deduplicate the write batch request on `entity_id` primary key,

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2483 
