### PR TITLE
feat: Make arrow primary interchange for offline ODFV execution

### DIFF
--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -397,9 +397,8 @@ class OnDemandFeatureView(BaseFeatureView):
         pa_table: pyarrow.Table,
         full_feature_names: bool = False,
     ) -> pyarrow.Table:
-        # Apply on demand transformations
         if not isinstance(pa_table, pyarrow.Table):
-            raise TypeError("get_transformed_features_df only accepts pyarrow.Table")
+            raise TypeError("transform_arrow only accepts pyarrow.Table")
         columns_to_cleanup = []
         for source_fv_projection in self.source_feature_view_projections.values():
             for feature in source_fv_projection.features:
@@ -419,7 +418,6 @@ class OnDemandFeatureView(BaseFeatureView):
                     )
                     columns_to_cleanup.append(full_feature_ref)
 
-        # Compute transformed values and apply to each result row
         df_with_transformed_features: pyarrow.Table = (
             self.feature_transformation.transform_arrow(pa_table)
         )
@@ -435,7 +433,6 @@ class OnDemandFeatureView(BaseFeatureView):
             ):
                 rename_columns[short_name] = long_name
             elif not full_feature_names:
-                # Long name must be in dataframe.
                 rename_columns[long_name] = short_name
 
         # Cleanup extra columns used for transformation

--- a/sdk/python/feast/transformation/pandas_transformation.py
+++ b/sdk/python/feast/transformation/pandas_transformation.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List
 
 import dill
 import pandas as pd
+import pyarrow
 
 from feast.field import Field, from_value_type
 from feast.protos.feast.core.Transformation_pb2 import (
@@ -25,6 +26,19 @@ class PandasTransformation:
         """
         self.udf = udf
         self.udf_string = udf_string
+
+    def transform_arrow(self, pa_table: pyarrow.Table) -> pyarrow.Table:
+        if not isinstance(pa_table, pyarrow.Table):
+            raise TypeError(
+                f"pa_table should be type pyarrow.Table but got {type(pa_table).__name__}"
+            )
+        output_df = self.udf.__call__(pa_table.to_pandas())
+        output_df = pyarrow.Table.from_pandas(output_df)
+        if not isinstance(output_df, pyarrow.Table):
+            raise TypeError(
+                f"output_df should be type pyarrow.Table but got {type(output_df).__name__}"
+            )
+        return output_df
 
     def transform(self, input_df: pd.DataFrame) -> pd.DataFrame:
         if not isinstance(input_df, pd.DataFrame):

--- a/sdk/python/feast/transformation/python_transformation.py
+++ b/sdk/python/feast/transformation/python_transformation.py
@@ -2,6 +2,7 @@ from types import FunctionType
 from typing import Any, Dict, List
 
 import dill
+import pyarrow
 
 from feast.field import Field, from_value_type
 from feast.protos.feast.core.Transformation_pb2 import (
@@ -23,6 +24,11 @@ class PythonTransformation:
         """
         self.udf = udf
         self.udf_string = udf_string
+
+    def transform_arrow(self, pa_table: pyarrow.Table) -> pyarrow.Table:
+        raise Exception(
+            'OnDemandFeatureView mode "python" not supported for offline processing.'
+        )
 
     def transform(self, input_dict: Dict) -> Dict:
         if not isinstance(input_dict, Dict):

--- a/sdk/python/feast/transformation/substrait_transformation.py
+++ b/sdk/python/feast/transformation/substrait_transformation.py
@@ -34,6 +34,15 @@ class SubstraitTransformation:
         ).read_all()
         return table.to_pandas()
 
+    def transform_arrow(self, pa_table: pyarrow.Table) -> pyarrow.Table:
+        def table_provider(names, schema: pyarrow.Schema):
+            return pa_table.select(schema.names)
+
+        table: pyarrow.Table = pyarrow.substrait.run_query(
+            self.substrait_plan, table_provider=table_provider
+        ).read_all()
+        return table
+
     def infer_features(self, random_input: Dict[str, List[Any]]) -> List[Field]:
         df = pd.DataFrame.from_dict(random_input)
         output_df: pd.DataFrame = self.transform(df)

--- a/sdk/python/tests/unit/infra/offline_stores/test_offline_store.py
+++ b/sdk/python/tests/unit/infra/offline_stores/test_offline_store.py
@@ -216,7 +216,7 @@ def test_to_sql():
 
 @pytest.mark.parametrize("timeout", (None, 30))
 def test_to_df_timeout(retrieval_job, timeout: Optional[int]):
-    with patch.object(retrieval_job, "_to_df_internal") as mock_to_df_internal:
+    with patch.object(retrieval_job, "_to_arrow_internal") as mock_to_df_internal:
         retrieval_job.to_df(timeout=timeout)
         mock_to_df_internal.assert_called_once_with(timeout=timeout)
 


### PR DESCRIPTION
# What this PR does / why we need it:
ODFV execution in offline flow revolves around pandas as both `pandas` and `substrait` transformations take pandas dataframes as an input. `substrait` has an unnecessary performance penalty as a consequence because it has to then convert pandas to arrow before execution. This PR flips the order around and makes arrow the primary interchange for execution, therefore `substrait` transformation can work without ever touching pandas.

P.S. This PR only touches offline flow for now just to make the scope smaller. I'll make necessary changes to the online side later in a separate PR and get rid of some of the dead code that will be left unused.