### PR TITLE
Made URL to registry relative, fixes #2731

### DIFF
--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -62,7 +62,7 @@ def get_app(
                     "name": "Project",
                     "description": "Test project",
                     "id": project_id,
-                    "registryPath": f"http://{host}:{port}/registry",
+                    "registryPath": "/registry",
                 }
             ]
         }


### PR DESCRIPTION
Instead of having the URL to the registry be absolute (default to 0.0.0.0:8888), use a relative path. This means there's no SSL issues when putting the UI behind a SSL proxy, nor will it try to load it from localhost. This change allows the UI to be deployed to a central location.

Fixes #2731
