### PR TITLE
fix: Prefer installing gopy from feast's fork as opposed to upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,9 +172,9 @@ install-go-proto-dependencies:
 install-go-ci-dependencies:
 	# ToDo: currently gopy installation doesn't work w/o explicit go get in the next line
 	# ToDo: there should be a better way to install gopy
-	go get github.com/feast-dev/gopy
+	go get github.com/go-python/gopy@v0.4.0
 	go install golang.org/x/tools/cmd/goimports
-	go install github.com/gofeast-dev/gopy@v0.4.0
+	go install github.com/go-python/gopy@v0.4.0
 	python -m pip install pybindgen==0.22.0
 
 install-protoc-dependencies:

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,9 @@ install-go-proto-dependencies:
 install-go-ci-dependencies:
 	# ToDo: currently gopy installation doesn't work w/o explicit go get in the next line
 	# ToDo: there should be a better way to install gopy
-	go mod tidy
+	go get github.com/feast-dev/gopy
+	go install golang.org/x/tools/cmd/goimports
+	go install github.com/gofeast-dev/gopy@v0.4.0
 	python -m pip install pybindgen==0.22.0
 
 install-protoc-dependencies:

--- a/Makefile
+++ b/Makefile
@@ -172,9 +172,9 @@ install-go-proto-dependencies:
 install-go-ci-dependencies:
 	# ToDo: currently gopy installation doesn't work w/o explicit go get in the next line
 	# ToDo: there should be a better way to install gopy
-	go get github.com/go-python/gopy
+	go get github.com/feast-dev/gopy
 	go install golang.org/x/tools/cmd/goimports
-	go install github.com/go-python/gopy
+	go install github.com/feast-dev/gopy
 	python -m pip install pybindgen==0.22.0
 
 install-protoc-dependencies:

--- a/Makefile
+++ b/Makefile
@@ -170,11 +170,13 @@ install-go-proto-dependencies:
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0
 
 install-go-ci-dependencies:
-	# ToDo: currently gopy installation doesn't work w/o explicit go get in the next line
-	# ToDo: there should be a better way to install gopy
+	# TODO: currently gopy installation doesn't work w/o explicit go get in the next line
+	# TODO: there should be a better way to install gopy
 	go get github.com/go-python/gopy@v0.4.0
 	go install golang.org/x/tools/cmd/goimports
-	#go install github.com/go-python/gopy@v0.4.0
+	# The `go get` command on the previous lines download the lib along with replacing the dep to `feast-dev/gopy`
+	# but the following command is needed to install it for some reason.
+	go install github.com/go-python/gopy
 	python -m pip install pybindgen==0.22.0
 
 install-protoc-dependencies:

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ install-go-ci-dependencies:
 	# ToDo: there should be a better way to install gopy
 	go get github.com/go-python/gopy@v0.4.0
 	go install golang.org/x/tools/cmd/goimports
-	go install github.com/go-python/gopy@v0.4.0
+	#go install github.com/go-python/gopy@v0.4.0
 	python -m pip install pybindgen==0.22.0
 
 install-protoc-dependencies:

--- a/Makefile
+++ b/Makefile
@@ -172,9 +172,7 @@ install-go-proto-dependencies:
 install-go-ci-dependencies:
 	# ToDo: currently gopy installation doesn't work w/o explicit go get in the next line
 	# ToDo: there should be a better way to install gopy
-	go get github.com/feast-dev/gopy
-	go install golang.org/x/tools/cmd/goimports
-	go install github.com/feast-dev/gopy
+	go mod tidy
 	python -m pip install pybindgen==0.22.0
 
 install-protoc-dependencies:

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/feast-dev/feast
 
 go 1.17
 
