### PR TITLE
fix: Correct the returning class proto type of StreamFeatureView to StreamFeatureViewProto instead of FeatureViewProto.

### DIFF
--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -17,6 +17,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Type
 
 from google.protobuf.duration_pb2 import Duration
+from google.protobuf.message import Message
 from typeguard import typechecked
 
 from feast import utils
@@ -274,7 +275,7 @@ class FeatureView(BaseFeatureView):
             raise ValueError("Feature view has no entities.")
 
     @property
-    def proto_class(self) -> Type[FeatureViewProto]:
+    def proto_class(self) -> Type[Message]:
         return FeatureViewProto
 
     def with_join_key_map(self, join_key_map: Dict[str, str]):

--- a/sdk/python/feast/stream_feature_view.py
+++ b/sdk/python/feast/stream_feature_view.py
@@ -3,9 +3,10 @@ import functools
 import warnings
 from datetime import datetime, timedelta
 from types import FunctionType
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Type, Union
 
 import dill
+from google.protobuf.message import Message
 from typeguard import typechecked
 
 from feast import flags_helper, utils
@@ -297,6 +298,10 @@ class StreamFeatureView(FeatureView):
         )
         fv.projection = copy.copy(self.projection)
         return fv
+
+    @property
+    def proto_class(self) -> Type[Message]:
+        return StreamFeatureViewProto
 
 
 def stream_feature_view(

--- a/sdk/python/tests/unit/test_feature_views.py
+++ b/sdk/python/tests/unit/test_feature_views.py
@@ -10,6 +10,9 @@ from feast.entity import Entity
 from feast.feature_view import FeatureView
 from feast.field import Field
 from feast.infra.offline_stores.file_source import FileSource
+from feast.protos.feast.core.StreamFeatureView_pb2 import (
+    StreamFeatureView as StreamFeatureViewProto,
+)
 from feast.protos.feast.types.Value_pb2 import ValueType
 from feast.stream_feature_view import StreamFeatureView, stream_feature_view
 from feast.types import Float32
@@ -277,3 +280,22 @@ def test_hash():
 def test_field_types():
     with pytest.raises(TypeError):
         Field(name="name", dtype=ValueType.INT32)
+
+
+def test_stream_feature_view_proto_type():
+    stream_source = KafkaSource(
+        name="kafka",
+        timestamp_field="event_timestamp",
+        kafka_bootstrap_servers="",
+        message_format=AvroFormat(""),
+        topic="topic",
+        batch_source=FileSource(path="some path"),
+    )
+    sfv = StreamFeatureView(
+        name="test stream featureview proto class",
+        entities=[],
+        ttl=timedelta(days=30),
+        source=stream_source,
+        aggregations=[],
+    )
+    assert sfv.proto_class is StreamFeatureViewProto


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a logic error while checking the StreamFeatureView's proto_class.  In function "_check_conflicting_feature_view_names()" of "feast/infra/registry/registry.py", the code will check all FeatureView's proto_class. With the current implementation (v0.34.1), the StreamFeatureView is a subclass of FeatureView class, and it does not have its own overload of "proto_class()" function. As a result, the proto_class() will always return "FeatureViewProto" instead of "StreamFeatureViewProto".

The developer @romqn1999 mentioned this error and solution in the created issue [#3805](https://github.com/feast-dev/feast/issues/3805)


**Which issue(s) this PR fixes**:

Fixes #3805 #3836
