### PR TITLE
fix: Use configured user in env var instead of "user" for Trino

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
@@ -157,7 +157,7 @@ class TrinoOfflineStore(OfflineStore):
         created_timestamp_column: Optional[str],
         start_date: datetime,
         end_date: datetime,
-        user: str = "user",
+        user: Optional[str] = None,
         auth: Optional[Authentication] = None,
         http_scheme: Optional[str] = None,
     ) -> TrinoRetrievalJob:
@@ -176,7 +176,6 @@ class TrinoOfflineStore(OfflineStore):
             timestamps.append(created_timestamp_column)
         timestamp_desc_string = " DESC, ".join(timestamps) + " DESC"
         field_string = ", ".join(join_key_columns + feature_name_columns + timestamps)
-
         client = _get_trino_client(
             config=config, user=user, auth=auth, http_scheme=http_scheme
         )
@@ -212,7 +211,7 @@ class TrinoOfflineStore(OfflineStore):
         registry: Registry,
         project: str,
         full_feature_names: bool = False,
-        user: str = "user",
+        user: Optional[str] = None,
         auth: Optional[Authentication] = None,
         http_scheme: Optional[str] = None,
     ) -> TrinoRetrievalJob:
@@ -303,7 +302,7 @@ class TrinoOfflineStore(OfflineStore):
         timestamp_field: str,
         start_date: datetime,
         end_date: datetime,
-        user: str = "user",
+        user: Optional[str] = None,
         auth: Optional[Authentication] = None,
         http_scheme: Optional[str] = None,
     ) -> RetrievalJob:
@@ -375,7 +374,7 @@ def _upload_entity_df_and_get_entity_schema(
 
 
 def _get_trino_client(
-    config: RepoConfig, user: str, auth: Optional[Any], http_scheme: Optional[str]
+    config: RepoConfig, user: Optional[str], auth: Optional[Any], http_scheme: Optional[str]
 ) -> Trino:
     client = Trino(
         user=user,

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
@@ -374,7 +374,10 @@ def _upload_entity_df_and_get_entity_schema(
 
 
 def _get_trino_client(
-    config: RepoConfig, user: Optional[str], auth: Optional[Any], http_scheme: Optional[str]
+    config: RepoConfig,
+    user: Optional[str],
+    auth: Optional[Any],
+    http_scheme: Optional[str],
 ) -> Trino:
     client = Trino(
         user=user,


### PR DESCRIPTION
Signed-off-by: ammarar <ammar.alrashed@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: To use the configured user specified in env var. The current way is incorrect since it shadows whatever the user provides.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
