### PR TITLE
build: Looser upper bound on pyarrow dependency

### DIFF
--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -34,10 +34,6 @@ anyio==3.6.2
     #   watchfiles
 appdirs==1.4.4
     # via fissix
-appnope==0.1.3
-    # via
-    #   ipykernel
-    #   ipython
 argon2-cffi==21.3.0
     # via
     #   jupyter-server
@@ -211,9 +207,9 @@ execnet==1.9.0
     # via pytest-xdist
 executing==1.2.0
     # via stack-data
-fastapi==0.92.0
+fastapi==0.93.0
     # via feast (setup.py)
-fastavro==1.7.2
+fastavro==1.7.3
     # via
     #   feast (setup.py)
     #   pandavro
@@ -288,7 +284,7 @@ google-cloud-core==2.3.2
     #   google-cloud-datastore
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-datastore==2.14.0
+google-cloud-datastore==2.15.0
     # via feast (setup.py)
 google-cloud-firestore==2.10.0
     # via firebase-admin
@@ -352,7 +348,7 @@ httptools==0.5.0
     # via uvicorn
 httpx==0.23.3
     # via feast (setup.py)
-identify==2.5.18
+identify==2.5.19
     # via pre-commit
 idna==3.4
     # via
@@ -368,7 +364,7 @@ importlib-metadata==6.0.0
     # via great-expectations
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.21.2
+ipykernel==6.21.3
     # via
     #   ipywidgets
     #   nbclassic
@@ -441,7 +437,7 @@ jupyter-core==5.2.0
     #   notebook
 jupyter-events==0.6.3
     # via jupyter-server
-jupyter-server==2.3.0
+jupyter-server==2.4.0
     # via
     #   nbclassic
     #   notebook-shim
@@ -482,7 +478,7 @@ mock==2.0.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-moto==4.1.3
+moto==4.1.4
     # via feast (setup.py)
 msal==1.21.0
     # via
@@ -490,7 +486,7 @@ msal==1.21.0
     #   msal-extensions
 msal-extensions==1.0.0
     # via azure-identity
-msgpack==1.0.4
+msgpack==1.0.5
     # via cachecontrol
 msrest==0.7.1
     # via msrestazure
@@ -514,7 +510,7 @@ mypy-protobuf==3.1
     # via feast (setup.py)
 mysqlclient==2.1.1
     # via feast (setup.py)
-nbclassic==0.5.2
+nbclassic==0.5.3
     # via notebook
 nbclient==0.7.2
     # via nbconvert
@@ -538,7 +534,7 @@ nest-asyncio==1.5.6
     #   notebook
 nodeenv==1.7.0
     # via pre-commit
-notebook==6.5.2
+notebook==6.5.3
     # via great-expectations
 notebook-shim==0.2.2
     # via nbclassic
@@ -599,7 +595,7 @@ pickleshare==0.7.5
     # via ipython
 pip-tools==6.12.3
     # via feast (setup.py)
-platformdirs==3.0.0
+platformdirs==3.1.1
     # via
     #   black
     #   jupyter-core
@@ -627,7 +623,7 @@ proto-plus==1.22.2
     #   google-cloud-bigtable
     #   google-cloud-datastore
     #   google-cloud-firestore
-protobuf==4.22.0
+protobuf==4.22.1
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -682,7 +678,7 @@ pycparser==2.21
     # via cffi
 pycryptodomex==3.17
     # via snowflake-connector-python
-pydantic==1.10.5
+pydantic==1.10.6
     # via
     #   fastapi
     #   feast (setup.py)
@@ -720,7 +716,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pyspark==3.3.2
     # via feast (setup.py)
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   feast (setup.py)
     #   pytest-benchmark
@@ -775,6 +771,7 @@ pyyaml==6.0
     #   jupyter-events
     #   kubernetes
     #   pre-commit
+    #   responses
     #   uvicorn
 pyzmq==25.0.0
     # via
@@ -815,7 +812,7 @@ requests-oauthlib==1.3.1
     #   google-auth-oauthlib
     #   kubernetes
     #   msrest
-responses==0.22.0
+responses==0.23.0
     # via moto
 rfc3339-validator==0.1.4
     # via
