### PR TITLE
chore: Force entity inference without modifying `fv.schema`

### DIFF
--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -26,6 +26,7 @@ from tests.integration.feature_repos.universal.entities import (
 def driver_feature_view(
     data_source: DataSource,
     name="test_correctness",
+    infer_entities: bool = False,
     infer_features: bool = False,
     dtype: FeastType = Float32,
     entity_type: FeastType = Int64,
@@ -34,7 +35,7 @@ def driver_feature_view(
     return FeatureView(
         name=name,
         entities=[d],
-        schema=[Field(name=d.join_key, dtype=entity_type)]
+        schema=([] if infer_entities else [Field(name=d.join_key, dtype=entity_type)])
         + ([] if infer_features else [Field(name="value", dtype=dtype)]),
         ttl=timedelta(days=5),
         source=data_source,

--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -46,15 +46,12 @@ def test_entity_inference_types_match(environment, entity_type):
     fv = driver_feature_view(
         data_source=data_source,
         name=f"fv_entity_type_{entity_type.name.lower()}",
+        infer_entities=True,  # Forces entity inference by not including a field for the entity.
         dtype=_get_feast_type("int32", False),
         entity_type=entity_type,
     )
 
-    # TODO(felixwang9817): Refactor this by finding a better way to force type inference.
-    # Override the schema and entity_columns to force entity inference.
     entity = driver()
-    fv.schema = list(filter(lambda x: x.name != entity.join_key, fv.schema))
-    fv.entity_columns = []
     fs.apply([fv, entity])
 
     entity_type_to_expected_inferred_entity_type = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: #3403 is currently blocked on being able to run an entity inference test without overwriting the `fv.schema` attribute. This PR unblocks #3403.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
