### PR TITLE
feat: Add CustomSourceOptions to SavedDatasetStorage

### DIFF
--- a/protos/feast/core/SavedDataset.proto
+++ b/protos/feast/core/SavedDataset.proto
@@ -58,6 +58,7 @@ message SavedDatasetStorage {
     DataSource.SnowflakeOptions snowflake_storage = 7;
     DataSource.TrinoOptions trino_storage = 8;
     DataSource.SparkOptions spark_storage = 9;
+    DataSource.CustomSourceOptions custom_storage = 10;
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I am implementing a custom OfflineStore and found that I couldn't use CustomSourceOptions in
SavedDatasetStorage: currently you'd have to try to fit your custom options into one of the
existing implemented Options structs.