### PR TITLE
feat: Get Snowflake Query Output As Pyspark Dataframe (#2504)

### DIFF
--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -56,6 +56,14 @@ class FeatureViewNotFoundException(FeastObjectNotFoundException):
             super().__init__(f"Feature view {name} does not exist")
 
 
+class InvalidSparkSessionException(Exception):
+    def __init__(self, spark_arg):
+        super().__init__(
+            f" Need Spark Session to convert results to spark data frame\
+               recieved {type(spark_arg)} instead. "
+        )
+
+
 class OnDemandFeatureViewNotFoundException(FeastObjectNotFoundException):
     def __init__(self, name, project=None):
         if project:


### PR DESCRIPTION
1. Added feature to offline_store-> snowflake.py to return results of snowflake query as pyspark data frame.This helps spark-based users to distribute data, which often doesn't fit in driver nodes through pandas output.

2. Also added relevant error class, to notify user on missing spark session , particular to this usecase.

Signed-off-by: amithadiraju1694 <amith.adiraju@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

This adds feature to `SnowflakeRetrievalJob` to return result of snowflake query execution as a pyspark data frame. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2504 
