### PR TITLE
fix: Fix on demand feature view crash from inference when it uses df.apply

### DIFF
--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -1,8 +1,9 @@
 import copy
 import functools
 import warnings
+from datetime import datetime
 from types import MethodType
-from typing import Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 import dill
 import pandas as pd
@@ -442,6 +443,15 @@ class OnDemandFeatureView(BaseFeatureView):
         Raises:
             RegistryInferenceFailure: The set of features could not be inferred.
         """
+        rand_df_value: Dict[str, Any] = {
+            "float": 1.0,
+            "int": 1,
+            "str": "hello world",
+            "bytes": str.encode("hello world"),
+            "bool": True,
+            "datetime64[ns]": datetime.utcnow(),
+        }
+
         df = pd.DataFrame()
         for feature_view_projection in self.source_feature_view_projections.values():
             for feature in feature_view_projection.features:
@@ -449,11 +459,13 @@ class OnDemandFeatureView(BaseFeatureView):
                 df[f"{feature_view_projection.name}__{feature.name}"] = pd.Series(
                     dtype=dtype
                 )
-                df[f"{feature.name}"] = pd.Series(dtype=dtype)
+                df[f"{feature.name}"] = pd.Series(
+                    data=rand_df_value[dtype], dtype=dtype
+                )
         for request_data in self.source_request_sources.values():
             for field in request_data.schema:
                 dtype = feast_value_type_to_pandas_type(field.dtype.to_value_type())
-                df[f"{field.name}"] = pd.Series(dtype=dtype)
+                df[f"{field.name}"] = pd.Series(rand_df_value[dtype], dtype=dtype)
         output_df: pd.DataFrame = self.udf.__call__(df)
         inferred_features = []
         for f, dt in zip(output_df.columns, output_df.dtypes):

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -443,7 +443,9 @@ class OnDemandFeatureView(BaseFeatureView):
         Raises:
             RegistryInferenceFailure: The set of features could not be inferred.
         """
+        # Note: Pandas will cast string or mixed number / string values to object. Assume this is string.
         rand_df_value: Dict[str, Any] = {
+            "object": "hello world",
             "float": 1.0,
             "int": 1,
             "str": "hello world",

--- a/sdk/python/tests/example_repos/on_demand_feature_view_repo.py
+++ b/sdk/python/tests/example_repos/on_demand_feature_view_repo.py
@@ -1,0 +1,48 @@
+from datetime import timedelta
+
+import pandas as pd
+
+from feast import FeatureView, Field, FileSource
+from feast.on_demand_feature_view import on_demand_feature_view
+from feast.types import Float32, String
+
+driver_stats = FileSource(
+    name="driver_stats_source",
+    path="data/driver_stats_lat_lon.parquet",
+    timestamp_field="event_timestamp",
+    created_timestamp_column="created",
+    description="A table describing the stats of a driver based on hourly logs",
+    owner="test2@gmail.com",
+)
+
+driver_daily_features_view = FeatureView(
+    name="driver_daily_features",
+    entities=["driver"],
+    ttl=timedelta(seconds=8640000000),
+    schema=[
+        Field(name="daily_miles_driven", dtype=Float32),
+        Field(name="lat", dtype=Float32),
+        Field(name="lon", dtype=Float32),
+        Field(name="string_feature", dtype=String),
+    ],
+    online=True,
+    source=driver_stats,
+    tags={"production": "True"},
+    owner="test2@gmail.com",
+)
+
+
+@on_demand_feature_view(
+    sources=[driver_daily_features_view],
+    schema=[
+        Field(name="first_char", dtype=String),
+        Field(name="concat_string", dtype=String),
+    ],
+)
+def location_features_from_push(inputs: pd.DataFrame) -> pd.DataFrame:
+    df = pd.DataFrame()
+    df["concat_string"] = inputs.apply(
+        lambda x: x.string_feature + "hello", axis=1
+    ).astype("string")
+    df["first_char"] = inputs["string_feature"].str[:1].astype("string")
+    return df


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
Feast did schema inference on on demand transforms by passing in an empty dataframe to the UDF with the same expected columns.

This can cause a crash though if it uses dataframe.apply. Example:

```bash
File "/Users/dannychiao/.pyenv/versions/python-3.8/lib/python3.8/site-packages/pandas/core/frame.py", line 3602, in __setitem__
    self._set_item_frame_value(key, value)
  File "/Users/dannychiao/.pyenv/versions/python-3.8/lib/python3.8/site-packages/pandas/core/frame.py", line 3742, in _set_item_frame_value
    self._set_item_mgr(key, arraylike)
  File "/Users/dannychiao/.pyenv/versions/python-3.8/lib/python3.8/site-packages/pandas/core/frame.py", line 3754, in _set_item_mgr
    self._mgr.insert(len(self._info_axis), key, value)
  File "/Users/dannychiao/.pyenv/versions/python-3.8/lib/python3.8/site-packages/pandas/core/internals/managers.py", line 1162, in insert
    block = new_block(values=value, ndim=self.ndim, placement=slice(loc, loc + 1))
  File "/Users/dannychiao/.pyenv/versions/python-3.8/lib/python3.8/site-packages/pandas/core/internals/blocks.py", line 1937, in new_block
    check_ndim(values, placement, ndim)
  File "/Users/dannychiao/.pyenv/versions/python-3.8/lib/python3.8/site-packages/pandas/core/internals/blocks.py", line 1979, in check_ndim
    raise ValueError(
ValueError: Wrong number of items passed 8, placement implies 1
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
