### PR TITLE
fix: Upgrade the pyarrow to latest v14.0.1 for CVE-2023-47248.

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -353,7 +353,11 @@ class BigQueryOfflineStore(OfflineStore):
             return
 
         with tempfile.TemporaryFile() as parquet_temp_file:
-            pyarrow.parquet.write_table(table=data, where=parquet_temp_file)
+            # In Pyarrow v13.0, the parquet version was upgraded to v2.6 from v2.4.
+            # Set the coerce_timestamps to "us"(microseconds) for backward compatibility.
+            pyarrow.parquet.write_table(
+                table=data, where=parquet_temp_file, coerce_timestamps="us"
+            )
 
             parquet_temp_file.seek(0)
 
@@ -400,7 +404,11 @@ class BigQueryOfflineStore(OfflineStore):
         )
 
         with tempfile.TemporaryFile() as parquet_temp_file:
-            pyarrow.parquet.write_table(table=table, where=parquet_temp_file)
+            # In Pyarrow v13.0, the parquet version was upgraded to v2.6 from v2.4.
+            # Set the coerce_timestamps to "us"(microseconds) for backward compatibility.
+            pyarrow.parquet.write_table(
+                table=table, where=parquet_temp_file, coerce_timestamps="us"
+            )
 
             parquet_temp_file.seek(0)
 

