### PR TITLE
fix: Feature-server image is missing mysql dependency for mysql registry

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -3,7 +3,9 @@ FROM python:3.8
 RUN apt update && \
         apt install -y jq
 RUN pip install pip --upgrade
-RUN pip install "feast[aws,gcp,snowflake,redis,go]"
+COPY . .
+
+RUN pip install -r requirements.txt
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget
 RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -5,7 +5,7 @@ RUN apt update && \
 RUN pip install pip --upgrade
 COPY . .
 
-RUN pip install ".[aws,gcp,snowflake,redis,go]"
+RUN pip install -r requirements.txt
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget
 RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb

--- a/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
+++ b/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
@@ -1,0 +1,2 @@
+mysqlclient
+feast[aws,gcp,snowflake,redis,go]


### PR DESCRIPTION

-->

**What this PR does / why we need it**:

This PR is need to fix feast-feature-server (using helm chart) that can't connect to mysql as registry. (see issue below for more details)


- Add mysqlclient in order to use mysql as registry
- Add it to requirements.txt and also moved pip install feast in it

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3218
