### PR TITLE
fix: Fix issue when user specifies a port for feast ui 

### DIFF
--- a/sdk/python/feast/ui/README.md
+++ b/sdk/python/feast/ui/README.md
@@ -1,6 +1,6 @@
 # Example Feast UI App
 
-This is an example React App that imports the Feast UI module and relies on a "/projects-list" endpoint to get projects.
+This is an example React App that imports the Feast UI module. 
 
 See the module import in `src/index.js`. The main change this implements on top of a vanilla create-react-app is adding:
 
@@ -11,23 +11,15 @@ import "@feast-dev/feast-ui/dist/feast-ui.css";
 
 ReactDOM.render(
   <React.StrictMode>
-    <FeastUI
-      feastUIConfigs={{
-        projectListPromise: fetch("http://0.0.0.0:8888/projects-list", {
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }).then((res) => {
-          return res.json();
-        })
-      }}
-    />
+    <FeastUI />
   </React.StrictMode>,
   document.getElementById("root")
 );
 ```
 
-It is used by the `feast ui` command to scaffold a local UI server. The feast python package bundles in resources produced from `npm run build --omit=dev
+It is used by the `feast ui` command to scaffold a local UI server. The feast python package bundles in resources produced from `npm run build --omit=dev.` 
+
+The `feast ui` command will generate the necessary `projects-list.json` file and initialize it for the UI to read.
 
 
 **Note**: yarn start will not work on this because of the above dependency.

--- a/sdk/python/feast/ui/public/projects-list.json
+++ b/sdk/python/feast/ui/public/projects-list.json
@@ -1,0 +1,11 @@
+{
+    "projects": [
+      {
+        "name": "Project",
+        "description": "Test project",
+        "id": "project_id",
+        "registryPath": "http://0.0.0.0:8888/registry"
+      }
+    ]
+  }
+  

--- a/sdk/python/feast/ui/src/index.tsx
+++ b/sdk/python/feast/ui/src/index.tsx
@@ -1,22 +1,12 @@
-import React from 'react';
+import React from "react";
 import ReactDOM from "react-dom";
-import './index.css';
+import "./index.css";
 import FeastUI from "@feast-dev/feast-ui";
 import "@feast-dev/feast-ui/dist/feast-ui.css";
 
 ReactDOM.render(
   <React.StrictMode>
-    <FeastUI
-      feastUIConfigs={{
-        projectListPromise: fetch("http://0.0.0.0:8888/projects-list", {
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }).then((res) => {
-          return res.json();
-        })
-      }}
-    />
+    <FeastUI />
   </React.StrictMode>,
   document.getElementById("root")
 );

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -1,8 +1,8 @@
 import json
 import threading
-from importlib import resources
 from typing import Callable, Optional
 
+import pkg_resources
 import uvicorn
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -53,9 +53,9 @@ def get_app(
 
     async_refresh()
 
-    ui_dir = resources.files(__package__).joinpath("ui/build/")
+    ui_dir = pkg_resources.resource_filename(__name__, "ui/build/")
     # Initialize with the projects-list.json file
-    with ui_dir.joinpath("projects-list.json").open(mode="w") as f:
+    with open(ui_dir + "projects-list.json", mode="w") as f:
         projects_dict = {
             "projects": [
                 {
@@ -82,10 +82,9 @@ def get_app(
 
         return Response(content, media_type="text/html")
 
-    with resources.as_file(ui_dir) as react_app_dir:
-        app.mount(
-            "/", StaticFiles(directory=react_app_dir, html=True), name="site",
-        )
+    app.mount(
+        "/", StaticFiles(directory=ui_dir, html=True), name="site",
+    )
 
     return app
 

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -1,12 +1,12 @@
 import json
 import threading
+from importlib import resources
 from typing import Callable, Optional
 
 import uvicorn
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from importlib_resources import as_file, files
 
 import feast
 
@@ -53,7 +53,7 @@ def get_app(
 
     async_refresh()
 
-    ui_dir = files(__package__).joinpath("ui/build/")
+    ui_dir = resources.files(__package__).joinpath("ui/build/")
     # Initialize with the projects-list.json file
     with ui_dir.joinpath("projects-list.json").open(mode="w") as f:
         projects_dict = {
@@ -82,7 +82,7 @@ def get_app(
 
         return Response(content, media_type="text/html")
 
-    with as_file(ui_dir) as react_app_dir:
+    with resources.as_file(ui_dir) as react_app_dir:
         app.mount(
             "/", StaticFiles(directory=react_app_dir, html=True), name="site",
         )

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -2,11 +2,11 @@ import json
 import threading
 from typing import Callable, Optional
 
-from importlib_resources import files, as_file
 import uvicorn
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from importlib_resources import as_file, files
 
 import feast
 
@@ -19,8 +19,6 @@ def get_app(
     host: str,
     port: int,
 ):
-    ui_dir = files(__package__).joinpath("ui/build/")
-
     app = FastAPI()
 
     app.add_middleware(
@@ -55,9 +53,9 @@ def get_app(
 
     async_refresh()
 
+    ui_dir = files(__package__).joinpath("ui/build/")
     # Initialize with the projects-list.json file
-    try:
-        f = ui_dir.joinpath("projects-list.json").open(mode="w")
+    with ui_dir.joinpath("projects-list.json").open(mode="w") as f:
         projects_dict = {
             "projects": [
                 {
@@ -69,12 +67,6 @@ def get_app(
             ]
         }
         f.write(json.dumps(projects_dict))
-    except Exception as e:
-        raise RuntimeError(
-            "Failed to initialize projects-list.json with registry path"
-        ) from e
-    finally:
-        f.close()
 
     @app.get("/registry")
     def read_registry():


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
Changes the JS to look for a fixed projects-list.json (aka the default), and now `feast ui` will write to that json file so we can configure the host + port appropriately.

Before, this was hard-coded so users could not actually control the host / port.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
