### PR TITLE
ci: Fix go unit tests failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ install-feast-ci-locally:
 
 # Needs feast package to setup the feature store
 # CGO flag is due to this issue: https://github.com/golang/go/wiki/InvalidFlag
-test-go: compile-protos-go compile-go-lib install-feast-ci-locally
+test-go: compile-protos-python compile-protos-go compile-go-lib install-feast-ci-locally
 	CGO_LDFLAGS_ALLOW=".*" go test -tags cgo,ccalloc ./...
 
 format-go:

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ install-go-ci-dependencies:
 	python -m pip install pybindgen==0.22.0 protobuf==3.20.1
 
 install-protoc-dependencies:
-	pip install grpcio-tools==1.47.0 mypy-protobuf==3.1.0
+	pip install --ignore-installed protobuf grpcio-tools==1.47.0 mypy-protobuf==3.1.0
 
 compile-protos-go: install-go-proto-dependencies install-protoc-dependencies
 	python setup.py build_go_protos

--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ install-feast-ci-locally:
 
 # Needs feast package to setup the feature store
 # CGO flag is due to this issue: https://github.com/golang/go/wiki/InvalidFlag
-test-go: compile-protos-python compile-protos-go compile-go-lib install-feast-ci-locally
+test-go: compile-protos-go compile-protos-python  compile-go-lib install-feast-ci-locally
 	CGO_LDFLAGS_ALLOW=".*" go test -tags cgo,ccalloc ./...
 
 format-go:

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ REQUIRED = [
     "numpy>=1.22,<3",
     "pandas>=1.4.3,<2",
     "pandavro==1.5.*", # For some reason pandavro higher than 1.5.* only support pandas less than 1.3.
-    "protobuf>3.20",
+    "protobuf>3.20,<4",
     "proto-plus>=1.20.0,<2",
     "pyarrow>=4,<9",
     "pydantic>=1,<2",

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ REQUIRED = [
     "numpy>=1.22,<3",
     "pandas>=1.4.3,<2",
     "pandavro==1.5.*", # For some reason pandavro higher than 1.5.* only support pandas less than 1.3.
-    "protobuf>3.20,<4",
+    "protobuf>3.20",
     "proto-plus>=1.20.0,<2",
     "pyarrow>=4,<9",
     "pydantic>=1,<2",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
Unclear why tests passed before, but the Go unit tests run the Feast Python CLI, which relies on Python protos being built. The original `make test-go` command does not build those Python protos.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
