### PR TITLE
chore: Feature view as property instead to remove duplicate source of truth

### DIFF
--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -257,11 +257,9 @@ class FeatureView(BaseFeatureView):
         """Returns a list of all the join keys."""
         return [entity.name for entity in self.entity_columns]
 
-    
     @property
     def schema(self) -> List[Field]:
         return self.entity_columns + self.features
-
 
     def ensure_valid(self):
         """

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -85,7 +85,6 @@ class FeatureView(BaseFeatureView):
     ttl: Optional[timedelta]
     batch_source: DataSource
     stream_source: Optional[DataSource]
-    schema: List[Field]
     entity_columns: List[Field]
     features: List[Field]
     online: bool
@@ -135,7 +134,7 @@ class FeatureView(BaseFeatureView):
         self.name = name
         self.entities = [e.name for e in entities] if entities else [DUMMY_ENTITY_NAME]
         self.ttl = ttl
-        self.schema = schema or []
+        schema = schema or []
 
         # Initialize data sources.
         if (
@@ -169,7 +168,7 @@ class FeatureView(BaseFeatureView):
                 "A feature view should not have entities that share a join key."
             )
 
-        for field in self.schema:
+        for field in schema:
             if field.name in join_keys:
                 self.entity_columns.append(field)
 
@@ -190,7 +189,7 @@ class FeatureView(BaseFeatureView):
                 features.append(field)
 
         # TODO(felixwang9817): Add more robust validation of features.
-        cols = [field.name for field in self.schema]
+        cols = [field.name for field in schema]
         for col in cols:
             if (
                 self.batch_source.field_mapping is not None
@@ -257,6 +256,12 @@ class FeatureView(BaseFeatureView):
     def join_keys(self) -> List[str]:
         """Returns a list of all the join keys."""
         return [entity.name for entity in self.entity_columns]
+
+    
+    @property
+    def schema(self) -> List[Field]:
+        return self.entity_columns + self.features
+
 
     def ensure_valid(self):
         """

--- a/sdk/python/tests/unit/infra/test_inference_unit_tests.py
+++ b/sdk/python/tests/unit/infra/test_inference_unit_tests.py
@@ -244,8 +244,8 @@ def test_feature_view_inference_on_entity_value_types():
         ),
     )
 
-    # The schema is only used as a parameter, as is therefore not updated during inference.
-    assert len(feature_view_1.schema) == 1
+    # The schema must be entity and features
+    assert len(feature_view_1.schema) == 2
 
     # Since there is already a feature specified, additional features are not inferred.
     assert len(feature_view_1.features) == 1
@@ -314,14 +314,14 @@ def test_feature_view_inference_on_entity_columns(simple_dataset_1):
             ),
         )
 
-        # The schema is only used as a parameter, as is therefore not updated during inference.
-        assert len(feature_view_1.schema) == 1
-
         # Since there is already a feature specified, additional features are not inferred.
         assert len(feature_view_1.features) == 1
 
         # The single entity column is inferred correctly.
         assert len(feature_view_1.entity_columns) == 1
+
+        # The schema is a property concatenating features and entity_columns
+        assert len(feature_view_1.schema) == 2
 
 
 def test_feature_view_inference_on_feature_columns(simple_dataset_1):
@@ -349,8 +349,8 @@ def test_feature_view_inference_on_feature_columns(simple_dataset_1):
             ),
         )
 
-        # The schema is only used as a parameter, as is therefore not updated during inference.
-        assert len(feature_view_1.schema) == 1
+        # The schema is a property concatenating features and entity_columns
+        assert len(feature_view_1.schema) == 4
 
         # All three feature columns are inferred correctly.
         assert len(feature_view_1.features) == 3
@@ -407,9 +407,9 @@ def test_update_feature_services_with_inferred_features(simple_dataset_1):
             }
         )
 
-        assert len(feature_view_1.schema) == 0
+        assert len(feature_view_1.schema) == 4
         assert len(feature_view_1.features) == 3
-        assert len(feature_view_2.schema) == 0
+        assert len(feature_view_2.schema) == 4
         assert len(feature_view_2.features) == 3
         assert len(feature_service.feature_view_projections[0].features) == 1
         assert len(feature_service.feature_view_projections[1].features) == 3


### PR DESCRIPTION
Signed-off-by: gbmarc1 <marcantoine.belanger@shopify.com>

**What this PR does / why we need it**:
This PR replaces the `schema` attribute in the `FeatureView` object by a property. The `schema` and `entity_columns` + `features` would duplicate the source of truth internally. 
This PR exposes the `schema` as a property that is built from the `entity_columns` and `features` attributes.

Furthermore, there was a problem in the `from_proto` method were the `schema` attribute would not be assigned. This PR also avoid that gymnastic.
