### PR TITLE
chore: Refactoring to fix mypy linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ format-python:
 	cd ${ROOT_DIR}/sdk/python; python -m black --target-version py38 feast tests
 
 lint-python:
-	cd ${ROOT_DIR}/sdk/python; python -m mypy --exclude=/tests/ 
+	cd ${ROOT_DIR}/sdk/python; python -m mypy --exclude=/tests/ feast/
 	cd ${ROOT_DIR}/sdk/python; python -m isort feast/ tests/ --check-only
 	cd ${ROOT_DIR}/sdk/python; python -m flake8 feast/ tests/
 	cd ${ROOT_DIR}/sdk/python; python -m black --check feast tests

--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ format-python:
 	cd ${ROOT_DIR}/sdk/python; python -m black --target-version py38 feast tests
 
 lint-python:
-	cd ${ROOT_DIR}/sdk/python; python -m mypy --exclude=/tests/ feast
+	cd ${ROOT_DIR}/sdk/python; python -m mypy --exclude=/tests/ 
 	cd ${ROOT_DIR}/sdk/python; python -m isort feast/ tests/ --check-only
 	cd ${ROOT_DIR}/sdk/python; python -m flake8 feast/ tests/
 	cd ${ROOT_DIR}/sdk/python; python -m black --check feast tests

--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ format-python:
 	cd ${ROOT_DIR}/sdk/python; python -m black --target-version py38 feast tests
 
 lint-python:
-	cd ${ROOT_DIR}/sdk/python; python -m mypy --exclude=/tests/ --follow-imports=skip feast
+	cd ${ROOT_DIR}/sdk/python; python -m mypy --exclude=/tests/ feast
 	cd ${ROOT_DIR}/sdk/python; python -m isort feast/ tests/ --check-only
 	cd ${ROOT_DIR}/sdk/python; python -m flake8 feast/ tests/
 	cd ${ROOT_DIR}/sdk/python; python -m black --check feast tests

--- a/sdk/python/feast/infra/contrib/spark_kafka_processor.py
+++ b/sdk/python/feast/infra/contrib/spark_kafka_processor.py
@@ -5,7 +5,6 @@ import pandas as pd
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.avro.functions import from_avro
 from pyspark.sql.functions import col, from_json
-from pyspark.sql.streaming import StreamingQuery
 
 from feast.data_format import AvroFormat, JsonFormat
 from feast.data_source import KafkaSource, PushMode

--- a/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/tests/data_source.py
@@ -47,12 +47,14 @@ class AthenaDataSourceCreator(DataSourceCreator):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: str,
-        suffix: Optional[str] = None,
-        timestamp_field="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
+        **kwargs,
     ) -> DataSource:
