### PR TITLE
feat: Enhance customization of Trino connections when using Trino-based Offline Stores

### DIFF
--- a/docs/reference/offline-stores/trino.md
+++ b/docs/reference/offline-stores/trino.md
@@ -27,6 +27,47 @@ offline_store:
     catalog: memory
     connector:
         type: memory
+    user: trino
+    source: feast-trino-offline-store
+    http-scheme: https
+    ssl-verify: false
+    x-trino-extra-credential-header: foo=bar, baz=qux
+
+    # enables authentication in Trino connections, pick the one you need
+    # if you don't need authentication, you can safely remove the whole auth block
+    auth:
+        # Basic Auth
+        type: basic
+        config:
+            username: foo
+            password: $FOO
+
+        # Certificate
+        type: certificate
+        config:
+            cert-file: /path/to/cert/file
+            key-file: /path/to/key/file
+
+        # JWT
+        type: jwt
+        config:
+            token: $JWT_TOKEN
+
+        # OAuth2 (no config required)
+        type: oauth2
+
+        # Kerberos
+        type: kerberos
+        config:
+            config-file: /path/to/kerberos/config/file
+            service-name: foo
+            mutual-authentication: true
+            force-preemptive: true
+            hostname-override: custom-hostname
+            sanitize-mutual-error-response: true
+            principal: principal-name
+            delegate: true
+            ca_bundle: /path/to/ca/bundle/file
 online_store:
     path: data/online_store.db
 ```

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/data_source.py
@@ -67,6 +67,11 @@ class TrinoSourceCreator(DataSourceCreator):
             catalog="memory",
             host="localhost",
             port=self.exposed_port,
+            source="trino-python-client",
+            http_scheme="http",
+            verify=False,
+            extra_credential=None,
+            auth=None,
         )
 
     def teardown(self):

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import os
 import signal
 from dataclasses import dataclass
 from enum import Enum
@@ -30,33 +29,26 @@ class QueryStatus(Enum):
 class Trino:
     def __init__(
         self,
-        host: Optional[str] = None,
-        port: Optional[int] = None,
-        user: Optional[str] = None,
-        catalog: Optional[str] = None,
-        auth: Optional[Any] = None,
-        http_scheme: Optional[str] = None,
-        source: Optional[str] = None,
-        extra_credential: Optional[str] = None,
+        host: str,
+        port: int,
+        user: str,
+        catalog: str,
+        source: Optional[str],
+        http_scheme: str,
+        verify: bool,
+        extra_credential: Optional[str],
+        auth: Optional[trino.Authentication],
     ):
-        self.host = host or os.getenv("TRINO_HOST")
-        self.port = port or os.getenv("TRINO_PORT")
-        self.user = user or os.getenv("TRINO_USER")
-        self.catalog = catalog or os.getenv("TRINO_CATALOG")
-        self.auth = auth or os.getenv("TRINO_AUTH")
-        self.http_scheme = http_scheme or os.getenv("TRINO_HTTP_SCHEME")
-        self.source = source or os.getenv("TRINO_SOURCE")
-        self.extra_credential = extra_credential or os.getenv("TRINO_EXTRA_CREDENTIAL")
+        self.host = host
+        self.port = port
+        self.user = user
+        self.catalog = catalog
+        self.source = source
+        self.http_scheme = http_scheme
+        self.verify = verify
+        self.extra_credential = extra_credential
+        self.auth = auth
         self._cursor: Optional[Cursor] = None
-
-        if self.host is None:
-            raise ValueError("TRINO_HOST must be set if not passed in")
-        if self.port is None:
-            raise ValueError("TRINO_PORT must be set if not passed in")
-        if self.user is None:
-            raise ValueError("TRINO_USER must be set if not passed in")
-        if self.catalog is None:
-            raise ValueError("TRINO_CATALOG must be set if not passed in")
 
     def _get_cursor(self) -> Cursor:
         if self._cursor is None:
@@ -70,9 +62,10 @@ class Trino:
                 port=self.port,
                 user=self.user,
                 catalog=self.catalog,
-                auth=self.auth,
-                http_scheme=self.http_scheme,
                 source=self.source,
+                http_scheme=self.http_scheme,
+                verify=self.verify,
+                auth=self.auth,
                 http_headers=headers,
             ).cursor()
 

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_source.py
@@ -227,10 +227,20 @@ class TrinoSource(DataSource):
     def get_table_column_names_and_types(
         self, config: RepoConfig
     ) -> Iterable[Tuple[str, str]]:
+        auth = None
+        if config.offline_store.auth is not None:
+            auth = config.offline_store.auth.to_trino_auth()
+
         client = Trino(
             catalog=config.offline_store.catalog,
             host=config.offline_store.host,
             port=config.offline_store.port,
+            user=config.offline_store.user,
+            source=config.offline_store.source,
+            http_scheme=config.offline_store.http_scheme,
+            verify=config.offline_store.verify,
+            extra_credential=config.offline_store.extra_credential,
+            auth=auth,
         )
         if self.table:
             table_schema = client.execute_query(


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

Right now, the Trino Offline Store implementation lacks support for authentication. Taking a look at the code it seems like it is supported via the `TRINO_AUTH` environment variable; however, environment variables can only hold string values. The issue here is that `TRINO_AUTH` is passed to [`trino.dbapi.connect`](https://github.com/trinodb/trino-python-client/blob/master/trino/dbapi.py#L119) as is (i.e. a string), but it must be a `trino.Authentication` instance. So in practice, there's no way to make authentication work.

Aside from that, the current implementation supports customizing Trino connections via `feature_store.yaml` file, or via environment variables as hinted above. Particularly, the set of supported parameters on both sides is as follows:

**`feature_store.yaml`**
* `host`
* `port`
* `catalog`

**Environment variables**
* `TRINO_HOST` (mirror of `feature_store.yaml`'s `host` parameter)
* `TRINO_PORT` (mirror of `feature_store.yaml`'s `port` parameter)
* `TRINO_USER`
* `TRINO_CATALOG` (mirror of `feature_store.yaml`'s `catalog` parameter)
* `TRINO_HTTP_SCHEME`
* `TRINO_SOURCE`
* `TRINO_EXTRA_CREDENTIAL`
* `TRINO_AUTH` (supported but not usable, as explained above)

These configurations should be doable through the `feature_store.yaml` file to be consistent with the set of parameters already supported. Hence this PR.

**A word of warning on compatibility**

If you are using some of the environment variables above to customize Trino connections, you must update your `feature_store.yaml` file to make sure your setup doesn't break.

An example on how to incorporate those environment variables into your `feature_store.yaml`:
```yaml
offline_store:
    type: feast_trino.trino.TrinoOfflineStore
    host: $TRINO_HOST
    port: $TRINO_PORT
    catalog: $TRINO_CATALOG
    connector:
        type: memory
    user: $TRINO_USER
    source: $TRINO_SOURCE
    http-scheme: $TRINO_HTTP_SCHEME
    x-trino-extra-credential-header: $TRINO_EXTRA_CREDENTIAL
```

**Which issue(s) this PR fixes**:
* Unify Trino connections' configuration in a single point (`feature_store.yaml`) to ease customization.
* Add an extra configuration (`ssl-verify`) to specify whether Trino SSL certificates should be validated on `feast`'s side or not. This parameter is the equivalent to the `verify` flag in popular Python HTTP libs like `requests`.
* Ensure that the `TrinoOfflineStore` class satisfies the signature of abstract methods included in the `OfflineStore` abstract class.
* Add support for multiple authentication mechanisms:
  * Kerberos
  * Basic Auth
  * JWT
  * OAuth2
  * Certificate
* Update Trino Offline Store's docs to provide examples on how to customize these connections.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