@@ -913,9 +910,7 @@ thriftpy2==0.4.16
 tinycss2==1.2.1
     # via nbconvert
 toml==0.10.2
-    # via
-    #   feast (setup.py)
-    #   responses
+    # via feast (setup.py)
 tomli==2.0.1
     # via
     #   black
@@ -937,7 +932,7 @@ tornado==6.2
     #   nbclassic
     #   notebook
     #   terminado
-tqdm==4.64.1
+tqdm==4.65.0
     # via
     #   feast (setup.py)
     #   great-expectations
@@ -957,7 +952,7 @@ traitlets==5.9.0
     #   nbconvert
     #   nbformat
     #   notebook
-trino==0.321.0
+trino==0.322.0
     # via feast (setup.py)
 typeguard==2.13.3
     # via feast (setup.py)
@@ -974,17 +969,17 @@ types-python-dateutil==2.8.19.10
 types-pytz==2022.7.1.2
     # via feast (setup.py)
 types-pyyaml==6.0.12.8
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   responses
 types-redis==4.5.1.4
     # via feast (setup.py)
 types-requests==2.28.11.15
     # via feast (setup.py)
-types-setuptools==67.4.0.3
+types-setuptools==67.6.0.0
     # via feast (setup.py)
 types-tabulate==0.9.0.1
     # via feast (setup.py)
-types-toml==0.10.8.5
-    # via responses
 types-urllib3==1.26.25.8
     # via types-requests
 typing-extensions==4.5.0
@@ -1018,7 +1013,7 @@ urllib3==1.26.14
     #   responses
     #   rockset
     #   snowflake-connector-python
-uvicorn[standard]==0.20.0
+uvicorn[standard]==0.21.0
     # via feast (setup.py)
 uvloop==0.17.0
     # via uvicorn

--- a/sdk/python/requirements/py3.10-requirements.txt
+++ b/sdk/python/requirements/py3.10-requirements.txt
@@ -22,7 +22,7 @@ certifi==2022.12.7
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -39,15 +39,15 @@ dask==2023.3.0
     # via feast (setup.py)
 dill==0.3.6
     # via feast (setup.py)
-fastapi==0.92.0
+fastapi==0.93.0
     # via feast (setup.py)
-fastavro==1.7.2
+fastavro==1.7.3
     # via
     #   feast (setup.py)
     #   pandavro
 fissix==21.11.13
     # via bowler
-fsspec==2023.1.0
+fsspec==2023.3.0
     # via dask
 greenlet==2.0.2
     # via sqlalchemy
@@ -84,7 +84,7 @@ mmh3==3.0.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-mypy==1.0.1
+mypy==1.1.1
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
@@ -106,14 +106,14 @@ partd==1.3.0
     # via dask
 proto-plus==1.22.2
     # via feast (setup.py)
-protobuf==4.22.0
+protobuf==4.22.1
     # via
     #   feast (setup.py)
     #   grpcio-reflection
     #   proto-plus
-pyarrow==8.0.0
+pyarrow==11.0.0
     # via feast (setup.py)
-pydantic==1.10.5
+pydantic==1.10.6
     # via
     #   fastapi
     #   feast (setup.py)
@@ -163,7 +163,7 @@ toolz==0.12.0
     # via
     #   dask
     #   partd
-tqdm==4.64.1
+tqdm==4.65.0
     # via feast (setup.py)
 typeguard==2.13.3
     # via feast (setup.py)
@@ -174,7 +174,7 @@ typing-extensions==4.5.0
     #   sqlalchemy2-stubs
 urllib3==1.26.14
     # via requests
-uvicorn[standard]==0.20.0
+uvicorn[standard]==0.21.0
     # via feast (setup.py)
 uvloop==0.17.0
     # via uvicorn

--- a/sdk/python/requirements/py3.8-ci-requirements.txt
+++ b/sdk/python/requirements/py3.8-ci-requirements.txt
@@ -34,10 +34,6 @@ anyio==3.6.2
     #   watchfiles
 appdirs==1.4.4
     # via fissix
-appnope==0.1.3
-    # via
-    #   ipykernel
-    #   ipython
 argon2-cffi==21.3.0
     # via
     #   jupyter-server
