### PR TITLE
Support s3gov schema by snowflake offline store during materialization

### DIFF
--- a/sdk/python/feast/infra/materialization/contrib/bytewax/Dockerfile
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/Dockerfile
@@ -25,5 +25,5 @@ COPY README.md README.md
 # git dir to infer the version of feast we're installing.
 # https://github.com/pypa/setuptools_scm#usage-from-docker
 # I think it also assumes that this dockerfile is being built from the root of the directory.
-RUN --mount=source=.git,target=.git,type=bind pip3 install --no-cache-dir -e '.[aws,gcp,bytewax]'
+RUN --mount=source=.git,target=.git,type=bind pip3 install --no-cache-dir '.[aws,gcp,bytewax,snowflake]'
 

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_dataflow.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_dataflow.py
@@ -21,7 +21,7 @@ class BytewaxMaterializationDataflow:
         config: RepoConfig,
         feature_view: FeatureView,
         paths: List[str],
-        worker_index: int
+        worker_index: int,
     ):
         self.config = config
         self.feature_store = FeatureStore(config=config)
@@ -33,13 +33,7 @@ class BytewaxMaterializationDataflow:
         self._run_dataflow()
 
     def process_path(self, path):
-<<<<<<< HEAD
         dataset = pq.ParquetDataset(path, use_legacy_dataset=False)
-=======
-        fs = s3fs.S3FileSystem()
-        logger.info(f"Processing path {path}")
-        dataset = pq.ParquetDataset(path, filesystem=fs, use_legacy_dataset=False)
->>>>>>> 15c523a2 (SAASMLOPS-809 fix bytewax workers so they only process a single file (#6))
         batches = []
         for fragment in dataset.fragments:
             for batch in fragment.to_table().to_batches():

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -293,7 +293,7 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
             },
             {
                 "name": "BYTEWAX_REPLICAS",
-                "value": f"{pods}",
+                "value": "1",
             },
             {
                 "name": "BYTEWAX_KEEP_CONTAINER_ALIVE",
@@ -349,7 +349,7 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
                                 "env": [
                                     {
                                         "name": "BYTEWAX_REPLICAS",
-                                        "value": f"{pods}",
+                                        "value": "1",
                                     }
                                 ],
                                 "image": "busybox",

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -216,7 +216,10 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
                     total_pods,
                 )
                 offset += batch_size
-                if offset >= total_pods:
+                if (
+                    offset >= total_pods
+                    or job.status() == MaterializationJobStatus.ERROR
+                ):
                     break
         else:
             job_id = str(uuid.uuid4())

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -248,9 +248,6 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
                 f"(of {total_pods}) complete with status {job.status()}"
             )
         except BaseException as e:
-            if self.batch_engine_config.print_pod_logs_on_failure:
-                self._print_pod_logs(job.job_id(), feature_view, batch_start)
-
             logger.info(f"Deleting job {job.job_id()}")
             try:
                 self.batch_v1.delete_namespaced_job(job.job_id(), self.namespace)
@@ -267,6 +264,12 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
                 logger.warning(
                     f"Could not delete configmap due to API Error: {ae.body}"
                 )
+
+            if (
+                job.status() == MaterializationJobStatus.ERROR
+                and self.batch_engine_config.print_pod_logs_on_failure
+            ):
+                self._print_pod_logs(job.job_id(), feature_view, batch_start)
 
         return job
 

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -71,7 +71,7 @@ class BytewaxMaterializationEngineConfig(FeastConfigBaseModel):
     """ (optional) additional labels to append to kubernetes objects """
 
     max_parallelism: int = 10
-    """ (optional) Maximum number of pods allowed to run in parallel per job"""
+    """ (optional) Maximum number of pods allowed to run in parallel"""
 
     synchronous: bool = False
     """ (optional) If true, wait for materialization for one feature to complete before moving to the next """

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -200,6 +200,11 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
             batch_size = self.batch_engine_config.job_batch_size
             if batch_size < 1:
                 raise ValueError("job_batch_size must be a value greater than 0")
+            if batch_size < self.batch_engine_config.max_parallelism:
+                logger.warning(
+                    "job_batch_size is less than max_parallelism. Setting job_batch_size = max_parallelism"
+                )
+                batch_size = self.batch_engine_config.max_parallelism
 
             while True:
                 next_offset = min(offset + batch_size, total_pods)

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -205,7 +205,7 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
                 try:
                     self.batch_v1.delete_namespaced_job(job.job_id(), self.namespace)
                 except ApiException as de:
-                    logger.warning(f"Could not delete job due to API Error: {ae.body}")
+                    logger.warning(f"Could not delete job due to API Error: {de.body}")
                 raise e
             self._print_pod_logs(job.job_id(), feature_view)
         return job
