### PR TITLE
fix: Add aws-sts dependency in java sdk so that S3 client acquires IRSA role

### DIFF
--- a/java/serving/pom.xml
+++ b/java/serving/pom.xml
@@ -244,6 +244,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sts</artifactId>
+      <version>1.12.476</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.adobe.testing</groupId>
       <artifactId>s3mock-testcontainers</artifactId>
       <version>2.2.3</version>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
To use S3 based registry, Java server needs access to S3 bucket and objects. Currently, the default S3 client uses default chain to acquire credentials. At present, S3 client acquire the role associated with EKS Node, instead of IRSA role. 

This change is to include `aws-java-sdk-sts` dependency so that default credential chain uses web identity and assume IRSA Role.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/feast-dev/feast/issues/3648

Reference: 
https://github.com/aws/aws-sdk-java/issues/2136