### PR TITLE
fix: Fix macos wheel version for 310 and also checkout edited go files

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -86,6 +86,8 @@ jobs:
         env:
           CIBW_BUILD: "cp310-macosx_x86_64"
           CIBW_ARCHS: "native"
+          CIBW_ENVIRONMENT: >
+            _PYTHON_HOST_PLATFORM=macosx-10.15-x86_64
       - uses: actions/upload-artifact@v2
         with:
           name: wheels

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -86,8 +86,10 @@ jobs:
         env:
           CIBW_BUILD: "cp310-macosx_x86_64"
           CIBW_ARCHS: "native"
+          # Need this environment variable because of this issue: https://github.com/pypa/cibuildwheel/issues/952.
           CIBW_ENVIRONMENT: >
             _PYTHON_HOST_PLATFORM=macosx-10.15-x86_64
+          # There's a `git restore` in here because remnant go.mod, go.sum changes from the build mess up the wheel naming.
           CIBW_BEFORE_BUILD: |
             git status
             git restore go.mod go.sum

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -56,29 +56,29 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Build UI
         run: make build-ui
-      # - name: Build wheels
-      #   uses: pypa/cibuildwheel@v2.7.0
-      #   env:
-      #     CIBW_BUILD: "cp3*_x86_64"
-      #     CIBW_SKIP: "cp36-* *-musllinux_x86_64 cp310-macosx_x86_64"
-      #     CIBW_ARCHS: "native"
-      #     CIBW_ENVIRONMENT: >
-      #       COMPILE_GO=True PATH=$PATH:/usr/local/go/bin
-      #     CIBW_BEFORE_ALL_LINUX: |
-      #       curl -o go.tar.gz https://dl.google.com/go/go1.18.2.linux-amd64.tar.gz
-      #       tar -C /usr/local -xzf go.tar.gz
-      #       go version
-      #     CIBW_BEFORE_ALL_MACOS: |
-      #       curl -o python.pkg https://www.python.org/ftp/python/3.9.12/python-3.9.12-macosx10.9.pkg
-      #       sudo installer -pkg python.pkg -target /
-      #     # There's a `git restore` in here because `make install-go-ci-dependencies` is actually messing up go.mod & go.sum.
-      #     CIBW_BEFORE_BUILD: |
-      #       make install-protoc-dependencies
-      #       make install-go-proto-dependencies
-      #       make install-go-ci-dependencies
-      #       git status
-      #       git restore go.mod go.sum
-      #     CIBW_BEFORE_TEST: "cd {project} && git status"
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.7.0
+        env:
+          CIBW_BUILD: "cp3*_x86_64"
+          CIBW_SKIP: "cp36-* *-musllinux_x86_64 cp310-macosx_x86_64"
+          CIBW_ARCHS: "native"
+          CIBW_ENVIRONMENT: >
+            COMPILE_GO=True PATH=$PATH:/usr/local/go/bin
+          CIBW_BEFORE_ALL_LINUX: |
+            curl -o go.tar.gz https://dl.google.com/go/go1.18.2.linux-amd64.tar.gz
+            tar -C /usr/local -xzf go.tar.gz
+            go version
+          CIBW_BEFORE_ALL_MACOS: |
+            curl -o python.pkg https://www.python.org/ftp/python/3.9.12/python-3.9.12-macosx10.9.pkg
+            sudo installer -pkg python.pkg -target /
+          # There's a `git restore` in here because `make install-go-ci-dependencies` is actually messing up go.mod & go.sum.
+          CIBW_BEFORE_BUILD: |
+            make install-protoc-dependencies
+            make install-go-proto-dependencies
+            make install-go-ci-dependencies
+            git status
+            git restore go.mod go.sum
+          CIBW_BEFORE_TEST: "cd {project} && git status"
       # py3.10 on MacOS does not work with Go so we have to install separately. Issue is tracked here: https://github.com/feast-dev/feast/issues/2881.
       - name: Build py310 specific wheels for macos
         if: matrix.os == 'macos-10.15'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -56,29 +56,29 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Build UI
         run: make build-ui
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.7.0
-        env:
-          CIBW_BUILD: "cp3*_x86_64"
-          CIBW_SKIP: "cp36-* *-musllinux_x86_64 cp310-macosx_x86_64"
-          CIBW_ARCHS: "native"
-          CIBW_ENVIRONMENT: >
-            COMPILE_GO=True PATH=$PATH:/usr/local/go/bin
-          CIBW_BEFORE_ALL_LINUX: |
-            curl -o go.tar.gz https://dl.google.com/go/go1.18.2.linux-amd64.tar.gz
-            tar -C /usr/local -xzf go.tar.gz
-            go version
-          CIBW_BEFORE_ALL_MACOS: |
-            curl -o python.pkg https://www.python.org/ftp/python/3.9.12/python-3.9.12-macosx10.9.pkg
-            sudo installer -pkg python.pkg -target /
-          # There's a `git restore` in here because `make install-go-ci-dependencies` is actually messing up go.mod & go.sum.
-          CIBW_BEFORE_BUILD: |
-            make install-protoc-dependencies
-            make install-go-proto-dependencies
-            make install-go-ci-dependencies
-            git status
-            git restore go.mod go.sum
-          CIBW_BEFORE_TEST: "cd {project} && git status"
+      # - name: Build wheels
+      #   uses: pypa/cibuildwheel@v2.7.0
+      #   env:
+      #     CIBW_BUILD: "cp3*_x86_64"
+      #     CIBW_SKIP: "cp36-* *-musllinux_x86_64 cp310-macosx_x86_64"
+      #     CIBW_ARCHS: "native"
+      #     CIBW_ENVIRONMENT: >
+      #       COMPILE_GO=True PATH=$PATH:/usr/local/go/bin
+      #     CIBW_BEFORE_ALL_LINUX: |
+      #       curl -o go.tar.gz https://dl.google.com/go/go1.18.2.linux-amd64.tar.gz
+      #       tar -C /usr/local -xzf go.tar.gz
+      #       go version
+      #     CIBW_BEFORE_ALL_MACOS: |
+      #       curl -o python.pkg https://www.python.org/ftp/python/3.9.12/python-3.9.12-macosx10.9.pkg
+      #       sudo installer -pkg python.pkg -target /
+      #     # There's a `git restore` in here because `make install-go-ci-dependencies` is actually messing up go.mod & go.sum.
+      #     CIBW_BEFORE_BUILD: |
+      #       make install-protoc-dependencies
+      #       make install-go-proto-dependencies
+      #       make install-go-ci-dependencies
+      #       git status
+      #       git restore go.mod go.sum
+      #     CIBW_BEFORE_TEST: "cd {project} && git status"
       # py3.10 on MacOS does not work with Go so we have to install separately. Issue is tracked here: https://github.com/feast-dev/feast/issues/2881.
       - name: Build py310 specific wheels for macos
         if: matrix.os == 'macos-10.15'

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -88,6 +88,9 @@ jobs:
           CIBW_ARCHS: "native"
           CIBW_ENVIRONMENT: >
             _PYTHON_HOST_PLATFORM=macosx-10.15-x86_64
+          CIBW_BEFORE_BUILD: |
+            git status
+            git restore go.mod go.sum
       - uses: actions/upload-artifact@v2
         with:
           name: wheels


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
Workflow that worked: https://github.com/kevjumba/feast/runs/7117446862?check_suite_focus=true
Also fixes issue where cibuildwheel installs the wheel to macos 10.9 when the environment is 10.15. Issue is here: https://github.com/pypa/cibuildwheel/issues/952
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
