### PR TITLE
fix: Build dockerfile correctly

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -8,9 +8,8 @@ RUN apt update && \
         build-essential
 
 RUN pip install pip --upgrade
-COPY . .
+RUN pip install "feast[aws,gcp,snowflake,redis,go,mysql]"
 
-RUN pip install -r requirements.txt
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget
 RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && \
 
 RUN pip install pip --upgrade
 COPY . .
-RUN pip install ".feast[aws,gcp,snowflake,redis,go,mysql]"
+RUN pip install ".[aws,gcp,snowflake,redis,go,mysql]"
 
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -8,7 +8,8 @@ RUN apt update && \
         build-essential
 
 RUN pip install pip --upgrade
-RUN pip install "feast[aws,gcp,snowflake,redis,go,mysql]"
+COPY . .
+RUN pip install ".feast[aws,gcp,snowflake,redis,go,mysql]"
 
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -8,9 +8,8 @@ RUN apt update && \
         build-essential
 
 RUN pip install pip --upgrade
-COPY . .
+RUN pip install "feast[aws,gcp,snowflake,redis,go,mysql]"
 
-RUN pip install -r requirements.txt
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget
 RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -9,7 +9,7 @@ RUN apt update && \
 
 RUN pip install pip --upgrade
 COPY . .
-RUN pip install ".feast[aws,gcp,snowflake,redis,go,mysql]"
+RUN pip install ".[aws,gcp,snowflake,redis,go,mysql]"
 
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -8,7 +8,8 @@ RUN apt update && \
         build-essential
 
 RUN pip install pip --upgrade
-RUN pip install "feast[aws,gcp,snowflake,redis,go,mysql]"
+COPY . .
+RUN pip install ".feast[aws,gcp,snowflake,redis,go,mysql]"
 
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget

--- a/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
+++ b/sdk/python/feast/infra/feature_servers/multicloud/requirements.txt
@@ -1,1 +1,0 @@
-feast[aws,gcp,snowflake,redis,go,mysql]


### PR DESCRIPTION
Signed-off-by: Felix Wang <wangfelix98@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: #3223 introduced this `requirements.txt`. However, `docker build` copies files from the root directory, so the correct command would be `RUN pip install -r sdk/python/feast/infra/feature_servers/multicloud/requirements.txt` instead of `RUN pip install -r requirements.txt`. Instead of running this command, I decided to just remove the `requirements.txt` file and install the dependencies directly.

This bug is the reason why the Docker images were not built correctly during the latest 0.25.0 release.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
