### PR TITLE
fix: Configuration to stop coercion of tz for entity_df

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1111,7 +1111,8 @@ class FeatureStore:
 
         # Check that the right request data is present in the entity_df
         if type(entity_df) == pd.DataFrame:
-            entity_df = utils.make_df_tzaware(cast(pd.DataFrame, entity_df))
+            if self.config.coerce_tz_aware:
+                entity_df = utils.make_df_tzaware(cast(pd.DataFrame, entity_df))
             for fv in request_feature_views:
                 for feature in fv.features:
                     if feature.name not in entity_df.columns:

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -167,6 +167,9 @@ class RepoConfig(FeastBaseModel):
     feature values for entities that have already been written into the online store.
     """
 
+    coerce_tz_aware: Optional[bool] = True
+    """ If True, coerces entity_df timestamp columns to be timezone aware (to UTC by default). """
+
     def __init__(self, **data: Any):
         super().__init__(**data)
 


### PR DESCRIPTION
Signed-off-by: ammarar <ammar.alrashed@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: Currently, for `get_historical_features` coerces `entity_df` datetime columns to have timezone if the columns don't have timezone. The problem this coercion causes for Trino offline specifically is that if the `entity_df` passed does not have timezone, the Trino provider converts it to `timestamp(3) with time zone`.  However, it should be `timestamp(3)` instead.

So this fix is basically to give option to the user to use this functionality or not.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
