### PR TITLE
fix: Remove or empty string statement in to_proto() definition

### DIFF
--- a/sdk/python/feast/feature_view_projection.py
+++ b/sdk/python/feast/feature_view_projection.py
@@ -41,7 +41,7 @@ class FeatureViewProjection:
     def to_proto(self) -> FeatureViewProjectionProto:
         feature_reference_proto = FeatureViewProjectionProto(
             feature_view_name=self.name,
-            feature_view_name_alias=self.name_alias or "",
+            feature_view_name_alias=self.name_alias or None,
             join_key_map=self.join_key_map,
         )
         for feature in self.features:


### PR DESCRIPTION
Fixes #4030
