### PR TITLE
feat: adds k8s config options to Bytewax materialization engine

### DIFF
--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -46,6 +46,17 @@ class BytewaxMaterializationEngineConfig(FeastConfigBaseModel):
     These environment variables can be used to reference Kubernetes secrets.
     """
 
+    image_pull_secrets: List[str] = []
+    """ (optional) The secrets to use when pulling the image to run for the materialization job """
+
+    resources: dict = {}
+    """ (optional) The resource requests and limits for the materialization containers """
+
+    service_account_name: StrictStr = ""
+    """ (optional) The service account name to use when running the job """
+
+    annotations: dict = {}
+    """ (optional) Annotations to apply to the job container. Useful for linking the service account to IAM roles, operational metadata, etc  """
 
 class BytewaxMaterializationEngine(BatchMaterializationEngine):
     def __init__(
@@ -248,9 +259,14 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
                 "parallelism": pods,
                 "completionMode": "Indexed",
                 "template": {
+                    "metadata": {
+                        "annotations": self.batch_engine_config.annotations,
+                    },
                     "spec": {
                         "restartPolicy": "Never",
                         "subdomain": f"dataflow-{job_id}",
+                        "imagePullSecrets": self.batch_engine_config.image_pull_secrets,
+                        "serviceAccountName": self.batch_engine_config.service_account_name,
                         "initContainers": [
                             {
                                 "env": [
@@ -300,7 +316,7 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
                                         "protocol": "TCP",
                                     }
                                 ],
-                                "resources": {},
+                                "resources": self.batch_engine_config.resources,
                                 "securityContext": {
                                     "allowPrivilegeEscalation": False,
                                     "capabilities": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
This PR adds configuration options to the Bytewax materialization engine so that it can be configured to run on at-scale Kubernetes clusters.

The Bytewax materialization engine now supports the following options:

* `image_pull_secrets` so that you can pull your engine container from a secured repository
* `service_account_name` so that the job can run under a service account
* `annotations` for attaching metadata to the job descriptor. Useful for tying the job container to an AWS role when running on EKS
* `resources` for fine-tuning the memory and CPU requirements of the materialization engine

Example of full configuration is included in the updated documentation:

```yaml
batch_engine:
  type: bytewax
  namespace: bytewax
  image: bytewax/bytewax-feast:latest
  image_pull_secrets:
    - my_container_secret
  service_account_name: my-k8s-service-account
  annotations:
    # example annotation you might include if running on AWS EKS
    iam.amazonaws.com/role: arn:aws:iam::<account number>:role/MyBytewaxPlatformRole
  resources:
    limits:
      cpu: 1000m
      memory: 2048Mi
    requests:
      cpu: 500m
      memory: 1024Mi
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3517
