### PR TITLE
feat: Add gunicorn for serve with multiprocess

### DIFF
--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -649,6 +649,21 @@ def init_command(project_directory, minimal: bool, template: str):
     show_default=True,
     help="Disable logging served features",
 )
+@click.option(
+    "--workers",
+    "-w",
+    type=click.INT,
+    default=1,
+    show_default=True,
+    help="Number of worker",
+)
+@click.option(
+    "--keep-alive-timeout",
+    type=click.INT,
+    default=5,
+    show_default=True,
+    help="Timeout for keep alive",
+)
 @click.pass_context
 def serve_command(
     ctx: click.Context,
@@ -657,11 +672,21 @@ def serve_command(
     type_: str,
     no_access_log: bool,
     no_feature_log: bool,
+    workers: int,
+    keep_alive_timeout: int,
 ):
     """Start a feature server locally on a given port."""
     store = create_feature_store(ctx)
 
-    store.serve(host, port, type_, no_access_log, no_feature_log)
+    store.serve(
+        host=host,
+        port=port,
+        type_=type_,
+        no_access_log=no_access_log,
+        no_feature_log=no_feature_log,
+        workers=workers,
+        keep_alive_timeout=keep_alive_timeout,
+    )
 
 
 @cli.command("serve_transformations")

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -2152,7 +2152,6 @@ class FeatureStore:
         allow_cache=False,
         hide_dummy_entity: bool = True,
     ) -> Tuple[List[FeatureView], List[RequestFeatureView], List[OnDemandFeatureView]]:
-
         fvs = {
             fv.name: fv
             for fv in [
@@ -2223,6 +2222,8 @@ class FeatureStore:
         type_: str,
         no_access_log: bool,
         no_feature_log: bool,
+        workers: int,
+        keep_alive_timeout: int,
     ) -> None:
         """Start the feature consumption server locally on a given port."""
         type_ = type_.lower()
@@ -2231,7 +2232,14 @@ class FeatureStore:
                 f"Python server only supports 'http'. Got '{type_}' instead."
             )
         # Start the python server
-        feature_server.start_server(self, host, port, no_access_log)
+        feature_server.start_server(
+            self,
+            host=host,
+            port=port,
+            no_access_log=no_access_log,
+            workers=workers,
+            keep_alive_timeout=keep_alive_timeout,
+        )
 
     @log_exceptions_and_usage
     def get_feature_server_endpoint(self) -> Optional[str]:

--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -326,6 +326,8 @@ grpcio-testing==1.54.2
     # via feast (setup.py)
 grpcio-tools==1.54.2
     # via feast (setup.py)
+gunicorn==20.1.0
+    # via feast (setup.py)
 h11==0.14.0
     # via
     #   httpcore

--- a/sdk/python/requirements/py3.10-requirements.txt
+++ b/sdk/python/requirements/py3.10-requirements.txt
@@ -59,6 +59,8 @@ grpcio==1.54.2
     #   grpcio-reflection
 grpcio-reflection==1.54.2
     # via feast (setup.py)
+gunicorn==20.1.0
+    # via feast (setup.py)
 h11==0.14.0
     # via
     #   httpcore

--- a/sdk/python/requirements/py3.8-ci-requirements.txt
+++ b/sdk/python/requirements/py3.8-ci-requirements.txt
@@ -330,6 +330,8 @@ grpcio-testing==1.54.2
     # via feast (setup.py)
 grpcio-tools==1.54.2
     # via feast (setup.py)
+gunicorn==20.1.0
+    # via feast (setup.py)
 h11==0.14.0
     # via
     #   httpcore

--- a/sdk/python/requirements/py3.8-requirements.txt
+++ b/sdk/python/requirements/py3.8-requirements.txt
@@ -59,6 +59,8 @@ grpcio==1.54.2
     #   grpcio-reflection
 grpcio-reflection==1.54.2
     # via feast (setup.py)
+gunicorn==20.1.0
+    # via feast (setup.py)
 h11==0.14.0
     # via
     #   httpcore

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -326,6 +326,8 @@ grpcio-testing==1.54.2
     # via feast (setup.py)
 grpcio-tools==1.54.2
     # via feast (setup.py)
+gunicorn==20.1.0
+    # via feast (setup.py)
 h11==0.14.0
     # via
     #   httpcore

--- a/sdk/python/requirements/py3.9-requirements.txt
+++ b/sdk/python/requirements/py3.9-requirements.txt
@@ -59,6 +59,8 @@ grpcio==1.54.2
     #   grpcio-reflection
 grpcio-reflection==1.54.2
     # via feast (setup.py)
+gunicorn==20.1.0
+    # via feast (setup.py)
 h11==0.14.0
     # via
     #   httpcore

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ REQUIRED = [
     "typeguard==2.13.3",
     "fastapi>=0.68.0,<1",
     "uvicorn[standard]>=0.14.0,<1",
+    "gunicorn",
     "dask>=2021.1.0",
     "bowler",  # Needed for automatic repo upgrades
     # FastAPI does not correctly pull starlette dependency on httpx see thread(https://github.com/tiangolo/fastapi/issues/5656).
@@ -103,9 +104,7 @@ SPARK_REQUIRED = [
     "pyspark>=3.0.0,<4",
 ]
 
-TRINO_REQUIRED = [
-    "trino>=0.305.0,<0.400.0", "regex"
-]
+TRINO_REQUIRED = ["trino>=0.305.0,<0.400.0", "regex"]
 
 POSTGRES_REQUIRED = [
     "psycopg2-binary>=2.8.3,<3",


### PR DESCRIPTION
**What this PR does / why we need it**:
Required for better performance of serve api application.
Using only one uvicorn process per pod in a typical kubernetes environment is inefficient.
gunicorn is recommended to manage stable multi-process in fastapi. Therefore, add the function to use processes as many as the number of workers received as arguments. 

In addition, when using LoadBalancer, options related to keep alive, which must be handled with care, are added to the gunicorn argument.

**Which issue(s) this PR fixes**:
Fixes #
