### PR TITLE
feat: Updated Trino class to support custom Connection object

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py
@@ -5,7 +5,6 @@ import os
 import signal
 from dataclasses import dataclass
 from enum import Enum
-from optparse import Option
 from typing import Any, Dict, List, Optional
 
 import numpy as np

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py
@@ -37,7 +37,7 @@ class Trino:
         catalog: Optional[str] = None,
         auth: Optional[Any] = None,
         http_scheme: Optional[str] = None,
-        conn: Optional[Connection] = None
+        conn: Optional[Connection] = None,
     ):
         """Initialize a authorized Trino client.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

It updates Trino class to support more customized authorized Connection object. E.g. I have a conn that's authorized with [http-headers](https://github.com/trinodb/trino-python-client/blob/771eec36b658c536d8f5f6bb1710fca6b766c390/trino/dbapi.py#L102).


Just put here for discussion, an alternative way of supporting `conn` without removing `_get_curosr(self)` method can be like

```diff
diff --git a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py
index 1d4b5881..159a4e83 100644
--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import trino
-from trino.dbapi import Cursor
+from trino.dbapi import Connection, Cursor
 from trino.exceptions import TrinoQueryError
 
 from feast.infra.offline_stores.contrib.trino_offline_store.trino_type_map import (
@@ -36,6 +36,7 @@ class Trino:
         catalog: Optional[str] = None,
         auth: Optional[Any] = None,
         http_scheme: Optional[str] = None,
+        conn: Optional[Connection] = None,
     ):
         self.host = host or os.getenv("TRINO_HOST")
         self.port = port or os.getenv("TRINO_PORT")
@@ -43,6 +44,7 @@ class Trino:
         self.catalog = catalog or os.getenv("TRINO_CATALOG")
         self.auth = auth or os.getenv("TRINO_AUTH")
         self.http_scheme = http_scheme or os.getenv("TRINO_HTTP_SCHEME")
+        self._conn = conn
         self._cursor: Optional[Cursor] = None
 
         if self.host is None:
@@ -56,15 +58,17 @@ class Trino:
 
     def _get_cursor(self) -> Cursor:
         if self._cursor is None:
-            self._cursor = trino.dbapi.connect(
-                host=self.host,
-                port=self.port,
-                user=self.user,
-                catalog=self.catalog,
-                auth=self.auth,
-                http_scheme=self.http_scheme,
-            ).cursor()
-
+            if self._conn is None:
+                self._cursor = trino.dbapi.connect(
+                    host=self.host,
+                    port=self.port,
+                    user=self.user,
+                    catalog=self.catalog,
+                    auth=self.auth,
+                    http_scheme=self.http_scheme,
+                ).cursor()
+            else:
+                self._cursor = self._conn.cursor()
         return self._cursor
 
     def create_query(self, query_text: str) -> Query:
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # NA
