### PR TITLE
fix: Fix Spark offline store type conversion to arrow

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -7,11 +7,11 @@ import numpy as np
 import pandas
 import pandas as pd
 import pyarrow
+import pyarrow.parquet as pq
 import pyspark
 from pydantic import StrictStr
 from pyspark import SparkConf
 from pyspark.sql import SparkSession
-import pyarrow.parquet as pq
 from pytz import utc
 
 from feast import FeatureView, OnDemandFeatureView
@@ -272,7 +272,7 @@ class SparkRetrievalJob(RetrievalJob):
 
         # write to temp parquet and then load it as pyarrow table from disk
         with tempfile.TemporaryDirectory() as temp_dir:
-            self.to_spark_df().write.parquet(temp_dir,mode="overwrite")
+            self.to_spark_df().write.parquet(temp_dir, mode="overwrite")
             return pq.read_table(temp_dir)
 
     def persist(self, storage: SavedDatasetStorage):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Fixes some integration tests related to the spark offline store. Specifically when empty list data is converted from a spark data frame to arrow. This PR fixes 5 failing tests.

The current implementation converts from spark df --> pandas --> arrow.
The new implementation writes the data temporarily to parquet and then loads it with arrow.

**Which issue(s) this PR fixes**:

None
