### PR TITLE
fix: Redshift push ignores schema

### DIFF
--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -369,7 +369,7 @@ class RedshiftOfflineStore(OfflineStore):
             s3_resource=s3_resource,
             s3_path=f"{config.offline_store.s3_staging_location}/push/{uuid.uuid4()}.parquet",
             iam_role=config.offline_store.iam_role,
-            table_name=redshift_options.table,
+            table_name=redshift_options.fully_qualified_table_name,
             schema=pa_schema,
             fail_if_exists=False,
         )

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -302,11 +302,11 @@ class RedshiftOptions:
         Returns:
             A string in the format of <database>.<schema>.<table>.
             May be empty or None if the table is not set.
-        """""
+        """
 
         if not self.table:
             return self.table
-        
+
         # self.table may already contain the database and schema
         parts = self.table.split(".")
         if len(parts) == 3:
@@ -319,7 +319,9 @@ class RedshiftOptions:
             schema = self.schema
             table = parts[0]
         else:
-            raise ValueError(f"Invalid table name: {self.table} - can't determine database and schema")
+            raise ValueError(
+                f"Invalid table name: {self.table} - can't determine database and schema"
+            )
 
         if database and schema:
             return f"{database}.{schema}.{table}"

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -307,20 +307,26 @@ class RedshiftOptions:
         if not self.table:
             return self.table
         
-        # If the table name is already fully qualified, return it as is
-        if self.table.count(".") == 2:
-            return self.table
-        elif self.table.count(".") == 1 and self.database:
-            return f"{self.database}.{self.table}"
-        elif self.table.count(".") == 1:
-            return self.table
-
-        if self.database and self.schema:
-            return f"{self.database}.{self.schema}.{self.table}"
-        elif self.schema:
-            return f"{self.schema}.{self.table}"
+        # self.table may already contain the database and schema
+        parts = self.table.split(".")
+        if len(parts) == 3:
+            database, schema, table = parts
+        elif len(parts) == 2:
+            database = self.database
+            schema, table = parts
+        elif len(parts) == 1:
+            database = self.database
+            schema = self.schema
+            table = parts[0]
         else:
-            return self.table
+            raise ValueError(f"Invalid table name: {self.table} - can't determine database and schema")
+
+        if database and schema:
+            return f"{database}.{schema}.{table}"
+        elif schema:
+            return f"{schema}.{table}"
+        else:
+            return table
 
     def to_proto(self) -> DataSourceProto.RedshiftOptions:
         """

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -295,17 +295,17 @@ class RedshiftOptions:
         return redshift_options
 
     @property
-    def fully_qualified_table_name(self) -> Optional[str]:
+    def fully_qualified_table_name(self) -> str:
         """
         The fully qualified table name of this Redshift table.
-        
+
         Returns:
             A string in the format of <database>.<schema>.<table>.
             May be empty or None if the table is not set.
         """
 
         if not self.table:
-            return self.table
+            return ""
 
         # self.table may already contain the database and schema
         parts = self.table.split(".")

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -301,7 +301,7 @@ class RedshiftOptions:
 
         Returns:
             A string in the format of <database>.<schema>.<table>
-            May be empty or None if the table is not set.
+            May be empty or None if the table is not set
         """
 
         if not self.table:

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -306,6 +306,14 @@ class RedshiftOptions:
 
         if not self.table:
             return self.table
+        
+        # If the table name is already fully qualified, return it as is
+        if self.table.count(".") == 2:
+            return self.table
+        elif self.table.count(".") == 1 and self.database:
+            return f"{self.database}.{self.table}"
+        elif self.table.count(".") == 1:
+            return self.table
 
         if self.database and self.schema:
             return f"{self.database}.{self.schema}.{self.table}"

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -300,7 +300,7 @@ class RedshiftOptions:
         The fully qualified table name of this Redshift table.
 
         Returns:
-            A string in the format of <database>.<schema>.<table>.
+            A string in the format of <database>.<schema>.<table>
             May be empty or None if the table is not set.
         """
 
@@ -359,7 +359,6 @@ class SavedDatasetRedshiftStorage(SavedDatasetStorage):
 
     @staticmethod
     def from_proto(storage_proto: SavedDatasetStorageProto) -> SavedDatasetStorage:
-
         return SavedDatasetRedshiftStorage(
             table_ref=RedshiftOptions.from_proto(storage_proto.redshift_storage).table
         )

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -293,7 +293,7 @@ class RedshiftOptions:
         )
 
         return redshift_options
-    
+
     @property
     def fully_qualified_table_name(self) -> str:
         if self.database and self.schema:

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -295,7 +295,18 @@ class RedshiftOptions:
         return redshift_options
 
     @property
-    def fully_qualified_table_name(self) -> str:
+    def fully_qualified_table_name(self) -> Optional[str]:
+        """
+        The fully qualified table name of this Redshift table.
+        
+        Returns:
+            A string in the format of <database>.<schema>.<table>.
+            May be empty or None if the table is not set.
+        """""
+
+        if not self.table:
+            return self.table
+
         if self.database and self.schema:
             return f"{self.database}.{self.schema}.{self.table}"
         elif self.schema:

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -293,6 +293,15 @@ class RedshiftOptions:
         )
 
         return redshift_options
+    
+    @property
+    def fully_qualified_table_name(self) -> str:
+        if self.database and self.schema:
+            return f"{self.database}.{self.schema}.{self.table}"
+        elif self.schema:
+            return f"{self.schema}.{self.table}"
+        else:
+            return self.table
 
     def to_proto(self) -> DataSourceProto.RedshiftOptions:
         """

