### PR TITLE
fix: Make infer dummy entity join key idempotent

### DIFF
--- a/sdk/python/feast/inference.py
+++ b/sdk/python/feast/inference.py
@@ -156,7 +156,11 @@ def update_feature_views_with_inferred_features_and_entities(
                 )
 
         # Infer a dummy entity column for entityless feature views.
-        if len(fv.entities) == 1 and fv.entities[0] == DUMMY_ENTITY_NAME:
+        if (
+            len(fv.entities) == 1
+            and fv.entities[0] == DUMMY_ENTITY_NAME
+            and not fv.entity_columns
+        ):
             fv.entity_columns.append(Field(name=DUMMY_ENTITY_ID, dtype=String))
 
         # Run inference for entity columns if there are fewer entity fields than expected.


### PR DESCRIPTION
Signed-off-by: Miles Adkins <miles.adkins@snowflake.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Updates a dummy entity join key only once even if `update_feature_views_with_inferred_features_and_entities` is called multiple times in `feast.apply()`


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3114
