### PR TITLE
docs: Update the link to the Black Code Style.

### DIFF
--- a/docs/project/development-guide.md
+++ b/docs/project/development-guide.md
@@ -162,7 +162,7 @@ This will allow the installed feast version to automatically reflect changes to 
 
 ### Code Style & Linting
 Feast Python SDK / CLI codebase:
-- Conforms to [Black code style](https://black.readthedocs.io/en/stable/the_black_code_style.html)
+- Conforms to [Black code style](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html)
 - Has type annotations as enforced by `mypy`
 - Has imports sorted by `isort`
 - Is lintable by `flake8`


### PR DESCRIPTION
**What this PR does / why we need it**:
In file "docs/project/development-guide.md", the web link to the black code style is outdated.

**Which issue(s) this PR fixes**:
NA. No one filed a bug for this.
Fixes #
