### PR TITLE
fix: Init go server triggering

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -2283,7 +2283,7 @@ class FeatureStore:
     ) -> None:
         """Start the feature consumption server locally on a given port."""
         type_ = type_.lower()
-        if self.config.go_feature_serving and self._go_server:
+        if self.config.go_feature_serving:
             # Start go server instead of python if the flag is enabled
             self._lazy_init_go_server()
             enable_logging = (


### PR DESCRIPTION
**What this PR does / why we need it**:

Unlike the [documentation](https://docs.feast.dev/reference/feature-servers/go-feature-server)
go_feature_serving: Go server will not run with only True flag.

The existing code assumed the situation where _lazy_init_go_server() is executed and self._go_server is not None, but with the usual feast serve --go

**Which issue(s) this PR fixes**:
Fixes (https://github.com/feast-dev/feast/issues/3352)
