### PR TITLE
feat: Support postgres DSNs with alternate scheme

### DIFF
--- a/.github/fork_workflows/fork_pr_integration_tests_gcp.yml
+++ b/.github/fork_workflows/fork_pr_integration_tests_gcp.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           go-version: 1.18.0
       - name: Set up gcloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/java_master_only.yml
+++ b/.github/workflows/java_master_only.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v1
         with:
-          version: '290.0.1'
+          version: '411.0.0'
           export_default_credentials: true
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
@@ -150,7 +150,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-it-maven-
       - name: Set up gcloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -72,9 +72,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v1
         with:
-          version: '290.0.1'
+          version: '411.0.0'
           export_default_credentials: true
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
@@ -122,7 +122,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-it-maven-
       - name: Set up gcloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
@@ -195,7 +195,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -145,7 +145,7 @@ jobs:
         with:
           go-version: 1.18.0
       - name: Set up gcloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           go-version: 1.18.0
       - name: Set up gcloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
@@ -109,9 +109,9 @@ jobs:
       VERSION_WITHOUT_PREFIX: ${{ needs.get-version.outputs.version_without_prefix }}
     steps:
       - uses: actions/checkout@v2
-      - uses: google-github-actions/setup-gcloud@v0
+      - uses: google-github-actions/setup-gcloud@v1
         with:
-          version: '290.0.1'
+          version: '411.0.0'
           export_default_credentials: true
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,9 @@ test-python-integration-local:
 		FEAST_LOCAL_ONLINE_CONTAINER=True \
 		python -m pytest -n 8 --integration \
 			-k "not gcs_registry and \
- 				not s3_registry and \
- 				not test_lambda_materialization and \
- 				not test_snowflake" \
+				not s3_registry and \
+				not test_lambda_materialization and \
+				not test_snowflake" \
 		sdk/python/tests \
 	) || echo "This script uses Docker, and it isn't running - please start the Docker Daemon and try again!";
 
@@ -96,9 +96,9 @@ test-python-universal-spark:
 	PYTHONPATH='.' \
 	FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.spark_repo_configuration \
 	PYTEST_PLUGINS=feast.infra.offline_stores.contrib.spark_offline_store.tests \
- 	FEAST_USAGE=False IS_TEST=True \
- 	python -m pytest -n 8 --integration \
- 	 	-k "not test_historical_retrieval_fails_on_validation and \
+	FEAST_USAGE=False IS_TEST=True \
+	python -m pytest -n 8 --integration \
+		-k "not test_historical_retrieval_fails_on_validation and \
 			not test_historical_retrieval_with_validation and \
 			not test_historical_features_persisting and \
 			not test_historical_retrieval_fails_on_validation and \
@@ -114,15 +114,15 @@ test-python-universal-spark:
 			not s3_registry and \
 			not test_universal_types and \
 			not test_snowflake" \
- 	 sdk/python/tests
+	sdk/python/tests
 
 test-python-universal-trino:
 	PYTHONPATH='.' \
 	FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.trino_repo_configuration \
 	PYTEST_PLUGINS=feast.infra.offline_stores.contrib.trino_offline_store.tests \
- 	FEAST_USAGE=False IS_TEST=True \
- 	python -m pytest -n 8 --integration \
- 	 	-k "not test_historical_retrieval_fails_on_validation and \
+	FEAST_USAGE=False IS_TEST=True \
+	python -m pytest -n 8 --integration \
+		-k "not test_historical_retrieval_fails_on_validation and \
 			not test_historical_retrieval_with_validation and \
 			not test_historical_features_persisting and \
 			not test_historical_retrieval_fails_on_validation and \
@@ -137,8 +137,8 @@ test-python-universal-trino:
 			not gcs_registry and \
 			not s3_registry and \
 			not test_universal_types and \
-            not test_snowflake" \
- 	 sdk/python/tests
+			not test_snowflake" \
+	sdk/python/tests
 
 
 # Note: to use this, you'll need to have Microsoft ODBC 17 installed.
@@ -147,14 +147,14 @@ test-python-universal-mssql:
 	PYTHONPATH='.' \
 	FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.mssql_repo_configuration \
 	PYTEST_PLUGINS=feast.infra.offline_stores.contrib.mssql_offline_store.tests \
