### PR TITLE
ci: Stop running tests for python 3.7

### DIFF
--- a/.github/workflows/java_master_only.yml
+++ b/.github/workflows/java_master_only.yml
@@ -93,7 +93,7 @@ jobs:
           architecture: x64
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
           architecture: 'x64'
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -74,7 +74,7 @@ jobs:
           architecture: x64
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
           architecture: 'x64'
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,14 +6,14 @@ jobs:
   lint-python:
     runs-on: [ubuntu-latest]
     env:
-      PYTHON: 3.7
+      PYTHON: 3.8
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
         id: setup-python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           architecture: x64
       - name: Setup Go
         id: setup-go
@@ -59,7 +59,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Upgrade pip version
         run: |
           pip install --upgrade "pip>=21.3.1,<22.1"

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
         go-version: [ 1.17.0 ]
         os: [ ubuntu-latest ]
     env:

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7" ]
+        python-version: [ "3.8" ]
         os: [ ubuntu-latest ]
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,11 +7,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10" ]
         os: [ ubuntu-latest, macOS-latest ]
         exclude:
-          - os: macOS-latest
-            python-version: "3.8"
           - os: macOS-latest
             python-version: "3.9"
           - os: macOS-latest
@@ -85,7 +83,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Upgrade pip version
         run: |
           pip install --upgrade "pip>=22.1,<23"


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Python 3.7  is approaching EoL, and isn't used by a lot of feast users. It's also not a great experience on M1 Macs per @kevjumba. Let's remove it to speed up CI time. We still support 3.7 as the minimum python version, and don't prevent users installing feast on py 3.7, just that we should run tests on newer versions.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
