### PR TITLE
chore: Use latest Python code in Java Integration Tests

### DIFF
--- a/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
+++ b/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
@@ -33,6 +33,7 @@ import io.grpc.util.MutableHandlerRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -60,9 +61,9 @@ abstract class ServingEnvironment {
         new DockerComposeContainer(
                 new File("src/test/resources/docker-compose/docker-compose-redis-it.yml"))
             .withExposedService("redis", 6379)
-            .withExposedService("feast", 8080)
-            .waitingFor("feast", Wait.forListeningPort())
-            .withLogConsumer("feast", f -> System.out.print(((OutputFrame) f).getUtf8String()));
+            .withExposedService(
+                "feast", 8080, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(180)))
+            .withTailChildContainers(true);
     environment.start();
   }
 

--- a/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
+++ b/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.DockerComposeContainer;
-import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Testcontainers;
 

--- a/java/serving/src/test/resources/docker-compose/docker-compose-redis-it.yml
+++ b/java/serving/src/test/resources/docker-compose/docker-compose-redis-it.yml
@@ -12,4 +12,6 @@ services:
       - "8080"
     links:
       - redis
+    volumes:
+      - $PWD/../../../../../../:/mnt/feast
 

--- a/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
+++ b/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
@@ -5,11 +5,8 @@ WORKDIR /usr/src/
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-RUN git clone https://github.com/feast-dev/feast.git /root/feast
-RUN cd /root/feast/ && pip install -e '.[redis]'
-
 WORKDIR /app
 COPY . .
 EXPOSE 8080
 
-CMD ["/bin/sh", "-c", "python materialize.py && feast serve_transformations --port 8080"]
+CMD ["./entrypoint.sh"]

--- a/java/serving/src/test/resources/docker-compose/feast10/entrypoint.sh
+++ b/java/serving/src/test/resources/docker-compose/feast10/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+set -e
+
+# feast root directory is expected to be mounted (eg, by docker compose)
+cd /mnt/feast
+pip install -e '.[redis]'
+
+cd /app
+python materialize.py
+feast serve_transformations --port 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Mount root repo directory in docker compose to install latest Python code. This will allow Python and Java code to be in sync during integration tests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
