### PR TITLE
fix: Update the commands for install-python-ci-dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build: protos build-java build-docker
 
 install-python-ci-dependencies:
 	python -m piptools sync sdk/python/requirements/py$(PYTHON)-ci-requirements.txt
-	COMPILE_GO=true python setup.py develop
+	python setup.py build_python_protos --inplace
 
 lock-python-ci-dependencies:
 	python -m piptools compile -U --extra ci --output-file sdk/python/requirements/py$(PYTHON)-ci-requirements.txt


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the commands of install-python-ci-dependencies in Makefile. 

**Which issue(s) this PR fixes**:

Fixes #4000 
