### PR TITLE
feat: Use string as a substitute for unregistered types during schema inference

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -538,7 +538,8 @@ def bq_to_feast_value_type(bq_type_as_str: str) -> ValueType:
         "NULL": ValueType.NULL,
     }
 
-    value_type = type_map[bq_type_as_str]
+    value_type = type_map.get(bq_type_as_str, ValueType.STRING)
+
     if is_list:
         value_type = ValueType[value_type.name + "_LIST"]
 


### PR DESCRIPTION
**What this PR does / why we need it**:

For column types that exist in bigquery but don't currently exist in Feast's typemap (e.g. DATE), most of them can be used as strings.
Currently, attempting schema inference will result in an error saying that there is no type.
In order to use schema inference more actively, it seems reasonable to infer these columns as string type.

**Which issue(s) this PR fixes**:
Fixes #
