### PR TITLE
chore: Remove gcp requirement for local tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,10 @@ test-python-integration-local:
 			-k "not test_apply_entity_integration and \
 				not test_apply_feature_view_integration and \
 				not test_apply_data_source_integration and \
-				not test_lambda_materialization" \
+				not test_lambda_materialization and \
+				not test_feature_view_inference_success and \
+				not test_update_file_data_source_with_inferred_event_timestamp_col and \
+				not test_nullable_online_store" \
 		sdk/python/tests \
 	) || echo "This script uses Docker, and it isn't running - please start the Docker Daemon and try again!";
 

--- a/sdk/python/tests/example_repos/empty_feature_repo.py
+++ b/sdk/python/tests/example_repos/empty_feature_repo.py
@@ -1,0 +1,3 @@
+# This example feature repo is deliberately left empty. It should be used for tests that do not need
+# any feature views or other objects (for example, a test that checks that a feature service can be
+# applied and retrieved correctly).

--- a/sdk/python/tests/example_repos/example_feature_repo_1.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_1.py
@@ -1,22 +1,26 @@
 from datetime import timedelta
 
-from feast import BigQuerySource, Entity, FeatureService, FeatureView, Field, PushSource
+from feast import Entity, FeatureService, FeatureView, Field, FileSource, PushSource
 from feast.types import Float32, Int64, String
 