- 	FEAST_USAGE=False IS_TEST=True \
+	FEAST_USAGE=False IS_TEST=True \
 	FEAST_LOCAL_ONLINE_CONTAINER=True \
- 	python -m pytest -n 8 --integration \
- 	 	-k "not gcs_registry and \
+	python -m pytest -n 8 --integration \
+		-k "not gcs_registry and \
 			not s3_registry and \
 			not test_lambda_materialization and \
 			not test_snowflake" \
- 	 sdk/python/tests
+	sdk/python/tests
 
 
 # To use Athena as an offline store, you need to create an Athena database and an S3 bucket on AWS. 
@@ -165,22 +165,22 @@ test-python-universal-athena:
 	PYTHONPATH='.' \
 	FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.athena_repo_configuration \
 	PYTEST_PLUGINS=feast.infra.offline_stores.contrib.athena_offline_store.tests \
- 	FEAST_USAGE=False IS_TEST=True \
+	FEAST_USAGE=False IS_TEST=True \
 	ATHENA_REGION=ap-northeast-2 \
 	ATHENA_DATA_SOURCE=AwsDataCatalog \
 	ATHENA_DATABASE=default \
 	ATHENA_WORKGROUP=primary \
 	ATHENA_S3_BUCKET_NAME=feast-integration-tests \
- 	python -m pytest -n 8 --integration \
- 	 	-k "not test_go_feature_server and \
-		    not test_logged_features_validation and \
-		    not test_lambda and \
-		    not test_feature_logging and \
-		    not test_offline_write and \
-		    not test_push_offline and \
-		    not test_historical_retrieval_with_validation and \
-		    not test_historical_features_persisting and \
-		    not test_historical_retrieval_fails_on_validation and \
+	python -m pytest -n 8 --integration \
+		-k "not test_go_feature_server and \
+			not test_logged_features_validation and \
+			not test_lambda and \
+			not test_feature_logging and \
+			not test_offline_write and \
+			not test_push_offline and \
+			not test_historical_retrieval_with_validation and \
+			not test_historical_features_persisting and \
+			not test_historical_retrieval_fails_on_validation and \
 			not gcs_registry and \
 			not s3_registry and \
 			not test_snowflake" \
@@ -193,11 +193,11 @@ test-python-universal-postgres-offline:
 		FEAST_USAGE=False \
 		IS_TEST=True \
 		python -m pytest -n 8 --integration \
- 			-k "not test_historical_retrieval_with_validation and \
+			-k "not test_historical_retrieval_with_validation and \
 				not test_historical_features_persisting and \
- 				not test_universal_cli and \
- 				not test_go_feature_server and \
- 				not test_feature_logging and \
+				not test_universal_cli and \
+				not test_go_feature_server and \
+				not test_feature_logging and \
 				not test_reorder_columns and \
 				not test_logged_features_validation and \
 				not test_lambda_materialization_consistency and \
@@ -205,8 +205,8 @@ test-python-universal-postgres-offline:
 				not test_push_features_to_offline_store and \
 				not gcs_registry and \
 				not s3_registry and \
- 				not test_universal_types" \
- 			sdk/python/tests
+				not test_universal_types" \
+		sdk/python/tests
 
 test-python-universal-postgres-online:
 	PYTHONPATH='.' \
@@ -215,9 +215,9 @@ test-python-universal-postgres-online:
 		FEAST_USAGE=False \
 		IS_TEST=True \
 		python -m pytest -n 8 --integration \
- 			-k "not test_universal_cli and \
- 				not test_go_feature_server and \
- 				not test_feature_logging and \
+			-k "not test_universal_cli and \
+				not test_go_feature_server and \
+				not test_feature_logging and \
 				not test_reorder_columns and \
 				not test_logged_features_validation and \
 				not test_lambda_materialization_consistency and \
@@ -225,20 +225,63 @@ test-python-universal-postgres-online:
 				not test_push_features_to_offline_store and \
 				not gcs_registry and \
 				not s3_registry and \
- 				not test_universal_types and \
+				not test_universal_types and \
 				not test_snowflake" \
- 			sdk/python/tests
+		sdk/python/tests
 
