### PR TITLE
fix: Implements connection pool for postgres online store

### DIFF
--- a/sdk/python/feast/infra/online_stores/contrib/postgres.py
+++ b/sdk/python/feast/infra/online_stores/contrib/postgres.py
@@ -1,9 +1,9 @@
+import contextlib
 import logging
 from collections import defaultdict
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
-import contextlib
 import psycopg2
 import pytz
 from psycopg2 import sql
@@ -14,12 +14,13 @@ from feast import Entity
 from feast.feature_view import FeatureView
 from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
-from feast.infra.utils.postgres.connection_utils import _get_connection_pool, _get_conn
-from feast.infra.utils.postgres.postgres_config import PostgreSQLConfig, ConnectionType
+from feast.infra.utils.postgres.connection_utils import _get_conn, _get_connection_pool
+from feast.infra.utils.postgres.postgres_config import ConnectionType, PostgreSQLConfig
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import RepoConfig
 from feast.usage import log_exceptions_and_usage
+
 
 class PostgreSQLOnlineStoreConfig(PostgreSQLConfig):
     type: Literal["postgres"] = "postgres"

--- a/sdk/python/feast/infra/online_stores/contrib/postgres.py
+++ b/sdk/python/feast/infra/online_stores/contrib/postgres.py
@@ -15,7 +15,7 @@ from feast.feature_view import FeatureView
 from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.infra.utils.postgres.connection_utils import _get_connection_pool, _get_conn
-from feast.infra.utils.postgres.postgres_config import PostgreSQLConfig, Connection
+from feast.infra.utils.postgres.postgres_config import PostgreSQLConfig, ConnectionType
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import RepoConfig
@@ -32,7 +32,7 @@ class PostgreSQLOnlineStore(OnlineStore):
     @contextlib.contextmanager
     def _get_conn(self, config: RepoConfig):
         assert config.online_store.type == "postgres"
-        if config.online_store.conn_type == Connection.pool:
+        if config.online_store.conn_type == ConnectionType.pool:
             if not self._conn_pool:
                 self._conn_pool = _get_connection_pool(config.online_store)
             connection = self._conn_pool.getconn()

--- a/sdk/python/feast/infra/online_stores/contrib/postgres.py
+++ b/sdk/python/feast/infra/online_stores/contrib/postgres.py
@@ -14,7 +14,7 @@ from feast import Entity
 from feast.feature_view import FeatureView
 from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
-from feast.infra.utils.postgres.connection_utils import _get_connection_pool, _get
+from feast.infra.utils.postgres.connection_utils import _get_connection_pool, _get_conn
 from feast.infra.utils.postgres.postgres_config import PostgreSQLConfig, Connection
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto

--- a/sdk/python/feast/infra/online_stores/contrib/postgres.py
+++ b/sdk/python/feast/infra/online_stores/contrib/postgres.py
@@ -8,6 +8,7 @@ import psycopg2
 import pytz
 from psycopg2 import sql
 from psycopg2.extras import execute_values
+from psycopg2.pool import SimpleConnectionPool
 from pydantic.schema import Literal
 
 from feast import Entity
@@ -28,7 +29,7 @@ class PostgreSQLOnlineStoreConfig(PostgreSQLConfig):
 
 class PostgreSQLOnlineStore(OnlineStore):
     _conn: Optional[psycopg2._psycopg.connection] = None
-    _conn_pool: Optional[psycopg2.pool.SimpleConnectionPool] = None
+    _conn_pool: Optional[SimpleConnectionPool] = None
 
     @contextlib.contextmanager
     def _get_conn(self, config: RepoConfig):

--- a/sdk/python/feast/infra/utils/postgres/connection_utils.py
+++ b/sdk/python/feast/infra/utils/postgres/connection_utils.py
@@ -22,6 +22,7 @@ def _get_conn(config: PostgreSQLConfig):
         sslcert=config.sslcert_path,
         sslrootcert=config.sslrootcert_path,
         options="-c search_path={}".format(config.db_schema or config.user),