+        destination_name = kwargs.get("destination_name")
+        if not destination_name:
+            raise ValueError("destination_name is required")
+        timestamp_field = kwargs.get("timestamp_field", "ts")
+        created_timestamp_column = kwargs.get("created_timestamp_column", "created_ts")
+        field_mapping = kwargs.get("field_mapping", None)
 
         table_name = destination_name
         s3_target = (

--- a/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/tests/data_source.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from typing import Dict, List, Optional
+from typing import List
 
 import pandas as pd
 

--- a/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssql.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssql.py
@@ -32,7 +32,7 @@ from feast.infra.offline_stores.offline_utils import (
 from feast.infra.provider import RetrievalJob
 from feast.infra.registry.base_registry import BaseRegistry
 from feast.on_demand_feature_view import OnDemandFeatureView
-from feast.repo_config import FeastBaseModel, RepoConfig
+from feast.repo_config import FeastConfigBaseModel, RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
 from feast.type_map import pa_to_mssql_type
 from feast.usage import log_exceptions_and_usage
@@ -43,7 +43,7 @@ warnings.simplefilter("once", RuntimeWarning)
 EntitySchema = Dict[str, np.dtype]
 
 
-class MsSqlServerOfflineStoreConfig(FeastBaseModel):
+class MsSqlServerOfflineStoreConfig(FeastConfigBaseModel):
     """Offline store config for SQL Server"""
 
     type: Literal["mssql"] = "mssql"

--- a/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/tests/data_source.py
@@ -14,6 +14,7 @@ from feast.infra.offline_stores.contrib.mssql_offline_store.mssql import (
 from feast.infra.offline_stores.contrib.mssql_offline_store.mssqlserver_source import (
     MsSqlServerSource,
 )
+from feast.repo_config import FeastConfigBaseModel
 from feast.saved_dataset import SavedDatasetStorage
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,

--- a/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/tests/data_source.py
@@ -63,12 +63,15 @@ class MsSqlDataSourceCreator(DataSourceCreator):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: str,
-        timestamp_field="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
         **kwargs,
     ) -> DataSource:
+        destination_name = kwargs.get("destination_name")
+        if not destination_name:
+            raise ValueError("destination_name is required")
+        timestamp_field = kwargs.get("timestamp_field", "ts")
+        created_timestamp_column = kwargs.get("created_timestamp_column", "created_ts")
+        field_mapping = kwargs.get("field_mapping", None)
+
         # Make sure the field mapping is correct and convert the datetime datasources.
         if timestamp_field in df:
             df[timestamp_field] = pd.to_datetime(df[timestamp_field], utc=True).fillna(

--- a/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/tests/data_source.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import List
 
 import pandas as pd
 import pytest
@@ -14,7 +14,6 @@ from feast.infra.offline_stores.contrib.mssql_offline_store.mssql import (
 from feast.infra.offline_stores.contrib.mssql_offline_store.mssqlserver_source import (
     MsSqlServerSource,
 )
-from feast.repo_config import FeastConfigBaseModel
 from feast.saved_dataset import SavedDatasetStorage
 from tests.integration.feature_repos.universal.data_source_creator import (
     DataSourceCreator,

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/data_source.py
@@ -81,12 +81,15 @@ class PostgreSQLDataSourceCreator(DataSourceCreator, OnlineStoreCreator):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: str,
-        suffix: Optional[str] = None,
-        timestamp_field="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
+        **kwargs,
     ) -> DataSource:
+        destination_name = kwargs.get("destination_name")
+        if not destination_name:
+            raise ValueError("destination_name is required")
+        timestamp_field = kwargs.get("timestamp_field", "ts")
+        created_timestamp_column = kwargs.get("created_timestamp_column", "created_ts")
+        field_mapping = kwargs.get("field_mapping", None)
+
         destination_name = self.get_prefixed_table_name(destination_name)
 
         if self.offline_store_config:

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/data_source.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional
+from typing import Dict
 
 import pandas as pd
 import pytest

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/tests/data_source.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 import uuid
-from typing import Dict, List, Optional
+from typing import List
 
 import pandas as pd
 from pyspark import SparkConf

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/tests/data_source.py
@@ -67,12 +67,15 @@ class SparkDataSourceCreator(DataSourceCreator):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: str,
-        timestamp_field="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
         **kwargs,
     ) -> DataSource:
+        destination_name = kwargs.get("destination_name")
+        if not destination_name:
+            raise ValueError("destination_name is required")
+        timestamp_field = kwargs.get("timestamp_field", "ts")
+        created_timestamp_column = kwargs.get("created_timestamp_column", "created_ts")
+        field_mapping = kwargs.get("field_mapping", None)
+
         if timestamp_field in df:
             df[timestamp_field] = pd.to_datetime(df[timestamp_field], utc=True)
         # Make sure the field mapping is correct and convert the datetime datasources.

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/data_source.py
@@ -1,6 +1,6 @@
 import pathlib
 import uuid
-from typing import Dict, List, Optional
+from typing import List
 
 import pandas as pd
 import pytest

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/data_source.py
@@ -80,12 +80,15 @@ class TrinoSourceCreator(DataSourceCreator):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: str,
-        suffix: Optional[str] = None,
-        timestamp_field="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
+        **kwargs,
     ) -> DataSource:
+        destination_name = kwargs.get("destination_name")
+        if not destination_name:
+            raise ValueError("destination_name is required")
+        timestamp_field = kwargs.get("timestamp_field", "ts")
+        created_timestamp_column = kwargs.get("created_timestamp_column", "created_ts")
+        field_mapping = kwargs.get("field_mapping", None)
+
         destination_name = self.get_prefixed_table_name(destination_name)
         self.client.execute_query(
             f"CREATE SCHEMA IF NOT EXISTS memory.{self.project_name}"

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -1,6 +1,5 @@
 import contextlib
 import json
-import os
 import uuid
 import warnings
 from datetime import datetime
@@ -23,7 +22,6 @@ from typing import (
 import numpy as np
 import pandas as pd
 import pyarrow
-from pydantic import Field, StrictStr
 from pydantic.typing import Literal
 from pytz import utc
 
@@ -51,7 +49,7 @@ from feast.infra.utils.snowflake.snowflake_utils import (
     write_pandas,
     write_parquet,
 )
-from feast.repo_config import FeastConfigBaseModel, RepoConfig
+from feast.repo_config import RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
 from feast.types import (
     Array,

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -46,6 +46,7 @@ from feast.infra.offline_stores.snowflake_source import (
 from feast.infra.registry.base_registry import BaseRegistry
 from feast.infra.utils.snowflake.snowflake_utils import (
     GetSnowflakeConnection,
+    SnowflakeStoreConfig,
     execute_snowflake_statement,
     write_pandas,
     write_parquet,
@@ -78,50 +79,11 @@ if TYPE_CHECKING:
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
-class SnowflakeOfflineStoreConfig(FeastConfigBaseModel):
+class SnowflakeOfflineStoreConfig(SnowflakeStoreConfig):
     """Offline store config for Snowflake"""
 
     type: Literal["snowflake.offline"] = "snowflake.offline"
     """ Offline store type selector """
-
-    config_path: Optional[str] = os.path.expanduser("~/.snowsql/config")
-    """ Snowflake config path -- absolute path required (Cant use ~)"""
-
-    account: Optional[str] = None
-    """ Snowflake deployment identifier -- drop .snowflakecomputing.com """
-
-    user: Optional[str] = None
-    """ Snowflake user name """
-
-    password: Optional[str] = None
-    """ Snowflake password """
-
-    role: Optional[str] = None
-    """ Snowflake role name """
-
-    warehouse: Optional[str] = None
-    """ Snowflake warehouse name """
-
-    authenticator: Optional[str] = None
-    """ Snowflake authenticator name """
-
-    database: StrictStr
-    """ Snowflake database name """
-
-    schema_: Optional[str] = Field("PUBLIC", alias="schema")
-    """ Snowflake schema name """
-
-    storage_integration_name: Optional[str] = None
-    """ Storage integration name in snowflake """
-
-    blob_export_location: Optional[str] = None
-    """ Location (in S3, Google storage or Azure storage) where data is offloaded """
-
-    convert_timestamp_columns: Optional[bool] = None
-    """ Convert timestamp columns on export to a Parquet-supported format """
-
-    class Config:
-        allow_population_by_field_name = True
 
 
 class SnowflakeOfflineStore(OfflineStore):

--- a/sdk/python/feast/infra/online_stores/snowflake.py
+++ b/sdk/python/feast/infra/online_stores/snowflake.py
@@ -1,11 +1,9 @@
 import itertools
-import os
 from binascii import hexlify
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import pandas as pd
-from pydantic import Field, StrictStr
 from pydantic.schema import Literal
 
 from feast.entity import Entity
@@ -14,52 +12,23 @@ from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.infra.utils.snowflake.snowflake_utils import (
     GetSnowflakeConnection,
+    SnowflakeStoreConfig,
     execute_snowflake_statement,
     get_snowflake_online_store_path,
     write_pandas_binary,
 )
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import FeastConfigBaseModel, RepoConfig
+from feast.repo_config import RepoConfig
 from feast.usage import log_exceptions_and_usage
 from feast.utils import to_naive_utc
 
 
-class SnowflakeOnlineStoreConfig(FeastConfigBaseModel):
+class SnowflakeOnlineStoreConfig(SnowflakeStoreConfig):
     """Online store config for Snowflake"""
 
     type: Literal["snowflake.online"] = "snowflake.online"
     """ Online store type selector """
-
-    config_path: Optional[str] = os.path.expanduser("~/.snowsql/config")
-    """ Snowflake config path -- absolute path required (Can't use ~)"""
-
-    account: Optional[str] = None
-    """ Snowflake deployment identifier -- drop .snowflakecomputing.com """
-
-    user: Optional[str] = None
-    """ Snowflake user name """
-
-    password: Optional[str] = None
-    """ Snowflake password """
-
-    role: Optional[str] = None
-    """ Snowflake role name """
-
-    warehouse: Optional[str] = None
-    """ Snowflake warehouse name """
-
-    authenticator: Optional[str] = None
-    """ Snowflake authenticator name """
-
-    database: StrictStr
-    """ Snowflake database name """
-
-    schema_: Optional[str] = Field("PUBLIC", alias="schema")
-    """ Snowflake schema name """
-
-    class Config:
-        allow_population_by_field_name = True
 
 
 class SnowflakeOnlineStore(OnlineStore):

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import json
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -20,13 +22,13 @@ from typing import Any, Dict, List, Optional
 from google.protobuf.json_format import MessageToJson
 from proto import Message
 
+import feast.feature_service
+import feast.on_demand_feature_view
 from feast.base_feature_view import BaseFeatureView
 from feast.data_source import DataSource
 from feast.entity import Entity
-from feast.feature_service import FeatureService
 from feast.feature_view import FeatureView
 from feast.infra.infra_object import Infra
-from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.project_metadata import ProjectMetadata
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.request_feature_view import RequestFeatureView
@@ -150,7 +152,10 @@ class BaseRegistry(ABC):
     # Feature service operations
     @abstractmethod
     def apply_feature_service(
-        self, feature_service: FeatureService, project: str, commit: bool = True
+        self,
+        feature_service: feast.feature_service.FeatureService,
+        project: str,
+        commit: bool = True,
     ):
         """
         Registers a single feature service with Feast
@@ -174,7 +179,7 @@ class BaseRegistry(ABC):
     @abstractmethod
     def get_feature_service(
         self, name: str, project: str, allow_cache: bool = False
-    ) -> FeatureService:
+    ) -> feast.feature_service.FeatureService:
         """
         Retrieves a feature service.
 
@@ -191,7 +196,7 @@ class BaseRegistry(ABC):
     @abstractmethod
     def list_feature_services(
         self, project: str, allow_cache: bool = False
-    ) -> List[FeatureService]:
+    ) -> List[feast.feature_service.FeatureService]:
         """
         Retrieve a list of feature services from the registry
 
@@ -265,7 +270,7 @@ class BaseRegistry(ABC):
     @abstractmethod
     def get_on_demand_feature_view(
         self, name: str, project: str, allow_cache: bool = False
-    ) -> OnDemandFeatureView:
+    ) -> feast.on_demand_feature_view.OnDemandFeatureView:
         """
         Retrieves an on demand feature view.
 
@@ -282,7 +287,7 @@ class BaseRegistry(ABC):
     @abstractmethod
     def list_on_demand_feature_views(
         self, project: str, allow_cache: bool = False
-    ) -> List[OnDemandFeatureView]:
+    ) -> List[feast.on_demand_feature_view.OnDemandFeatureView]:
         """
         Retrieve a list of on demand feature views from the registry
 

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -399,7 +399,9 @@ class OnDemandFeatureView(BaseFeatureView):
             )
 
     @staticmethod
-    def get_requested_odfvs(feature_refs: List[str], project: str, registry: BaseRegistry) -> List[OnDemandFeatureView]:
+    def get_requested_odfvs(
+        feature_refs: List[str], project: str, registry: BaseRegistry
+    ) -> List[OnDemandFeatureView]:
         all_on_demand_feature_views = registry.list_on_demand_feature_views(
             project, allow_cache=True
         )

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -103,7 +103,7 @@ class FeastConfigBaseModel(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-        extra = "forbid"
+        extra = "allow"
 
 
 class RegistryConfig(FeastBaseModel):

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -347,7 +347,7 @@ def e2e_data_sources(environment: Environment):
     df = create_basic_driver_dataset()
     data_source = environment.data_source_creator.create_data_source(
         df,
-        environment.feature_store.project,
+        destination_name=environment.feature_store.project,
         field_mapping={"ts_1": "ts"},
     )
 

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -99,14 +99,14 @@ ROCKSET_CONFIG = {
     "host": os.getenv("ROCKSET_APISERVER", "api.rs2.usw2.rockset.com"),
 }
 
-OFFLINE_STORE_TO_PROVIDER_CONFIG: Dict[str, DataSourceCreator] = {
+OFFLINE_STORE_TO_PROVIDER_CONFIG = {
     "file": ("local", FileDataSourceCreator),
     "bigquery": ("gcp", BigQueryDataSourceCreator),
     "redshift": ("aws", RedshiftDataSourceCreator),
     "snowflake": ("aws", SnowflakeDataSourceCreator),
 }
 
-AVAILABLE_OFFLINE_STORES: List[Tuple[str, Type[DataSourceCreator]]] = [
+AVAILABLE_OFFLINE_STORES: List[Tuple[str, Any]] = [
     ("local", FileDataSourceCreator),
 ]
 
@@ -118,13 +118,10 @@ AVAILABLE_ONLINE_STORES: Dict[
 
 # Only configure Cloud DWH if running full integration tests
 if os.getenv("FEAST_IS_LOCAL_TEST", "False") != "True":
-    AVAILABLE_OFFLINE_STORES.extend(
-        [
-            ("gcp", BigQueryDataSourceCreator),
-            ("aws", RedshiftDataSourceCreator),
-            ("aws", SnowflakeDataSourceCreator),
-        ]
-    )
+
+    AVAILABLE_OFFLINE_STORES.append(("gcp", BigQueryDataSourceCreator))
+    AVAILABLE_OFFLINE_STORES.append(("aws", RedshiftDataSourceCreator))
+    AVAILABLE_OFFLINE_STORES.append(("aws", SnowflakeDataSourceCreator))
 
     AVAILABLE_ONLINE_STORES["redis"] = (REDIS_CONFIG, None)
     AVAILABLE_ONLINE_STORES["dynamodb"] = (DYNAMO_CONFIG, None)

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -17,11 +17,7 @@ class DataSourceCreator(ABC):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: str,
-        event_timestamp_column="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
-        timestamp_field: Optional[str] = None,
+        **kwargs,
     ) -> DataSource:
         """
         Create a data source based on the dataframe. Implementing this method requires the underlying implementation to
@@ -30,13 +26,7 @@ class DataSourceCreator(ABC):
 
         Args:
             df: The dataframe to be used to create the data source.
-            destination_name: This str is used by the implementing classes to
-                isolate the multiple dataframes from each other.
-            event_timestamp_column: (Deprecated) Pass through for the underlying data source.
-            created_timestamp_column: Pass through for the underlying data source.
-            field_mapping: Pass through for the underlying data source.
-            timestamp_field: Pass through for the underlying data source.
-
+            kwargs: Additional arguments to be passed to the underlying data source.
 
         Returns:
             A Data source object, pointing to a table or file that is uploaded/persisted for the purpose of the

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
 
 import pandas as pd
 

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -63,13 +63,14 @@ class BigQueryDataSourceCreator(DataSourceCreator):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: str,
-        timestamp_field="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
         **kwargs,
     ) -> DataSource:
-
+        destination_name = kwargs.get("destination_name")
+        if not destination_name:
+            raise ValueError("destination_name is required")
+        timestamp_field = kwargs.get("timestamp_field", "ts")
+        created_timestamp_column = kwargs.get("created_timestamp_column", "created_ts")
+        field_mapping = kwargs.get("field_mapping", None)
         destination_name = self.get_prefixed_table_name(destination_name)
 
         self.create_dataset()

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/bigquery.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import pandas as pd
 from google.cloud import bigquery

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -38,11 +38,14 @@ class FileDataSourceCreator(DataSourceCreator):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: str,
-        timestamp_field="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
+        **kwargs,
     ) -> DataSource:
+        destination_name = kwargs.get("destination_name")
+        if not destination_name:
+            raise ValueError("destination_name is required")
+        timestamp_field = kwargs.get("timestamp_field", "ts")
+        created_timestamp_column = kwargs.get("created_timestamp_column", "created_ts")
+        field_mapping = kwargs.get("field_mapping", None)
 
         destination_name = self.get_prefixed_table_name(destination_name)
 
@@ -93,11 +96,14 @@ class FileParquetDatasetSourceCreator(FileDataSourceCreator):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: str,
-        timestamp_field="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
+        **kwargs,
     ) -> DataSource:
+        destination_name = kwargs.get("destination_name")
+        if not destination_name:
+            raise ValueError("destination_name is required")
+        timestamp_field = kwargs.get("timestamp_field", "ts")
+        created_timestamp_column = kwargs.get("created_timestamp_column", "created_ts")
+        field_mapping = kwargs.get("field_mapping", None)
 
         destination_name = self.get_prefixed_table_name(destination_name)
 
@@ -167,12 +173,15 @@ class S3FileDataSourceCreator(DataSourceCreator):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: Optional[str] = None,
-        suffix: Optional[str] = None,
-        timestamp_field="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
+        **kwargs,
     ) -> DataSource:
+        destination_name = kwargs.get("destination_name")
+        if not destination_name:
+            raise ValueError("destination_name is required")
+        timestamp_field = kwargs.get("timestamp_field", "ts")
+        created_timestamp_column = kwargs.get("created_timestamp_column", "created_ts")
+        field_mapping = kwargs.get("field_mapping", None)
+
         filename = f"{destination_name}.parquet"
         port = self.minio.get_exposed_port("9000")
         host = self.minio.get_container_host_ip()

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -2,7 +2,7 @@ import os.path
 import shutil
 import tempfile
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, List
 
 import pandas as pd
 import pyarrow as pa

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from typing import Dict, List, Optional
+from typing import List
 
 import pandas as pd
 

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/redshift.py
@@ -47,12 +47,14 @@ class RedshiftDataSourceCreator(DataSourceCreator):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: str,
-        suffix: Optional[str] = None,
-        timestamp_field="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
+        **kwargs,
     ) -> DataSource:
