### PR TITLE
fix: Updated ui_dir server call to make the directory if missing

### DIFF
--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -1,3 +1,4 @@
+import os
 import json
 import threading
 from typing import Callable, Optional
@@ -54,6 +55,10 @@ def get_app(
     async_refresh()
 
     ui_dir = pkg_resources.resource_filename(__name__, "ui/build/")
+    dirExists = os.path.exists(ui_dir)
+    if not dirExists:
+        os.makedirs(ui_dir)
+
     # Initialize with the projects-list.json file
     with open(ui_dir + "projects-list.json", mode="w") as f:
         projects_dict = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
This updates the `feast ui` command to create the `ui/build/` folder if it does not exist. Without this, the `feast ui` will fail.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
