### PR TITLE
feat: Support retrieval from multiple feature views with different join keys

### DIFF
--- a/java/serving/src/main/java/feast/serving/registry/Registry.java
+++ b/java/serving/src/main/java/feast/serving/registry/Registry.java
@@ -33,6 +33,7 @@ public class Registry {
   private Map<String, OnDemandFeatureViewProto.OnDemandFeatureViewSpec>
       onDemandFeatureViewNameToSpec;
   private final Map<String, FeatureServiceProto.FeatureServiceSpec> featureServiceNameToSpec;
+  private final Map<String, String> entityNameToJoinKey;
 
   Registry(RegistryProto.Registry registry) {
     this.registry = registry;
@@ -60,6 +61,12 @@ public class Registry {
             .collect(
                 Collectors.toMap(
                     FeatureServiceProto.FeatureServiceSpec::getName, Function.identity()));
+    this.entityNameToJoinKey =
+        registry.getEntitiesList().stream()
+            .map(EntityProto.Entity::getSpec)
+            .collect(
+                Collectors.toMap(
+                    EntityProto.EntitySpecV2::getName, EntityProto.EntitySpecV2::getJoinKey));
   }
 
   public RegistryProto.Registry getRegistry() {
@@ -114,5 +121,13 @@ public class Registry {
           String.format("Unable to find feature service with name: %s", name));
     }
     return spec;
+  }
+
+  public String getEntityJoinKey(String name) {
+    String joinKey = entityNameToJoinKey.get(name);
+    if (joinKey == null) {
+      throw new SpecRetrievalException(String.format("Unable to find entity with name: %s", name));
+    }
+    return joinKey;
   }
 }

--- a/java/serving/src/main/java/feast/serving/registry/RegistryRepository.java
+++ b/java/serving/src/main/java/feast/serving/registry/RegistryRepository.java
@@ -102,4 +102,8 @@ public class RegistryRepository {
   public List<String> getEntitiesList(ServingAPIProto.FeatureReferenceV2 featureReference) {
     return getFeatureViewSpec(featureReference).getEntitiesList();
   }
+
+  public String getEntityJoinKey(String name) {
+    return this.registry.getEntityJoinKey(name);
+  }
 }

--- a/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
+++ b/java/serving/src/main/java/feast/serving/service/OnlineServingServiceV2.java
@@ -34,10 +34,10 @@ import feast.proto.types.ValueProto;
 import feast.serving.registry.RegistryRepository;
 import feast.serving.util.Metrics;
 import feast.storage.api.retriever.OnlineRetrieverV2;
-import io.grpc.Status;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -50,6 +50,11 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
   private final RegistryRepository registryRepository;
   private final OnlineTransformationService onlineTransformationService;
   private final String project;
