### PR TITLE
fix: Bytewax materialization engine fails when loading feature_store.yaml

### DIFF
--- a/sdk/python/feast/infra/materialization/contrib/bytewax/Dockerfile
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/Dockerfile
@@ -25,5 +25,5 @@ COPY README.md README.md
 # git dir to infer the version of feast we're installing.
 # https://github.com/pypa/setuptools_scm#usage-from-docker
 # I think it also assumes that this dockerfile is being built from the root of the directory.
-RUN --mount=source=.git,target=.git,type=bind pip3 install --no-cache-dir '.[aws,gcp,bytewax,snowflake]'
+RUN --mount=source=.git,target=.git,type=bind pip3 install --no-cache-dir '.[aws,gcp,bytewax,snowflake,postgres]'
 

--- a/sdk/python/feast/infra/materialization/contrib/bytewax/dataflow.py
+++ b/sdk/python/feast/infra/materialization/contrib/bytewax/dataflow.py
@@ -12,10 +12,10 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
     with open("/var/feast/feature_store.yaml") as f:
-        feast_config = yaml.safe_load(f)
+        feast_config = yaml.load(f, Loader=yaml.Loader)
 
         with open("/var/feast/bytewax_materialization_config.yaml") as b:
-            bytewax_config = yaml.safe_load(b)
+            bytewax_config = yaml.load(b, Loader=yaml.Loader)
 
             config = RepoConfig(**feast_config)
             store = FeatureStore(config=config)


### PR DESCRIPTION
**What this PR does / why we need it:**
PR ensures that the Bytewax materialization engine works.

**Which issue(s) this PR fixes**
yaml.safe_load() raises an error while trying to reconstruct the object below:

    pathlib.PosixPath

The error occurs while running materialization using Bytewax at the point where the feature_store.yaml is loaded. The code where this happens is in [sdk/python/feast/infra/materialization/contrib/bytewax/dataflow.py](https://github.com/feast-dev/feast/blob/ac6529c380bc623a15054350c9936b69617b4bee/sdk/python/feast/infra/materialization/contrib/bytewax/dataflow.py#L14). 

Fixes https://github.com/feast-dev/feast/issues/3893