### PR TITLE
fix: Use CopyFrom() instead of __deepycopy__() for creating a copy of protobuf object.

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -82,7 +82,7 @@ from feast.infra.registry.registry import Registry
 from feast.infra.registry.sql import SqlRegistry
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.online_response import OnlineResponse
-from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
+from feast.protos.feast.core.InfraObject_pb2 import Infra as InfraProto
 from feast.protos.feast.serving.ServingService_pb2 import (
     FieldStatus,
     GetOnlineFeaturesResponse,
@@ -746,7 +746,7 @@ class FeatureStore:
         # Compute the desired difference between the current infra, as stored in the registry,
         # and the desired infra.
         self._registry.refresh(project=self.project)
-        current_infra_proto = RegistryProto().infra
+        current_infra_proto = InfraProto()
         current_infra_proto.CopyFrom(self._registry.proto().infra)
         desired_registry_proto = desired_repo_contents.to_registry_proto()
         new_infra = self._provider.plan_infra(self.config, desired_registry_proto)

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -82,6 +82,7 @@ from feast.infra.registry.registry import Registry
 from feast.infra.registry.sql import SqlRegistry
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.online_response import OnlineResponse
+from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.protos.feast.serving.ServingService_pb2 import (
     FieldStatus,
     GetOnlineFeaturesResponse,
@@ -745,7 +746,8 @@ class FeatureStore:
         # Compute the desired difference between the current infra, as stored in the registry,
         # and the desired infra.
         self._registry.refresh(project=self.project)
-        current_infra_proto = self._registry.proto().infra.__deepcopy__()
+        current_infra_proto = RegistryProto().infra
+        current_infra_proto.CopyFrom(self._registry.proto().infra)
         desired_registry_proto = desired_repo_contents.to_registry_proto()
         new_infra = self._provider.plan_infra(self.config, desired_registry_proto)
         new_infra_proto = new_infra.to_proto()

--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -43,13 +43,13 @@ attrs==23.2.0
     #   referencing
 avro==1.10.0
     # via feast (setup.py)
-azure-core==1.30.0
+azure-core==1.30.1
     # via
     #   azure-identity
     #   azure-storage-blob
 azure-identity==1.15.0
     # via feast (setup.py)
-azure-storage-blob==12.19.0
+azure-storage-blob==12.19.1
     # via feast (setup.py)
 babel==2.14.0
     # via
@@ -63,18 +63,18 @@ black==22.12.0
     # via feast (setup.py)
 bleach==6.1.0
     # via nbconvert
-boto3==1.34.49
+boto3==1.34.59
     # via
     #   feast (setup.py)
     #   moto
-botocore==1.34.49
+botocore==1.34.59
     # via
     #   boto3
     #   moto
     #   s3transfer
 bowler==0.9.0
     # via feast (setup.py)
-build==1.0.3
+build==1.1.1
     # via
     #   feast (setup.py)
     #   pip-tools
@@ -82,7 +82,7 @@ bytewax==0.15.1
     # via feast (setup.py)
 cachecontrol==0.14.0
     # via firebase-admin
-cachetools==5.3.2
+cachetools==5.3.3
     # via google-auth
 cassandra-driver==3.29.0
     # via feast (setup.py)
@@ -127,8 +127,10 @@ comm==0.2.1
     #   ipykernel
     #   ipywidgets
 coverage[toml]==7.4.3
-    # via pytest-cov
-cryptography==42.0.4
+    # via
+    #   coverage
+    #   pytest-cov
+cryptography==42.0.5
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -177,7 +179,7 @@ execnet==2.0.2
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.109.2
+fastapi==0.110.0
     # via feast (setup.py)
 fastjsonschema==2.19.1
     # via nbformat
@@ -213,9 +215,9 @@ google-api-core[grpc]==2.17.1
     #   google-cloud-datastore
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.119.0
+google-api-python-client==2.121.0
     # via firebase-admin
-google-auth==2.28.1
+google-auth==2.28.2
     # via
     #   google-api-core
     #   google-api-python-client
@@ -226,7 +228,9 @@ google-auth==2.28.1
 google-auth-httplib2==0.2.0
     # via google-api-python-client
 google-cloud-bigquery[pandas]==3.12.0
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   google-cloud-bigquery
 google-cloud-bigquery-storage==2.24.0
     # via feast (setup.py)
 google-cloud-bigtable==2.23.0
@@ -242,7 +246,7 @@ google-cloud-datastore==2.19.0
     # via feast (setup.py)
 google-cloud-firestore==2.15.0
     # via firebase-admin
-google-cloud-storage==2.14.0
+google-cloud-storage==2.15.0
     # via
     #   feast (setup.py)
     #   firebase-admin
@@ -260,13 +264,13 @@ googleapis-common-protos[grpc]==1.62.0
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
-great-expectations==0.18.9
+great-expectations==0.18.10
     # via feast (setup.py)
 greenlet==3.0.3
     # via sqlalchemy
 grpc-google-iam-v1==0.13.0
     # via google-cloud-bigtable
-grpcio==1.62.0
+grpcio==1.62.1
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -278,15 +282,15 @@ grpcio==1.62.0
     #   grpcio-status
     #   grpcio-testing
     #   grpcio-tools
-grpcio-health-checking==1.62.0
+grpcio-health-checking==1.62.1
     # via feast (setup.py)
-grpcio-reflection==1.62.0
+grpcio-reflection==1.62.1
     # via feast (setup.py)
-grpcio-status==1.62.0
+grpcio-status==1.62.1
     # via google-api-core
-grpcio-testing==1.62.0
+grpcio-testing==1.62.1
     # via feast (setup.py)
-grpcio-tools==1.62.0
+grpcio-tools==1.62.1
     # via feast (setup.py)
 gunicorn==21.2.0
     # via feast (setup.py)
@@ -333,13 +337,13 @@ importlib-metadata==6.11.0
     # via
     #   dask
     #   feast (setup.py)
-importlib-resources==6.1.1
+importlib-resources==6.1.3
     # via feast (setup.py)
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.29.2
+ipykernel==6.29.3
     # via jupyterlab
-ipython==8.22.1
+ipython==8.22.2
     # via
     #   great-expectations
     #   ipykernel
@@ -369,7 +373,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-json5==0.9.17
+json5==0.9.22
     # via jupyterlab-server
 jsonpatch==1.33
     # via great-expectations
@@ -403,9 +407,9 @@ jupyter-core==5.7.1
     #   nbformat
 jupyter-events==0.9.0
     # via jupyter-server
-jupyter-lsp==2.2.2
+jupyter-lsp==2.2.4
     # via jupyterlab
-jupyter-server==2.12.5
+jupyter-server==2.13.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -414,7 +418,7 @@ jupyter-server==2.12.5
     #   notebook-shim
 jupyter-server-terminals==0.5.2
     # via jupyter-server
-jupyterlab==4.1.2
+jupyterlab==4.1.4
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
@@ -437,7 +441,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-marshmallow==3.20.2
+marshmallow==3.21.1
     # via great-expectations
 matplotlib-inline==0.1.6
     # via
@@ -467,13 +471,13 @@ msal==1.27.0
     #   msal-extensions
 msal-extensions==1.1.0
     # via azure-identity
-msgpack==1.0.7
+msgpack==1.0.8
     # via cachecontrol
 multipledispatch==1.0.0
     # via ibis-framework
 multiprocess==0.70.16
     # via bytewax
-mypy==1.8.0
+mypy==1.9.0
     # via
     #   feast (setup.py)
     #   sqlalchemy
@@ -485,7 +489,7 @@ mypy-protobuf==3.1.0
     # via feast (setup.py)
 nbclient==0.9.0
     # via nbconvert
-nbconvert==7.16.1
+nbconvert==7.16.2
     # via jupyter-server
 nbformat==5.9.2
     # via
@@ -497,7 +501,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 nodeenv==1.8.0
     # via pre-commit
-notebook==7.1.0
+notebook==7.1.1
     # via great-expectations
 notebook-shim==0.2.4
     # via
@@ -517,7 +521,7 @@ oauthlib==3.2.2
     # via requests-oauthlib
 overrides==7.7.0
     # via jupyter-server
-packaging==23.2
+packaging==24.0
     # via
     #   build
     #   dask
@@ -538,13 +542,14 @@ packaging==23.2
     #   pytest
     #   snowflake-connector-python
     #   sphinx
-pandas==2.2.0 ; python_version >= "3.9"
+pandas==2.2.1
     # via
     #   altair
     #   db-dtypes
     #   feast (setup.py)
     #   google-cloud-bigquery
     #   great-expectations
+    #   ibis-framework
     #   snowflake-connector-python
 pandocfilters==1.5.1
     # via nbconvert
@@ -560,7 +565,7 @@ pbr==6.0.0
     # via mock
 pexpect==4.9.0
     # via ipython
-pip-tools==7.4.0
+pip-tools==7.4.1
     # via feast (setup.py)
 platformdirs==3.11.0
     # via
@@ -588,7 +593,7 @@ proto-plus==1.23.0
     #   google-cloud-bigtable
     #   google-cloud-datastore
     #   google-cloud-firestore
-protobuf==4.23.4
+protobuf==4.25.3
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -625,7 +630,7 @@ py-cpuinfo==9.0.0
     # via pytest-benchmark
 py4j==0.10.9.7
     # via pyspark
-pyarrow==15.0.0
+pyarrow==15.0.1
     # via
     #   db-dtypes
     #   feast (setup.py)
@@ -646,7 +651,7 @@ pycodestyle==2.10.0
     # via flake8
 pycparser==2.21
     # via cffi
-pydantic==2.6.2
+pydantic==2.6.3
     # via
     #   fastapi
     #   feast (setup.py)
@@ -672,9 +677,9 @@ pymysql==1.1.0
     # via feast (setup.py)
 pyodbc==5.1.0
     # via feast (setup.py)
-pyopenssl==24.0.0
+pyopenssl==24.1.0
     # via snowflake-connector-python
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via
     #   great-expectations
     #   httplib2
@@ -682,7 +687,7 @@ pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
-pyspark==3.5.0
+pyspark==3.5.1
     # via feast (setup.py)
 pytest==7.4.4
     # via
@@ -708,7 +713,7 @@ pytest-timeout==1.4.2
     # via feast (setup.py)
 pytest-xdist==3.5.0
     # via feast (setup.py)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   botocore
@@ -775,7 +780,7 @@ requests==2.31.0
     #   snowflake-connector-python
     #   sphinx
     #   trino
-requests-oauthlib==1.3.1
+requests-oauthlib==1.4.0
     # via kubernetes
 responses==0.25.0
     # via moto
@@ -787,7 +792,7 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rich==13.7.0
+rich==13.7.1
     # via ibis-framework
 rockset==2.1.1
     # via feast (setup.py)
@@ -818,14 +823,16 @@ six==1.16.0
     #   python-dateutil
     #   rfc3339-validator
     #   thriftpy2
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
 snowflake-connector-python[pandas]==3.7.1
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   snowflake-connector-python
 sortedcontainers==2.4.0
     # via snowflake-connector-python
 soupsieve==2.5
@@ -844,7 +851,7 @@ sphinxcontrib-qthelp==1.0.7
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-sqlalchemy[mypy]==1.4.51
+sqlalchemy[mypy]==1.4.52
     # via
     #   feast (setup.py)
     #   sqlalchemy
@@ -856,7 +863,7 @@ stack-data==0.6.3
     # via ipython
 starlette==0.36.3
     # via fastapi
-substrait==0.12.1
+substrait==0.14.0
     # via ibis-substrait
 tabulate==0.9.0
     # via feast (setup.py)
@@ -868,7 +875,7 @@ terminado==0.18.0
     #   jupyter-server-terminals
 testcontainers==3.7.1
     # via feast (setup.py)
-thriftpy2==0.4.17
+thriftpy2==0.4.20
     # via happybase
 tinycss2==1.2.1
     # via nbconvert
@@ -884,7 +891,7 @@ tomli==2.0.1
     #   pip-tools
     #   pyproject-hooks
     #   pytest
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via snowflake-connector-python
 toolz==0.12.1
     # via
@@ -929,27 +936,27 @@ types-protobuf==3.19.22
     #   mypy-protobuf
 types-pymysql==1.1.0.1
     # via feast (setup.py)
-types-pyopenssl==24.0.0.20240130
+types-pyopenssl==24.0.0.20240311
     # via types-redis
-types-python-dateutil==2.8.19.20240106
+types-python-dateutil==2.8.19.20240311
     # via
     #   arrow
     #   feast (setup.py)
 types-pytz==2024.1.0.20240203
     # via feast (setup.py)
-types-pyyaml==6.0.12.12
+types-pyyaml==6.0.12.20240311
     # via feast (setup.py)
-types-redis==4.6.0.20240218
+types-redis==4.6.0.20240311
     # via feast (setup.py)
 types-requests==2.30.0.0
     # via feast (setup.py)
-types-setuptools==69.1.0.20240223
+types-setuptools==69.1.0.20240310
     # via feast (setup.py)
 types-tabulate==0.9.0.20240106
     # via feast (setup.py)
 types-urllib3==1.26.25.14
     # via types-requests
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   anyio
     #   async-lru
@@ -986,8 +993,10 @@ urllib3==1.26.18
     #   requests
     #   responses
     #   rockset
-uvicorn[standard]==0.27.1
-    # via feast (setup.py)
+uvicorn[standard]==0.28.0
+    # via
+    #   feast (setup.py)
+    #   uvicorn
 uvloop==0.19.0
     # via uvicorn
 virtualenv==20.23.0

--- a/sdk/python/requirements/py3.10-requirements.txt
+++ b/sdk/python/requirements/py3.10-requirements.txt
@@ -44,7 +44,7 @@ dill==0.3.8
     # via feast (setup.py)
 exceptiongroup==1.2.0
     # via anyio
-fastapi==0.109.2
+fastapi==0.110.0
     # via feast (setup.py)
 fissix==21.11.13
     # via bowler
@@ -52,18 +52,6 @@ fsspec==2024.2.0
     # via dask
 greenlet==3.0.3
     # via sqlalchemy
-grpcio==1.62.0
-    # via
-    #   feast (setup.py)
-    #   grpcio-health-checking
-    #   grpcio-reflection
-    #   grpcio-tools
-grpcio-health-checking==1.62.0
-    # via feast (setup.py)
-grpcio-reflection==1.62.0
-    # via feast (setup.py)
-grpcio-tools==1.62.0
-    # via feast (setup.py)
 gunicorn==21.2.0
     # via feast (setup.py)
 h11==0.14.0
@@ -85,7 +73,7 @@ importlib-metadata==6.11.0
     # via
     #   dask
     #   feast (setup.py)
-importlib-resources==6.1.1
+importlib-resources==6.1.3
     # via feast (setup.py)
 jinja2==3.1.3
     # via feast (setup.py)
@@ -101,7 +89,7 @@ mmh3==4.1.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-mypy==1.8.0
+mypy==1.9.0
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
@@ -112,27 +100,24 @@ numpy==1.24.4
     #   feast (setup.py)
     #   pandas
     #   pyarrow
-packaging==23.2
+packaging==24.0
     # via
     #   dask
     #   gunicorn
-pandas==2.2.0
+pandas==2.2.1
     # via feast (setup.py)
 partd==1.4.1
     # via dask
 proto-plus==1.23.0
     # via feast (setup.py)
-protobuf==4.23.4
+protobuf==4.25.3
     # via
     #   feast (setup.py)
-    #   grpcio-health-checking
-    #   grpcio-reflection
-    #   grpcio-tools
     #   mypy-protobuf
     #   proto-plus
-pyarrow==15.0.0
+pyarrow==15.0.1
     # via feast (setup.py)
-pydantic==2.6.2
+pydantic==2.6.3
     # via
     #   fastapi
     #   feast (setup.py)
@@ -140,7 +125,7 @@ pydantic-core==2.16.3
     # via pydantic
 pygments==2.17.2
     # via feast (setup.py)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via pandas
 python-dotenv==1.0.1
     # via uvicorn
@@ -163,11 +148,11 @@ rpds-py==0.18.0
     #   referencing
 six==1.16.0
     # via python-dateutil
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-sqlalchemy[mypy]==1.4.51
+sqlalchemy[mypy]==1.4.52
     # via
     #   feast (setup.py)
     #   sqlalchemy
@@ -191,9 +176,9 @@ tqdm==4.66.2
     # via feast (setup.py)
 typeguard==4.1.5
     # via feast (setup.py)
-types-protobuf==4.24.0.20240129
+types-protobuf==4.24.0.20240311
     # via mypy-protobuf
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   anyio
     #   fastapi
@@ -203,10 +188,14 @@ typing-extensions==4.9.0
     #   sqlalchemy2-stubs
     #   typeguard
     #   uvicorn
+tzdata==2024.1
+    # via pandas
 urllib3==2.2.1
     # via requests
-uvicorn[standard]==0.27.1
-    # via feast (setup.py)
+uvicorn[standard]==0.28.0
+    # via
+    #   feast (setup.py)
+    #   uvicorn
 uvloop==0.19.0
     # via uvicorn
 volatile==2.1.0
@@ -217,6 +206,3 @@ websockets==12.0
     # via uvicorn
 zipp==3.17.0
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/sdk/python/requirements/py3.8-ci-requirements.txt
+++ b/sdk/python/requirements/py3.8-ci-requirements.txt
@@ -43,13 +43,13 @@ attrs==23.2.0
     #   referencing
 avro==1.10.0
     # via feast (setup.py)
-azure-core==1.30.0
+azure-core==1.30.1
     # via
     #   azure-identity
     #   azure-storage-blob
 azure-identity==1.15.0
     # via feast (setup.py)
-azure-storage-blob==12.19.0
+azure-storage-blob==12.19.1
     # via feast (setup.py)
 babel==2.14.0
     # via
@@ -67,18 +67,18 @@ black==22.12.0
     # via feast (setup.py)
 bleach==6.1.0
     # via nbconvert
-boto3==1.34.49
+boto3==1.34.59
     # via
     #   feast (setup.py)
     #   moto
-botocore==1.34.49
+botocore==1.34.59
     # via
     #   boto3
     #   moto
     #   s3transfer
 bowler==0.9.0
     # via feast (setup.py)
-build==1.0.3
+build==1.1.1
     # via
     #   feast (setup.py)
     #   pip-tools
@@ -86,7 +86,7 @@ bytewax==0.15.1
     # via feast (setup.py)
 cachecontrol==0.14.0
     # via firebase-admin
-cachetools==5.3.2
+cachetools==5.3.3
     # via google-auth
 cassandra-driver==3.29.0
     # via feast (setup.py)
@@ -132,7 +132,7 @@ comm==0.2.1
     #   ipywidgets
 coverage[toml]==7.4.3
     # via pytest-cov
-cryptography==42.0.4
+cryptography==42.0.5
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -180,7 +180,7 @@ execnet==2.0.2
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.109.2
+fastapi==0.110.0
     # via feast (setup.py)
 fastjsonschema==2.19.1
     # via nbformat
@@ -216,9 +216,9 @@ google-api-core[grpc]==2.17.1
     #   google-cloud-datastore
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.119.0
+google-api-python-client==2.121.0
     # via firebase-admin
-google-auth==2.28.1
+google-auth==2.28.2
     # via
     #   google-api-core
     #   google-api-python-client
@@ -245,7 +245,7 @@ google-cloud-datastore==2.19.0
     # via feast (setup.py)
 google-cloud-firestore==2.15.0
     # via firebase-admin
-google-cloud-storage==2.14.0
+google-cloud-storage==2.15.0
     # via
     #   feast (setup.py)
     #   firebase-admin
@@ -263,13 +263,13 @@ googleapis-common-protos[grpc]==1.62.0
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
-great-expectations==0.18.9
+great-expectations==0.18.10
     # via feast (setup.py)
 greenlet==3.0.3
     # via sqlalchemy
 grpc-google-iam-v1==0.13.0
     # via google-cloud-bigtable
-grpcio==1.62.0
+grpcio==1.62.1
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -281,15 +281,15 @@ grpcio==1.62.0
     #   grpcio-status
     #   grpcio-testing
     #   grpcio-tools
-grpcio-health-checking==1.62.0
+grpcio-health-checking==1.62.1
     # via feast (setup.py)
-grpcio-reflection==1.62.0
+grpcio-reflection==1.62.1
     # via feast (setup.py)
-grpcio-status==1.62.0
+grpcio-status==1.62.1
     # via google-api-core
-grpcio-testing==1.62.0
+grpcio-testing==1.62.1
     # via feast (setup.py)
-grpcio-tools==1.62.0
+grpcio-tools==1.62.1
     # via feast (setup.py)
 gunicorn==21.2.0
     # via feast (setup.py)
@@ -344,7 +344,7 @@ importlib-metadata==6.11.0
     #   nbconvert
     #   sphinx
     #   typeguard
-importlib-resources==6.1.1
+importlib-resources==6.1.3
     # via
     #   feast (setup.py)
     #   jsonschema
@@ -352,7 +352,7 @@ importlib-resources==6.1.1
     #   jupyterlab
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.29.2
+ipykernel==6.29.3
     # via jupyterlab
 ipython==8.12.3
     # via
@@ -384,7 +384,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-json5==0.9.17
+json5==0.9.22
     # via jupyterlab-server
 jsonpatch==1.33
     # via great-expectations
@@ -418,9 +418,9 @@ jupyter-core==5.7.1
     #   nbformat
 jupyter-events==0.9.0
     # via jupyter-server
-jupyter-lsp==2.2.2
+jupyter-lsp==2.2.4
     # via jupyterlab
-jupyter-server==2.12.5
+jupyter-server==2.13.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -429,7 +429,7 @@ jupyter-server==2.12.5
     #   notebook-shim
 jupyter-server-terminals==0.5.2
     # via jupyter-server
-jupyterlab==4.1.2
+jupyterlab==4.1.4
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
@@ -452,7 +452,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-marshmallow==3.20.2
+marshmallow==3.21.1
     # via great-expectations
 matplotlib-inline==0.1.6
     # via
@@ -482,13 +482,13 @@ msal==1.27.0
     #   msal-extensions
 msal-extensions==1.1.0
     # via azure-identity
-msgpack==1.0.7
+msgpack==1.0.8
     # via cachecontrol
 multipledispatch==0.6.0
     # via ibis-framework
 multiprocess==0.70.16
     # via bytewax
-mypy==1.8.0
+mypy==1.9.0
     # via
     #   feast (setup.py)
     #   sqlalchemy
@@ -500,7 +500,7 @@ mypy-protobuf==3.1.0
     # via feast (setup.py)
 nbclient==0.9.0
     # via nbconvert
-nbconvert==7.16.1
+nbconvert==7.16.2
     # via jupyter-server
 nbformat==5.9.2
     # via
@@ -512,7 +512,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 nodeenv==1.8.0
     # via pre-commit
-notebook==7.1.0
+notebook==7.1.1
     # via great-expectations
 notebook-shim==0.2.4
     # via
@@ -532,7 +532,7 @@ oauthlib==3.2.2
     # via requests-oauthlib
 overrides==7.7.0
     # via jupyter-server
-packaging==23.2
+packaging==24.0
     # via
     #   build
     #   dask
@@ -560,6 +560,7 @@ pandas==1.5.3 ; python_version < "3.9"
     #   feast (setup.py)
     #   google-cloud-bigquery
     #   great-expectations
+    #   ibis-framework
     #   snowflake-connector-python
 pandocfilters==1.5.1
     # via nbconvert
@@ -577,7 +578,7 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==7.4.0
+pip-tools==7.4.1
     # via feast (setup.py)
 pkgutil-resolve-name==1.3.10
     # via jsonschema
@@ -607,7 +608,7 @@ proto-plus==1.23.0
     #   google-cloud-bigtable
     #   google-cloud-datastore
     #   google-cloud-firestore
-protobuf==4.23.4
+protobuf==4.25.3
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -644,7 +645,7 @@ py-cpuinfo==9.0.0
     # via pytest-benchmark
 py4j==0.10.9.7
     # via pyspark
-pyarrow==15.0.0
+pyarrow==15.0.1
     # via
     #   db-dtypes
     #   feast (setup.py)
@@ -662,7 +663,7 @@ pycodestyle==2.10.0
     # via flake8
 pycparser==2.21
     # via cffi
-pydantic==2.6.2
+pydantic==2.6.3
     # via
     #   fastapi
     #   feast (setup.py)
@@ -688,9 +689,9 @@ pymysql==1.1.0
     # via feast (setup.py)
 pyodbc==5.1.0
     # via feast (setup.py)
-pyopenssl==24.0.0
+pyopenssl==24.1.0
     # via snowflake-connector-python
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via
     #   great-expectations
     #   httplib2
@@ -698,7 +699,7 @@ pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
-pyspark==3.5.0
+pyspark==3.5.1
     # via feast (setup.py)
 pytest==7.4.4
     # via
@@ -724,7 +725,7 @@ pytest-timeout==1.4.2
     # via feast (setup.py)
 pytest-xdist==3.5.0
     # via feast (setup.py)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   botocore
@@ -792,7 +793,7 @@ requests==2.31.0
     #   snowflake-connector-python
     #   sphinx
     #   trino
-requests-oauthlib==1.3.1
+requests-oauthlib==1.4.0
     # via kubernetes
 responses==0.25.0
     # via moto
@@ -804,7 +805,7 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rich==13.7.0
+rich==13.7.1
     # via ibis-framework
 rockset==2.1.1
     # via feast (setup.py)
@@ -835,11 +836,10 @@ six==1.16.0
     #   kubernetes
     #   mock
     #   multipledispatch
-    #   pandavro
     #   python-dateutil
     #   rfc3339-validator
     #   thriftpy2
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
     #   httpx
@@ -865,7 +865,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy[mypy]==1.4.51
+sqlalchemy[mypy]==1.4.52
     # via
     #   feast (setup.py)
     #   sqlalchemy
@@ -887,7 +887,7 @@ terminado==0.18.0
     #   jupyter-server-terminals
 testcontainers==3.7.1
     # via feast (setup.py)
-thriftpy2==0.4.17
+thriftpy2==0.4.20
     # via happybase
 tinycss2==1.2.1
     # via nbconvert
@@ -903,7 +903,7 @@ tomli==2.0.1
     #   pip-tools
     #   pyproject-hooks
     #   pytest
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via snowflake-connector-python
 toolz==0.12.1
     # via
@@ -948,27 +948,27 @@ types-protobuf==3.19.22
     #   mypy-protobuf
 types-pymysql==1.1.0.1
     # via feast (setup.py)
-types-pyopenssl==24.0.0.20240130
+types-pyopenssl==24.0.0.20240311
     # via types-redis
-types-python-dateutil==2.8.19.20240106
+types-python-dateutil==2.8.19.20240311
     # via
     #   arrow
     #   feast (setup.py)
 types-pytz==2024.1.0.20240203
     # via feast (setup.py)
-types-pyyaml==6.0.12.12
+types-pyyaml==6.0.12.20240311
     # via feast (setup.py)
-types-redis==4.6.0.20240218
+types-redis==4.6.0.20240311
     # via feast (setup.py)
 types-requests==2.30.0.0
     # via feast (setup.py)
-types-setuptools==69.1.0.20240223
+types-setuptools==69.1.0.20240310
     # via feast (setup.py)
 types-tabulate==0.9.0.20240106
     # via feast (setup.py)
 types-urllib3==1.26.25.14
     # via types-requests
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   annotated-types
     #   anyio
@@ -1009,7 +1009,7 @@ urllib3==1.26.18
     #   responses
     #   rockset
     #   snowflake-connector-python
-uvicorn[standard]==0.27.1
+uvicorn[standard]==0.28.0
     # via feast (setup.py)
 uvloop==0.19.0
     # via uvicorn

--- a/sdk/python/requirements/py3.8-requirements.txt
+++ b/sdk/python/requirements/py3.8-requirements.txt
@@ -44,7 +44,7 @@ dill==0.3.8
     # via feast (setup.py)
 exceptiongroup==1.2.0
     # via anyio
-fastapi==0.109.2
+fastapi==0.110.0
     # via feast (setup.py)
 fissix==21.11.13
     # via bowler
@@ -52,18 +52,6 @@ fsspec==2024.2.0
     # via dask
 greenlet==3.0.3
     # via sqlalchemy
-grpcio==1.62.0
-    # via
-    #   feast (setup.py)
-    #   grpcio-health-checking
-    #   grpcio-reflection
-    #   grpcio-tools
-grpcio-health-checking==1.62.0
-    # via feast (setup.py)
-grpcio-reflection==1.62.0
-    # via feast (setup.py)
-grpcio-tools==1.62.0
-    # via feast (setup.py)
 gunicorn==21.2.0
     # via feast (setup.py)
 h11==0.14.0
@@ -86,7 +74,7 @@ importlib-metadata==6.11.0
     #   dask
     #   feast (setup.py)
     #   typeguard
-importlib-resources==6.1.1
+importlib-resources==6.1.3
     # via
     #   feast (setup.py)
     #   jsonschema
@@ -105,7 +93,7 @@ mmh3==4.1.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-mypy==1.8.0
+mypy==1.9.0
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
@@ -116,7 +104,7 @@ numpy==1.24.4
     #   feast (setup.py)
     #   pandas
     #   pyarrow
-packaging==23.2
+packaging==24.0
     # via
     #   dask
     #   gunicorn
@@ -128,17 +116,14 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 proto-plus==1.23.0
     # via feast (setup.py)
-protobuf==4.23.4
+protobuf==4.25.3
     # via
     #   feast (setup.py)
-    #   grpcio-health-checking
-    #   grpcio-reflection
-    #   grpcio-tools
     #   mypy-protobuf
     #   proto-plus
-pyarrow==15.0.0
+pyarrow==15.0.1
     # via feast (setup.py)
-pydantic==2.6.2
+pydantic==2.6.3
     # via
     #   fastapi
     #   feast (setup.py)
@@ -146,7 +131,7 @@ pydantic-core==2.16.3
     # via pydantic
 pygments==2.17.2
     # via feast (setup.py)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via pandas
 python-dotenv==1.0.1
     # via uvicorn
@@ -169,11 +154,11 @@ rpds-py==0.18.0
     #   referencing
 six==1.16.0
     # via python-dateutil
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-sqlalchemy[mypy]==1.4.51
+sqlalchemy[mypy]==1.4.52
     # via
     #   feast (setup.py)
     #   sqlalchemy
@@ -197,9 +182,9 @@ tqdm==4.66.2
     # via feast (setup.py)
 typeguard==4.1.5
     # via feast (setup.py)
-types-protobuf==4.24.0.20240129
+types-protobuf==4.24.0.20240311
     # via mypy-protobuf
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   annotated-types
     #   anyio
@@ -211,9 +196,11 @@ typing-extensions==4.9.0
     #   starlette
     #   typeguard
     #   uvicorn
+tzdata==2024.1
+    # via pandas
 urllib3==2.2.1
     # via requests
-uvicorn[standard]==0.27.1
+uvicorn[standard]==0.28.0
     # via feast (setup.py)
 uvloop==0.19.0
     # via uvicorn
@@ -227,6 +214,3 @@ zipp==3.17.0
     # via
     #   importlib-metadata
     #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -43,13 +43,13 @@ attrs==23.2.0
     #   referencing
 avro==1.10.0
     # via feast (setup.py)
-azure-core==1.30.0
+azure-core==1.30.1
     # via
     #   azure-identity
     #   azure-storage-blob
 azure-identity==1.15.0
     # via feast (setup.py)
-azure-storage-blob==12.19.0
+azure-storage-blob==12.19.1
     # via feast (setup.py)
 babel==2.14.0
     # via
@@ -63,18 +63,18 @@ black==22.12.0
     # via feast (setup.py)
 bleach==6.1.0
     # via nbconvert
-boto3==1.34.49
+boto3==1.34.59
     # via
     #   feast (setup.py)
     #   moto
-botocore==1.34.49
+botocore==1.34.59
     # via
     #   boto3
     #   moto
     #   s3transfer
 bowler==0.9.0
     # via feast (setup.py)
-build==1.0.3
+build==1.1.1
     # via
     #   feast (setup.py)
     #   pip-tools
@@ -82,7 +82,7 @@ bytewax==0.15.1
     # via feast (setup.py)
 cachecontrol==0.14.0
     # via firebase-admin
-cachetools==5.3.2
+cachetools==5.3.3
     # via google-auth
 cassandra-driver==3.29.0
     # via feast (setup.py)
@@ -127,8 +127,10 @@ comm==0.2.1
     #   ipykernel
     #   ipywidgets
 coverage[toml]==7.4.3
-    # via pytest-cov
-cryptography==42.0.4
+    # via
+    #   coverage
+    #   pytest-cov
+cryptography==42.0.5
     # via
     #   azure-identity
     #   azure-storage-blob
@@ -177,7 +179,7 @@ execnet==2.0.2
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.109.2
+fastapi==0.110.0
     # via feast (setup.py)
 fastjsonschema==2.19.1
     # via nbformat
@@ -213,9 +215,9 @@ google-api-core[grpc]==2.17.1
     #   google-cloud-datastore
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.119.0
+google-api-python-client==2.121.0
     # via firebase-admin
-google-auth==2.28.1
+google-auth==2.28.2
     # via
     #   google-api-core
     #   google-api-python-client
@@ -226,7 +228,9 @@ google-auth==2.28.1
 google-auth-httplib2==0.2.0
     # via google-api-python-client
 google-cloud-bigquery[pandas]==3.12.0
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   google-cloud-bigquery
 google-cloud-bigquery-storage==2.24.0
     # via feast (setup.py)
 google-cloud-bigtable==2.23.0
@@ -242,7 +246,7 @@ google-cloud-datastore==2.19.0
     # via feast (setup.py)
 google-cloud-firestore==2.15.0
     # via firebase-admin
-google-cloud-storage==2.14.0
+google-cloud-storage==2.15.0
     # via
     #   feast (setup.py)
     #   firebase-admin
@@ -260,13 +264,13 @@ googleapis-common-protos[grpc]==1.62.0
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
-great-expectations==0.18.9
+great-expectations==0.18.10
     # via feast (setup.py)
 greenlet==3.0.3
     # via sqlalchemy
 grpc-google-iam-v1==0.13.0
     # via google-cloud-bigtable
-grpcio==1.62.0
+grpcio==1.62.1
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -278,15 +282,15 @@ grpcio==1.62.0
     #   grpcio-status
     #   grpcio-testing
     #   grpcio-tools
-grpcio-health-checking==1.62.0
+grpcio-health-checking==1.62.1
     # via feast (setup.py)
-grpcio-reflection==1.62.0
+grpcio-reflection==1.62.1
     # via feast (setup.py)
-grpcio-status==1.62.0
+grpcio-status==1.62.1
     # via google-api-core
-grpcio-testing==1.62.0
+grpcio-testing==1.62.1
     # via feast (setup.py)
-grpcio-tools==1.62.0
+grpcio-tools==1.62.1
     # via feast (setup.py)
 gunicorn==21.2.0
     # via feast (setup.py)
@@ -341,11 +345,11 @@ importlib-metadata==6.11.0
     #   nbconvert
     #   sphinx
     #   typeguard
-importlib-resources==6.1.1
+importlib-resources==6.1.3
     # via feast (setup.py)
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.29.2
+ipykernel==6.29.3
     # via jupyterlab
 ipython==8.18.1
     # via
@@ -377,7 +381,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-json5==0.9.17
+json5==0.9.22
     # via jupyterlab-server
 jsonpatch==1.33
     # via great-expectations
@@ -411,9 +415,9 @@ jupyter-core==5.7.1
     #   nbformat
 jupyter-events==0.9.0
     # via jupyter-server
-jupyter-lsp==2.2.2
+jupyter-lsp==2.2.4
     # via jupyterlab
-jupyter-server==2.12.5
+jupyter-server==2.13.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -422,7 +426,7 @@ jupyter-server==2.12.5
     #   notebook-shim
 jupyter-server-terminals==0.5.2
     # via jupyter-server
-jupyterlab==4.1.2
+jupyterlab==4.1.4
     # via notebook
 jupyterlab-pygments==0.3.0
     # via nbconvert
@@ -445,7 +449,7 @@ markupsafe==2.1.5
     #   jinja2
     #   nbconvert
     #   werkzeug
-marshmallow==3.20.2
+marshmallow==3.21.1
     # via great-expectations
 matplotlib-inline==0.1.6
     # via
@@ -475,13 +479,13 @@ msal==1.27.0
     #   msal-extensions
 msal-extensions==1.1.0
     # via azure-identity
-msgpack==1.0.7
+msgpack==1.0.8
     # via cachecontrol
 multipledispatch==1.0.0
     # via ibis-framework
 multiprocess==0.70.16
     # via bytewax
-mypy==1.8.0
+mypy==1.9.0
     # via
     #   feast (setup.py)
     #   sqlalchemy
@@ -493,7 +497,7 @@ mypy-protobuf==3.1.0
     # via feast (setup.py)
 nbclient==0.9.0
     # via nbconvert
-nbconvert==7.16.1
+nbconvert==7.16.2
     # via jupyter-server
 nbformat==5.9.2
     # via
@@ -505,7 +509,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 nodeenv==1.8.0
     # via pre-commit
-notebook==7.1.0
+notebook==7.1.1
     # via great-expectations
 notebook-shim==0.2.4
     # via
@@ -525,7 +529,7 @@ oauthlib==3.2.2
     # via requests-oauthlib
 overrides==7.7.0
     # via jupyter-server
-packaging==23.2
+packaging==24.0
     # via
     #   build
     #   dask
@@ -546,13 +550,14 @@ packaging==23.2
     #   pytest
     #   snowflake-connector-python
     #   sphinx
-pandas==2.2.0
+pandas==2.2.1
     # via
     #   altair
     #   db-dtypes
     #   feast (setup.py)
     #   google-cloud-bigquery
     #   great-expectations
+    #   ibis-framework
     #   snowflake-connector-python
 pandocfilters==1.5.1
     # via nbconvert
@@ -568,7 +573,7 @@ pbr==6.0.0
     # via mock
 pexpect==4.9.0
     # via ipython
-pip-tools==7.4.0
+pip-tools==7.4.1
     # via feast (setup.py)
 platformdirs==3.11.0
     # via
@@ -596,7 +601,7 @@ proto-plus==1.23.0
     #   google-cloud-bigtable
     #   google-cloud-datastore
     #   google-cloud-firestore
-protobuf==4.23.4
+protobuf==4.25.3
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -633,7 +638,7 @@ py-cpuinfo==9.0.0
     # via pytest-benchmark
 py4j==0.10.9.7
     # via pyspark
-pyarrow==15.0.0
+pyarrow==15.0.1
     # via
     #   db-dtypes
     #   feast (setup.py)
@@ -654,7 +659,7 @@ pycodestyle==2.10.0
     # via flake8
 pycparser==2.21
     # via cffi
-pydantic==2.6.2
+pydantic==2.6.3
     # via
     #   fastapi
     #   feast (setup.py)
@@ -680,9 +685,9 @@ pymysql==1.1.0
     # via feast (setup.py)
 pyodbc==5.1.0
     # via feast (setup.py)
-pyopenssl==24.0.0
+pyopenssl==24.1.0
     # via snowflake-connector-python
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via
     #   great-expectations
     #   httplib2
@@ -690,7 +695,7 @@ pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
-pyspark==3.5.0
+pyspark==3.5.1
     # via feast (setup.py)
 pytest==7.4.4
     # via
@@ -716,7 +721,7 @@ pytest-timeout==1.4.2
     # via feast (setup.py)
 pytest-xdist==3.5.0
     # via feast (setup.py)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   arrow
     #   botocore
@@ -783,7 +788,7 @@ requests==2.31.0
     #   snowflake-connector-python
     #   sphinx
     #   trino
-requests-oauthlib==1.3.1
+requests-oauthlib==1.4.0
     # via kubernetes
 responses==0.25.0
     # via moto
@@ -795,7 +800,7 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rich==13.7.0
+rich==13.7.1
     # via ibis-framework
 rockset==2.1.1
     # via feast (setup.py)
@@ -828,14 +833,16 @@ six==1.16.0
     #   python-dateutil
     #   rfc3339-validator
     #   thriftpy2
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
 snowflake-connector-python[pandas]==3.7.1
-    # via feast (setup.py)
+    # via
+    #   feast (setup.py)
+    #   snowflake-connector-python
 sortedcontainers==2.4.0
     # via snowflake-connector-python
 soupsieve==2.5
@@ -854,7 +861,7 @@ sphinxcontrib-qthelp==1.0.7
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
-sqlalchemy[mypy]==1.4.51
+sqlalchemy[mypy]==1.4.52
     # via
     #   feast (setup.py)
     #   sqlalchemy
@@ -866,7 +873,7 @@ stack-data==0.6.3
     # via ipython
 starlette==0.36.3
     # via fastapi
-substrait==0.12.1
+substrait==0.14.0
     # via ibis-substrait
 tabulate==0.9.0
     # via feast (setup.py)
@@ -878,7 +885,7 @@ terminado==0.18.0
     #   jupyter-server-terminals
 testcontainers==3.7.1
     # via feast (setup.py)
-thriftpy2==0.4.17
+thriftpy2==0.4.20
     # via happybase
 tinycss2==1.2.1
     # via nbconvert
@@ -894,7 +901,7 @@ tomli==2.0.1
     #   pip-tools
     #   pyproject-hooks
     #   pytest
-tomlkit==0.12.3
+tomlkit==0.12.4
     # via snowflake-connector-python
 toolz==0.12.1
     # via
@@ -939,27 +946,27 @@ types-protobuf==3.19.22
     #   mypy-protobuf
 types-pymysql==1.1.0.1
     # via feast (setup.py)
-types-pyopenssl==24.0.0.20240130
+types-pyopenssl==24.0.0.20240311
     # via types-redis
-types-python-dateutil==2.8.19.20240106
+types-python-dateutil==2.8.19.20240311
     # via
     #   arrow
     #   feast (setup.py)
 types-pytz==2024.1.0.20240203
     # via feast (setup.py)
-types-pyyaml==6.0.12.12
+types-pyyaml==6.0.12.20240311
     # via feast (setup.py)
-types-redis==4.6.0.20240218
+types-redis==4.6.0.20240311
     # via feast (setup.py)
 types-requests==2.30.0.0
     # via feast (setup.py)
-types-setuptools==69.1.0.20240223
+types-setuptools==69.1.0.20240310
     # via feast (setup.py)
 types-tabulate==0.9.0.20240106
     # via feast (setup.py)
 types-urllib3==1.26.25.14
     # via types-requests
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   anyio
     #   async-lru
@@ -1000,8 +1007,10 @@ urllib3==1.26.18
     #   responses
     #   rockset
     #   snowflake-connector-python
-uvicorn[standard]==0.27.1
-    # via feast (setup.py)
+uvicorn[standard]==0.28.0
+    # via
+    #   feast (setup.py)
+    #   uvicorn
 uvloop==0.19.0
     # via uvicorn
 virtualenv==20.23.0

--- a/sdk/python/requirements/py3.9-requirements.txt
+++ b/sdk/python/requirements/py3.9-requirements.txt
@@ -44,7 +44,7 @@ dill==0.3.8
     # via feast (setup.py)
 exceptiongroup==1.2.0
     # via anyio
-fastapi==0.109.2
+fastapi==0.110.0
     # via feast (setup.py)
 fissix==21.11.13
     # via bowler
@@ -52,18 +52,6 @@ fsspec==2024.2.0
     # via dask
 greenlet==3.0.3
     # via sqlalchemy
-grpcio==1.62.0
-    # via
-    #   feast (setup.py)
-    #   grpcio-health-checking
-    #   grpcio-reflection
-    #   grpcio-tools
-grpcio-health-checking==1.62.0
-    # via feast (setup.py)
-grpcio-reflection==1.62.0
-    # via feast (setup.py)
-grpcio-tools==1.62.0
-    # via feast (setup.py)
 gunicorn==21.2.0
     # via feast (setup.py)
 h11==0.14.0
@@ -86,7 +74,7 @@ importlib-metadata==6.11.0
     #   dask
     #   feast (setup.py)
     #   typeguard
-importlib-resources==6.1.1
+importlib-resources==6.1.3
     # via feast (setup.py)
 jinja2==3.1.3
     # via feast (setup.py)
@@ -102,7 +90,7 @@ mmh3==4.1.0
     # via feast (setup.py)
 moreorless==0.4.0
     # via bowler
-mypy==1.8.0
+mypy==1.9.0
     # via sqlalchemy
 mypy-extensions==1.0.0
     # via mypy
@@ -113,27 +101,24 @@ numpy==1.24.4
     #   feast (setup.py)
     #   pandas
     #   pyarrow
-packaging==23.2
+packaging==24.0
     # via
     #   dask
     #   gunicorn
-pandas==2.2.0
+pandas==2.2.1
     # via feast (setup.py)
 partd==1.4.1
     # via dask
 proto-plus==1.23.0
     # via feast (setup.py)
-protobuf==4.23.4
+protobuf==4.25.3
     # via
     #   feast (setup.py)
-    #   grpcio-health-checking
-    #   grpcio-reflection
-    #   grpcio-tools
     #   mypy-protobuf
     #   proto-plus
-pyarrow==15.0.0
+pyarrow==15.0.1
     # via feast (setup.py)
-pydantic==2.6.2
+pydantic==2.6.3
     # via
     #   fastapi
     #   feast (setup.py)
@@ -141,7 +126,7 @@ pydantic-core==2.16.3
     # via pydantic
 pygments==2.17.2
     # via feast (setup.py)
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via pandas
 python-dotenv==1.0.1
     # via uvicorn
@@ -164,11 +149,11 @@ rpds-py==0.18.0
     #   referencing
 six==1.16.0
     # via python-dateutil
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-sqlalchemy[mypy]==1.4.51
+sqlalchemy[mypy]==1.4.52
     # via
     #   feast (setup.py)
     #   sqlalchemy
@@ -192,9 +177,9 @@ tqdm==4.66.2
     # via feast (setup.py)
 typeguard==4.1.5
     # via feast (setup.py)
-types-protobuf==4.24.0.20240129
+types-protobuf==4.24.0.20240311
     # via mypy-protobuf
-typing-extensions==4.9.0
+typing-extensions==4.10.0
     # via
     #   anyio
     #   fastapi
@@ -205,10 +190,14 @@ typing-extensions==4.9.0
     #   starlette
     #   typeguard
     #   uvicorn
+tzdata==2024.1
+    # via pandas
 urllib3==2.2.1
     # via requests
-uvicorn[standard]==0.27.1
-    # via feast (setup.py)
+uvicorn[standard]==0.28.0
+    # via
+    #   feast (setup.py)
+    #   uvicorn
 uvloop==0.19.0
     # via uvicorn
 volatile==2.1.0
@@ -221,6 +210,3 @@ zipp==3.17.0
     # via
     #   importlib-metadata
     #   importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ REQUIRED = [
     "numpy>=1.22,<1.25",
     "pandas>=1.4.3,<3",
     # Higher than 4.23.4 seems to cause a seg fault
-    "protobuf<4.23.4,>3.20",
+    "protobuf>=4.24.0",
     "proto-plus>=1.20.0,<2",
     "pyarrow>=4",
     "pydantic>=2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ REQUIRED = [
     "numpy>=1.22,<1.25",
     "pandas>=1.4.3,<3",
     # Higher than 4.23.4 seems to cause a seg fault
-    "protobuf>=4.24.0",
+    "protobuf>=4.24.0,<5.0.0",
     "proto-plus>=1.20.0,<2",
     "pyarrow>=4",
     "pydantic>=2.0.0",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fix the segmentation fault error while upgrading the "protobuf" version to above 4.24.0.

Based on my debug, the root cause is this line of code under the "plan()" function of "FeatureStore" class. (around line 748 of https://github.com/feast-dev/feast/blob/master/sdk/python/feast/feature_store.py )
`current_infra_proto = self._registry.proto().infra.__deepcopy__()`

The above "self._registry.proto().infra" could return an Empty object and will create a segmentation fault. 

My current solution is to create an empty object first and use the "CopyFrom()"  method from protobuf.

My test env:
python 3.8
protobuf 4.25.3


**Which issue(s) this PR fixes**:
Fixes #3921 
