### PR TITLE
fix: Cannot connect to a remote s3 parquet file source

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -180,8 +180,8 @@ class FileSource(DataSource):
             self.path, self.file_options.s3_endpoint_override
         )
         schema = ParquetDataset(
-            path if filesystem is None else filesystem.open_input_file(path)
-        ).schema.to_arrow_schema()
+            path, filesystem=None if filesystem is None else filesystem
+        ).schema
         return zip(schema.names, map(str, schema.types))
 
     @staticmethod


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

This PR fixes an issue with feast when working with remote s3 parquet files.  When defining an entry such as the following snippet
```
game_batch = FileSource(
    path=f"s3://datalake/data/game.parquet",
    # file_format="parquet",
    s3_endpoint_override="https://minio.ops.io/",
    timestamp_field="update_datetime",
    created_timestamp_column="created_datetime"
)
```
a TypeError: not a path-like object error is thrown by pyarrow on feast apply.
![image](https://user-images.githubusercontent.com/29164652/171352233-3969fe73-9603-4def-a6bc-82d01d728059.png)

Fixes https://github.com/feast-dev/feast/issues/2641, #2781 


