### PR TITLE
fix: Fix numpy version specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ REQUIRED = [
     "Jinja2>=2,<4",
     "jsonschema",
     "mmh3",
-    "numpy<1.22,<2",
+    "numpy>1.22,<2",
     "pandas>=1,<2",
     "pandavro==1.5.*",
     "protobuf>3.20,<4",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

The install script for version 0.22 creates conflicts with other packages over the version of numpy. It looks like the version specification is wrong as it is unusual to see redundant constraints like what is there now (i.e: <1.22 _and_ also <2). 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