-driver_locations_source = BigQuerySource(
-    table="feast-oss.public.drivers",
+# Note that file source paths are not validated, so there doesn't actually need to be any data
+# at the paths for these file sources. Since these paths are effectively fake, this example
+# feature repo should not be used for historical retrieval.
+
+driver_locations_source = FileSource(
+    path="data/driver_locations.parquet",
     timestamp_field="event_timestamp",
     created_timestamp_column="created_timestamp",
 )
 
-customer_profile_source = BigQuerySource(
+customer_profile_source = FileSource(
     name="customer_profile_source",
-    table="feast-oss.public.customers",
+    path="data/customer_profiles.parquet",
     timestamp_field="event_timestamp",
 )
 
-customer_driver_combined_source = BigQuerySource(
-    table="feast-oss.public.customer_driver",
+customer_driver_combined_source = FileSource(
+    path="data/customer_driver_combined.parquet",
     timestamp_field="event_timestamp",
 )
 

--- a/sdk/python/tests/example_repos/example_feature_repo_1.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_1.py
@@ -9,18 +9,6 @@ driver_locations_source = BigQuerySource(
     created_timestamp_column="created_timestamp",
 )
 
-driver_locations_source_query = BigQuerySource(
-    query="SELECT * from feast-oss.public.drivers",
-    timestamp_field="event_timestamp",
-    created_timestamp_column="created_timestamp",
-)
-
-driver_locations_source_query_2 = BigQuerySource(
-    query="SELECT lat * 2 FROM feast-oss.public.drivers",
-    timestamp_field="event_timestamp",
-    created_timestamp_column="created_timestamp",
-)
-
 customer_profile_source = BigQuerySource(
     name="customer_profile_source",
     table="feast-oss.public.customers",

--- a/sdk/python/tests/example_repos/example_feature_repo_with_driver_stats_feature_view.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_with_driver_stats_feature_view.py
@@ -1,0 +1,30 @@
+from datetime import timedelta
+
+from feast import Entity, FeatureView, Field, FileSource
+from feast.types import Float32, Int32, Int64
+
+driver_hourly_stats = FileSource(
+    path="data/driver_stats.parquet",  # Fake path
+    timestamp_field="event_timestamp",
+    created_timestamp_column="created",
+)
+
+driver = Entity(
+    name="driver_id",
+    description="driver id",
+)
+
+driver_hourly_stats_view = FeatureView(
+    name="driver_hourly_stats",
+    entities=[driver],
+    ttl=timedelta(days=1),
+    schema=[
+        Field(name="conv_rate", dtype=Float32),
+        Field(name="acc_rate", dtype=Float32),
+        Field(name="avg_daily_trips", dtype=Int64),
+        Field(name="driver_id", dtype=Int32),
+    ],
+    online=True,
+    source=driver_hourly_stats,
+    tags={},
+)

--- a/sdk/python/tests/example_repos/example_feature_repo_with_feature_service.py
+++ b/sdk/python/tests/example_repos/example_feature_repo_with_feature_service.py
@@ -1,0 +1,36 @@
+from datetime import timedelta
+
+from feast import Entity, FeatureService, FeatureView, Field, FileSource
+from feast.types import Float32, Int64, String
+
+driver_locations_source = FileSource(
+    path="data/driver_locations.parquet",
+    timestamp_field="event_timestamp",
+    created_timestamp_column="created_timestamp",
+)
+
+driver = Entity(
+    name="driver",  # The name is derived from this argument, not object name.
+    join_keys=["driver_id"],
+    description="driver id",
+)
+
+driver_locations = FeatureView(
+    name="driver_locations",
+    entities=[driver],
+    ttl=timedelta(days=1),
+    schema=[
+        Field(name="lat", dtype=Float32),
+        Field(name="lon", dtype=String),
+        Field(name="driver_id", dtype=Int64),
+    ],
+    online=True,
+    batch_source=driver_locations_source,
+    tags={},
+)
+
+all_drivers_feature_service = FeatureService(
+    name="driver_locations_service",
+    features=[driver_locations],
+    tags={"release": "production"},
+)

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 import pytest
 
 from feast import BigQuerySource, Entity, FeatureView, Field
-from feast.feature_service import FeatureService
 from feast.types import Float32, String
 from tests.integration.feature_repos.universal.entities import driver
 from tests.integration.feature_repos.universal.feature_views import driver_feature_view
@@ -72,28 +71,3 @@ def test_partial() -> None:
 
         basic_rw_test(store, view_name="driver_locations")
         basic_rw_test(store, view_name="driver_locations_100")
-
-
-@pytest.mark.integration
-def test_read_pre_applied() -> None:
-    """
-    Read feature values from the FeatureStore using a FeatureService.
-    """
-    runner = CliRunner()
-    with runner.local_repo(
-        get_example_repo("example_feature_repo_1.py"), "bigquery"
-    ) as store:
-
-        assert len(store.list_feature_services()) == 1
-        fs = store.get_feature_service("driver_locations_service")
-        assert len(fs.tags) == 1
-        assert fs.tags["release"] == "production"
-
-        fv = store.get_feature_view("driver_locations")
-
-        fs = FeatureService(name="new_feature_service", features=[fv[["lon"]]])
-
-        store.apply([fs])
-
-        assert len(store.list_feature_services()) == 2
-        store.get_feature_service("new_feature_service")

--- a/sdk/python/tests/integration/e2e/test_universal_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_universal_e2e.py
@@ -2,12 +2,8 @@ from datetime import timedelta
 
 import pytest
 
-from feast import BigQuerySource, Entity, FeatureView, Field
-from feast.types import Float32, String
 from tests.integration.feature_repos.universal.entities import driver
 from tests.integration.feature_repos.universal.feature_views import driver_feature_view
-from tests.utils.basic_read_write_test import basic_rw_test
-from tests.utils.cli_repo_creator import CliRunner, get_example_repo
 from tests.utils.e2e_test_validation import validate_offline_online_store_consistency
 
 
@@ -31,43 +27,3 @@ def test_e2e_consistency(environment, e2e_data_sources, infer_features):
     split_dt = df["ts_1"][4].to_pydatetime() - timedelta(seconds=1)
 
     validate_offline_online_store_consistency(fs, fv, split_dt)
-
-
-@pytest.mark.integration
-def test_partial() -> None:
-    """
-    Add another table to existing repo using partial apply API. Make sure both the table
-    applied via CLI apply and the new table are passing RW test.
-    """
-
-    runner = CliRunner()
-    with runner.local_repo(
-        get_example_repo("example_feature_repo_1.py"), "bigquery"
-    ) as store:
-        driver = Entity(name="driver", join_keys=["test"])
-
-        driver_locations_source = BigQuerySource(
-            table="feast-oss.public.drivers",
-            timestamp_field="event_timestamp",
-            created_timestamp_column="created_timestamp",
-        )
-
-        driver_locations_100 = FeatureView(
-            name="driver_locations_100",
-            entities=[driver],
-            ttl=timedelta(days=1),
-            schema=[
-                Field(name="lat", dtype=Float32),
-                Field(name="lon", dtype=String),
-                Field(name="name", dtype=String),
-                Field(name="test", dtype=String),
-            ],
-            online=True,
-            batch_source=driver_locations_source,
-            tags={},
-        )
-
-        store.apply([driver_locations_100])
-
-        basic_rw_test(store, view_name="driver_locations")
-        basic_rw_test(store, view_name="driver_locations_100")

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -75,11 +75,11 @@ REDIS_CLUSTER_CONFIG = {
 
 SNOWFLAKE_CONFIG = {
     "type": "snowflake.online",
-    "account": os.environ["SNOWFLAKE_CI_DEPLOYMENT"],
-    "user": os.environ["SNOWFLAKE_CI_USER"],
-    "password": os.environ["SNOWFLAKE_CI_PASSWORD"],
-    "role": os.environ["SNOWFLAKE_CI_ROLE"],
-    "warehouse": os.environ["SNOWFLAKE_CI_WAREHOUSE"],
+    "account": os.environ.get("SNOWFLAKE_CI_DEPLOYMENT", ""),
+    "user": os.environ.get("SNOWFLAKE_CI_USER", ""),
+    "password": os.environ.get("SNOWFLAKE_CI_PASSWORD", ""),
+    "role": os.environ.get("SNOWFLAKE_CI_ROLE", ""),
+    "warehouse": os.environ.get("SNOWFLAKE_CI_WAREHOUSE", ""),
     "database": "FEAST",
     "schema": "ONLINE",
 }

--- a/sdk/python/tests/integration/online_store/test_online_retrieval.py
+++ b/sdk/python/tests/integration/online_store/test_online_retrieval.py
@@ -21,7 +21,7 @@ def test_online() -> None:
     """
     runner = CliRunner()
     with runner.local_repo(
-        get_example_repo("example_feature_repo_1.py"), "bigquery"
+        get_example_repo("example_feature_repo_1.py"), "file"
     ) as store:
         # Write some data to two tables
 
@@ -268,7 +268,7 @@ def test_online_to_df():
 
     runner = CliRunner()
     with runner.local_repo(
-        get_example_repo("example_feature_repo_1.py"), "bigquery"
+        get_example_repo("example_feature_repo_1.py"), "file"
     ) as store:
         # Write three tables to online store
         driver_locations_fv = store.get_feature_view(name="driver_locations")

--- a/sdk/python/tests/integration/online_store/test_online_retrieval.py
+++ b/sdk/python/tests/integration/online_store/test_online_retrieval.py
@@ -24,7 +24,6 @@ def test_online() -> None:
         get_example_repo("example_feature_repo_1.py"), "file"
     ) as store:
         # Write some data to two tables
-
         driver_locations_fv = store.get_feature_view(name="driver_locations")
         customer_profile_fv = store.get_feature_view(name="customer_profile")
         customer_driver_combined_fv = store.get_feature_view(

--- a/sdk/python/tests/integration/registration/test_universal_cli.py
+++ b/sdk/python/tests/integration/registration/test_universal_cli.py
@@ -159,7 +159,7 @@ def test_nullable_online_store(test_nullable_online_store) -> None:
             repo_config.write_text(dedent(feature_store_yaml))
 
             repo_example = repo_path / "example.py"
-            repo_example.write_text(get_example_repo("example_feature_repo_1.py"))
+            repo_example.write_text(get_example_repo("empty_feature_repo.py"))
             result = runner.run(["apply"], cwd=repo_path)
             assertpy.assert_that(result.returncode).is_equal_to(0)
         finally:

--- a/sdk/python/tests/unit/cli/test_cli_apply_duplicates.py
+++ b/sdk/python/tests/unit/cli/test_cli_apply_duplicates.py
@@ -49,9 +49,8 @@ def run_simple_apply_test(example_repo_file_name: str, expected_error: bytes):
 
 def test_cli_apply_imported_featureview() -> None:
     """
-    Test apply feature views with duplicated names and single py file in a feature repo using CLI
+    Tests that applying a feature view imported from a separate Python file is successful.
     """
-
     with tempfile.TemporaryDirectory() as repo_dir_name, tempfile.TemporaryDirectory() as data_dir_name:
         runner = CliRunner()
         # Construct an example repo in a temporary dir
@@ -72,6 +71,7 @@ def test_cli_apply_imported_featureview() -> None:
             )
         )
 
+        # Import feature view from an existing file so it exists in two files.
         repo_example = repo_path / "example.py"
         repo_example.write_text(get_example_repo("example_feature_repo_2.py"))
         repo_example_2 = repo_path / "example_2.py"
@@ -92,9 +92,9 @@ def test_cli_apply_imported_featureview() -> None:
 
 def test_cli_apply_imported_featureview_with_duplication() -> None:
     """
-    Test apply feature views with duplicated names and single py file in a feature repo using CLI
+    Tests that applying feature views with duplicated names is not possible, even if one of the
+    duplicated feature views is imported from another file.
     """
-
     with tempfile.TemporaryDirectory() as repo_dir_name, tempfile.TemporaryDirectory() as data_dir_name:
         runner = CliRunner()
         # Construct an example repo in a temporary dir
@@ -115,6 +115,7 @@ def test_cli_apply_imported_featureview_with_duplication() -> None:
             )
         )
 
+        # Import feature view with duplicated name to try breaking the deduplication logic.
         repo_example = repo_path / "example.py"
         repo_example.write_text(get_example_repo("example_feature_repo_2.py"))
         repo_example_2 = repo_path / "example_2.py"
@@ -147,7 +148,6 @@ def test_cli_apply_duplicated_featureview_names_multiple_py_files() -> None:
     """
     Test apply feature views with duplicated names from multiple py files in a feature repo using CLI
     """
-
     with tempfile.TemporaryDirectory() as repo_dir_name, tempfile.TemporaryDirectory() as data_dir_name:
         runner = CliRunner()
         # Construct an example repo in a temporary dir

--- a/sdk/python/tests/unit/cli/test_cli_apply_duplicates.py
+++ b/sdk/python/tests/unit/cli/test_cli_apply_duplicates.py
@@ -73,7 +73,9 @@ def test_cli_apply_imported_featureview() -> None:
 
         # Import feature view from an existing file so it exists in two files.
         repo_example = repo_path / "example.py"
-        repo_example.write_text(get_example_repo("example_feature_repo_2.py"))
+        repo_example.write_text(
+            get_example_repo("example_feature_repo_with_driver_stats_feature_view.py")
+        )
         repo_example_2 = repo_path / "example_2.py"
         repo_example_2.write_text(
             "from example import driver_hourly_stats_view\n"
@@ -117,7 +119,9 @@ def test_cli_apply_imported_featureview_with_duplication() -> None:
 
         # Import feature view with duplicated name to try breaking the deduplication logic.
         repo_example = repo_path / "example.py"
-        repo_example.write_text(get_example_repo("example_feature_repo_2.py"))
+        repo_example.write_text(
+            get_example_repo("example_feature_repo_with_driver_stats_feature_view.py")
+        )
         repo_example_2 = repo_path / "example_2.py"
         repo_example_2.write_text(
             "from datetime import timedelta\n"
@@ -170,7 +174,11 @@ def test_cli_apply_duplicated_featureview_names_multiple_py_files() -> None:
         # Create multiple py files containing the same feature view name
         for i in range(3):
             repo_example = repo_path / f"example{i}.py"
-            repo_example.write_text(get_example_repo("example_feature_repo_2.py"))
+            repo_example.write_text(
+                get_example_repo(
+                    "example_feature_repo_with_driver_stats_feature_view.py"
+                )
+            )
         rc, output = runner.run_with_output(["apply"], cwd=repo_path)
 
         assert (

--- a/sdk/python/tests/unit/local_feast_tests/test_feature_service_apply.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_feature_service_apply.py
@@ -1,5 +1,5 @@
 from feast.feature_service import FeatureService
-from tests.utils.cli_utils import CliRunner, get_example_repo
+from tests.utils.cli_repo_creator import CliRunner, get_example_repo
 
 
 def test_read_pre_applied() -> None:

--- a/sdk/python/tests/unit/local_feast_tests/test_feature_service_apply.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_feature_service_apply.py
@@ -1,0 +1,29 @@
+import pytest
+
+from feast.feature_service import FeatureService
+from tests.utils.cli_utils import CliRunner, get_example_repo
+
+
+@pytest.mark.integration
+def test_read_pre_applied() -> None:
+    """
+    Read feature values from the FeatureStore using a FeatureService.
+    """
+    runner = CliRunner()
+    with runner.local_repo(
+        get_example_repo("example_feature_repo_1.py"), "file"
+    ) as store:
+
+        assert len(store.list_feature_services()) == 1
+        fs = store.get_feature_service("driver_locations_service")
+        assert len(fs.tags) == 1
+        assert fs.tags["release"] == "production"
+
+        fv = store.get_feature_view("driver_locations")
+
+        fs = FeatureService(name="new_feature_service", features=[fv[["lon"]]])
+
+        store.apply([fs])
+
+        assert len(store.list_feature_services()) == 2
+        store.get_feature_service("new_feature_service")

--- a/sdk/python/tests/unit/local_feast_tests/test_feature_service_apply.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_feature_service_apply.py
@@ -8,7 +8,7 @@ def test_read_pre_applied() -> None:
     """
     runner = CliRunner()
     with runner.local_repo(
-        get_example_repo("example_feature_repo_1.py"), "file"
+        get_example_repo("example_feature_repo_with_feature_service.py"), "file"
     ) as store:
         assert len(store.list_feature_services()) == 1
         fs = store.get_feature_service("driver_locations_service")

--- a/sdk/python/tests/unit/local_feast_tests/test_feature_service_apply.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_feature_service_apply.py
@@ -1,10 +1,7 @@
-import pytest
-
 from feast.feature_service import FeatureService
 from tests.utils.cli_utils import CliRunner, get_example_repo
 
 
-@pytest.mark.integration
 def test_read_pre_applied() -> None:
     """
     Read feature values from the FeatureStore using a FeatureService.

--- a/sdk/python/tests/unit/local_feast_tests/test_feature_service_apply.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_feature_service_apply.py
@@ -10,7 +10,6 @@ def test_read_pre_applied() -> None:
     with runner.local_repo(
         get_example_repo("example_feature_repo_1.py"), "file"
     ) as store:
-
         assert len(store.list_feature_services()) == 1
         fs = store.get_feature_service("driver_locations_service")
         assert len(fs.tags) == 1

--- a/sdk/python/tests/unit/local_feast_tests/test_feature_service_read.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_feature_service_read.py
@@ -8,7 +8,7 @@ def test_feature_service_read() -> None:
     """
     runner = CliRunner()
     with runner.local_repo(
-        get_example_repo("example_feature_repo_1.py"), "file"
+        get_example_repo("example_feature_repo_with_feature_service.py"), "file"
     ) as store:
         basic_rw_test(
             store,

--- a/sdk/python/tests/unit/local_feast_tests/test_feature_service_read.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_feature_service_read.py
@@ -10,7 +10,6 @@ def test_feature_service_read() -> None:
     with runner.local_repo(
         get_example_repo("example_feature_repo_1.py"), "file"
     ) as store:
-
         basic_rw_test(
             store,
             view_name="driver_locations",

--- a/sdk/python/tests/unit/local_feast_tests/test_feature_service_read.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_feature_service_read.py
@@ -12,7 +12,7 @@ def test_feature_service_read() -> None:
 
     runner = CliRunner()
     with runner.local_repo(
-        get_example_repo("example_feature_repo_1.py"), "bigquery"
+        get_example_repo("example_feature_repo_1.py"), "file"
     ) as store:
 
         basic_rw_test(

--- a/sdk/python/tests/unit/local_feast_tests/test_feature_service_read.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_feature_service_read.py
@@ -1,15 +1,11 @@
-import pytest
-
 from tests.utils.basic_read_write_test import basic_rw_test
 from tests.utils.cli_repo_creator import CliRunner, get_example_repo
 
 
-@pytest.mark.integration
 def test_feature_service_read() -> None:
     """
     Read feature values from the FeatureStore using a FeatureService.
     """
-
     runner = CliRunner()
     with runner.local_repo(
         get_example_repo("example_feature_repo_1.py"), "file"

--- a/sdk/python/tests/unit/local_feast_tests/test_stream_feature_view_apply.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_stream_feature_view_apply.py
@@ -1,14 +1,8 @@
-import os
-import tempfile
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from feast.aggregation import Aggregation
 from feast.data_format import AvroFormat
 from feast.data_source import KafkaSource
-from feast.driver_test_data import (
-    create_driver_hourly_stats_df,
-    create_global_daily_stats_df,
-)
 from feast.entity import Entity
 from feast.field import Field
 from feast.stream_feature_view import stream_feature_view
@@ -22,82 +16,65 @@ def test_apply_stream_feature_view(simple_dataset_1) -> None:
     Test apply of StreamFeatureView.
     """
     runner = CliRunner()
-    with tempfile.TemporaryDirectory() as data_dir:
-        # Generate test data.
-        end_date = datetime.now().replace(microsecond=0, second=0, minute=0)
-        start_date = end_date - timedelta(days=15)
+    with runner.local_repo(
+        get_example_repo("empty_feature_repo.py"), "file"
+    ) as fs, prep_file_source(
+        df=simple_dataset_1, timestamp_field="ts_1"
+    ) as file_source:
+        entity = Entity(name="driver_entity", join_keys=["test_key"])
 
-        driver_entities = [1001, 1002, 1003, 1004, 1005]
-        driver_df = create_driver_hourly_stats_df(driver_entities, start_date, end_date)
-        driver_stats_path = os.path.join(data_dir, "driver_stats.parquet")
-        driver_df.to_parquet(path=driver_stats_path, allow_truncated_timestamps=True)
+        stream_source = KafkaSource(
+            name="kafka",
+            timestamp_field="event_timestamp",
+            kafka_bootstrap_servers="",
+            message_format=AvroFormat(""),
+            topic="topic",
+            batch_source=file_source,
+            watermark_delay_threshold=timedelta(days=1),
+        )
 
-        global_df = create_global_daily_stats_df(start_date, end_date)
-        global_stats_path = os.path.join(data_dir, "global_stats.parquet")
-        global_df.to_parquet(path=global_stats_path, allow_truncated_timestamps=True)
+        @stream_feature_view(
+            entities=[entity],
+            ttl=timedelta(days=30),
+            owner="test@example.com",
+            online=True,
+            schema=[Field(name="dummy_field", dtype=Float32)],
+            description="desc",
+            aggregations=[
+                Aggregation(
+                    column="dummy_field",
+                    function="max",
+                    time_window=timedelta(days=1),
+                ),
+                Aggregation(
+                    column="dummy_field2",
+                    function="count",
+                    time_window=timedelta(days=24),
+                ),
+            ],
+            timestamp_field="event_timestamp",
+            mode="spark",
+            source=stream_source,
+            tags={},
+        )
+        def simple_sfv(df):
+            return df
 
-        with runner.local_repo(
-            get_example_repo("example_feature_repo_2.py")
-            .replace("%PARQUET_PATH%", driver_stats_path)
-            .replace("%PARQUET_PATH_GLOBAL%", global_stats_path),
-            "file",
-        ) as fs, prep_file_source(
-            df=simple_dataset_1, timestamp_field="ts_1"
-        ) as file_source:
-            entity = Entity(name="driver_entity", join_keys=["test_key"])
+        fs.apply([entity, simple_sfv])
 
-            stream_source = KafkaSource(
-                name="kafka",
-                timestamp_field="event_timestamp",
-                kafka_bootstrap_servers="",
-                message_format=AvroFormat(""),
-                topic="topic",
-                batch_source=file_source,
-                watermark_delay_threshold=timedelta(days=1),
-            )
+        stream_feature_views = fs.list_stream_feature_views()
+        assert len(stream_feature_views) == 1
+        assert stream_feature_views[0] == simple_sfv
 
-            @stream_feature_view(
-                entities=[entity],
-                ttl=timedelta(days=30),
-                owner="test@example.com",
-                online=True,
-                schema=[Field(name="dummy_field", dtype=Float32)],
-                description="desc",
-                aggregations=[
-                    Aggregation(
-                        column="dummy_field",
-                        function="max",
-                        time_window=timedelta(days=1),
-                    ),
-                    Aggregation(
-                        column="dummy_field2",
-                        function="count",
-                        time_window=timedelta(days=24),
-                    ),
-                ],
-                timestamp_field="event_timestamp",
-                mode="spark",
-                source=stream_source,
-                tags={},
-            )
-            def simple_sfv(df):
-                return df
+        features = fs.get_online_features(
+            features=["simple_sfv:dummy_field"],
+            entity_rows=[{"test_key": 1001}],
+        ).to_dict(include_event_timestamps=True)
 
-            fs.apply([entity, simple_sfv])
-
-            stream_feature_views = fs.list_stream_feature_views()
-            assert len(stream_feature_views) == 1
-            assert stream_feature_views[0] == simple_sfv
-
-            features = fs.get_online_features(
-                features=["simple_sfv:dummy_field"],
-                entity_rows=[{"test_key": 1001}],
-            ).to_dict(include_event_timestamps=True)
-
-            assert "test_key" in features
-            assert features["test_key"] == [1001]
-            assert "dummy_field" in features
-            assert features["dummy_field"] == [None]
+        assert "test_key" in features
+        assert features["test_key"] == [1001]
+        assert "dummy_field" in features
+        assert features["dummy_field"] == [None]
 
 
 def test_stream_feature_view_udf(simple_dataset_1) -> None:
@@ -105,85 +82,68 @@ def test_stream_feature_view_udf(simple_dataset_1) -> None:
     Test apply of StreamFeatureView udfs are serialized correctly and usable.
     """
     runner = CliRunner()
-    with tempfile.TemporaryDirectory() as data_dir:
-        # Generate test data.
-        end_date = datetime.now().replace(microsecond=0, second=0, minute=0)
-        start_date = end_date - timedelta(days=15)
+    with runner.local_repo(
+        get_example_repo("empty_feature_repo.py"), "file"
+    ) as fs, prep_file_source(
+        df=simple_dataset_1, timestamp_field="ts_1"
+    ) as file_source:
+        entity = Entity(name="driver_entity", join_keys=["test_key"])
 
-        driver_entities = [1001, 1002, 1003, 1004, 1005]
-        driver_df = create_driver_hourly_stats_df(driver_entities, start_date, end_date)
-        driver_stats_path = os.path.join(data_dir, "driver_stats.parquet")
-        driver_df.to_parquet(path=driver_stats_path, allow_truncated_timestamps=True)
+        stream_source = KafkaSource(
+            name="kafka",
+            timestamp_field="event_timestamp",
+            kafka_bootstrap_servers="",
+            message_format=AvroFormat(""),
+            topic="topic",
+            batch_source=file_source,
+            watermark_delay_threshold=timedelta(days=1),
+        )
 
-        global_df = create_global_daily_stats_df(start_date, end_date)
-        global_stats_path = os.path.join(data_dir, "global_stats.parquet")
-        global_df.to_parquet(path=global_stats_path, allow_truncated_timestamps=True)
-
-        with runner.local_repo(
-            get_example_repo("example_feature_repo_2.py")
-            .replace("%PARQUET_PATH%", driver_stats_path)
-            .replace("%PARQUET_PATH_GLOBAL%", global_stats_path),
-            "file",
-        ) as fs, prep_file_source(
-            df=simple_dataset_1, timestamp_field="ts_1"
-        ) as file_source:
-            entity = Entity(name="driver_entity", join_keys=["test_key"])
-
-            stream_source = KafkaSource(
-                name="kafka",
-                timestamp_field="event_timestamp",
-                kafka_bootstrap_servers="",
-                message_format=AvroFormat(""),
-                topic="topic",
-                batch_source=file_source,
-                watermark_delay_threshold=timedelta(days=1),
-            )
-
-            @stream_feature_view(
-                entities=[entity],
-                ttl=timedelta(days=30),
-                owner="test@example.com",
-                online=True,
-                schema=[Field(name="dummy_field", dtype=Float32)],
-                description="desc",
-                aggregations=[
-                    Aggregation(
-                        column="dummy_field",
-                        function="max",
-                        time_window=timedelta(days=1),
-                    ),
-                    Aggregation(
-                        column="dummy_field2",
-                        function="count",
-                        time_window=timedelta(days=24),
-                    ),
-                ],
-                timestamp_field="event_timestamp",
-                mode="spark",
-                source=stream_source,
-                tags={},
-            )
-            def pandas_view(pandas_df):
-                import pandas as pd
-
-                assert type(pandas_df) == pd.DataFrame
-                df = pandas_df.transform(lambda x: x + 10, axis=1)
-                df.insert(2, "C", [20.2, 230.0, 34.0], True)
-                return df
-
+        @stream_feature_view(
+            entities=[entity],
+            ttl=timedelta(days=30),
+            owner="test@example.com",
+            online=True,
+            schema=[Field(name="dummy_field", dtype=Float32)],
+            description="desc",
+            aggregations=[
+                Aggregation(
+                    column="dummy_field",
+                    function="max",
+                    time_window=timedelta(days=1),
+                ),
+                Aggregation(
+                    column="dummy_field2",
+                    function="count",
+                    time_window=timedelta(days=24),
+                ),
+            ],
+            timestamp_field="event_timestamp",
+            mode="spark",
+            source=stream_source,
+            tags={},
+        )
+        def pandas_view(pandas_df):
             import pandas as pd
 
-            fs.apply([entity, pandas_view])
+            assert type(pandas_df) == pd.DataFrame
+            df = pandas_df.transform(lambda x: x + 10, axis=1)
+            df.insert(2, "C", [20.2, 230.0, 34.0], True)
+            return df
 
-            stream_feature_views = fs.list_stream_feature_views()
-            assert len(stream_feature_views) == 1
-            assert stream_feature_views[0] == pandas_view
+        import pandas as pd
 
-            sfv = stream_feature_views[0]
+        fs.apply([entity, pandas_view])
 
-            df = pd.DataFrame({"A": [1, 2, 3], "B": [10, 20, 30]})
-            new_df = sfv.udf(df)
-            expected_df = pd.DataFrame(
-                {"A": [11, 12, 13], "B": [20, 30, 40], "C": [20.2, 230.0, 34.0]}
-            )
-            assert new_df.equals(expected_df)
+        stream_feature_views = fs.list_stream_feature_views()
+        assert len(stream_feature_views) == 1
+        assert stream_feature_views[0] == pandas_view
+
+        sfv = stream_feature_views[0]
+
+        df = pd.DataFrame({"A": [1, 2, 3], "B": [10, 20, 30]})
+        new_df = sfv.udf(df)
+        expected_df = pd.DataFrame(
+            {"A": [11, 12, 13], "B": [20, 30, 40], "C": [20.2, 230.0, 34.0]}
+        )
+        assert new_df.equals(expected_df)

--- a/sdk/python/tests/unit/online_store/test_online_retrieval.py
+++ b/sdk/python/tests/unit/online_store/test_online_retrieval.py
@@ -14,7 +14,6 @@ from feast.repo_config import RegistryConfig
 from tests.utils.cli_repo_creator import CliRunner, get_example_repo
 
 
-@pytest.mark.integration
 def test_online() -> None:
     """
     Test reading from the online store in local mode.
@@ -250,13 +249,11 @@ def test_online() -> None:
         os.rename(store.config.registry + "_fake", store.config.registry)
 
 
-@pytest.mark.integration
 def test_online_to_df():
     """
     Test dataframe conversion. Make sure the response columns and rows are
     the same order as the request.
     """
-
     driver_ids = [1, 2, 3]
     customer_ids = [4, 5, 6]
     name = "foo"

--- a/sdk/python/tests/utils/basic_read_write_test.py
+++ b/sdk/python/tests/utils/basic_read_write_test.py
@@ -11,7 +11,10 @@ def basic_rw_test(
 ) -> None:
     """
     This is a provider-independent test suite for reading and writing from the online store, to
-    be used by provider-specific  tests.
+    be used by provider-specific tests.
+
+    The specified feature view must have exactly two features: one named 'lat' with type Float32
+    and one with name 'lon' with type String.
     """
     table = store.get_feature_view(name=view_name)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: This PR allows unit tests to be run (`make test`) without any GCP credentials, which were previously required. It also adds several new example feature repos, as previously many tests would share the same feature repo, making it very hard to reason about how each test used the repo.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