+replace github.com/go-python/gopy v0.4.0 => github.com/feast-dev/gopy v0.4.1-0.20220429180328-4257ac71a4d0
+
 require (
 	github.com/apache/arrow/go/v8 v8.0.0-20220408212425-58fe60f59289
 	github.com/ghodss/yaml v1.0.0
@@ -40,12 +42,10 @@ require (
 	golang.org/x/net v0.0.0-20220407224826-aac1ed45d8e3 // indirect
 	golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/tools v0.1.10 // indirect
+	golang.org/x/tools v0.1.11-0.20220413170336-afc6aad76eb1 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
-
-replace github.com/go-python/gopy v0.4.0 => github.com/feast-dev/gopy v0.4.1-0.20220429180328-4257ac71a4d0

--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,6 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/goccy/go-json v0.9.6 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/gonuts/commander v0.1.0 // indirect
-	github.com/gonuts/flag v0.1.0 // indirect
 	github.com/google/flatbuffers v2.0.6+incompatible // indirect
 	github.com/klauspost/asmfmt v1.3.2 // indirect
 	github.com/klauspost/compress v1.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.8-0.20211029000441-d6a9af8af023/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
-golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
-golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
+golang.org/x/tools v0.1.11-0.20220413170336-afc6aad76eb1 h1:Z3vE1sGlC7qiyFJkkDcZms8Y3+yV8+W7HmDSmuf71tM=
+golang.org/x/tools v0.1.11-0.20220413170336-afc6aad76eb1/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -146,9 +146,7 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gonuts/commander v0.1.0 h1:EcDTiVw9oAVORFjQOEOuHQqcl6OXMyTgELocTq6zJ0I=
 github.com/gonuts/commander v0.1.0/go.mod h1:qkb5mSlcWodYgo7vs8ulLnXhfinhZsZcm6+H/z1JjgY=
-github.com/gonuts/flag v0.1.0 h1:fqMv/MZ+oNGu0i9gp0/IQ/ZaPIDoAZBOBaJoV7viCWM=
 github.com/gonuts/flag v0.1.0/go.mod h1:ZTmTGtrSPejTo/SRNhCqwLTmiAgyBdCkLYhHrAoBdz4=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/sdk/python/tests/integration/online_store/test_e2e_local.py
+++ b/sdk/python/tests/integration/online_store/test_e2e_local.py
@@ -130,7 +130,7 @@ def _test_materialize_and_online_retrieval(
         cwd=Path(store.repo_path),
     )
 
-    assert r.returncode == 0
+    assert r.returncode == 0, f"stdout: {r.stdout}\n stderr: {r.stderr}"
     _assert_online_features(store, driver_df, end_date - timedelta(days=7))
 
     # Test `feast materialize-incremental` and online retrieval.
@@ -138,7 +138,7 @@ def _test_materialize_and_online_retrieval(
         ["materialize-incremental", end_date.isoformat()], cwd=Path(store.repo_path),
     )
 
-    assert r.returncode == 0
+    assert r.returncode == 0, f"stdout: {r.stdout}\n stderr: {r.stderr}"
     _assert_online_features(store, driver_df, end_date)
 
 

--- a/sdk/python/tests/utils/cli_utils.py
+++ b/sdk/python/tests/utils/cli_utils.py
@@ -76,6 +76,9 @@ class CliRunner:
                 path: {data_path / "online_store.db"}
             offline_store:
                 type: {offline_store}
+            flags:
+              alpha_features: true
+              on_demand_transforms: true
             """
                 )
             )
@@ -84,9 +87,13 @@ class CliRunner:
             repo_example.write_text(example_repo_py)
 
             result = self.run(["apply"], cwd=repo_path)
-            assert result.returncode == 0
+            assert (
+                result.returncode == 0
+            ), f"stdout: {result.stdout}\n stderr: {result.stderr}"
 
             yield FeatureStore(repo_path=str(repo_path), config=None)
 
             result = self.run(["teardown"], cwd=repo_path)
-            assert result.returncode == 0
+            assert (
+                result.returncode == 0
+            ), f"stdout: {result.stdout}\n stderr: {result.stderr}"

--- a/sdk/python/tests/utils/cli_utils.py
+++ b/sdk/python/tests/utils/cli_utils.py
@@ -76,9 +76,6 @@ class CliRunner:
                 path: {data_path / "online_store.db"}
             offline_store:
                 type: {offline_store}
-            flags:
-              alpha_features: true
-              on_demand_transforms: true
             """
                 )
             )

