### PR TITLE
fix: Fix field mapping logic during feature inference

### DIFF
--- a/sdk/python/feast/inference.py
+++ b/sdk/python/feast/inference.py
@@ -199,10 +199,10 @@ def _infer_features_and_entities(
         fv.batch_source.timestamp_field,
         fv.batch_source.created_timestamp_column,
     }
-    for column in columns_to_exclude:
-        if column in fv.batch_source.field_mapping:
-            columns_to_exclude.remove(column)
-            columns_to_exclude.add(fv.batch_source.field_mapping[column])
+    for original_col, mapped_col in fv.batch_source.field_mapping.items():
+        if mapped_col in columns_to_exclude:
+            columns_to_exclude.remove(mapped_col)
+            columns_to_exclude.add(original_col)
 
     table_column_names_and_types = fv.batch_source.get_table_column_names_and_types(
         config


### PR DESCRIPTION
Signed-off-by: Miles Adkins <miles.adkins@snowflake.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Fixed a bug where field mappings to timestamp and createdstamp were not being skipped over when registering query result as features/entities


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
