### PR TITLE
chore: Add tests to bool test type

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -300,7 +300,7 @@ PYTHON_SCALAR_VALUE_TYPE_TO_PROTO_VALUE: Dict[
     ValueType.DOUBLE: ("double_val", lambda x: x, {float, np.float64}),
     ValueType.STRING: ("string_val", lambda x: str(x), None),
     ValueType.BYTES: ("bytes_val", lambda x: x, {bytes}),
-    ValueType.BOOL: ("bool_val", lambda x: x, {bool, np.bool_}),
+    ValueType.BOOL: ("bool_val", lambda x: x, {bool, np.bool_, int, np.int_}),
 }
 
 
@@ -405,9 +405,14 @@ def _python_value_to_proto_value(
             if (sample == 0 or sample == 0.0) and feast_value_type != ValueType.BOOL:
                 # Numpy convert 0 to int. However, in the feature view definition, the type of column may be a float.
                 # So, if value is 0, type validation must pass if scalar_types are either int or float.
-                assert type(sample) in [np.int64, int, np.float64, float]
+                allowed_types = {np.int64, int, np.float64, float}
+                assert (
+                    type(sample) in allowed_types
+                ), f"Type `{type(sample)}` not in {allowed_types}"
             else:
-                assert type(sample) in valid_scalar_types
+                assert (
+                    type(sample) in valid_scalar_types
+                ), f"Type `{type(sample)}` not in {valid_scalar_types}"
         if feast_value_type == ValueType.BOOL:
             # ProtoValue does not support conversion of np.bool_ so we need to convert it to support np.bool_.
             return [

--- a/sdk/python/tests/unit/test_type_map.py
+++ b/sdk/python/tests/unit/test_type_map.py
@@ -5,6 +5,7 @@ from feast.type_map import (
     python_values_to_proto_values,
 )
 from feast.value_type import ValueType
+import pytest
 
 
 def test_null_unix_timestamp():
@@ -26,3 +27,24 @@ def test_null_unix_timestamp_list():
     converted = feast_value_type_to_python_type(protos[0])
 
     assert converted[0] is None
+
+
+@pytest.mark.parametrize(
+    "values",
+    (
+        np.array([True]),
+        np.array([False]),
+        np.array([0]),
+        np.array([1]),
+        [True],
+        [False],
+        [0],
+        [1],
+    ),
+)
+def test_python_values_to_proto_values_bool(values):
+
+    protos = python_values_to_proto_values(values, ValueType.BOOL)
+    converted = feast_value_type_to_python_type(protos[0])
+
+    assert converted is bool(values[0])

--- a/sdk/python/tests/unit/test_type_map.py
+++ b/sdk/python/tests/unit/test_type_map.py
@@ -1,11 +1,11 @@
 import numpy as np
+import pytest
 
 from feast.type_map import (
     feast_value_type_to_python_type,
     python_values_to_proto_values,
 )
 from feast.value_type import ValueType
-import pytest
 
 
 def test_null_unix_timestamp():


### PR DESCRIPTION
**What this PR does / why we need it**:
- We need test to avoid regressions
- Also, add support for int in `_python_value_to_proto_value` for bool values. 

@adchia Make sure that it indeed make sense to add the int support! Not sure about this one.