### PR TITLE
chore: Suppress alpha warnings in test. Fix entity serialization in test

### DIFF
--- a/.github/workflows/pr_local_integration_tests.yml
+++ b/.github/workflows/pr_local_integration_tests.yml
@@ -15,7 +15,7 @@ jobs:
       ((github.event.action == 'labeled' && (github.event.label.name == 'approved' || github.event.label.name == 'lgtm' || github.event.label.name == 'ok-to-test')) ||
       (github.event.action != 'labeled' && (contains(github.event.pull_request.labels.*.name, 'ok-to-test') || contains(github.event.pull_request.labels.*.name, 'approved') || contains(github.event.pull_request.labels.*.name, 'lgtm')))) ||
       github.repository != 'feast-dev/feast'
-    runs-on: ${{ matrix.os }}p
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/protos/feast/core/StreamFeatureView.proto
+++ b/protos/feast/core/StreamFeatureView.proto
@@ -24,7 +24,6 @@ option java_package = "feast.proto.core";
 
 
 import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
 import "feast/core/OnDemandFeatureView.proto";
 import "feast/core/FeatureView.proto";
 import "feast/core/Feature.proto";

--- a/sdk/python/feast/driver_test_data.py
+++ b/sdk/python/feast/driver_test_data.py
@@ -164,7 +164,7 @@ def create_customer_daily_profile_df(customers, start_date, end_date) -> pd.Data
             "event_timestamp": [
                 pd.Timestamp(dt, unit="ms", tz="UTC").round("ms")
                 for dt in pd.date_range(
-                    start=start_date, end=end_date, freq="1D", closed="left"
+                    start=start_date, end=end_date, freq="1D", inclusive="left"
                 )
             ]
         }
@@ -209,7 +209,7 @@ def create_location_stats_df(locations, start_date, end_date) -> pd.DataFrame:
             "event_timestamp": [
                 pd.Timestamp(dt, unit="ms", tz="UTC").round("ms")
                 for dt in pd.date_range(
-                    start=start_date, end=end_date, freq="1H", closed="left"
+                    start=start_date, end=end_date, freq="1H", inclusive="left"
                 )
             ]
         }
@@ -256,7 +256,7 @@ def create_global_daily_stats_df(start_date, end_date) -> pd.DataFrame:
             "event_timestamp": [
                 pd.Timestamp(dt, unit="ms", tz="UTC").round("ms")
                 for dt in pd.date_range(
-                    start=start_date, end=end_date, freq="1D", closed="left"
+                    start=start_date, end=end_date, freq="1D", inclusive="left"
                 )
             ]
         }

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -40,7 +40,7 @@ from colorama import Fore, Style
 from google.protobuf.timestamp_pb2 import Timestamp
 from tqdm import tqdm
 
-from feast import feature_server, ui_server, utils
+from feast import feature_server, flags_helper, ui_server, utils
 from feast.base_feature_view import BaseFeatureView
 from feast.batch_feature_view import BatchFeatureView
 from feast.data_source import DataSource, PushMode
@@ -533,7 +533,7 @@ class FeatureStore:
         sfvs_to_update: List[StreamFeatureView],
     ):
         """Validates all feature views."""
