### PR TITLE
feat: Add simple TLS support in Go RedisOnlineStore

### DIFF
--- a/go/internal/feast/onlinestore/redisonlinestore_test.go
+++ b/go/internal/feast/onlinestore/redisonlinestore_test.go
@@ -1,0 +1,53 @@
+package onlinestore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRedisOnlineStore(t *testing.T) {
+	var config = map[string]interface{}{
+		"connection_string": "redis://localhost:6379",
+	}
+	store, err := NewRedisOnlineStore("test", config)
+	assert.Nil(t, err)
+	var opts = store.client.Options()
+	assert.Equal(t, opts.Addr, "redis://localhost:6379")
+	assert.Equal(t, opts.Password, "")
+	assert.Equal(t, opts.DB, 0)
+	assert.Nil(t, opts.TLSConfig)
+}
+
+func TestNewRedisOnlineStoreWithPassword(t *testing.T) {
+	var config = map[string]interface{}{
+		"connection_string": "redis://localhost:6379,password=secret",
+	}
+	store, err := NewRedisOnlineStore("test", config)
+	assert.Nil(t, err)
+	var opts = store.client.Options()
+	assert.Equal(t, opts.Addr, "redis://localhost:6379")
+	assert.Equal(t, opts.Password, "secret")
+}
+
+func TestNewRedisOnlineStoreWithDB(t *testing.T) {
+	var config = map[string]interface{}{
+		"connection_string": "redis://localhost:6379,db=1",
+	}
+	store, err := NewRedisOnlineStore("test", config)
+	assert.Nil(t, err)
+	var opts = store.client.Options()
+	assert.Equal(t, opts.Addr, "redis://localhost:6379")
+	assert.Equal(t, opts.DB, 1)
+}
+
+func TestNewRedisOnlineStoreWithSsl(t *testing.T) {
+	var config = map[string]interface{}{
+		"connection_string": "redis://localhost:6379,ssl=true",
+	}
+	store, err := NewRedisOnlineStore("test", config)
+	assert.Nil(t, err)
+	var opts = store.client.Options()
+	assert.Equal(t, opts.Addr, "redis://localhost:6379")
+	assert.NotNil(t, opts.TLSConfig)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This will allow users to append ',ssl=True' to their connection string in order to enable TLS/SSL support in the Go Redis client. It looks like this was an intended feature that just hasn't been implemented yet.

Per the go-redis docs: 'To enable TLS/SSL, you need to provide an empty tls.Config.' https://redis.uptrace.dev/guide/go-redis.html#using-tls