@@ -293,7 +293,7 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
             },
             {
                 "name": "BYTEWAX_REPLICAS",
-                "value": "1",
+                "value": f"{pods}",
             },
             {
                 "name": "BYTEWAX_KEEP_CONTAINER_ALIVE",
@@ -331,8 +331,8 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
             "spec": {
                 "ttlSecondsAfterFinished": 3600,
                 "backoffLimit": self.batch_engine_config.retry_limit,
-                "completions": 1,
-                "parallelism": 1,
+                "completions": pods,
+                "parallelism": min(pods, self.batch_engine_config.max_parallelism),
                 "completionMode": "Indexed",
                 "template": {
                     "metadata": {
@@ -349,7 +349,7 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
                                 "env": [
                                     {
                                         "name": "BYTEWAX_REPLICAS",
-                                        "value": "1",
+                                        "value": f"{pods}",
                                     }
                                 ],
                                 "image": "busybox",

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_engine.py
@@ -87,6 +87,9 @@ class BytewaxMaterializationEngineConfig(FeastConfigBaseModel):
     mini_batch_size: int = 1000
     """ (optional) Number of rows to process per write operation (default 1000)"""
 
+    active_deadline_seconds: int = 86400
+    """ (optional) Maximum amount of time a materialization job is allowed to run"""
+
 
 class BytewaxMaterializationEngine(BatchMaterializationEngine):
     def __init__(
@@ -333,6 +336,7 @@ class BytewaxMaterializationEngine(BatchMaterializationEngine):
                 "backoffLimit": self.batch_engine_config.retry_limit,
                 "completions": pods,
                 "parallelism": min(pods, self.batch_engine_config.max_parallelism),
+                "activeDeadlineSeconds": self.batch_engine_config.active_deadline_seconds,
                 "completionMode": "Indexed",
                 "template": {
                     "metadata": {

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_job.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/bytewax_materialization_job.py
@@ -36,10 +36,13 @@ class BytewaxMaterializationJob(MaterializationJob):
                 if job_status.completion_time is None:
                     return MaterializationJobStatus.RUNNING
             elif job_status.failed is not None:
+                self._error = Exception(f"Job {self.job_id()} failed")
                 return MaterializationJobStatus.ERROR
-            elif job_status.active is None and job_status.succeeded is not None:
-                if job_status.conditions[0].type == "Complete":
-                    return MaterializationJobStatus.SUCCEEDED
+            elif job_status.active is None:
+                if job_status.completion_time is not None:
+                    if job_status.conditions[0].type == "Complete":
+                        return MaterializationJobStatus.SUCCEEDED
+                return MaterializationJobStatus.WAITING
 
     def should_be_retried(self):
         return False

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/dataflow.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/dataflow.py
@@ -1,4 +1,5 @@
 import os
+
 import yaml
 
 from feast import FeatureStore, RepoConfig
@@ -20,5 +21,5 @@ if __name__ == "__main__":
                 config,
                 store.get_feature_view(bytewax_config["feature_view"]),
                 bytewax_config["paths"],
-                int(os.environ["JOB_COMPLETION_INDEX"])
+                int(os.environ["JOB_COMPLETION_INDEX"]),
             )

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/dataflow.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/dataflow.py
@@ -1,3 +1,4 @@
+import os
 import yaml
 
 from feast import FeatureStore, RepoConfig
@@ -19,4 +20,5 @@ if __name__ == "__main__":
                 config,
                 store.get_feature_view(bytewax_config["feature_view"]),
                 bytewax_config["paths"],
+                int(os.environ["JOB_COMPLETION_INDEX"])
             )

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -588,8 +588,10 @@ class SnowflakeRetrievalJob(RetrievalJob):
         file_name_column_index = [
             idx for idx, rm in enumerate(cursor.description) if rm.name == "FILE_NAME"
         ][0]
+        # s3gov schema is used by Snowflake in AWS govcloud regions
+        native_export_path = self.export_path.replace("s3gov://", "s3://")
         return [
-            f"{self.export_path}/{row[file_name_column_index]}"
+            f"{native_export_path}/{row[file_name_column_index]}"
             for row in cursor.fetchall()
         ]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

- We need to run Feast in AWS govcloud regions 
- We also use Snowflake as our offline datastore
- bytewax is online materializer
- DynamoDB is online store
This stack works really well in commercial AWS regions.

However, it is a different story when it comes to AWS govcloud. 
It turned out that you have to use special snowflake schema `s3gov` when data exported by Snowflake with `COPY INTO location` during Feast materialization into online store.  

`blob_export_location` is set to 's3gov://bucket/path` to get a temp data dump to s3. Export part works just fine.

But, following data upload into online data store fails, because pyarrow doesn't recognize `s3gov` schema of temp data dump. Here is actual error
```
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "/usr/local/lib/python3.10/site-packages/feast/infra/materialization/contrib/bytewax/bytewax_materialization_dataflow.py", line 36, in process_path
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -     dataset = pq.ParquetDataset(path, use_legacy_dataset=False)
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "/usr/local/lib64/python3.10/site-packages/pyarrow/parquet/core.py", line 1724, in __new__
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -     return _ParquetDatasetV2(
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "/usr/local/lib64/python3.10/site-packages/pyarrow/parquet/core.py", line 2401, in __init__
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -     if filesystem.get_file_info(path_or_paths).is_file:
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "pyarrow/_fs.pyx", line 571, in pyarrow._fs.FileSystem.get_file_info
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "pyarrow/error.pxi", line 144, in pyarrow.lib.pyarrow_internal_check_status
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "pyarrow/error.pxi", line 100, in pyarrow.lib.check_status
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO - pyarrow.lib.ArrowInvalid: Expected a local filesystem path, got a URI: 's3gov://bucket/path_to/temporary_1e8c3ddfb3104a229b89a04a22718d42_0_0_0.snappy.parquet'
```

Proposed solution is to remove `gov` from data dump paths, so pyarrow can read data using native path.

Sorry for a bit messy PR. First contribution into this project. Our clone needs some housekeeping.  Please check this file `sdk/python/feast/infra/offline_stores/snowflake.py`. Will take care of the rest.
    

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
