### PR TITLE
fix: Fixing Spark min / max entity df event timestamps range return order

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -324,8 +324,8 @@ def _get_entity_df_event_timestamp_range(
         df = spark_session.sql(entity_df).select(entity_df_event_timestamp_col)
         # TODO(kzhang132): need utc conversion here.
         entity_df_event_timestamp_range = (
-            df.agg({entity_df_event_timestamp_col: "max"}).collect()[0][0],
             df.agg({entity_df_event_timestamp_col: "min"}).collect()[0][0],
+            df.agg({entity_df_event_timestamp_col: "max"}).collect()[0][0],
         )
     else:
         raise InvalidEntityType(type(entity_df))


### PR DESCRIPTION
… max entity-DF event timestamps in the Spark offline store.

Signed-off-by: Lev Pickovsky <lev.pickovsky@ironsrc.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
This PR is meant to fix the returned order of elements when calculating the timestamp range of an entity-DF in the _get_entity_df_event_timestamp_range method of the Spark offline store class in case the entity-DF is provided as a string. This method returns a tuple with 2 elements - the min and max timestamps encountered in the entity-DF. Currently, in case the entity-DF is a string, it returns the max as the first element and the min as the second, but the code that uses these values later on seems to expect the min element to be the first one (and it can also be observed that the min is the first one to be returned when the provided entity-DF is a Pandas DF). The issue was discovered following failing real-life tests of the Spark offline store which this fix seems to have resolved.