### PR TITLE
feat: Adding redis sentinel support

### DIFF
--- a/docs/reference/online-stores/redis.md
+++ b/docs/reference/online-stores/redis.md
@@ -45,6 +45,21 @@ online_store:
 ```
 {% endcode %}
 
+Connecting to a Redis Sentinel with SSL enabled and password authentication:
+
+{% code title="feature_store.yaml" %}
+```yaml
+project: my_feature_repo
+registry: data/registry.db
+provider: local
+online_store:
+  type: redis
+  redis_type: redis_sentinel
+  sentinel_master: mymaster
+  connection_string: "redis1:26379,ssl=true,password=my_password"
+```
+{% endcode %}
+
 Additionally, the redis online store also supports automatically deleting data via a TTL mechanism.
 The TTL is applied at the entity level, so feature values from any associated feature views for an entity are removed together. 
 This TTL can be set in the `feature_store.yaml`, using the `key_ttl_seconds` field in the online store. For example:

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -187,13 +187,9 @@ class RedisOnlineStore(OnlineStore):
                 sentinel_hosts = []
 
                 for item in startup_nodes:
-                    sentinel_hosts.append((item['host'], int(item['port'])))
+                    sentinel_hosts.append((item["host"], int(item["port"])))
 
-                sentinel = Sentinel( 
-                    sentinel_hosts,
-                    **kwargs
-                )
-                                    
+                sentinel = Sentinel(sentinel_hosts, **kwargs)
                 master = sentinel.master_for(online_store_config.sentinel_master)
                 self._client = master
             else:


### PR DESCRIPTION
**What this PR does / why we need it**:

Redis Sentinel is a standard strategy for autonomous high availability.

[Redis Docs for Sentinel](https://redis.io/docs/management/sentinel/)

I did not create an issue. Also, docs updated too.
