### PR TITLE
feat: Cassandra online store, concurrency in bulk write operations

### DIFF
--- a/docs/reference/online-stores/cassandra.md
+++ b/docs/reference/online-stores/cassandra.md
@@ -33,6 +33,7 @@ online_store:
         local_dc: 'datacenter1'                                             # optional
         load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'  # optional
     read_concurrency: 100                                                   # optional
+    write_concurrency: 100                                                  # optional
 ```
 {% endcode %}
 
@@ -54,6 +55,7 @@ online_store:
         local_dc: 'eu-central-1'                                            # optional
         load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'  # optional
     read_concurrency: 100                                                   # optional
+    write_concurrency: 100                                                  # optional
 ```
 {% endcode %}
 

--- a/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/README.md
+++ b/sdk/python/feast/infra/online_stores/contrib/cassandra_online_store/README.md
@@ -59,6 +59,7 @@ online_store:
         local_dc: 'datacenter1'                                             # optional
         load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'  # optional
     read_concurrency: 100                                                   # optional
+    write_concurrency: 100                                                  # optional
 ```
 
 #### Astra DB setup:
@@ -86,6 +87,7 @@ online_store:
         local_dc: 'eu-central-1'                                            # optional
         load_balancing_policy: 'TokenAwarePolicy(DCAwareRoundRobinPolicy)'  # optional
     read_concurrency: 100                                                   # optional
+    write_concurrency: 100                                                  # optional
 ```
 
 #### Protocol version and load-balancing settings
@@ -113,13 +115,13 @@ The former parameter is a region name for Astra DB instances (as can be verified
 See the source code of the online store integration for the allowed values of
 the latter parameter.
 
-#### Read concurrency value
+#### Read/write concurrency value
 
-You can optionally specify the value of `read_concurrency`, which will be
-passed to the Cassandra driver function handling
-[concurrent reading of multiple entities](https://docs.datastax.com/en/developer/python-driver/3.25/api/cassandra/concurrent/#module-cassandra.concurrent).
-Consult the reference for guidance on this parameter (which in most cases can be left to its default value of 100).
-This is relevant only for retrieval of several entities at once.
+You can optionally specify the value of `read_concurrency` and `write_concurrency`,
+which will be passed to the Cassandra driver function handling
+[concurrent reading/writing of multiple entities](https://docs.datastax.com/en/developer/python-driver/3.25/api/cassandra/concurrent/#module-cassandra.concurrent).
+Consult the reference for guidance on this parameter (which in most cases can be left to its default value of).
+This is relevant only for retrieval of several entities at once and during bulk writes, such as in the materialization step.
 
 ### More info
 

--- a/sdk/python/feast/templates/cassandra/bootstrap.py
+++ b/sdk/python/feast/templates/cassandra/bootstrap.py
@@ -122,11 +122,17 @@ def collect_cassandra_store_settings():
         c_local_dc = None
         c_load_balancing_policy = None
 
-    needs_concurrency = click.confirm("Specify read concurrency level?", default=False)
-    if needs_concurrency:
-        c_concurrency = click.prompt("    Concurrency level?", default=100, type=int)
+    specify_concurrency = click.confirm("Specify concurrency levels?", default=False)
+    if specify_concurrency:
+        c_r_concurrency = click.prompt(
+            "    Read-concurrency level?", default=100, type=int
+        )
+        c_w_concurrency = click.prompt(
+            "    Write-concurrency level?", default=100, type=int
+        )
     else:
-        c_concurrency = None
+        c_r_concurrency = None
+        c_w_concurrency = None
 
     return {
         "c_secure_bundle_path": c_secure_bundle_path,
@@ -138,7 +144,8 @@ def collect_cassandra_store_settings():
         "c_protocol_version": c_protocol_version,
         "c_local_dc": c_local_dc,
         "c_load_balancing_policy": c_load_balancing_policy,
-        "c_concurrency": c_concurrency,
+        "c_r_concurrency": c_r_concurrency,
+        "c_w_concurrency": c_w_concurrency,
     }
 
 
@@ -156,7 +163,8 @@ def apply_cassandra_store_settings(config_file, settings):
         'c_protocol_version'
         'c_local_dc'
         'c_load_balancing_policy'
-        'c_concurrency'
+        'c_r_concurrency'
+        'c_w_concurrency'
     """
     write_setting_or_remove(
         config_file,
@@ -224,12 +232,18 @@ def apply_cassandra_store_settings(config_file, settings):
         remove_lines_from_file(config_file, "load_balancing:")
         remove_lines_from_file(config_file, "local_dc:")
         remove_lines_from_file(config_file, "load_balancing_policy:")
-    #
+
     write_setting_or_remove(
         config_file,
-        settings["c_concurrency"],
+        settings["c_r_concurrency"],
         "read_concurrency",
-        "100",
+        "c_r_concurrency",
+    )
+    write_setting_or_remove(
+        config_file,
+        settings["c_w_concurrency"],
+        "write_concurrency",
+        "c_w_concurrency",
     )
 
 

--- a/sdk/python/feast/templates/cassandra/feature_repo/feature_store.yaml
+++ b/sdk/python/feast/templates/cassandra/feature_repo/feature_store.yaml
@@ -16,5 +16,6 @@ online_store:
     load_balancing:
         local_dc: c_local_dc
         load_balancing_policy: c_load_balancing_policy
-    read_concurrency: 100
+    read_concurrency: c_r_concurrency
+    write_concurrency: c_w_concurrency
 entity_key_serialization_version: 2


### PR DESCRIPTION
This implements the counterpart of #3356 but for writing. Using the native concurrency offered by Cassandra drivers allows for much faster write operations to the online store, which is crucial especially in the Materialize phase.

On a realistic setup (EC2 instance running the materialization on a DB in the same region), speedups of a factor about 12x are achieved.

Similarly to the read-optimization mentioned above, a new `write_concurrency` parameter is introduced (with defaults and full backward-compatibility) to control the level of concurrency should it ever be needed (the defaults should be fine in all cases, anyway).

In order to preserve the behaviour of the callbacks to `progress` during writes to the online store, which makes the progress bar behave correctly, in the function `online_write_batch` an ad-hoc iterator is built (see `unroll_insertion_tuples`) which, while it unfolds the whole set of rows to write, takes the care of invoking `progress` once per entity (each entity in general entails multiple rows to the DB table).

The documentation and the guided `feast init -t cassandra` procedure are also updated to reflect this.