- test-python-universal-mysql-online:
+test-python-universal-postgres-offline-cockroachdb:
+	PYTHONPATH='.' \
+		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.postgres_repo_configuration_cockroachdb \
+		PYTEST_PLUGINS=sdk.python.feast.infra.offline_stores.contrib.postgres_offline_store.tests \
+		FEAST_USAGE=False \
+		IS_TEST=True \
+		python -m pytest -n 8 --integration \
+			-k "not test_historical_retrieval_with_validation and \
+				not test_historical_features_persisting and \
+				not test_universal_cli and \
+				not test_go_feature_server and \
+				not test_feature_logging and \
+				not test_reorder_columns and \
+				not test_logged_features_validation and \
+				not test_lambda_materialization_consistency and \
+				not test_offline_write and \
+				not test_push_features_to_offline_store and \
+				not gcs_registry and \
+				not s3_registry and \
+				not test_universal_types" \
+		sdk/python/tests
+
+test-python-universal-postgres-online-cockroachdb:
+	PYTHONPATH='.' \
+		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.contrib.postgres_repo_configuration_cockroachdb \
+		PYTEST_PLUGINS=sdk.python.feast.infra.offline_stores.contrib.postgres_offline_store.tests \
+		FEAST_USAGE=False \
+		IS_TEST=True \
+		python -m pytest -n 8 --integration \
+			-k "not test_universal_cli and \
+				not test_go_feature_server and \
+				not test_feature_logging and \
+				not test_reorder_columns and \
+				not test_logged_features_validation and \
+				not test_lambda_materialization_consistency and \
+				not test_offline_write and \
+				not test_push_features_to_offline_store and \
+				not gcs_registry and \
+				not s3_registry and \
+				not test_universal_types and \
+				not test_snowflake" \
+		sdk/python/tests
+
+test-python-universal-mysql-online:
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.contrib.mysql_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.mysql \
 		FEAST_USAGE=False \
 		IS_TEST=True \
 		python -m pytest -n 8 --integration \
- 			-k "not test_universal_cli and \
- 				not test_go_feature_server and \
- 				not test_feature_logging and \
+			-k "not test_universal_cli and \
+				not test_go_feature_server and \
+				not test_feature_logging and \
 				not test_reorder_columns and \
 				not test_logged_features_validation and \
 				not test_lambda_materialization_consistency and \
@@ -246,9 +289,9 @@ test-python-universal-postgres-online:
 				not test_push_features_to_offline_store and \
 				not gcs_registry and \
 				not s3_registry and \
- 				not test_universal_types and \
+				not test_universal_types and \
 				not test_snowflake" \
- 			sdk/python/tests
+		sdk/python/tests
 
 test-python-universal-cassandra:
 	PYTHONPATH='.' \
@@ -266,16 +309,16 @@ test-python-universal-cassandra-no-cloud-providers:
 	FEAST_USAGE=False \
 	IS_TEST=True \
 	python -m pytest -x --integration \
-	-k "not test_lambda_materialization_consistency   and \
-	  not test_apply_entity_integration               and \
-	  not test_apply_feature_view_integration         and \
-	  not test_apply_entity_integration               and \
-	  not test_apply_feature_view_integration         and \
-	  not test_apply_data_source_integration          and \
-	  not test_nullable_online_store				  and \
-	  not gcs_registry 								  and \
-	  not s3_registry								  and \
-	  not test_snowflake" \
+		-k "not test_lambda_materialization_consistency and \
+	  		not test_apply_entity_integration and \
+	  		not test_apply_feature_view_integration and \
+	  		not test_apply_entity_integration and \
+	  		not test_apply_feature_view_integration and \
+	  		not test_apply_data_source_integration and \
+	  		not test_nullable_online_store and \
+	  		not gcs_registry and \
+	  		not s3_registry and \
+	  		not test_snowflake" \
 	sdk/python/tests
 
 test-python-universal:
@@ -448,12 +491,12 @@ install-dependencies-proto-docs:
 	mv protoc3/include/* $$HOME/include
 
 compile-protos-docs:
-	rm -rf 	$(ROOT_DIR)/dist/grpc
+	rm -rf $(ROOT_DIR)/dist/grpc
 	mkdir -p dist/grpc;
 	cd ${ROOT_DIR}/protos && protoc --docs_out=../dist/grpc feast/*/*.proto
 
 build-sphinx: compile-protos-python
