### PR TITLE
fix: Specifies timeout in exception polling

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -608,7 +608,7 @@ def block_until_done(
             client.cancel_job(bq_job.job_id)
             raise BigQueryJobCancelled(job_id=bq_job.job_id)
 
-        # We explicitly set the timeout to None because `google-api-core` keeps changing default value and
+        # We explicitly set the timeout to None because `google-api-core` changed the default value and
         # breaks downstream libraries.
         # https://github.com/googleapis/python-api-core/issues/479
         if bq_job.exception(timeout=None):

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -608,8 +608,11 @@ def block_until_done(
             client.cancel_job(bq_job.job_id)
             raise BigQueryJobCancelled(job_id=bq_job.job_id)
 
-        if bq_job.exception():
-            raise bq_job.exception()
+        # We explicitly set the timeout to None because `google-api-core` keeps changing default value and
+        # breaks downstream libraries.
+        # https://github.com/googleapis/python-api-core/issues/479
+        if bq_job.exception(timeout=None):
+            raise bq_job.exception(timeout=None)
 
 
 def _get_table_reference_for_new_entity(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
google-api-core==2.11.0 change the default value for polling the exception as per ->
https://github.com/googleapis/python-api-core/issues/479

`block_until_done` funciton would failt because of a TypeError

This is a quick patch to support google-api-core 2.11.0
