### PR TITLE
fix: Remove incorrect call to logging.basicConfig

### DIFF
--- a/sdk/python/feast/__init__.py
+++ b/sdk/python/feast/__init__.py
@@ -1,5 +1,3 @@
-import logging
-
 from pkg_resources import DistributionNotFound, get_distribution
 
 from feast.infra.offline_stores.bigquery_source import BigQuerySource
@@ -26,12 +24,6 @@ from .repo_config import RepoConfig
 from .request_feature_view import RequestFeatureView
 from .stream_feature_view import StreamFeatureView
 from .value_type import ValueType
-
-logging.basicConfig(
-    format="%(asctime)s %(levelname)s:%(message)s",
-    datefmt="%m/%d/%Y %I:%M:%S %p",
-    level=logging.INFO,
-)
 
 try:
     __version__ = get_distribution(__name__).version


### PR DESCRIPTION
This configures logging for all applications may just be interested in importing the feast package, which is incorrect. We should only configure logging at the application level, so things like the CLI, or or webservers.

Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2664 
