### PR TITLE
feat: Add teardown-project command

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -45,6 +45,7 @@ from feast.repo_operations import (
     plan,
     registry_dump,
     teardown,
+    teardown_project
 )
 from feast.repo_upgrade import RepoUpgrader
 from feast.utils import maybe_local_tz
@@ -546,6 +547,20 @@ def teardown_command(ctx: click.Context):
     repo_config = load_repo_config(repo, fs_yaml_file)
 
     teardown(repo_config, repo)
+
+
+@cli.command("teardown-project", cls=NoOptionDefaultFormat)
+@click.pass_context
+def teardown_project_command(ctx: click.Context):
+    """
+    Tear down deployed feature store infrastructure for project
+    """
+    repo = ctx.obj["CHDIR"]
+    fs_yaml_file = ctx.obj["FS_YAML_FILE"]
+    cli_check_repo(repo, fs_yaml_file)
+    repo_config = load_repo_config(repo, fs_yaml_file)
+
+    teardown_project(repo_config, repo)
 
 
 @cli.command("registry-dump")

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -45,7 +45,7 @@ from feast.repo_operations import (
     plan,
     registry_dump,
     teardown,
-    teardown_project
+    teardown_project,
 )
 from feast.repo_upgrade import RepoUpgrader
 from feast.utils import maybe_local_tz

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1013,6 +1013,18 @@ class FeatureStore:
         self._registry.teardown()
 
     @log_exceptions_and_usage
+    def teardown_project(self):
+        """Tears down all local and cloud resources for the feature store project defined."""
+        tables: List[FeatureView] = []
+        feature_views = self.list_feature_views()
+
+        tables.extend(feature_views)
+
+        entities = self.list_entities()
+
+        self._get_provider().teardown_infra(self.project, tables, entities)
+
+    @log_exceptions_and_usage
     def get_historical_features(
         self,
         entity_df: Union[pd.DataFrame, str],

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1014,7 +1014,7 @@ class FeatureStore:
 
     @log_exceptions_and_usage
     def teardown_project(self):
-        """Tears down all local and cloud resources for the feature store project defined."""
+        """Tears down all local and cloud resources for the feature store project defined without removing registry."""
         tables: List[FeatureView] = []
         feature_views = self.list_feature_views()
 

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -345,6 +345,13 @@ def teardown(repo_config: RepoConfig, repo_path: Path):
 
 
 @log_exceptions_and_usage
+def teardown_project(repo_config: RepoConfig, repo_path: Path):
+    # Cannot pass in both repo_path and repo_config to FeatureStore.
+    feature_store = FeatureStore(repo_path=repo_path, config=None)
+    feature_store.teardown_project()
+
+
+@log_exceptions_and_usage
 def registry_dump(repo_config: RepoConfig, repo_path: Path) -> str:
     """For debugging only: output contents of the metadata registry"""
     registry_config = repo_config.registry


### PR DESCRIPTION
What this PR does / why we need it:

This PR adds an additional CLI command `teardown-project`. The existing `teardown` command brings _ALL_ infrastructure down declared in the feature registry, including the registry itself. There are many instances when projects are using a shared registry for discoverability on the UI and they need the ability to bring down the project level infrastructure without interfering with each other. 

Which issue(s) this PR fixes:

Fixes https://github.com/feast-dev/feast/issues/3591

