### PR TITLE
fix: Substrait ODFVs for online

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -2037,11 +2037,10 @@ class FeatureStore:
 
             proto_values = []
             for selected_feature in selected_subset:
-                if odfv.mode in ["python", "pandas"]:
-                    feature_vector = transformed_features[selected_feature]
-                    proto_values.append(
-                        python_values_to_proto_values(feature_vector, ValueType.UNKNOWN)
-                    )
+                feature_vector = transformed_features[selected_feature]
+                proto_values.append(
+                    python_values_to_proto_values(feature_vector, ValueType.UNKNOWN)
+                )
 
             odfv_result_names |= set(selected_subset)
 

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -128,7 +128,7 @@ class RetrievalJob(ABC):
         features_df = self._to_df_internal(timeout=timeout)
         if self.on_demand_feature_views:
             for odfv in self.on_demand_feature_views:
-                if odfv.mode != "pandas":
+                if odfv.mode not in {"pandas", "substrait"}:
                     raise Exception(
                         f'OnDemandFeatureView mode "{odfv.mode}" not supported for offline processing.'
                     )

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -465,7 +465,7 @@ class OnDemandFeatureView(BaseFeatureView):
             return self.get_transformed_features_dict(
                 feature_dict=features,
             )
-        elif self.mode == "pandas" and isinstance(features, pd.DataFrame):
+        elif self.mode in {"pandas", "substrait"} and isinstance(features, pd.DataFrame):
             return self.get_transformed_features_df(
                 df_with_features=features,
                 full_feature_names=full_feature_names,

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -465,7 +465,9 @@ class OnDemandFeatureView(BaseFeatureView):
             return self.get_transformed_features_dict(
                 feature_dict=features,
             )
-        elif self.mode in {"pandas", "substrait"} and isinstance(features, pd.DataFrame):
+        elif self.mode in {"pandas", "substrait"} and isinstance(
+            features, pd.DataFrame
+        ):
             return self.get_transformed_features_df(
                 df_with_features=features,
                 full_feature_names=full_feature_names,

--- a/sdk/python/tests/unit/test_substrait_transformation.py
+++ b/sdk/python/tests/unit/test_substrait_transformation.py
@@ -84,7 +84,10 @@ def test_ibis_pandas_parity():
             [driver, driver_stats_source, driver_stats_fv, substrait_view, pandas_view]
         )
 
-        store.materialize(start_date=datetime(2000, 4, 12, 10, 59, 42), end_date=datetime(3000, 4, 12, 10, 59, 42))
+        store.materialize(
+            start_date=datetime(2000, 4, 12, 10, 59, 42),
+            end_date=datetime(3000, 4, 12, 10, 59, 42),
+        )
 
         entity_df = pd.DataFrame.from_dict(
             {
@@ -99,9 +102,6 @@ def test_ibis_pandas_parity():
             }
         )
 
-        substrait_view.infer_features()
-        pandas_view.infer_features()
-
         requested_features = [
             "driver_hourly_stats:conv_rate",
             "driver_hourly_stats:acc_rate",
@@ -111,8 +111,7 @@ def test_ibis_pandas_parity():
         ]
 
         training_df = store.get_historical_features(
-            entity_df=entity_df,
-            features=requested_features
+            entity_df=entity_df, features=requested_features
         )
 
         assert training_df.to_df()["conv_rate_plus_acc"].equals(
@@ -125,7 +124,10 @@ def test_ibis_pandas_parity():
 
         online_response = store.get_online_features(
             features=requested_features,
-            entity_rows=[{"driver_id": 1001}, {"driver_id": 1002}, {"driver_id": 1003}]
+            entity_rows=[{"driver_id": 1001}, {"driver_id": 1002}, {"driver_id": 1003}],
         )
 
-        assert online_response.to_dict()['conv_rate_plus_acc'] == online_response.to_dict()['conv_rate_plus_acc_substrait']
+        assert (
+            online_response.to_dict()["conv_rate_plus_acc"]
+            == online_response.to_dict()["conv_rate_plus_acc_substrait"]
+        )


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes `substrait` odfvs for online processing and adds necessary unit tests.