--- a/sdk/python/tests/unit/infra/offline_stores/test_redshift.py
+++ b/sdk/python/tests/unit/infra/offline_stores/test_redshift.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pyarrow as pa
+
+from feast import FeatureView
+from feast.infra.offline_stores import offline_utils
+from feast.infra.offline_stores.redshift import (
+    RedshiftOfflineStore,
+    RedshiftOfflineStoreConfig,
+)
+from feast.infra.offline_stores.redshift_source import RedshiftSource
+from feast.infra.utils import aws_utils
+from feast.repo_config import RepoConfig
+
+
+@patch.object(aws_utils, "upload_arrow_table_to_redshift")
+def test_offline_write_batch(
+    mock_upload_arrow_table_to_redshift: MagicMock,
+    simple_dataset_1: pd.DataFrame,
+):
+    repo_config = RepoConfig(
+        registry="registry",
+        project="project",
+        provider="local",
+        offline_store=RedshiftOfflineStoreConfig(
+            type="redshift",
+            region="us-west-2",
+            cluster_id="cluster_id",
+            database="database",
+            user="user",
+            iam_role="abcdef",
+            s3_staging_location="s3://bucket/path",
+        ),
+    )
+
+    batch_source = RedshiftSource(
+        name="test_source",
+        timestamp_field="ts",
+        table="table_name",
+        schema="schema_name",
+    )
+    feature_view = FeatureView(
+        name="test_view",
+        source=batch_source,
+    )
+
+    pa_dataset = pa.Table.from_pandas(simple_dataset_1)
+
+    # patch some more things so that the function can run
+    def mock_get_pyarrow_schema_from_batch_source(*args, **kwargs) -> pa.Schema:
+        return pa_dataset.schema, pa_dataset.column_names
+
+    with patch.object(
+        offline_utils,
+        "get_pyarrow_schema_from_batch_source",
+        new=mock_get_pyarrow_schema_from_batch_source,
+    ):
+        RedshiftOfflineStore.offline_write_batch(
+            repo_config, feature_view, pa_dataset, progress=None
+        )
+
+    # check that we have included the fully qualified table name
+    mock_upload_arrow_table_to_redshift.assert_called_once()
+
+    call = mock_upload_arrow_table_to_redshift.call_args_list[0]
+    assert call.kwargs["table_name"] == "schema_name.table_name"

--- a/sdk/python/tests/unit/test_data_sources.py
+++ b/sdk/python/tests/unit/test_data_sources.py
@@ -191,16 +191,34 @@ def test_column_conflict():
             created_timestamp_column="event_timestamp",
         )
 
+
 @pytest.mark.parametrize(
     "source_kwargs,expected_name",
     [
-        ({"database": "test_database", "schema": "test_schema", "table": "test_table"}, "test_database.test_schema.test_table"),
-        ({"database": "test_database", "table": "test_table"}, "test_database.public.test_table"),
+        (
+            {
+                "database": "test_database",
+                "schema": "test_schema",
+                "table": "test_table",
+            },
+            "test_database.test_schema.test_table",
+        ),
+        (
+            {"database": "test_database", "table": "test_table"},
+            "test_database.public.test_table",
+        ),
         ({"table": "test_table"}, "public.test_table"),
         ({"database": "test_database", "table": "b.c"}, "test_database.b.c"),
         ({"database": "test_database", "table": "a.b.c"}, "a.b.c"),
-        ({"database": "test_database", "schema": "test_schema", "query": "select * from abc"}, ""),
-    ]
+        (
+            {
+                "database": "test_database",
+                "schema": "test_schema",
+                "query": "select * from abc",
+            },
+            "",
+        ),
+    ],
 )
 def test_redshift_fully_qualified_table_name(source_kwargs, expected_name):
     redshift_source = RedshiftSource(
@@ -211,7 +229,7 @@ def test_redshift_fully_qualified_table_name(source_kwargs, expected_name):
         description="test description",
         tags={"test": "test"},
         owner="test@gmail.com",
-        **source_kwargs
+        **source_kwargs,
     )
 
     assert redshift_source.redshift_options.fully_qualified_table_name == expected_name

--- a/sdk/python/tests/unit/test_data_sources.py
+++ b/sdk/python/tests/unit/test_data_sources.py
@@ -190,3 +190,28 @@ def test_column_conflict():
             timestamp_field="event_timestamp",
             created_timestamp_column="event_timestamp",
         )
+
+@pytest.mark.parametrize(
+    "source_kwargs,expected_name",
+    [
+        ({"database": "test_database", "schema": "test_schema", "table": "test_table"}, "test_database.test_schema.test_table"),
+        ({"database": "test_database", "table": "test_table"}, "test_database.public.test_table"),
+        ({"table": "test_table"}, "public.test_table"),
+        ({"database": "test_database", "table": "b.c"}, "test_database.b.c"),
+        ({"database": "test_database", "table": "a.b.c"}, "a.b.c"),
+        ({"database": "test_database", "schema": "test_schema", "query": "select * from abc"}, ""),
+    ]
+)
+def test_redshift_fully_qualified_table_name(source_kwargs, expected_name):
+    redshift_source = RedshiftSource(
+        name="test_source",
+        timestamp_field="event_timestamp",
+        created_timestamp_column="created_timestamp",
+        field_mapping={"foo": "bar"},
+        description="test description",
+        tags={"test": "test"},
+        owner="test@gmail.com",
+        **source_kwargs
+    )
+
+    assert redshift_source.redshift_options.fully_qualified_table_name == expected_name


### PR DESCRIPTION
**What this PR does / why we need it**:

When Feast writes to a Redshift offline store, this PR ensures that it takes the fully qualified table name into consideration so that it does not write to the wrong place in the database.



**Which issue(s) this PR fixes**:

Fixes #3651 