### PR TITLE
fix: Transformation server doesn't generate files from proto

### DIFF
--- a/sdk/python/feast/infra/transformation_servers/Dockerfile
+++ b/sdk/python/feast/infra/transformation_servers/Dockerfile
@@ -15,7 +15,7 @@ COPY README.md README.md
 
 
 # Install dependencies
-RUN --mount=source=.git,target=.git,type=bind pip3 install --no-cache-dir -e '.[gcp,aws]'
+RUN --mount=source=.git,target=.git,type=bind pip3 install --no-cache-dir '.[gcp,aws]'
 
 # Start feature transformation server
 CMD [ "python", "app.py" ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Transformation Server docker image does editable pip install and the resulting installation lacks python files generated from protobuf. The image is currently failing on startup.

**Which issue(s) this PR fixes**:
Fixes #3627
