### PR TITLE
fix: Typo Correction in Feast UI Readme

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -46,7 +46,7 @@ ReactDOM.render(
 );
 ```
 
-When you start the React app, it will look for `project-list.json` to find a list of your projects. The JSON should looks something like this.
+When you start the React app, it will look for `projects-list.json` to find a list of your projects. The JSON should looks something like this.
 
 ```json
 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
The PR addresses a specific typo within the Feast UI README file. The correction involves updating the reference to the `projects-list.json` file, ensuring that it accurately reflects the intended file name. This change is important for maintaining the clarity and utility of the documentation, thereby preventing potential confusion among users attempting to configure the customized Feast UI.

**Which issue(s) this PR fixes**:
This PR resolves the issue highlighted in [Feast Issue #3332](https://github.com/feast-dev/feast/issues/3332)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3332
