### PR TITLE
fix: Move gRPC dependencies to an extra

### DIFF
--- a/java/serving/src/test/resources/docker-compose/feast10/entrypoint.sh
+++ b/java/serving/src/test/resources/docker-compose/feast10/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # feast root directory is expected to be mounted (eg, by docker compose)
 cd /mnt/feast
-pip install -e '.[redis]'
+pip install -e '.[grpcio,redis]'
 
 cd /app
 python materialize.py

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,6 @@ REQUIRED = [
     "click>=7.0.0,<9.0.0",
     "colorama>=0.3.9,<1",
     "dill~=0.3.0",
-    "grpcio>=1.56.2,<2",
-    "grpcio-tools>=1.56.2,<2",
-    "grpcio-reflection>=1.56.2,<2",
-    "grpcio-health-checking>=1.56.2,<2",
     "mypy-protobuf==3.1",
     "Jinja2>=2,<4",
     "jsonschema",
@@ -143,7 +139,14 @@ HAZELCAST_REQUIRED = [
 
 IBIS_REQUIRED = [
     "ibis-framework",
-    "ibis-substrait"
+    "ibis-substrait",
+]
+
+GRPCIO_REQUIRED = [
+    "grpcio>=1.56.2,<2",
+    "grpcio-tools>=1.56.2,<2",
+    "grpcio-reflection>=1.56.2,<2",
+    "grpcio-health-checking>=1.56.2,<2",
 ]
 
 CI_REQUIRED = (
@@ -205,6 +208,7 @@ CI_REQUIRED = (
     + ROCKSET_REQUIRED
     + HAZELCAST_REQUIRED
     + IBIS_REQUIRED
+    + GRPCIO_REQUIRED
 )
 
 
@@ -371,6 +375,7 @@ setup(
         "docs": DOCS_REQUIRED,
         "cassandra": CASSANDRA_REQUIRED,
         "hazelcast": HAZELCAST_REQUIRED,
+        "grpcio": GRPCIO_REQUIRED,
         "rockset": ROCKSET_REQUIRED,
         "ibis": IBIS_REQUIRED
     },


### PR DESCRIPTION
PR #3687 added a spiffy feature to ingest streaming features, but this came along with a large batch of depdencies.  Notable this induces a core dependency on `protobuf>=4.21.6` while Feast itself is on `protobuf<4.23.4,>3.20`.  This is a fiddly narrow range and excludes all 3.x uses.