### PR TITLE
feat: Enabling Datadog in feature server

### DIFF
--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -1,4 +1,5 @@
 import json
+import os
 import traceback
 import warnings
 
@@ -9,20 +10,22 @@ from fastapi.logger import logger
 from fastapi.params import Depends
 from google.protobuf.json_format import MessageToDict, Parse
 from pydantic import BaseModel
-import os
+
 import feast
 from feast import proto_json
 from feast.data_source import PushMode
 from feast.errors import PushSourceNotFoundException
 from feast.protos.feast.serving.ServingService_pb2 import GetOnlineFeaturesRequest
 
-if os.environ.get('ENABLE_DATADOG') == 'true':
+if os.environ.get("ENABLE_DATADOG") == "true":
     try:
         print("datadog_enabled")
         from ddtrace import patch
+
         patch(fastapi=True)
     except ImportError as e:
-        from feast.errors import FeastExtrasDependencyImportError 
+        from feast.errors import FeastExtrasDependencyImportError
+
         raise FeastExtrasDependencyImportError("datadog", str(e))
 
 # TODO: deprecate this in favor of push features

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -9,13 +9,21 @@ from fastapi.logger import logger
 from fastapi.params import Depends
 from google.protobuf.json_format import MessageToDict, Parse
 from pydantic import BaseModel
-
+import os
 import feast
 from feast import proto_json
 from feast.data_source import PushMode
 from feast.errors import PushSourceNotFoundException
 from feast.protos.feast.serving.ServingService_pb2 import GetOnlineFeaturesRequest
 
+if os.environ.get('ENABLE_DATADOG') == 'true':
+    try:
+        print("datadog_enabled")
+        from ddtrace import patch
+        patch(fastapi=True)
+    except ImportError as e:
+        from feast.errors import FeastExtrasDependencyImportError 
+        raise FeastExtrasDependencyImportError("datadog", str(e))
 
 # TODO: deprecate this in favor of push features
 class WriteToFeatureStoreRequest(BaseModel):

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -28,6 +28,7 @@ if os.environ.get("ENABLE_DATADOG") == "true":
 
         raise FeastExtrasDependencyImportError("datadog", str(e))
 
+
 # TODO: deprecate this in favor of push features
 class WriteToFeatureStoreRequest(BaseModel):
     feature_view_name: str

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,9 @@ REQUIRED = [
     "dask>=2021.*,<2022.02.0",
     "bowler",  # Needed for automatic repo upgrades
 ]
+DATADOG_REQUIRED = [
+    "ddtrace==1.5.0",
+]
 
 GCP_REQUIRED = [
     "google-cloud-bigquery[pandas]>=2,<4",
@@ -196,6 +199,7 @@ CI_REQUIRED = (
     + HBASE_REQUIRED
     + CASSANDRA_REQUIRED
     + AZURE_REQUIRED
+    + DATADOG_REQUIRED
 )
 
 
@@ -533,6 +537,7 @@ setup(
         "go": GO_REQUIRED,
         "docs": DOCS_REQUIRED,
         "cassandra": CASSANDRA_REQUIRED,
+        "datadog": DATADOG_REQUIRED,
     },
     include_package_data=True,
     license="Apache",


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR enables Datadog with feast. Using Datadog's tracing (dtrace) library.

Fixes #
