### PR TITLE
docs: Install instructions fix directory issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pip install feast
 ### 2. Create a feature repository
 ```commandline
 feast init my_feature_repo
-cd my_feature_repo
+cd my_feature_repo/feature_repo
 ```
 
 ### 3. Register your feature definitions and set up your feature store


### PR DESCRIPTION
What this PR does / why we need it:
When you run 'feast init my_feature_repo', it makes a 'my_feature_repo' directory. However the 'feature_store.yaml' file is within another directory called 'feature_repo'. So the feast apply command gives an error if you are simply in the 'my_feature_store' directory.

Which issue(s) this PR fixes:
This fixes a minor issue in the README with the install instructions

Fixes #

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
