### PR TITLE
feat: Replace Identity Comparison with Equality Comparison in `parse_repo`

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -122,7 +122,7 @@ def parse_repo(repo_root: Path) -> RepoContents:
             obj = getattr(module, attr_name)
 
             if isinstance(obj, DataSource) and not any(
-                (obj is ds) for ds in res.data_sources
+                (obj == ds) for ds in res.data_sources
             ):
                 res.data_sources.append(obj)
 
@@ -135,12 +135,12 @@ def parse_repo(repo_root: Path) -> RepoContents:
                     batch_source = obj.batch_source
 
                     if batch_source and not any(
-                        (batch_source is ds) for ds in res.data_sources
+                        (batch_source == ds) for ds in res.data_sources
                     ):
                         res.data_sources.append(batch_source)
             if (
                 isinstance(obj, FeatureView)
-                and not any((obj is fv) for fv in res.feature_views)
+                and not any((obj == fv) for fv in res.feature_views)
                 and not isinstance(obj, StreamFeatureView)
                 and not isinstance(obj, BatchFeatureView)
             ):
@@ -149,52 +149,52 @@ def parse_repo(repo_root: Path) -> RepoContents:
                 # Handle batch sources defined with feature views.
                 batch_source = obj.batch_source
                 assert batch_source
-                if not any((batch_source is ds) for ds in res.data_sources):
+                if not any((batch_source == ds) for ds in res.data_sources):
                     res.data_sources.append(batch_source)
 
                 # Handle stream sources defined with feature views.
                 if obj.stream_source:
                     stream_source = obj.stream_source
-                    if not any((stream_source is ds) for ds in res.data_sources):
+                    if not any((stream_source == ds) for ds in res.data_sources):
                         res.data_sources.append(stream_source)
             elif isinstance(obj, StreamFeatureView) and not any(
-                (obj is sfv) for sfv in res.stream_feature_views
+                (obj == sfv) for sfv in res.stream_feature_views
             ):
                 res.stream_feature_views.append(obj)
 
                 # Handle batch sources defined with feature views.
                 batch_source = obj.batch_source
-                if not any((batch_source is ds) for ds in res.data_sources):
+                if not any((batch_source == ds) for ds in res.data_sources):
                     res.data_sources.append(batch_source)
 
                 # Handle stream sources defined with feature views.
                 stream_source = obj.stream_source
                 assert stream_source
-                if not any((stream_source is ds) for ds in res.data_sources):
+                if not any((stream_source == ds) for ds in res.data_sources):
                     res.data_sources.append(stream_source)
             elif isinstance(obj, BatchFeatureView) and not any(
-                (obj is bfv) for bfv in res.feature_views
+                (obj == bfv) for bfv in res.feature_views
             ):
                 res.feature_views.append(obj)
 
                 # Handle batch sources defined with feature views.
                 batch_source = obj.batch_source
-                if not any((batch_source is ds) for ds in res.data_sources):
+                if not any((batch_source == ds) for ds in res.data_sources):
                     res.data_sources.append(batch_source)
             elif isinstance(obj, Entity) and not any(
-                (obj is entity) for entity in res.entities
+                (obj == entity) for entity in res.entities
             ):
                 res.entities.append(obj)
             elif isinstance(obj, FeatureService) and not any(
-                (obj is fs) for fs in res.feature_services
+                (obj == fs) for fs in res.feature_services
             ):
                 res.feature_services.append(obj)
             elif isinstance(obj, OnDemandFeatureView) and not any(
-                (obj is odfv) for odfv in res.on_demand_feature_views
+                (obj == odfv) for odfv in res.on_demand_feature_views
             ):
                 res.on_demand_feature_views.append(obj)
             elif isinstance(obj, RequestFeatureView) and not any(
-                (obj is rfv) for rfv in res.request_feature_views
+                (obj == rfv) for rfv in res.request_feature_views
             ):
                 res.request_feature_views.append(obj)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
This Pull Request updates the parse_repo function in `repo_operations.py`, transitioning from the identity operator `is` to the equality operator `==` for object comparisons.

Previously, the `parse_repo` function utilized the `is` operator to compare Feast objects such as data sources, feature views, and entities. The `is` operator compares if two variables point to the exact same object in memory. However, this approach can be overly restrictive.

When Feast objects are imported across different parts of the repository definition files, they may not share the same memory address, even though they represent the same logical object. This discrepancy led to erroneous distinctions between objects that should have been recognized as identical.

To address this, I've replaced the `is` operator with `==`. The `==` operator evaluates whether two variables are equal in value, independent of their memory addresses. This adjustment enhances the flexibility and accuracy of object comparison within `parse_repo`, permitting objects imported across the repository to be correctly recognized as equal when their values match.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3312
