### PR TITLE
fix: Making the query_timeout variable as optional int because upstream is considered to be optional

### DIFF
--- a/sdk/python/feast/infra/contrib/spark_kafka_processor.py
+++ b/sdk/python/feast/infra/contrib/spark_kafka_processor.py
@@ -21,7 +21,7 @@ from feast.stream_feature_view import StreamFeatureView
 class SparkProcessorConfig(ProcessorConfig):
     spark_session: SparkSession
     processing_time: str
-    query_timeout: int
+    query_timeout: Optional[int] = None
 
 
 class SparkKafkaProcessor(StreamProcessor):


### PR DESCRIPTION
making the query_timeout variable as optional int because upstream timeout is also optional. This is expected to fix the issue - https://github.com/feast-dev/feast/issues/3799