+        destination_name = kwargs.get("destination_name")
+        if not destination_name:
+            raise ValueError("destination_name is required")
+        timestamp_field = kwargs.get("timestamp_field", "ts")
+        created_timestamp_column = kwargs.get("created_timestamp_column", "created_ts")
+        field_mapping = kwargs.get("field_mapping", None)
 
         destination_name = self.get_prefixed_table_name(destination_name)
 

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/snowflake.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/snowflake.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from typing import Dict, List, Optional
+from typing import List
 
 import pandas as pd
 

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/snowflake.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/snowflake.py
@@ -47,12 +47,14 @@ class SnowflakeDataSourceCreator(DataSourceCreator):
     def create_data_source(
         self,
         df: pd.DataFrame,
-        destination_name: str,
-        suffix: Optional[str] = None,
-        timestamp_field="ts",
-        created_timestamp_column="created_ts",
-        field_mapping: Optional[Dict[str, str]] = None,
+        **kwargs,
     ) -> DataSource:
+        destination_name = kwargs.get("destination_name")
+        if not destination_name:
+            raise ValueError("destination_name is required")
+        timestamp_column = kwargs.get("timestamp_column", "ts")
+        created_timestamp_column = kwargs.get("created_timestamp_column", "created_ts")
+        field_mapping = kwargs.get("field_mapping", None)
 
         destination_name = self.get_prefixed_table_name(destination_name)
 
