### PR TITLE
fix: Add postgres to the feature server Dockerfile to fix helm chart flow

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && \
 
 RUN pip install pip --upgrade
 COPY . .
-RUN pip install ".[aws,gcp,snowflake,redis,go,mysql]"
+RUN pip install ".[aws,gcp,snowflake,redis,go,mysql,postgres]"
 
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -9,7 +9,7 @@ RUN apt update && \
 
 RUN pip install pip --upgrade
 COPY . .
-RUN pip install ".[aws,gcp,snowflake,redis,go,mysql]"
+RUN pip install ".[aws,gcp,snowflake,redis,go,mysql,postgres]"
 
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget


### PR DESCRIPTION
Signed-off-by: Danny Chiao <danny@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
This enables a SQL registry (postgres based) when using the helm charts for the python feature server

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
