### PR TITLE
fix: Broken non-root path with projects-list.json

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -97,7 +97,7 @@ ReactDOM.render(
       reactQueryClient={queryClient}
       feastUIConfigs={{
         tabsRegistry: tabsRegistry,
-        projectListPromise: fetch(process.env.PUBLIC_URL || "" + "/projects-list.json", {
+        projectListPromise: fetch((process.env.PUBLIC_URL || "") + "/projects-list.json", {
             headers: {
               "Content-Type": "application/json",
             },


### PR DESCRIPTION
I think the previous coder intended for the OR operator to take precedence over the string concatenation operator but in fact, with NodeJS, string concatenation takes precedence over OR. You can confirm it by running the following commands in shell:

```sh
$ export PUBLIC_URL=/feast
$ node -e 'console.log(process.env.PUBLIC_URL || "" + "/projects-list.json")'
/feast (wrong)
$ node -e 'console.log((process.env.PUBLIC_URL || "") + "/projects-list.json")'
/feast/projects-list.json (correct)
```

This PR fixes that.