@@ -215,9 +211,9 @@ execnet==1.9.0
     # via pytest-xdist
 executing==1.2.0
     # via stack-data
-fastapi==0.92.0
+fastapi==0.94.0
     # via feast (setup.py)
-fastavro==1.7.2
+fastavro==1.7.3
     # via
     #   feast (setup.py)
     #   pandavro
@@ -292,7 +288,7 @@ google-cloud-core==2.3.2
     #   google-cloud-datastore
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-datastore==2.14.0
+google-cloud-datastore==2.15.0
     # via feast (setup.py)
 google-cloud-firestore==2.10.0
     # via firebase-admin
@@ -356,7 +352,7 @@ httptools==0.5.0
     # via uvicorn
 httpx==0.23.3
     # via feast (setup.py)
-identify==2.5.18
+identify==2.5.19
     # via pre-commit
 idna==3.4
     # via
@@ -378,7 +374,7 @@ importlib-resources==5.12.0
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.21.2
+ipykernel==6.21.3
     # via
     #   ipywidgets
     #   nbclassic
@@ -451,7 +447,7 @@ jupyter-core==5.2.0
     #   notebook
 jupyter-events==0.6.3
     # via jupyter-server
-jupyter-server==2.3.0
+jupyter-server==2.4.0
     # via
     #   nbclassic
     #   notebook-shim
@@ -492,7 +488,7 @@ mock==2.0.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-moto==4.1.3
+moto==4.1.4
     # via feast (setup.py)
 msal==1.21.0
     # via
@@ -500,7 +496,7 @@ msal==1.21.0
     #   msal-extensions
 msal-extensions==1.0.0
     # via azure-identity
-msgpack==1.0.4
+msgpack==1.0.5
     # via cachecontrol
 msrest==0.7.1
     # via msrestazure
@@ -524,7 +520,7 @@ mypy-protobuf==3.1
     # via feast (setup.py)
 mysqlclient==2.1.1
     # via feast (setup.py)
-nbclassic==0.5.2
+nbclassic==0.5.3
     # via notebook
 nbclient==0.7.2
     # via nbconvert
@@ -548,7 +544,7 @@ nest-asyncio==1.5.6
     #   notebook
 nodeenv==1.7.0
     # via pre-commit
-notebook==6.5.2
+notebook==6.5.3
     # via great-expectations
 notebook-shim==0.2.2
     # via nbclassic
@@ -611,7 +607,7 @@ pip-tools==6.12.3
     # via feast (setup.py)
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-platformdirs==3.0.0
+platformdirs==3.1.1
     # via
     #   black
     #   jupyter-core
@@ -639,7 +635,7 @@ proto-plus==1.22.2
     #   google-cloud-bigtable
     #   google-cloud-datastore
     #   google-cloud-firestore
-protobuf==4.22.0
+protobuf==4.22.1
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -694,7 +690,7 @@ pycparser==2.21
     # via cffi
 pycryptodomex==3.17
     # via snowflake-connector-python
-pydantic==1.10.5
+pydantic==1.10.6
     # via
     #   fastapi
     #   feast (setup.py)
@@ -732,7 +728,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pyspark==3.3.2
     # via feast (setup.py)
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   feast (setup.py)
     #   pytest-benchmark
@@ -788,6 +784,7 @@ pyyaml==6.0
     #   jupyter-events
     #   kubernetes
     #   pre-commit
+    #   responses
     #   uvicorn
 pyzmq==25.0.0
     # via
@@ -828,7 +825,7 @@ requests-oauthlib==1.3.1
     #   google-auth-oauthlib
     #   kubernetes
     #   msrest
-responses==0.22.0
+responses==0.23.0
     # via moto
 rfc3339-validator==0.1.4
     # via
@@ -909,7 +906,7 @@ sqlalchemy2-stubs==0.0.2a32
     # via sqlalchemy
 stack-data==0.6.2
     # via ipython
-starlette==0.25.0
+starlette==0.26.0.post1
     # via fastapi
 tabulate==0.9.0
     # via feast (setup.py)
@@ -928,9 +925,7 @@ thriftpy2==0.4.16
 tinycss2==1.2.1
     # via nbconvert
 toml==0.10.2
