### PR TITLE
fix: Feature logging to Redshift is broken

### DIFF
--- a/sdk/python/feast/feature_logging.py
+++ b/sdk/python/feast/feature_logging.py
@@ -52,17 +52,6 @@ class FeatureServiceLoggingSource(LoggingSource):
         fields: Dict[str, pa.DataType] = {}
 
         for projection in self._feature_service.feature_view_projections:
-            for feature in projection.features:
-                fields[
-                    f"{projection.name_to_use()}__{feature.name}"
-                ] = FEAST_TYPE_TO_ARROW_TYPE[feature.dtype]
-                fields[
-                    f"{projection.name_to_use()}__{feature.name}__timestamp"
-                ] = PA_TIMESTAMP_TYPE
-                fields[
-                    f"{projection.name_to_use()}__{feature.name}__status"
-                ] = pa.int32()
-
             try:
                 feature_view = registry.get_feature_view(projection.name, self._project)
             except FeatureViewNotFoundException:
@@ -91,9 +80,21 @@ class FeatureServiceLoggingSource(LoggingSource):
                         from_value_type(entity.value_type)
                     ]
 
+            for feature in projection.features:
+                fields[
+                    f"{projection.name_to_use()}__{feature.name}"
+                ] = FEAST_TYPE_TO_ARROW_TYPE[feature.dtype]
+                fields[
+                    f"{projection.name_to_use()}__{feature.name}__timestamp"
+                ] = PA_TIMESTAMP_TYPE
+                fields[
+                    f"{projection.name_to_use()}__{feature.name}__status"
+                ] = pa.int32()
+
         # system columns
-        fields[REQUEST_ID_FIELD] = pa.string()
         fields[LOG_TIMESTAMP_FIELD] = pa.timestamp("us", tz=UTC)
+        fields[LOG_DATE_FIELD] = pa.date32()
+        fields[REQUEST_ID_FIELD] = pa.string()
 
         return pa.schema(
             [pa.field(name, data_type) for name, data_type in fields.items()]

--- a/sdk/python/feast/feature_logging.py
+++ b/sdk/python/feast/feature_logging.py
@@ -52,6 +52,11 @@ class FeatureServiceLoggingSource(LoggingSource):
         fields: Dict[str, pa.DataType] = {}
 
         for projection in self._feature_service.feature_view_projections:
+            # The order of fields in the generated schema should match
+            # the order created on the other side (inside Go logger).
+            # Otherwise, some offline stores might not accept parquet files (produced by Go).
+            # Go code can be found here:
+            # https://github.com/feast-dev/feast/blob/master/go/internal/feast/server/logging/memorybuffer.go#L51
             try:
                 feature_view = registry.get_feature_view(projection.name, self._project)
             except FeatureViewNotFoundException:


### PR DESCRIPTION
Signed-off-by: Oleksii Moskalenko <moskalenko.alexey@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Redshift requires the order of fields in parquet file (produced in Go) to exactly match schema (generated from feature service in Python). Even in field ordering. This PR fixes field ordering in schema generated in Python.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
