### PR TITLE
fix: Remove unnecessary dependency on mysqlclient

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -4,7 +4,6 @@ RUN apt update && \
         apt install -y \
         jq \
         python3-dev \
-        default-libmysqlclient-dev \
         build-essential
 
 RUN pip install pip --upgrade

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -4,7 +4,6 @@ RUN apt update && \
         apt install -y \
         jq \
         python3-dev \
-        default-libmysqlclient-dev \
         build-essential
 
 RUN pip install pip --upgrade

--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -472,8 +472,6 @@ mypy-extensions==1.0.0
     #   mypy
 mypy-protobuf==3.1.0
     # via feast (setup.py)
-mysqlclient==2.2.0
-    # via feast (setup.py)
 nbclient==0.9.0
     # via nbconvert
 nbconvert==7.11.0

--- a/sdk/python/requirements/py3.8-ci-requirements.txt
+++ b/sdk/python/requirements/py3.8-ci-requirements.txt
@@ -488,8 +488,6 @@ mypy-extensions==1.0.0
     #   mypy
 mypy-protobuf==3.1.0
     # via feast (setup.py)
-mysqlclient==2.2.0
-    # via feast (setup.py)
 nbclient==0.9.0
     # via nbconvert
 nbconvert==7.11.0

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -479,8 +479,6 @@ mypy-extensions==1.0.0
     #   mypy
 mypy-protobuf==3.1.0
     # via feast (setup.py)
-mysqlclient==2.2.0
-    # via feast (setup.py)
 nbclient==0.9.0
     # via nbconvert
 nbconvert==7.11.0

--- a/sdk/python/tests/unit/test_sql_registry.py
+++ b/sdk/python/tests/unit/test_sql_registry.py
@@ -103,7 +103,7 @@ def mysql_registry():
 
     registry_config = RegistryConfig(
         registry_type="sql",
-        path=f"mysql+mysqldb://{POSTGRES_USER}:{POSTGRES_PASSWORD}@127.0.0.1:{container_port}/{POSTGRES_DB}",
+        path=f"mysql+pymysql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@127.0.0.1:{container_port}/{POSTGRES_DB}",
     )
 
     yield SqlRegistry(registry_config, "project", None)

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ POSTGRES_REQUIRED = [
     "psycopg2-binary>=2.8.3,<3",
 ]
 
-MYSQL_REQUIRED = ["mysqlclient", "pymysql", "types-PyMySQL"]
+MYSQL_REQUIRED = ["pymysql", "types-PyMySQL"]
 
 HBASE_REQUIRED = [
     "happybase>=1.2.0,<3",


### PR DESCRIPTION
**What this PR does / why we need it**:
feast mysql extra declares dependency on `mysqlclient`, but that's actually incorrect because `mysqlclient` is only used in sql registry tests, mysql online store implementation uses `pymysql`. this PR changes the relevant tests to use pymysql as well and removes `mysqlclient` from the project.

P.S. This might break someone's build if they relied on a transitive dependency provided by feast, but I don't think that's enough of a reason to keep an unnecessary extra dependency.

**Which issue(s) this PR fixes**:
Fixes #3916 