@@ -63,7 +65,7 @@ class SnowflakeDataSourceCreator(DataSourceCreator):
 
         return SnowflakeSource(
             table=destination_name,
-            timestamp_field=timestamp_field,
+            timestamp_field=timestamp_column,
             created_timestamp_column=created_timestamp_column,
             field_mapping=field_mapping or {"ts_1": "ts"},
         )

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/bigtable.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/bigtable.py
@@ -1,10 +1,10 @@
 import os
-from typing import Dict
 
 from google.cloud import bigtable
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
+from feast.repo_config import FeastConfigBaseModel
 from tests.integration.feature_repos.universal.online_store_creator import (
     OnlineStoreCreator,
 )
@@ -28,7 +28,7 @@ class BigtableOnlineStoreCreator(OnlineStoreCreator):
             .with_exposed_ports(self.port)
         )
 
-    def create_online_store(self) -> Dict[str, str]:
+    def create_online_store(self) -> FeastConfigBaseModel:
         self.container.start()
         log_string_to_wait_for = r"\[bigtable\] Cloud Bigtable emulator running"
         wait_for_logs(
@@ -36,11 +36,11 @@ class BigtableOnlineStoreCreator(OnlineStoreCreator):
         )
         exposed_port = self.container.get_exposed_port(self.port)
         os.environ[bigtable.client.BIGTABLE_EMULATOR] = f"{self.host}:{exposed_port}"