-    # via
-    #   feast (setup.py)
-    #   responses
+    # via feast (setup.py)
 tomli==2.0.1
     # via
     #   black
@@ -952,7 +947,7 @@ tornado==6.2
     #   nbclassic
     #   notebook
     #   terminado
-tqdm==4.64.1
+tqdm==4.65.0
     # via
     #   feast (setup.py)
     #   great-expectations
@@ -972,7 +967,7 @@ traitlets==5.9.0
     #   nbconvert
     #   nbformat
     #   notebook
-trino==0.321.0
+trino==0.322.0
     # via feast (setup.py)
 typeguard==2.13.3
     # via feast (setup.py)
@@ -989,17 +984,17 @@ types-python-dateutil==2.8.19.10
 types-pytz==2022.7.1.2
     # via feast (setup.py)
 types-pyyaml==6.0.12.8
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   responses
 types-redis==4.5.1.4
     # via feast (setup.py)
 types-requests==2.28.11.15
     # via feast (setup.py)
-types-setuptools==67.4.0.3
+types-setuptools==67.6.0.0
     # via feast (setup.py)
 types-tabulate==0.9.0.1
     # via feast (setup.py)
-types-toml==0.10.8.5
-    # via responses
 types-urllib3==1.26.25.8
     # via types-requests
 typing-extensions==4.5.0
@@ -1036,7 +1031,7 @@ urllib3==1.26.14
     #   responses
     #   rockset
     #   snowflake-connector-python
-uvicorn[standard]==0.20.0
+uvicorn[standard]==0.21.0
     # via feast (setup.py)
 uvloop==0.17.0
     # via uvicorn

--- a/sdk/python/requirements/py3.8-requirements.txt
+++ b/sdk/python/requirements/py3.8-requirements.txt
@@ -22,7 +22,7 @@ certifi==2022.12.7
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -39,15 +39,15 @@ dask==2023.3.0
     # via feast (setup.py)
 dill==0.3.6
     # via feast (setup.py)
-fastapi==0.92.0
+fastapi==0.94.0
     # via feast (setup.py)
-fastavro==1.7.2
+fastavro==1.7.3
     # via
     #   feast (setup.py)
     #   pandavro
 fissix==21.11.13
     # via bowler
-fsspec==2023.1.0
+fsspec==2023.3.0
     # via dask
 greenlet==2.0.2
     # via sqlalchemy
@@ -86,7 +86,7 @@ mmh3==3.0.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-mypy==1.0.1
+mypy==1.1.1
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
@@ -110,14 +110,14 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 proto-plus==1.22.2
     # via feast (setup.py)
-protobuf==4.22.0
+protobuf==4.22.1
     # via
     #   feast (setup.py)
     #   grpcio-reflection
     #   proto-plus
-pyarrow==8.0.0
+pyarrow==11.0.0
     # via feast (setup.py)
-pydantic==1.10.5
+pydantic==1.10.6
     # via
     #   fastapi
     #   feast (setup.py)
@@ -153,7 +153,7 @@ sqlalchemy[mypy]==1.4.46
     # via feast (setup.py)
 sqlalchemy2-stubs==0.0.2a32
     # via sqlalchemy
-starlette==0.25.0
+starlette==0.26.0.post1
     # via fastapi
 tabulate==0.9.0
     # via feast (setup.py)
@@ -167,7 +167,7 @@ toolz==0.12.0
     # via
     #   dask
     #   partd
-tqdm==4.64.1
+tqdm==4.65.0
     # via feast (setup.py)
 typeguard==2.13.3
     # via feast (setup.py)
@@ -179,7 +179,7 @@ typing-extensions==4.5.0
     #   starlette
 urllib3==1.26.14
     # via requests
-uvicorn[standard]==0.20.0
+uvicorn[standard]==0.21.0
     # via feast (setup.py)
 uvloop==0.17.0
     # via uvicorn

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -34,10 +34,6 @@ anyio==3.6.2
     #   watchfiles
 appdirs==1.4.4
     # via fissix
-appnope==0.1.3
-    # via
-    #   ipykernel
-    #   ipython
 argon2-cffi==21.3.0
     # via
     #   jupyter-server
