### PR TITLE
fix: Allow trancated timestamps when converting

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -356,7 +356,10 @@ class BigQueryOfflineStore(OfflineStore):
             # In Pyarrow v13.0, the parquet version was upgraded to v2.6 from v2.4.
             # Set the coerce_timestamps to "us"(microseconds) for backward compatibility.
             pyarrow.parquet.write_table(
-                table=data, where=parquet_temp_file, coerce_timestamps="us"
+                table=data,
+                where=parquet_temp_file,
+                coerce_timestamps="us",
+                allow_truncated_timestamps=True,
             )
 
             parquet_temp_file.seek(0)
@@ -407,7 +410,10 @@ class BigQueryOfflineStore(OfflineStore):
             # In Pyarrow v13.0, the parquet version was upgraded to v2.6 from v2.4.
             # Set the coerce_timestamps to "us"(microseconds) for backward compatibility.
             pyarrow.parquet.write_table(
-                table=table, where=parquet_temp_file, coerce_timestamps="us"
+                table=table,
+                where=parquet_temp_file,
+                coerce_timestamps="us",
+                allow_truncated_timestamps=True,
             )
 
             parquet_temp_file.seek(0)

--- a/sdk/python/feast/infra/utils/aws_utils.py
+++ b/sdk/python/feast/infra/utils/aws_utils.py
@@ -353,7 +353,12 @@ def upload_arrow_table_to_redshift(
         with tempfile.TemporaryFile(suffix=".parquet") as parquet_temp_file:
             # In Pyarrow v13.0, the parquet version was upgraded to v2.6 from v2.4.
             # Set the coerce_timestamps to "us"(microseconds) for backward compatibility.
-            pq.write_table(table, parquet_temp_file, coerce_timestamps="us")
+            pq.write_table(
+                table,
+                parquet_temp_file,
+                coerce_timestamps="us",
+                allow_truncated_timestamps=True,
+            )
             parquet_temp_file.seek(0)
             s3_resource.Object(bucket, key).put(Body=parquet_temp_file)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
If timestamp_fields is entered in Microseconds, a 500 error occurs.
Allow truncation of numbers when coercing nano seconds in pyarrow write_table.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3860