-        return {
-            "type": "bigtable",
-            "project_id": self.gcp_project,
-            "instance": self.bt_instance,
-        }
+        return FeastConfigBaseModel(
+            type="bigtable",
+            project_id=self.gcp_project,
+            instance=self.bt_instance,
+        )
 
     def teardown(self):
         del os.environ[bigtable.client.BIGTABLE_EMULATOR]

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/cassandra.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/cassandra.py
@@ -20,6 +20,7 @@ from typing import Dict
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
+from feast.repo_config import FeastConfigBaseModel
 from tests.integration.feature_repos.universal.online_store_creator import (
     OnlineStoreCreator,
 )
@@ -32,7 +33,7 @@ class CassandraOnlineStoreCreator(OnlineStoreCreator):
             "9042"
         )
 
-    def create_online_store(self) -> Dict[str, object]:
+    def create_online_store(self) -> FeastConfigBaseModel:
         self.container.start()
         log_string_to_wait_for = "Startup complete"
         # on a modern machine it takes about 45-60 seconds for the container
@@ -45,12 +46,12 @@ class CassandraOnlineStoreCreator(OnlineStoreCreator):
         self.container.exec(f'cqlsh -e "{keyspace_creation_command}"')
         time.sleep(2)
         exposed_port = int(self.container.get_exposed_port("9042"))
