### PR TITLE
fix: Change the feature store plan method to public modifier

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -511,8 +511,8 @@ class FeatureStore:
         return _feature_refs
 
     def _should_use_plan(self):
-        """Returns True if _plan and _apply_diffs should be used, False otherwise."""
-        # Currently only the local provider with sqlite online store supports _plan and _apply_diffs.
+        """Returns True if plan and _apply_diffs should be used, False otherwise."""
+        # Currently only the local provider with sqlite online store supports plan and _apply_diffs.
         return self.config.provider == "local" and (
             self.config.online_store and self.config.online_store.type == "sqlite"
         )
@@ -636,7 +636,7 @@ class FeatureStore:
         return feature_views_to_materialize
 
     @log_exceptions_and_usage
-    def _plan(
+    def plan(
         self, desired_repo_contents: RepoContents
     ) -> Tuple[RegistryDiff, InfraDiff, Infra]:
         """Dry-run registering objects to metadata store.
@@ -670,7 +670,7 @@ class FeatureStore:
             ...     ttl=timedelta(seconds=86400 * 1),
             ...     batch_source=driver_hourly_stats,
             ... )
-            >>> registry_diff, infra_diff, new_infra = fs._plan(RepoContents(
+            >>> registry_diff, infra_diff, new_infra = fs.plan(RepoContents(
             ...     data_sources=[driver_hourly_stats],
             ...     feature_views=[driver_hourly_stats_view],
             ...     on_demand_feature_views=list(),

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -183,7 +183,7 @@ def plan(repo_config: RepoConfig, repo_path: Path, skip_source_validation: bool)
         for data_source in data_sources:
             data_source.validate(store.config)
 
-    registry_diff, infra_diff, _ = store._plan(repo)
+    registry_diff, infra_diff, _ = store.plan(repo)
     click.echo(registry_diff.to_string())
     click.echo(infra_diff.to_string())
 
@@ -262,7 +262,7 @@ def apply_total_with_repo_instance(
         for data_source in data_sources:
             data_source.validate(store.config)
 
-    registry_diff, infra_diff, new_infra = store._plan(repo)
+    registry_diff, infra_diff, new_infra = store.plan(repo)
 
     # For each object in the registry, determine whether it should be kept or deleted.
     (


### PR DESCRIPTION
Signed-off-by: Breno Costa <brenocosta0901@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

According to issue #2895 , the private method `FeatureStore._plan` should be refactored to the public method `FeatureStore.plan` because methods that back a CLI operation should have a public facing programatic API.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2895
