### PR TITLE
docs: Correction in spelling mistake in file_source.py line number 59

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -56,7 +56,7 @@ class FileSource(DataSource):
             tags (optional): A dictionary of key-value pairs to store arbitrary metadata.
             owner (optional): The owner of the file source, typically the email of the primary
                 maintainer.
-            timestamp_field (optional): Event timestamp foe;d used for point in time
+            timestamp_field (optional): Event timestamp field used for point in time
                 joins of feature values.
 
         Examples:


### PR DESCRIPTION
**What this PR does / why we need it**:
Correction in spelling mistake in file_source.py line number 59

**Which issue(s) this PR fixes**:
Spelling Mistake in FileSource #3353

Fixes #
original docstring
timestamp_field (optional): Event timestamp foe;d used for point in time joins of feature values.

fixed docstring
timestamp_field (optional): Event timestamp field used for point in time joins of feature values.


