### PR TITLE
fix: Get container host addresses from testcontainers

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/data_source.py
@@ -62,10 +62,11 @@ class TrinoSourceCreator(DataSourceCreator):
                 "must be include into pytest plugins"
             )
         self.exposed_port = self.container.get_exposed_port("8080")
+        self.container_host = self.container.get_container_host_ip()
         self.client = Trino(
             user="user",
             catalog="memory",
-            host="localhost",
+            host=self.container_host,
             port=self.exposed_port,
             source="trino-python-client",
             http_scheme="http",
@@ -123,7 +124,7 @@ class TrinoSourceCreator(DataSourceCreator):
 
     def create_offline_store_config(self) -> FeastConfigBaseModel:
         return TrinoOfflineStoreConfig(
-            host="localhost",
+            host=self.container_host,
             port=self.exposed_port,
             catalog="memory",
             dataset=self.project_name,

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/redis.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/redis.py
@@ -20,7 +20,11 @@ class RedisOnlineStoreCreator(OnlineStoreCreator):
             container=self.container, predicate=log_string_to_wait_for, timeout=10
         )
         exposed_port = self.container.get_exposed_port("6379")
-        return {"type": "redis", "connection_string": f"localhost:{exposed_port},db=0"}
+        container_host = self.container.get_container_host_ip()
+        return {
+            "type": "redis",
+            "connection_string": f"{container_host}:{exposed_port},db=0",
+        }
 
     def teardown(self):
         self.container.stop()

--- a/sdk/python/tests/unit/test_sql_registry.py
+++ b/sdk/python/tests/unit/test_sql_registry.py
@@ -66,10 +66,11 @@ def pg_registry():
     )
     logger.info("Waited for %s seconds until postgres container was up", waited)
     container_port = container.get_exposed_port(5432)
+    container_host = container.get_container_host_ip()
 
     registry_config = RegistryConfig(
         registry_type="sql",
-        path=f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@127.0.0.1:{container_port}/{POSTGRES_DB}",
+        path=f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{container_host}:{container_port}/{POSTGRES_DB}",
     )
 
     yield SqlRegistry(registry_config, "project", None)
@@ -100,10 +101,11 @@ def mysql_registry():
     )
     logger.info("Waited for %s seconds until mysql container was up", waited)
     container_port = container.get_exposed_port(3306)
+    container_host = container.get_container_host_ip()
 
     registry_config = RegistryConfig(
         registry_type="sql",
-        path=f"mysql+pymysql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@127.0.0.1:{container_port}/{POSTGRES_DB}",
+        path=f"mysql+pymysql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{container_host}:{container_port}/{POSTGRES_DB}",
     )
 
     yield SqlRegistry(registry_config, "project", None)


### PR DESCRIPTION
**What this PR does / why we need it**:
Testing container hosts are hardcoded to either localhost, which makes the life for people who develop inside containers hard. This PR instead gets host from testcontainer's `get_container_host_ip`. This also doesn't always get it right, but at least lets the developer override the values with some env vars. For example in my case (vscode running inside Docker for Windows WSL container with docker socket mounted) this config seems to get tests working:
```
volumes:
  - //var/run/docker.sock:/var/run/docker.sock
environment:
  TC_HOST: host.docker.internal
  DOCKER_HOST: unix:///var/run/docker.sock
```