### PR TITLE
fix: Fix typo as the cli does not support shortcut-f option.

### DIFF
--- a/docs/how-to-guides/structuring-repos.md
+++ b/docs/how-to-guides/structuring-repos.md
@@ -96,7 +96,7 @@ An example of how such a repository would be structured is as follows:
 
 Users can then apply the applying them to each environment in this way:
 ```shell
-feast -f staging/feature_store.yaml apply
+feast --feature-store-yaml staging/feature_store.yaml apply
 ```
 
 This setup has the advantage that you can share the feature definitions entirely, which may prevent issues with copy-pasting code.

--- a/docs/how-to-guides/structuring-repos.md
+++ b/docs/how-to-guides/structuring-repos.md
@@ -96,7 +96,7 @@ An example of how such a repository would be structured is as follows:
 
 Users can then apply the applying them to each environment in this way:
 ```shell
-feast --feature-store-yaml staging/feature_store.yaml apply
+feast -f staging/feature_store.yaml apply
 ```
 
 This setup has the advantage that you can share the feature definitions entirely, which may prevent issues with copy-pasting code.

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -76,6 +76,7 @@ class NoOptionDefaultFormat(click.Command):
 )
 @click.option(
     "--feature-store-yaml",
+    "-f",
     help="Override the directory where the CLI should look for the feature_store.yaml file.",
 )
 @click.pass_context


### PR DESCRIPTION
The code in cli.py (line 75) doest not configure shortcut:
@click.option( "--feature-store-yaml", help="Override the directory where the CLI should look for the feature_store.yaml file.", )

Refer to an closed obsolete PR: https://github.com/feast-dev/feast/pull/3783

**Which issue(s) this PR fixes**:
Fixes #3771