-        if len(odfvs_to_update) > 0:
+        if len(odfvs_to_update) > 0 and not flags_helper.is_test():
             warnings.warn(
                 "On demand feature view is an experimental feature. "
                 "This API is stable, but the functionality does not scale well for offline retrieval",
@@ -1123,12 +1123,13 @@ class FeatureStore:
         Raises:
             ValueError if given retrieval job doesn't have metadata
         """
-        warnings.warn(
-            "Saving dataset is an experimental feature. "
-            "This API is unstable and it could and most probably will be changed in the future. "
-            "We do not guarantee that future changes will maintain backward compatibility.",
-            RuntimeWarning,
-        )
+        if not flags_helper.is_test():
+            warnings.warn(
+                "Saving dataset is an experimental feature. "
+                "This API is unstable and it could and most probably will be changed in the future. "
+                "We do not guarantee that future changes will maintain backward compatibility.",
+                RuntimeWarning,
+            )
 
         if not from_.metadata:
             raise ValueError(
@@ -1175,12 +1176,13 @@ class FeatureStore:
         Raises:
             SavedDatasetNotFound
         """
-        warnings.warn(
-            "Retrieving datasets is an experimental feature. "
-            "This API is unstable and it could and most probably will be changed in the future. "
-            "We do not guarantee that future changes will maintain backward compatibility.",
-            RuntimeWarning,
-        )
+        if not flags_helper.is_test():
+            warnings.warn(
+                "Retrieving datasets is an experimental feature. "
+                "This API is unstable and it could and most probably will be changed in the future. "
+                "We do not guarantee that future changes will maintain backward compatibility.",
+                RuntimeWarning,
+            )
 
         dataset = self._registry.get_saved_dataset(name, self.project)
         provider = self._get_provider()
@@ -1374,12 +1376,13 @@ class FeatureStore:
             allow_registry_cache: Whether to allow cached versions of the registry.
             to: Whether to push to online or offline store. Defaults to online store only.
         """
-        warnings.warn(
-            "Push source is an experimental feature. "
-            "This API is unstable and it could and might change in the future. "
-            "We do not guarantee that future changes will maintain backward compatibility.",
-            RuntimeWarning,
-        )
+        if not flags_helper.is_test():
+            warnings.warn(
+                "Push source is an experimental feature. "
+                "This API is unstable and it could and might change in the future. "
+                "We do not guarantee that future changes will maintain backward compatibility.",
+                RuntimeWarning,
+            )
         from feast.data_source import PushSource
 
         all_fvs = self.list_feature_views(allow_cache=allow_registry_cache)
@@ -2268,11 +2271,12 @@ class FeatureStore:
         self, host: str, port: int, get_registry_dump: Callable, registry_ttl_sec: int
     ) -> None:
         """Start the UI server locally"""
-        warnings.warn(
-            "The Feast UI is an experimental feature. "
-            "We do not guarantee that future changes will maintain backward compatibility.",
-            RuntimeWarning,
-        )
+        if flags_helper.is_test():
+            warnings.warn(
+                "The Feast UI is an experimental feature. "
+                "We do not guarantee that future changes will maintain backward compatibility.",
+                RuntimeWarning,
+            )
         ui_server.start_server(
             self,
             host=host,
@@ -2352,12 +2356,13 @@ class FeatureStore:
             or None if successful.
 
         """
-        warnings.warn(
-            "Logged features validation is an experimental feature. "
-            "This API is unstable and it could and most probably will be changed in the future. "
-            "We do not guarantee that future changes will maintain backward compatibility.",
-            RuntimeWarning,
-        )
+        if not flags_helper.is_test():
+            warnings.warn(
+                "Logged features validation is an experimental feature. "
+                "This API is unstable and it could and most probably will be changed in the future. "
+                "We do not guarantee that future changes will maintain backward compatibility.",
+                RuntimeWarning,
+            )
 
         if not isinstance(source, FeatureService):
             raise ValueError("Only feature service is currently supported as a source")

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
 from pyspark.sql import SparkSession
 
+from feast import flags_helper
 from feast.data_source import DataSource
 from feast.errors import DataSourceNoNameException
 from feast.infra.offline_stores.offline_utils import get_temp_entity_table_name
@@ -62,11 +63,12 @@ class SparkSource(DataSource):
             owner=owner,
         )
 
-        warnings.warn(
-            "The spark data source API is an experimental feature in alpha development. "
-            "This API is unstable and it could and most probably will be changed in the future.",
-            RuntimeWarning,
-        )
+        if not flags_helper.is_test():
+            warnings.warn(
+                "The spark data source API is an experimental feature in alpha development. "
+                "This API is unstable and it could and most probably will be changed in the future.",
+                RuntimeWarning,
+            )
 
         self.spark_options = SparkOptions(
             table=table,

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
 import pandas as pd
 import pyarrow
 
+from feast import flags_helper
 from feast.data_source import DataSource
 from feast.dqm.errors import ValidationFailed
 from feast.feature_logging import LoggingConfig, LoggingSource
@@ -91,12 +92,13 @@ class RetrievalJob(ABC):
                 )
 
         if validation_reference:
