### PR TITLE
fix: Add filesystem kwargs when read prev_table on FileRetrievalJob (…

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file.py
+++ b/sdk/python/feast/infra/offline_stores/file.py
@@ -453,7 +453,9 @@ class FileOfflineStore(OfflineStore):
         filesystem, path = FileSource.create_filesystem_and_path(
             file_options.uri, file_options.s3_endpoint_override
         )
-        prev_table = pyarrow.parquet.read_table(path, memory_map=True)
+        prev_table = pyarrow.parquet.read_table(
+            path, filesystem=filesystem, memory_map=True
+        )
         if table.schema != prev_table.schema:
             table = table.cast(prev_table.schema)
         new_table = pyarrow.concat_tables([table, prev_table])


### PR DESCRIPTION
…#3490)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
For ```FileSource``` ingest to offline store rights.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
Use filesystem kwargs for read dataset.
It works with local & s3fs both.