### PR TITLE
fix: Trino as an OfflineStore Access Denied when BasicAuthenticaion 

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
@@ -40,7 +40,7 @@ from feast.usage import log_exceptions_and_usage
 
 class BasicAuthModel(FeastConfigBaseModel):
     username: StrictStr
-    password: SecretStr
+    password: StrictStr  # original: SecretStr
 
 
 class KerberosAuthModel(FeastConfigBaseModel):


### PR DESCRIPTION
**What this PR does / why we need it:**

When Feast with OfflineStore as Trino with basic Authentication, password is converted with `SecretStr` in Pydantic type.
Then error occurred with 401('Access Denied: Invalid credentials').
It can be solved when I replace `SecretStr` into `StrictStr` where `.feast.infra.offline_stores.contrib.trino_offline_store.trino.py` line 43.

* Before
![image](https://github.com/feast-dev/feast/assets/40623259/a636933d-8125-4f1f-95ec-140500f26ab9)

*  After 
![image](https://github.com/feast-dev/feast/assets/40623259/cdbdd618-f01f-4492-808d-23d3a75eda20)

And `feature_store.yaml` format is like below
```yaml
project: deepfm_repo
# By default, the registry is a file (but can be turned into a more scalable SQL-backed registry)
registry: data/registry.db
# The provider primarily specifies default offline / online stores & storing the registry in a given cloud
provider: local

offline_store:
  type: trino
  host: localhost
  port: 443
  catalog: lakehouse
  connector:
    type: hive
    file_format: parquet
  user: aidt-devops
  source: feast-trino-offline-store
  http-scheme: https
  ssl-verify: true
  # enables authentication in Trino connections, pick the one you need
  # if you don't need authentication, you can safely remove the whole auth block
  auth:
    # Basic Auth
    type: basic
    config:
      username: aidt-devops
      password: devops123@
entity_key_serialization_version: 2
```
