### PR TITLE
ci: Do not retrigger integration tests on lgtm

### DIFF
--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -54,7 +54,7 @@ jobs:
   integration-test:
     # all jobs MUST have this if check for 'ok-to-test' or 'approved' for security purposes.
     if:
-      (github.event.action == 'labeled' && (github.event.label.name == 'lgtm' || github.event.label.name == 'approved' || github.event.label.name == 'ok-to-test')) ||
+      (github.event.action == 'labeled' && (github.event.label.name == 'approved' || github.event.label.name == 'ok-to-test')) ||
       (github.event.action != 'labeled' && (contains(github.event.pull_request.labels.*.name, 'ok-to-test') || contains(github.event.pull_request.labels.*.name, 'approved')))
     runs-on: ubuntu-latest
     needs: unit-test-java

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -14,9 +14,9 @@ on:
 
 jobs:
   build-docker-image:
-    # all jobs MUST have this if check for 'ok-to-test' or 'approved' or 'lgtm' for security purposes.
+    # all jobs MUST have this if check for 'ok-to-test' or 'approved' for security purposes.
     if:
-      (github.event.action == 'labeled' && (github.event.label.name == 'lgtm' || github.event.label.name == 'approved' || github.event.label.name == 'ok-to-test')) ||
+      (github.event.action == 'labeled' && (github.event.label.name == 'approved' || github.event.label.name == 'ok-to-test')) ||
       (github.event.action != 'labeled' && (contains(github.event.pull_request.labels.*.name, 'ok-to-test') || contains(github.event.pull_request.labels.*.name, 'approved')))
     runs-on: ubuntu-latest
     steps:
@@ -72,9 +72,9 @@ jobs:
     outputs:
       DOCKER_IMAGE_TAG: ${{ steps.image-tag.outputs.DOCKER_IMAGE_TAG }}
   integration-test-python:
-    # all jobs MUST have this if check for 'ok-to-test' or 'approved' or 'lgtm' for security purposes.
+    # all jobs MUST have this if check for 'ok-to-test' or 'approved' for security purposes.
     if:
-      (github.event.action == 'labeled' && (github.event.label.name == 'lgtm' || github.event.label.name == 'approved' || github.event.label.name == 'ok-to-test')) ||
+      (github.event.action == 'labeled' && (github.event.label.name == 'approved' || github.event.label.name == 'ok-to-test')) ||
       (github.event.action != 'labeled' && (contains(github.event.pull_request.labels.*.name, 'ok-to-test') || contains(github.event.pull_request.labels.*.name, 'approved')))
     needs: build-docker-image
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: Currently we trigger integration tests on `lgtm`, which is unnecessary since `lgtm` is already a requirement for merging. This PR stops triggering integration tests on `lgtm`, so we avoid the scenario where a PR has already passed all integration tests, only for the tests to be retriggered once someone stamps it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
