### PR TITLE
fix: Update import logic to remove `pyspark` dependency from Snowflake Offline Store

### DIFF
--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import contextlib
 import os
 import uuid
@@ -461,7 +459,7 @@ class SnowflakeRetrievalJob(RetrievalJob):
         with self._query_generator() as query:
             return query
 
-    def to_spark_df(self, spark_session: SparkSession) -> DataFrame:
+    def to_spark_df(self, spark_session: "SparkSession") -> "DataFrame":
         """
         Method to convert snowflake query results to pyspark data frame.
 

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from functools import reduce
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     ContextManager,
@@ -62,6 +63,9 @@ except ImportError as e:
     from feast.errors import FeastExtrasDependencyImportError
 
     raise FeastExtrasDependencyImportError("snowflake", str(e))
+
+if TYPE_CHECKING:
+    from pyspark.sql import DataFrame, SparkSession
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import os
 import uuid

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -63,13 +63,6 @@ except ImportError as e:
 
     raise FeastExtrasDependencyImportError("snowflake", str(e))
 
-try:
-    from pyspark.sql import DataFrame, SparkSession
-except ImportError as e:
-    from feast.errors import FeastExtrasDependencyImportError
-
-    raise FeastExtrasDependencyImportError("spark", str(e))
-
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
@@ -472,6 +465,13 @@ class SnowflakeRetrievalJob(RetrievalJob):
         Returns:
             spark_df: A pyspark dataframe.
         """
+
+        try:
+            from pyspark.sql import DataFrame, SparkSession
+        except ImportError as e:
+            from feast.errors import FeastExtrasDependencyImportError
+
+            raise FeastExtrasDependencyImportError("spark", str(e))
 
         if isinstance(spark_session, SparkSession):
             with self._query_generator() as query:


### PR DESCRIPTION
**What this PR does / why we need it**:
* Moves the pyspark import inside of the relevant method so that the Snowflake offline store does not have a necessary dependency on pyspark
* Uses typing.TYPE_CHECKING to do the imports while type checking, but not in runtime

**Resulting behavior**
* The Snowflake Offline Store can be used without `pyspark` installed
  * However, when running an environment without `pyspark`, then calling `to_spark_df` raises a `FeastExtrasDependencyImportError`

**Which issue(s) this PR fixes**:
Fixes [this issue](https://github.com/feast-dev/feast/issues/3383)
