### PR TITLE
fix: Bugfix for grabbing historical data from Snowflake with array type features.

### DIFF
--- a/docs/reference/data-sources/overview.md
+++ b/docs/reference/data-sources/overview.md
@@ -19,13 +19,13 @@ Details for each specific data source can be found [here](README.md).
 Below is a matrix indicating which data sources support which types.
 
 | | File | BigQuery | Snowflake | Redshift | Postgres | Spark | Trino |
-| :-------------------------------- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
-| `bytes`     | yes | yes | yes | yes | yes | yes | yes |
-| `string`    | yes | yes | yes | yes | yes | yes | yes |
-| `int32`     | yes | yes | yes | yes | yes | yes | yes |
-| `int64`     | yes | yes | yes | yes | yes | yes | yes |
-| `float32`   | yes | yes | yes | yes | yes | yes | yes |
-| `float64`   | yes | yes | yes | yes | yes | yes | yes |
-| `bool`      | yes | yes | yes | yes | yes | yes | yes |
-| `timestamp` | yes | yes | yes | yes | yes | yes | yes |
-| array types | yes | yes | no  | no  | yes | yes | no  |
+| :-------------------------------- | :-- | :-- |:----------| :-- | :-- | :-- | :-- |
+| `bytes`     | yes | yes | yes       | yes | yes | yes | yes |
+| `string`    | yes | yes | yes       | yes | yes | yes | yes |
+| `int32`     | yes | yes | yes       | yes | yes | yes | yes |
+| `int64`     | yes | yes | yes       | yes | yes | yes | yes |
+| `float32`   | yes | yes | yes       | yes | yes | yes | yes |
+| `float64`   | yes | yes | yes       | yes | yes | yes | yes |
+| `bool`      | yes | yes | yes       | yes | yes | yes | yes |
+| `timestamp` | yes | yes | yes       | yes | yes | yes | yes |
+| array types | yes | yes | yes       | no  | yes | yes | no  |

--- a/docs/reference/data-sources/snowflake.md
+++ b/docs/reference/data-sources/snowflake.md
@@ -46,5 +46,5 @@ The full set of configuration options is available [here](https://rtd.feast.dev/
 
 ## Supported Types
 
-Snowflake data sources support all eight primitive types, but currently do not support array types.
+Snowflake data sources support all eight primitive types. Array types are also supported but not with type inference.
 For a comparison against other batch data sources, please see [here](overview.md#functionality-matrix).

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -463,7 +463,9 @@ class SnowflakeRetrievalJob(RetrievalJob):
                     Array(Float32),
                     Array(Bool),
                 ]:
-                    df[feature.name] = [json.loads(x) for x in df[feature.name]]
+                    df[feature.name] = [
+                        json.loads(x) if x else None for x in df[feature.name]
+                    ]
 
         return df
 

--- a/sdk/python/tests/unit/infra/offline_stores/test_snowflake.py
+++ b/sdk/python/tests/unit/infra/offline_stores/test_snowflake.py
@@ -1,14 +1,18 @@
 import re
 from unittest.mock import ANY, MagicMock, patch
 
+import pandas as pd
 import pytest
+from pytest_mock import MockFixture
 
+from feast import FeatureView, Field, FileSource
 from feast.infra.offline_stores.snowflake import (
     SnowflakeOfflineStoreConfig,
     SnowflakeRetrievalJob,
 )
 from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from feast.repo_config import RepoConfig
+from feast.types import Array, String
 
 
 @pytest.fixture(params=["s3", "s3gov"])
@@ -55,3 +59,25 @@ def test_to_remote_storage(retrieval_job):
         mock_get_file_names_from_copy.assert_called_once_with(ANY, ANY)
         native_path = mock_get_file_names_from_copy.call_args[0][1]
         assert re.match("^s3://.*", native_path), "path should be s3://*"
+
+
+def test_snowflake_to_df_internal(
+    retrieval_job: SnowflakeRetrievalJob, mocker: MockFixture
+):
+    mock_execute = mocker.patch(
+        "feast.infra.offline_stores.snowflake.execute_snowflake_statement"
+    )
+    mock_execute.return_value.fetch_pandas_all.return_value = pd.DataFrame.from_dict(
+        {"feature1": ['["1", "2", "3"]', None, "[]"]}  # For Valid, Null, and Empty
+    )
+
+    feature_view = FeatureView(
+        name="my-feature-view",
+        entities=[],
+        schema=[
+            Field(name="feature1", dtype=Array(String)),
+        ],
+        source=FileSource(path="dummy.path"),  # Dummy value
+    )
+    retrieval_job._feature_views = [feature_view]
+    retrieval_job._to_df_internal()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
5. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
6. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
7. Make sure documentation is updated for your PR!
8. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
9. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

A bug appears when the following happens.

1. Fetch from a Snowflake-backed FeatureView.
2. The FeatureView has an array-type column.
3. One of the fetched entities does not have a record in the Snowflake table.

This add a null check and includes the documentation around Snowflake now supporting array types. I forgot to add it in my previous PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # 3963
