### PR TITLE
chore: Support consistent reads in dynamodb

### DIFF
--- a/sdk/python/feast/infra/materialization/lambda/lambda_engine.py
+++ b/sdk/python/feast/infra/materialization/lambda/lambda_engine.py
@@ -227,7 +227,7 @@ class LambdaMaterializationEngine(BatchMaterializationEngine):
 
             logger.info(
                 f"Ingested task; request id {response['ResponseMetadata']['RequestId']}, "
-                f"rows written: {output}"
+                f"Output: {output}"
             )
 
         for f in not_done:

--- a/sdk/python/feast/infra/materialization/lambda/lambda_engine.py
+++ b/sdk/python/feast/infra/materialization/lambda/lambda_engine.py
@@ -227,7 +227,7 @@ class LambdaMaterializationEngine(BatchMaterializationEngine):
 
             logger.info(
                 f"Ingested task; request id {response['ResponseMetadata']['RequestId']}, "
-                f"rows written: {output['written_rows']}"
+                f"rows written: {output}"
             )
 
         for f in not_done:

--- a/sdk/python/tests/integration/materialization/test_lambda.py
+++ b/sdk/python/tests/integration/materialization/test_lambda.py
@@ -24,11 +24,15 @@ from tests.utils.e2e_test_validation import validate_offline_online_store_consis
 def test_lambda_materialization_consistency():
     lambda_config = IntegrationTestRepoConfig(
         provider="aws",
-        online_store={"type": "dynamodb", "region": "us-west-2"},
+        online_store={
+            "type": "dynamodb",
+            "region": "us-west-2",
+            "consistent_reads": True,
+        },
         offline_store_creator=RedshiftDataSourceCreator,
         batch_engine={
             "type": "lambda",
-            "materialization_image": "402087665549.dkr.ecr.us-west-2.amazonaws.com/feast-lambda-consumer:v1",
+            "materialization_image": "402087665549.dkr.ecr.us-west-2.amazonaws.com/feast-lambda-consumer:v2",
             "lambda_role": "arn:aws:iam::402087665549:role/lambda_execution_role",
         },
         registry_location=RegistryLocation.S3,


### PR DESCRIPTION
Signed-off-by: Achal Shah <achals@gmail.com>

consistent reads will also help with the lambda integration tests, since the flakes are likley because of eventually consistent reads after materialization.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
