### PR TITLE
fix: Support passing batch source to streaming sources for backfills

### DIFF
--- a/go/embedded/online_features.go
+++ b/go/embedded/online_features.go
@@ -63,13 +63,13 @@ func (s *OnlineFeatureService) GetEntityTypesMap(featureRefs []string) (map[stri
 
 	joinKeyTypes := make(map[string]int32)
 
-	for viewName, _ := range viewNames {
+	for viewName := range viewNames {
 		view, err := s.fs.GetFeatureView(viewName, true)
 		if err != nil {
 			// skip on demand feature views
 			continue
 		}
-		for entityName, _ := range view.Entities {
+		for entityName := range view.Entities {
 			entity := entitiesByName[entityName]
 			joinKeyTypes[entity.JoinKey] = int32(entity.ValueType.Number())
 		}
@@ -98,7 +98,7 @@ func (s *OnlineFeatureService) GetEntityTypesMapByFeatureService(featureServiceN
 			// skip on demand feature views
 			continue
 		}
-		for entityName, _ := range view.Entities {
+		for entityName := range view.Entities {
 			entity := entitiesByName[entityName]
 			joinKeyTypes[entity.JoinKey] = int32(entity.ValueType.Number())
 		}

--- a/protos/feast/core/DataSource.proto
+++ b/protos/feast/core/DataSource.proto
@@ -26,7 +26,7 @@ import "feast/core/DataFormat.proto";
 import "feast/types/Value.proto";
 
 // Defines a Data Source that can be used source Feature data
-// Next available id: 26
+// Next available id: 27
 message DataSource {
   // Field indexes should *not* be reused. Not sure if fields 6-10 were used previously or not,
   // but they are going to be reserved for backwards compatibility.
@@ -82,6 +82,10 @@ message DataSource {
   // first party sources as well.
   string data_source_class_type = 17;
 
+  // Optional batch source for streaming sources for historical features and materialization.
+  DataSource batch_source = 26;
+
+
   // Defines options for DataSource that sources features from a file
   message FileOptions {
     FileFormat file_format = 1;
@@ -128,6 +132,7 @@ message DataSource {
 
     // Defines the stream data format encoding feature/entity data in Kafka messages.
     StreamFormat message_format = 3;
+
   }
 
   // Defines options for DataSource that sources features from Kinesis records.
@@ -199,8 +204,6 @@ message DataSource {
   message PushOptions {
     // Mapping of feature name to type
     map<string, feast.types.ValueType.Enum> schema = 1;
-    // Optional batch source for the push source for historical features and materialization.
-    DataSource batch_source = 2;
   }
 
 

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -704,7 +704,7 @@ class PushSource(DataSource):
         for key, val in schema_pb.items():
             schema[key] = ValueType(val)
 
-        assert data_source.push_options.HasField("batch_source")
+        assert data_source.HasField("batch_source")
         batch_source = DataSource.from_proto(data_source.batch_source)
 
         return PushSource(

--- a/sdk/python/tests/unit/test_data_sources.py
+++ b/sdk/python/tests/unit/test_data_sources.py
@@ -12,8 +12,8 @@ def test_push_with_batch():
         batch_source=BigQuerySource(table="test.test"),
     )
     push_source_proto = push_source.to_proto()
+    assert push_source_proto.HasField("batch_source")
     assert push_source_proto.push_options is not None
-    assert push_source_proto.push_options.HasField("batch_source")
 
     push_source_unproto = PushSource.from_proto(push_source_proto)
 


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Similar to the PushSource, we want to is to fold in batch source as a field in streaming sources, since they are used for semantically for "backfill". 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
