### PR TITLE
chore: Move google-api dependencies to GCP extras

### DIFF
--- a/sdk/python/requirements/py3.10-requirements.txt
+++ b/sdk/python/requirements/py3.10-requirements.txt
@@ -17,15 +17,10 @@ attrs==22.2.0
     #   jsonschema
 bowler==0.9.0
     # via feast (setup.py)
-cachetools==5.3.0
-    # via google-auth
 certifi==2022.12.7
     # via
     #   httpcore
     #   httpx
-    #   requests
-charset-normalizer==3.0.1
-    # via requests
 click==8.1.3
     # via
     #   bowler
@@ -51,14 +46,6 @@ fissix==21.11.13
     # via bowler
 fsspec==2023.1.0
     # via dask
-google-api-core==2.11.0
-    # via feast (setup.py)
-google-auth==2.16.0
-    # via google-api-core
-googleapis-common-protos==1.58.0
-    # via
-    #   feast (setup.py)
-    #   google-api-core
 greenlet==2.0.2
     # via sqlalchemy
 grpcio==1.51.1
@@ -80,7 +67,6 @@ httpx==0.23.3
 idna==3.4
     # via
     #   anyio
-    #   requests
     #   rfc3986
 jinja2==3.1.2
     # via feast (setup.py)
@@ -119,18 +105,10 @@ proto-plus==1.22.2
 protobuf==4.21.12
     # via
     #   feast (setup.py)
-    #   google-api-core
-    #   googleapis-common-protos
     #   grpcio-reflection
     #   proto-plus
 pyarrow==8.0.0
     # via feast (setup.py)
-pyasn1==0.4.8
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.2.8
-    # via google-auth
 pydantic==1.10.4
     # via
     #   fastapi
@@ -150,15 +128,10 @@ pyyaml==6.0
     #   dask
     #   feast (setup.py)
     #   uvicorn
-requests==2.28.2
-    # via google-api-core
 rfc3986[idna2008]==1.5.0
     # via httpx
-rsa==4.9
-    # via google-auth
 six==1.16.0
     # via
-    #   google-auth
     #   pandavro
     #   python-dateutil
 sniffio==1.3.0
@@ -193,8 +166,6 @@ typing-extensions==4.4.0
     #   mypy
     #   pydantic
     #   sqlalchemy2-stubs
-urllib3==1.26.14
-    # via requests
 uvicorn[standard]==0.20.0
     # via feast (setup.py)
 uvloop==0.17.0

--- a/sdk/python/requirements/py3.8-requirements.txt
+++ b/sdk/python/requirements/py3.8-requirements.txt
@@ -17,15 +17,10 @@ attrs==22.2.0
     #   jsonschema
 bowler==0.9.0
     # via feast (setup.py)
-cachetools==5.3.0
-    # via google-auth
 certifi==2022.12.7
     # via
     #   httpcore
     #   httpx
-    #   requests
-charset-normalizer==3.0.1
-    # via requests
 click==8.1.3
     # via
     #   bowler
@@ -51,14 +46,6 @@ fissix==21.11.13
     # via bowler
 fsspec==2023.1.0
     # via dask
-google-api-core==2.11.0
-    # via feast (setup.py)
-google-auth==2.16.0
-    # via google-api-core
-googleapis-common-protos==1.58.0
-    # via
-    #   feast (setup.py)
-    #   google-api-core
 greenlet==2.0.2
     # via sqlalchemy
 grpcio==1.51.1
@@ -80,7 +67,6 @@ httpx==0.23.3
 idna==3.4
     # via
     #   anyio
-    #   requests
     #   rfc3986
 importlib-resources==5.10.2
     # via jsonschema
@@ -123,18 +109,10 @@ proto-plus==1.22.2
 protobuf==4.21.12
     # via
     #   feast (setup.py)
-    #   google-api-core
-    #   googleapis-common-protos
     #   grpcio-reflection
     #   proto-plus
 pyarrow==8.0.0
     # via feast (setup.py)
-pyasn1==0.4.8
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.2.8
-    # via google-auth
 pydantic==1.10.4
     # via
     #   fastapi
@@ -154,15 +132,10 @@ pyyaml==6.0
     #   dask
     #   feast (setup.py)
     #   uvicorn
