### PR TITLE
fix: Stop running go mod tidy in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -434,8 +434,6 @@ class build_ext(_build_ext):
                               env={"PATH": bin_path, **go_env})
         subprocess.check_call(["go", "install", "github.com/go-python/gopy"],
                               env={"PATH": bin_path, **go_env})
-        subprocess.check_call(["go", "mod", "tidy"],
-                              env={"PATH": bin_path, **go_env})
         subprocess.check_call(
             [
                 "gopy",


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

This fixes a problem similar to https://github.com/pypa/cibuildwheel/issues/189#issuecomment-549933912.

Running `go mod tidy` was updating `go.mod` and `go.sum`, which was causeing cibuildwheel to produce dirty builds. This comamnd isn't really even needed, so nixing it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
