### PR TITLE
fix: Infer features for feature services when they depend on feature views without schemas

### DIFF
--- a/sdk/python/feast/feature_service.py
+++ b/sdk/python/feast/feature_service.py
@@ -39,6 +39,7 @@ class FeatureService:
     """
 
     name: str
+    _features: List[Union[FeatureView, OnDemandFeatureView]]
     feature_view_projections: List[FeatureViewProjection]
     description: str
     tags: Dict[str, str]
@@ -93,23 +94,33 @@ class FeatureService:
             _features = []
 
         self.name = _name
+        self._features = _features
         self.feature_view_projections = []
-
-        for feature_grouping in _features:
-            if isinstance(feature_grouping, BaseFeatureView):
-                self.feature_view_projections.append(feature_grouping.projection)
-            else:
-                raise ValueError(
-                    f"The feature service {name} has been provided with an invalid type "
-                    f'{type(feature_grouping)} as part of the "features" argument.)'
-                )
-
         self.description = description
         self.tags = tags or {}
         self.owner = owner
         self.created_timestamp = None
         self.last_updated_timestamp = None
         self.logging_config = logging_config
+        self.infer_features()
+
+    def infer_features(self, fvs_to_update: Optional[List[FeatureView]] = None):
+        self.feature_view_projections = []
+        for feature_grouping in self._features:
+            if isinstance(feature_grouping, BaseFeatureView):
+                # For feature services that depend on an unspecified feature view, apply inferred schema
+                if len(feature_grouping.projection.features) == 0:
+                    if fvs_to_update is not None:
+                        for fv in fvs_to_update:
+                            if fv.name == feature_grouping.name:
+                                feature_grouping.projection.features = fv.features
+                                break
+                self.feature_view_projections.append(feature_grouping.projection)
+            else:
+                raise ValueError(
+                    f"The feature service {self.name} has been provided with an invalid type "
+                    f'{type(feature_grouping)} as part of the "features" argument.)'
+                )
 
     def __repr__(self):
         items = (f"{k} = {v}" for k, v in self.__dict__.items())
@@ -119,7 +130,7 @@ class FeatureService:
         return str(MessageToJson(self.to_proto()))
 
     def __hash__(self):
-        return hash((self.name))
+        return hash(self.name)
 
     def __eq__(self, other):
         if not isinstance(other, FeatureService):

--- a/sdk/python/feast/feature_service.py
+++ b/sdk/python/feast/feature_service.py
@@ -109,12 +109,14 @@ class FeatureService:
         for feature_grouping in self._features:
             if isinstance(feature_grouping, BaseFeatureView):
                 # For feature services that depend on an unspecified feature view, apply inferred schema
-                if len(feature_grouping.projection.features) == 0:
-                    if fvs_to_update is not None:
-                        if feature_grouping.name in fvs_to_update:
-                            feature_grouping.projection.features = fvs_to_update[
-                                feature_grouping.name
-                            ].features
+                if (
+                    fvs_to_update is not None
+                    and len(feature_grouping.projection.features) == 0
+                    and feature_grouping.name in fvs_to_update
+                ):
+                    feature_grouping.projection.features = fvs_to_update[
+                        feature_grouping.name
+                    ].features
                 self.feature_view_projections.append(feature_grouping.projection)
             else:
                 raise ValueError(

--- a/sdk/python/feast/feature_service.py
+++ b/sdk/python/feast/feature_service.py
@@ -104,17 +104,17 @@ class FeatureService:
         self.logging_config = logging_config
         self.infer_features()
 
-    def infer_features(self, fvs_to_update: Optional[List[FeatureView]] = None):
+    def infer_features(self, fvs_to_update: Optional[Dict[str, FeatureView]] = None):
         self.feature_view_projections = []
         for feature_grouping in self._features:
             if isinstance(feature_grouping, BaseFeatureView):
                 # For feature services that depend on an unspecified feature view, apply inferred schema
                 if len(feature_grouping.projection.features) == 0:
                     if fvs_to_update is not None:
-                        for fv in fvs_to_update:
-                            if fv.name == feature_grouping.name:
-                                feature_grouping.projection.features = fv.features
-                                break
+                        if feature_grouping.name in fvs_to_update:
+                            feature_grouping.projection.features = fvs_to_update[
+                                feature_grouping.name
+                            ].features
                 self.feature_view_projections.append(feature_grouping.projection)
             else:
                 raise ValueError(

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -499,8 +499,9 @@ class FeatureStore:
         for odfv in odfvs_to_update:
             odfv.infer_features()
 
+        fvs_to_update_map = {view.name: view for view in views_to_update}
         for feature_service in feature_services_to_update:
-            feature_service.infer_features(fvs_to_update=views_to_update)
+            feature_service.infer_features(fvs_to_update=fvs_to_update_map)
 
     @log_exceptions_and_usage
     def _plan(

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -475,8 +475,9 @@ class FeatureStore:
         entities_to_update: List[Entity],
         views_to_update: List[FeatureView],
         odfvs_to_update: List[OnDemandFeatureView],
+        feature_services_to_update: List[FeatureService],
     ):
-        """Makes inferences for entities, feature views, and odfvs."""
+        """Makes inferences for entities, feature views, odfvs, and feature services."""
         update_entities_with_inferred_types_from_feature_views(
             entities_to_update, views_to_update, self.config
         )
@@ -497,6 +498,9 @@ class FeatureStore:
 
         for odfv in odfvs_to_update:
             odfv.infer_features()
+
+        for feature_service in feature_services_to_update:
+            feature_service.infer_features(fvs_to_update=views_to_update)
 
     @log_exceptions_and_usage
     def _plan(
@@ -553,6 +557,7 @@ class FeatureStore:
             desired_repo_contents.entities,
             desired_repo_contents.feature_views,
             desired_repo_contents.on_demand_feature_views,
+            desired_repo_contents.feature_services,
         )
 
         # Compute the desired difference between the current objects in the registry and
@@ -692,7 +697,11 @@ class FeatureStore:
             views_to_update, odfvs_to_update, request_views_to_update
         )
         self._make_inferences(
-            data_sources_to_update, entities_to_update, views_to_update, odfvs_to_update
+            data_sources_to_update,
+            entities_to_update,
+            views_to_update,
+            odfvs_to_update,
+            services_to_update,
         )
 
         # Handle all entityless feature views by using DUMMY_ENTITY as a placeholder entity.

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -7,6 +7,7 @@ from feast import (
     BigQuerySource,
     Entity,
     Feature,
+    FeatureService,
     FileSource,
     RedshiftSource,
     RepoConfig,
@@ -332,3 +333,23 @@ def test_update_feature_views_with_inferred_features():
     )
     assert len(feature_view_2.schema) == 1
     assert len(feature_view_2.features) == 1
+
+
+def test_update_feature_services_with_inferred_features(simple_dataset_1):
+    with prep_file_source(df=simple_dataset_1, timestamp_field="ts_1") as file_source:
+        entity1 = Entity(name="test1", join_keys=["id_join_key"])
+        feature_view_1 = FeatureView(
+            name="test1", entities=[entity1], source=file_source,
+        )
+        feature_service = FeatureService(name="fs_1", features=[feature_view_1])
+        assert len(feature_service.feature_view_projections) == 1
+        assert len(feature_service.feature_view_projections[0].features) == 0
+
+        update_feature_views_with_inferred_features(
+            [feature_view_1], [entity1], RepoConfig(provider="local", project="test")
+        )
+        feature_service.infer_features(fvs_to_update=[feature_view_1])
+
+        assert len(feature_view_1.schema) == 3
+        assert len(feature_view_1.features) == 3
+        assert len(feature_service.feature_view_projections[0].features) == 3

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -348,7 +348,9 @@ def test_update_feature_services_with_inferred_features(simple_dataset_1):
         update_feature_views_with_inferred_features(
             [feature_view_1], [entity1], RepoConfig(provider="local", project="test")
         )
-        feature_service.infer_features(fvs_to_update=[feature_view_1])
+        feature_service.infer_features(
+            fvs_to_update={feature_view_1.name: feature_view_1}
+        )
 
         assert len(feature_view_1.schema) == 3
         assert len(feature_view_1.features) == 3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
If a feature service depends on a feature view that doesn't have a schema (i.e. relying on feature inference), the feature service does not inherit the inferred schema.

This results in a particularly weird error for FileSources suggesting that pandas dataframes do not have a "persist()" method (like Dask dataframes do)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
