### PR TITLE
fix: Spark kafka processor sorting

### DIFF
--- a/sdk/python/feast/infra/contrib/spark_kafka_processor.py
+++ b/sdk/python/feast/infra/contrib/spark_kafka_processor.py
@@ -131,7 +131,7 @@ class SparkKafkaProcessor(StreamProcessor):
             # Also add a 'created' column.
             rows = (
                 rows.sort_values(
-                    by=self.join_keys + [self.sfv.timestamp_field], ascending=True
+                    by=[*self.join_keys, self.sfv.timestamp_field], ascending=False
                 )
                 .groupby(self.join_keys)
                 .nth(0)


### PR DESCRIPTION
Signed-off-by: shaurya.rawat <shaurya.rawat@new-work.se>

**What this PR does / why we need it**:
Minor fix for the sorting in `sdk/python/feast/infra/contrib/spark_kafka_processor.py` to make sure latest values are picked up for each entity. 