### PR TITLE
fix: Feature-server image is missing mysql dependency for mysql registry

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -1,7 +1,12 @@
 FROM python:3.8
 
 RUN apt update && \
-        apt install -y jq
+        apt install -y \
+        jq \
+        python3-dev \
+        default-libmysqlclient-dev \
+        build-essential
+
 RUN pip install pip --upgrade
 COPY . .
 

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -3,7 +3,9 @@ FROM python:3.8
 RUN apt update && \
         apt install -y jq
 RUN pip install pip --upgrade
-RUN pip install "feast[aws,gcp,snowflake,redis,go]"
+COPY . .
+
+RUN pip install -r requirements.txt
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget
 RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -1,7 +1,12 @@
 FROM python:3.8
 
 RUN apt update && \
-        apt install -y jq
+        apt install -y \
+        jq \
+        python3-dev \
+        default-libmysqlclient-dev \
+        build-essential
+
 RUN pip install pip --upgrade
 COPY . .
 

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -5,7 +5,7 @@ RUN apt update && \
 RUN pip install pip --upgrade
 COPY . .
 
-RUN pip install ".[aws,gcp,snowflake,redis,go]"
+RUN pip install -r requirements.txt
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget
 RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb

--- a/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
+++ b/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
@@ -1,0 +1,2 @@
+mysqlclient
+feast[aws,gcp,snowflake,redis,go]

--- a/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
+++ b/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
@@ -1,2 +1,1 @@
-mysqlclient
-feast[aws,gcp,snowflake,redis,go]
+feast[mysql]

--- a/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
+++ b/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
@@ -1,1 +1,1 @@
-feast[mysql]
+feast[aws,gcp,snowflake,redis,go,mysql]


### PR DESCRIPTION
Signed-off-by: 11425176+ptran32@users.noreply.github.com <11425176+ptran32@users.noreply.github.com>

Author: 11425176+ptran32@users.noreply.github.com <11425176+ptran32@users.noreply.github.com>

What this PR does / why we need it:
This PR is need to fix feast-feature-server (using helm chart) that can't connect to mysql as registry. (see issue below for more details)

* Add mysqlclient in order to use mysql as registry
* Add it to requirements.txt and also moved pip install feast in it
Which issue(s) this PR fixes:

Fixes [#3218](https://github.com/feast-dev/feast/issues/3218)