@@ -211,9 +207,9 @@ execnet==1.9.0
     # via pytest-xdist
 executing==1.2.0
     # via stack-data
-fastapi==0.92.0
+fastapi==0.93.0
     # via feast (setup.py)
-fastavro==1.7.2
+fastavro==1.7.3
     # via
     #   feast (setup.py)
     #   pandavro
@@ -288,7 +284,7 @@ google-cloud-core==2.3.2
     #   google-cloud-datastore
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-datastore==2.14.0
+google-cloud-datastore==2.15.0
     # via feast (setup.py)
 google-cloud-firestore==2.10.0
     # via firebase-admin
@@ -352,7 +348,7 @@ httptools==0.5.0
     # via uvicorn
 httpx==0.23.3
     # via feast (setup.py)
-identify==2.5.18
+identify==2.5.19
     # via pre-commit
 idna==3.4
     # via
@@ -372,7 +368,7 @@ importlib-metadata==6.0.0
     #   sphinx
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.21.2
+ipykernel==6.21.3
     # via
     #   ipywidgets
     #   nbclassic
@@ -445,7 +441,7 @@ jupyter-core==5.2.0
     #   notebook
 jupyter-events==0.6.3
     # via jupyter-server
-jupyter-server==2.3.0
+jupyter-server==2.4.0
     # via
     #   nbclassic
     #   notebook-shim
@@ -486,7 +482,7 @@ mock==2.0.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-moto==4.1.3
+moto==4.1.4
     # via feast (setup.py)
 msal==1.21.0
     # via
@@ -494,7 +490,7 @@ msal==1.21.0
     #   msal-extensions
 msal-extensions==1.0.0
     # via azure-identity
-msgpack==1.0.4
+msgpack==1.0.5
     # via cachecontrol
 msrest==0.7.1
     # via msrestazure
@@ -518,7 +514,7 @@ mypy-protobuf==3.1
     # via feast (setup.py)
 mysqlclient==2.1.1
     # via feast (setup.py)
-nbclassic==0.5.2
+nbclassic==0.5.3
     # via notebook
 nbclient==0.7.2
     # via nbconvert
@@ -542,7 +538,7 @@ nest-asyncio==1.5.6
     #   notebook
 nodeenv==1.7.0
     # via pre-commit
-notebook==6.5.2
+notebook==6.5.3
     # via great-expectations
 notebook-shim==0.2.2
     # via nbclassic
@@ -603,7 +599,7 @@ pickleshare==0.7.5
     # via ipython
 pip-tools==6.12.3
     # via feast (setup.py)
-platformdirs==3.0.0
+platformdirs==3.1.1
     # via
     #   black
     #   jupyter-core
@@ -631,7 +627,7 @@ proto-plus==1.22.2
     #   google-cloud-bigtable
     #   google-cloud-datastore
     #   google-cloud-firestore
-protobuf==4.22.0
+protobuf==4.22.1
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -686,7 +682,7 @@ pycparser==2.21
     # via cffi
 pycryptodomex==3.17
     # via snowflake-connector-python
-pydantic==1.10.5
+pydantic==1.10.6
     # via
     #   fastapi
     #   feast (setup.py)
@@ -724,7 +720,7 @@ pyrsistent==0.19.3
     # via jsonschema
 pyspark==3.3.2
     # via feast (setup.py)
-pytest==7.2.1
+pytest==7.2.2
     # via
     #   feast (setup.py)
     #   pytest-benchmark
@@ -779,6 +775,7 @@ pyyaml==6.0
     #   jupyter-events
     #   kubernetes
     #   pre-commit
+    #   responses
     #   uvicorn
 pyzmq==25.0.0
     # via
@@ -819,7 +816,7 @@ requests-oauthlib==1.3.1
     #   google-auth-oauthlib
     #   kubernetes
     #   msrest
-responses==0.22.0
+responses==0.23.0
     # via moto
 rfc3339-validator==0.1.4
     # via
@@ -919,9 +916,7 @@ thriftpy2==0.4.16
 tinycss2==1.2.1
     # via nbconvert
 toml==0.10.2
-    # via
-    #   feast (setup.py)
-    #   responses
+    # via feast (setup.py)
 tomli==2.0.1
     # via
     #   black