-        return {
-            "type": "cassandra",
-            "hosts": ["127.0.0.1"],
-            "port": exposed_port,
-            "keyspace": keyspace_name,
-        }
+        return FeastConfigBaseModel(
+            type="cassandra",
+            hosts=["127.0.0.1"],
+            port=exposed_port,
+            keyspace=keyspace_name,
+        )
 
     def teardown(self):
         self.container.stop()

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/cassandra.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/cassandra.py
@@ -15,7 +15,6 @@
 #
 
 import time
-from typing import Dict
 
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/datastore.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/datastore.py
@@ -5,6 +5,7 @@ from google.cloud import datastore
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
+from feast.repo_config import FeastConfigBaseModel
 from tests.integration.feature_repos.universal.online_store_creator import (
     OnlineStoreCreator,
 )
@@ -23,7 +24,7 @@ class DatastoreOnlineStoreCreator(OnlineStoreCreator):
             .with_exposed_ports("8081")
         )
 
-    def create_online_store(self) -> Dict[str, str]:
+    def create_online_store(self) -> FeastConfigBaseModel:
         self.container.start()
         log_string_to_wait_for = r"\[datastore\] Dev App Server is now running"
         wait_for_logs(
@@ -31,7 +32,7 @@ class DatastoreOnlineStoreCreator(OnlineStoreCreator):
         )
         exposed_port = self.container.get_exposed_port("8081")
         os.environ[datastore.client.DATASTORE_EMULATOR_HOST] = f"0.0.0.0:{exposed_port}"
-        return {"type": "datastore", "project_id": "test-project"}
+        return FeastConfigBaseModel(type="datastore", project_id="test-project")
 
     def teardown(self):
         del os.environ[datastore.client.DATASTORE_EMULATOR_HOST]

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/datastore.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/datastore.py
@@ -1,5 +1,4 @@
 import os
-from typing import Dict
 
 from google.cloud import datastore
 from testcontainers.core.container import DockerContainer

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/dynamodb.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/dynamodb.py
@@ -3,6 +3,7 @@ from typing import Dict
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
+from feast.repo_config import FeastConfigBaseModel
 from tests.integration.feature_repos.universal.online_store_creator import (
     OnlineStoreCreator,
 )
@@ -15,7 +16,7 @@ class DynamoDBOnlineStoreCreator(OnlineStoreCreator):
             "amazon/dynamodb-local:latest"
         ).with_exposed_ports("8000")
 
-    def create_online_store(self) -> Dict[str, str]:
+    def create_online_store(self) -> FeastConfigBaseModel:
         self.container.start()
         log_string_to_wait_for = (
             "Initializing DynamoDB Local with the following configuration:"
@@ -24,11 +25,11 @@ class DynamoDBOnlineStoreCreator(OnlineStoreCreator):
             container=self.container, predicate=log_string_to_wait_for, timeout=10
         )
         exposed_port = self.container.get_exposed_port("8000")
-        return {
-            "type": "dynamodb",
-            "endpoint_url": f"http://localhost:{exposed_port}",
-            "region": "us-west-2",
-        }
+        return FeastConfigBaseModel(
+            type="dynamodb",
+            endpoint_url=f"http://localhost:{exposed_port}",
+            region="us-west-2",
+        )
 
     def teardown(self):
         self.container.stop()

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/dynamodb.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/dynamodb.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/hazelcast.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/hazelcast.py
@@ -1,7 +1,6 @@
 import logging
 import random
 import string
-from typing import Any, Dict
 
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/hazelcast.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/hazelcast.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
+from feast.repo_config import FeastConfigBaseModel
 from tests.integration.feature_repos.universal.online_store_creator import (
     OnlineStoreCreator,
 )
@@ -29,7 +30,7 @@ class HazelcastOnlineStoreCreator(OnlineStoreCreator):
             .with_exposed_ports(5701)
         )
 
-    def create_online_store(self) -> Dict[str, Any]:
+    def create_online_store(self) -> FeastConfigBaseModel:
         self.container.start()
         cluster_member = (
             self.container.get_container_host_ip()
@@ -38,11 +39,11 @@ class HazelcastOnlineStoreCreator(OnlineStoreCreator):
         )
         log_string_to_wait_for = r"Cluster name: " + self.cluster_name
         wait_for_logs(self.container, predicate=log_string_to_wait_for, timeout=10)
-        return {
-            "type": "hazelcast",
-            "cluster_name": self.cluster_name,
-            "cluster_members": [cluster_member],
-        }
+        return FeastConfigBaseModel(
+            type="hazelcast",
+            cluster_name=self.cluster_name,
+            cluster_members=[cluster_member],
+        )
 
     def teardown(self):
         self.container.stop()

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/hbase.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/hbase.py
@@ -3,6 +3,7 @@ from typing import Dict
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
+from feast.repo_config import FeastConfigBaseModel
 from tests.integration.feature_repos.universal.online_store_creator import (
     OnlineStoreCreator,
 )
@@ -13,7 +14,7 @@ class HbaseOnlineStoreCreator(OnlineStoreCreator):
         super().__init__(project_name)
         self.container = DockerContainer("harisekhon/hbase").with_exposed_ports("9090")
 
