### PR TITLE
feat: Cassandra online store, concurrent fetching for multiple entities

### DIFF
--- a/docs/reference/online-stores/cassandra.md
+++ b/docs/reference/online-stores/cassandra.md
@@ -32,6 +32,7 @@ online_store:
     load_balancing:                                                         # optional
         local_dc: 'datacenter1'                                             # optional
         load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'  # optional
+    read_concurrency: 100                                                   # optional
 ```
 {% endcode %}
 
@@ -52,7 +53,7 @@ online_store:
     load_balancing:                                                         # optional
         local_dc: 'eu-central-1'                                            # optional
         load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'  # optional
-
+    read_concurrency: 100                                                   # optional
 ```
 {% endcode %}
 

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/README.md
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/README.md
@@ -58,6 +58,7 @@ online_store:
     load_balancing:                                                         # optional
         local_dc: 'datacenter1'                                             # optional
         load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'  # optional
+    read_concurrency: 100                                                   # optional
 ```
 
 #### Astra DB setup:
@@ -84,6 +85,7 @@ online_store:
     load_balancing:                                                         # optional
         local_dc: 'eu-central-1'                                            # optional
         load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'  # optional
+    read_concurrency: 100                                                   # optional
 ```
 
 #### Protocol version and load-balancing settings
@@ -110,6 +112,14 @@ of the driver, according to the warnings issued in the logs, this will become ma
 The former parameter is a region name for Astra DB instances (as can be verified on the Astra DB UI).
 See the source code of the online store integration for the allowed values of
 the latter parameter.
+
+#### Read concurrency value
+
+You can optionally specify the value of `read_concurrency`, which will be
+passed to the Cassandra driver function handling
+[concurrent reading of multiple entities](https://docs.datastax.com/en/developer/python-driver/3.25/api/cassandra/concurrent/#module-cassandra.concurrent).
+Consult the reference for guidance on this parameter (which in most cases can be left to its default value of 100).
+This is relevant only for retrieval of several entities at once.
 
 ### More info
 

--- a/sdk/python/feast/templates/cassandra/bootstrap.py
+++ b/sdk/python/feast/templates/cassandra/bootstrap.py
@@ -70,7 +70,7 @@ def collect_cassandra_store_settings():
             sys.exit(1)
         needs_port = click.confirm("Need to specify port?", default=False)
         if needs_port:
-            c_port = click.prompt("Port to use", default=9042, type=int)
+            c_port = click.prompt("    Port to use", default=9042, type=int)
         else:
             c_port = None
         use_auth = click.confirm(
@@ -78,8 +78,8 @@ def collect_cassandra_store_settings():
             default=False,
         )
         if use_auth:
-            c_username = click.prompt("Database username")
-            c_password = click.prompt("Database password", hide_input=True)
+            c_username = click.prompt("    Database username")
+            c_password = click.prompt("    Database password", hide_input=True)
         else:
             c_username = None
             c_password = None
@@ -95,7 +95,7 @@ def collect_cassandra_store_settings():
     )
     if specify_protocol_version:
         c_protocol_version = click.prompt(
-            "Protocol version",
+            "    Protocol version",
             default={"A": 4, "C": 5}.get(db_type, 5),
             type=int,
         )
@@ -105,11 +105,11 @@ def collect_cassandra_store_settings():
     specify_lb = click.confirm("Specify load-balancing?", default=False)
     if specify_lb:
         c_local_dc = click.prompt(
-            "Local datacenter (for load-balancing)",
+            "    Local datacenter (for load-balancing)",
             default="datacenter1" if db_type == "C" else None,
         )
         c_load_balancing_policy = click.prompt(
-            "Load-balancing policy",
+            "    Load-balancing policy",
             type=click.Choice(
                 [
                     "TokenAwarePolicy(DCAwareRoundRobinPolicy)",
@@ -122,6 +122,12 @@ def collect_cassandra_store_settings():
         c_local_dc = None
         c_load_balancing_policy = None
 
+    needs_concurrency = click.confirm("Specify read concurrency level?", default=False)
+    if needs_concurrency:
+        c_concurrency = click.prompt("    Concurrency level?", default=100, type=int)
+    else:
+        c_concurrency = None
+
     return {
         "c_secure_bundle_path": c_secure_bundle_path,
         "c_hosts": c_hosts,
@@ -132,6 +138,7 @@ def collect_cassandra_store_settings():
         "c_protocol_version": c_protocol_version,
         "c_local_dc": c_local_dc,
         "c_load_balancing_policy": c_load_balancing_policy,
+        "c_concurrency": c_concurrency,
     }
 
 
@@ -149,6 +156,7 @@ def apply_cassandra_store_settings(config_file, settings):
         'c_protocol_version'
         'c_local_dc'
         'c_load_balancing_policy'
+        'c_concurrency'
     """
     write_setting_or_remove(
         config_file,
@@ -216,6 +224,13 @@ def apply_cassandra_store_settings(config_file, settings):
         remove_lines_from_file(config_file, "load_balancing:")
         remove_lines_from_file(config_file, "local_dc:")
         remove_lines_from_file(config_file, "load_balancing_policy:")
+    #
+    write_setting_or_remove(
+        config_file,
+        settings["c_concurrency"],
+        "read_concurrency",
+        "100",
+    )
 
 
 def bootstrap():

--- a/sdk/python/feast/templates/cassandra/feature_repo/feature_store.yaml
+++ b/sdk/python/feast/templates/cassandra/feature_repo/feature_store.yaml
@@ -16,4 +16,5 @@ online_store:
     load_balancing:
         local_dc: c_local_dc
         load_balancing_policy: c_load_balancing_policy
+    read_concurrency: 100
 entity_key_serialization_version: 2


### PR DESCRIPTION
This changes the retrieval of features from the Cassandra online store by leveraging the
Cassandra driver's native concurrency capabilities.

When there are several entities to be retrieved, instead of a sequential read one-by-one, entity after entity,
the reads are executed concurrently, with the driver ensuring the results are kept in the correct order and the call
returns when all results are available.
This, as measured in realistic environments, implies a speedup of 2-3x for retrieval of 20 to 100 entities at once.

Using the Cassandra driver's `execute_concurrent_with_args` function requires a new parameter controlling the maximum amount of concurrency to use (somewhat bounded by the number of vCPUs at hand): for transparency, this is exposed in the feature store configuration yaml as a new parameter, which is documented and correctly handled by the guided procedure of `feast init -t cassandra`.