### PR TITLE
feat: Support s3gov schema by snowflake offline store during materialization

### DIFF
--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -584,12 +584,16 @@ class SnowflakeRetrievalJob(RetrievalJob):
               HEADER = TRUE
         """
         cursor = execute_snowflake_statement(self.snowflake_conn, query)
+        # s3gov schema is used by Snowflake in AWS govcloud regions
+        # remove gov portion from schema and pass it to online store upload
+        native_export_path = self.export_path.replace("s3gov://", "s3://")
+        return self._get_file_names_from_copy_into(cursor, native_export_path)
 
+
+    def _get_file_names_from_copy_into(self, cursor, native_export_path) -> List[str]:
         file_name_column_index = [
             idx for idx, rm in enumerate(cursor.description) if rm.name == "FILE_NAME"
         ][0]
-        # s3gov schema is used by Snowflake in AWS govcloud regions
-        native_export_path = self.export_path.replace("s3gov://", "s3://")
         return [
             f"{native_export_path}/{row[file_name_column_index]}"
             for row in cursor.fetchall()

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -588,8 +588,10 @@ class SnowflakeRetrievalJob(RetrievalJob):
         file_name_column_index = [
             idx for idx, rm in enumerate(cursor.description) if rm.name == "FILE_NAME"
         ][0]
+        # s3gov schema is used by Snowflake in AWS govcloud regions
+        native_export_path = self.export_path.replace("s3gov://", "s3://")
         return [
-            f"{self.export_path}/{row[file_name_column_index]}"
+            f"{native_export_path}/{row[file_name_column_index]}"
             for row in cursor.fetchall()
         ]
 

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -589,7 +589,6 @@ class SnowflakeRetrievalJob(RetrievalJob):
         native_export_path = self.export_path.replace("s3gov://", "s3://")
         return self._get_file_names_from_copy_into(cursor, native_export_path)
 
-
     def _get_file_names_from_copy_into(self, cursor, native_export_path) -> List[str]:
         file_name_column_index = [
             idx for idx, rm in enumerate(cursor.description) if rm.name == "FILE_NAME"

--- a/sdk/python/tests/unit/infra/offline_stores/test_snowflake.py
+++ b/sdk/python/tests/unit/infra/offline_stores/test_snowflake.py
@@ -1,0 +1,53 @@
+from unittest.mock import Mock, MagicMock, patch, ANY
+import pytest
+
+from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
+
+from feast.infra.offline_stores.snowflake import (
+    SnowflakeOfflineStoreConfig,
+    SnowflakeRetrievalJob,
+)
+
+from feast.repo_config import RepoConfig
+
+import re
+
+@pytest.fixture(params=['s3','s3gov'])
+def retrieval_job(request):
+    offline_store_config = SnowflakeOfflineStoreConfig(
+        type="snowflake.offline",
+        account="snow",
+        user="snow",
+        password="snow",
+        role="snow",
+        warehouse="snow",
+        database="FEAST",
+        schema="OFFLINE",
+        storage_integration_name="FEAST_S3",
+        blob_export_location=f"{request.param}://feast-snowflake-offload/export",
+    )
+    retrieval_job = SnowflakeRetrievalJob(
+        query="SELECT * FROM snowflake",
+        snowflake_conn=MagicMock(),
+        config=RepoConfig(
+            registry="s3://ml-test/repo/registry.db",
+            project="test",
+            provider="snowflake.offline",
+            online_store=SqliteOnlineStoreConfig(type="sqlite"),
+            offline_store=offline_store_config,
+        ),
+        full_feature_names=True,
+        on_demand_feature_views=[],
+    )
+    return retrieval_job
+
+
+def test_to_remote_storage(retrieval_job):
+    stored_files = ["just a path", "maybe another"]
+    with patch.object(retrieval_job, "to_snowflake", return_value=None) as mock_to_snowflake, \
+        patch.object(retrieval_job, "_get_file_names_from_copy_into", return_value=stored_files) as mock_get_file_names_from_copy:
+        assert retrieval_job.to_remote_storage() == stored_files, "should return the list of files"
+        mock_to_snowflake.assert_called_once()
+        mock_get_file_names_from_copy.assert_called_once_with(ANY, ANY)
+        native_path = mock_get_file_names_from_copy.call_args[0][1]
+        assert re.match(f"^s3://.*", native_path), "path should be s3://*"

--- a/sdk/python/tests/unit/infra/offline_stores/test_snowflake.py
+++ b/sdk/python/tests/unit/infra/offline_stores/test_snowflake.py
@@ -1,18 +1,17 @@
-from unittest.mock import Mock, MagicMock, patch, ANY
-import pytest
+import re
+from unittest.mock import ANY, MagicMock, patch
 
-from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
+import pytest
 
 from feast.infra.offline_stores.snowflake import (
     SnowflakeOfflineStoreConfig,
     SnowflakeRetrievalJob,
 )
-
+from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from feast.repo_config import RepoConfig
 
-import re
 
-@pytest.fixture(params=['s3','s3gov'])
+@pytest.fixture(params=["s3", "s3gov"])
 def retrieval_job(request):
     offline_store_config = SnowflakeOfflineStoreConfig(
         type="snowflake.offline",
@@ -44,10 +43,15 @@ def retrieval_job(request):
 
 def test_to_remote_storage(retrieval_job):
     stored_files = ["just a path", "maybe another"]
-    with patch.object(retrieval_job, "to_snowflake", return_value=None) as mock_to_snowflake, \
-        patch.object(retrieval_job, "_get_file_names_from_copy_into", return_value=stored_files) as mock_get_file_names_from_copy:
-        assert retrieval_job.to_remote_storage() == stored_files, "should return the list of files"
+    with patch.object(
+        retrieval_job, "to_snowflake", return_value=None
+    ) as mock_to_snowflake, patch.object(
+        retrieval_job, "_get_file_names_from_copy_into", return_value=stored_files
+    ) as mock_get_file_names_from_copy:
+        assert (
+            retrieval_job.to_remote_storage() == stored_files
+        ), "should return the list of files"
         mock_to_snowflake.assert_called_once()
         mock_get_file_names_from_copy.assert_called_once_with(ANY, ANY)
         native_path = mock_get_file_names_from_copy.call_args[0][1]
-        assert re.match(f"^s3://.*", native_path), "path should be s3://*"
+        assert re.match("^s3://.*", native_path), "path should be s3://*"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

- We need to run Feast in AWS govcloud regions 
- We also use Snowflake as our offline datastore
- bytewax is online materializer
- DynamoDB is online store
This stack works really well in commercial AWS regions.

However, it is a different story when it comes to AWS govcloud. 
It turned out that you have to use special snowflake schema `s3gov` when data exported by Snowflake with `COPY INTO location` during Feast materialization into online store.  

`blob_export_location` is set to 's3gov://bucket/path` to get a temp data dump to s3. Export part works just fine.

But, following data upload into online data store fails, because pyarrow doesn't recognize `s3gov` schema of temp data dump. Here is actual error
```
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "/usr/local/lib/python3.10/site-packages/feast/infra/materialization/contrib/bytewax/bytewax_materialization_dataflow.py", line 36, in process_path
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -     dataset = pq.ParquetDataset(path, use_legacy_dataset=False)
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "/usr/local/lib64/python3.10/site-packages/pyarrow/parquet/core.py", line 1724, in __new__
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -     return _ParquetDatasetV2(
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "/usr/local/lib64/python3.10/site-packages/pyarrow/parquet/core.py", line 2401, in __init__
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -     if filesystem.get_file_info(path_or_paths).is_file:
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "pyarrow/_fs.pyx", line 571, in pyarrow._fs.FileSystem.get_file_info
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "pyarrow/error.pxi", line 144, in pyarrow.lib.pyarrow_internal_check_status
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO -   File "pyarrow/error.pxi", line 100, in pyarrow.lib.check_status
[2024-01-10, 19:45:52 UTC] {pod_manager.py:367} INFO - pyarrow.lib.ArrowInvalid: Expected a local filesystem path, got a URI: 's3gov://bucket/path_to/temporary_1e8c3ddfb3104a229b89a04a22718d42_0_0_0.snappy.parquet'
```

Proposed solution is to remove `gov` from data dump paths, so pyarrow can read data using native path.

Added unit tests for `snowflake.to_remote_storage` method to ensure native s3 schema is always passed to file uploader. 

