### PR TITLE
fix: Fixing custom S3 endpoint read fail #2781

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -179,9 +179,15 @@ class FileSource(DataSource):
         filesystem, path = FileSource.create_filesystem_and_path(
             self.path, self.file_options.s3_endpoint_override
         )
-        schema = ParquetDataset(
-            path if filesystem is None else filesystem.open_input_file(path)
-        ).schema.to_arrow_schema()
+        # Adding support for different file format path
+        # based on S3 filesystem
+        if filesystem is None:
+            schema = ParquetDataset(path).schema.to_arrow_schema()
+        else:
+            schema = ParquetDataset(
+                filesystem.open_input_file(path), filesystem=filesystem
+            ).schema
+
         return zip(schema.names, map(str, schema.types))
 
     @staticmethod


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
This PR fixes the issues when working with remote S3 parquet files. This PR will enable you to add custom endpoints for reading S3 files stored at a remote location.

**Which issue(s) this PR fixes**:
![image](https://user-images.githubusercontent.com/16669345/173225356-aa155b1b-d90a-4f58-be90-8570deee9aa4.png)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2781 
