### PR TITLE
fix: Run feature server w/o gunicorn on windows

### DIFF
--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -49,3 +49,6 @@ DEFAULT_REGISTRY_SERVER_PORT = 6570
 
 # Environment variable for feature server docker image tag
 DOCKER_IMAGE_TAG_ENV_NAME: str = "FEAST_SERVER_DOCKER_IMAGE_TAG"
+
+# Default feature server registry ttl (seconds)
+DEFAULT_FEATURE_SERVER_REGISTRY_TTL = 5

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -236,7 +236,7 @@ def start_server(
     no_access_log: bool,
     workers: int,
     keep_alive_timeout: int,
-    registry_ttl_sec: int = 5,
+    registry_ttl_sec: int,
 ):
     if sys.platform != "win32":
         FeastServeApplication(

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -1,10 +1,10 @@
 import json
+import sys
 import threading
 import traceback
 import warnings
 from typing import List, Optional
 
-import gunicorn.app.base
 import pandas as pd
 from dateutil import parser
 from fastapi import FastAPI, HTTPException, Request, Response, status
@@ -202,24 +202,27 @@ def get_app(store: "feast.FeatureStore", registry_ttl_sec: int = 5):
     return app
 
 
-class FeastServeApplication(gunicorn.app.base.BaseApplication):
-    def __init__(self, store: "feast.FeatureStore", **options):
-        self._app = get_app(
-            store=store,
-            registry_ttl_sec=options.get("registry_ttl_sec", 5),
-        )
-        self._options = options
-        super().__init__()
+if sys.platform != "win32":
+    import gunicorn.app.base
 
-    def load_config(self):
-        for key, value in self._options.items():
-            if key.lower() in self.cfg.settings and value is not None:
-                self.cfg.set(key.lower(), value)
+    class FeastServeApplication(gunicorn.app.base.BaseApplication):
+        def __init__(self, store: "feast.FeatureStore", **options):
+            self._app = get_app(
+                store=store,
+                registry_ttl_sec=options.get("registry_ttl_sec", 5),
+            )
+            self._options = options
+            super().__init__()
 
-        self.cfg.set("worker_class", "uvicorn.workers.UvicornWorker")
+        def load_config(self):
+            for key, value in self._options.items():
+                if key.lower() in self.cfg.settings and value is not None:
+                    self.cfg.set(key.lower(), value)
 
-    def load(self):
-        return self._app
+            self.cfg.set("worker_class", "uvicorn.workers.UvicornWorker")
+
+        def load(self):
+            return self._app
 
 
 def start_server(
@@ -231,11 +234,17 @@ def start_server(
     keep_alive_timeout: int,
     registry_ttl_sec: int = 5,
 ):
-    FeastServeApplication(
-        store=store,
-        bind=f"{host}:{port}",
-        accesslog=None if no_access_log else "-",
-        workers=workers,
-        keepalive=keep_alive_timeout,
-        registry_ttl_sec=registry_ttl_sec,
-    ).run()
+    if sys.platform != "win32":
+        FeastServeApplication(
+            store=store,
+            bind=f"{host}:{port}",
+            accesslog=None if no_access_log else "-",
+            workers=workers,
+            keepalive=keep_alive_timeout,
+            registry_ttl_sec=registry_ttl_sec,
+        ).run()
+    else:
+        import uvicorn
+
+        app = get_app(store, registry_ttl_sec)
+        uvicorn.run(app, host=host, port=port, access_log=(not no_access_log))

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 
 import feast
 from feast import proto_json, utils
+from feast.constants import DEFAULT_FEATURE_SERVER_REGISTRY_TTL
 from feast.data_source import PushMode
 from feast.errors import PushSourceNotFoundException
 from feast.protos.feast.serving.ServingService_pb2 import GetOnlineFeaturesRequest
@@ -45,7 +46,10 @@ class MaterializeIncrementalRequest(BaseModel):
     feature_views: Optional[List[str]] = None
 
 
-def get_app(store: "feast.FeatureStore", registry_ttl_sec: int = 5):
+def get_app(
+    store: "feast.FeatureStore",
+    registry_ttl_sec: int = DEFAULT_FEATURE_SERVER_REGISTRY_TTL,
+):
     proto_json.patch()
 
     app = FastAPI()
@@ -209,7 +213,7 @@ if sys.platform != "win32":
         def __init__(self, store: "feast.FeatureStore", **options):
             self._app = get_app(
                 store=store,
-                registry_ttl_sec=options.get("registry_ttl_sec", 5),
+                registry_ttl_sec=options["registry_ttl_sec"],
             )
             self._options = options
             super().__init__()

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ REQUIRED = [
     "typeguard>=4.0.0",
     "fastapi>=0.68.0",
     "uvicorn[standard]>=0.14.0,<1",
-    "gunicorn",
+    "gunicorn; platform_system != 'Windows'",
     # https://github.com/dask/dask/issues/10996
     "dask>=2021.1.0,<2024.3.0",
     "bowler",  # Needed for automatic repo upgrades


### PR DESCRIPTION
**What this PR does / why we need it**:
#3636 introduced `gunicorn` to run `uvicorn` workers to improve feature server performance. Unfortunately `gunicorn` import happens at the module level and breaks feast on windows which is not supported by `gunicorn`. This PR checks which platform is being used and falls back on pure `uvicorn` server on windows. 

**Which issue(s) this PR fixes**:
Fixes #3770