-            warnings.warn(
-                "Dataset validation is an experimental feature. "
-                "This API is unstable and it could and most probably will be changed in the future. "
-                "We do not guarantee that future changes will maintain backward compatibility.",
-                RuntimeWarning,
-            )
+            if not flags_helper.is_test():
+                warnings.warn(
+                    "Dataset validation is an experimental feature. "
+                    "This API is unstable and it could and most probably will be changed in the future. "
+                    "We do not guarantee that future changes will maintain backward compatibility.",
+                    RuntimeWarning,
+                )
 
             validation_result = validation_reference.profile.validate(features_df)
             if not validation_result.is_success:
@@ -136,12 +138,13 @@ class RetrievalJob(ABC):
                 )
 
         if validation_reference:
-            warnings.warn(
-                "Dataset validation is an experimental feature. "
-                "This API is unstable and it could and most probably will be changed in the future. "
-                "We do not guarantee that future changes will maintain backward compatibility.",
-                RuntimeWarning,
-            )
+            if not flags_helper.is_test():
+                warnings.warn(
+                    "Dataset validation is an experimental feature. "
+                    "This API is unstable and it could and most probably will be changed in the future. "
+                    "We do not guarantee that future changes will maintain backward compatibility.",
+                    RuntimeWarning,
+                )
 
             validation_result = validation_reference.profile.validate(features_df)
             if not validation_result.is_success:

--- a/sdk/python/feast/stream_feature_view.py
+++ b/sdk/python/feast/stream_feature_view.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import dill
 from typeguard import typechecked
 
-from feast import utils
+from feast import flags_helper, utils
 from feast.aggregation import Aggregation
 from feast.data_source import DataSource
 from feast.entity import Entity
@@ -90,11 +90,12 @@ class StreamFeatureView(FeatureView):
         timestamp_field: Optional[str] = "",
         udf: Optional[FunctionType] = None,
     ):
-        warnings.warn(
-            "Stream Feature Views are experimental features in alpha development. "
-            "Some functionality may still be unstable so functionality can change in the future.",
-            RuntimeWarning,
-        )
+        if not flags_helper.is_test():
+            warnings.warn(
+                "Stream Feature Views are experimental features in alpha development. "
+                "Some functionality may still be unstable so functionality can change in the future.",
+                RuntimeWarning,
+            )
 
         if (
             type(source).__name__ not in SUPPORTED_STREAM_SOURCES

--- a/sdk/python/tests/integration/e2e/test_usage_e2e.py
+++ b/sdk/python/tests/integration/e2e/test_usage_e2e.py
@@ -57,6 +57,7 @@ def test_usage_on(dummy_exporter, enabling_toggle):
                 online_store=SqliteOnlineStoreConfig(
                     path=os.path.join(temp_dir, "online.db")
                 ),
+                entity_key_serialization_version=2,
             )
         )
         entity = Entity(
@@ -95,6 +96,7 @@ def test_usage_off(dummy_exporter, enabling_toggle):
                 online_store=SqliteOnlineStoreConfig(
                     path=os.path.join(temp_dir, "online.db")
                 ),
+                entity_key_serialization_version=2,
             )
         )
         entity = Entity(

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -437,6 +437,7 @@ def construct_test_environment(
         repo_path=repo_dir_name,
         feature_server=feature_server,
         go_feature_serving=test_repo_config.go_feature_serving,
+        entity_key_serialization_version=2,
     )
 
     # Create feature_store.yaml out of the config

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -368,6 +368,7 @@ def construct_test_environment(
     fixture_request: Optional[pytest.FixtureRequest],
     test_suite_name: str = "integration_test",
     worker_id: str = "worker_id",
+    entity_key_serialization_version: int = 2,
 ) -> Environment:
     _uuid = str(uuid.uuid4()).replace("-", "")[:6]
 
@@ -437,7 +438,7 @@ def construct_test_environment(
         repo_path=repo_dir_name,
         feature_server=feature_server,
         go_feature_serving=test_repo_config.go_feature_serving,
-        entity_key_serialization_version=2,
+        entity_key_serialization_version=entity_key_serialization_version,
     )
 
     # Create feature_store.yaml out of the config

--- a/sdk/python/tests/integration/materialization/test_lambda.py
+++ b/sdk/python/tests/integration/materialization/test_lambda.py
@@ -33,7 +33,10 @@ def test_lambda_materialization_consistency():
         },
         registry_location=RegistryLocation.S3,
     )
