### PR TITLE
fix: Feature view `entities` from_proto type

### DIFF
--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -400,7 +400,7 @@ class FeatureView(BaseFeatureView):
             feature_view.stream_source = stream_source
 
         # This avoids the deprecation warning.
-        feature_view.entities = feature_view_proto.spec.entities
+        feature_view.entities = list(feature_view_proto.spec.entities)
 
         # Instead of passing in a schema, we set the features and entity columns.
         feature_view.features = [


### PR DESCRIPTION


**What this PR does / why we need it**:
fix: Converts `feature_view_proto.spec.entities` from `google.protobuf.internal.containers.RepeatedScalarFieldContainer` to `list`

`google.protobuf.internal.containers.RepeatedScalarFieldContainer` is not serializable and still a proto not a list.

![image](https://user-images.githubusercontent.com/29891099/223868021-0a678f0f-7bfd-412f-a798-5d29ccd9e79a.png)

