### PR TITLE
fix: Update typeguard version to >=4.0.0

### DIFF
--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -895,7 +895,7 @@ traitlets==5.14.1
     #   nbformat
 trino==0.327.0
     # via feast (setup.py)
-typeguard==2.13.3
+typeguard==4.1.5
     # via feast (setup.py)
 types-protobuf==3.19.22
     # via

--- a/sdk/python/requirements/py3.10-requirements.txt
+++ b/sdk/python/requirements/py3.10-requirements.txt
@@ -200,7 +200,7 @@ toolz==0.12.1
     #   partd
 tqdm==4.66.2
     # via feast (setup.py)
-typeguard==2.13.3
+typeguard==4.1.5
     # via feast (setup.py)
 types-protobuf==4.24.0.20240129
     # via mypy-protobuf

--- a/sdk/python/requirements/py3.8-ci-requirements.txt
+++ b/sdk/python/requirements/py3.8-ci-requirements.txt
@@ -919,7 +919,7 @@ traitlets==5.14.1
     #   nbformat
 trino==0.327.0
     # via feast (setup.py)
-typeguard==2.13.3
+typeguard==4.1.5
     # via feast (setup.py)
 types-protobuf==3.19.22
     # via

--- a/sdk/python/requirements/py3.8-requirements.txt
+++ b/sdk/python/requirements/py3.8-requirements.txt
@@ -203,7 +203,7 @@ toolz==0.12.1
     #   partd
 tqdm==4.66.2
     # via feast (setup.py)
-typeguard==2.13.3
+typeguard==4.1.5
     # via feast (setup.py)
 types-protobuf==4.24.0.20240129
     # via mypy-protobuf

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -904,7 +904,7 @@ traitlets==5.14.1
     #   nbformat
 trino==0.327.0
     # via feast (setup.py)
-typeguard==2.13.3
+typeguard==4.1.5
     # via feast (setup.py)
 types-protobuf==3.19.22
     # via

--- a/sdk/python/requirements/py3.9-requirements.txt
+++ b/sdk/python/requirements/py3.9-requirements.txt
@@ -198,7 +198,7 @@ toolz==0.12.1
     #   partd
 tqdm==4.66.2
     # via feast (setup.py)
-typeguard==2.13.3
+typeguard==4.1.5
     # via feast (setup.py)
 types-protobuf==4.24.0.20240129
     # via mypy-protobuf

--- a/sdk/python/tests/unit/test_feature_views.py
+++ b/sdk/python/tests/unit/test_feature_views.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import pytest
+from typeguard import TypeCheckError
 
 from feast.aggregation import Aggregation
 from feast.batch_feature_view import BatchFeatureView
@@ -278,7 +279,7 @@ def test_hash():
 
 
 def test_field_types():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeCheckError):
         Field(name="name", dtype=ValueType.INT32)
 
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ REQUIRED = [
     "tenacity>=7,<9",
     "toml>=0.10.0,<1",
     "tqdm>=4,<5",
-    "typeguard==2.13.3",
+    "typeguard>=4.0.0",
     "fastapi>=0.68.0",
     "uvicorn[standard]>=0.14.0,<1",
     "gunicorn",


### PR DESCRIPTION
**What this PR does / why we need it**:

Pinning typeguard to 2.X.X causes quite a few incompatibilities with other dependencies. The [original reason](https://github.com/feast-dev/feast/issues/3538) why this pinning happened has been fixed with [this commit](https://github.com/agronholm/typeguard/commit/216a7b982a8444b72e28392c7dcae13bcc5120e2)
 which is in typeguard==3.0.1