### PR TITLE
chore: Rename stream data source parameters

### DIFF
--- a/java/serving/src/test/java/feast/serving/util/DataGenerator.java
+++ b/java/serving/src/test/java/feast/serving/util/DataGenerator.java
@@ -226,7 +226,7 @@ public class DataGenerator {
         .setKafkaOptions(
             KafkaOptions.newBuilder()
                 .setTopic(topic)
-                .setBootstrapServers(servers)
+                .setKafkaBootstrapServers(servers)
                 .setMessageFormat(createProtoFormat("class.path"))
                 .build())
         .setTimestampField(timestampColumn)

--- a/protos/feast/core/DataSource.proto
+++ b/protos/feast/core/DataSource.proto
@@ -136,7 +136,8 @@ message DataSource {
     // Defines the stream data format encoding feature/entity data in Kafka messages.
     StreamFormat message_format = 3;
 
-    google.protobuf.Duration watermark = 4;
+    // Watermark delay threshold for stream data
+    google.protobuf.Duration watermark_delay_threshold = 4;
   }
 
   // Defines options for DataSource that sources features from Kinesis records.

--- a/protos/feast/core/DataSource.proto
+++ b/protos/feast/core/DataSource.proto
@@ -128,7 +128,7 @@ message DataSource {
   // Java Protobuf class at the given class path
   message KafkaOptions {
     // Comma separated list of Kafka bootstrap servers. Used for feature tables without a defined source host[:port]]
-    string bootstrap_servers = 1;
+    string kafka_bootstrap_servers = 1;
 
     // Kafka topic to collect feature data from.
     string topic = 2;

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -178,8 +178,8 @@ class DataSource(ABC):
 
     Args:
         name: Name of data source, which should be unique within a project
-        event_timestamp_column (optional): (Deprecated) Event timestamp column used for point in time
-            joins of feature values.
+        event_timestamp_column (optional): (Deprecated in favor of timestamp_field) Event
+            timestamp column used for point in time joins of feature values.
         created_timestamp_column (optional): Timestamp column indicating when the row
             was created, used for deduplicating rows.
         field_mapping (optional): A dictionary mapping of column names in this data

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -260,6 +260,14 @@ class DataSource(ABC):
         self.date_partition_column = (
             date_partition_column if date_partition_column else ""
         )
+        if date_partition_column:
+            warnings.warn(
+                (
+                    "The argument 'date_partition_column' is being deprecated. "
+                    "Feast 0.25 and onwards will not support 'date_timestamp_column' for data sources."
+                ),
+                DeprecationWarning,
+            )
         self.description = description or ""
         self.tags = tags or {}
         self.owner = owner or ""

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -220,8 +220,8 @@ class DataSource(ABC):
         Creates a DataSource object.
         Args:
             name: Name of data source, which should be unique within a project
-            event_timestamp_column (optional): (Deprecated) Event timestamp column used for point in time
-                joins of feature values.
+            event_timestamp_column (optional): (Deprecated in favor of timestamp_field) Event
+                timestamp column used for point in time joins of feature values.
             created_timestamp_column (optional): Timestamp column indicating when the row
                 was created, used for deduplicating rows.
             field_mapping (optional): A dictionary mapping of column names in this data
@@ -396,8 +396,8 @@ class KafkaSource(DataSource):
 
         Args:
             name: Name of data source, which should be unique within a project
-            event_timestamp_column: (Deprecated) Event timestamp column used for point in time
-                joins of feature values.
+            event_timestamp_column (optional): (Deprecated in favor of timestamp_field) Event
+                timestamp column used for point in time joins of feature values.
             bootstrap_servers: (Deprecated) The servers of the kafka broker in the form "localhost:9092".
             kafka_bootstrap_servers: The servers of the kafka broker in the form "localhost:9092".
             message_format: StreamFormat of serialized messages.

--- a/sdk/python/feast/infra/contrib/spark_kafka_processor.py
+++ b/sdk/python/feast/infra/contrib/spark_kafka_processor.py
@@ -77,7 +77,7 @@ class SparkKafkaProcessor(StreamProcessor):
                 self.spark.readStream.format("kafka")
                 .option(
                     "kafka.bootstrap.servers",
-                    self.data_source.kafka_options.bootstrap_servers,
+                    self.data_source.kafka_options.kafka_bootstrap_servers,
                 )
                 .option("subscribe", self.data_source.kafka_options.topic)
                 .option("startingOffsets", "latest")  # Query start
@@ -100,7 +100,7 @@ class SparkKafkaProcessor(StreamProcessor):
                 self.spark.readStream.format("kafka")
                 .option(
                     "kafka.bootstrap.servers",
-                    self.data_source.kafka_options.bootstrap_servers,
+                    self.data_source.kafka_options.kafka_bootstrap_servers,
                 )
                 .option("subscribe", self.data_source.kafka_options.topic)
                 .option("startingOffsets", "latest")  # Query start

--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -37,7 +37,8 @@ class BigQuerySource(DataSource):
 
         Args:
             table (optional): The BigQuery table where features can be found.
-            event_timestamp_column: (Deprecated) Event timestamp column used for point in time joins of feature values.
+            event_timestamp_column (optional): (Deprecated in favor of timestamp_field) Event
+                timestamp column used for point in time joins of feature values.
             created_timestamp_column (optional): Timestamp column when row was created, used for deduplicating rows.
             field_mapping: A dictionary mapping of column names in this data source to feature names in a feature table
                 or view. Only used for feature columns, not entities or timestamp columns.

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -44,7 +44,8 @@ class FileSource(DataSource):
 
             path: File path to file containing feature data. Must contain an event_timestamp column, entity columns and
                 feature columns.
-            event_timestamp_column(optional): (Deprecated) Event timestamp column used for point in time joins of feature values.
+            event_timestamp_column (optional): (Deprecated in favor of timestamp_field) Event
+                timestamp column used for point in time joins of feature values.
             created_timestamp_column (optional): Timestamp column when row was created, used for deduplicating rows.
             file_format (optional): Explicitly set the file format. Allows Feast to bypass inferring the file format.
             field_mapping: A dictionary mapping of column names in this data source to feature names in a feature table

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -39,8 +39,8 @@ class RedshiftSource(DataSource):
         Creates a RedshiftSource object.
 
         Args:
-            event_timestamp_column (optional): (Deprecated) Event timestamp column used for point in
-                time joins of feature values.
+            event_timestamp_column (optional): (Deprecated in favor of timestamp_field) Event
+                timestamp column used for point in time joins of feature values.
             table (optional): Redshift table where the features are stored.
             schema (optional): Redshift schema in which the table is located.
             created_timestamp_column (optional): Timestamp column indicating when the

--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -43,8 +43,8 @@ class SnowflakeSource(DataSource):
             warehouse (optional): Snowflake warehouse where the database is stored.
             schema (optional): Snowflake schema in which the table is located.
             table (optional): Snowflake table where the features are stored.
-            event_timestamp_column (optional): (Deprecated) Event timestamp column used for point in
-                time joins of feature values.
+            event_timestamp_column (optional): (Deprecated in favor of timestamp_field) Event
+                timestamp column used for point in time joins of feature values.
             query (optional): The query to be executed to obtain the features.
             created_timestamp_column (optional): Timestamp column indicating when the
                 row was created, used for deduplicating rows.

--- a/sdk/python/tests/integration/registration/test_registry.py
+++ b/sdk/python/tests/integration/registration/test_registry.py
@@ -319,7 +319,7 @@ def test_apply_stream_feature_view_success(test_registry):
         message_format=AvroFormat(""),
         topic="topic",
         batch_source=FileSource(path="some path"),
-        watermark=timedelta(days=1),
+        watermark_delay_threshold=timedelta(days=1),
     )
 
     sfv = StreamFeatureView(

--- a/sdk/python/tests/integration/registration/test_registry.py
+++ b/sdk/python/tests/integration/registration/test_registry.py
@@ -315,7 +315,7 @@ def test_apply_stream_feature_view_success(test_registry):
     stream_source = KafkaSource(
         name="kafka",
         timestamp_field="event_timestamp",
-        bootstrap_servers="",
+        kafka_bootstrap_servers="",
         message_format=AvroFormat(""),
         topic="topic",
         batch_source=FileSource(path="some path"),

--- a/sdk/python/tests/integration/registration/test_stream_feature_view_apply.py
+++ b/sdk/python/tests/integration/registration/test_stream_feature_view_apply.py
@@ -33,7 +33,7 @@ def test_apply_stream_feature_view(simple_dataset_1) -> None:
             message_format=AvroFormat(""),
             topic="topic",
             batch_source=file_source,
-            watermark=timedelta(days=1),
+            watermark_delay_threshold=timedelta(days=1),
         )
 
         @stream_feature_view(
@@ -97,7 +97,7 @@ def test_stream_feature_view_udf(simple_dataset_1) -> None:
             message_format=AvroFormat(""),
             topic="topic",
             batch_source=file_source,
-            watermark=timedelta(days=1),
+            watermark_delay_threshold=timedelta(days=1),
         )
 
         @stream_feature_view(

--- a/sdk/python/tests/integration/registration/test_stream_feature_view_apply.py
+++ b/sdk/python/tests/integration/registration/test_stream_feature_view_apply.py
@@ -29,7 +29,7 @@ def test_apply_stream_feature_view(simple_dataset_1) -> None:
         stream_source = KafkaSource(
             name="kafka",
             timestamp_field="event_timestamp",
-            bootstrap_servers="",
+            kafka_bootstrap_servers="",
             message_format=AvroFormat(""),
             topic="topic",
             batch_source=file_source,
@@ -93,7 +93,7 @@ def test_stream_feature_view_udf(simple_dataset_1) -> None:
         stream_source = KafkaSource(
             name="kafka",
             timestamp_field="event_timestamp",
-            bootstrap_servers="",
+            kafka_bootstrap_servers="",
             message_format=AvroFormat(""),
             topic="topic",
             batch_source=file_source,

--- a/sdk/python/tests/unit/test_data_sources.py
+++ b/sdk/python/tests/unit/test_data_sources.py
@@ -93,7 +93,7 @@ def test_default_data_source_kw_arg_warning():
         )
         assert source.name == "name"
         assert source.timestamp_field == "column"
-        assert source.kafka_options.bootstrap_servers == "bootstrap_servers"
+        assert source.kafka_options.kafka_bootstrap_servers == "bootstrap_servers"
         assert source.kafka_options.topic == "topic"
     with pytest.raises(ValueError):
         KafkaSource("name", "column", "bootstrap_servers", topic="topic")
@@ -145,7 +145,7 @@ def test_default_data_source_kw_arg_warning():
     with pytest.warns(UserWarning):
         source = KafkaSource(
             timestamp_field="column",
-            bootstrap_servers="bootstrap_servers",
+            kafka_bootstrap_servers="bootstrap_servers",
             message_format=ProtoFormat("class_path"),
             topic="topic",
         )
@@ -203,7 +203,7 @@ def test_proto_conversion():
 
     kafka_source = KafkaSource(
         name="test_source",
-        bootstrap_servers="test_servers",
+        kafka_bootstrap_servers="test_servers",
         message_format=ProtoFormat("class_path"),
         topic="test_topic",
         timestamp_field="event_timestamp",

--- a/sdk/python/tests/unit/test_feature_views.py
+++ b/sdk/python/tests/unit/test_feature_views.py
@@ -31,7 +31,7 @@ def test_create_batch_feature_view():
     stream_source = KafkaSource(
         name="kafka",
         timestamp_field="event_timestamp",
-        bootstrap_servers="",
+        kafka_bootstrap_servers="",
         message_format=AvroFormat(""),
         topic="topic",
         batch_source=FileSource(path="some path"),
@@ -49,7 +49,7 @@ def test_create_stream_feature_view():
     stream_source = KafkaSource(
         name="kafka",
         timestamp_field="event_timestamp",
-        bootstrap_servers="",
+        kafka_bootstrap_servers="",
         message_format=AvroFormat(""),
         topic="topic",
         batch_source=FileSource(path="some path"),
@@ -100,7 +100,7 @@ def test_stream_feature_view_serialization():
     stream_source = KafkaSource(
         name="kafka",
         timestamp_field="event_timestamp",
-        bootstrap_servers="",
+        kafka_bootstrap_servers="",
         message_format=AvroFormat(""),
         topic="topic",
         batch_source=FileSource(path="some path"),
@@ -137,7 +137,7 @@ def test_stream_feature_view_udfs():
     stream_source = KafkaSource(
         name="kafka",
         timestamp_field="event_timestamp",
-        bootstrap_servers="",
+        kafka_bootstrap_servers="",
         message_format=AvroFormat(""),
         topic="topic",
         batch_source=FileSource(path="some path"),
@@ -183,7 +183,7 @@ def test_stream_feature_view_initialization_with_optional_fields_omitted():
     stream_source = KafkaSource(
         name="kafka",
         timestamp_field="event_timestamp",
-        bootstrap_servers="",
+        kafka_bootstrap_servers="",
         message_format=AvroFormat(""),
         topic="topic",
         batch_source=FileSource(path="some path"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: This PR renames `bootstrap_servers` to `kafka_bootstrap_servers` and `watermark` to `watermark_delay_threshold` for `KafkaSource`. It also deprecates the `date_partition_column` for all data sources.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
