### PR TITLE
feat: Added option for global tables for Dynamodb online 

### DIFF
--- a/docs/reference/online-stores/dynamodb.md
+++ b/docs/reference/online-stores/dynamodb.md
@@ -81,6 +81,7 @@ For multi-region tables, the following inline policy can be used to grant Feast 
         {
             "Action": [
                 "dynamodb:CreateTable",
+                "dynamodb:UpdateTable",
                 "dynamodb:DescribeTable",
                 "dynamodb:DeleteTable",
                 "dynamodb:BatchWriteItem",

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -111,7 +111,7 @@ class DynamoDBOnlineStore(OnlineStore):
 
         for table_instance in tables_to_keep:
             try:
-                dynamodb_resource.create_table(
+                table = dynamodb_resource.create_table(
                     TableName=_get_table_name(online_config, config, table_instance),
                     KeySchema=[{"AttributeName": "entity_id", "KeyType": "HASH"}],
                     AttributeDefinitions=[
@@ -128,10 +128,7 @@ class DynamoDBOnlineStore(OnlineStore):
                     },
                 )
                 if online_config.global_table_region:
-                    dynamodb_resource.update_table(
-                        TableName=_get_table_name(
-                            online_config, config, table_instance
-                        ),
+                    table.update(
                         ReplicaUpdates=[
                             {
                                 "Create": {
@@ -460,7 +457,7 @@ class DynamoDBTable(InfraObject):
         dynamodb_resource = self._get_dynamodb_resource(self.region, self.endpoint_url)
 
         try:
-            dynamodb_resource.create_table(
+            table = dynamodb_resource.create_table(
                 TableName=f"{self.name}",
                 KeySchema=[{"AttributeName": "entity_id", "KeyType": "HASH"}],
                 AttributeDefinitions=[
@@ -477,8 +474,7 @@ class DynamoDBTable(InfraObject):
                 },
             )
             if self.global_table_region:
-                dynamodb_resource.update_table(
-                    TableName=f"{self.name}",
+                table.update(
                     ReplicaUpdates=[
                         {
                             "Create": {

--- a/sdk/python/tests/unit/infra/online_store/test_dynamodb_online_store.py
+++ b/sdk/python/tests/unit/infra/online_store/test_dynamodb_online_store.py
@@ -18,6 +18,7 @@ from tests.utils.dynamo_table_creator import (
     create_n_customer_test_samples,
     create_test_table,
     insert_data_test_table,
+    create_test_table_global,
 )
 
 REGISTRY = "s3://test_registry/registry.db"
@@ -25,6 +26,7 @@ PROJECT = "test_aws"
 PROVIDER = "aws"
 TABLE_NAME = "dynamodb_online_store"
 REGION = "us-west-2"
+GLOBAL_TABLE_REGION = "us-east-1"
 
 
 @dataclass
@@ -59,6 +61,7 @@ def test_dynamodb_online_store_config_default():
     assert dynamodb_store_config.endpoint_url is None
     assert dynamodb_store_config.region == aws_region
     assert dynamodb_store_config.table_name_template == "{project}.{table_name}"
+    assert dynamodb_store_config.global_table_region == None
 
 
 def test_dynamodb_table_default_params():
@@ -69,6 +72,7 @@ def test_dynamodb_table_default_params():
     assert dynamodb_table.name == tbl_name
     assert dynamodb_table.region == aws_region
     assert dynamodb_table.endpoint_url is None
+    assert dynamodb_table.global_table_region is None
     assert dynamodb_table._dynamodb_client is None
     assert dynamodb_table._dynamodb_resource is None
 
@@ -76,6 +80,7 @@ def test_dynamodb_table_default_params():
 def test_dynamodb_online_store_config_custom_params():
     """Test DynamoDBOnlineStoreConfig custom parameters."""
     aws_region = "us-west-2"
+    global_table_region = "us-east-1"
     batch_size = 20
     endpoint_url = "http://localhost:8000"
     table_name_template = "feast_test.dynamodb_table"
@@ -84,23 +89,29 @@ def test_dynamodb_online_store_config_custom_params():
         batch_size=batch_size,
         endpoint_url=endpoint_url,
         table_name_template=table_name_template,
+        global_table_region=global_table_region,
     )
     assert dynamodb_store_config.type == "dynamodb"
     assert dynamodb_store_config.batch_size == batch_size
     assert dynamodb_store_config.endpoint_url == endpoint_url
     assert dynamodb_store_config.region == aws_region
     assert dynamodb_store_config.table_name_template == table_name_template
+    assert dynamodb_store_config.global_table_region == global_table_region
 
 
 def test_dynamodb_table_custom_params():
     """Test DynamoDBTable custom parameters."""
     tbl_name = "dynamodb-test"
     aws_region = "us-west-2"
+    global_table_region = "us-east-1"
     endpoint_url = "http://localhost:8000"
-    dynamodb_table = DynamoDBTable(tbl_name, aws_region, endpoint_url)
+    dynamodb_table = DynamoDBTable(
+        tbl_name, aws_region, endpoint_url, global_table_region
+    )
     assert dynamodb_table.name == tbl_name
     assert dynamodb_table.region == aws_region
     assert dynamodb_table.endpoint_url == endpoint_url
+    assert dynamodb_table.global_table_region == global_table_region
     assert dynamodb_table._dynamodb_client is None
     assert dynamodb_table._dynamodb_resource is None
 
@@ -109,8 +120,11 @@ def test_dynamodb_online_store_config_dynamodb_client(dynamodb_online_store):
     """Test DynamoDBOnlineStoreConfig configure DynamoDB client with endpoint_url."""
     aws_region = "us-west-2"
     endpoint_url = "http://localhost:8000"
+    global_table_region = "us-east-1"
     dynamodb_store_config = DynamoDBOnlineStoreConfig(
-        region=aws_region, endpoint_url=endpoint_url
+        region=aws_region,
+        endpoint_url=endpoint_url,
+        global_table_region=global_table_region,
     )
     dynamodb_client = dynamodb_online_store._get_dynamodb_client(
         dynamodb_store_config.region, dynamodb_store_config.endpoint_url
@@ -124,7 +138,10 @@ def test_dynamodb_table_dynamodb_client():
     tbl_name = "dynamodb-test"
     aws_region = "us-west-2"
     endpoint_url = "http://localhost:8000"
-    dynamodb_table = DynamoDBTable(tbl_name, aws_region, endpoint_url)
+    global_table_region = "us-east-1"
+    dynamodb_table = DynamoDBTable(
+        tbl_name, aws_region, endpoint_url, global_table_region
+    )
     dynamodb_client = dynamodb_table._get_dynamodb_client(
         dynamodb_table.region, dynamodb_table.endpoint_url
     )
@@ -167,6 +184,27 @@ def test_dynamodb_online_store_online_read(
     """Test DynamoDBOnlineStore online_read method."""
     db_table_name = f"{TABLE_NAME}_online_read_{n_samples}"
     create_test_table(PROJECT, db_table_name, REGION)
+    data = create_n_customer_test_samples(n=n_samples)
+    insert_data_test_table(data, PROJECT, db_table_name, REGION)
+
+    entity_keys, features, *rest = zip(*data)
+    returned_items = dynamodb_online_store.online_read(
+        config=repo_config,
+        table=MockFeatureView(name=db_table_name),
+        entity_keys=entity_keys,
+    )
+    assert len(returned_items) == len(data)
+    assert [item[1] for item in returned_items] == list(features)
+
+
+@mock_dynamodb
+@pytest.mark.parametrize("n_samples", [5, 50, 100])
+def test_dynamodb_global_table_online_store_online_read(
+    repo_config, dynamodb_online_store, n_samples
+):
+    """Test DynamoDBOnlineStore online_read method."""
+    db_table_name = f"{TABLE_NAME}_online_read_{n_samples}"
+    create_test_table_global(PROJECT, db_table_name, REGION, GLOBAL_TABLE_REGION)
     data = create_n_customer_test_samples(n=n_samples)
     insert_data_test_table(data, PROJECT, db_table_name, REGION)
 
@@ -243,6 +281,38 @@ def test_dynamodb_online_store_teardown(repo_config, dynamodb_online_store):
     db_table_delete_name_two = f"{TABLE_NAME}_delete_teardown_2"
     create_test_table(PROJECT, db_table_delete_name_one, REGION)
     create_test_table(PROJECT, db_table_delete_name_two, REGION)
+
+    dynamodb_online_store.teardown(
+        config=repo_config,
+        tables=[
+            MockFeatureView(name=db_table_delete_name_one),
+            MockFeatureView(name=db_table_delete_name_two),
+        ],
+        entities=None,
+    )
+
+    # Check tables non exist
+    dynamodb_client = dynamodb_online_store._get_dynamodb_client(REGION)
+    existing_tables = dynamodb_client.list_tables()
+    existing_tables = existing_tables.get("TableNames", None)
+
+    assert existing_tables is not None
+    assert len(existing_tables) == 0
+
+
+@mock_dynamodb
+def test_dynamodb_global_table_online_store_teardown(
+    repo_config, dynamodb_online_store
+):
+    """Test DynamoDBOnlineStore teardown method."""
+    db_table_delete_name_one = f"{TABLE_NAME}_delete_teardown_1"
+    db_table_delete_name_two = f"{TABLE_NAME}_delete_teardown_2"
+    create_test_table_global(
+        PROJECT, db_table_delete_name_one, REGION, GLOBAL_TABLE_REGION
+    )
+    create_test_table_global(
+        PROJECT, db_table_delete_name_two, REGION, GLOBAL_TABLE_REGION
+    )
 
     dynamodb_online_store.teardown(
         config=repo_config,

--- a/sdk/python/tests/utils/dynamo_table_creator.py
+++ b/sdk/python/tests/utils/dynamo_table_creator.py
@@ -36,6 +36,30 @@ def create_test_table(project, tbl_name, region):
     )
 
 
+def create_test_table_global(project, tbl_name, region, global_table_region):
+    client = boto3.client("dynamodb", region_name=region)
+    client.create_table(
+        TableName=f"{project}.{tbl_name}",
+        KeySchema=[{"AttributeName": "entity_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[{"AttributeName": "entity_id", "AttributeType": "S"}],
+        BillingMode="PAY_PER_REQUEST",
+        StreamSpecification={
+            "StreamEnabled": True,
+            "StreamViewType": "NEW_AND_OLD_IMAGES",
+        },
+    )
+    client.update_table(
+        TableName=f"{project}.{tbl_name}",
+        ReplicaUpdates=[
+            {
+                "Create": {
+                    "RegionName": global_table_region,
+                }
+            }
+        ],
+    )
+
+
 def delete_test_table(project, tbl_name, region):
     client = boto3.client("dynamodb", region_name=region)
     client.delete_table(TableName=f"{project}.{tbl_name}")


### PR DESCRIPTION
**What this PR does / why we need it**:

The current dynamodb online store does not support [global tables](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/V2globaltables_HowItWorks.html).  This PR adds an optional attribute to the dynamodb config.  If a `global_table_region` is specified, `feast apply` will create a replica dynamodb table in that region.