### PR TITLE
fix: Explicitly translate errors when instantiating the go fs 

### DIFF
--- a/sdk/python/tests/integration/e2e/test_go_feature_server.py
+++ b/sdk/python/tests/integration/e2e/test_go_feature_server.py
@@ -122,7 +122,7 @@ def grpc_client(grpc_server_port):
 
 
 @pytest.mark.integration
-# @pytest.mark.goserver Disabling because the go fs tests are flaking in CI. TODO(achals): uncomment after fixed.
+@pytest.mark.goserver
 def test_go_grpc_server(grpc_client):
     resp: GetOnlineFeaturesResponse = grpc_client.GetOnlineFeatures(
         GetOnlineFeaturesRequest(
@@ -148,7 +148,7 @@ def test_go_grpc_server(grpc_client):
 
 
 @pytest.mark.integration
-# @pytest.mark.goserver Disabling because the go fs tests are flaking in CI. TODO(achals): uncomment after fixed.
+@pytest.mark.goserver
 def test_go_http_server(http_server_port):
     response = requests.post(
         f"http://localhost:{http_server_port}/get-online-features",
@@ -186,7 +186,7 @@ def test_go_http_server(http_server_port):
 
 
 @pytest.mark.integration
-# @pytest.mark.goserver Disabling because the go fs tests are flaking in CI. TODO(achals): uncomment after fixed.
+@pytest.mark.goserver
 @pytest.mark.universal_offline_stores
 @pytest.mark.parametrize("full_feature_names", [True, False], ids=lambda v: str(v))
 def test_feature_logging(

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -443,7 +443,7 @@ def test_online_retrieval_with_event_timestamps(
 
 @pytest.mark.integration
 @pytest.mark.universal_online_stores
-# @pytest.mark.goserver Disabling because the go fs tests are flaking in CI. TODO(achals): uncomment after fixed.
+@pytest.mark.goserver
 @pytest.mark.parametrize("full_feature_names", [True, False], ids=lambda v: str(v))
 def test_stream_feature_view_online_retrieval(
     environment, universal_data_sources, feature_server_endpoint, full_feature_names
@@ -519,7 +519,7 @@ def test_stream_feature_view_online_retrieval(
 
 @pytest.mark.integration
 @pytest.mark.universal_online_stores
-# @pytest.mark.goserver Disabling because the go fs tests are flaking in CI. TODO(achals): uncomment after fixed.
+@pytest.mark.goserver
 @pytest.mark.parametrize("full_feature_names", [True, False], ids=lambda v: str(v))
 def test_online_retrieval(
     environment, universal_data_sources, feature_server_endpoint, full_feature_names


### PR DESCRIPTION
Also convert bool params when calling the transformation callback, since typeguard doesn't like type-unsafe funny business.

Signed-off-by: Achal Shah <achals@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
