### PR TITLE
Change online UI schema field to be optional

### DIFF
--- a/ui/src/parsers/feastFeatureViews.ts
+++ b/ui/src/parsers/feastFeatureViews.ts
@@ -39,7 +39,7 @@ const FeastFeatureViewSchema = z.object({
     features: z.array(FeastFeatureColumnSchema),
     ttl: z.string().transform((val) => parseInt(val)),
     batchSource: FeastBatchSourceSchema,
-    online: z.boolean(),
+    online: z.boolean().optional(),
     owner: z.string().optional(),
     tags: z.record(z.string()).optional(),
   }),


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
Change the `online` field in feastFeatureViews schema to be optional.
This addresses a problem with the UI erroring out when trying to present
offline FeatureViews since protobuf would not pass along the `online`
tag.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2719
