### PR TITLE
chore: Fix gitpod init commands to preserve pip modules

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full:latest
+
+ENV PYTHONUSERBASE=/workspace/.pip-modules
+ENV PATH=$PYTHONUSERBASE/bin:$PATH
+ENV PIP_USER=yes

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,11 +1,20 @@
 #  https://www.gitpod.io/docs/config-gitpod-file
+image:
+  file: .gitpod.Dockerfile
 tasks:
   - init: |
       pip install pre-commit
       pre-commit install --hook-type pre-commit --hook-type pre-push
-      pip install -e '.[dev]'
+      pip install '.[dev]'
       make compile-protos-go
       make compile-go-lib
+    command: |
+      git config --global alias.ci 'commit -s'
+      git config --global alias.sw switch
+      git config --global alias.st status
+      git config --global alias.co checkout
+      git config --global alias.br branch
+      git config --global alias.df diff
 github:
   prebuilds:
     # enable for the default branch (defaults to true)


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

gitpod prebuilds lose information about `pip install`'d modules when prebuild is turned on. This change is inspired by [gitpod-io/gitpod/issues/7078#issuecomment-997139674](https://github.com/gitpod-io/gitpod/issues/7078#issuecomment-997139674) to preserve the module information.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