-requests==2.28.2
-    # via google-api-core
 rfc3986[idna2008]==1.5.0
     # via httpx
-rsa==4.9
-    # via google-auth
 six==1.16.0
     # via
-    #   google-auth
     #   pandavro
     #   python-dateutil
 sniffio==1.3.0
@@ -198,8 +171,6 @@ typing-extensions==4.4.0
     #   pydantic
     #   sqlalchemy2-stubs
     #   starlette
-urllib3==1.26.14
-    # via requests
 uvicorn[standard]==0.20.0
     # via feast (setup.py)
 uvloop==0.17.0

--- a/sdk/python/requirements/py3.9-requirements.txt
+++ b/sdk/python/requirements/py3.9-requirements.txt
@@ -17,15 +17,10 @@ attrs==22.2.0
     #   jsonschema
 bowler==0.9.0
     # via feast (setup.py)
-cachetools==5.3.0
-    # via google-auth
 certifi==2022.12.7
     # via
     #   httpcore
     #   httpx
-    #   requests
-charset-normalizer==3.0.1
-    # via requests
 click==8.1.3
     # via
     #   bowler
@@ -51,14 +46,6 @@ fissix==21.11.13
     # via bowler
 fsspec==2023.1.0
     # via dask
-google-api-core==2.11.0
-    # via feast (setup.py)
-google-auth==2.16.0
-    # via google-api-core
-googleapis-common-protos==1.58.0
-    # via
-    #   feast (setup.py)
-    #   google-api-core
 greenlet==2.0.2
     # via sqlalchemy
 grpcio==1.51.1
@@ -80,7 +67,6 @@ httpx==0.23.3
 idna==3.4
     # via
     #   anyio
-    #   requests
     #   rfc3986
 jinja2==3.1.2
     # via feast (setup.py)
@@ -119,18 +105,10 @@ proto-plus==1.22.2
 protobuf==4.21.12
     # via
     #   feast (setup.py)
-    #   google-api-core
-    #   googleapis-common-protos
     #   grpcio-reflection
     #   proto-plus
 pyarrow==8.0.0
     # via feast (setup.py)
-pyasn1==0.4.8
-    # via
-    #   pyasn1-modules
-    #   rsa
-pyasn1-modules==0.2.8
-    # via google-auth
 pydantic==1.10.4
     # via
     #   fastapi
@@ -150,15 +128,10 @@ pyyaml==6.0
     #   dask
     #   feast (setup.py)
     #   uvicorn
-requests==2.28.2
-    # via google-api-core
 rfc3986[idna2008]==1.5.0
     # via httpx
-rsa==4.9
-    # via google-auth
 six==1.16.0
     # via
-    #   google-auth
     #   pandavro
     #   python-dateutil
 sniffio==1.3.0
@@ -194,8 +167,6 @@ typing-extensions==4.4.0
     #   pydantic
     #   sqlalchemy2-stubs
     #   starlette
-urllib3==1.26.14
-    # via requests
 uvicorn[standard]==0.20.0
     # via feast (setup.py)
 uvloop==0.17.0

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,6 @@ REQUIRED = [
     "colorama>=0.3.9,<1",
     "dill~=0.3.0",
     "fastavro>=1.1.0,<2",
-    "google-api-core>=1.23.0,<3",
-    "googleapis-common-protos>=1.52.0,<2",
     "grpcio>=1.47.0,<2",
     "grpcio-reflection>=1.47.0,<2",
     "Jinja2>=2,<4",
@@ -80,6 +78,8 @@ REQUIRED = [
 ]
 
 GCP_REQUIRED = [
+    "google-api-core>=1.23.0,<3",
+    "googleapis-common-protos>=1.52.0,<2",
     "google-cloud-bigquery[pandas]>=2,<4",
     "google-cloud-bigquery-storage >= 2.0.0,<3",
     "google-cloud-datastore>=2.1.0,<3",


### PR DESCRIPTION
These dependencies were added before any extras existed in setup.py. Feast users would generally expect that using AWS or Azure does not require Google Cloud apis.

Fixex #3458

Signed-off-by: Chris Burroughs <chris.burroughs@gmail.com>