### PR TITLE
fix: Add getter/setter for RestServer

### DIFF
--- a/java/serving/src/main/java/feast/serving/service/config/ApplicationProperties.java
+++ b/java/serving/src/main/java/feast/serving/service/config/ApplicationProperties.java
@@ -56,6 +56,14 @@ public class ApplicationProperties {
     this.grpc = grpc;
   }
 
+  public RestServer getRest() {
+    return rest;
+  }
+
+  public void setRest(RestServer rest) {
+    this.rest = rest;
+  }
+
   /**
    * Validates all FeastProperties. This method runs after properties have been initialized and
    * individually and conditionally validates each class.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

The error below occurs when we start Java Server:

```
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "rest" (class feast.serving.service.config.ApplicationProperties), not marked as ignorable (2 known properties: "feast", "grpc"])
```

This PR fixes it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
