### PR TITLE
feat: Add tag description in Field in the Feast UI

### DIFF
--- a/ui/src/pages/features/FeatureOverviewTab.tsx
+++ b/ui/src/pages/features/FeatureOverviewTab.tsx
@@ -3,13 +3,16 @@ import {
   EuiHorizontalRule,
   EuiLoadingSpinner,
   EuiTitle,
+  EuiSpacer,
   EuiPanel,
   EuiFlexItem,
+  EuiText,
   EuiDescriptionList,
   EuiDescriptionListTitle,
   EuiDescriptionListDescription,
 } from "@elastic/eui";
 import EuiCustomLink from "../../components/EuiCustomLink";
+import TagsDisplay from "../../components/TagsDisplay";
 import React from "react";
 import { useParams } from "react-router-dom";
 import useLoadFeature from "./useLoadFeature";
@@ -53,13 +56,27 @@ const FeatureOverviewTab = () => {
 
                   <EuiDescriptionListTitle>FeatureView</EuiDescriptionListTitle>
                   <EuiDescriptionListDescription>
-                    <EuiCustomLink 
+                    <EuiCustomLink
                       href={`/p/${projectName}/feature-view/${FeatureViewName}`}
                       to={`/p/${projectName}/feature-view/${FeatureViewName}`}>
-                      {FeatureViewName} 
+                      {FeatureViewName}
                     </EuiCustomLink>
                   </EuiDescriptionListDescription>
                 </EuiDescriptionList>
+              </EuiPanel>
+              <EuiSpacer size="m" />
+              <EuiPanel hasBorder={true} grow={false}>
+                <EuiTitle size="xs">
+                  <h3>Tags</h3>
+                </EuiTitle>
+                <EuiHorizontalRule margin="xs" />
+                {featureData?.tags ? (
+                  <TagsDisplay
+                    tags={featureData.tags}
+                  />
+                ) : (
+                  <EuiText>No Tags specified on this field.</EuiText>
+                )}
               </EuiPanel>
             </EuiFlexItem>
           </EuiFlexGroup>


### PR DESCRIPTION
Signed-off-by: Benjamin Tan <benjamintanweihao@gmail.com>

**What this PR does / why we need it**:

We have added descriptions via tags in Fields. While the Feast UI shows descriptions for Feature Views, this is not so for Fields.

![](https://i.imgur.com/IsVRFcQ.png)
