### PR TITLE
feat: Updating protos to separate transformation

### DIFF
--- a/protos/feast/core/OnDemandFeatureView.proto
+++ b/protos/feast/core/OnDemandFeatureView.proto
@@ -50,8 +50,8 @@ message OnDemandFeatureViewSpec {
     map<string, OnDemandSource> sources = 4;
 
     oneof transformation {
-        UserDefinedFunction user_defined_function = 5;
-        OnDemandSubstraitTransformation on_demand_substrait_transformation = 9;
+        UserDefinedFunction user_defined_function = 5 [deprecated = true];
+        OnDemandSubstraitTransformation on_demand_substrait_transformation = 9 [deprecated = true];
     }
     // Oneof with {user_defined_function, on_demand_substrait_transformation}
     FeatureTransformationV2 feature_transformation = 10;

--- a/protos/feast/core/OnDemandFeatureView.proto
+++ b/protos/feast/core/OnDemandFeatureView.proto
@@ -27,6 +27,7 @@ import "feast/core/FeatureView.proto";
 import "feast/core/FeatureViewProjection.proto";
 import "feast/core/Feature.proto";
 import "feast/core/DataSource.proto";
+import "feast/core/Transformation.proto";
 
 message OnDemandFeatureView {
     // User-specified specifications of this feature view.
@@ -48,10 +49,8 @@ message OnDemandFeatureViewSpec {
     // Map of sources for this feature view.
     map<string, OnDemandSource> sources = 4;
 
-    oneof transformation {
-        UserDefinedFunction user_defined_function = 5;
-        OnDemandSubstraitTransformation on_demand_substrait_transformation = 9;
-    }
+    // Oneof with {user_defined_function, on_demand_substrait_transformation}
+    FeatureTransformation transformation = 5;
 
     // Description of the on demand feature view.
     string description = 6;
@@ -61,6 +60,7 @@ message OnDemandFeatureViewSpec {
 
     // Owner of the on demand feature view.
     string owner = 8;
+    string mode = 9;
 }
 
 message OnDemandFeatureViewMeta {
@@ -77,20 +77,4 @@ message OnDemandSource {
         FeatureViewProjection feature_view_projection = 3;
         DataSource request_data_source = 2;
     }
-}
-
-// Serialized representation of python function.
-message UserDefinedFunction {
-    // The function name
-    string name = 1;
-
-    // The python-syntax function body (serialized by dill)
-    bytes body = 2;
-
-    // The string representation of the udf
-    string body_text = 3;
-}
-
-message OnDemandSubstraitTransformation {
-    bytes substrait_plan = 1;
 }

--- a/protos/feast/core/OnDemandFeatureView.proto
+++ b/protos/feast/core/OnDemandFeatureView.proto
@@ -49,8 +49,12 @@ message OnDemandFeatureViewSpec {
     // Map of sources for this feature view.
     map<string, OnDemandSource> sources = 4;
 
+    oneof transformation {
+        UserDefinedFunction user_defined_function = 5;
+        OnDemandSubstraitTransformation on_demand_substrait_transformation = 9;
+    }
     // Oneof with {user_defined_function, on_demand_substrait_transformation}
-    FeatureTransformation transformation = 5;
+    FeatureTransformationV2 feature_transformation = 10;
 
     // Description of the on demand feature view.
     string description = 6;
@@ -60,7 +64,7 @@ message OnDemandFeatureViewSpec {
 
     // Owner of the on demand feature view.
     string owner = 8;
-    string mode = 9;
+    string mode = 11;
 }
 
 message OnDemandFeatureViewMeta {
@@ -77,4 +81,24 @@ message OnDemandSource {
         FeatureViewProjection feature_view_projection = 3;
         DataSource request_data_source = 2;
     }
+}
+
+// Serialized representation of python function.
+message UserDefinedFunction {
+    option deprecated = true;
+
+    // The function name
+    string name = 1;
+
+    // The python-syntax function body (serialized by dill)
+    bytes body = 2;
+
+    // The string representation of the udf
+    string body_text = 3;
+}
+
+message OnDemandSubstraitTransformation {
+    option deprecated = true;
+
+    bytes substrait_plan = 1;
 }

--- a/protos/feast/core/StreamFeatureView.proto
+++ b/protos/feast/core/StreamFeatureView.proto
@@ -80,6 +80,7 @@ message StreamFeatureViewSpec {
     // Serialized function that is encoded in the streamfeatureview
     UserDefinedFunction user_defined_function = 13;
 
+
     // Mode of execution
     string mode = 14;
 
@@ -88,5 +89,8 @@ message StreamFeatureViewSpec {
 
     // Timestamp field for aggregation
     string timestamp_field = 16;
+
+    // Oneof with {user_defined_function, on_demand_substrait_transformation}
+    FeatureTransformation transformation = 17;
 }
 

--- a/protos/feast/core/StreamFeatureView.proto
+++ b/protos/feast/core/StreamFeatureView.proto
@@ -29,6 +29,7 @@ import "feast/core/FeatureView.proto";
 import "feast/core/Feature.proto";
 import "feast/core/DataSource.proto";
 import "feast/core/Aggregation.proto";
+import "feast/core/Transformation.proto";
 
 message StreamFeatureView {
     // User-specified specifications of this feature view.

--- a/protos/feast/core/StreamFeatureView.proto
+++ b/protos/feast/core/StreamFeatureView.proto
@@ -91,6 +91,6 @@ message StreamFeatureViewSpec {
     string timestamp_field = 16;
 
     // Oneof with {user_defined_function, on_demand_substrait_transformation}
-    FeatureTransformation transformation = 17;
+    FeatureTransformationV2 feature_transformation = 17;
 }
 

--- a/protos/feast/core/StreamFeatureView.proto
+++ b/protos/feast/core/StreamFeatureView.proto
@@ -78,7 +78,7 @@ message StreamFeatureViewSpec {
     bool online = 12;
 
     // Serialized function that is encoded in the streamfeatureview
-    UserDefinedFunction user_defined_function = 13;
+    UserDefinedFunction user_defined_function = 13 [deprecated = true];
 
 
     // Mode of execution

--- a/protos/feast/core/Transformation.proto
+++ b/protos/feast/core/Transformation.proto
@@ -19,10 +19,12 @@ message UserDefinedFunction {
     string body_text = 3;
 }
 
+// A feature transformation executed as a user-defined function
 message FeatureTransformation {
+  // Note this Transformation starts at 5 for backwards compatibility
   oneof transformation {
-    UserDefinedFunction user_defined_function = 1;
-    OnDemandSubstraitTransformation on_demand_substrait_transformation = 2;
+    UserDefinedFunction user_defined_function = 5;
+    OnDemandSubstraitTransformation on_demand_substrait_transformation = 6;
   }
 }
 

--- a/protos/feast/core/Transformation.proto
+++ b/protos/feast/core/Transformation.proto
@@ -23,8 +23,8 @@ message UserDefinedFunctionV2 {
 message FeatureTransformationV2 {
   // Note this Transformation starts at 5 for backwards compatibility
   oneof transformation {
-    UserDefinedFunctionV2 user_defined_function = 5;
-    OnDemandSubstraitTransformationV2 on_demand_substrait_transformation = 6;
+    UserDefinedFunctionV2 user_defined_function = 1;
+    OnDemandSubstraitTransformationV2 on_demand_substrait_transformation = 2;
   }
 }
 

--- a/protos/feast/core/Transformation.proto
+++ b/protos/feast/core/Transformation.proto
@@ -8,7 +8,7 @@ option java_package = "feast.proto.core";
 import "google/protobuf/duration.proto";
 
 // Serialized representation of python function.
-message UserDefinedFunction {
+message UserDefinedFunctionV2 {
     // The function name
     string name = 1;
 
@@ -20,14 +20,14 @@ message UserDefinedFunction {
 }
 
 // A feature transformation executed as a user-defined function
-message FeatureTransformation {
+message FeatureTransformationV2 {
   // Note this Transformation starts at 5 for backwards compatibility
   oneof transformation {
-    UserDefinedFunction user_defined_function = 5;
-    OnDemandSubstraitTransformation on_demand_substrait_transformation = 6;
+    UserDefinedFunctionV2 user_defined_function = 5;
+    OnDemandSubstraitTransformationV2 on_demand_substrait_transformation = 6;
   }
 }
 
-message OnDemandSubstraitTransformation {
+message OnDemandSubstraitTransformationV2 {
   bytes substrait_plan = 1;
 }

--- a/protos/feast/core/Transformation.proto
+++ b/protos/feast/core/Transformation.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package feast.core;
+
+option go_package = "github.com/feast-dev/feast/go/protos/feast/core";
+option java_outer_classname = "FeatureTransformationProto";
+option java_package = "feast.proto.core";
+
+import "google/protobuf/duration.proto";
+
+// Serialized representation of python function.
+message UserDefinedFunction {
+    // The function name
+    string name = 1;
+
+    // The python-syntax function body (serialized by dill)
+    bytes body = 2;
+
+    // The string representation of the udf
+    string body_text = 3;
+}
+
+message FeatureTransformation {
+  oneof transformation {
+    UserDefinedFunction user_defined_function = 1;
+    OnDemandSubstraitTransformation on_demand_substrait_transformation = 2;
+  }
+}
+
+message OnDemandSubstraitTransformation {
+  bytes substrait_plan = 1;
+}

--- a/sdk/python/feast/diff/registry_diff.py
+++ b/sdk/python/feast/diff/registry_diff.py
@@ -163,6 +163,27 @@ def diff_registry_objects(
                                     getattr(new_udf, _udf_field.name),
                                 )
                             )
+                elif _field.name == "feature_transformation":
+                    current_spec = cast(OnDemandFeatureViewSpec, current_spec)
+                    new_spec = cast(OnDemandFeatureViewSpec, new_spec)
+                    current_udf = (
+                        current_spec.feature_transformation.user_defined_function
+                    )
+                    new_udf = new_spec.feature_transformation.user_defined_function
+                    for _udf_field in current_udf.DESCRIPTOR.fields:
+                        if _udf_field.name == "body":
+                            continue
+                        if getattr(current_udf, _udf_field.name) != getattr(
+                            new_udf, _udf_field.name
+                        ):
+                            transition = TransitionType.UPDATE
+                            property_diffs.append(
+                                PropertyDiff(
+                                    _field.name + "." + _udf_field.name,
+                                    getattr(current_udf, _udf_field.name),
+                                    getattr(new_udf, _udf_field.name),
+                                )
+                            )
                 else:
                     transition = TransitionType.UPDATE
                     property_diffs.append(

--- a/sdk/python/feast/diff/registry_diff.py
+++ b/sdk/python/feast/diff/registry_diff.py
@@ -147,7 +147,9 @@ def diff_registry_objects(
                 if _field.name == "transformation":
                     current_spec = cast(OnDemandFeatureViewSpec, current_spec)
                     new_spec = cast(OnDemandFeatureViewSpec, new_spec)
-                    current_udf = current_spec.feature_transformation.user_defined_function
+                    current_udf = (
+                        current_spec.feature_transformation.user_defined_function
+                    )
                     new_udf = new_spec.feature_transformation.user_defined_function
                     for _udf_field in current_udf.DESCRIPTOR.fields:
                         if _udf_field.name == "body":

--- a/sdk/python/feast/diff/registry_diff.py
+++ b/sdk/python/feast/diff/registry_diff.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, cast
 
@@ -144,32 +145,23 @@ def diff_registry_objects(
             if _field.name in FIELDS_TO_IGNORE:
                 continue
             elif getattr(current_spec, _field.name) != getattr(new_spec, _field.name):
-                if _field.name == "transformation":
+                # TODO: Delete "transformation" after we've safely deprecated it from the proto
+                if _field.name in ["transformation", "feature_transformation"]:
+                    warnings.warn(
+                        "transformation will be deprecated in the future please use feature_transformation instead.",
+                        DeprecationWarning,
+                    )
                     current_spec = cast(OnDemandFeatureViewSpec, current_spec)
                     new_spec = cast(OnDemandFeatureViewSpec, new_spec)
-                    current_udf = (
+                    # Check if the old proto is populated and use that if it is
+                    deprecated_udf = current_spec.user_defined_function
+                    feature_transformation_udf = (
                         current_spec.feature_transformation.user_defined_function
                     )
-                    new_udf = new_spec.feature_transformation.user_defined_function
-                    for _udf_field in current_udf.DESCRIPTOR.fields:
-                        if _udf_field.name == "body":
-                            continue
-                        if getattr(current_udf, _udf_field.name) != getattr(
-                            new_udf, _udf_field.name
-                        ):
-                            transition = TransitionType.UPDATE
-                            property_diffs.append(
-                                PropertyDiff(
-                                    _field.name + "." + _udf_field.name,
-                                    getattr(current_udf, _udf_field.name),
-                                    getattr(new_udf, _udf_field.name),
-                                )
-                            )
-                elif _field.name == "feature_transformation":
-                    current_spec = cast(OnDemandFeatureViewSpec, current_spec)
-                    new_spec = cast(OnDemandFeatureViewSpec, new_spec)
                     current_udf = (
-                        current_spec.feature_transformation.user_defined_function
+                        deprecated_udf
+                        if deprecated_udf.body_text != ""
+                        else feature_transformation_udf
                     )
                     new_udf = new_spec.feature_transformation.user_defined_function
                     for _udf_field in current_udf.DESCRIPTOR.fields:

--- a/sdk/python/feast/diff/registry_diff.py
+++ b/sdk/python/feast/diff/registry_diff.py
@@ -147,8 +147,8 @@ def diff_registry_objects(
                 if _field.name == "user_defined_function":
                     current_spec = cast(OnDemandFeatureViewSpec, current_spec)
                     new_spec = cast(OnDemandFeatureViewSpec, new_spec)
-                    current_udf = current_spec.user_defined_function
-                    new_udf = new_spec.user_defined_function
+                    current_udf = current_spec.transformation.user_defined_function
+                    new_udf = new_spec.transformation.user_defined_function
                     for _udf_field in current_udf.DESCRIPTOR.fields:
                         if _udf_field.name == "body":
                             continue

--- a/sdk/python/feast/diff/registry_diff.py
+++ b/sdk/python/feast/diff/registry_diff.py
@@ -144,7 +144,7 @@ def diff_registry_objects(
             if _field.name in FIELDS_TO_IGNORE:
                 continue
             elif getattr(current_spec, _field.name) != getattr(new_spec, _field.name):
-                if _field.name == "user_defined_function":
+                if _field.name == "transformation":
                     current_spec = cast(OnDemandFeatureViewSpec, current_spec)
                     new_spec = cast(OnDemandFeatureViewSpec, new_spec)
                     current_udf = current_spec.transformation.user_defined_function

--- a/sdk/python/feast/diff/registry_diff.py
+++ b/sdk/python/feast/diff/registry_diff.py
@@ -147,8 +147,8 @@ def diff_registry_objects(
                 if _field.name == "transformation":
                     current_spec = cast(OnDemandFeatureViewSpec, current_spec)
                     new_spec = cast(OnDemandFeatureViewSpec, new_spec)
-                    current_udf = current_spec.transformation.user_defined_function
-                    new_udf = new_spec.transformation.user_defined_function
+                    current_udf = current_spec.feature_transformation.user_defined_function
+                    new_udf = new_spec.feature_transformation.user_defined_function
                     for _udf_field in current_udf.DESCRIPTOR.fields:
                         if _udf_field.name == "body":
                             continue

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -663,7 +663,7 @@ class BaseRegistry(ABC):
         ):
             odfv_dict = self._message_to_sorted_dict(on_demand_feature_view.to_proto())
 
-            odfv_dict["spec"]["userDefinedFunction"][
+            odfv_dict["spec"]["transformation"]["userDefinedFunction"][
                 "body"
             ] = on_demand_feature_view.transformation.udf_string
             registry_dict["onDemandFeatureViews"].append(odfv_dict)

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -662,8 +662,7 @@ class BaseRegistry(ABC):
             key=lambda on_demand_feature_view: on_demand_feature_view.name,
         ):
             odfv_dict = self._message_to_sorted_dict(on_demand_feature_view.to_proto())
-
-            odfv_dict["spec"]["transformation"]["userDefinedFunction"][
+            odfv_dict["spec"]["featureTransformation"]["userDefinedFunction"][
                 "body"
             ] = on_demand_feature_view.transformation.udf_string
             registry_dict["onDemandFeatureViews"].append(odfv_dict)

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from datetime import datetime
@@ -662,9 +663,16 @@ class BaseRegistry(ABC):
             key=lambda on_demand_feature_view: on_demand_feature_view.name,
         ):
             odfv_dict = self._message_to_sorted_dict(on_demand_feature_view.to_proto())
+            # We are logging a warning because the registry object may be read from a proto that is not updated
+            # i.e., we have to submit dual writes but in order to ensure the read behavior succeeds we have to load
+            # both objects to compare any changes in the registry
+            warnings.warn(
+                "We will be deprecating the usage of spec.userDefinedFunction in a future release please upgrade cautiously.",
+                DeprecationWarning,
+            )
             odfv_dict["spec"]["featureTransformation"]["userDefinedFunction"][
                 "body"
-            ] = on_demand_feature_view.transformation.udf_string
+            ] = on_demand_feature_view.feature_transformation.udf_string
             registry_dict["onDemandFeatureViews"].append(odfv_dict)
         for request_feature_view in sorted(
             self.list_request_feature_views(project=project),
@@ -683,6 +691,7 @@ class BaseRegistry(ABC):
                 "body"
             ] = stream_feature_view.udf_string
             registry_dict["streamFeatureViews"].append(sfv_dict)
+
         for saved_dataset in sorted(
             self.list_saved_datasets(project=project), key=lambda item: item.name
         ):

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -66,6 +66,7 @@ class OnDemandFeatureView(BaseFeatureView):
     source_feature_view_projections: Dict[str, FeatureViewProjection]
     source_request_sources: Dict[str, RequestSource]
     transformation: Union[OnDemandPandasTransformation]
+    feature_transformation: Union[OnDemandPandasTransformation]
     description: str
     tags: Dict[str, str]
     owner: str
@@ -86,6 +87,7 @@ class OnDemandFeatureView(BaseFeatureView):
         udf: Optional[FunctionType] = None,
         udf_string: str = "",
         transformation: Optional[Union[OnDemandPandasTransformation]] = None,
+        feature_transformation: Optional[Union[OnDemandPandasTransformation]] = None,
         description: str = "",
         tags: Optional[Dict[str, str]] = None,
         owner: str = "",
@@ -104,6 +106,7 @@ class OnDemandFeatureView(BaseFeatureView):
                 dataframes as inputs.
             udf_string (deprecated): The source code version of the udf (for diffing and displaying in Web UI)
             transformation: The user defined transformation.
+            feature_transformation: The user defined transformation.
             description (optional): A human-readable description.
             tags (optional): A dictionary of key-value pairs to store arbitrary metadata.
             owner (optional): The owner of the on demand feature view, typically the email
@@ -142,6 +145,7 @@ class OnDemandFeatureView(BaseFeatureView):
                 ] = odfv_source.projection
 
         self.transformation = transformation
+        self.feature_transformation = self.transformation
 
     @property
     def proto_class(self) -> Type[OnDemandFeatureViewProto]:
@@ -154,6 +158,7 @@ class OnDemandFeatureView(BaseFeatureView):
             sources=list(self.source_feature_view_projections.values())
             + list(self.source_request_sources.values()),
             transformation=self.transformation,
+            feature_transformation=self.transformation,
             description=self.description,
             tags=self.tags,
             owner=self.owner,
@@ -175,6 +180,7 @@ class OnDemandFeatureView(BaseFeatureView):
             != other.source_feature_view_projections
             or self.source_request_sources != other.source_request_sources
             or self.transformation != other.transformation
+            or self.feature_transformation != other.feature_transformation
         ):
             return False
 

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -260,14 +260,18 @@ class OnDemandFeatureView(BaseFeatureView):
                 )
 
         if (
-            on_demand_feature_view_proto.spec.transformation.WhichOneof("transformation")
+            on_demand_feature_view_proto.spec.transformation.WhichOneof(
+                "transformation"
+            )
             == "user_defined_function"
         ):
             transformation = OnDemandPandasTransformation.from_proto(
                 on_demand_feature_view_proto.spec.transformation.user_defined_function
             )
         elif (
-            on_demand_feature_view_proto.spec.transformation.WhichOneof("transformation")
+            on_demand_feature_view_proto.spec.transformation.WhichOneof(
+                "transformation"
+            )
             == "on_demand_substrait_transformation"
         ):
             transformation = OnDemandSubstraitTransformation.from_proto(

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -28,7 +28,7 @@ from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
     OnDemandSource,
 )
 from feast.protos.feast.core.Transformation_pb2 import (
-    FeatureTransformation as FeatureTransformationProto,
+    FeatureTransformationV2 as FeatureTransformationProto,
 )
 from feast.type_map import (
     feast_value_type_to_pandas_type,
@@ -220,7 +220,7 @@ class OnDemandFeatureView(BaseFeatureView):
             name=self.name,
             features=[feature.to_proto() for feature in self.features],
             sources=sources,
-            transformation=feature_transformation,
+            feature_transformation=feature_transformation,
             description=self.description,
             tags=self.tags,
             owner=self.owner,
@@ -260,22 +260,22 @@ class OnDemandFeatureView(BaseFeatureView):
                 )
 
         if (
-            on_demand_feature_view_proto.spec.transformation.WhichOneof(
+            on_demand_feature_view_proto.spec.feature_transformation.WhichOneof(
                 "transformation"
             )
             == "user_defined_function"
         ):
             transformation = OnDemandPandasTransformation.from_proto(
-                on_demand_feature_view_proto.spec.transformation.user_defined_function
+                on_demand_feature_view_proto.spec.feature_transformation.user_defined_function
             )
         elif (
-            on_demand_feature_view_proto.spec.transformation.WhichOneof(
+            on_demand_feature_view_proto.spec.feature_transformation.WhichOneof(
                 "transformation"
             )
             == "on_demand_substrait_transformation"
         ):
             transformation = OnDemandSubstraitTransformation.from_proto(
-                on_demand_feature_view_proto.spec.transformation.on_demand_substrait_transformation
+                on_demand_feature_view_proto.spec.feature_transformation.on_demand_substrait_transformation
             )
         else:
             raise Exception("At least one transformation type needs to be provided")

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -260,14 +260,14 @@ class OnDemandFeatureView(BaseFeatureView):
                 )
 
         if (
-            on_demand_feature_view_proto.spec.WhichOneof("transformation")
+            on_demand_feature_view_proto.spec.transformation.WhichOneof("transformation")
             == "user_defined_function"
         ):
             transformation = OnDemandPandasTransformation.from_proto(
                 on_demand_feature_view_proto.spec.transformation.user_defined_function
             )
         elif (
-            on_demand_feature_view_proto.spec.WhichOneof("transformation")
+            on_demand_feature_view_proto.spec.transformation.WhichOneof("transformation")
             == "on_demand_substrait_transformation"
         ):
             transformation = OnDemandSubstraitTransformation.from_proto(

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -270,6 +270,8 @@ class OnDemandFeatureView(BaseFeatureView):
                 "transformation"
             )
             == "user_defined_function"
+            and on_demand_feature_view_proto.spec.feature_transformation.user_defined_function.body_text
+            != ""
         ):
             transformation = OnDemandPandasTransformation.from_proto(
                 on_demand_feature_view_proto.spec.feature_transformation.user_defined_function
@@ -282,6 +284,14 @@ class OnDemandFeatureView(BaseFeatureView):
         ):
             transformation = OnDemandSubstraitTransformation.from_proto(
                 on_demand_feature_view_proto.spec.feature_transformation.on_demand_substrait_transformation
+            )
+        elif (
+            hasattr(on_demand_feature_view_proto.spec, "user_defined_function")
+            and on_demand_feature_view_proto.spec.feature_transformation.user_defined_function.body_text
+            == ""
+        ):
+            transformation = OnDemandPandasTransformation.from_proto(
+                on_demand_feature_view_proto.spec.user_defined_function
             )
         else:
             raise Exception("At least one transformation type needs to be provided")

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -30,6 +30,9 @@ from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
 from feast.protos.feast.core.Transformation_pb2 import (
     FeatureTransformationV2 as FeatureTransformationProto,
 )
+from feast.protos.feast.core.Transformation_pb2 import (
+    UserDefinedFunctionV2 as UserDefinedFunctionProto,
+)
 from feast.type_map import (
     feast_value_type_to_pandas_type,
     python_type_to_feast_value_type,
@@ -290,8 +293,13 @@ class OnDemandFeatureView(BaseFeatureView):
             and on_demand_feature_view_proto.spec.feature_transformation.user_defined_function.body_text
             == ""
         ):
+            backwards_compatible_udf = UserDefinedFunctionProto(
+                name=on_demand_feature_view_proto.spec.user_defined_function.name,
+                body=on_demand_feature_view_proto.spec.user_defined_function.body,
+                body_text=on_demand_feature_view_proto.spec.user_defined_function.body_text,
+            )
             transformation = OnDemandPandasTransformation.from_proto(
-                on_demand_feature_view_proto.spec.user_defined_function
+                user_defined_function_proto=backwards_compatible_udf,
             )
         else:
             raise Exception("At least one transformation type needs to be provided")

--- a/sdk/python/feast/on_demand_pandas_transformation.py
+++ b/sdk/python/feast/on_demand_pandas_transformation.py
@@ -3,7 +3,7 @@ from types import FunctionType
 import dill
 import pandas as pd
 
-from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
+from feast.protos.feast.core.Transformation_pb2 import (
     UserDefinedFunction as UserDefinedFunctionProto,
 )
 

--- a/sdk/python/feast/on_demand_pandas_transformation.py
+++ b/sdk/python/feast/on_demand_pandas_transformation.py
@@ -4,7 +4,7 @@ import dill
 import pandas as pd
 
 from feast.protos.feast.core.Transformation_pb2 import (
-    UserDefinedFunction as UserDefinedFunctionProto,
+    UserDefinedFunctionV2 as UserDefinedFunctionProto,
 )
 
 

--- a/sdk/python/feast/on_demand_substrait_transformation.py
+++ b/sdk/python/feast/on_demand_substrait_transformation.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pyarrow
 import pyarrow.substrait as substrait  # type: ignore # noqa
 
-from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
+from feast.protos.feast.core.Transformation_pb2 import (
     OnDemandSubstraitTransformation as OnDemandSubstraitTransformationProto,
 )
 

--- a/sdk/python/feast/on_demand_substrait_transformation.py
+++ b/sdk/python/feast/on_demand_substrait_transformation.py
@@ -3,7 +3,7 @@ import pyarrow
 import pyarrow.substrait as substrait  # type: ignore # noqa
 
 from feast.protos.feast.core.Transformation_pb2 import (
-    OnDemandSubstraitTransformation as OnDemandSubstraitTransformationProto,
+    OnDemandSubstraitTransformationV2 as OnDemandSubstraitTransformationProto,
 )
 
 

--- a/sdk/python/feast/stream_feature_view.py
+++ b/sdk/python/feast/stream_feature_view.py
@@ -16,14 +16,14 @@ from feast.entity import Entity
 from feast.feature_view import FeatureView
 from feast.field import Field
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
-from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
-    UserDefinedFunction as UserDefinedFunctionProto,
-)
 from feast.protos.feast.core.StreamFeatureView_pb2 import (
     StreamFeatureView as StreamFeatureViewProto,
 )
 from feast.protos.feast.core.StreamFeatureView_pb2 import (
     StreamFeatureViewSpec as StreamFeatureViewSpecProto,
+)
+from feast.protos.feast.core.Transformation_pb2 import (
+    UserDefinedFunction as UserDefinedFunctionProto,
 )
 
 warnings.simplefilter("once", RuntimeWarning)

--- a/sdk/python/tests/unit/diff/test_registry_diff.py
+++ b/sdk/python/tests/unit/diff/test_registry_diff.py
@@ -137,6 +137,7 @@ def test_diff_odfv(simple_dataset_1):
         # if no code is changed
         assert len(feast_object_diffs.feast_object_property_diffs) == 3
         assert feast_object_diffs.feast_object_property_diffs[0].property_name == "name"
+        # Note we should only now be looking at changes for the feature_transformation field
         assert (
             feast_object_diffs.feast_object_property_diffs[1].property_name
             == "feature_transformation.name"

--- a/sdk/python/tests/unit/diff/test_registry_diff.py
+++ b/sdk/python/tests/unit/diff/test_registry_diff.py
@@ -139,11 +139,11 @@ def test_diff_odfv(simple_dataset_1):
         assert feast_object_diffs.feast_object_property_diffs[0].property_name == "name"
         assert (
             feast_object_diffs.feast_object_property_diffs[1].property_name
-            == "user_defined_function.name"
+            == "transformation.name"
         )
         assert (
             feast_object_diffs.feast_object_property_diffs[2].property_name
-            == "user_defined_function.body_text"
+            == "transformation.body_text"
         )
 
 

--- a/sdk/python/tests/unit/diff/test_registry_diff.py
+++ b/sdk/python/tests/unit/diff/test_registry_diff.py
@@ -139,11 +139,11 @@ def test_diff_odfv(simple_dataset_1):
         assert feast_object_diffs.feast_object_property_diffs[0].property_name == "name"
         assert (
             feast_object_diffs.feast_object_property_diffs[1].property_name
-            == "transformation.name"
+            == "feature_transformation.name"
         )
         assert (
             feast_object_diffs.feast_object_property_diffs[2].property_name
-            == "transformation.body_text"
+            == "feature_transformation.body_text"
         )
 
 

--- a/sdk/python/tests/unit/test_feature_views.py
+++ b/sdk/python/tests/unit/test_feature_views.py
@@ -1,22 +1,16 @@
-import copy
 from datetime import timedelta
 
 import pytest
 from typeguard import TypeCheckError
 
-from feast.aggregation import Aggregation
 from feast.batch_feature_view import BatchFeatureView
 from feast.data_format import AvroFormat
-from feast.data_source import KafkaSource, PushSource
+from feast.data_source import KafkaSource
 from feast.entity import Entity
 from feast.feature_view import FeatureView
 from feast.field import Field
 from feast.infra.offline_stores.file_source import FileSource
-from feast.protos.feast.core.StreamFeatureView_pb2 import (
-    StreamFeatureView as StreamFeatureViewProto,
-)
 from feast.protos.feast.types.Value_pb2 import ValueType
-from feast.stream_feature_view import StreamFeatureView, stream_feature_view
 from feast.types import Float32
 
 
@@ -65,167 +59,8 @@ def test_create_batch_feature_view():
         )
 
 
-def test_create_stream_feature_view():
-    stream_source = KafkaSource(
-        name="kafka",
-        timestamp_field="event_timestamp",
-        kafka_bootstrap_servers="",
-        message_format=AvroFormat(""),
-        topic="topic",
-        batch_source=FileSource(path="some path"),
-    )
-    StreamFeatureView(
-        name="test kafka stream feature view",
-        entities=[],
-        ttl=timedelta(days=30),
-        source=stream_source,
-        aggregations=[],
-    )
-
-    push_source = PushSource(
-        name="push source", batch_source=FileSource(path="some path")
-    )
-    StreamFeatureView(
-        name="test push source feature view",
-        entities=[],
-        ttl=timedelta(days=30),
-        source=push_source,
-        aggregations=[],
-    )
-
-    with pytest.raises(TypeError):
-        StreamFeatureView(
-            name="test batch feature view",
-            entities=[],
-            ttl=timedelta(days=30),
-            aggregations=[],
-        )
-
-    with pytest.raises(ValueError):
-        StreamFeatureView(
-            name="test batch feature view",
-            entities=[],
-            ttl=timedelta(days=30),
-            source=FileSource(path="some path"),
-            aggregations=[],
-        )
-
-
 def simple_udf(x: int):
     return x + 3
-
-
-def test_stream_feature_view_serialization():
-    entity = Entity(name="driver_entity", join_keys=["test_key"])
-    stream_source = KafkaSource(
-        name="kafka",
-        timestamp_field="event_timestamp",
-        kafka_bootstrap_servers="",
-        message_format=AvroFormat(""),
-        topic="topic",
-        batch_source=FileSource(path="some path"),
-    )
-
-    sfv = StreamFeatureView(
-        name="test kafka stream feature view",
-        entities=[entity],
-        ttl=timedelta(days=30),
-        owner="test@example.com",
-        online=True,
-        schema=[Field(name="dummy_field", dtype=Float32)],
-        description="desc",
-        aggregations=[
-            Aggregation(
-                column="dummy_field",
-                function="max",
-                time_window=timedelta(days=1),
-            )
-        ],
-        timestamp_field="event_timestamp",
-        mode="spark",
-        source=stream_source,
-        udf=simple_udf,
-        tags={},
-    )
-
-    sfv_proto = sfv.to_proto()
-
-    new_sfv = StreamFeatureView.from_proto(sfv_proto=sfv_proto)
-    assert new_sfv == sfv
-
-
-def test_stream_feature_view_udfs():
-    entity = Entity(name="driver_entity", join_keys=["test_key"])
-    stream_source = KafkaSource(
-        name="kafka",
-        timestamp_field="event_timestamp",
-        kafka_bootstrap_servers="",
-        message_format=AvroFormat(""),
-        topic="topic",
-        batch_source=FileSource(path="some path"),
-    )
-
-    @stream_feature_view(
-        entities=[entity],
-        ttl=timedelta(days=30),
-        owner="test@example.com",
-        online=True,
-        schema=[Field(name="dummy_field", dtype=Float32)],
-        description="desc",
-        aggregations=[
-            Aggregation(
-                column="dummy_field",
-                function="max",
-                time_window=timedelta(days=1),
-            )
-        ],
-        timestamp_field="event_timestamp",
-        source=stream_source,
-    )
-    def pandas_udf(pandas_df):
-        import pandas as pd
-
-        assert type(pandas_df) == pd.DataFrame
-        df = pandas_df.transform(lambda x: x + 10, axis=1)
-        return df
-
-    import pandas as pd
-
-    df = pd.DataFrame({"A": [1, 2, 3], "B": [10, 20, 30]})
-    sfv = pandas_udf
-    sfv_proto = sfv.to_proto()
-    new_sfv = StreamFeatureView.from_proto(sfv_proto)
-    new_df = new_sfv.udf(df)
-
-    expected_df = pd.DataFrame({"A": [11, 12, 13], "B": [20, 30, 40]})
-
-    assert new_df.equals(expected_df)
-
-
-def test_stream_feature_view_initialization_with_optional_fields_omitted():
-    entity = Entity(name="driver_entity", join_keys=["test_key"])
-    stream_source = KafkaSource(
-        name="kafka",
-        timestamp_field="event_timestamp",
-        kafka_bootstrap_servers="",
-        message_format=AvroFormat(""),
-        topic="topic",
-        batch_source=FileSource(path="some path"),
-    )
-
-    sfv = StreamFeatureView(
-        name="test kafka stream feature view",
-        entities=[entity],
-        schema=[],
-        description="desc",
-        timestamp_field="event_timestamp",
-        source=stream_source,
-        tags={},
-    )
-    sfv_proto = sfv.to_proto()
-
-    new_sfv = StreamFeatureView.from_proto(sfv_proto=sfv_proto)
-    assert new_sfv == sfv
 
 
 def test_hash():
@@ -282,41 +117,3 @@ def test_hash():
 def test_field_types():
     with pytest.raises(TypeCheckError):
         Field(name="name", dtype=ValueType.INT32)
-
-
-def test_stream_feature_view_proto_type():
-    stream_source = KafkaSource(
-        name="kafka",
-        timestamp_field="event_timestamp",
-        kafka_bootstrap_servers="",
-        message_format=AvroFormat(""),
-        topic="topic",
-        batch_source=FileSource(path="some path"),
-    )
-    sfv = StreamFeatureView(
-        name="test stream featureview proto class",
-        entities=[],
-        ttl=timedelta(days=30),
-        source=stream_source,
-        aggregations=[],
-    )
-    assert sfv.proto_class is StreamFeatureViewProto
-
-
-def test_stream_feature_view_copy():
-    stream_source = KafkaSource(
-        name="kafka",
-        timestamp_field="event_timestamp",
-        kafka_bootstrap_servers="",
-        message_format=AvroFormat(""),
-        topic="topic",
-        batch_source=FileSource(path="some path"),
-    )
-    sfv = StreamFeatureView(
-        name="test stream featureview proto class",
-        entities=[],
-        ttl=timedelta(days=30),
-        source=stream_source,
-        aggregations=[],
-    )
-    assert sfv == copy.copy(sfv)

--- a/sdk/python/tests/unit/test_on_demand_feature_view.py
+++ b/sdk/python/tests/unit/test_on_demand_feature_view.py
@@ -129,3 +129,7 @@ def test_hash():
     assert on_demand_feature_view_5.transformation == OnDemandPandasTransformation(
         udf2, "udf2 source code"
     )
+    assert (
+        on_demand_feature_view_5.feature_transformation
+        == on_demand_feature_view_5.transformation
+    )

--- a/sdk/python/tests/unit/test_on_demand_feature_view.py
+++ b/sdk/python/tests/unit/test_on_demand_feature_view.py
@@ -133,3 +133,65 @@ def test_hash():
         on_demand_feature_view_5.feature_transformation
         == on_demand_feature_view_5.transformation
     )
+
+
+@pytest.mark.filterwarnings("ignore:udf and udf_string parameters are deprecated")
+def test_from_proto_backwards_compatable_udf():
+    file_source = FileSource(name="my-file-source", path="test.parquet")
+    feature_view = FeatureView(
+        name="my-feature-view",
+        entities=[],
+        schema=[
+            Field(name="feature1", dtype=Float32),
+            Field(name="feature2", dtype=Float32),
+        ],
+        source=file_source,
+    )
+    sources = [feature_view]
+    on_demand_feature_view = OnDemandFeatureView(
+        name="my-on-demand-feature-view",
+        sources=sources,
+        schema=[
+            Field(name="output1", dtype=Float32),
+            Field(name="output2", dtype=Float32),
+        ],
+        transformation=OnDemandPandasTransformation(
+            udf=udf1, udf_string="udf1 source code"
+        ),
+    )
+
+    # We need a proto with the "udf1 source code" in the user_defined_function.body_text
+    # and to populate it in feature_transformation
+    proto = on_demand_feature_view.to_proto()
+    assert (
+        on_demand_feature_view.transformation.udf_string
+        == proto.spec.feature_transformation.user_defined_function.body_text
+    )
+    # Because of the current set of code this is just confirming it is empty
+    assert proto.spec.user_defined_function.body_text == ""
+    assert proto.spec.user_defined_function.body == b""
+    assert proto.spec.user_defined_function.name == ""
+
+    # Assuming we pull it from the registry we set it to the feature_transformation proto values
+    proto.spec.user_defined_function.name = (
+        proto.spec.feature_transformation.user_defined_function.name
+    )
+    proto.spec.user_defined_function.body = (
+        proto.spec.feature_transformation.user_defined_function.body
+    )
+    proto.spec.user_defined_function.body_text = (
+        proto.spec.feature_transformation.user_defined_function.body_text
+    )
+
+    # And now we're going to null the feature_transformation proto object before reserializing the entire proto
+    # proto.spec.user_defined_function.body_text = on_demand_feature_view.transformation.udf_string
+    proto.spec.feature_transformation.user_defined_function.name = ""
+    proto.spec.feature_transformation.user_defined_function.body = b""
+    proto.spec.feature_transformation.user_defined_function.body_text = ""
+
+    # And now we expect the to get the same object back under feature_transformation
+    reserialized_proto = OnDemandFeatureView.from_proto(proto)
+    assert (
+        reserialized_proto.feature_transformation.udf_string
+        == on_demand_feature_view.feature_transformation.udf_string
+    )

--- a/sdk/python/tests/unit/test_sql_registry.py
+++ b/sdk/python/tests/unit/test_sql_registry.py
@@ -382,8 +382,8 @@ def test_apply_on_demand_feature_view_success(sql_registry):
 @pytest.mark.parametrize(
     "sql_registry",
     [
-        # lazy_fixture("mysql_registry"),
-        # lazy_fixture("pg_registry"),
+        lazy_fixture("mysql_registry"),
+        lazy_fixture("pg_registry"),
         lazy_fixture("sqlite_registry"),
     ],
 )

--- a/sdk/python/tests/unit/test_sql_registry.py
+++ b/sdk/python/tests/unit/test_sql_registry.py
@@ -382,8 +382,8 @@ def test_apply_on_demand_feature_view_success(sql_registry):
 @pytest.mark.parametrize(
     "sql_registry",
     [
-        lazy_fixture("mysql_registry"),
-        lazy_fixture("pg_registry"),
+        # lazy_fixture("mysql_registry"),
+        # lazy_fixture("pg_registry"),
         lazy_fixture("sqlite_registry"),
     ],
 )

--- a/sdk/python/tests/unit/test_stream_feature_view.py
+++ b/sdk/python/tests/unit/test_stream_feature_view.py
@@ -1,0 +1,252 @@
+import copy
+from datetime import timedelta
+
+import pytest
+
+from feast.aggregation import Aggregation
+from feast.batch_feature_view import BatchFeatureView
+from feast.data_format import AvroFormat
+from feast.data_source import KafkaSource, PushSource
+from feast.entity import Entity
+from feast.field import Field
+from feast.infra.offline_stores.file_source import FileSource
+from feast.protos.feast.core.StreamFeatureView_pb2 import (
+    StreamFeatureView as StreamFeatureViewProto,
+)
+from feast.stream_feature_view import StreamFeatureView, stream_feature_view
+from feast.types import Float32
+
+
+def test_create_batch_feature_view():
+    batch_source = FileSource(path="some path")
+    BatchFeatureView(
+        name="test batch feature view",
+        entities=[],
+        ttl=timedelta(days=30),
+        source=batch_source,
+    )
+
+    with pytest.raises(TypeError):
+        BatchFeatureView(
+            name="test batch feature view", entities=[], ttl=timedelta(days=30)
+        )
+
+    stream_source = KafkaSource(
+        name="kafka",
+        timestamp_field="event_timestamp",
+        kafka_bootstrap_servers="",
+        message_format=AvroFormat(""),
+        topic="topic",
+        batch_source=FileSource(path="some path"),
+    )
+    with pytest.raises(ValueError):
+        BatchFeatureView(
+            name="test batch feature view",
+            entities=[],
+            ttl=timedelta(days=30),
+            source=stream_source,
+        )
+
+
+def test_create_stream_feature_view():
+    stream_source = KafkaSource(
+        name="kafka",
+        timestamp_field="event_timestamp",
+        kafka_bootstrap_servers="",
+        message_format=AvroFormat(""),
+        topic="topic",
+        batch_source=FileSource(path="some path"),
+    )
+    StreamFeatureView(
+        name="test kafka stream feature view",
+        entities=[],
+        ttl=timedelta(days=30),
+        source=stream_source,
+        aggregations=[],
+    )
+
+    push_source = PushSource(
+        name="push source", batch_source=FileSource(path="some path")
+    )
+    StreamFeatureView(
+        name="test push source feature view",
+        entities=[],
+        ttl=timedelta(days=30),
+        source=push_source,
+        aggregations=[],
+    )
+
+    with pytest.raises(TypeError):
+        StreamFeatureView(
+            name="test batch feature view",
+            entities=[],
+            ttl=timedelta(days=30),
+            aggregations=[],
+        )
+
+    with pytest.raises(ValueError):
+        StreamFeatureView(
+            name="test batch feature view",
+            entities=[],
+            ttl=timedelta(days=30),
+            source=FileSource(path="some path"),
+            aggregations=[],
+        )
+
+
+def simple_udf(x: int):
+    return x + 3
+
+
+def test_stream_feature_view_serialization():
+    entity = Entity(name="driver_entity", join_keys=["test_key"])
+    stream_source = KafkaSource(
+        name="kafka",
+        timestamp_field="event_timestamp",
+        kafka_bootstrap_servers="",
+        message_format=AvroFormat(""),
+        topic="topic",
+        batch_source=FileSource(path="some path"),
+    )
+
+    sfv = StreamFeatureView(
+        name="test kafka stream feature view",
+        entities=[entity],
+        ttl=timedelta(days=30),
+        owner="test@example.com",
+        online=True,
+        schema=[Field(name="dummy_field", dtype=Float32)],
+        description="desc",
+        aggregations=[
+            Aggregation(
+                column="dummy_field",
+                function="max",
+                time_window=timedelta(days=1),
+            )
+        ],
+        timestamp_field="event_timestamp",
+        mode="spark",
+        source=stream_source,
+        udf=simple_udf,
+        tags={},
+    )
+
+    sfv_proto = sfv.to_proto()
+
+    new_sfv = StreamFeatureView.from_proto(sfv_proto=sfv_proto)
+    assert new_sfv == sfv
+    assert (
+        sfv_proto.spec.feature_transformation.user_defined_function.name == "simple_udf"
+    )
+
+
+def test_stream_feature_view_udfs():
+    entity = Entity(name="driver_entity", join_keys=["test_key"])
+    stream_source = KafkaSource(
+        name="kafka",
+        timestamp_field="event_timestamp",
+        kafka_bootstrap_servers="",
+        message_format=AvroFormat(""),
+        topic="topic",
+        batch_source=FileSource(path="some path"),
+    )
+
+    @stream_feature_view(
+        entities=[entity],
+        ttl=timedelta(days=30),
+        owner="test@example.com",
+        online=True,
+        schema=[Field(name="dummy_field", dtype=Float32)],
+        description="desc",
+        aggregations=[
+            Aggregation(
+                column="dummy_field",
+                function="max",
+                time_window=timedelta(days=1),
+            )
+        ],
+        timestamp_field="event_timestamp",
+        source=stream_source,
+    )
+    def pandas_udf(pandas_df):
+        import pandas as pd
+
+        assert type(pandas_df) == pd.DataFrame
+        df = pandas_df.transform(lambda x: x + 10, axis=1)
+        return df
+
+    import pandas as pd
+
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [10, 20, 30]})
+    sfv = pandas_udf
+    sfv_proto = sfv.to_proto()
+    new_sfv = StreamFeatureView.from_proto(sfv_proto)
+    new_df = new_sfv.udf(df)
+
+    expected_df = pd.DataFrame({"A": [11, 12, 13], "B": [20, 30, 40]})
+
+    assert new_df.equals(expected_df)
+
+
+def test_stream_feature_view_initialization_with_optional_fields_omitted():
+    entity = Entity(name="driver_entity", join_keys=["test_key"])
+    stream_source = KafkaSource(
+        name="kafka",
+        timestamp_field="event_timestamp",
+        kafka_bootstrap_servers="",
+        message_format=AvroFormat(""),
+        topic="topic",
+        batch_source=FileSource(path="some path"),
+    )
+
+    sfv = StreamFeatureView(
+        name="test kafka stream feature view",
+        entities=[entity],
+        schema=[],
+        description="desc",
+        timestamp_field="event_timestamp",
+        source=stream_source,
+        tags={},
+    )
+    sfv_proto = sfv.to_proto()
+
+    new_sfv = StreamFeatureView.from_proto(sfv_proto=sfv_proto)
+    assert new_sfv == sfv
+
+
+def test_stream_feature_view_proto_type():
+    stream_source = KafkaSource(
+        name="kafka",
+        timestamp_field="event_timestamp",
+        kafka_bootstrap_servers="",
+        message_format=AvroFormat(""),
+        topic="topic",
+        batch_source=FileSource(path="some path"),
+    )
+    sfv = StreamFeatureView(
+        name="test stream featureview proto class",
+        entities=[],
+        ttl=timedelta(days=30),
+        source=stream_source,
+        aggregations=[],
+    )
+    assert sfv.proto_class is StreamFeatureViewProto
+
+
+def test_stream_feature_view_copy():
+    stream_source = KafkaSource(
+        name="kafka",
+        timestamp_field="event_timestamp",
+        kafka_bootstrap_servers="",
+        message_format=AvroFormat(""),
+        topic="topic",
+        batch_source=FileSource(path="some path"),
+    )
+    sfv = StreamFeatureView(
+        name="test stream featureview proto class",
+        entities=[],
+        ttl=timedelta(days=30),
+        source=stream_source,
+        aggregations=[],
+    )
+    assert sfv == copy.copy(sfv)

--- a/ui/src/pages/feature-views/OnDemandFeatureViewOverviewTab.tsx
+++ b/ui/src/pages/feature-views/OnDemandFeatureViewOverviewTab.tsx
@@ -57,7 +57,7 @@ const OnDemandFeatureViewOverviewTab = ({
             </EuiTitle>
             <EuiHorizontalRule margin="xs" />
             <EuiCodeBlock language="py" fontSize="m" paddingSize="m">
-              {data?.spec?.userDefinedFunction?.bodyText}
+              {data?.spec?.transformation?.userDefinedFunction?.bodyText}
             </EuiCodeBlock>
           </EuiPanel>
         </EuiFlexItem>

--- a/ui/src/pages/feature-views/OnDemandFeatureViewOverviewTab.tsx
+++ b/ui/src/pages/feature-views/OnDemandFeatureViewOverviewTab.tsx
@@ -57,7 +57,7 @@ const OnDemandFeatureViewOverviewTab = ({
             </EuiTitle>
             <EuiHorizontalRule margin="xs" />
             <EuiCodeBlock language="py" fontSize="m" paddingSize="m">
-              {data?.spec?.transformation?.userDefinedFunction?.bodyText}
+              {data?.spec?.feature_transformation?.userDefinedFunction?.bodyText}
             </EuiCodeBlock>
           </EuiPanel>
         </EuiFlexItem>

--- a/ui/src/pages/feature-views/OnDemandFeatureViewOverviewTab.tsx
+++ b/ui/src/pages/feature-views/OnDemandFeatureViewOverviewTab.tsx
@@ -57,7 +57,7 @@ const OnDemandFeatureViewOverviewTab = ({
             </EuiTitle>
             <EuiHorizontalRule margin="xs" />
             <EuiCodeBlock language="py" fontSize="m" paddingSize="m">
-              {data?.spec?.feature_transformation?.userDefinedFunction?.bodyText}
+              {data?.spec?.featureTransformation?.userDefinedFunction?.bodyText}
             </EuiCodeBlock>
           </EuiPanel>
         </EuiFlexItem>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

**What this PR does / why we need it**:

This PR updates the `OnDemandFeatureView` and `StreamingFeatureView` protobuf objectss into separate `FeatureTransformation` protobuf objects explicitly. This is a much cleaner way for machine learning engineers to understand the transformations. 

This PR will do the following:
1. Create the new `FeatureTransformation.proto` file and object
2. Deprecate `UserDefinedFunction` in the `OnDemandFeatureView.proto` and `StreamFeatureView.proto` files
3. Store the new `FeatureTransformationProto` in the `OnDemandFeatureViewSpec` and `StreamFeatureViewSpecProto` objects so that when writes are executed the new protos are stored alongside the old protos
4. Read from both the old `UserDefinedFunction` proto and the new `FeatureTransformation` proto and handle the case when  `UserDefinedFunction` is present and  `FeatureTransformation` is missing
5. Add warnings that the `UserDefinedFunction` will be deprecated
6. Update the UI to use the newly structured object

We will make this release with dual writes and the "coalesce-like" read so that the behavior is backwards compatible and also enables a safe roll out for users. 

We will deprecate the `UserDefinedFunction` before releasing to Feast `1.0.0`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