--- a/setup.py
+++ b/setup.py
@@ -425,7 +425,6 @@ class build_ext(_build_ext):
 
         destination = os.path.dirname(os.path.abspath(self.get_ext_fullpath(ext.name)))
         subprocess.check_call(["go", "mod", "tidy"], env={"PATH": bin_path, **go_env})
-        # subprocess.check_call(["go", "install", "github.com/go-python/gopy@v0.4.0"])
         subprocess.check_call(
             [
                 "gopy",

--- a/setup.py
+++ b/setup.py
@@ -423,7 +423,8 @@ class build_ext(_build_ext):
         )
 
         destination = os.path.dirname(os.path.abspath(self.get_ext_fullpath(ext.name)))
-        subprocess.check_call(["go", "mod", "tidy"])
+        subprocess.check_call(["go", "install", "golang.org/x/tools/cmd/goimports"])
+        subprocess.check_call(["go", "install", "github.com/go-python/gopy@v0.4.0"])
         subprocess.check_call(
             [
                 "gopy",

--- a/setup.py
+++ b/setup.py
@@ -424,7 +424,7 @@ class build_ext(_build_ext):
 
         destination = os.path.dirname(os.path.abspath(self.get_ext_fullpath(ext.name)))
         subprocess.check_call(["go", "install", "golang.org/x/tools/cmd/goimports"])
-        subprocess.check_call(["go", "install", "github.com/go-python/gopy"])
+        subprocess.check_call(["go", "install", "github.com/feast-dev/gopy"])
         subprocess.check_call(
             [
                 "gopy",

--- a/setup.py
+++ b/setup.py
@@ -408,6 +408,7 @@ class build_ext(_build_ext):
         )
 
     def build_extension(self, ext: Extension):
+        print(f"Building extension {ext}")
         if not self._is_go_ext(ext):
             # the base class may mutate `self.compiler`
             compiler = copy.deepcopy(self.compiler)
@@ -423,8 +424,8 @@ class build_ext(_build_ext):
         )
 
         destination = os.path.dirname(os.path.abspath(self.get_ext_fullpath(ext.name)))
-        subprocess.check_call(["go", "install", "golang.org/x/tools/cmd/goimports"])
-        subprocess.check_call(["go", "install", "github.com/go-python/gopy@v0.4.0"])
+        subprocess.check_call(["go", "mod", "tidy"], env={"PATH": bin_path, **go_env})
+        # subprocess.check_call(["go", "install", "github.com/go-python/gopy@v0.4.0"])
         subprocess.check_call(
             [
                 "gopy",
@@ -456,6 +457,7 @@ class build_ext(_build_ext):
             src_dir = os.path.join(self.build_lib, src_dir)
 
             # copy whole directory
+            print(f"Copying from {src_dir} to {dest_dir}")
             copy_tree(src_dir, dest_dir)
 
 

--- a/setup.py
+++ b/setup.py
@@ -423,8 +423,7 @@ class build_ext(_build_ext):
         )
 
         destination = os.path.dirname(os.path.abspath(self.get_ext_fullpath(ext.name)))
-        subprocess.check_call(["go", "install", "golang.org/x/tools/cmd/goimports"])
-        subprocess.check_call(["go", "install", "github.com/feast-dev/gopy"])
+        subprocess.check_call(["go", "mod", "tidy"])
         subprocess.check_call(
             [
                 "gopy",


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
In `go.mod`, we're replacing `go-python/gopy` with `feast-dev/gopy`, but for whatever reason we don't do the same thing in `setup.py` or `Makefile`. This results in us using a different version of gopy from the one that will actually work (i.e. our fork). 

This was made worse by the face the the upstream repo landed a bunch of commits and the new version of that project totally borked our build process.

I *think* this should fix the release pipeline (https://github.com/feast-dev/feast/runs/6993658741?check_suite_focus=true) as well as the flaky test (#2830)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