-	cd 	$(ROOT_DIR)/sdk/python/docs && $(MAKE) build-api-source
+	cd $(ROOT_DIR)/sdk/python/docs && $(MAKE) build-api-source
 
 build-templates:
 	python infra/scripts/compile-templates.py

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pip install feast
 ### 2. Create a feature repository
 ```commandline
 feast init my_feature_repo
-cd my_feature_repo/feature_repo
+cd my_feature_repo
 ```
 
 ### 3. Register your feature definitions and set up your feature store

--- a/docs/project/maintainers.md
+++ b/docs/project/maintainers.md
@@ -36,7 +36,7 @@ Fork specific integration tests are run by the `fork_pr_integration_tests.yml_[p
 
     ```yaml
     - name: Set up gcloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1
         with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/__init__.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/__init__.py
@@ -1,1 +1,1 @@
-from .data_source import postgres_container  # noqa
+from .data_source import cockroach_container, postgres_container  # noqa

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/data_source.py
@@ -1,8 +1,12 @@
 import logging
+import os
+import time
+from tempfile import mkdtemp
 from typing import Dict, Optional
 
 import pandas as pd
 import pytest
+from docker.models.containers import ExecResult
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
@@ -12,6 +16,7 @@ from feast.infra.offline_stores.contrib.postgres_offline_store.postgres import (
     PostgreSQLSource,
 )
 from feast.infra.utils.postgres.connection_utils import df_to_postgres_table
+from feast.repo_config import FeastConfigBaseModel
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,
 )
@@ -24,6 +29,10 @@ logger = logging.getLogger(__name__)
 POSTGRES_USER = "test"
 POSTGRES_PASSWORD = "test"
 POSTGRES_DB = "test"
+
+COCKROACH_USER = "test"
+COCKROACH_DATABASE = "test"
+HOST_PATH = mkdtemp()
 
 
 @pytest.fixture(scope="session")
@@ -46,6 +55,55 @@ def postgres_container():
         interval=10,
     )
     logger.info("Waited for %s seconds until postgres container was up", waited)
+
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="session")
+def cockroach_container():
+    container = (
+        DockerContainer("docker.io/cockroachdb/cockroach:latest")
+        .with_command("start-single-node")
+        .with_exposed_ports(26257)
+        .with_env("COCKROACH_USER", COCKROACH_USER)
+        .with_env("COCKROACH_DATABASE", COCKROACH_DATABASE)
+        .with_env("HOST_PATH", HOST_PATH)
+        .with_volume_mapping(host=HOST_PATH, container="/cockroach/certs", mode="rw")
+    )
+
+    container.start()
+
+    log_string_to_wait_for = "initialized new cluster"
+    waited = wait_for_logs(
+        container=container,
+        predicate=log_string_to_wait_for,
+        timeout=30,
+        interval=10,
+    )
+    logger.info("Waited for %s seconds until cockroach container was up", waited)
+
+    result: ExecResult = ExecResult(exit_code=1, output=None)  # type: ignore
+    timeout: float = time.time() + 60  # type: ignore
+
+    while result.exit_code != 0 and not time.time() > timeout:
+        result = container.exec(
+            [
+                "grep",
+                "-q",
+                "init_finished",
+                "init_success",
+            ]
+        )
+        time.sleep(1)
+
+    container.exec(
+        [
+            "chown",
+            f"{os.getuid()}:{os.getgid()}",
+            f"certs/client.{COCKROACH_USER}.key",
+        ]
+    )
 
     yield container
     container.stop()
@@ -85,7 +143,7 @@ class PostgreSQLDataSourceCreator(DataSourceCreator, OnlineStoreCreator):
         suffix: Optional[str] = None,
         timestamp_field="ts",
         created_timestamp_column="created_ts",
-        field_mapping: Dict[str, str] = None,
+        field_mapping: Optional[Dict[str, str]] = None,
     ) -> DataSource:
         destination_name = self.get_prefixed_table_name(destination_name)
 
