### PR TITLE
fix: Protobuf lower bound to 3.20 to alert that Feast is incompatible with tensorflow

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -162,6 +162,7 @@ class BigQuerySource(DataSource):
             from google.api_core import client_info as http_client_info
         except ImportError as e:
             from feast.errors import FeastExtrasDependencyImportError
+
             raise FeastExtrasDependencyImportError("gcp", str(e))
 
         from google.cloud import bigquery

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ REQUIRED = [
     "numpy>=1.22,<3",
     "pandas>=1.4.3,<2",
     "pandavro~=1.5.0",  # For some reason pandavro higher than 1.5.* only support pandas less than 1.3.
-    "protobuf<5,>3",
+    "protobuf<5,>3.20",
     "proto-plus>=1.20.0,<2",
     "pyarrow>=4,<9",
     "pydantic>=1,<2",


### PR DESCRIPTION
**What this PR does / why we need it**:
protobuf in python sdk should be lower bound to 3.20 because they introduced the `builder` in 3.20.

```
feast/protos/feast/types/Value_pb2.py:5
      1 # -*- coding: utf-8 -*-
      2 # Generated by the protocol buffer compiler.  DO NOT EDIT!
      3 # source: feast/types/Value.proto
      4 """Generated protocol buffer code."""
----> 5 from google.protobuf.internal import builder as _builder
      6 from google.protobuf import descriptor as _descriptor
      7 from google.protobuf import descriptor_pool as _descriptor_pool

ImportError: cannot import name 'builder' from 'google.protobuf.internal' /lib/python3.9/site-packages/google/protobuf/internal/__init__.py)
```

**Which issue(s) this PR fixes**:

Fixes #3287
