### PR TITLE
fix: Reject undefined features when using `get_historical_features` or `get_online_features`

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -875,7 +875,7 @@ class FeatureStore:
                 DeprecationWarning,
             )
 
-        # TODO(achal): _group_feature_refs returns the on demand feature views, but it's no passed into the provider.
+        # TODO(achal): _group_feature_refs returns the on demand feature views, but it's not passed into the provider.
         # This is a weird interface quirk - we should revisit the `get_historical_features` to
         # pass in the on demand feature views as well.
         fvs, odfvs, request_fvs, request_fv_refs = _group_feature_refs(
@@ -2125,8 +2125,12 @@ def _group_feature_refs(
     for ref in features:
         view_name, feat_name = ref.split(":")
         if view_name in view_index:
+            view_index[view_name].projection.get_feature(feat_name)  # For validation
             views_features[view_name].add(feat_name)
         elif view_name in on_demand_view_index:
+            on_demand_view_index[view_name].projection.get_feature(
+                feat_name
+            )  # For validation
             on_demand_view_features[view_name].add(feat_name)
             # Let's also add in any FV Feature dependencies here.
             for input_fv_projection in on_demand_view_index[
@@ -2135,6 +2139,9 @@ def _group_feature_refs(
                 for input_feat in input_fv_projection.features:
                     views_features[input_fv_projection.name].add(input_feat.name)
         elif view_name in request_view_index:
+            request_view_index[view_name].projection.get_feature(
+                feat_name
+            )  # For validation
             request_views_features[view_name].add(feat_name)
             request_view_refs.add(ref)
         else:

--- a/sdk/python/feast/feature_view_projection.py
+++ b/sdk/python/feast/feature_view_projection.py
@@ -64,3 +64,11 @@ class FeatureViewProjection:
             name_alias=None,
             features=base_feature_view.features,
         )
+
+    def get_feature(self, feature_name: str) -> Field:
+        try:
+            return next(field for field in self.features if field.name == feature_name)
+        except StopIteration:
+            raise KeyError(
+                f"Feature {feature_name} not found in projection {self.name_to_use()}"
+            )


### PR DESCRIPTION
Signed-off-by: Abhin Chhabra <abhin.chhabra@shopify.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Increase the scope of validations provided by `_group_feature_refs` to also check if the features are part of the feature view. It also adds a `get_feature` method to the `FeatureViewProjection` class that could be useful in other cases too. 

In the event of an invalid feature being requested, a `KeyError` is raised, which is consistent with the existing behaviour when completely non-existent features are requested in `get_historical_features`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2576
