### PR TITLE
fix: Get all columns with describe table method from RedshiftData-api

### DIFF
--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -206,7 +206,8 @@ class RedshiftSource(DataSource):
         client = aws_utils.get_redshift_data_client(config.offline_store.region)
         if self.table:
             try:
-                table = client.describe_table(
+                paginator = client.get_paginator("describe_table")
+                response_iterator = paginator.paginate(
                     ClusterIdentifier=config.offline_store.cluster_id,
                     Database=(
                         self.database
@@ -217,6 +218,7 @@ class RedshiftSource(DataSource):
                     Table=self.table,
                     Schema=self.schema,
                 )
+                table = response_iterator.build_full_result()
             except ClientError as e:
                 if e.response["Error"]["Code"] == "ValidationException":
                     raise RedshiftCredentialsError() from e


### PR DESCRIPTION
Signed-off-by: Alexandre Brehelin <alexandre.brehelin@needelp.com>

**What this PR does / why we need it**:
As described in issues, with current get_table_column_names_and_types method in Redshift source we can't register data with more than 500 columns.  
Push method raise an error because input DataFrame doesn't fit condition (`set(input_columns) != set(source_columns)`) return by get_table_column_names_and_types. 
By default, describe table method return only 500 first columns from table. To get all columns we have to iterate through page results. 

**Which issue(s) this PR fixes**:
Fixes #3282 
