### PR TITLE
feat: Add `to_remote_storage` functionality to `SparkOfflineStore`

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/tests/data_source.py
@@ -58,6 +58,10 @@ class SparkDataSourceCreator(DataSourceCreator):
         self.spark_offline_store_config = SparkOfflineStoreConfig()
         self.spark_offline_store_config.type = "spark"
         self.spark_offline_store_config.spark_conf = self.spark_conf
+        self.spark_offline_store_config.staging_location = "file://" + str(
+            tempfile.TemporaryDirectory()
+        )
+        self.spark_offline_store_config.region = "eu-west-1"
         return self.spark_offline_store_config
 
     def create_data_source(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Add `to_remote_storage ` method to `SparkRetrivalJob` to write to remote storage. Both a local file-based and s3-based option have been implemented.

This is facilitated by 2 new config parameters for the `SparkOfflineStore`:
`staging_location`: should either start with `file://` or `s3://` to specify uri accordingly
`region`: aws region if applicable

Spark Universal tests pass. This is untested with an S3-based `staging_location`.

This PR is required in preparation for implementing a `SparkBatchMaterializationEngine` in a later PR.

**Which issue(s) this PR fixes**: None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
First step towards solving https://github.com/feast-dev/feast/issues/3167
