### PR TITLE
fix: Add Stream Feature Views to helper that collect Feature View names

### DIFF
--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -884,4 +884,7 @@ class Registry(BaseRegistry):
         request_fvs = {
             fv.spec.name: fv for fv in self.cached_registry_proto.request_feature_views
         }
-        return {**odfvs, **fvs, **request_fvs}
+        sfv = {
+            fv.spec.name: fv for fv in self.cached_registry_proto.stream_feature_views
+        }
+        return {**odfvs, **fvs, **request_fvs, **sfv}


### PR DESCRIPTION
I noticed that the stream feature views were not being included in the check for conflicting feature views.