### PR TITLE
fix: Conversion of null timestamp from proto to python

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -46,6 +46,9 @@ from feast.protos.feast.types.Value_pb2 import (
 from feast.protos.feast.types.Value_pb2 import Value as ProtoValue
 from feast.value_type import ListType, ValueType
 
+# null timestamps get converted to -9223372036854775808
+NULL_TIMESTAMP_INT_VALUE = np.datetime64("NaT").astype(int)
+
 
 def feast_value_type_to_python_type(field_value_proto: ProtoValue) -> Any:
     """
@@ -69,9 +72,18 @@ def feast_value_type_to_python_type(field_value_proto: ProtoValue) -> Any:
 
     # Convert UNIX_TIMESTAMP values to `datetime`
     if val_attr == "unix_timestamp_list_val":
-        val = [datetime.fromtimestamp(v, tz=timezone.utc) for v in val]
+        val = [
+            datetime.fromtimestamp(v, tz=timezone.utc)
+            if v != NULL_TIMESTAMP_INT_VALUE
+            else None
+            for v in val
+        ]
     elif val_attr == "unix_timestamp_val":
-        val = datetime.fromtimestamp(val, tz=timezone.utc)
+        val = (
+            datetime.fromtimestamp(val, tz=timezone.utc)
+            if val != NULL_TIMESTAMP_INT_VALUE
+            else None
+        )
 
     return val
 

--- a/sdk/python/tests/unit/test_type_map.py
+++ b/sdk/python/tests/unit/test_type_map.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from feast.type_map import (
+    feast_value_type_to_python_type,
+    python_values_to_proto_values,
+)
+from feast.value_type import ValueType
+
+
+def test_null_unix_timestamp():
+    """Test that null UnixTimestamps get converted from proto correctly."""
+
+    data = np.array(["NaT"], dtype="datetime64")
+    protos = python_values_to_proto_values(data, ValueType.UNIX_TIMESTAMP)
+    converted = feast_value_type_to_python_type(protos[0])
+
+    assert converted is None
+
+
+def test_null_unix_timestamp_list():
+    """Test that UnixTimestamp lists with a null get converted from proto
+    correctly."""
+
+    data = np.array([["NaT"]], dtype="datetime64")
+    protos = python_values_to_proto_values(data, ValueType.UNIX_TIMESTAMP_LIST)
+    converted = feast_value_type_to_python_type(protos[0])
+
+    assert converted[0] is None


### PR DESCRIPTION
Signed-off-by: Andrew Pope <apope@nursefly.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Currently, the python to proto function converts a null timestamp to the value -9223372036854775808, which then fails when converting back to python type. This fixes the conversion of null UnixTimestamp values from proto to python by checking for that value and converting it to null.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/feast-dev/feast/issues/2803
