### PR TITLE
fix: Extend SQL registry config with a sqlalchemy_config_kwargs key

### DIFF
--- a/docs/getting-started/concepts/registry.md
+++ b/docs/getting-started/concepts/registry.md
@@ -57,6 +57,8 @@ registry:
     registry_type: sql
     path: postgresql://postgres:mysecretpassword@127.0.0.1:55001/feast
     cache_ttl_seconds: 60
+    sqlalchemy_config_kwargs:
+        pool_pre_ping: true
 ```
 
 This supports any SQLAlchemy compatible database as a backend. The exact schema can be seen in [sql.py](https://github.com/feast-dev/feast/blob/master/sdk/python/feast/infra/registry/sql.py)

--- a/docs/getting-started/concepts/registry.md
+++ b/docs/getting-started/concepts/registry.md
@@ -58,6 +58,7 @@ registry:
     path: postgresql://postgres:mysecretpassword@127.0.0.1:55001/feast
     cache_ttl_seconds: 60
     sqlalchemy_config_kwargs:
+        echo: false
         pool_pre_ping: true
 ```
 

--- a/docs/tutorials/using-scalable-registry.md
+++ b/docs/tutorials/using-scalable-registry.md
@@ -29,6 +29,8 @@ registry:
     registry_type: sql
     path: postgresql://postgres:mysecretpassword@127.0.0.1:55001/feast
     cache_ttl_seconds: 60
+    sqlalchemy_config_kwargs:
+        pool_pre_ping: true
 ```
 
 Specifically, the registry_type needs to be set to sql in the registry config block. On doing so, the path should refer to the [Database URL](https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls) for the database to be used, as expected by SQLAlchemy. No other additional commands are currently needed to configure this registry.

--- a/docs/tutorials/using-scalable-registry.md
+++ b/docs/tutorials/using-scalable-registry.md
@@ -30,6 +30,7 @@ registry:
     path: postgresql://postgres:mysecretpassword@127.0.0.1:55001/feast
     cache_ttl_seconds: 60
     sqlalchemy_config_kwargs:
+        echo: false
         pool_pre_ping: true
 ```
 

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -202,7 +202,9 @@ class SqlRegistry(BaseRegistry):
         repo_path: Optional[Path],
     ):
         assert registry_config is not None, "SqlRegistry needs a valid registry_config"
-        self.engine: Engine = create_engine(registry_config.path, **registry_config.sqlalchemy_config_kwargs)
+        self.engine: Engine = create_engine(
+            registry_config.path, **registry_config.sqlalchemy_config_kwargs
+        )
         metadata.create_all(self.engine)
         self.cached_registry_proto = self.proto()
         proto_registry_utils.init_project_metadata(self.cached_registry_proto, project)

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
 from threading import Lock
