### PR TITLE
feat: Read file recursively on sparksource

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -8,7 +8,7 @@ from pyspark.sql import SparkSession
 
 from feast import flags_helper
 from feast.data_source import DataSource
-from feast.errors import DataSourceNoNameException
+from feast.errors import DataSourceNoNameException, DataSourceNotFoundException
 from feast.infra.offline_stores.offline_utils import get_temp_entity_table_name
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
 from feast.protos.feast.core.SavedDataset_pb2 import (
@@ -183,6 +183,7 @@ class SparkSource(DataSource):
             logger.exception(
                 "Spark read of file source failed.\n" + traceback.format_exc()
             )
+            raise DataSourceNotFoundException(path=self.path)
         tmp_table_name = get_temp_entity_table_name()
         df.createOrReplaceTempView(tmp_table_name)
 

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -174,7 +174,11 @@ class SparkSource(DataSource):
         if spark_session is None:
             raise AssertionError("Could not find an active spark session.")
         try:
-            df = spark_session.read.format(self.file_format).load(self.path)
+            df = (
+                spark_session.read.option("recursiveFileLookup", "true")
+                .format(self.file_format)
+                .load(self.path)
+            )
         except Exception:
             logger.exception(
                 "Spark read of file source failed.\n" + traceback.format_exc()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**: When do the feature engineering(feature1) with parquet files, we want by cadence return a 'file' with a partition as file name, example /path/to/feature1/day1, /path/to/feature1/day2, so when declare path for sparksource, we want to just need to declare to /path/to/feature1 and under the hood, there will have another team or job to take care of the day1, day2,...,dayn part(those will be partitioned by cadence).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
