### PR TITLE
fix: Trying to import pyspark lazily to avoid the dependency on the library

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -4,8 +4,6 @@ import warnings
 from enum import Enum
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
-from pyspark.sql import SparkSession
-
 from feast import flags_helper
 from feast.data_source import DataSource
 from feast.errors import DataSourceNoNameException, DataSourceNotFoundException
@@ -162,6 +160,13 @@ class SparkSource(DataSource):
 
     def get_table_query_string(self) -> str:
         """Returns a string that can directly be used to reference this table in SQL"""
+        try:
+            from pyspark.sql import SparkSession
+        except ImportError as e:
+            from feast.errors import FeastExtrasDependencyImportError
+
+            raise FeastExtrasDependencyImportError("spark", str(e))
+
         if self.table:
             # Backticks make sure that spark sql knows this a table reference.
             table = ".".join([f"`{x}`" for x in self.table.split(".")])


### PR DESCRIPTION
Importing pyspark lazily.

This change will fix the issue - https://github.com/feast-dev/feast/issues/3872

Picked up changes from the PR - https://github.com/feast-dev/feast/pull/3873