### PR TITLE
fix: Disable the Feast Usage feature by default.

### DIFF
--- a/docs/reference/usage.md
+++ b/docs/reference/usage.md
@@ -2,11 +2,11 @@
 
 ## How Feast SDK usage is measured
 
-The Feast project logs anonymous usage statistics and errors in order to inform our planning. Several client methods are tracked, beginning in Feast 0.9. Users are assigned a UUID which is sent along with the name of the method, the Feast version, the OS \(using `sys.platform`\), and the current time.
+The Feast project has a feature to log usage statistics and errors. Several client methods are tracked, beginning in Feast 0.9. Users are assigned a UUID which is sent along with the name of the method, the Feast version, the OS \(using `sys.platform`\), and the current time.
 
 The [source code](https://github.com/feast-dev/feast/blob/master/sdk/python/feast/usage.py) is available here.
 
-## How to disable usage logging
+## How to enable the usage logging
 
-Set the environment variable `FEAST_USAGE` to `False`.
+Set the environment variable `FEAST_USAGE` to `True` (in String type) and config your endpoint by the variable `FEAST_USAGE_ENDPOINT`.  
 

--- a/sdk/python/feast/constants.py
+++ b/sdk/python/feast/constants.py
@@ -29,11 +29,11 @@ FEAST_FS_YAML_FILE_PATH_ENV_NAME: str = "FEAST_FS_YAML_FILE_PATH"
 # Environment variable for registry
 REGISTRY_ENV_NAME: str = "REGISTRY_BASE64"
 
-# Environment variable for toggling usage
+# Environment variable for toggling the Usage feature
 FEAST_USAGE = "FEAST_USAGE"
 
-# Default value for FEAST_USAGE when environment variable is not set
-DEFAULT_FEAST_USAGE_VALUE = "True"
+# Environment variable for FEAST_USAGE_ENDPOINT
+FEAST_USAGE_ENDPOINT = "FEAST_USAGE_ENDPOINT"
 
 # Environment variable for the path for overwriting universal test configs
 FULL_REPO_CONFIGS_MODULE_ENV_NAME: str = "FULL_REPO_CONFIGS_MODULE"

--- a/sdk/python/feast/usage.py
+++ b/sdk/python/feast/usage.py
@@ -30,15 +30,17 @@ from pathlib import Path
 import requests
 
 from feast import flags_helper
-from feast.constants import DEFAULT_FEAST_USAGE_VALUE, FEAST_USAGE
+from feast.constants import FEAST_USAGE, FEAST_USAGE_ENDPOINT
 from feast.version import get_version
-
-USAGE_ENDPOINT = "https://usage.feast.dev"
 
 _logger = logging.getLogger(__name__)
 _executor = concurrent.futures.ThreadPoolExecutor(max_workers=3)
 
-_is_enabled = os.getenv(FEAST_USAGE, default=DEFAULT_FEAST_USAGE_VALUE) == "True"
+_is_enabled = os.getenv(FEAST_USAGE, default="False") == "True"
+
+# Default usage endpoint value.
+# Will raise an exception if the configured value is not working.
+_usage_endpoint = os.getenv(FEAST_USAGE_ENDPOINT, default="")
 
 _constant_attributes = {
     "project_id": "",
@@ -177,7 +179,7 @@ _set_installation_id()
 
 
 def _export(event: typing.Dict[str, typing.Any]):
-    _executor.submit(requests.post, USAGE_ENDPOINT, json=event, timeout=2)
+    _executor.submit(requests.post, _usage_endpoint, json=event, timeout=2)
 
 
 def _produce_event(ctx: UsageContext):


### PR DESCRIPTION
# What this PR does / why we need it:
The "usage.feast.dev" is no long available.  Let's disable it by default.

# Which issue(s) this PR fixes:


# Fixes #3886 
