### PR TITLE
fix: Make generated temp table name escaped

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -515,7 +515,7 @@ class BigQueryRetrievalJob(RetrievalJob):
                 temp_dest_table = f"{tmp_dest['projectId']}.{tmp_dest['datasetId']}.{tmp_dest['tableId']}"
 
                 # persist temp table
-                sql = f"CREATE TABLE `{dest}` AS SELECT * FROM {temp_dest_table}"
+                sql = f"CREATE TABLE `{dest}` AS SELECT * FROM `{temp_dest_table}`"
                 self._execute_query(sql, timeout=timeout)
 
             print(f"Done writing to '{dest}'.")

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ REQUIRED = [
     "Jinja2>=2,<4",
     "jsonschema",
     "mmh3",
-    "numpy>=1.22,<1.25",
+    "numpy>=1.22,<1.27",
     "pandas>=1.4.3,<2",
     # For some reason pandavro higher than 1.5.* only support pandas less than 1.3.
     "pandavro~=1.5.0",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ REQUIRED = [
     "Jinja2>=2,<4",
     "jsonschema",
     "mmh3",
-    "numpy>=1.22,<1.27",
+    "numpy>=1.22,<1.25",
     "pandas>=1.4.3,<2",
     # For some reason pandavro higher than 1.5.* only support pandas less than 1.3.
     "pandavro~=1.5.0",


### PR DESCRIPTION
We need to encapsulate the table path as the "tmp" table path can contain symbols that BigQuery can't process without encapsulation.