### PR TITLE
chore: Respect environment variables when calling check_call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -249,6 +249,7 @@ class BuildPythonProtosCommand(Command):
                 self.python_folder,
             ]
             + proto_files,
+            env=os.environ
         )
 
     def run(self):
@@ -334,6 +335,8 @@ class BuildGoProtosCommand(Command):
         proto_files = glob.glob(os.path.join(self.proto_folder, path))
 
         try:
+            e = os.environ.copy()
+            e["PATH"] = self.path_val
             subprocess.check_call(
                 self.go_protoc
                 + [
@@ -347,7 +350,7 @@ class BuildGoProtosCommand(Command):
                     "--go-grpc_opt=module=github.com/feast-dev/feast/go/protos",
                 ]
                 + proto_files,
-                env={"PATH": self.path_val},
+                env=e,
             )
         except CalledProcessError as e:
             print(f"Stderr: {e.stderr}")


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

If we set something like PYTHONUSERBASE for gitpod builds, then the site-packages for python are located in a non-standard location and modules cannot be located. This fixes that by inheriting the python process' environment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
