### PR TITLE
fix: Deprecate 3.7 wheels and fix verification workflow

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -66,7 +66,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.7.0
         env:
           CIBW_BUILD: "cp3*_x86_64"
-          CIBW_SKIP: "cp36-* *-musllinux_x86_64 cp310-macosx_x86_64"
+          CIBW_SKIP: "cp36-* cp37-* *-musllinux_x86_64 cp310-macosx_x86_64"
           CIBW_ARCHS: "native"
           CIBW_ENVIRONMENT: >
             COMPILE_GO=True PATH=$PATH:/usr/local/go/bin
@@ -150,7 +150,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest,  macos-10.15 ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10"]
+        python-version: [ "3.8", "3.9", "3.10"]
         from-source: [ True, False ]
     env:
       # this script is for testing servers

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -187,6 +187,18 @@ jobs:
           cd dist/
           pip install wheel
           for f in *.whl; do pip install $f || true; done
+      - name: Install apache-arrow on ubuntu
+        if: ${{ matrix.from-source && matrix.os == 'ubuntu-latest'}
+        run: |
+            sudo apt update
+            sudo apt install -y -V ca-certificates lsb-release wget
+            wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+            sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+            sudo apt update
+            sudo apt install -y -V libarrow-dev
+      - name: Install apache-arrow on macos
+        if: ${{ matrix.from-source && matrix.os == 'macOS-latest' && matrix.python-version != '3.10' }}
+        run: brew install apache-arrow
       - name: Install dist with go
         if: ${{ matrix.from-source && (matrix.python-version != '3.10' || matrix.os == 'ubuntu-latest')}}
         env:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -197,7 +197,7 @@ jobs:
             sudo apt update
             sudo apt install -y -V libarrow-dev
       - name: Install apache-arrow on macos
-        if: ${{ matrix.from-source && matrix.os == 'macOS-latest' && matrix.python-version != '3.10' }}
+        if: ${{ matrix.from-source && matrix.os == 'macos-10.15' && matrix.python-version != '3.10' }}
         run: brew install apache-arrow
       - name: Install dist with go
         if: ${{ matrix.from-source && (matrix.python-version != '3.10' || matrix.os == 'ubuntu-latest')}}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -188,7 +188,7 @@ jobs:
           pip install wheel
           for f in *.whl; do pip install $f || true; done
       - name: Install apache-arrow on ubuntu
-        if: ${{ matrix.from-source && matrix.os == 'ubuntu-latest'}
+        if: ${{ matrix.from-source && matrix.os == 'ubuntu-latest' }}
         run: |
             sudo apt update
             sudo apt install -y -V ca-certificates lsb-release wget


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
3.7 is getting deprecated and our numpy dependency no longer supports 3.7. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
