### PR TITLE
fix: Fixed path inside quickstart notebook

### DIFF
--- a/examples/quickstart/quickstart.ipynb
+++ b/examples/quickstart/quickstart.ipynb
@@ -155,7 +155,7 @@
         }
       ],
       "source": [
-        "%cd feature_repo\n",
+        "%cd feature_repo/feature_repo\n",
         "!ls -R"
       ]
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
it fixies `quickstart.ipynb` notebook

Hi.
When running `quickstart.ipynb` notebook, there is a problem with the hierarchy of the directories.
After `!feast init feature_repo` we can see two nested `feature_repo` directories on the hierarchy on the left:
<img width="607" alt="image" src="https://user-images.githubusercontent.com/36787333/213689153-9c2d9ee0-9463-475c-b7bf-c36f54c252c2.png">
and then when runninng `!pygmentize feature_store.yaml` we got an error
`Error: no such file or directory`
<img width="517" alt="image" src="https://user-images.githubusercontent.com/36787333/213689344-c54516f0-5471-49ff-bccd-5411519a6536.png">

Fix: make `%cd feature_repo/feature_repo`
Tested in colab: "Run all cells without errors".