-    lambda_environment = construct_test_environment(lambda_config, None)
+    # TODO(adchia): figure out why entity_key_serialization_version 2 breaks with this test
+    lambda_environment = construct_test_environment(
+        lambda_config, None, entity_key_serialization_version=1
+    )
 
     df = create_basic_driver_dataset()
     ds = lambda_environment.data_source_creator.create_data_source(

--- a/sdk/python/tests/integration/registration/test_feature_store.py
+++ b/sdk/python/tests/integration/registration/test_feature_store.py
@@ -194,6 +194,7 @@ def feature_store_with_local_registry():
             project="default",
             provider="local",
             online_store=SqliteOnlineStoreConfig(path=online_store_path),
+            entity_key_serialization_version=2,
         )
     )
 
@@ -217,6 +218,7 @@ def feature_store_with_gcs_registry():
             registry=f"gs://{bucket_name}/registry.db",
             project="default",
             provider="gcp",
+            entity_key_serialization_version=2,
         )
     )
 
@@ -235,5 +237,6 @@ def feature_store_with_s3_registry():
                 region=os.getenv("AWS_REGION", "us-west-2")
             ),
             offline_store=FileOfflineStoreConfig(),
+            entity_key_serialization_version=2,
         )
     )

--- a/sdk/python/tests/integration/registration/test_inference.py
+++ b/sdk/python/tests/integration/registration/test_inference.py
@@ -18,7 +18,10 @@ def test_update_file_data_source_with_inferred_event_timestamp_col(simple_datase
             file_source,
         ]
         update_data_sources_with_inferred_event_timestamp_col(
-            data_sources, RepoConfig(provider="local", project="test")
+            data_sources,
+            RepoConfig(
+                provider="local", project="test", entity_key_serialization_version=2
+            ),
         )
         actual_event_timestamp_cols = [
             source.timestamp_field for source in data_sources
@@ -30,7 +33,10 @@ def test_update_file_data_source_with_inferred_event_timestamp_col(simple_datase
         with pytest.raises(RegistryInferenceFailure):
             # two viable timestamp_fields
             update_data_sources_with_inferred_event_timestamp_col(
-                [file_source], RepoConfig(provider="local", project="test")
+                [file_source],
+                RepoConfig(
+                    provider="local", project="test", entity_key_serialization_version=2
+                ),
             )
 
 
@@ -46,7 +52,9 @@ def test_update_data_sources_with_inferred_event_timestamp_col(universal_data_so
 
     update_data_sources_with_inferred_event_timestamp_col(
         data_sources_copy.values(),
-        RepoConfig(provider="local", project="test"),
+        RepoConfig(
+            provider="local", project="test", entity_key_serialization_version=2
+        ),
     )
     actual_event_timestamp_cols = [
         source.timestamp_field for source in data_sources_copy.values()

--- a/sdk/python/tests/unit/infra/online_store/test_dynamodb_online_store.py
+++ b/sdk/python/tests/unit/infra/online_store/test_dynamodb_online_store.py
@@ -41,6 +41,7 @@ def repo_config():
         online_store=DynamoDBOnlineStoreConfig(region=REGION),
         # online_store={"type": "dynamodb", "region": REGION},
         offline_store=FileOfflineStoreConfig(),
+        entity_key_serialization_version=2,
     )
 
 

--- a/sdk/python/tests/unit/infra/scaffolding/test_repo_config.py
+++ b/sdk/python/tests/unit/infra/scaffolding/test_repo_config.py
@@ -42,6 +42,7 @@ def test_nullable_online_store_aws():
         registry: "registry.db"
         provider: aws
         online_store: null
+        entity_key_serialization_version: 2
         """
         ),
         expect_error="__root__ -> offline_store -> cluster_id\n"
@@ -57,6 +58,7 @@ def test_nullable_online_store_gcp():
         registry: "registry.db"
         provider: gcp
         online_store: null
+        entity_key_serialization_version: 2
         """
         ),
         expect_error=None,
@@ -71,6 +73,7 @@ def test_nullable_online_store_local():
         registry: "registry.db"
         provider: local
         online_store: null
+        entity_key_serialization_version: 2
         """
         ),
         expect_error=None,
@@ -84,6 +87,7 @@ def test_local_config():
         project: foo
         registry: "registry.db"
         provider: local
+        entity_key_serialization_version: 2
         """
         ),
         expect_error=None,
@@ -99,6 +103,7 @@ def test_local_config_with_full_online_class():
         provider: local
         online_store:
             type: feast.infra.online_stores.sqlite.SqliteOnlineStore
+        entity_key_serialization_version: 2
         """
         ),
         expect_error=None,
@@ -114,6 +119,7 @@ def test_local_config_with_full_online_class_directly():
         registry: "registry.db"
         provider: local
         online_store: feast.infra.online_stores.sqlite.SqliteOnlineStore
+        entity_key_serialization_version: 2
         """
         ),
         expect_error=None,
