### PR TITLE
chore: Extra dependencies in setup.py for Go <-> Python interop

### DIFF
--- a/docs/reference/feature-servers/go-feature-retrieval.md
+++ b/docs/reference/feature-servers/go-feature-retrieval.md
@@ -12,6 +12,11 @@ The Go Feature Retrieval component currently only supports Redis and Sqlite as o
 
 As long as you are running macOS or linux, on x86, with python version 3.7-3.10, the go component comes pre-compiled when you install feast.
 
+However, some additional dependencies are required for Go <-> Python interoperability. To install these dependencies run the following command in your console:
+```
+pip install feast[go]
+```
+
 For developers, if you want to build from source, run `make compile-go-lib` to build and compile the go server.
 
 ## Usage

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -114,7 +114,7 @@ GE_REQUIRED = [
 ]
 
 GO_REQUIRED = [
-    "cffi==1.15.0",
+    "cffi==1.15.*",
 ]
 
 CI_REQUIRED = (

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -113,6 +113,10 @@ GE_REQUIRED = [
     "great_expectations>=0.14.0,<0.15.0"
 ]
 
+GO_REQUIRED = [
+    "cffi==1.15.0",
+]
+
 CI_REQUIRED = (
     [
         "cryptography==3.4.8",
@@ -440,6 +444,7 @@ setup(
         "trino": TRINO_REQUIRED,
         "postgres": POSTGRES_REQUIRED,
         "ge": GE_REQUIRED,
+        "go": GO_REQUIRED,
     },
     include_package_data=True,
     license="Apache",


### PR DESCRIPTION
Signed-off-by: pyalex <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

In order for Python to fully interop with Go we might need to install some extra python packages. This PR adds new dependency group `go` to `setup.py`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
