### PR TITLE
fix: Pin pip<22.1 to get around breaking change in pip==22.1

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: 1.17.7
       - name: Upgrade pip version
         run: |
-          pip install --upgrade "pip>=21.3.1"
+          pip install --upgrade "pip>=21.3.1,<22.1"
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -62,7 +62,7 @@ jobs:
           python-version: "3.7"
       - name: Upgrade pip version
         run: |
-          pip install --upgrade "pip>=21.3.1"
+          pip install --upgrade "pip>=21.3.1,<22.1"
       - name: Install dependencies
         run:  make install-go-proto-dependencies
       - name: Lint go

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -107,7 +107,7 @@ jobs:
         run: aws sts get-caller-identity
       - name: Upgrade pip version
         run: |
-          pip install --upgrade "pip>=21.3.1"
+          pip install --upgrade "pip>=21.3.1,<22.1"
       - name: Get pip cache dir
         id: pip-cache
         run: |

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -133,7 +133,7 @@ jobs:
         run: aws sts get-caller-identity
       - name: Upgrade pip version
         run: |
-          pip install --upgrade "pip>=21.3.1"
+          pip install --upgrade "pip>=21.3.1,<22.1"
       - name: Get pip cache dir
         id: pip-cache
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.17.7
       - name: Upgrade pip version
         run: |
-          pip install --upgrade "pip>=21.3.1"
+          pip install --upgrade "pip>=21.3.1,<22.1"
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -75,7 +75,7 @@ jobs:
           python-version: "3.7"
       - name: Upgrade pip version
         run: |
-          pip install --upgrade "pip>=21.3.1"
+          pip install --upgrade "pip>=21.3.1,<22.1"
       - name: Setup Go
         id: setup-go
         uses: actions/setup-go@v2

--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ feast apply
 ### 4. Explore your data in the web UI (experimental)
 
 ![Web UI](ui/sample.png)
-```commandline
-feast ui
-```
 
 ### 5. Build a training dataset
 ```python


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>


We're running into [jazzband/pip-tools/issues/1617](https://github.com/jazzband/pip-tools/issues/1617). [Example failure](https://github.com/feast-dev/feast/runs/6409958901?check_suite_focus=true).
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
