### PR TITLE
chore: Remove upper bound on dask dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ REQUIRED = [
     "typeguard",
     "fastapi>=0.68.0,<1",
     "uvicorn[standard]>=0.14.0,<1",
-    "dask>=2021.*,<2022.02.0",
+    "dask>=2021.*",
     "bowler",  # Needed for automatic repo upgrades
 ]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

_Motivation_: Being able to use feast in an application with more recent versions of dask in a Python 3.8+ environment without having to work around conflicts due to versions specified in package.

This PR removes the upper bound on dask requirement added in #2342 This upper bound was added because newer versions of dask dropped support for Python 3.7. 

However, **the upper bound isn't necesesary for Python 3.7 compatibility (unless a version of dask was released that had the wrong `python_requires` specified.)**
  - pip install dask (or "dask>=2021.*") in a Python 3.7 environment installs dask==2022.2.0 which was the last version that specfied comaptitibility with Python 3.7 (with `python_requires` in the pacakge config)
  

_Additional context_

It seems that in practice feast has dropped support for Python 3.7:
- CI tests are no longer run for 3.7 https://github.com/feast-dev/feast/pull/2810
  - So any incompatibility introduced for 3.7 would be unlikely to be caught
  - Example: the latest version of feast specifies ["numpy>=1.22,<3", "pandas>=1.4.3,<2",](https://github.com/feast-dev/feast/blob/v0.26.0/setup.py#L60-L61). Both of these require Python 3.8. Which means a pip install feast==0.26.0 won't work in a Python 3.7 environment. numpy version was updated most recently in https://github.com/feast-dev/feast/pull/2887