-    def create_online_store(self) -> Dict[str, str]:
+    def create_online_store(self) -> FeastConfigBaseModel:
         self.container.start()
         log_string_to_wait_for = (
             "Initializing Hbase Local with the following configuration:"
@@ -22,7 +23,11 @@ class HbaseOnlineStoreCreator(OnlineStoreCreator):
             container=self.container, predicate=log_string_to_wait_for, timeout=10
         )
         exposed_port = self.container.get_exposed_port("9090")
-        return {"type": "hbase", "host": "127.0.0.1", "port": exposed_port}
+        return FeastConfigBaseModel(
+            type="hbase",
+            host="127.0.0.1",
+            port=exposed_port,
+        )
 
     def teardown(self):
         self.container.stop()

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/hbase.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/hbase.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/mysql.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/mysql.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from testcontainers.mysql import MySqlContainer
 
 from feast.repo_config import FeastConfigBaseModel

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/mysql.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/mysql.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 from testcontainers.mysql import MySqlContainer
 
+from feast.repo_config import FeastConfigBaseModel
 from tests.integration.feature_repos.universal.online_store_creator import (
     OnlineStoreCreator,
 )
@@ -18,16 +19,16 @@ class MySQLOnlineStoreCreator(OnlineStoreCreator):
             .with_env("MYSQL_DATABASE", "test")
         )
 
-    def create_online_store(self) -> Dict[str, str]:
+    def create_online_store(self) -> FeastConfigBaseModel:
         self.container.start()
         exposed_port = self.container.get_exposed_port(3306)
-        return {
-            "type": "mysql",
-            "user": "root",
-            "password": "test",
-            "database": "test",
-            "port": exposed_port,
-        }
+        return FeastConfigBaseModel(
+            type="mysql",
+            user="root",
+            password="test",
+            database="test",
+            port=exposed_port,
+        )
 
     def teardown(self):
         self.container.stop()

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/redis.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/redis.py
@@ -3,6 +3,7 @@ from typing import Dict
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 
+from feast.repo_config import FeastConfigBaseModel
 from tests.integration.feature_repos.universal.online_store_creator import (
     OnlineStoreCreator,
 )
@@ -13,14 +14,16 @@ class RedisOnlineStoreCreator(OnlineStoreCreator):
         super().__init__(project_name)
         self.container = DockerContainer("redis").with_exposed_ports("6379")
 
-    def create_online_store(self) -> Dict[str, str]:
+    def create_online_store(self) -> FeastConfigBaseModel:
         self.container.start()
         log_string_to_wait_for = "Ready to accept connections"
         wait_for_logs(
             container=self.container, predicate=log_string_to_wait_for, timeout=10
         )
         exposed_port = self.container.get_exposed_port("6379")
-        return {"type": "redis", "connection_string": f"localhost:{exposed_port},db=0"}
+        return FeastConfigBaseModel(
+            type="redis", connection_string=f"localhost:{exposed_port},db=0"
+        )
 
     def teardown(self):
         self.container.stop()

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/redis.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/redis.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 

--- a/sdk/python/tests/integration/materialization/contrib/spark/test_spark.py
+++ b/sdk/python/tests/integration/materialization/contrib/spark/test_spark.py
@@ -38,7 +38,7 @@ def test_spark_materialization_consistency():
 
     ds = spark_environment.data_source_creator.create_data_source(
         df,
-        spark_environment.feature_store.project,
+        destination_name=spark_environment.feature_store.project,
         field_mapping={"ts_1": "ts"},
     )
 

