### PR TITLE
fix: Fix handling of TTL in Go server

### DIFF
--- a/go/internal/feast/onlineserving/serving.go
+++ b/go/internal/feast/onlineserving/serving.go
@@ -633,6 +633,9 @@ func getUniqueEntityRows(joinKeysProto []*prototypes.EntityKey) ([]*prototypes.E
 }
 
 func checkOutsideTtl(featureTimestamp *timestamppb.Timestamp, currentTimestamp *timestamppb.Timestamp, ttl *durationpb.Duration) bool {
+	if ttl.Seconds == 0 {
+		return false
+	}
 	return currentTimestamp.GetSeconds()-featureTimestamp.GetSeconds() > ttl.Seconds
 }
 


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
According to the FeatureView docstring, 'A ttl of 0 indicates that this group of features lives forever.' However, the Go feature server doesn't currently respect this, returning OUTSIDE_MAX_AGE for FeatureViews that have a TTL of 0. This fixes that issue by always returning false for checkOutsideTtl if the TTL is 0.