@@ -106,17 +164,17 @@ class PostgreSQLDataSourceCreator(DataSourceCreator, OnlineStoreCreator):
     def get_prefixed_table_name(self, suffix: str) -> str:
         return f"{self.project_name}_{suffix}"
 
-    def create_online_store(self) -> Dict[str, str]:
+    def create_online_store(self) -> FeastConfigBaseModel:
         assert self.container
-        return {
-            "type": "postgres",
-            "host": "localhost",
-            "port": self.container.get_exposed_port(5432),
-            "database": POSTGRES_DB,
-            "db_schema": "feature_store",
-            "user": POSTGRES_USER,
-            "password": POSTGRES_PASSWORD,
-        }
+        return FeastConfigBaseModel(
+            type="postgres",
+            host="localhost",
+            port=self.container.get_exposed_port(5432),
+            database=POSTGRES_DB,
+            db_schema="feature_store",
+            user=POSTGRES_USER,
+            password=POSTGRES_PASSWORD,
+        )
 
     def create_saved_dataset_destination(self):
         # FIXME: ...
@@ -124,3 +182,48 @@ class PostgreSQLDataSourceCreator(DataSourceCreator, OnlineStoreCreator):
 
     def teardown(self):
         pass
+
+
+class CockroachDBDataSourceCreator(PostgreSQLDataSourceCreator):
+    def __init__(
+        self, project_name: str, fixture_request: pytest.FixtureRequest, **kwargs
+    ):
+        super().__init__(project_name, fixture_request, **kwargs)
+
+        self.container = fixture_request.getfixturevalue("cockroach_container")
+        if not self.container:
+            raise RuntimeError(
+                "In order to use this data source "
+                "'feast.infra.offline_stores.contrib.postgres_offline_store.tests' "
+                "must be include into pytest plugins"
+            )
+
+        self.offline_store_config = PostgreSQLOfflineStoreConfig(
+            type="postgres",
+            schme="cockroachdb",
+            host="127.0.0.1",
+            port=self.container.get_exposed_port(26257),
+            database=self.container.env["COCKROACH_DATABASE"],
+            db_schema="public",
+            user=self.container.env["COCKROACH_USER"],
+            sslmode="verify-ca",
+            sslkey_path=f'{self.container.env["HOST_PATH"]}/client.{self.container.env["COCKROACH_USER"]}.key',
+            sslcert_path=f'{self.container.env["HOST_PATH"]}/client.{self.container.env["COCKROACH_USER"]}.crt',
+            sslrootcert_path=f'{self.container.env["HOST_PATH"]}/ca.crt',
+        )
+
+    def create_online_store(self) -> FeastConfigBaseModel:
+        assert self.container
+        return FeastConfigBaseModel(
+            type="postgres",
+            schme="cockroachdb",
+            host="127.0.0.1",
+            port=self.container.get_exposed_port(26257),
+            database=COCKROACH_DATABASE,
+            db_schema="feature_store",
+            user=COCKROACH_USER,
+            sslmode="verify-ca",
+            sslkey_path=f'{self.container.env["HOST_PATH"]}/client.{self.container.env["COCKROACH_USER"]}.key',
+            sslcert_path=f'{self.container.env["HOST_PATH"]}/client.{self.container.env["COCKROACH_USER"]}.crt',
+            sslrootcert_path=f'{self.container.env["HOST_PATH"]}/ca.crt',
+        )

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_repo_configuration_cockroachdb.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_repo_configuration_cockroachdb.py
@@ -1,0 +1,11 @@
+from feast.infra.offline_stores.contrib.postgres_offline_store.tests.data_source import (
+    CockroachDBDataSourceCreator,
+)
+from tests.integration.feature_repos.repo_configuration import REDIS_CONFIG
+from tests.integration.feature_repos.universal.online_store.redis import (
+    RedisOnlineStoreCreator,
+)
+
+AVAILABLE_OFFLINE_STORES = [("local", CockroachDBDataSourceCreator)]
+
+AVAILABLE_ONLINE_STORES = {"redis": (REDIS_CONFIG, RedisOnlineStoreCreator)}

