### PR TITLE
fix: Saved datasets no longer break CLI registry-dump command

### DIFF
--- a/sdk/python/feast/infra/registry/proto_registry_utils.py
+++ b/sdk/python/feast/infra/registry/proto_registry_utils.py
@@ -214,7 +214,7 @@ def list_saved_datasets(
 ) -> List[SavedDataset]:
     saved_datasets = []
     for saved_dataset in registry_proto.saved_datasets:
-        if saved_dataset.project == project:
+        if saved_dataset.spec.project == project:
             saved_datasets.append(SavedDataset.from_proto(saved_dataset))
     return saved_datasets
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

This PR fixes an issue where creating a saved dataset breaks the CLI `feast registry-dump` command. A `SavedDatasetProto` object was being incorrectly accessed in the `list_saved_datasets()` utility function, leading to a `AttributeError` when running the CLI `feast registry-dump` command.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3715
