### PR TITLE
fix: Add conn.commit() to Postgresonline_write_batch.online_write_batch

### DIFF
--- a/sdk/python/feast/infra/online_stores/contrib/postgres.py
+++ b/sdk/python/feast/infra/online_stores/contrib/postgres.py
@@ -99,6 +99,7 @@ class PostgreSQLOnlineStore(OnlineStore):
                     cur_batch,
                     page_size=batch_size,
                 )
+                conn.commit()
                 if progress:
                     progress(len(cur_batch))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that the materialization step in the PostgreSQLOnlineStore succeeds and thus the data is pushed to the online store. It does so by running `conn.commit()` after the insert SQL statement has ran.

**Which issue(s) this PR fixes**:
Fixes #3903