--- a/sdk/python/feast/infra/online_stores/contrib/postgres_repo_configuration_cockroachdb.py
+++ b/sdk/python/feast/infra/online_stores/contrib/postgres_repo_configuration_cockroachdb.py
@@ -1,0 +1,10 @@
+from feast.infra.offline_stores.contrib.postgres_offline_store.tests.data_source import (
+    CockroachDBDataSourceCreator,
+)
+from tests.integration.feature_repos.integration_test_repo_config import (
+    IntegrationTestRepoConfig,
+)
+
+FULL_REPO_CONFIGS = [
+    IntegrationTestRepoConfig(online_store_creator=CockroachDBDataSourceCreator),
+]

--- a/sdk/python/feast/infra/registry/contrib/postgres/postgres_registry_store.py
+++ b/sdk/python/feast/infra/registry/contrib/postgres/postgres_registry_store.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import psycopg2
+import psycopg2.errors
 from psycopg2 import sql
 
 from feast.infra.registry.registry_store import RegistryStore
@@ -11,12 +12,13 @@ from feast.repo_config import RegistryConfig
 
 
 class PostgresRegistryConfig(RegistryConfig):
+    scheme: Optional[str]
     host: str
     port: int
     database: str
     db_schema: str
     user: str
-    password: str
+    password: Optional[str]
     sslmode: Optional[str]
     sslkey_path: Optional[str]
     sslcert_path: Optional[str]
