### PR TITLE
fix: Fix copy method for StreamFeatureView

### DIFF
--- a/sdk/python/feast/stream_feature_view.py
+++ b/sdk/python/feast/stream_feature_view.py
@@ -284,7 +284,6 @@ class StreamFeatureView(FeatureView):
         fv = StreamFeatureView(
             name=self.name,
             schema=self.schema,
-            entities=self.entities,
             ttl=self.ttl,
             tags=self.tags,
             online=self.online,
@@ -293,9 +292,12 @@ class StreamFeatureView(FeatureView):
             aggregations=self.aggregations,
             mode=self.mode,
             timestamp_field=self.timestamp_field,
-            source=self.source,
+            source=self.stream_source if self.stream_source else self.batch_source,
             udf=self.udf,
         )
+        fv.entities = self.entities
+        fv.features = copy.copy(self.features)
+        fv.entity_columns = copy.copy(self.entity_columns)
         fv.projection = copy.copy(self.projection)
         return fv
 

--- a/sdk/python/tests/unit/test_feature_views.py
+++ b/sdk/python/tests/unit/test_feature_views.py
@@ -1,3 +1,4 @@
+import copy
 from datetime import timedelta
 
 import pytest
@@ -299,3 +300,22 @@ def test_stream_feature_view_proto_type():
         aggregations=[],
     )
     assert sfv.proto_class is StreamFeatureViewProto
+
+
+def test_stream_feature_view_copy():
+    stream_source = KafkaSource(
+        name="kafka",
+        timestamp_field="event_timestamp",
+        kafka_bootstrap_servers="",
+        message_format=AvroFormat(""),
+        topic="topic",
+        batch_source=FileSource(path="some path"),
+    )
+    sfv = StreamFeatureView(
+        name="test stream featureview proto class",
+        entities=[],
+        ttl=timedelta(days=30),
+        source=stream_source,
+        aggregations=[],
+    )
+    assert sfv == copy.copy(sfv)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
This PR fixes `__copy__` method of `StreamFeatureView` which is used here https://github.com/feast-dev/feast/blob/4e450ad3b1b6d2f66fd87e07805bb57772390142/sdk/python/feast/feature_store.py#L2191.

I believe this issue prevents the possibility to get features defined in `StreamFeatureView` using `FeatureService`s.

