### PR TITLE
chore: Bump deprecation version from 0.23 to 0.24

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -196,7 +196,7 @@ def data_source_describe(ctx: click.Context, name: str):
 
     warnings.warn(
         "Describing data sources will only work properly if all data sources have names or table names specified. "
-        "Starting Feast 0.23, data source unique names will be required to encourage data source discovery.",
+        "Starting Feast 0.24, data source unique names will be required to encourage data source discovery.",
         RuntimeWarning,
     )
     print(
@@ -223,7 +223,7 @@ def data_source_list(ctx: click.Context):
 
     warnings.warn(
         "Listing data sources will only work properly if all data sources have names or table names specified. "
-        "Starting Feast 0.23, data source unique names will be required to encourage data source discovery",
+        "Starting Feast 0.24, data source unique names will be required to encourage data source discovery",
         RuntimeWarning,
     )
     print(tabulate(table, headers=["NAME", "CLASS"], tablefmt="plain"))

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -239,7 +239,7 @@ class DataSource(ABC):
             warnings.warn(
                 (
                     "Names for data sources need to be supplied. "
-                    "Data sources without names will not be supported after Feast 0.23."
+                    "Data sources without names will not be supported after Feast 0.24."
                 ),
                 UserWarning,
             )
@@ -248,7 +248,7 @@ class DataSource(ABC):
             warnings.warn(
                 (
                     "The argument 'event_timestamp_column' is being deprecated. Please use 'timestamp_field' instead. "
-                    "instead. Feast 0.23 and onwards will not support the argument 'event_timestamp_column' for datasources."
+                    "instead. Feast 0.24 and onwards will not support the argument 'event_timestamp_column' for datasources."
                 ),
                 DeprecationWarning,
             )
@@ -431,7 +431,7 @@ class KafkaSource(DataSource):
             warnings.warn(
                 (
                     "Kafka parameters should be specified as a keyword argument instead of a positional arg."
-                    "Feast 0.23+ will not support positional arguments to construct Kafka sources"
+                    "Feast 0.24+ will not support positional arguments to construct Kafka sources"
                 ),
                 DeprecationWarning,
             )
@@ -592,7 +592,7 @@ class RequestSource(DataSource):
             warnings.warn(
                 (
                     "Request source parameters should be specified as a keyword argument instead of a positional arg."
-                    "Feast 0.23+ will not support positional arguments to construct request sources"
+                    "Feast 0.24+ will not support positional arguments to construct request sources"
                 ),
                 DeprecationWarning,
             )
@@ -611,7 +611,7 @@ class RequestSource(DataSource):
             raise ValueError("Schema needs to be provided for Request Source")
         if isinstance(_schema, Dict):
             warnings.warn(
-                "Schema in RequestSource is changing type. The schema data type Dict[str, ValueType] is being deprecated in Feast 0.23. "
+                "Schema in RequestSource is changing type. The schema data type Dict[str, ValueType] is being deprecated in Feast 0.24. "
                 "Please use List[Field] instead for the schema",
                 DeprecationWarning,
             )
@@ -663,7 +663,7 @@ class RequestSource(DataSource):
 
         if deprecated_schema and not schema_pb:
             warnings.warn(
-                "Schema in RequestSource is changing type. The schema data type Dict[str, ValueType] is being deprecated in Feast 0.23. "
+                "Schema in RequestSource is changing type. The schema data type Dict[str, ValueType] is being deprecated in Feast 0.24. "
                 "Please use List[Field] instead for the schema",
                 DeprecationWarning,
             )
@@ -724,7 +724,7 @@ class RequestSource(DataSource):
 class RequestDataSource(RequestSource):
     def __init__(self, *args, **kwargs):
         warnings.warn(
-            "The 'RequestDataSource' class is deprecated and was renamed to RequestSource. Please use RequestSource instead. This class name will be removed in Feast 0.23.",
+            "The 'RequestDataSource' class is deprecated and was renamed to RequestSource. Please use RequestSource instead. This class name will be removed in Feast 0.24.",
             DeprecationWarning,
         )
         super().__init__(*args, **kwargs)
@@ -803,7 +803,7 @@ class KinesisSource(DataSource):
             warnings.warn(
                 (
                     "Kinesis parameters should be specified as a keyword argument instead of a positional arg."
-                    "Feast 0.23+ will not support positional arguments to construct kinesis sources"
+                    "Feast 0.24+ will not support positional arguments to construct kinesis sources"
                 ),
                 DeprecationWarning,
             )
@@ -922,7 +922,7 @@ class PushSource(DataSource):
             warnings.warn(
                 (
                     "Push source parameters should be specified as a keyword argument instead of a positional arg."
-                    "Feast 0.23+ will not support positional arguments to construct push sources"
+                    "Feast 0.24+ will not support positional arguments to construct push sources"
                 ),
                 DeprecationWarning,
             )

--- a/sdk/python/feast/diff/registry_diff.py
+++ b/sdk/python/feast/diff/registry_diff.py
@@ -67,7 +67,7 @@ class RegistryDiff:
             if feast_object_diff.transition_type == TransitionType.UNCHANGED:
                 continue
             if feast_object_diff.feast_object_type == FeastObjectType.DATA_SOURCE:
-                # TODO(adchia): Print statements out starting in Feast 0.23
+                # TODO(adchia): Print statements out starting in Feast 0.24
                 continue
             action, color = message_action_map[feast_object_diff.transition_type]
             log_string += f"{action} {feast_object_diff.feast_object_type.value} {Style.BRIGHT + color}{feast_object_diff.name}{Style.RESET_ALL}\n"

--- a/sdk/python/feast/entity.py
+++ b/sdk/python/feast/entity.py
@@ -90,7 +90,7 @@ class Entity:
             warnings.warn(
                 (
                     "Entity name should be specified as a keyword argument instead of a positional arg."
-                    "Feast 0.23+ will not support positional arguments to construct Entities"
+                    "Feast 0.24+ will not support positional arguments to construct Entities"
                 ),
                 DeprecationWarning,
             )
@@ -108,7 +108,7 @@ class Entity:
             warnings.warn(
                 (
                     "The `value_type` parameter is being deprecated. Instead, the type of an entity "
-                    "should be specified as a Field in the schema of a feature view. Feast 0.23 and "
+                    "should be specified as a Field in the schema of a feature view. Feast 0.24 and "
                     "onwards will not support the `value_type` parameter. The `entities` parameter of "
                     "feature views should also be changed to a List[Entity] instead of a List[str]; if "
                     "this is not done, entity columns will be mistakenly interpreted as feature columns."
@@ -125,7 +125,7 @@ class Entity:
             warnings.warn(
                 (
                     "The `join_key` parameter is being deprecated in favor of the `join_keys` parameter. "
-                    "Please switch from using `join_key` to `join_keys`. Feast 0.23 and onwards will not "
+                    "Please switch from using `join_key` to `join_keys`. Feast 0.24 and onwards will not "
                     "support the `join_key` parameter."
                 ),
                 DeprecationWarning,

--- a/sdk/python/feast/feature_service.py
+++ b/sdk/python/feast/feature_service.py
@@ -72,7 +72,7 @@ class FeatureService:
             warnings.warn(
                 (
                     "Feature service parameters should be specified as a keyword argument instead of a positional arg."
-                    "Feast 0.23+ will not support positional arguments to construct feature service"
+                    "Feast 0.24+ will not support positional arguments to construct feature service"
                 ),
                 DeprecationWarning,
             )

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -2504,7 +2504,7 @@ def _validate_data_sources(data_sources: List[DataSource]):
                     f"More than one data source with name {case_insensitive_ds_name} found. "
                     f"Please ensure that all data source names are case-insensitively unique. "
                     f"It may be necessary to ignore certain files in your feature repository by using a .feastignore "
-                    f"file. Starting in Feast 0.23, unique names (perhaps inferred from the table name) will be "
+                    f"file. Starting in Feast 0.24, unique names (perhaps inferred from the table name) will be "
                     f"required in data sources to encourage data source discovery"
                 )
         else:

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -148,7 +148,7 @@ class FeatureView(BaseFeatureView):
             warnings.warn(
                 (
                     "feature view parameters should be specified as a keyword argument instead of a positional arg."
-                    "Feast 0.23+ will not support positional arguments to construct feature views"
+                    "Feast 0.24+ will not support positional arguments to construct feature views"
                 ),
                 DeprecationWarning,
             )
@@ -178,7 +178,7 @@ class FeatureView(BaseFeatureView):
             warnings.warn(
                 (
                     "The `entities` parameter should be a list of `Entity` objects. "
-                    "Feast 0.23 and onwards will not support passing in a list of "
+                    "Feast 0.24 and onwards will not support passing in a list of "
                     "strings to define entities."
                 ),
                 DeprecationWarning,
@@ -191,7 +191,7 @@ class FeatureView(BaseFeatureView):
             warnings.warn(
                 (
                     "The option to pass a Duration object to the ttl parameter is being deprecated. "
-                    "Please pass a timedelta object instead. Feast 0.23 and onwards will not support "
+                    "Please pass a timedelta object instead. Feast 0.24 and onwards will not support "
                     "Duration objects."
                 ),
                 DeprecationWarning,
@@ -206,7 +206,7 @@ class FeatureView(BaseFeatureView):
                 (
                     "The `features` parameter is being deprecated in favor of the `schema` parameter. "
                     "Please switch from using `features` to `schema`. This will also requiring switching "
-                    "feature definitions from using `Feature` to `Field`. Feast 0.23 and onwards will not "
+                    "feature definitions from using `Feature` to `Field`. Feast 0.24 and onwards will not "
                     "support the `features` parameter."
                 ),
                 DeprecationWarning,
@@ -282,7 +282,7 @@ class FeatureView(BaseFeatureView):
         else:
             warnings.warn(
                 "batch_source and stream_source have been deprecated in favor of `source`."
-                "The deprecated fields will be removed in Feast 0.23.",
+                "The deprecated fields will be removed in Feast 0.24.",
                 DeprecationWarning,
             )
             if stream_source is not None and isinstance(stream_source, PushSource):

--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -63,7 +63,7 @@ class BigQuerySource(DataSource):
             warnings.warn(
                 (
                     "The argument 'date_partition_column' is not supported for BigQuery sources. "
-                    "It will be removed in Feast 0.23+"
+                    "It will be removed in Feast 0.24+"
                 ),
                 DeprecationWarning,
             )
@@ -76,7 +76,7 @@ class BigQuerySource(DataSource):
             else:
                 warnings.warn(
                     (
-                        f"Starting in Feast 0.23, Feast will require either a name for a data source (if using query) or `table`: {self.query}"
+                        f"Starting in Feast 0.24, Feast will require either a name for a data source (if using query) or `table`: {self.query}"
                     ),
                     DeprecationWarning,
                 )

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -59,7 +59,7 @@ class SparkSource(DataSource):
             warnings.warn(
                 (
                     "The argument 'date_partition_column' is not supported for Spark sources."
-                    "It will be removed in Feast 0.23+"
+                    "It will be removed in Feast 0.24+"
                 ),
                 DeprecationWarning,
             )

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -70,7 +70,7 @@ class FileSource(DataSource):
                 warnings.warn(
                     (
                         "File Source parameters should be specified as a keyword argument instead of a positional arg."
-                        "Feast 0.23+ will not support positional arguments to construct File sources"
+                        "Feast 0.24+ will not support positional arguments to construct File sources"
                     ),
                     DeprecationWarning,
                 )
@@ -95,7 +95,7 @@ class FileSource(DataSource):
             warnings.warn(
                 (
                     "The argument 'date_partition_column' is not supported for File sources."
-                    "It will be removed in Feast 0.23+"
+                    "It will be removed in Feast 0.24+"
                 ),
                 DeprecationWarning,
             )

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -73,7 +73,7 @@ class RedshiftSource(DataSource):
             else:
                 warnings.warn(
                     (
-                        f"Starting in Feast 0.23, Feast will require either a name for a data source (if using query) "
+                        f"Starting in Feast 0.24, Feast will require either a name for a data source (if using query) "
                         f"or `table`: {self.query}"
                     ),
                     DeprecationWarning,
@@ -82,7 +82,7 @@ class RedshiftSource(DataSource):
             warnings.warn(
                 (
                     "The argument 'date_partition_column' is not supported for Redshift sources."
-                    "It will be removed in Feast 0.23+"
+                    "It will be removed in Feast 0.24+"
                 ),
                 DeprecationWarning,
             )

--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -79,7 +79,7 @@ class SnowflakeSource(DataSource):
             else:
                 warnings.warn(
                     (
-                        f"Starting in Feast 0.23, Feast will require either a name for a data source (if using query) "
+                        f"Starting in Feast 0.24, Feast will require either a name for a data source (if using query) "
                         f"or `table`: {self.query}"
                     ),
                     DeprecationWarning,
@@ -89,7 +89,7 @@ class SnowflakeSource(DataSource):
             warnings.warn(
                 (
                     "The argument 'date_partition_column' is not supported for Snowflake sources."
-                    "It will be removed in Feast 0.23+"
+                    "It will be removed in Feast 0.24+"
                 ),
                 DeprecationWarning,
             )

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -128,7 +128,7 @@ class OnDemandFeatureView(BaseFeatureView):
                 (
                     "The `features` parameter is being deprecated in favor of the `schema` parameter. "
                     "Please switch from using `features` to `schema`. This will also requiring switching "
-                    "feature definitions from using `Feature` to `Field`. Feast 0.23 and onwards will not "
+                    "feature definitions from using `Feature` to `Field`. Feast 0.24 and onwards will not "
                     "support the `features` parameter."
                 ),
                 DeprecationWarning,
@@ -140,7 +140,7 @@ class OnDemandFeatureView(BaseFeatureView):
             warnings.warn(
                 (
                     "The `inputs` parameter is being deprecated. Please use `sources` instead. "
-                    "Feast 0.23 and onwards will not support the `inputs` parameter."
+                    "Feast 0.24 and onwards will not support the `inputs` parameter."
                 ),
                 DeprecationWarning,
             )
@@ -161,7 +161,7 @@ class OnDemandFeatureView(BaseFeatureView):
             warnings.warn(
                 (
                     "On demand feature view parameters should be specified as keyword arguments "
-                    "instead of positional arguments. Feast 0.23 and onwards will not support "
+                    "instead of positional arguments. Feast 0.24 and onwards will not support "
                     "positional arguments in on demand feature view definitions."
                 ),
                 DeprecationWarning,
@@ -182,7 +182,7 @@ class OnDemandFeatureView(BaseFeatureView):
                     (
                         "The `features` parameter is being deprecated in favor of the `schema` parameter. "
                         "Please switch from using `features` to `schema`. This will also requiring switching "
-                        "feature definitions from using `Feature` to `Field`. Feast 0.23 and onwards will not "
+                        "feature definitions from using `Feature` to `Field`. Feast 0.24 and onwards will not "
                         "support the `features` parameter."
                     ),
                     DeprecationWarning,
@@ -203,7 +203,7 @@ class OnDemandFeatureView(BaseFeatureView):
                 warnings.warn(
                     (
                         "The `inputs` parameter is being deprecated. Please use `sources` instead. "
-                        "Feast 0.23 and onwards will not support the `inputs` parameter."
+                        "Feast 0.24 and onwards will not support the `inputs` parameter."
                     ),
                     DeprecationWarning,
                 )
@@ -560,7 +560,7 @@ def on_demand_feature_view(
             (
                 "The `features` parameter is being deprecated in favor of the `schema` parameter. "
                 "Please switch from using `features` to `schema`. This will also requiring switching "
-                "feature definitions from using `Feature` to `Field`. Feast 0.23 and onwards will not "
+                "feature definitions from using `Feature` to `Field`. Feast 0.24 and onwards will not "
                 "support the `features` parameter."
             ),
             DeprecationWarning,
@@ -572,7 +572,7 @@ def on_demand_feature_view(
         warnings.warn(
             (
                 "The `inputs` parameter is being deprecated. Please use `sources` instead. "
-                "Feast 0.23 and onwards will not support the `inputs` parameter."
+                "Feast 0.24 and onwards will not support the `inputs` parameter."
             ),
             DeprecationWarning,
         )
@@ -592,7 +592,7 @@ def on_demand_feature_view(
         warnings.warn(
             (
                 "On demand feature view parameters should be specified as keyword arguments "
-                "instead of positional arguments. Feast 0.23 and onwards will not support "
+                "instead of positional arguments. Feast 0.24 and onwards will not support "
                 "positional arguments in on demand feature view definitions."
             ),
             DeprecationWarning,
@@ -611,7 +611,7 @@ def on_demand_feature_view(
                 (
                     "The `features` parameter is being deprecated in favor of the `schema` parameter. "
                     "Please switch from using `features` to `schema`. This will also requiring switching "
-                    "feature definitions from using `Feature` to `Field`. Feast 0.23 and onwards will not "
+                    "feature definitions from using `Feature` to `Field`. Feast 0.24 and onwards will not "
                     "support the `features` parameter."
                 ),
                 DeprecationWarning,
@@ -632,7 +632,7 @@ def on_demand_feature_view(
                 warnings.warn(
                     (
                         "The `inputs` parameter is being deprecated. Please use `sources` instead. "
-                        "Feast 0.23 and onwards will not support the `inputs` parameter."
+                        "Feast 0.24 and onwards will not support the `inputs` parameter."
                     ),
                     DeprecationWarning,
                 )

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -183,7 +183,7 @@ def test_on_demand_features_type_inference():
         test_view_with_missing_feature.infer_features()
 
 
-# TODO(kevjumba): remove this in feast 0.23 when deprecating
+# TODO(kevjumba): remove this in feast 0.24 when deprecating
 @pytest.mark.parametrize(
     "request_source_schema",
     [

--- a/sdk/python/tests/integration/registration/test_registry.py
+++ b/sdk/python/tests/integration/registration/test_registry.py
@@ -370,7 +370,7 @@ def test_apply_stream_feature_view_success(test_registry):
 @pytest.mark.parametrize(
     "test_registry", [lazy_fixture("local_registry")],
 )
-# TODO(kevjumba): remove this in feast 0.23 when deprecating
+# TODO(kevjumba): remove this in feast 0.24 when deprecating
 @pytest.mark.parametrize(
     "request_source_schema",
     [[Field(name="my_input_1", dtype=Int32)], {"my_input_1": ValueType.INT32}],

--- a/sdk/python/tests/unit/test_data_sources.py
+++ b/sdk/python/tests/unit/test_data_sources.py
@@ -84,7 +84,7 @@ def test_hash():
     assert len(s4) == 3
 
 
-# TODO(kevjumba): Remove this test in feast 0.23 when positional arguments are removed.
+# TODO(kevjumba): Remove this test in feast 0.24 when positional arguments are removed.
 def test_default_data_source_kw_arg_warning():
     # source_class = request.param
     with pytest.warns(DeprecationWarning):


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: This PR bumps the deprecation of all Feast object parameters, and related logic, from 0.23 to 0.24.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
