### PR TITLE
fix: Dask zero division error if parquet dataset has only one partition

### DIFF
--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -112,10 +112,10 @@ class FileParquetDatasetSourceCreator(FileDataSourceCreator):
             format="parquet",
             existing_data_behavior="overwrite_or_ignore",
         )
-        self.files.append(dataset_path)
+        self.files.append(dataset_path.name)
         return FileSource(
             file_format=ParquetFormat(),
-            path=str(dataset_path),
+            path=dataset_path.name,
             timestamp_field=timestamp_field,
             created_timestamp_column=created_timestamp_column,
             field_mapping=field_mapping or {"ts_1": "ts"},

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -105,7 +105,13 @@ class FileParquetDatasetSourceCreator(FileDataSourceCreator):
             prefix=f"{self.project_name}_{destination_name}"
         )
         table = pa.Table.from_pandas(df)
-        pq.write_to_dataset(table, dataset_path.name, compression="snappy")
+        pq.write_to_dataset(
+            table,
+            base_dir=dataset_path.name,
+            compression="snappy",
+            format="parquet",
+            existing_data_behavior="overwrite_or_ignore",
+        )
         self.files.append(dataset_path)
         return FileSource(
             file_format=ParquetFormat(),

--- a/sdk/python/tests/utils/e2e_test_validation.py
+++ b/sdk/python/tests/utils/e2e_test_validation.py
@@ -27,6 +27,7 @@ from tests.integration.feature_repos.universal.data_sources.bigquery import (
 )
 from tests.integration.feature_repos.universal.data_sources.file import (
     FileDataSourceCreator,
+    FileParquetDatasetSourceCreator,
 )
 from tests.integration.feature_repos.universal.data_sources.redshift import (
     RedshiftDataSourceCreator,
@@ -209,6 +210,11 @@ NULLABLE_ONLINE_STORE_CONFIGS: List[IntegrationTestRepoConfig] = [
     IntegrationTestRepoConfig(
         provider="local",
         offline_store_creator=FileDataSourceCreator,
+        online_store=None,
+    ),
+    IntegrationTestRepoConfig(
+        provider="local",
+        offline_store_creator=FileParquetDatasetSourceCreator,
         online_store=None,
     ),
 ]


### PR DESCRIPTION
Signed-off-by: Max Zwiessele <ibinbei@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
When loading data in parquet dataset format it can happen that the dataset only has one partition in the `event_timestamp` column. If that is the case, dask will fail to process the dataset, erroring with a `ZeroDividionError` similar to 

https://github.com/feast-dev/feast/blob/769c31869eb8d9bb693f8a2876cc68b8cdd16521/sdk/python/feast/infra/offline_stores/file.py#L327

This PR adds a `try-catch` block to gracefully circumvent the error and process the data in only one partition.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A