-from typing import Any, Callable, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from pydantic import StrictStr
 from sqlalchemy import (  # type: ignore
@@ -190,6 +190,9 @@ class SqlRegistryConfig(RegistryConfig):
     """ str: Path to metadata store.
     If registry_type is 'sql', then this is a database URL as expected by SQLAlchemy """
 
+    sqlalchemy_config_kwargs: Optional[Dict[str, str]] = {"echo": False}
+    """ Dict[str, str]: Extra arguments to pass to SQLAlchemy.create_engine. """
+
 
 class SqlRegistry(BaseRegistry):
     def __init__(
@@ -199,7 +202,7 @@ class SqlRegistry(BaseRegistry):
         repo_path: Optional[Path],
     ):
         assert registry_config is not None, "SqlRegistry needs a valid registry_config"
-        self.engine: Engine = create_engine(registry_config.path, echo=False)
+        self.engine: Engine = create_engine(registry_config.path, **registry_config.sqlalchemy_config_kwargs)
         metadata.create_all(self.engine)
         self.cached_registry_proto = self.proto()
         proto_registry_utils.init_project_metadata(self.cached_registry_proto, project)

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -190,8 +190,8 @@ class SqlRegistryConfig(RegistryConfig):
     """ str: Path to metadata store.
     If registry_type is 'sql', then this is a database URL as expected by SQLAlchemy """
 
-    sqlalchemy_config_kwargs: Optional[Dict[str, str]] = {"echo": False}
-    """ Dict[str, str]: Extra arguments to pass to SQLAlchemy.create_engine. """
+    sqlalchemy_config_kwargs: Optional[Dict[str, Any]] = {"echo": False}
+    """ Dict[str, Any]: Extra arguments to pass to SQLAlchemy.create_engine. """
 
 
 class SqlRegistry(BaseRegistry):

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -190,7 +190,7 @@ class SqlRegistryConfig(RegistryConfig):
     """ str: Path to metadata store.
     If registry_type is 'sql', then this is a database URL as expected by SQLAlchemy """
 
-    sqlalchemy_config_kwargs: Optional[Dict[str, Any]] = {"echo": False}
+    sqlalchemy_config_kwargs: Dict[str, Any] = {"echo": False}
     """ Dict[str, Any]: Extra arguments to pass to SQLAlchemy.create_engine. """
 
 

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -125,8 +125,8 @@ class RegistryConfig(FeastBaseModel):
     s3_additional_kwargs: Optional[Dict[str, str]] = None
     """ Dict[str, str]: Extra arguments to pass to boto3 when writing the registry file to S3. """
 
-    sqlalchemy_config_kwargs: Optional[Dict[str, str]] = {}
-    """ Dict[str, str]: Extra arguments to pass to SQLAlchemy.create_engine. """
+    sqlalchemy_config_kwargs: Optional[Dict[str, Any]] = {}
+    """ Dict[str, Any]: Extra arguments to pass to SQLAlchemy.create_engine. """
 
 
 class RepoConfig(FeastBaseModel):

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -125,6 +125,9 @@ class RegistryConfig(FeastBaseModel):
     s3_additional_kwargs: Optional[Dict[str, str]] = None
     """ Dict[str, str]: Extra arguments to pass to boto3 when writing the registry file to S3. """
 
+    sqlalchemy_config_kwargs: Optional[Dict[str, str]] = {}
+    """ Dict[str, str]: Extra arguments to pass to SQLAlchemy.create_engine. """
+
 
 class RepoConfig(FeastBaseModel):
     """Repo config. Typically loaded from `feature_store.yaml`"""

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -125,7 +125,7 @@ class RegistryConfig(FeastBaseModel):
     s3_additional_kwargs: Optional[Dict[str, str]] = None
     """ Dict[str, str]: Extra arguments to pass to boto3 when writing the registry file to S3. """
 
-    sqlalchemy_config_kwargs: Optional[Dict[str, Any]] = {}
+    sqlalchemy_config_kwargs: Dict[str, Any] = {}
     """ Dict[str, Any]: Extra arguments to pass to SQLAlchemy.create_engine. """
 
 

--- a/sdk/python/tests/unit/test_sql_registry.py
+++ b/sdk/python/tests/unit/test_sql_registry.py
@@ -71,6 +71,7 @@ def pg_registry():
     registry_config = RegistryConfig(
         registry_type="sql",
         path=f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{container_host}:{container_port}/{POSTGRES_DB}",
+        sqlalchemy_config_kwargs={"echo": False, "pool_pre_ping": True},
     )
 
     yield SqlRegistry(registry_config, "project", None)
@@ -106,6 +107,7 @@ def mysql_registry():
     registry_config = RegistryConfig(
         registry_type="sql",
         path=f"mysql+pymysql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{container_host}:{container_port}/{POSTGRES_DB}",
+        sqlalchemy_config_kwargs={"echo": False, "pool_pre_ping": True},
     )
 
     yield SqlRegistry(registry_config, "project", None)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

The PR introduces an optional `sqlalchemy_config_kwargs` key to the [SQL Registry](https://docs.feast.dev/getting-started/concepts/registry#sql-registry) config. The new key allows passing in custom `**kwargs` to [sqlalchemy.create_engine](https://github.com/feast-dev/feast/blob/fa8492dfe7f38ab493a8d35a412ec9334a0ff6b9/sdk/python/feast/infra/registry/sql.py#L202).

One such kwarg is [pool_pre_ping: true](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine) which in turn helps avoid errors due to closed or timed out connections. Such errors happen in particular when running the Python Feature Server as an API.

Example errors this prevents:
```python
psycopg2.OperationalError: connection to server at "<SERVER_DNS>" (<IP_ADDRESS>), port 5432 failed: Connection timed out
	Is the server running on that host and accepting TCP/IP connections?
```

```python
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
```

If `sqlalchemy_config_kwargs` is not provided, by default the `echo=False` option is applied just as in the original code [sdk/python/feast/infra/registry/sql.py#L202](https://github.com/feast-dev/feast/blob/fa8492dfe7f38ab493a8d35a412ec9334a0ff6b9/sdk/python/feast/infra/registry/sql.py#L202).

The following files are updated:
* docs/getting-started/concepts/registry.md - to show how the new key can be used
* docs/tutorials/using-scalable-registry.md - same as above
* sdk/python/feast/infra/registry/sql.py - required
* sdk/python/feast/repo_config.py - needed to silence a linter error that enforces strict OOP (i.e. a base class must define property which is overriden in a derived class)
*  sdk/python/tests/unit/test_sql_registry.py - added to the PostgreSQL and MySQL unit tests

All unit tests pass.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