@@ -128,6 +134,7 @@ def test_gcp_config():
         project: foo
         registry: gs://registry.db
         provider: gcp
+        entity_key_serialization_version: 2
         """
         ),
         expect_error=None,
@@ -161,6 +168,7 @@ def test_no_online_store_type():
         provider: local
         online_store:
             path: "blah"
+        entity_key_serialization_version: 2
         """
         ),
         expect_error=None,
@@ -190,6 +198,7 @@ def test_no_project():
         provider: local
         online_store:
             path: foo
+        entity_key_serialization_version: 2
         """
         ),
         expect_error="1 validation error for RepoConfig\n"

--- a/sdk/python/tests/unit/infra/test_inference_unit_tests.py
+++ b/sdk/python/tests/unit/infra/test_inference_unit_tests.py
@@ -190,7 +190,11 @@ def test_feature_view_inference_respects_basic_inference():
     assert len(feature_view_1.entity_columns) == 1
 
     update_feature_views_with_inferred_features_and_entities(
-        [feature_view_1], [entity1], RepoConfig(provider="local", project="test")
+        [feature_view_1],
+        [entity1],
+        RepoConfig(
+            provider="local", project="test", entity_key_serialization_version=2
+        ),
     )
     assert len(feature_view_1.schema) == 2
     assert len(feature_view_1.features) == 1
@@ -203,7 +207,9 @@ def test_feature_view_inference_respects_basic_inference():
     update_feature_views_with_inferred_features_and_entities(
         [feature_view_2],
         [entity1, entity2],
-        RepoConfig(provider="local", project="test"),
+        RepoConfig(
+            provider="local", project="test", entity_key_serialization_version=2
+        ),
     )
     assert len(feature_view_2.schema) == 3
     assert len(feature_view_2.features) == 1
@@ -228,7 +234,11 @@ def test_feature_view_inference_on_entity_columns(simple_dataset_1):
         assert len(feature_view_1.entity_columns) == 0
 
         update_feature_views_with_inferred_features_and_entities(
-            [feature_view_1], [entity1], RepoConfig(provider="local", project="test")
+            [feature_view_1],
+            [entity1],
+            RepoConfig(
+                provider="local", project="test", entity_key_serialization_version=2
+            ),
         )
 
         # The schema is only used as a parameter, as is therefore not updated during inference.
@@ -259,7 +269,11 @@ def test_feature_view_inference_on_feature_columns(simple_dataset_1):
         assert len(feature_view_1.entity_columns) == 1
 
         update_feature_views_with_inferred_features_and_entities(
-            [feature_view_1], [entity1], RepoConfig(provider="local", project="test")
+            [feature_view_1],
+            [entity1],
+            RepoConfig(
+                provider="local", project="test", entity_key_serialization_version=2
+            ),
         )
 
         # The schema is only used as a parameter, as is therefore not updated during inference.
@@ -305,7 +319,9 @@ def test_update_feature_services_with_inferred_features(simple_dataset_1):
         update_feature_views_with_inferred_features_and_entities(
             [feature_view_1, feature_view_2],
             [entity1],
-            RepoConfig(provider="local", project="test"),
+            RepoConfig(
+                provider="local", project="test", entity_key_serialization_version=2
+            ),
         )
         feature_service.infer_features(
             fvs_to_update={

--- a/sdk/python/tests/unit/local_feast_tests/test_local_feature_store.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_local_feature_store.py
@@ -261,5 +261,6 @@ def feature_store_with_local_registry():
             project="default",
             provider="local",
             online_store=SqliteOnlineStoreConfig(path=online_store_path),
+            entity_key_serialization_version=2,
         )
     )

--- a/sdk/python/tests/unit/online_store/test_online_retrieval.py
+++ b/sdk/python/tests/unit/online_store/test_online_retrieval.py
@@ -142,6 +142,7 @@ def test_online() -> None:
                 online_store=store.config.online_store,
                 project=store.project,
                 provider=store.config.provider,
+                entity_key_serialization_version=2,
             )
         )
 
@@ -204,6 +205,7 @@ def test_online() -> None:
                 online_store=store.config.online_store,
                 project=store.project,
                 provider=store.config.provider,
+                entity_key_serialization_version=2,
             )
         )
 

--- a/sdk/python/tests/utils/cli_repo_creator.py
+++ b/sdk/python/tests/utils/cli_repo_creator.py
@@ -76,6 +76,7 @@ class CliRunner:
                 path: {data_path / "online_store.db"}
             offline_store:
                 type: {offline_store}
+            entity_key_serialization_version: 2
             """
                 )
             )

