### PR TITLE
feat: Added Spark support for Delta and Avro

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -25,6 +25,8 @@ class SparkSourceFormat(Enum):
     csv = "csv"
     json = "json"
     parquet = "parquet"
+    delta = "delta"
+    avro = "avro"
 
 
 class SparkSource(DataSource):


### PR DESCRIPTION
When using spark as your offline store, it's useful to be able to read from Delta tables, so that you get a consistent view of the data, even when writing and reading at the same time (eg when using Spark Streaming to stream updates to the table, and materialising every 10 minutes).

Since we're calling `spark_session.read.format(<FORMAT>)`, which is the preferred way of reading delta and Avro, this should work without further changes.

I've added Avro support because some (cloud) products support writing the contents of a topic to Avro automatically - being able to materialise from this persisted stream could be useful if you don't feel like building it yourself.