### PR TITLE
fix: Add dummy alias to pull_all_from_table_or_query

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
@@ -214,7 +214,7 @@ class PostgreSQLOfflineStore(OfflineStore):
 
         query = f"""
             SELECT {field_string}
-            FROM {from_expression}
+            FROM {from_expression} AS paftoq_alias
             WHERE "{timestamp_field}" BETWEEN '{start_date}'::timestamptz AND '{end_date}'::timestamptz
         """
 

--- a/sdk/python/tests/unit/infra/test_key_encoding_utils.py
+++ b/sdk/python/tests/unit/infra/test_key_encoding_utils.py
@@ -9,14 +9,14 @@ def test_serialize_entity_key():
     # Should be fine
     serialize_entity_key(
         EntityKeyProto(
-            join_keys=["user"], entity_values=[ValueProto(int64_val=int(2 ** 15))]
+            join_keys=["user"], entity_values=[ValueProto(int64_val=int(2**15))]
         ),
         entity_key_serialization_version=2,
     )
     # True int64, but should also be fine.
     serialize_entity_key(
         EntityKeyProto(
-            join_keys=["user"], entity_values=[ValueProto(int64_val=int(2 ** 31))]
+            join_keys=["user"], entity_values=[ValueProto(int64_val=int(2**31))]
         ),
         entity_key_serialization_version=2,
     )
@@ -25,6 +25,6 @@ def test_serialize_entity_key():
     with pytest.raises(BaseException):
         serialize_entity_key(
             EntityKeyProto(
-                join_keys=["user"], entity_values=[ValueProto(int64_val=int(2 ** 31))]
+                join_keys=["user"], entity_values=[ValueProto(int64_val=int(2**31))]
             ),
         )


### PR DESCRIPTION
Signed-off-by: Ivan Krizanic <ikrizanic75@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
Fixes missing alias in subquery when using `pull_all_from_table_or_query()` method.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2954 