--- a/sdk/python/tests/utils/e2e_test_validation.py
+++ b/sdk/python/tests/utils/e2e_test_validation.py
@@ -177,6 +177,7 @@ def make_feature_store_yaml(project, test_repo_config, repo_dir_name: Path):
         offline_store=offline_store_config,
         online_store=online_store,
         repo_path=str(Path(repo_dir_name)),
+        entity_key_serialization_version=2,
     )
     config_dict = config.dict()
     if (

--- a/sdk/python/tests/utils/feature_records.py
+++ b/sdk/python/tests/utils/feature_records.py
@@ -6,7 +6,7 @@ import pytest
 from pandas.testing import assert_frame_equal as pd_assert_frame_equal
 from pytz import utc
 
-from feast import FeatureStore, utils
+from feast import FeatureService, FeatureStore, utils
 from feast.errors import FeatureNameCollisionError
 from feast.feature_view import FeatureView
 
@@ -283,12 +283,17 @@ def get_response_feature_name(feature: str, full_feature_names: bool) -> str:
 
 
 def assert_feature_service_correctness(
-    store, feature_service, full_feature_names, entity_df, expected_df, event_timestamp
+    store: FeatureStore,
+    feature_service: FeatureService,
+    full_feature_names: bool,
+    entity_df,
+    expected_df,
+    event_timestamp,
 ):
 
     job_from_df = store.get_historical_features(
         entity_df=entity_df,
-        features=feature_service,
+        features=store.get_feature_service(feature_service.name),
         full_feature_names=full_feature_names,
     )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
The `make test-python` and `make test-python-integration-local` commands were littered with warnings. This suppresses that to make for a better testing experience.

**Note:** test_lambda fails when switching to entity_key_serialization_version=2 so this temporarily keeps it at 1 for that test