### PR TITLE
ci: Auto update yarn.lock as part of release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,7 +133,7 @@ jobs:
   publish-python-sdk:
     if: github.repository == 'feast-dev/feast'
     runs-on: ubuntu-latest
-    needs: [build_wheels, publish-web-ui-npm]
+    needs: [build_wheels]
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -181,28 +181,3 @@ jobs:
           mkdir -p /root/.m2/
           echo -n "$MAVEN_SETTINGS" > /root/.m2/settings.xml
           infra/scripts/publish-java-sdk.sh --revision ${VERSION_WITHOUT_PREFIX} --gpg-key-import-dir /root
-
-  publish-web-ui-npm:
-    if: github.repository == 'feast-dev/feast'
-    runs-on: ubuntu-latest
-    env:
-      # This publish is working using an NPM automation token to bypass 2FA
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '17.x'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Install yarn dependencies
-        working-directory: ./ui
-        run: yarn install
-      - name: Build yarn rollup
-        working-directory: ./ui
-        run: yarn build:lib
-      - name: Publish UI package
-        working-directory: ./ui
-        run: npm publish
-        env:
-          # This publish is working using an NPM automation token to bypass 2FA
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,67 @@ on:
         type: string
 
 jobs:
+
+  get_dry_release_versions:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.event.inputs.token }}
+    outputs:
+      current_version: ${{ steps.get_versions.outputs.current_version }}
+      next_version: ${{ steps.get_versions.outputs.next_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: Release (Dry Run)
+        id: get_versions
+        run: |
+          CURRENT_VERSION=$(npx -p @semantic-release/changelog -p @semantic-release/git -p @semantic-release/exec -p semantic-release semantic-release --dry-run | grep "associated with version " | sed -E 's/.* version//' | sed -E 's/ on.*//')
+          NEXT_VERSION=$(npx -p @semantic-release/changelog -p @semantic-release/git -p @semantic-release/exec -p semantic-release semantic-release --dry-run | grep 'The next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/')
+          echo ::set-output name=current_version::$CURRENT_VERSION
+          echo ::set-output name=next_version::$NEXT_VERSION
+          echo "Current version is ${CURRENT_VERSION}"
+          echo "Next version is ${NEXT_VERSION}"
+
+  publish-web-ui-npm:
+    if: github.repository == 'feast-dev/feast'
+    needs: get_dry_release_versions
+    runs-on: ubuntu-latest
+    env:
+      # This publish is working using an NPM automation token to bypass 2FA
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      CURRENT_VERSION: ${{ needs.get_dry_release_versions.outputs.current_version }}
+      NEXT_VERSION: ${{ needs.get_dry_release_versions.outputs.next_version }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '17.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Bump file versions (temporarily for Web UI publish)
+        run: python ./infra/scripts/release/bump_file_versions.py ${CURRENT_VERSION} ${NEXT_VERSION}
+      - name: Install yarn dependencies
+        working-directory: ./ui
+        run: yarn install
+      - name: Build yarn rollup
+        working-directory: ./ui
+        run: yarn build:lib
+      - name: Publish UI package
+        working-directory: ./ui
+        run: npm publish
+        env:
+          # This publish is working using an NPM automation token to bypass 2FA
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   release:
     name: release
     runs-on: ubuntu-latest
+    needs: publish-web-ui-npm
     env:
       GITHUB_TOKEN: ${{ github.event.inputs.token }}
       GIT_AUTHOR_NAME: feast-ci-bot

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -40,8 +40,8 @@ module.exports = {
             // Validate the type of release we are doing
             "verifyReleaseCmd": "./infra/scripts/validate-release.sh  ${nextRelease.type} " + current_branch,
 
-            // Bump all version files
-            "prepareCmd": "python ./infra/scripts/release/bump_file_versions.py ${lastRelease.version} ${nextRelease.version}"
+            // Bump all version files and build UI / update yarn.lock
+            "prepareCmd": "python ./infra/scripts/release/bump_file_versions.py ${lastRelease.version} ${nextRelease.version}; make build-ui"
         }],
 
         ["@semantic-release/release-notes-generator", {
@@ -66,7 +66,8 @@ module.exports = {
                     "CHANGELOG.md",
                     "java/pom.xml",
                     "infra/charts/**/*.*",
-                    "ui/package.json"
+                    "ui/package.json",
+                    "sdk/python/feast/ui/yarn.lock"
                 ],
                 message: "chore(release): release ${nextRelease.version}\n\n${nextRelease.notes}"
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
There was an issue now that the release publishes new NPM packages for the UI as part of the flow. Roughly it's:
1. Semantic release bumps file versions (including ui package version) and creates a tagged commit. 
2. When building the wheel, it needs to compile the Feast UI to bundle into the release. This updates the `yarn.lock` file because now there's a new published NPM version of the Feast UI.
3. Because now the client is dirty with local changes, the built wheel is a dev wheel instead of a clean wheel (see https://github.com/pypa/setuptools_scm/#default-versioning-scheme).

This change instead now will publish the NPM release before running semantic release:
- Find the new release with a dry run of the semantic release to get the old / new release versions (Semantic Release does not support this yet, as per https://github.com/semantic-release/semantic-release/issues/753)
- Temporarily bump file versions using above versions
- Publish Web UI

Then, Semantic release will additionally run `make build-ui` and check in the updated yarn.lock file before tagging the release
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
