### PR TITLE
feat: Add ability to give boto extra args for registry config

### DIFF
--- a/sdk/python/feast/infra/registry/s3.py
+++ b/sdk/python/feast/infra/registry/s3.py
@@ -25,6 +25,7 @@ class S3RegistryStore(RegistryStore):
         self._uri = urlparse(uri)
         self._bucket = self._uri.hostname
         self._key = self._uri.path.lstrip("/")
+        self._boto_extra_args = registry_config.boto_extra_args or {}
 
         self.s3_client = boto3.resource(
             "s3", endpoint_url=os.environ.get("FEAST_S3_ENDPOINT_URL")
@@ -77,4 +78,4 @@ class S3RegistryStore(RegistryStore):
         file_obj = TemporaryFile()
         file_obj.write(registry_proto.SerializeToString())
         file_obj.seek(0)
-        self.s3_client.Bucket(self._bucket).put_object(Body=file_obj, Key=self._key)
+        self.s3_client.Bucket(self._bucket).put_object(Body=file_obj, Key=self._key, **self._boto_extra_args)

--- a/sdk/python/feast/infra/registry/s3.py
+++ b/sdk/python/feast/infra/registry/s3.py
@@ -25,7 +25,7 @@ class S3RegistryStore(RegistryStore):
         self._uri = urlparse(uri)
         self._bucket = self._uri.hostname
         self._key = self._uri.path.lstrip("/")
-        self._boto_extra_args = registry_config.boto_extra_args or {}
+        self._boto_extra_args = registry_config.s3_additional_kwargs or {}
 
         self.s3_client = boto3.resource(
             "s3", endpoint_url=os.environ.get("FEAST_S3_ENDPOINT_URL")
@@ -78,4 +78,6 @@ class S3RegistryStore(RegistryStore):
         file_obj = TemporaryFile()
         file_obj.write(registry_proto.SerializeToString())
         file_obj.seek(0)
-        self.s3_client.Bucket(self._bucket).put_object(Body=file_obj, Key=self._key, **self._boto_extra_args)
+        self.s3_client.Bucket(self._bucket).put_object(
+            Body=file_obj, Key=self._key, **self._boto_extra_args
+        )

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -112,6 +112,9 @@ class RegistryConfig(FeastBaseModel):
      set to infinity by setting TTL to 0 seconds, which means the cache will only be loaded once and will never
      expire. Users can manually refresh the cache by calling feature_store.refresh_registry() """
 
+    boto_extra_args: Optional[Dict[str, str]]
+    """ Dict[str, str]: Extra arguments to pass when writing the registry file to S3. """
+
 
 class RepoConfig(FeastBaseModel):
     """Repo config. Typically loaded from `feature_store.yaml`"""

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -112,8 +112,8 @@ class RegistryConfig(FeastBaseModel):
      set to infinity by setting TTL to 0 seconds, which means the cache will only be loaded once and will never
      expire. Users can manually refresh the cache by calling feature_store.refresh_registry() """
 
-    boto_extra_args: Optional[Dict[str, str]]
-    """ Dict[str, str]: Extra arguments to pass when writing the registry file to S3. """
+    s3_additional_kwargs: Optional[Dict[str, str]]
+    """ Dict[str, str]: Extra arguments to pass to boto3 when writing the registry file to S3. """
 
 
 class RepoConfig(FeastBaseModel):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
Give the ability to add extra arguments to the boto3 put_object method when using the S3 registry.
We use this feature to enable `ServerSideEncryption=AES256` if required by our buckets.
For example: `feature_store.yaml`:
```
...
registry:
    path: s3://my-bucket/registry.db
    boto_extra_args:
        ServerSideEncryption: AES256
...
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A
