### PR TITLE
fix: Remove parentheses in pull_latest_from_table_or_query

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
@@ -94,7 +94,7 @@ class PostgreSQLOfflineStore(OfflineStore):
             FROM (
                 SELECT {a_field_string},
                 ROW_NUMBER() OVER({partition_by_join_key_string} ORDER BY {timestamp_desc_string}) AS _feast_row
-                FROM ({from_expression}) a
+                FROM {from_expression} a
                 WHERE a."{timestamp_field}" BETWEEN '{start_date}'::timestamptz AND '{end_date}'::timestamptz
             ) b
             WHERE _feast_row = 1


### PR DESCRIPTION
**What this PR does / why we need it**:
[pull_latest_from_table_or_query](https://github.com/feast-dev/feast/blob/9df2224283e04760116b61bed3c8bfa7f17cbf7e/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py#L60) attempts to pull the latest data using the outputted string from [get_table_query_string](https://github.com/feast-dev/feast/blob/9df2224283e04760116b61bed3c8bfa7f17cbf7e/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres_source.py#L119). However on line [97](https://github.com/feast-dev/feast/blob/9df2224283e04760116b61bed3c8bfa7f17cbf7e/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py#L97) of postgres.py the query includes open and close parens assuming an inner query. These params should be removed from the query and handled by get_table_query_string (which it is).

**Which issue(s) this PR fixes**:
Fixes #3804 
