### PR TITLE
fix: Ensure that Snowflake accounts for number columns that overspecify precision

### DIFF
--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -265,8 +265,13 @@ class SnowflakeSource(DataSource):
                         else:
                             if len(result) > 0:
                                 max_value = result.iloc[0][0]
-                                if max_value is not None and len(str(max_value)) <= 18:
-                                    row["snowflake_type"] = "NUMBER"
+                                if max_value is not None and len(str(max_value)) <= 9:
+                                    row["snowflake_type"] = "NUMBER32"
+                                    continue
+                                elif (
+                                    max_value is not None and len(str(max_value)) <= 18
+                                ):
+                                    row["snowflake_type"] = "NUMBER64"
                                     continue
                             raise NotImplementedError(
                                 "NaNs or Numbers larger than INT64 are not supported"

--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -263,6 +263,11 @@ class SnowflakeSource(DataSource):
                                 result.dtypes[column].name
                             ]
                         else:
+                            if len(result) > 0:
+                                max_value = result.iloc[0][0]
+                                if max_value is not None and len(str(max_value)) <= 18:
+                                    row["snowflake_type"] = "NUMBER"
+                                    continue
                             raise NotImplementedError(
                                 "NaNs or Numbers larger than INT64 are not supported"
                             )


### PR DESCRIPTION
This is because the default numeric type in Snowflake has up to 38 digits (surpassing the limits of INT64)

Signed-off-by: Danny Chiao <danny@tecton.ai>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
