### PR TITLE
fix: Change numpy version on setup.py and upgrade it to resolve dependabot warning

### DIFF
--- a/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
+++ b/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 
 WORKDIR /usr/src/
 

--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -384,7 +384,7 @@ nbformat==5.4.0
     # via great-expectations
 nodeenv==1.6.0
     # via pre-commit
-numpy==1.21.6
+numpy==1.22.0
     # via
     #   altair
     #   feast (setup.py)

--- a/sdk/python/requirements/py3.10-requirements.txt
+++ b/sdk/python/requirements/py3.10-requirements.txt
@@ -89,7 +89,7 @@ mypy==0.961
     # via sqlalchemy
 mypy-extensions==0.4.3
     # via mypy
-numpy==1.21.6
+numpy==1.22.0
     # via
     #   feast (setup.py)
     #   pandas

--- a/sdk/python/requirements/py3.8-ci-requirements.txt
+++ b/sdk/python/requirements/py3.8-ci-requirements.txt
@@ -390,7 +390,7 @@ nbformat==5.4.0
     # via great-expectations
 nodeenv==1.6.0
     # via pre-commit
-numpy==1.21.6
+numpy==1.22.0
     # via
     #   altair
     #   feast (setup.py)

--- a/sdk/python/requirements/py3.8-requirements.txt
+++ b/sdk/python/requirements/py3.8-requirements.txt
@@ -91,7 +91,7 @@ mypy==0.961
     # via sqlalchemy
 mypy-extensions==0.4.3
     # via mypy
-numpy==1.21.6
+numpy==1.22.0
     # via
     #   feast (setup.py)
     #   pandas

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -384,7 +384,7 @@ nbformat==5.4.0
     # via great-expectations
 nodeenv==1.6.0
     # via pre-commit
-numpy==1.21.6
+numpy==1.22.0
     # via
     #   altair
     #   feast (setup.py)

--- a/sdk/python/requirements/py3.9-requirements.txt
+++ b/sdk/python/requirements/py3.9-requirements.txt
@@ -89,7 +89,7 @@ mypy==0.961
     # via sqlalchemy
 mypy-extensions==0.4.3
     # via mypy
-numpy==1.21.6
+numpy==1.22.0
     # via
     #   feast (setup.py)
     #   pandas

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ REQUIRED = [
     "Jinja2>=2,<4",
     "jsonschema",
     "mmh3",
-    "numpy<1.22,<2",
+    "numpy>=1.22,<2",
     "pandas>=1,<2",
     "pandavro==1.5.*",
     "protobuf>=3.10,<3.20",


### PR DESCRIPTION
**What this PR does / why we need it**:
Dependabot cannot update numpy to a non-vulnerable version because the numpy version is pinned on setup.py, and it looks like numpy version was wrongly pinned by a recent change introduced on PR https://github.com/feast-dev/feast/pull/2647

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
