### PR TITLE
feat: Add support for in_cluster config and additional labels for bytewax materialization

### DIFF
--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -64,6 +64,9 @@ class BytewaxMaterializationEngineConfig(FeastConfigBaseModel):
     labels: dict = {}
     """ (optional) additional labels to append to kubernetes objects """
 
+    max_parallelism: int = 10
+    """ (optional) Maximum number of pods  (default 10) allowed to run in parallel per job"""
+
 
 class BytewaxMaterializationEngine(BatchMaterializationEngine):
     def __init__(
@@ -275,7 +278,7 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
             "spec": {
                 "ttlSecondsAfterFinished": 3600,
                 "completions": pods,
-                "parallelism": pods,
+                "parallelism": min(pods, self.batch_engine_config.max_parallelism),
                 "completionMode": "Indexed",
                 "template": {
                     "metadata": {

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ REDIS_REQUIRED = [
     "hiredis>=2.0.0,<3",
 ]
 
-AWS_REQUIRED = ["boto3>=1.17.0,<2", "docker>=5.0.2"]
+AWS_REQUIRED = ["boto3>=1.17.0,<2", "docker>=5.0.2", "s3fs"]
 
 BYTEWAX_REQUIRED = ["bytewax==0.15.1", "docker>=5.0.2", "kubernetes<=20.13.0"]
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds 2 new features to bytewax materialization.  

The first is to support loading kubernetes config from in_cluster config, so that materialization can easily be run as a kubernetes job. 

The second is to support adding additional labels to kubernetes objects created by bytewax so they can better be tracked.

It also addresses missing dependencies that were causing failures in the bytewax worker image by adding s3fs and pyOpenSSL dependencies

**Which issue(s) this PR fixes**:
Fixes #3746
Fixes #3745 
