### PR TITLE
fix: Update SparkSource to have proper comparable that inspects SparkOptions

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -185,6 +185,18 @@ class SparkSource(DataSource):
 
         return f"`{tmp_table_name}`"
 
+    # Note: Python requires redefining hash in child classes that override __eq__
+    def __hash__(self):
+        return super().__hash__()
+
+    def __eq__(self, other):
+        if not isinstance(other, SparkSource):
+            raise TypeError("Comparisons should only involve SparkSource class objects.")
+        return (
+            super().__eq__(other)
+            and self.spark_options == other.spark_options
+        )
+
 
 class SparkOptions:
     allowed_formats = [format.value for format in SparkSourceFormat]
@@ -281,6 +293,17 @@ class SparkOptions:
         )
 
         return spark_options_proto
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SparkOptions):
+            raise TypeError("Comparisons should only involve SparkOptions class objects.")
+
+        return (
+            self.table == other.table
+            and self.query == other.query
+            and self.path == other.path
+            and self.file_format == other.file_format
+        )
 
 
 class SavedDatasetSparkStorage(SavedDatasetStorage):

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -187,6 +187,7 @@ class SparkSource(DataSource):
 
     # Note: Python requires redefining hash in child classes that override __eq__
     def __hash__(self):
+
         return super().__hash__()
 
     def __eq__(self, other):

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -191,11 +191,10 @@ class SparkSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, SparkSource):
-            raise TypeError("Comparisons should only involve SparkSource class objects.")
-        return (
-            super().__eq__(other)
-            and self.spark_options == other.spark_options
-        )
+            raise TypeError(
+                "Comparisons should only involve SparkSource class objects."
+            )
+        return super().__eq__(other) and self.spark_options == other.spark_options
 
 
 class SparkOptions:
@@ -296,7 +295,9 @@ class SparkOptions:
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SparkOptions):
-            raise TypeError("Comparisons should only involve SparkOptions class objects.")
+            raise TypeError(
+                "Comparisons should only involve SparkOptions class objects."
+            )
 
         return (
             self.table == other.table

--- a/sdk/python/tests/unit/test_data_sources.py
+++ b/sdk/python/tests/unit/test_data_sources.py
@@ -10,10 +10,12 @@ from feast.data_source import (
 )
 from feast.field import Field
 from feast.infra.offline_stores.bigquery_source import BigQuerySource
+from feast.infra.offline_stores.contrib.spark_offline_store.spark_source import (
+    SparkSource,
+)
 from feast.infra.offline_stores.file_source import FileSource
 from feast.infra.offline_stores.redshift_source import RedshiftSource
 from feast.infra.offline_stores.snowflake_source import SnowflakeSource
-from feast.infra.offline_stores.contrib.spark_offline_store.spark_source import SparkSource
 from feast.types import Bool, Float32, Int64
 
 
@@ -235,52 +237,34 @@ def test_redshift_fully_qualified_table_name(source_kwargs, expected_name):
 
     assert redshift_source.redshift_options.fully_qualified_table_name == expected_name
 
+
 @pytest.mark.parameterize(
-        "test_data,are_equal",
-        [
-            (
-                SparkSource(
-                    name='name',
-                    table='table',
-                    query='query',
-                    file_format='file_format'
-                ),
-                True
+    "test_data,are_equal",
+    [
+        (
+            SparkSource(
+                name="name", table="table", query="query", file_format="file_format"
             ),
-            (
-                SparkSource(
-                    table='table',
-                    query='query',
-                    file_format='file_format'
-                ),
-                False
+            True,
+        ),
+        (SparkSource(table="table", query="query", file_format="file_format"), False),
+        (
+            SparkSource(
+                name="name", table="table", query="query", file_format="file_format1"
             ),
-            (
-                SparkSource(
-                    name='name',
-                    table='table',
-                    query='query',
-                    file_format='file_format1'
-                ),
-                False
+            False,
+        ),
+        (
+            SparkSource(
+                name="name", table="table", query="query1", file_format="file_format"
             ),
-            (
-                SparkSource(
-                    name='name',
-                    table='table',
-                    query='query1',
-                    file_format='file_format'
-                ),
-                True
-            ),
-        ]
+            True,
+        ),
+    ],
 )
 def test_spark_source_equality(test_data, are_equal):
     default = SparkSource(
-        name='name',
-        table='table1',
-        query='query',
-        file_format='file_format'
+        name="name", table="table1", query="query", file_format="file_format"
     )
     if are_equal:
         assert default == test_data

--- a/sdk/python/tests/unit/test_data_sources.py
+++ b/sdk/python/tests/unit/test_data_sources.py
@@ -270,3 +270,4 @@ def test_spark_source_equality(test_data, are_equal):
         assert default == test_data
     else:
         assert default != test_data
+

--- a/sdk/python/tests/unit/test_data_sources.py
+++ b/sdk/python/tests/unit/test_data_sources.py
@@ -13,6 +13,7 @@ from feast.infra.offline_stores.bigquery_source import BigQuerySource
 from feast.infra.offline_stores.file_source import FileSource
 from feast.infra.offline_stores.redshift_source import RedshiftSource
 from feast.infra.offline_stores.snowflake_source import SnowflakeSource
+from feast.infra.offline_stores.contrib.spark_offline_store.spark_source import SparkSource
 from feast.types import Bool, Float32, Int64
 
 
@@ -233,3 +234,55 @@ def test_redshift_fully_qualified_table_name(source_kwargs, expected_name):
     )
 
     assert redshift_source.redshift_options.fully_qualified_table_name == expected_name
+
+@pytest.mark.parameterize(
+        "test_data,are_equal",
+        [
+            (
+                SparkSource(
+                    name='name',
+                    table='table',
+                    query='query',
+                    file_format='file_format'
+                ),
+                True
+            ),
+            (
+                SparkSource(
+                    table='table',
+                    query='query',
+                    file_format='file_format'
+                ),
+                False
+            ),
+            (
+                SparkSource(
+                    name='name',
+                    table='table',
+                    query='query',
+                    file_format='file_format1'
+                ),
+                False
+            ),
+            (
+                SparkSource(
+                    name='name',
+                    table='table',
+                    query='query1',
+                    file_format='file_format'
+                ),
+                True
+            ),
+        ]
+)
+def test_spark_source_equality(test_data, are_equal):
+    default = SparkSource(
+        name='name',
+        table='table1',
+        query='query',
+        file_format='file_format'
+    )
+    if are_equal:
+        assert default == test_data
+    else:
+        assert default != test_data


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
This updates the `SparkSource` data type to be properly comparable. The previous form defaults to using the `__eq__` implementation from the `DataSource` class. This misses updates to additional properties on the `SparkSource` class (i.e. anything that feeds into the `SparkOptions` class). 

This PR resolves this and adds tests to confirm the updated functionality. This means that `FeatureStore.plan()` and `FeatureStore.apply()` will properly pick up changes to `SparkSources` correctly.