--- a/sdk/python/feast/infra/utils/aws_utils.py
+++ b/sdk/python/feast/infra/utils/aws_utils.py
@@ -351,7 +351,9 @@ def upload_arrow_table_to_redshift(
     else:
         # Write the PyArrow Table on disk in Parquet format and upload it to S3
         with tempfile.TemporaryFile(suffix=".parquet") as parquet_temp_file:
-            pq.write_table(table, parquet_temp_file)
+            # In Pyarrow v13.0, the parquet version was upgraded to v2.6 from v2.4.
+            # Set the coerce_timestamps to "us"(microseconds) for backward compatibility.
+            pq.write_table(table, parquet_temp_file, coerce_timestamps="us")
             parquet_temp_file.seek(0)
             s3_resource.Object(bucket, key).put(Body=parquet_temp_file)
 

--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -57,11 +57,11 @@ black==22.12.0
     # via feast (setup.py)
 bleach==6.1.0
     # via nbconvert
-boto3==1.28.80
+boto3==1.29.2
     # via
     #   feast (setup.py)
     #   moto
-botocore==1.31.80
+botocore==1.32.2
     # via
     #   boto3
     #   moto
@@ -121,7 +121,9 @@ comm==0.2.0
     #   ipykernel
     #   ipywidgets
 coverage[toml]==7.3.2
-    # via pytest-cov
+    # via
+    #   coverage
+    #   pytest-cov
 cryptography==41.0.5
     # via
     #   azure-identity
@@ -135,7 +137,7 @@ cryptography==41.0.5
     #   snowflake-connector-python
     #   types-pyopenssl
     #   types-redis
-dask==2023.10.1
+dask==2023.11.0
     # via feast (setup.py)
 db-dtypes==1.1.1
     # via google-cloud-bigquery
@@ -177,7 +179,7 @@ fastavro==1.9.0
     # via
     #   feast (setup.py)
     #   pandavro
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 filelock==3.13.1
     # via
@@ -199,7 +201,7 @@ geojson==2.5.0
     # via rockset
 geomet==0.2.1.post1
     # via cassandra-driver
-google-api-core[grpc]==2.13.0
+google-api-core[grpc]==2.14.0
     # via
     #   feast (setup.py)
     #   firebase-admin
@@ -211,7 +213,7 @@ google-api-core[grpc]==2.13.0
     #   google-cloud-datastore
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.107.0
+google-api-python-client==2.108.0
     # via firebase-admin
 google-auth==2.23.4
     # via
@@ -224,7 +226,9 @@ google-auth==2.23.4
 google-auth-httplib2==0.1.1
     # via google-api-python-client
 google-cloud-bigquery[pandas]==3.12.0
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   google-cloud-bigquery
 google-cloud-bigquery-storage==2.22.0
     # via feast (setup.py)
 google-cloud-bigtable==2.21.0
@@ -262,7 +266,7 @@ great-expectations==0.15.50
     # via feast (setup.py)
 greenlet==3.0.1
     # via sqlalchemy
-grpc-google-iam-v1==0.12.6
+grpc-google-iam-v1==0.12.7
     # via google-cloud-bigtable
 grpcio==1.59.2
     # via
@@ -298,7 +302,7 @@ hazelcast-python-client==5.3.0
     # via feast (setup.py)
 hiredis==2.2.3
     # via feast (setup.py)
-httpcore==1.0.1
+httpcore==1.0.2
     # via httpx
 httplib2==0.22.0
     # via
@@ -368,7 +372,7 @@ jsonpointer==2.4
     # via
     #   jsonpatch
     #   jsonschema
-jsonschema[format-nongpl]==4.19.2
+jsonschema[format-nongpl]==4.20.0
     # via
     #   altair
     #   feast (setup.py)
@@ -376,7 +380,7 @@ jsonschema[format-nongpl]==4.19.2
     #   jupyter-events
     #   jupyterlab-server
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 jupyter-client==8.6.0
     # via
@@ -396,7 +400,7 @@ jupyter-events==0.9.0
     # via jupyter-server
 jupyter-lsp==2.2.0
     # via jupyterlab
-jupyter-server==2.10.0
+jupyter-server==2.10.1
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -409,7 +413,7 @@ jupyterlab==4.0.8
     # via notebook
 jupyterlab-pygments==0.2.2
     # via nbconvert
-jupyterlab-server==2.25.0
+jupyterlab-server==2.25.1
     # via
     #   jupyterlab
     #   notebook
@@ -419,7 +423,7 @@ kubernetes==20.13.0
     # via feast (setup.py)
 locket==1.0.0
     # via partd
-makefun==1.15.1
+makefun==1.15.2
     # via great-expectations
 markupsafe==2.1.3
     # via
@@ -446,7 +450,7 @@ mock==2.0.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-moto==4.2.7
+moto==4.2.9
     # via feast (setup.py)
 msal==1.25.0
     # via
@@ -564,7 +568,7 @@ pre-commit==3.3.1
     # via feast (setup.py)
 prometheus-client==0.18.0
     # via jupyter-server
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via ipython
 proto-plus==1.22.3
     # via
@@ -610,7 +614,7 @@ py-cpuinfo==9.0.0
     # via pytest-benchmark
 py4j==0.10.9.7
     # via pyspark
-pyarrow==10.0.1
+pyarrow==14.0.1
     # via
     #   db-dtypes
     #   feast (setup.py)
@@ -683,7 +687,7 @@ pytest-ordering==0.6
     # via feast (setup.py)
 pytest-timeout==1.4.2
     # via feast (setup.py)
-pytest-xdist==3.3.1
+pytest-xdist==3.4.0
     # via feast (setup.py)
 python-dateutil==2.8.2
     # via
@@ -723,7 +727,7 @@ pyzmq==25.1.1
     #   jupyter-server
 redis==4.6.0
     # via feast (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -751,7 +755,7 @@ requests==2.31.0
     #   trino
 requests-oauthlib==1.3.1
     # via kubernetes
-responses==0.24.0
+responses==0.24.1
     # via moto
 rfc3339-validator==0.1.4
     # via
@@ -763,7 +767,7 @@ rfc3986-validator==0.1.1
     #   jupyter-events
 rockset==2.1.0
     # via feast (setup.py)
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -798,8 +802,10 @@ sniffio==1.3.0
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python[pandas]==3.4.0
-    # via feast (setup.py)
+snowflake-connector-python[pandas]==3.5.0
+    # via
+    #   feast (setup.py)
+    #   snowflake-connector-python
 sortedcontainers==2.4.0
     # via snowflake-connector-python
 soupsieve==2.5
@@ -825,8 +831,10 @@ sphinxcontrib-qthelp==1.0.6
 sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
 sqlalchemy[mypy]==1.4.50
-    # via feast (setup.py)
-sqlalchemy2-stubs==0.0.2a36
+    # via
+    #   feast (setup.py)
+    #   sqlalchemy
+sqlalchemy2-stubs==0.0.2a37
     # via sqlalchemy
 stack-data==0.6.3
     # via ipython
@@ -836,7 +844,7 @@ tabulate==0.9.0
     # via feast (setup.py)
 tenacity==8.2.3
     # via feast (setup.py)
-terminado==0.17.1
+terminado==0.18.0
     # via
     #   jupyter-server
     #   jupyter-server-terminals
@@ -858,7 +866,7 @@ tomli==2.0.1
     #   pip-tools
     #   pyproject-hooks
     #   pytest
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via snowflake-connector-python
 toolz==0.12.0
     # via
@@ -916,7 +924,7 @@ types-redis==4.6.0.10
     # via feast (setup.py)
 types-requests==2.30.0.0
     # via feast (setup.py)
-types-setuptools==68.2.0.0
+types-setuptools==68.2.0.1
     # via feast (setup.py)
 types-tabulate==0.9.0.3
     # via feast (setup.py)
@@ -955,7 +963,9 @@ urllib3==1.26.18
     #   rockset
     #   snowflake-connector-python
 uvicorn[standard]==0.24.0.post1
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   uvicorn
 uvloop==0.19.0
     # via uvicorn
 virtualenv==20.23.0
@@ -966,7 +976,7 @@ volatile==2.1.0
     # via bowler
 watchfiles==0.21.0
     # via uvicorn
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 webcolors==1.13
     # via jsonschema
@@ -987,7 +997,7 @@ wheel==0.41.3
     # via pip-tools
 widgetsnbextension==4.0.9
     # via ipywidgets
-wrapt==1.15.0
+wrapt==1.16.0
     # via testcontainers
 xmltodict==0.13.0
     # via moto

--- a/sdk/python/requirements/py3.10-requirements.txt
+++ b/sdk/python/requirements/py3.10-requirements.txt
@@ -36,7 +36,7 @@ cloudpickle==3.0.0
     # via dask
 colorama==0.4.6
     # via feast (setup.py)
-dask==2023.10.1
+dask==2023.11.0
     # via feast (setup.py)
 dill==0.3.7
     # via feast (setup.py)
@@ -72,7 +72,7 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.1
+httpcore==1.0.2
     # via httpx
 httptools==0.6.1
     # via uvicorn
@@ -91,9 +91,9 @@ importlib-resources==6.1.1
     # via feast (setup.py)
 jinja2==3.1.2
     # via feast (setup.py)
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via feast (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 locket==1.0.0
     # via partd
@@ -103,7 +103,7 @@ mmh3==4.0.1
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-mypy==1.6.1
+mypy==1.7.0
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
@@ -137,7 +137,7 @@ protobuf==4.23.3
     #   grpcio-tools
     #   mypy-protobuf
     #   proto-plus
-pyarrow==11.0.0
+pyarrow==14.0.1
     # via feast (setup.py)
 pydantic==1.10.13
     # via
@@ -156,13 +156,13 @@ pyyaml==6.0.1
     #   dask
     #   feast (setup.py)
     #   uvicorn
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via feast (setup.py)
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -175,8 +175,10 @@ sniffio==1.3.0
     #   anyio
     #   httpx
 sqlalchemy[mypy]==1.4.50
-    # via feast (setup.py)
-sqlalchemy2-stubs==0.0.2a36
+    # via
+    #   feast (setup.py)
+    #   sqlalchemy
+sqlalchemy2-stubs==0.0.2a37
     # via sqlalchemy
 starlette==0.27.0
     # via fastapi
@@ -205,10 +207,12 @@ typing-extensions==4.8.0
     #   pydantic
     #   sqlalchemy2-stubs
     #   uvicorn
-urllib3==2.0.7
+urllib3==2.1.0
     # via requests
 uvicorn[standard]==0.24.0.post1
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   uvicorn
 uvloop==0.19.0
     # via uvicorn
 volatile==2.1.0

--- a/sdk/python/requirements/py3.8-ci-requirements.txt
+++ b/sdk/python/requirements/py3.8-ci-requirements.txt
@@ -63,11 +63,11 @@ black==22.12.0
     # via feast (setup.py)
 bleach==6.1.0
     # via nbconvert
-boto3==1.28.80
+boto3==1.29.2
     # via
     #   feast (setup.py)
     #   moto
-botocore==1.31.80
+botocore==1.32.2
     # via
     #   boto3
     #   moto
@@ -127,7 +127,9 @@ comm==0.2.0
     #   ipykernel
     #   ipywidgets
 coverage[toml]==7.3.2
-    # via pytest-cov
+    # via
+    #   coverage
+    #   pytest-cov
 cryptography==41.0.5
     # via
     #   azure-identity
@@ -182,7 +184,7 @@ fastavro==1.9.0
     # via
     #   feast (setup.py)
     #   pandavro
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 filelock==3.13.1
     # via
@@ -204,7 +206,7 @@ geojson==2.5.0
     # via rockset
 geomet==0.2.1.post1
     # via cassandra-driver
-google-api-core[grpc]==2.13.0
+google-api-core[grpc]==2.14.0
     # via
     #   feast (setup.py)
     #   firebase-admin
@@ -216,7 +218,7 @@ google-api-core[grpc]==2.13.0
     #   google-cloud-datastore
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.107.0
+google-api-python-client==2.108.0
     # via firebase-admin
 google-auth==2.23.4
     # via
@@ -229,7 +231,9 @@ google-auth==2.23.4
 google-auth-httplib2==0.1.1
     # via google-api-python-client
 google-cloud-bigquery[pandas]==3.12.0
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   google-cloud-bigquery
 google-cloud-bigquery-storage==2.22.0
     # via feast (setup.py)
 google-cloud-bigtable==2.21.0
@@ -267,7 +271,7 @@ great-expectations==0.15.50
     # via feast (setup.py)
 greenlet==3.0.1
     # via sqlalchemy
-grpc-google-iam-v1==0.12.6
+grpc-google-iam-v1==0.12.7
     # via google-cloud-bigtable
 grpcio==1.59.2
     # via
@@ -303,7 +307,7 @@ hazelcast-python-client==5.3.0
     # via feast (setup.py)
 hiredis==2.2.3
     # via feast (setup.py)
-httpcore==1.0.1
+httpcore==1.0.2
     # via httpx
 httplib2==0.22.0
     # via
@@ -384,7 +388,7 @@ jsonpointer==2.4
     # via
     #   jsonpatch
     #   jsonschema
-jsonschema[format-nongpl]==4.19.2
+jsonschema[format-nongpl]==4.20.0
     # via
     #   altair
     #   feast (setup.py)
@@ -392,7 +396,7 @@ jsonschema[format-nongpl]==4.19.2
     #   jupyter-events
     #   jupyterlab-server
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 jupyter-client==8.6.0
     # via
@@ -412,7 +416,7 @@ jupyter-events==0.9.0
     # via jupyter-server
 jupyter-lsp==2.2.0
     # via jupyterlab
-jupyter-server==2.10.0
+jupyter-server==2.10.1
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -425,7 +429,7 @@ jupyterlab==4.0.8
     # via notebook
 jupyterlab-pygments==0.2.2
     # via nbconvert
-jupyterlab-server==2.25.0
+jupyterlab-server==2.25.1
     # via
     #   jupyterlab
     #   notebook
@@ -435,7 +439,7 @@ kubernetes==20.13.0
     # via feast (setup.py)
 locket==1.0.0
     # via partd
-makefun==1.15.1
+makefun==1.15.2
     # via great-expectations
 markupsafe==2.1.3
     # via
@@ -462,7 +466,7 @@ mock==2.0.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-moto==4.2.7
+moto==4.2.9
     # via feast (setup.py)
 msal==1.25.0
     # via
@@ -584,7 +588,7 @@ pre-commit==3.3.1
     # via feast (setup.py)
 prometheus-client==0.18.0
     # via jupyter-server
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via ipython
 proto-plus==1.22.3
     # via
@@ -630,7 +634,7 @@ py-cpuinfo==9.0.0
     # via pytest-benchmark
 py4j==0.10.9.7
     # via pyspark
-pyarrow==10.0.1
+pyarrow==14.0.1
     # via
     #   db-dtypes
     #   feast (setup.py)
@@ -703,7 +707,7 @@ pytest-ordering==0.6
     # via feast (setup.py)
 pytest-timeout==1.4.2
     # via feast (setup.py)
-pytest-xdist==3.3.1
+pytest-xdist==3.4.0
     # via feast (setup.py)
 python-dateutil==2.8.2
     # via
@@ -744,7 +748,7 @@ pyzmq==25.1.1
     #   jupyter-server
 redis==4.6.0
     # via feast (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -772,7 +776,7 @@ requests==2.31.0
     #   trino
 requests-oauthlib==1.3.1
     # via kubernetes
-responses==0.24.0
+responses==0.24.1
     # via moto
 rfc3339-validator==0.1.4
     # via
@@ -784,7 +788,7 @@ rfc3986-validator==0.1.1
     #   jupyter-events
 rockset==2.1.0
     # via feast (setup.py)
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -821,8 +825,10 @@ sniffio==1.3.0
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python[pandas]==3.4.0
-    # via feast (setup.py)
+snowflake-connector-python[pandas]==3.5.0
+    # via
+    #   feast (setup.py)
+    #   snowflake-connector-python
 sortedcontainers==2.4.0
     # via snowflake-connector-python
 soupsieve==2.5
@@ -842,8 +848,10 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sqlalchemy[mypy]==1.4.50
-    # via feast (setup.py)
-sqlalchemy2-stubs==0.0.2a36
+    # via
+    #   feast (setup.py)
+    #   sqlalchemy
+sqlalchemy2-stubs==0.0.2a37
     # via sqlalchemy
 stack-data==0.6.3
     # via ipython
@@ -853,7 +861,7 @@ tabulate==0.9.0
     # via feast (setup.py)
 tenacity==8.2.3
     # via feast (setup.py)
-terminado==0.17.1
+terminado==0.18.0
     # via
     #   jupyter-server
     #   jupyter-server-terminals
@@ -875,7 +883,7 @@ tomli==2.0.1
     #   pip-tools
     #   pyproject-hooks
     #   pytest
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via snowflake-connector-python
 toolz==0.12.0
     # via
@@ -933,7 +941,7 @@ types-redis==4.6.0.10
     # via feast (setup.py)
 types-requests==2.30.0.0
     # via feast (setup.py)
-types-setuptools==68.2.0.0
+types-setuptools==68.2.0.1
     # via feast (setup.py)
 types-tabulate==0.9.0.3
     # via feast (setup.py)
@@ -975,7 +983,9 @@ urllib3==1.26.18
     #   rockset
     #   snowflake-connector-python
 uvicorn[standard]==0.24.0.post1
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   uvicorn
 uvloop==0.19.0
     # via uvicorn
 virtualenv==20.23.0
@@ -986,7 +996,7 @@ volatile==2.1.0
     # via bowler
 watchfiles==0.21.0
     # via uvicorn
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 webcolors==1.13
     # via jsonschema
@@ -1007,7 +1017,7 @@ wheel==0.41.3
     # via pip-tools
 widgetsnbextension==4.0.9
     # via ipywidgets
-wrapt==1.15.0
+wrapt==1.16.0
     # via testcontainers
 xmltodict==0.13.0
     # via moto

--- a/sdk/python/requirements/py3.8-requirements.txt
+++ b/sdk/python/requirements/py3.8-requirements.txt
@@ -72,7 +72,7 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.1
+httpcore==1.0.2
     # via httpx
 httptools==0.6.1
     # via uvicorn
@@ -94,9 +94,9 @@ importlib-resources==6.1.1
     #   jsonschema-specifications
 jinja2==3.1.2
     # via feast (setup.py)
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via feast (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 locket==1.0.0
     # via partd
@@ -106,7 +106,7 @@ mmh3==4.0.1
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-mypy==1.6.1
+mypy==1.7.0
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
@@ -142,7 +142,7 @@ protobuf==4.23.3
     #   grpcio-tools
     #   mypy-protobuf
     #   proto-plus
-pyarrow==11.0.0
+pyarrow==14.0.1
     # via feast (setup.py)
 pydantic==1.10.13
     # via
@@ -161,13 +161,13 @@ pyyaml==6.0.1
     #   dask
     #   feast (setup.py)
     #   uvicorn
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via feast (setup.py)
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -180,8 +180,10 @@ sniffio==1.3.0
     #   anyio
     #   httpx
 sqlalchemy[mypy]==1.4.50
-    # via feast (setup.py)
-sqlalchemy2-stubs==0.0.2a36
+    # via
+    #   feast (setup.py)
+    #   sqlalchemy
+sqlalchemy2-stubs==0.0.2a37
     # via sqlalchemy
 starlette==0.27.0
     # via fastapi
@@ -211,10 +213,12 @@ typing-extensions==4.8.0
     #   sqlalchemy2-stubs
     #   starlette
     #   uvicorn
-urllib3==2.0.7
+urllib3==2.1.0
     # via requests
 uvicorn[standard]==0.24.0.post1
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   uvicorn
 uvloop==0.19.0
     # via uvicorn
 volatile==2.1.0

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -57,11 +57,11 @@ black==22.12.0
     # via feast (setup.py)
 bleach==6.1.0
     # via nbconvert
-boto3==1.28.80
+boto3==1.29.2
     # via
     #   feast (setup.py)
     #   moto
-botocore==1.31.80
+botocore==1.32.2
     # via
     #   boto3
     #   moto
@@ -121,7 +121,9 @@ comm==0.2.0
     #   ipykernel
     #   ipywidgets
 coverage[toml]==7.3.2
-    # via pytest-cov
+    # via
+    #   coverage
+    #   pytest-cov
 cryptography==41.0.5
     # via
     #   azure-identity
@@ -135,7 +137,7 @@ cryptography==41.0.5
     #   snowflake-connector-python
     #   types-pyopenssl
     #   types-redis
-dask==2023.10.1
+dask==2023.11.0
     # via feast (setup.py)
 db-dtypes==1.1.1
     # via google-cloud-bigquery
@@ -177,7 +179,7 @@ fastavro==1.9.0
     # via
     #   feast (setup.py)
     #   pandavro
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 filelock==3.13.1
     # via
@@ -199,7 +201,7 @@ geojson==2.5.0
     # via rockset
 geomet==0.2.1.post1
     # via cassandra-driver
-google-api-core[grpc]==2.13.0
+google-api-core[grpc]==2.14.0
     # via
     #   feast (setup.py)
     #   firebase-admin
@@ -211,7 +213,7 @@ google-api-core[grpc]==2.13.0
     #   google-cloud-datastore
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.107.0
+google-api-python-client==2.108.0
     # via firebase-admin
 google-auth==2.23.4
     # via
@@ -224,7 +226,9 @@ google-auth==2.23.4
 google-auth-httplib2==0.1.1
     # via google-api-python-client
 google-cloud-bigquery[pandas]==3.12.0
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   google-cloud-bigquery
 google-cloud-bigquery-storage==2.22.0
     # via feast (setup.py)
 google-cloud-bigtable==2.21.0
@@ -262,7 +266,7 @@ great-expectations==0.15.50
     # via feast (setup.py)
 greenlet==3.0.1
     # via sqlalchemy
-grpc-google-iam-v1==0.12.6
+grpc-google-iam-v1==0.12.7
     # via google-cloud-bigtable
 grpcio==1.59.2
     # via
@@ -298,7 +302,7 @@ hazelcast-python-client==5.3.0
     # via feast (setup.py)
 hiredis==2.2.3
     # via feast (setup.py)
-httpcore==1.0.1
+httpcore==1.0.2
     # via httpx
 httplib2==0.22.0
     # via
@@ -375,7 +379,7 @@ jsonpointer==2.4
     # via
     #   jsonpatch
     #   jsonschema
-jsonschema[format-nongpl]==4.19.2
+jsonschema[format-nongpl]==4.20.0
     # via
     #   altair
     #   feast (setup.py)
@@ -383,7 +387,7 @@ jsonschema[format-nongpl]==4.19.2
     #   jupyter-events
     #   jupyterlab-server
     #   nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 jupyter-client==8.6.0
     # via
@@ -403,7 +407,7 @@ jupyter-events==0.9.0
     # via jupyter-server
 jupyter-lsp==2.2.0
     # via jupyterlab
-jupyter-server==2.10.0
+jupyter-server==2.10.1
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -416,7 +420,7 @@ jupyterlab==4.0.8
     # via notebook
 jupyterlab-pygments==0.2.2
     # via nbconvert
-jupyterlab-server==2.25.0
+jupyterlab-server==2.25.1
     # via
     #   jupyterlab
     #   notebook
@@ -426,7 +430,7 @@ kubernetes==20.13.0
     # via feast (setup.py)
 locket==1.0.0
     # via partd
-makefun==1.15.1
+makefun==1.15.2
     # via great-expectations
 markupsafe==2.1.3
     # via
@@ -453,7 +457,7 @@ mock==2.0.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-moto==4.2.7
+moto==4.2.9
     # via feast (setup.py)
 msal==1.25.0
     # via
@@ -473,7 +477,7 @@ mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-mypy-protobuf==3.1
+mypy-protobuf==3.1.0
     # via feast (setup.py)
 mysqlclient==2.2.0
     # via feast (setup.py)
@@ -571,7 +575,7 @@ pre-commit==3.3.1
     # via feast (setup.py)
 prometheus-client==0.18.0
     # via jupyter-server
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via ipython
 proto-plus==1.22.3
     # via
@@ -617,7 +621,7 @@ py-cpuinfo==9.0.0
     # via pytest-benchmark
 py4j==0.10.9.7
     # via pyspark
-pyarrow==10.0.1
+pyarrow==14.0.1
     # via
     #   db-dtypes
     #   feast (setup.py)
@@ -690,7 +694,7 @@ pytest-ordering==0.6
     # via feast (setup.py)
 pytest-timeout==1.4.2
     # via feast (setup.py)
-pytest-xdist==3.3.1
+pytest-xdist==3.4.0
     # via feast (setup.py)
 python-dateutil==2.8.2
     # via
@@ -730,7 +734,7 @@ pyzmq==25.1.1
     #   jupyter-server
 redis==4.6.0
     # via feast (setup.py)
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -758,7 +762,7 @@ requests==2.31.0
     #   trino
 requests-oauthlib==1.3.1
     # via kubernetes
-responses==0.24.0
+responses==0.24.1
     # via moto
 rfc3339-validator==0.1.4
     # via
@@ -770,7 +774,7 @@ rfc3986-validator==0.1.1
     #   jupyter-events
 rockset==2.1.0
     # via feast (setup.py)
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -807,8 +811,10 @@ sniffio==1.3.0
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python[pandas]==3.4.0
-    # via feast (setup.py)
+snowflake-connector-python[pandas]==3.5.0
+    # via
+    #   feast (setup.py)
+    #   snowflake-connector-python
 sortedcontainers==2.4.0
     # via snowflake-connector-python
 soupsieve==2.5
@@ -834,8 +840,10 @@ sphinxcontrib-qthelp==1.0.6
 sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
 sqlalchemy[mypy]==1.4.50
-    # via feast (setup.py)
-sqlalchemy2-stubs==0.0.2a36
+    # via
+    #   feast (setup.py)
+    #   sqlalchemy
+sqlalchemy2-stubs==0.0.2a37
     # via sqlalchemy
 stack-data==0.6.3
     # via ipython
@@ -845,7 +853,7 @@ tabulate==0.9.0
     # via feast (setup.py)
 tenacity==8.2.3
     # via feast (setup.py)
-terminado==0.17.1
+terminado==0.18.0
     # via
     #   jupyter-server
     #   jupyter-server-terminals
@@ -867,7 +875,7 @@ tomli==2.0.1
     #   pip-tools
     #   pyproject-hooks
     #   pytest
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via snowflake-connector-python
 toolz==0.12.0
     # via
@@ -925,7 +933,7 @@ types-redis==4.6.0.10
     # via feast (setup.py)
 types-requests==2.30.0.0
     # via feast (setup.py)
-types-setuptools==68.2.0.0
+types-setuptools==68.2.0.1
     # via feast (setup.py)
 types-tabulate==0.9.0.3
     # via feast (setup.py)
@@ -967,7 +975,9 @@ urllib3==1.26.18
     #   rockset
     #   snowflake-connector-python
 uvicorn[standard]==0.24.0.post1
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   uvicorn
 uvloop==0.19.0
     # via uvicorn
 virtualenv==20.23.0
@@ -978,7 +988,7 @@ volatile==2.1.0
     # via bowler
 watchfiles==0.21.0
     # via uvicorn
-wcwidth==0.2.9
+wcwidth==0.2.10
     # via prompt-toolkit
 webcolors==1.13
     # via jsonschema
@@ -999,7 +1009,7 @@ wheel==0.41.3
     # via pip-tools
 widgetsnbextension==4.0.9
     # via ipywidgets
-wrapt==1.15.0
+wrapt==1.16.0
     # via testcontainers
 xmltodict==0.13.0
     # via moto

--- a/sdk/python/requirements/py3.9-requirements.txt
+++ b/sdk/python/requirements/py3.9-requirements.txt
@@ -36,7 +36,7 @@ cloudpickle==3.0.0
     # via dask
 colorama==0.4.6
     # via feast (setup.py)
-dask==2023.10.1
+dask==2023.11.0
     # via feast (setup.py)
 dill==0.3.7
     # via feast (setup.py)
@@ -72,7 +72,7 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==1.0.1
+httpcore==1.0.2
     # via httpx
 httptools==0.6.1
     # via uvicorn
@@ -91,9 +91,9 @@ importlib-resources==6.1.1
     # via feast (setup.py)
 jinja2==3.1.2
     # via feast (setup.py)
-jsonschema==4.19.2
+jsonschema==4.20.0
     # via feast (setup.py)
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
 locket==1.0.0
     # via partd
@@ -103,11 +103,11 @@ mmh3==4.0.1
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-mypy==1.6.1
+mypy==1.7.0
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
-mypy-protobuf==3.1
+mypy-protobuf==3.1.0
     # via feast (setup.py)
 numpy==1.24.4
     # via
@@ -137,7 +137,7 @@ protobuf==4.23.3
     #   grpcio-tools
     #   mypy-protobuf
     #   proto-plus
-pyarrow==11.0.0
+pyarrow==14.0.1
     # via feast (setup.py)
 pydantic==1.10.13
     # via
@@ -156,13 +156,13 @@ pyyaml==6.0.1
     #   dask
     #   feast (setup.py)
     #   uvicorn
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
 requests==2.31.0
     # via feast (setup.py)
-rpds-py==0.12.0
+rpds-py==0.13.0
     # via
     #   jsonschema
     #   referencing
@@ -175,8 +175,10 @@ sniffio==1.3.0
     #   anyio
     #   httpx
 sqlalchemy[mypy]==1.4.50
-    # via feast (setup.py)
-sqlalchemy2-stubs==0.0.2a36
+    # via
+    #   feast (setup.py)
+    #   sqlalchemy
+sqlalchemy2-stubs==0.0.2a37
     # via sqlalchemy
 starlette==0.27.0
     # via fastapi
@@ -206,10 +208,12 @@ typing-extensions==4.8.0
     #   sqlalchemy2-stubs
     #   starlette
     #   uvicorn
-urllib3==2.0.7
+urllib3==2.1.0
     # via requests
 uvicorn[standard]==0.24.0.post1
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   uvicorn
 uvloop==0.19.0
     # via uvicorn
 volatile==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ REQUIRED = [
     # Higher than 4.23.4 seems to cause a seg fault
     "protobuf<4.23.4,>3.20",
     "proto-plus>=1.20.0,<2",
-    "pyarrow>=4,<12",
+    "pyarrow>=4",
     "pydantic>=1,<2",
     "pygments>=2.12.0,<3",
     "PyYAML>=5.4.0,<7",


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the Pyarrow to the latest version v14.0.1 which has the fix for https://github.com/advisories/GHSA-5wvp-7f3h-6wmm

**Which issue(s) this PR fixes**:
Fixes # 3832

1. Before this PR, the Pyarrow version is v10.0.1 for Feast. It's default parquet format version is v2.4 for the function "[pyarrow.parquet.write_table()](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.write_table.html#pyarrow.parquet.write_table)".  Check the "version" argument.
2. With parquet format v2.4, this function will change the timestamps's resolution (check the doc of argument "coerce_timestamps": 
  "By default, for version='1.0' (the default) and version='2.4', nanoseconds are cast to microseconds (‘us’),"
3. After upgraded the Feast with "pyarrow==14.0.1", the datatype of timestamp will be "datetime[ns]" comparing to "datetime[us]" as before the upgration. This change created a problem while writing a Pyarrow table to Google BigQuery and AWS Redshift. From [my debugging](https://github.com/feast-dev/feast/pull/3835) they show a kind of Value error for columns with "datetime" type.
4. I explicitly set the argument "coerce_timestamps" to "us" to allow the write_table() to have the same behavior about "timestamp" as before w.r.t this Pyarrow version upgrade.
5. Not all function calls of "pyarrow.parquet.write_table()" are upgraded. Here is the list of founded function calls:

`./python/feast/transformation_server.py:54:        writer.write_table(result_arrow)
./python/feast/infra/offline_stores/file.py:109:            pyarrow.parquet.write_table(
./python/feast/infra/offline_stores/file.py:470:        writer.write_table(new_table)
./python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py:236:                pq.write_table(table, tmp_file.name)
./python/feast/infra/offline_stores/contrib/mssql_offline_store/mssql.py:373:            pyarrow.parquet.write_table(
./python/feast/infra/offline_stores/bigquery.py:358:            pyarrow.parquet.write_table(table=data, where=parquet_temp_file, coerce_timestamps="us")
./python/feast/infra/offline_stores/bigquery.py:407:            pyarrow.parquet.write_table(table=table, where=parquet_temp_file, coerce_timestamps="us")
./python/feast/infra/utils/aws_utils.py:207:        pq.write_table(table, file_path)
./python/feast/infra/utils/aws_utils.py:356:            pq.write_table(table, parquet_temp_file, coerce_timestamps="us")
./python/feast/infra/utils/aws_utils.py:1049:        pq.write_table(table, parquet_temp_file)`

I try to keep a minimum change. If there is an error shows up in the future, for example, the "upload_arrow_table_to_athena()" function of "aws_utils.py:1049", a new PR can be created with the necessary unit tests and integration tests.
