### PR TITLE
Fix: issue-4682: run store.plan() only when we need it.

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -296,8 +296,6 @@ def apply_total_with_repo_instance(
         for data_source in data_sources:
             data_source.validate(store.config)
 
-    registry_diff, infra_diff, new_infra = store.plan(repo)
-
     # For each object in the registry, determine whether it should be kept or deleted.
     (
         all_to_apply,
@@ -306,9 +304,10 @@ def apply_total_with_repo_instance(
         views_to_delete,
     ) = extract_objects_for_apply_delete(project, registry, repo)
 
-    click.echo(registry_diff.to_string())
-
     if store._should_use_plan():
+        registry_diff, infra_diff, new_infra = store.plan(repo)
+        click.echo(registry_diff.to_string())
+
         store._apply_diffs(registry_diff, infra_diff, new_infra)
         click.echo(infra_diff.to_string())
     else:


### PR DESCRIPTION
**What this PR does / why we need it**:

This line of code:
`registry_diff, infra_diff, new_infra = store.plan(repo)`

is always executed while we run "feast apply".   It will call the validate() method by default which makes the option "-skip-source-validation" invalid.

Based on the original code logic, I change it to run it only when it is required. The requirement comes from:
`if store._should_use_plan():`

In the implementation of _should_use_plan():
`    def _should_use_plan(self):
        """Returns True if plan and _apply_diffs should be used, False otherwise."""
        # Currently only the local provider with sqlite online store supports plan and _apply_diffs.
        return self.config.provider == "local" and (
            self.config.online_store and self.config.online_store.type == "sqlite"
        )
`

the "store._should_use_plan()" return True while the provider is "local" and the online store is "sqlite".

With this PR, we can alleviate the issue 4682. If a user wants to do local development, he/she may want to change the online store to a different one other than "SQLite", the action of double call "store.validate()" can be avoided.


**Which issue(s) this PR fixes**:
Fixes # 3682
