### PR TITLE
fix: Forcing ODFV udfs to be __main__ module and fixing false positive duplicate data source warning

### DIFF
--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -628,7 +628,14 @@ def on_demand_feature_view(
     if not _sources:
         raise ValueError("The `sources` parameter must be specified.")
 
+    def mainify(obj):
+        # Needed to allow dill to properly serialize the udf. Otherwise, clients will need to have a file with the same
+        # name as the original file defining the ODFV.
+        if obj.__module__ != "__main__":
+            obj.__module__ = "__main__"
+
     def decorator(user_function):
+        mainify(user_function)
         on_demand_feature_view_obj = OnDemandFeatureView(
             name=user_function.__name__,
             sources=_sources,

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -110,6 +110,7 @@ def parse_repo(repo_root: Path) -> RepoContents:
         request_feature_views=[],
     )
 
+    data_sources_set = set()
     for repo_file in get_repo_files(repo_root):
         module_path = py_path_to_module(repo_file)
         module = importlib.import_module(module_path)
@@ -118,7 +119,7 @@ def parse_repo(repo_root: Path) -> RepoContents:
             if isinstance(obj, DataSource) and not any(
                 (obj is ds) for ds in res.data_sources
             ):
-                res.data_sources.append(obj)
+                data_sources_set.add(obj)
             if isinstance(obj, FeatureView) and not any(
                 (obj is fv) for fv in res.feature_views
             ):
@@ -126,7 +127,7 @@ def parse_repo(repo_root: Path) -> RepoContents:
                 if isinstance(obj.stream_source, PushSource) and not any(
                     (obj is ds) for ds in res.data_sources
                 ):
-                    res.data_sources.append(obj.stream_source.batch_source)
+                    data_sources_set.add(obj.stream_source.batch_source)
             elif isinstance(obj, Entity) and not any(
                 (obj is entity) for entity in res.entities
             ):
@@ -144,6 +145,7 @@ def parse_repo(repo_root: Path) -> RepoContents:
             ):
                 res.request_feature_views.append(obj)
     res.entities.append(DUMMY_ENTITY)
+    res.data_sources.extend(data_sources_set)
     return res
 
 

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -129,7 +129,7 @@ def parse_repo(repo_root: Path) -> RepoContents:
                     (obj is ds) for ds in res.data_sources
                 ):
                     push_source_dep = obj.stream_source.batch_source
-                    # Don't add if the push source is a duplicate of an existing batch source
+                    # Don't add if the push source's batch source is a duplicate of an existing batch source
                     if push_source_dep not in data_sources_set:
                         res.data_sources.append(push_source_dep)
             elif isinstance(obj, Entity) and not any(

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -119,6 +119,7 @@ def parse_repo(repo_root: Path) -> RepoContents:
             if isinstance(obj, DataSource) and not any(
                 (obj is ds) for ds in res.data_sources
             ):
+                res.data_sources.append(obj)
                 data_sources_set.add(obj)
             if isinstance(obj, FeatureView) and not any(
                 (obj is fv) for fv in res.feature_views
@@ -127,7 +128,10 @@ def parse_repo(repo_root: Path) -> RepoContents:
                 if isinstance(obj.stream_source, PushSource) and not any(
                     (obj is ds) for ds in res.data_sources
                 ):
-                    data_sources_set.add(obj.stream_source.batch_source)
+                    push_source_dep = obj.stream_source.batch_source
+                    # Don't add if the push source is a duplicate of an existing batch source
+                    if push_source_dep not in data_sources_set:
+                        res.data_sources.append(push_source_dep)
             elif isinstance(obj, Entity) and not any(
                 (obj is entity) for entity in res.entities
             ):
@@ -145,7 +149,6 @@ def parse_repo(repo_root: Path) -> RepoContents:
             ):
                 res.request_feature_views.append(obj)
     res.entities.append(DUMMY_ENTITY)
-    res.data_sources.extend(data_sources_set)
     return res
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
- dill only can properly serialize a function if the module is __main__.
    - Otherwise, when you deserialize, it looks for the presence of the exact module the ODFV was defined in (e.g. so if you don’t have the feature repo handy, using odfvs will fail)
    - Forcing the udf to be __main__ resolves this issue. This should otherwise be fine since we expect the udf to be able to execute in arbitrary environments.
- Fixing duplicate data source conflict between push source and batch source which occurs if you depend on both a push source and a batch source. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
