### PR TITLE
fix: Handle complex Spark data types in SparkSource

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -160,8 +160,8 @@ class SparkSource(DataSource):
         )
         df = spark_session.sql(f"SELECT * FROM {self.get_table_query_string()}")
         return (
-            (fields["name"], fields["type"])
-            for fields in df.schema.jsonValue()["fields"]
+            (field.name, field.dataType.simpleString())
+            for field in df.schema
         )
 
     def get_table_query_string(self) -> str:

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -159,10 +159,7 @@ class SparkSource(DataSource):
             store_config=config.offline_store
         )
         df = spark_session.sql(f"SELECT * FROM {self.get_table_query_string()}")
-        return (
-            (field.name, field.dataType.simpleString())
-            for field in df.schema
-        )
+        return ((field.name, field.dataType.simpleString()) for field in df.schema)
 
     def get_table_query_string(self) -> str:
         """Returns a string that can directly be used to reference this table in SQL"""


### PR DESCRIPTION
**What this PR does / why we need it**:
`get_table_column_names_and_types` of `SparkSource` returns non-string data type for complex Spark types.

For example, if a feature view contains a feature of type `ArrayType(DoubleType(), False)`, current implementation would return a dictionary such as
```
{'type': 'array', 'elementType': 'double', 'containsNull': False}
```
With this fix, the returning data type would be `array<double>`.

This PR ensures that all Spark types are serialized as strings.

**Which issue(s) this PR fixes**:

Fixes #
