### PR TITLE
chore: Fix minor documentation typo

### DIFF
--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -159,7 +159,7 @@ class DataSource(ABC):
 
     Args:
         name: Name of data source, which should be unique within a project
-        timestamp_field (optional): (Deprecated) Event timestamp column used for point in time
+        event_timestamp_column (optional): (Deprecated) Event timestamp column used for point in time
             joins of feature values.
         created_timestamp_column (optional): Timestamp column indicating when the row
             was created, used for deduplicating rows.


### PR DESCRIPTION
**What this PR does / why we need it**:

The [python API docs for `data_source`](https://rtd.feast.dev/en/master/#module-feast.data_source) have a confusing typo.

![01-13-9487k-k4ab1](https://user-images.githubusercontent.com/773452/171483942-10b535f6-dca2-4a8a-b572-a9ec216a597d.png)

Based on the docs, it's unclear what the recommended path forward is. It looks like the recommendation is to use `timestamp_field`.

![image](https://user-images.githubusercontent.com/773452/171484191-535013df-e0da-484a-ad44-75ede3fdea48.png)

Signed-off-by: Abhin Chhabra <abhin.chhabra@shopify.com>

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