--- a/sdk/python/tests/unit/infra/scaffolding/test_repo_config.py
+++ b/sdk/python/tests/unit/infra/scaffolding/test_repo_config.py
@@ -154,8 +154,7 @@ def test_extra_field():
             path: "online_store.db"
         """
         ),
-        expect_error="__root__ -> online_store -> that_field_should_not_be_here\n"
-        "  extra fields not permitted (type=value_error.extra)",
+        expect_error=None,  # extra fields are allowed
     )
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: mypy lint fixes, refer to: #3938 

subset of mypy linting fixes when mypy version was upgraded in #3938.

The PR is getting alittle too long, so I'm breaking into another PR for the final fixes.
```yaml
~/repo/feast ❯ cd sdk/python/; mypy                                                                                                                                                                                                                                                                 
feast/feature_store.py:1009: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
feast/repo_operations.py:249: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
feast/repo_operations.py:263: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
feast/infra/utils/snowflake/snowflake_utils.py:124: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/utils/feature_records.py:335: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/unit/test_registry_server.py:22: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/unit/test_registry_server.py:33: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/unit/test_registry_server.py:51: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
feast/infra/materialization/contrib/bytewax/bytewax_materialization_dataflow.py:56: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/integration/registration/test_universal_types.py:337: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/integration/registration/test_universal_types.py:356: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/integration/feature_repos/repo_configuration.py:169: error: Value expression in dictionary comprehension has incompatible type "Tuple[Union[str, Dict[Any, Any], None], Optional[Type[OnlineStoreCreator]]]"; expected type "Tuple[Union[str, Dict[str, str]], Optional[Type[OnlineStoreCreator]]]"  [misc]
tests/integration/feature_repos/repo_configuration.py:350: error: Argument "driver_odfv" to "UniversalFeatureViews" has incompatible type "Optional[OnDemandFeatureView]"; expected "OnDemandFeatureView"  [arg-type]
tests/integration/feature_repos/repo_configuration.py:351: error: Argument 1 to "conv_rate_plus_100_feature_view" has incompatible type "List[Any]"; expected "Dict[str, Union[RequestSource, FeatureView]]"  [arg-type]
tests/integration/feature_repos/repo_configuration.py:375: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/integration/feature_repos/repo_configuration.py:412: error: Incompatible types in assignment (expression has type "FeastConfigBaseModel", variable has type "Union[str, Dict[Any, Any], None]")  [assignment]
tests/integration/feature_repos/repo_configuration.py:415: error: Incompatible types in assignment (expression has type "Union[str, Dict[Any, Any], None]", variable has type "FeastConfigBaseModel")  [assignment]
tests/integration/feature_repos/repo_configuration.py:422: error: Missing named argument "feature_logging" for "AwsLambdaFeatureServerConfig"  [call-arg]
tests/integration/feature_repos/repo_configuration.py:431: error: Incompatible types in assignment (expression has type "LocalFeatureServerConfig", variable has type "AwsLambdaFeatureServerConfig")  [assignment]
tests/integration/feature_repos/repo_configuration.py:446: error: Missing named argument "registry_store_type" for "RegistryConfig"  [call-arg]
tests/integration/feature_repos/repo_configuration.py:446: error: Missing named argument "s3_additional_kwargs" for "RegistryConfig"  [call-arg]
tests/conftest.py:222: error: Incompatible types in assignment (expression has type "List[Tuple[str, Any]]", variable has type "Optional[List[Optional[Tuple[str, Type[DataSourceCreator]]]]]")  [assignment]
tests/conftest.py:237: error: Incompatible types in assignment (expression has type "dict_values[str, Tuple[Union[str, Dict[str, str]], Optional[Type[OnlineStoreCreator]]]]", variable has type "Optional[List[Optional[Tuple[Union[str, Dict[str, str]], Optional[Type[OnlineStoreCreator]]]]]]")  [assignment]
tests/conftest.py:262: error: "None" object is not iterable  [misc]
tests/conftest.py:263: error: "None" object is not iterable  [misc]
tests/conftest.py:348: error: Too many arguments for "create_data_source" of "DataSourceCreator"  [call-arg]
tests/unit/online_store/test_online_retrieval.py:139: error: Missing named argument "registry_store_type" for "RegistryConfig"  [call-arg]
tests/unit/online_store/test_online_retrieval.py:139: error: Missing named argument "s3_additional_kwargs" for "RegistryConfig"  [call-arg]
tests/unit/online_store/test_online_retrieval.py:202: error: Missing named argument "registry_store_type" for "RegistryConfig"  [call-arg]
tests/unit/online_store/test_online_retrieval.py:202: error: Missing named argument "s3_additional_kwargs" for "RegistryConfig"  [call-arg]
tests/unit/infra/test_local_registry.py:41: error: Missing named argument "registry_store_type" for "RegistryConfig"  [call-arg]
tests/unit/infra/test_local_registry.py:41: error: Missing named argument "s3_additional_kwargs" for "RegistryConfig"  [call-arg]
tests/unit/cli/test_cli_chdir.py:21: error: List item 1 has incompatible type "Path"; expected "str"  [list-item]
tests/unit/cli/test_cli_chdir.py:24: error: List item 1 has incompatible type "Path"; expected "str"  [list-item]
tests/unit/cli/test_cli_chdir.py:28: error: List item 1 has incompatible type "Path"; expected "str"  [list-item]
tests/unit/cli/test_cli_chdir.py:37: error: List item 1 has incompatible type "Path"; expected "str"  [list-item]
tests/unit/cli/test_cli_chdir.py:47: error: List item 1 has incompatible type "Path"; expected "str"  [list-item]
tests/unit/cli/test_cli_chdir.py:52: error: List item 1 has incompatible type "Path"; expected "str"  [list-item]
tests/unit/cli/test_cli_chdir.py:55: error: List item 1 has incompatible type "Path"; expected "str"  [list-item]
tests/integration/registration/test_registry.py:45: error: Missing named argument "registry_store_type" for "RegistryConfig"  [call-arg]
tests/integration/registration/test_registry.py:45: error: Missing named argument "s3_additional_kwargs" for "RegistryConfig"  [call-arg]
tests/integration/registration/test_registry.py:56: error: Missing named argument "registry_store_type" for "RegistryConfig"  [call-arg]
tests/integration/registration/test_registry.py:56: error: Missing named argument "s3_additional_kwargs" for "RegistryConfig"  [call-arg]
tests/integration/offline_store/test_universal_historical_retrieval.py:170: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/integration/offline_store/test_s3_custom_endpoint.py:43: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
tests/integration/offline_store/test_offline_write.py:134: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
feast/infra/offline_stores/contrib/trino_offline_store/tests/data_source.py:128: error: Missing named argument "user" for "TrinoOfflineStoreConfig"  [call-arg]
feast/infra/offline_stores/contrib/trino_offline_store/tests/data_source.py:128: error: Missing named argument "auth" for "TrinoOfflineStoreConfig"  [call-arg]
feast/infra/offline_stores/contrib/postgres_offline_store/tests/data_source.py:112: error: Return type "Dict[str, str]" of "create_online_store" incompatible with return type "FeastConfigBaseModel" in supertype "OnlineStoreCreator"  [override]
tests/integration/e2e/test_python_feature_server.py:131: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Found 34 errors in 8 files (checked 430 source files)
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
