### PR TITLE
feat: Add possibility to save dataset as table, when spark config has remote warehouse info

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -352,13 +352,36 @@ class SparkRetrievalJob(RetrievalJob):
     ):
         """
         Run the retrieval and persist the results in the same offline store used for read.
-        Please note the persisting is done only within the scope of the spark session.
+        Please note the persisting is done only within the scope of the spark session for local warehouse directory.
         """
         assert isinstance(storage, SavedDatasetSparkStorage)
         table_name = storage.spark_options.table
         if not table_name:
             raise ValueError("Cannot persist, table_name is not defined")
-        self.to_spark_df().createOrReplaceTempView(table_name)
+        if self._has_remote_warehouse_in_config():
+            file_format = storage.spark_options.file_format
+            if not file_format:
+                self.to_spark_df().write.saveAsTable(table_name)
+            else:
+                self.to_spark_df().write.format(file_format).saveAsTable(table_name)
+        else:
+            self.to_spark_df().createOrReplaceTempView(table_name)
+
+    def _has_remote_warehouse_in_config(self) -> bool:
+        """
+        Check if Spark Session config has info about hive metastore uri
+        or warehouse directory is not a local path
+        """
+        self.spark_session.sparkContext.getConf().getAll()
+        try:
+            self.spark_session.conf.get("hive.metastore.uris")
+            return True
+        except Exception:
+            warehouse_dir = self.spark_session.conf.get("spark.sql.warehouse.dir")
+            if warehouse_dir and warehouse_dir.startswith("file:"):
+                return False
+            else:
+                return True
 
     def supports_remote_storage_export(self) -> bool:
         return self._config.offline_store.staging_location is not None


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

This PR adds a possibility to use saved_dataset as a table for different spark session.  The existing solution saves the dataset’s name in registry, but the data exists only within the scope of the spark session. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3644