+
+  public static final String DUMMY_ENTITY_ID = "__dummy_id";
+  public static final String DUMMY_ENTITY_VAL = "";
+  public static final ValueProto.Value DUMMY_ENTITY_VALUE =
+      ValueProto.Value.newBuilder().setStringVal(DUMMY_ENTITY_VAL).build();
 
   public OnlineServingServiceV2(
       OnlineRetrieverV2 retriever,
@@ -103,30 +108,17 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
 
     List<Map<String, ValueProto.Value>> entityRows = getEntityRows(request);
 
-    List<String> entityNames;
-    if (retrievedFeatureReferences.size() > 0) {
-      entityNames = this.registryRepository.getEntitiesList(retrievedFeatureReferences.get(0));
-    } else {
-      throw new RuntimeException("Requested features list must not be empty");
-    }
-
     Span storageRetrievalSpan = tracer.buildSpan("storageRetrieval").start();
     if (storageRetrievalSpan != null) {
       storageRetrievalSpan.setTag("entities", entityRows.size());
       storageRetrievalSpan.setTag("features", retrievedFeatureReferences.size());
     }
+
     List<List<feast.storage.api.retriever.Feature>> features =
-        retriever.getOnlineFeatures(entityRows, retrievedFeatureReferences, entityNames);
+        retrieveFeatures(retrievedFeatureReferences, entityRows);
 
     if (storageRetrievalSpan != null) {
       storageRetrievalSpan.finish();
-    }
-    if (features.size() != entityRows.size()) {
-      throw Status.INTERNAL
-          .withDescription(
-              "The no. of FeatureRow obtained from OnlineRetriever"
-                  + "does not match no. of entityRow passed.")
-          .asRuntimeException();
     }
 
     Span postProcessingSpan = tracer.buildSpan("postProcessing").start();
@@ -253,6 +245,78 @@ public class OnlineServingServiceV2 implements ServingServiceV2 {
     }
 
     return entityRows;
+  }
+
+  private List<List<feast.storage.api.retriever.Feature>> retrieveFeatures(
+      List<FeatureReferenceV2> featureReferences, List<Map<String, ValueProto.Value>> entityRows) {
+    // Prepare feature reference to index mapping. This mapping will be used to arrange the
+    // retrieved features to the same order as in the input.
+    if (featureReferences.isEmpty()) {
+      throw new RuntimeException("Requested features list must not be empty.");
+    }
+    Map<FeatureReferenceV2, Integer> featureReferenceToIndexMap =
+        new HashMap<>(featureReferences.size());
+    for (int i = 0; i < featureReferences.size(); i++) {
+      FeatureReferenceV2 featureReference = featureReferences.get(i);
+      if (featureReferenceToIndexMap.containsKey(featureReference)) {
+        throw new RuntimeException(
+            String.format(
+                "Found duplicate features %s:%s.",
+                featureReference.getFeatureViewName(), featureReference.getFeatureName()));
+      }
+      featureReferenceToIndexMap.put(featureReference, i);
+    }
+
+    // Create placeholders for retrieved features.
+    List<List<feast.storage.api.retriever.Feature>> features = new ArrayList<>(entityRows.size());
+    for (int i = 0; i < entityRows.size(); i++) {
+      List<feast.storage.api.retriever.Feature> featuresPerEntity =
+          new ArrayList<>(featureReferences.size());
+      for (int j = 0; j < featureReferences.size(); j++) {
+        featuresPerEntity.add(null);
+      }
+      features.add(featuresPerEntity);
+    }
+
+    // Group feature references by feature view.
+    Map<String, List<FeatureReferenceV2>> featureViewNameToFeatureReferencesMap =
+        featureReferences.stream()
+            .collect(Collectors.groupingBy(FeatureReferenceV2::getFeatureViewName));
+
+    // Retrieve features one feature view at a time.
+    for (List<FeatureReferenceV2> featureReferencesPerFeatureView :
+        featureViewNameToFeatureReferencesMap.values()) {
+      List<String> entityNames =
+          this.registryRepository.getEntitiesList(featureReferencesPerFeatureView.get(0));
+      List<Map<String, ValueProto.Value>> entityRowsPerFeatureView =
+          new ArrayList<>(entityRows.size());
+      for (Map<String, ValueProto.Value> entityRow : entityRows) {
+        Map<String, ValueProto.Value> entityRowPerFeatureView =
+            entityNames.stream()
+                .map(this.registryRepository::getEntityJoinKey)
+                .collect(
+                    Collectors.toMap(
+                        Function.identity(),
+                        joinKey -> {
+                          if (joinKey.equals(DUMMY_ENTITY_ID)) {
+                            return DUMMY_ENTITY_VALUE;
+                          }
+                          return entityRow.get(joinKey);
+                        }));
+        entityRowsPerFeatureView.add(entityRowPerFeatureView);
+      }
+      List<List<feast.storage.api.retriever.Feature>> featuresPerFeatureView =
+          retriever.getOnlineFeatures(
+              entityRowsPerFeatureView, featureReferencesPerFeatureView, entityNames);
+      for (int i = 0; i < featuresPerFeatureView.size(); i++) {
+        for (int j = 0; j < featureReferencesPerFeatureView.size(); j++) {
+          int k = featureReferenceToIndexMap.get(featureReferencesPerFeatureView.get(j));
+          features.get(i).set(k, featuresPerFeatureView.get(i).get(j));
+        }
+      }
+    }
+
+    return features;
   }
 
   private void populateOnDemandFeatures(

--- a/java/serving/src/test/java/feast/serving/it/ServingBaseTests.java
+++ b/java/serving/src/test/java/feast/serving/it/ServingBaseTests.java
@@ -172,5 +172,35 @@ abstract class ServingBaseTests extends ServingEnvironment {
     }
   }
 
