### PR TITLE
ci: Use testcontainers to spin up DynamoDB instances for local integration tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,7 @@ These tests create new temporary tables / datasets locally only, and they are cl
 
 The services with containerized replacements currently implemented are:
 - Datastore
+- DynamoDB
 - Redis
 
 You can run `make test-python-integration-container` to run tests against the containerized versions of dependencies.

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -18,6 +18,7 @@ from feast.constants import FULL_REPO_CONFIGS_MODULE_ENV_NAME
 from feast.data_source import DataSource
 from feast.errors import FeastModuleImportError
 from feast.repo_config import RegistryConfig, RepoConfig
+from sdk.python.tests.integration.feature_repos.universal.online_store.dynamodb import DynamoDBOnlineStoreCreator
 from tests.integration.feature_repos.integration_test_repo_config import (
     IntegrationTestRepoConfig,
 )
@@ -46,6 +47,9 @@ from tests.integration.feature_repos.universal.feature_views import (
 )
 from tests.integration.feature_repos.universal.online_store.datastore import (
     DatastoreOnlineStoreCreator,
+)
+from tests.integration.feature_repos.universal.online_store.dynamodb import (
+    DynamoDBOnlineStoreCreator
 )
 from tests.integration.feature_repos.universal.online_store.redis import (
     RedisOnlineStoreCreator,
@@ -130,7 +134,10 @@ else:
 
 if os.getenv("FEAST_LOCAL_ONLINE_CONTAINER", "False").lower() == "true":
     replacements = {"datastore": DatastoreOnlineStoreCreator}
-    replacement_dicts = [(REDIS_CONFIG, RedisOnlineStoreCreator)]
+    replacement_dicts = [
+        (REDIS_CONFIG, RedisOnlineStoreCreator),
+        (DYNAMO_CONFIG, DynamoDBOnlineStoreCreator)
+    ]
     for c in FULL_REPO_CONFIGS:
         if isinstance(c.online_store, dict):
             for _replacement in replacement_dicts:

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -18,7 +18,6 @@ from feast.constants import FULL_REPO_CONFIGS_MODULE_ENV_NAME
 from feast.data_source import DataSource
 from feast.errors import FeastModuleImportError
 from feast.repo_config import RegistryConfig, RepoConfig
-from sdk.python.tests.integration.feature_repos.universal.online_store.dynamodb import DynamoDBOnlineStoreCreator
 from tests.integration.feature_repos.integration_test_repo_config import (
     IntegrationTestRepoConfig,
 )
@@ -49,7 +48,7 @@ from tests.integration.feature_repos.universal.online_store.datastore import (
     DatastoreOnlineStoreCreator,
 )
 from tests.integration.feature_repos.universal.online_store.dynamodb import (
-    DynamoDBOnlineStoreCreator
+    DynamoDBOnlineStoreCreator,
 )
 from tests.integration.feature_repos.universal.online_store.redis import (
     RedisOnlineStoreCreator,
@@ -136,7 +135,7 @@ if os.getenv("FEAST_LOCAL_ONLINE_CONTAINER", "False").lower() == "true":
     replacements = {"datastore": DatastoreOnlineStoreCreator}
     replacement_dicts = [
         (REDIS_CONFIG, RedisOnlineStoreCreator),
-        (DYNAMO_CONFIG, DynamoDBOnlineStoreCreator)
+        (DYNAMO_CONFIG, DynamoDBOnlineStoreCreator),
     ]
     for c in FULL_REPO_CONFIGS:
         if isinstance(c.online_store, dict):

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/dynamodb.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/dynamodb.py
@@ -1,0 +1,26 @@
+from typing import Dict
+
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
+
+from tests.integration.feature_repos.universal.online_store_creator import (
+    OnlineStoreCreator,
+)
+
+class DynamoDBOnlineStoreCreator(OnlineStoreCreator):
+    def __init__(self, project_name: str):
+        super().__init__(project_name)
+        self.container = DockerContainer("amazon/dynamodb-local").with_exposed_ports("8000")
+
+    def create_online_store(self) -> Dict[str, str]:
+        self.container.start()
+        log_string_to_wait_for = "Initializing DynamoDB Local with the following configuration:"
+        wait_for_logs(
+            container=self.container, predicate=log_string_to_wait_for, timeout=5
+        )
+        exposed_port = self.container.get_exposed_port("8000")
+        return {"type": "dynamodb", "connection_string": f"localhost:{exposed_port}"}
+
+    def teardown(self):
+        self.container.stop()
+

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/dynamodb.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/dynamodb.py
@@ -7,20 +7,28 @@ from tests.integration.feature_repos.universal.online_store_creator import (
     OnlineStoreCreator,
 )
 
+
 class DynamoDBOnlineStoreCreator(OnlineStoreCreator):
     def __init__(self, project_name: str):
         super().__init__(project_name)
-        self.container = DockerContainer("amazon/dynamodb-local").with_exposed_ports("8000")
+        self.container = DockerContainer(
+            "amazon/dynamodb-local:latest"
+        ).with_exposed_ports("8000")
 
     def create_online_store(self) -> Dict[str, str]:
         self.container.start()
-        log_string_to_wait_for = "Initializing DynamoDB Local with the following configuration:"
+        log_string_to_wait_for = (
+            "Initializing DynamoDB Local with the following configuration:"
+        )
         wait_for_logs(
             container=self.container, predicate=log_string_to_wait_for, timeout=5
         )
         exposed_port = self.container.get_exposed_port("8000")
-        return {"type": "dynamodb", "connection_string": f"localhost:{exposed_port}"}
+        return {
+            "type": "dynamodb",
+            "endpoint_url": f"http://localhost:{exposed_port}",
+            "region": "us-west-2",
+        }
 
     def teardown(self):
         self.container.stop()
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2505

**Context**:

Use testcontainers to spin up a local Docker Container with DynamoDB. Integrate the `DynamoDBOnlineStoreCreator` for testing to replace any standard DynamoDB Online store with an ephemeral container emulating DynamoDB.
