### PR TITLE
fix: UI error when saved dataset is present in registry.

### DIFF
--- a/ui/src/parsers/feastSavedDataset.ts
+++ b/ui/src/parsers/feastSavedDataset.ts
@@ -8,11 +8,11 @@ const FeastSavedDatasetSchema = z.object({
     storage: z.object({
       fileStorage: z.object({
         fileFormat: z.object({
-          parquestFormat: z.object({}).optional(),
-        }),
+          parquetFormat: z.object({}).optional(),
+        }).optional(),
         fileUrl: z.string(),
-      }),
-    }),
+      }).optional(),
+    }).optional(),
     featureService: z
       .object({
         spec: z.object({
@@ -21,7 +21,7 @@ const FeastSavedDatasetSchema = z.object({
       })
       .transform((obj) => {
         return obj.spec.name;
-      }),
+      }).optional(),
     profile: z.string().optional(),
   }),
   meta: z.object({


### PR DESCRIPTION
Signed-off-by: alex.eijssen <alex.eijssen@energyessentials.nl>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
This PR fixes a loading issue encountered when you have a saved dataset in your registry. The compiler: https://github.com/feast-dev/feast/blob/master/ui/src/parsers/feastSavedDataset.ts, enforces certain variables to be there, which generally aren't. It's a very crude fix, but at least saving a dataset doesn't crash the whole ui anymore.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2996
