### PR TITLE
fix: Fix scan datasize to 0 for inference schema

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -181,8 +181,8 @@ class BigQuerySource(DataSource):
                 raise TypeError("Could not parse BigQuery table schema.")
         else:
             bq_columns_query = f"SELECT * FROM ({self.query}) LIMIT 0"
-            queryRes = client.query(bq_columns_query).result()
-            schema = queryRes.schema
+            query_res = client.query(bq_columns_query).result()
+            schema = query_res.schema
 
         name_type_pairs: List[Tuple[str, str]] = []
         for field in schema:

--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -180,7 +180,7 @@ class BigQuerySource(DataSource):
             if not isinstance(schema[0], bigquery.schema.SchemaField):
                 raise TypeError("Could not parse BigQuery table schema.")
         else:
-            bq_columns_query = f"SELECT * FROM ({self.query}) LIMIT 1"
+            bq_columns_query = f"SELECT * FROM ({self.query}) LIMIT 0"
             queryRes = client.query(bq_columns_query).result()
             schema = queryRes.schema
 


### PR DESCRIPTION
**What this PR does / why we need it**:

For bigquery schema inference, query the table (or query) data with LIMIT 1 and obtain a schema object.

LIMIT 1 actually returns one record, but the entire table is full scanned and costs are incurred.

For simple schema inference, it makes sense to get the schema with LIMIT 0 without scan bytes and billing.

**Which issue(s) this PR fixes**:
Fixes #3433