+        keepalives_idle=config.keepalives_idle
     )
     return conn
 

--- a/sdk/python/feast/infra/utils/postgres/connection_utils.py
+++ b/sdk/python/feast/infra/utils/postgres/connection_utils.py
@@ -26,6 +26,23 @@ def _get_conn(config: PostgreSQLConfig):
     return conn
 
 
+def _get_connection_pool(config: PostgreSQLConfig):
+    return psycopg2.pool.SimpleConnectionPool(
+        config.min_conn,
+        config.max_conn,
+        dbname=config.database,
+        host=config.host,
+        port=int(config.port),
+        user=config.user,
+        password=config.password,
+        sslmode=config.sslmode,
+        sslkey=config.sslkey_path,
+        sslcert=config.sslcert_path,
+        sslrootcert=config.sslrootcert_path,
+        options="-c search_path={}".format(config.db_schema or config.user),
+    )
+
+
 def _df_to_create_table_sql(entity_df, table_name) -> str:
     pa_table = pa.Table.from_pandas(entity_df)
     columns = [

--- a/sdk/python/feast/infra/utils/postgres/connection_utils.py
+++ b/sdk/python/feast/infra/utils/postgres/connection_utils.py
@@ -5,6 +5,7 @@ import pandas as pd
 import psycopg2
 import psycopg2.extras
 import pyarrow as pa
+from psycopg2.pool import SimpleConnectionPool
 
 from feast.infra.utils.postgres.postgres_config import PostgreSQLConfig
 from feast.type_map import arrow_to_pg_type
@@ -28,7 +29,7 @@ def _get_conn(config: PostgreSQLConfig):
 
 
 def _get_connection_pool(config: PostgreSQLConfig):
-    return psycopg2.pool.SimpleConnectionPool(
+    return SimpleConnectionPool(
         config.min_conn,
         config.max_conn,
         dbname=config.database,

--- a/sdk/python/feast/infra/utils/postgres/connection_utils.py
+++ b/sdk/python/feast/infra/utils/postgres/connection_utils.py
@@ -22,7 +22,7 @@ def _get_conn(config: PostgreSQLConfig):
         sslcert=config.sslcert_path,
         sslrootcert=config.sslrootcert_path,
         options="-c search_path={}".format(config.db_schema or config.user),
-        keepalives_idle=config.keepalives_idle
+        keepalives_idle=config.keepalives_idle,
     )
     return conn
 

--- a/sdk/python/feast/infra/utils/postgres/postgres_config.py
+++ b/sdk/python/feast/infra/utils/postgres/postgres_config.py
@@ -1,13 +1,18 @@
 from typing import Optional
 
-from pydantic import StrictStr
+from pydantic import StrictStr, validator
 
 from feast.repo_config import FeastConfigBaseModel
 
 
+class Connection(Enum):
+    singleton = 'singleton'
+    pool = 'pool'
+
 class PostgreSQLConfig(FeastConfigBaseModel):
     min_conn: int = 1
     max_conn: int = 10
+    conn_type: Connection = Connection.singleton
     host: StrictStr
     port: int = 5432
     database: StrictStr
@@ -18,3 +23,4 @@ class PostgreSQLConfig(FeastConfigBaseModel):
     sslkey_path: Optional[StrictStr] = None
     sslcert_path: Optional[StrictStr] = None
     sslrootcert_path: Optional[StrictStr] = None
+    keepalives_idle = 200,

--- a/sdk/python/feast/infra/utils/postgres/postgres_config.py
+++ b/sdk/python/feast/infra/utils/postgres/postgres_config.py
@@ -23,4 +23,4 @@ class PostgreSQLConfig(FeastConfigBaseModel):
     sslkey_path: Optional[StrictStr] = None
     sslcert_path: Optional[StrictStr] = None
     sslrootcert_path: Optional[StrictStr] = None
-    keepalives_idle = 200,
+    keepalives_idle: int = 0

--- a/sdk/python/feast/infra/utils/postgres/postgres_config.py
+++ b/sdk/python/feast/infra/utils/postgres/postgres_config.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import StrictStr, validator
+from pydantic import StrictStr
 
 from feast.repo_config import FeastConfigBaseModel
 

--- a/sdk/python/feast/infra/utils/postgres/postgres_config.py
+++ b/sdk/python/feast/infra/utils/postgres/postgres_config.py
@@ -5,14 +5,14 @@ from pydantic import StrictStr
 from feast.repo_config import FeastConfigBaseModel
 
 
-class Connection(Enum):
+class ConnectionType(Enum):
     singleton = 'singleton'
     pool = 'pool'
 
 class PostgreSQLConfig(FeastConfigBaseModel):
     min_conn: int = 1
     max_conn: int = 10
-    conn_type: Connection = Connection.singleton
+    conn_type: ConnectionType = ConnectionType.singleton
     host: StrictStr
     port: int = 5432
     database: StrictStr

--- a/sdk/python/feast/infra/utils/postgres/postgres_config.py
+++ b/sdk/python/feast/infra/utils/postgres/postgres_config.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Optional
 
 from pydantic import StrictStr
@@ -6,8 +7,9 @@ from feast.repo_config import FeastConfigBaseModel
 
 
 class ConnectionType(Enum):
-    singleton = 'singleton'
-    pool = 'pool'
+    singleton = "singleton"
+    pool = "pool"
+
 
 class PostgreSQLConfig(FeastConfigBaseModel):
     min_conn: int = 1

--- a/sdk/python/feast/infra/utils/postgres/postgres_config.py
+++ b/sdk/python/feast/infra/utils/postgres/postgres_config.py
@@ -6,6 +6,8 @@ from feast.repo_config import FeastConfigBaseModel
 
 
 class PostgreSQLConfig(FeastConfigBaseModel):
+    min_conn: int = 1
+    max_conn: int = 10
     host: StrictStr
     port: int = 5432
     database: StrictStr

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -403,7 +403,7 @@ def fake_ingest_data():
         "conv_rate": [0.5],
         "acc_rate": [0.6],
         "avg_daily_trips": [4],
-        "event_timestamp": [pd.Timestamp(datetime.datetime.utcnow()).round("ms")],
-        "created": [pd.Timestamp(datetime.datetime.utcnow()).round("ms")],
+        "event_timestamp": [pd.Timestamp(datetime.utcnow()).round("ms")],
+        "created": [pd.Timestamp(datetime.utcnow()).round("ms")],
     }
     return pd.DataFrame(data)

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -393,3 +393,17 @@ def feature_store_for_online_retrieval(
     ]
 
     return fs, feature_refs, entity_rows
+
+
+@pytest.fixture
+def fake_ingest_data():
+    """Fake data to ingest into the feature store"""
+    data = {
+        "driver_id": [1],
+        "conv_rate": [0.5],
+        "acc_rate": [0.6],
+        "avg_daily_trips": [4],
+        "event_timestamp": [pd.Timestamp(datetime.datetime.utcnow()).round("ms")],
+        "created": [pd.Timestamp(datetime.datetime.utcnow()).round("ms")],
+    }
+    return pd.DataFrame(data)

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -17,6 +17,7 @@ from feast.errors import FeatureNameCollisionError
 from feast.feature_service import FeatureService
 from feast.feature_view import FeatureView
 from feast.field import Field
+from feast.infra.utils.postgres.postgres_config import ConnectionType
 from feast.online_response import TIMESTAMP_POSTFIX
 from feast.types import Float32, Int32, String
 from feast.wait import wait_retry_backoff
@@ -30,12 +31,13 @@ from tests.integration.feature_repos.universal.feature_views import (
     driver_feature_view,
 )
 from tests.utils.data_source_test_creator import prep_file_source
-from feast.infra.utils.postgres.postgres_config import ConnectionType
 
 
 @pytest.mark.integration
 @pytest.mark.universal_online_stores(only=["postgres"])
-def test_connection_pool_online_stores(environment, universal_data_sources, fake_ingest_data):
+def test_connection_pool_online_stores(
+    environment, universal_data_sources, fake_ingest_data
+):
     if os.getenv("FEAST_IS_LOCAL_TEST", "False") == "True":
         return
     fs = environment.feature_store

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -30,11 +30,46 @@ from tests.integration.feature_repos.universal.feature_views import (
     driver_feature_view,
 )
 from tests.utils.data_source_test_creator import prep_file_source
+from feast.infra.utils.postgres.postgres_config import ConnectionType
+
+
+@pytest.mark.integration
+@pytest.mark.universal_online_stores(only=["postgres"])
+def test_connection_pool_online_stores(environment, universal_data_sources, fake_ingest_data):
+    if os.getenv("FEAST_IS_LOCAL_TEST", "False") == "True":
+        return
+    fs = environment.feature_store
+    fs.config.online_store.conn_type = ConnectionType.pool
+    fs.config.online_store.min_conn = 1
+    fs.config.online_store.max_conn = 10
+
+    entities, datasets, data_sources = universal_data_sources
+    driver_hourly_stats = create_driver_hourly_stats_feature_view(data_sources.driver)
+    driver_entity = driver()
+
+    # Register Feature View and Entity
+    fs.apply([driver_hourly_stats, driver_entity])
+
+    # directly ingest data into the Online Store
+    fs.write_to_online_store("driver_stats", fake_ingest_data)
+
+    # assert the right data is in the Online Store
+    df = fs.get_online_features(
+        features=[
+            "driver_stats:avg_daily_trips",
+            "driver_stats:acc_rate",
+            "driver_stats:conv_rate",
+        ],
+        entity_rows=[{"driver_id": 1}],
+    ).to_df()
+    assertpy.assert_that(df["avg_daily_trips"].iloc[0]).is_equal_to(4)
+    assertpy.assert_that(df["acc_rate"].iloc[0]).is_close_to(0.6, 1e-6)
+    assertpy.assert_that(df["conv_rate"].iloc[0]).is_close_to(0.5, 1e-6)
 
 
 @pytest.mark.integration
 @pytest.mark.universal_online_stores(only=["redis"])
-def test_entity_ttl_online_store(environment, universal_data_sources):
+def test_entity_ttl_online_store(environment, universal_data_sources, fake_ingest_data):
     if os.getenv("FEAST_IS_LOCAL_TEST", "False") == "True":
         return
     fs = environment.feature_store
@@ -47,19 +82,8 @@ def test_entity_ttl_online_store(environment, universal_data_sources):
     # Register Feature View and Entity
     fs.apply([driver_hourly_stats, driver_entity])
 
-    # fake data to ingest into Online Store
-    data = {
-        "driver_id": [1],
-        "conv_rate": [0.5],
-        "acc_rate": [0.6],
-        "avg_daily_trips": [4],
-        "event_timestamp": [pd.Timestamp(datetime.datetime.utcnow()).round("ms")],
-        "created": [pd.Timestamp(datetime.datetime.utcnow()).round("ms")],
-    }
-    df_ingest = pd.DataFrame(data)
-
     # directly ingest data into the Online Store
-    fs.write_to_online_store("driver_stats", df_ingest)
+    fs.write_to_online_store("driver_stats", fake_ingest_data)
 
     # assert the right data is in the Online Store
     df = fs.get_online_features(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
When using a postgres online store, there's a chance the single connection times-out due to inactivity, so we get: 
    InterfaceError
    connection already closed 
The mainstream solution for that is implementing a connection pool with psycopg in order to guanratee the connections to the database are managed correctly.

**Which issue(s) this PR fixes**:
https://github.com/feast-dev/feast/issues/3611

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