@@ -943,7 +938,7 @@ tornado==6.2
     #   nbclassic
     #   notebook
     #   terminado
-tqdm==4.64.1
+tqdm==4.65.0
     # via
     #   feast (setup.py)
     #   great-expectations
@@ -963,7 +958,7 @@ traitlets==5.9.0
     #   nbconvert
     #   nbformat
     #   notebook
-trino==0.321.0
+trino==0.322.0
     # via feast (setup.py)
 typeguard==2.13.3
     # via feast (setup.py)
@@ -980,17 +975,17 @@ types-python-dateutil==2.8.19.10
 types-pytz==2022.7.1.2
     # via feast (setup.py)
 types-pyyaml==6.0.12.8
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   responses
 types-redis==4.5.1.4
     # via feast (setup.py)
 types-requests==2.28.11.15
     # via feast (setup.py)
-types-setuptools==67.4.0.3
+types-setuptools==67.6.0.0
     # via feast (setup.py)
 types-tabulate==0.9.0.1
     # via feast (setup.py)
-types-toml==0.10.8.5
-    # via responses
 types-urllib3==1.26.25.8
     # via types-requests
 typing-extensions==4.5.0
@@ -1027,7 +1022,7 @@ urllib3==1.26.14
     #   responses
     #   rockset
     #   snowflake-connector-python
-uvicorn[standard]==0.20.0
+uvicorn[standard]==0.21.0
     # via feast (setup.py)
 uvloop==0.17.0
     # via uvicorn

--- a/sdk/python/requirements/py3.9-requirements.txt
+++ b/sdk/python/requirements/py3.9-requirements.txt
@@ -22,7 +22,7 @@ certifi==2022.12.7
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
@@ -39,15 +39,15 @@ dask==2023.3.0
     # via feast (setup.py)
 dill==0.3.6
     # via feast (setup.py)
-fastapi==0.92.0
+fastapi==0.93.0
     # via feast (setup.py)
-fastavro==1.7.2
+fastavro==1.7.3
     # via
     #   feast (setup.py)
     #   pandavro
 fissix==21.11.13
     # via bowler
-fsspec==2023.1.0
+fsspec==2023.3.0
     # via dask
 greenlet==2.0.2
     # via sqlalchemy
@@ -84,7 +84,7 @@ mmh3==3.0.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-mypy==1.0.1
+mypy==1.1.1
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
@@ -106,14 +106,14 @@ partd==1.3.0
     # via dask
 proto-plus==1.22.2
     # via feast (setup.py)
-protobuf==4.22.0
+protobuf==4.22.1
     # via
     #   feast (setup.py)
     #   grpcio-reflection
     #   proto-plus
-pyarrow==8.0.0
+pyarrow==11.0.0
     # via feast (setup.py)
-pydantic==1.10.5
+pydantic==1.10.6
     # via
     #   fastapi
     #   feast (setup.py)
@@ -163,7 +163,7 @@ toolz==0.12.0
     # via
     #   dask
     #   partd
-tqdm==4.64.1
+tqdm==4.65.0
     # via feast (setup.py)
 typeguard==2.13.3
     # via feast (setup.py)
@@ -175,7 +175,7 @@ typing-extensions==4.5.0
     #   starlette
 urllib3==1.26.14
     # via requests
-uvicorn[standard]==0.20.0
+uvicorn[standard]==0.21.0
     # via feast (setup.py)
 uvloop==0.17.0
     # via uvicorn

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ REQUIRED = [
     "pandavro~=1.5.0",  # For some reason pandavro higher than 1.5.* only support pandas less than 1.3.
     "protobuf<5,>3.20",
     "proto-plus>=1.20.0,<2",
-    "pyarrow>=4,<9",
+    "pyarrow>=4,<12",
     "pydantic>=1,<2",
     "pygments>=2.12.0,<3",
     "PyYAML>=5.4.0,<7",


### PR DESCRIPTION
**What this PR does / why we need it**:
Pyarrow==7.0.0 and 8.0.0 + homebrew python@3.10 do not like each [other](https://github.com/Homebrew/homebrew-core/issues/125329) on MacOS ventura.

Unbounding pyarrow to greater than 8 solves the issue.

