### PR TITLE
fix: Fix on demand feature view output in feast plan + Web UI crash

### DIFF
--- a/protos/feast/core/OnDemandFeatureView.proto
+++ b/protos/feast/core/OnDemandFeatureView.proto
@@ -83,4 +83,7 @@ message UserDefinedFunction {
 
     // The python-syntax function body (serialized by dill)
     bytes body = 2;
+
+    // The string representation of the udf
+    string body_text = 3;
 }

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -59,12 +59,12 @@ class OnDemandFeatureView(BaseFeatureView):
             maintainer.
     """
 
-    # TODO(adchia): remove inputs from proto and declaration
     name: str
     features: List[Field]
     source_feature_view_projections: Dict[str, FeatureViewProjection]
     source_request_sources: Dict[str, RequestSource]
     udf: FunctionType
+    udf_string: str
     description: str
     tags: Dict[str, str]
     owner: str
@@ -83,6 +83,7 @@ class OnDemandFeatureView(BaseFeatureView):
             ]
         ],
         udf: FunctionType,
+        udf_string: str,
         description: str = "",
         tags: Optional[Dict[str, str]] = None,
         owner: str = "",
@@ -99,6 +100,7 @@ class OnDemandFeatureView(BaseFeatureView):
                 which will refer to them by name.
             udf: The user defined transformation function, which must take pandas
                 dataframes as inputs.
+            udf_string: The source code version of the udf (for diffing and displaying in Web UI)
             description (optional): A human-readable description.
             tags (optional): A dictionary of key-value pairs to store arbitrary metadata.
             owner (optional): The owner of the on demand feature view, typically the email
@@ -125,6 +127,7 @@ class OnDemandFeatureView(BaseFeatureView):
                 ] = odfv_source.projection
 
         self.udf = udf  # type: ignore
+        self.udf_string = udf_string
 
     @property
     def proto_class(self) -> Type[OnDemandFeatureViewProto]:
@@ -157,6 +160,7 @@ class OnDemandFeatureView(BaseFeatureView):
             self.source_feature_view_projections
             != other.source_feature_view_projections
             or self.source_request_sources != other.source_request_sources
+            or self.udf_string != other.udf_string
             or self.udf.__code__.co_code != other.udf.__code__.co_code
         ):
             return False
@@ -198,6 +202,7 @@ class OnDemandFeatureView(BaseFeatureView):
             user_defined_function=UserDefinedFunctionProto(
                 name=self.udf.__name__,
                 body=dill.dumps(self.udf, recurse=True),
+                body_text=self.udf_string,
             ),
             description=self.description,
             tags=self.tags,
@@ -250,6 +255,7 @@ class OnDemandFeatureView(BaseFeatureView):
             udf=dill.loads(
                 on_demand_feature_view_proto.spec.user_defined_function.body
             ),
+            udf_string=on_demand_feature_view_proto.spec.user_defined_function.body_text,
             description=on_demand_feature_view_proto.spec.description,
             tags=dict(on_demand_feature_view_proto.spec.tags),
             owner=on_demand_feature_view_proto.spec.owner,
@@ -438,6 +444,7 @@ def on_demand_feature_view(
             obj.__module__ = "__main__"
 
     def decorator(user_function):
+        udf_string = dill.source.getsource(user_function)
         mainify(user_function)
         on_demand_feature_view_obj = OnDemandFeatureView(
             name=user_function.__name__,
@@ -447,6 +454,7 @@ def on_demand_feature_view(
             description=description,
             tags=tags,
             owner=owner,
+            udf_string=udf_string,
         )
         functools.update_wrapper(
             wrapper=on_demand_feature_view_obj, wrapped=user_function

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -83,7 +83,7 @@ class OnDemandFeatureView(BaseFeatureView):
             ]
         ],
         udf: FunctionType,
-        udf_string: str,
+        udf_string: str = "",
         description: str = "",
         tags: Optional[Dict[str, str]] = None,
         owner: str = "",
@@ -140,6 +140,7 @@ class OnDemandFeatureView(BaseFeatureView):
             sources=list(self.source_feature_view_projections.values())
             + list(self.source_request_sources.values()),
             udf=self.udf,
+            udf_string=self.udf_string,
             description=self.description,
             tags=self.tags,
             owner=self.owner,

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -24,7 +24,6 @@ from threading import Lock
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
-import dill
 from google.protobuf.internal.containers import RepeatedCompositeFieldContainer
 from google.protobuf.json_format import MessageToJson
 from proto import Message

--- a/sdk/python/feast/registry.py
+++ b/sdk/python/feast/registry.py
@@ -732,9 +732,10 @@ class BaseRegistry(abc.ABC):
             key=lambda on_demand_feature_view: on_demand_feature_view.name,
         ):
             odfv_dict = self._message_to_sorted_dict(on_demand_feature_view.to_proto())
-            odfv_dict["spec"]["userDefinedFunction"]["body"] = dill.source.getsource(
-                on_demand_feature_view.udf
-            )
+
+            odfv_dict["spec"]["userDefinedFunction"][
+                "body"
+            ] = on_demand_feature_view.udf_string
             registry_dict["onDemandFeatureViews"].append(odfv_dict)
         for request_feature_view in sorted(
             self.list_request_feature_views(project=project),

--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -69,6 +69,7 @@ def conv_rate_plus_100_feature_view(
         schema=[] if infer_features else _features,
         sources=sources,
         udf=conv_rate_plus_100,
+        udf_string="raw udf source",
     )
 
 
@@ -106,6 +107,7 @@ def similarity_feature_view(
         sources=sources,
         schema=[] if infer_features else _fields,
         udf=similarity,
+        udf_string="similarity raw udf",
     )
 
 

--- a/sdk/python/tests/unit/test_on_demand_feature_view.py
+++ b/sdk/python/tests/unit/test_on_demand_feature_view.py
@@ -55,7 +55,7 @@ def test_hash():
             Field(name="output2", dtype=Float32),
         ],
         udf=udf1,
-        udf_string="udf1 source code"
+        udf_string="udf1 source code",
     )
     on_demand_feature_view_2 = OnDemandFeatureView(
         name="my-on-demand-feature-view",
@@ -65,7 +65,7 @@ def test_hash():
             Field(name="output2", dtype=Float32),
         ],
         udf=udf1,
-        udf_string="udf1 source code"
+        udf_string="udf1 source code",
     )
     on_demand_feature_view_3 = OnDemandFeatureView(
         name="my-on-demand-feature-view",
@@ -75,7 +75,7 @@ def test_hash():
             Field(name="output2", dtype=Float32),
         ],
         udf=udf2,
-        udf_string="udf2 source code"
+        udf_string="udf2 source code",
     )
     on_demand_feature_view_4 = OnDemandFeatureView(
         name="my-on-demand-feature-view",

--- a/sdk/python/tests/unit/test_on_demand_feature_view.py
+++ b/sdk/python/tests/unit/test_on_demand_feature_view.py
@@ -55,6 +55,7 @@ def test_hash():
             Field(name="output2", dtype=Float32),
         ],
         udf=udf1,
+        udf_string="udf1 source code"
     )
     on_demand_feature_view_2 = OnDemandFeatureView(
         name="my-on-demand-feature-view",
@@ -64,6 +65,7 @@ def test_hash():
             Field(name="output2", dtype=Float32),
         ],
         udf=udf1,
+        udf_string="udf1 source code"
     )
     on_demand_feature_view_3 = OnDemandFeatureView(
         name="my-on-demand-feature-view",
@@ -73,6 +75,7 @@ def test_hash():
             Field(name="output2", dtype=Float32),
         ],
         udf=udf2,
+        udf_string="udf2 source code"
     )
     on_demand_feature_view_4 = OnDemandFeatureView(
         name="my-on-demand-feature-view",
@@ -82,6 +85,7 @@ def test_hash():
             Field(name="output2", dtype=Float32),
         ],
         udf=udf2,
+        udf_string="udf2 source code",
         description="test",
     )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
Before, `feast plan` would always show a change in on demand feature views because the serialization isn't deterministic. Now we store the actual source code (which also can be used to display in the Web UI).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
--
