### PR TITLE
fix: Update build_go_protos to use a consistent python path

### DIFF
--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -17,6 +17,7 @@ import pathlib
 import re
 import shutil
 import subprocess
+import sys
 from distutils.cmd import Command
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -356,7 +357,8 @@ class BuildGoEmbeddedCommand(Command):
             "-output",
             "feast/embedded_go/lib",
             "-vm",
-            "python3",
+            # Path of current python executable
+            sys.executable,
             "-no-make",
             "github.com/feast-dev/feast/go/embedded"
         ], env={


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

`python3` is misleading because it may refer to a differnet executable on the path from the one currently in use, specially if anyone has as many pyenvs as I do.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
