### PR TITLE
fix: Swap security label check on the PR title validation job to explicit permissions instead

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -7,12 +7,13 @@ on:
       - edited
       - synchronize
 
+permissions:
+  # read-only perms specified due to use of pull_request_target in lieu of security label check
+  pull-requests: read
+
 jobs:
   validate-title:
-    # when using pull_request_target, all jobs MUST have this if check for 'ok-to-test' or 'approved' for security purposes.
     if:
-      ((github.event.action == 'labeled' && (github.event.label.name == 'approved' || github.event.label.name == 'lgtm' || github.event.label.name == 'ok-to-test')) ||
-      (github.event.action != 'labeled' && (contains(github.event.pull_request.labels.*.name, 'ok-to-test') || contains(github.event.pull_request.labels.*.name, 'approved') || contains(github.event.pull_request.labels.*.name, 'lgtm')))) &&
       github.repository == 'feast-dev/feast'
     name: Validate PR title
     runs-on: ubuntu-latest


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:
After recently adding security label checks to all `pull_request_target` actions that were missing it, I noticed title validation checkjs started being [skipped](https://github.com/feast-dev/feast/actions/runs/8162568306/job/22313824999?pr=3986) due to the conditional paired with this trigger type. This PR takes the check logic back to the simple repo verify, but adds explicit read-only permissions matching the [recommended](https://github.com/amannn/action-semantic-pull-request#installation) install configuration.