+  @Test
+  public void shouldGetOnlineFeaturesFromAllFeatureViews() {
+    Map<String, ValueProto.RepeatedValue> entityRows =
+        ImmutableMap.of(
+            "entity",
+                ValueProto.RepeatedValue.newBuilder()
+                    .addVal(DataGenerator.createStrValue("key-1"))
+                    .build(),
+            "driver_id",
+                ValueProto.RepeatedValue.newBuilder()
+                    .addVal(DataGenerator.createInt64Value(1005))
+                    .build());
+
+    ImmutableList<String> featureReferences =
+        ImmutableList.of(
+            "feature_view_0:feature_0",
+            "feature_view_0:feature_1",
+            "driver_hourly_stats:conv_rate",
+            "driver_hourly_stats:avg_daily_trips");
+
+    ServingAPIProto.GetOnlineFeaturesRequest req =
+        TestUtils.createOnlineFeatureRequest(featureReferences, entityRows);
+
+    ServingAPIProto.GetOnlineFeaturesResponse resp = servingStub.getOnlineFeatures(req);
+
+    for (final int featureIdx : List.of(0, 1, 2, 3)) {
+      assertEquals(FieldStatus.PRESENT, resp.getResults(featureIdx).getStatuses(0));
+    }
+  }
+
   abstract void updateRegistryFile(RegistryProto.Registry registry);
 }

--- a/java/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
+++ b/java/serving/src/test/java/feast/serving/service/OnlineServingServiceTest.java
@@ -170,6 +170,8 @@ public class OnlineServingServiceTest {
         .thenReturn(featureSpecs.get(0));
     when(registry.getFeatureSpec(mockedFeatureRows.get(3).getFeatureReference()))
         .thenReturn(featureSpecs.get(1));
+    when(registry.getEntityJoinKey("entity1")).thenReturn("entity1");
+    when(registry.getEntityJoinKey("entity2")).thenReturn("entity2");
 
     when(tracer.buildSpan(ArgumentMatchers.any())).thenReturn(Mockito.mock(SpanBuilder.class));
 
@@ -237,6 +239,8 @@ public class OnlineServingServiceTest {
         .thenReturn(featureSpecs.get(0));
     when(registry.getFeatureSpec(mockedFeatureRows.get(1).getFeatureReference()))
         .thenReturn(featureSpecs.get(1));
+    when(registry.getEntityJoinKey("entity1")).thenReturn("entity1");
+    when(registry.getEntityJoinKey("entity2")).thenReturn("entity2");
 
     when(tracer.buildSpan(ArgumentMatchers.any())).thenReturn(Mockito.mock(SpanBuilder.class));
 
@@ -314,6 +318,8 @@ public class OnlineServingServiceTest {
         .thenReturn(featureSpecs.get(1));
     when(registry.getFeatureSpec(mockedFeatureRows.get(5).getFeatureReference()))
         .thenReturn(featureSpecs.get(0));
+    when(registry.getEntityJoinKey("entity1")).thenReturn("entity1");
+    when(registry.getEntityJoinKey("entity2")).thenReturn("entity2");
 
     when(tracer.buildSpan(ArgumentMatchers.any())).thenReturn(Mockito.mock(SpanBuilder.class));
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Currently Java Feature Server doesn't support retrieval from multiple feature views with different join keys. For each gPRC request, `OnlineServingServiceV2` calls `OnlineRetriever` once and only once. In this call the former sends all join keys in the original request to the latter, and the latter simply sorts and concatenates all join keys to make a Redis key.

This PR supports retrieval from multiple feature views with different join keys. For each gPRC request, it groups feature references by join keys and for each group it makes a call to `OnlineRetriever`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
