### PR TITLE
fix: Fix entity row to use join key instead of name

### DIFF
--- a/sdk/python/tests/benchmarks/test_benchmark_universal_online_retrieval.py
+++ b/sdk/python/tests/benchmarks/test_benchmark_universal_online_retrieval.py
@@ -38,7 +38,7 @@ def test_online_retrieval(environment, universal_data_sources, benchmark):
     sample_customers = random.sample(entities.customer_vals, 10)
 
     entity_rows = [
-        {"driver": d, "customer_id": c, "val_to_add": 50}
+        {"driver_id": d, "customer_id": c, "val_to_add": 50}
         for (d, c) in zip(sample_drivers, sample_customers)
     ]
 


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: Recently the `sdk/python/tests/benchmarks/test_benchmark_universal_online_retrieval.py::test_online_retrieval` test has been failing on master with the following error: `RuntimeError: key driver_id is missing in provided entity rows`. This PR fixes the bug.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
