### PR TITLE
fix: Remove opening file object when validating S3 parquet source

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -160,9 +160,7 @@ class FileSource(DataSource):
         if filesystem is None:
             schema = ParquetDataset(path).schema.to_arrow_schema()
         else:
-            schema = ParquetDataset(
-                path, filesystem=filesystem
-            ).schema
+            schema = ParquetDataset(path, filesystem=filesystem).schema
 
         return zip(schema.names, map(str, schema.types))
 

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -161,7 +161,7 @@ class FileSource(DataSource):
             schema = ParquetDataset(path).schema.to_arrow_schema()
         else:
             schema = ParquetDataset(
-                filesystem.open_input_file(path), filesystem=filesystem
+                path, filesystem=filesystem
             ).schema
 
         return zip(schema.names, map(str, schema.types))


### PR DESCRIPTION
Remove opening file object when validating S3 parquet source.
Let instead PyArrow handle opening the path using the filesystem.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
Fixes issue #3216 when trying to `feast apply` a `parquet dataset` to the feature registry.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3216
