### PR TITLE
fix: Add description attribute to the Field.from_proto method

### DIFF
--- a/sdk/python/feast/field.py
+++ b/sdk/python/feast/field.py
@@ -109,6 +109,7 @@ class Field:
             name=field_proto.name,
             dtype=from_value_type(value_type=value_type),
             tags=dict(field_proto.tags),
+            description=field_proto.description,
         )
 
     @classmethod

--- a/sdk/python/tests/unit/test_feature.py
+++ b/sdk/python/tests/unit/test_feature.py
@@ -27,3 +27,6 @@ def test_field_serialization_with_description():
 
     assert serialized_field.description == expected_description
     assert field_from_feature.description == expected_description
+
+    field = Field.from_proto(serialized_field)
+    assert field.description == expected_description 

--- a/sdk/python/tests/unit/test_feature.py
+++ b/sdk/python/tests/unit/test_feature.py
@@ -29,4 +29,4 @@ def test_field_serialization_with_description():
     assert field_from_feature.description == expected_description
 
     field = Field.from_proto(serialized_field)
-    assert field.description == expected_description 
+    assert field.description == expected_description


### PR DESCRIPTION
Signed-off-by: gbmarc1 <marcantoine.belanger@shopify.com>

**What this PR does / why we need it**:
description field was not added to the from_proto method. We add it here.

**Which issue(s) this PR fixes**:
None registered