@@ -26,12 +28,13 @@ class PostgresRegistryConfig(RegistryConfig):
 class PostgreSQLRegistryStore(RegistryStore):
     def __init__(self, config: PostgresRegistryConfig, registry_path: str):
         self.db_config = PostgreSQLConfig(
+            scheme=getattr(config, "scheme", "postgresql"),
             host=config.host,
-            port=config.port,
+            port=getattr(config, "port", 5432),
             database=config.database,
-            db_schema=config.db_schema,
+            db_schema=getattr(config, "db_schema", "public"),
             user=config.user,
-            password=config.password,
+            password=getattr(config, "password", None),
             sslmode=getattr(config, "sslmode", None),
             sslkey_path=getattr(config, "sslkey_path", None),
             sslcert_path=getattr(config, "sslcert_path", None),

--- a/sdk/python/feast/infra/utils/postgres/postgres_config.py
+++ b/sdk/python/feast/infra/utils/postgres/postgres_config.py
@@ -6,12 +6,13 @@ from feast.repo_config import FeastConfigBaseModel
 
 
 class PostgreSQLConfig(FeastConfigBaseModel):
+    scheme: Optional[StrictStr] = None
     host: StrictStr
     port: int = 5432
     database: StrictStr
     db_schema: StrictStr = "public"
     user: StrictStr
-    password: StrictStr
+    password: Optional[StrictStr] = None
     sslmode: Optional[StrictStr] = None
     sslkey_path: Optional[StrictStr] = None
     sslcert_path: Optional[StrictStr] = None

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -7,6 +7,7 @@ from typing import Any
 import yaml
 from pydantic import (
     BaseModel,
+    Extra,
     Field,
     StrictInt,
     StrictStr,
@@ -85,7 +86,7 @@ class FeastBaseModel(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-        extra = "allow"
+        extra = Extra.allow
 
 
 class FeastConfigBaseModel(BaseModel):
@@ -93,7 +94,7 @@ class FeastConfigBaseModel(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-        extra = "forbid"
+        extra = Extra.allow
 
 
 class RegistryConfig(FeastBaseModel):

--- a/setup.py
+++ b/setup.py
@@ -182,6 +182,7 @@ CI_REQUIRED = (
         "types-requests",
         "types-setuptools",
         "types-tabulate",
+        "sqlalchemy-cockroachdb==1.4.4",
     ]
     + GCP_REQUIRED
     + REDIS_REQUIRED


### PR DESCRIPTION
Signed-off-by: Khris Richardson <khris.richardson@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

First of all my apologies for the lengthy commit, and I understand if this is not something you wish to take on in its entirety, and am okay with refactoring or maintaining a fork to retain this functionality. A play in six acts:

ACT I

It started with a simple attempt to connect feast to a `cockroachdb` registry and offline store. While the offline store worked as-is, the registry was a different story, since `sqlalchemy` failed to detect the database version without also updating the DSN scheme from `postgresql` to `cockroachdb` in order to speak that dialect.

It was in light of the aforementioned that `sdk/python/feast/infra/utils/postgres/connection_utils.py` was updated to support `dsn` as one of the keyword arguments, since it seems that `scheme` is not one of the fields supported by the `psycopg2.connect` method.

ACT II

Updating the `_get_conn` method in turn required updating the `PostgresRegistryConfig` class in `sdk/python/feast/infra/registry/contrib/postgres/postgres_registry_store.py`. In doing so, I made the `password` attribute optional, since it's not technically required, nor is it encouraged when instead one could use private key authentication. I also set the default `port` and `db_schema` attributes consistent with the `PostgreSQLConfig` class in `sdk/python/feast/infra/utils/postgres/postgres_config.py`, wherein I also made the `password` attribute optional.

ACT III

At this point I made a decision to update the tests with a `cockroachdb` flavor, while I could have simply used `postgresql+psycopg2` as an alternative scheme. If `cockroachdb` isn't an integration you care to assume for whatever reason, I'd be happy to simplify this PR accordingly.

Since the main impetus behind this PR was to allow one to update the DSN for the registry to be compliant with `sqlalchemy`, tests were added in `sdk/python/tests/unit/test_sql_registry.py` for `cockroachdb`. A new `pytest` fixture was added for `cockroachdb`  in the likeness of `postgresql`, using public key authentication instead of password authentication, and the test fixture was added to all the tests. As can be observed on line 144, the DSN is set to `path=f"cockroachdb://{COCKROACH_USER}@127.0.0.1:{container_port}/{COCKROACH_DATABASE}?{params}"`, thus exercising the updates to the aforementioned `infra` modules.

ACT IV

In light of the updates to the registry, the `docs/tutorials/using-scalable-registry.md` document was updated to reflect how to make this change work in one's environment, whether from a standalone or containerized perspective. Namely this entails installing the appropriate supporting `sqlalchemy` module. In keeping with the other changes, I made this update specific to `cockroachdb`, but can make it more generic if so desired. There were not similar updates made to the `postgres` offline and online store markdown documents, given that the `sqlalchemy` requirement only impacted the registry.

ACT V

While the `_get_conn` method is invoked by the `postgres` offline and online stores in the `sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py` and `sdk/python/feast/infra/online_stores/contrib/postgres.py` files respectively without requiring any explicit changes, test coverage should still be added in the event that one opts to use an alternate scheme. Consequently to test the DSN updates, a new `cockroachdb` test fixture and creator class were added to `sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/data_source.py`. In doing so I modified the `field_mapping` attribute in the `DataSource` to reflect its optional nature (i,e. - it's default was set to `None`) . I also changed the signature of `create_online_store` to reflect that its output type was `FeastConfigBaseModel`, not `Dict[str, str]`.

Doing so had the after effect that the `FeastConfigBaseModel` `pydantic` class in `sdk/python/feast/repo_config.py` needed to allow extra fields. I figured it would be better to opt for accuracy than to skirt around the type safety checks and `pydantic` schema validation by using the incorrect output type. I acknowledge that there are other such test data sources for other stores that similarly output `Dict[str, str]` instead of `FeastConfigBaseModel`, but opted to leave them as-is, and suggest addressing them in a follow-up PR.

ACT VI

An alternative `postgres_repo_configuration` was added for offline store testing with `sdk/python/feast/infra/offline_stores/contrib/postgres_repo_configuration_cockroachdb.py`, and this addition was reflected in the `Makefile`, where I also addressed a handful of whitespace inconsistencies.

Similarly an alternative `postgres_repo_configuration` was added for online store testing with `sdk/python/feast/infra/online_stores/contrib/postgres_repo_configuration_cockroachdb.py`, and the `Makefile` was updated in kind.

I acknowledge that the names of these files break from the naming conventions and am open to suggestions for rectifying this.

As can be observed on lines 203 and 219 of `sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/data_source.py`, the `scheme` is set to `cockroachdb` to exercise the updates to the `infra` modules, while technically the `postgresql` scheme works as-is for both the offline and online stores.

The update to the `README.md` was a result of the pre-commit hook. `¯\_(ツ)_/¯`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
