### PR TITLE
chore: Remove UI from quickstart colab 

### DIFF
--- a/examples/quickstart/quickstart.ipynb
+++ b/examples/quickstart/quickstart.ipynb
@@ -952,45 +952,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "_dBcqkaCnOYv"
-      },
-      "source": [
-        "## Step 7: Explore registered features with the Web UI"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 21,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 52
-        },
-        "id": "mCUPypyhl5TH",
-        "outputId": "fb2475c3-b254-42e6-b638-7982d52d2a19"
-      },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "nohup: appending output to 'nohup.out'\n",
-            "Open the Web UI at https://c6cuffvc4qm-496ff2e9c6d22116-8888-colab.googleusercontent.com/\n"
-          ]
-        }
-      ],
-      "source": [
-        "from google.colab.output import eval_js\n",
-        "host = eval_js(\"google.colab.kernel.proxyPort(8888)\")\n",
-        "\n",
-        "!nohup feast ui &\n",
-        "\n",
-        "print(f\"Open the Web UI at {host}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "lg68gH2sy6H1"
       },
       "source": [


### PR DESCRIPTION
since Colab only supports Python 3.7 (and Feast deprecated Python 3.7). This means Colab isn't installing the latest versions of Feast (which fix issues in the UI).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
