### PR TITLE
feat: Incorporate substrait ODFVs into ibis-based offline store queries

### DIFF
--- a/protos/feast/core/Transformation.proto
+++ b/protos/feast/core/Transformation.proto
@@ -29,4 +29,5 @@ message FeatureTransformationV2 {
 
 message SubstraitTransformationV2 {
   bytes substrait_plan = 1;
+  bytes ibis_function = 2;
 }

--- a/sdk/python/feast/infra/offline_stores/ibis.py
+++ b/sdk/python/feast/infra/offline_stores/ibis.py
@@ -193,9 +193,15 @@ class IbisOfflineStore(OfflineStore):
             event_timestamp_col=event_timestamp_col,
         )
 
+        odfvs = OnDemandFeatureView.get_requested_odfvs(feature_refs, project, registry)
+
+        substrait_odfvs = [fv for fv in odfvs if fv.mode == "substrait"]
+        for odfv in substrait_odfvs:
+            res = odfv.transform_ibis(res, full_feature_names)
+
         return IbisRetrievalJob(
             res,
-            OnDemandFeatureView.get_requested_odfvs(feature_refs, project, registry),
+            [fv for fv in odfvs if fv.mode != "substrait"],
             full_feature_names,
             metadata=RetrievalMetadata(
                 features=feature_refs,

--- a/sdk/python/feast/transformation/pandas_transformation.py
+++ b/sdk/python/feast/transformation/pandas_transformation.py
@@ -27,7 +27,9 @@ class PandasTransformation:
         self.udf = udf
         self.udf_string = udf_string
 
-    def transform_arrow(self, pa_table: pyarrow.Table) -> pyarrow.Table:
+    def transform_arrow(
+        self, pa_table: pyarrow.Table, features: List[Field]
+    ) -> pyarrow.Table:
         if not isinstance(pa_table, pyarrow.Table):
             raise TypeError(
                 f"pa_table should be type pyarrow.Table but got {type(pa_table).__name__}"

--- a/sdk/python/feast/transformation/python_transformation.py
+++ b/sdk/python/feast/transformation/python_transformation.py
@@ -25,7 +25,9 @@ class PythonTransformation:
         self.udf = udf
         self.udf_string = udf_string
 
-    def transform_arrow(self, pa_table: pyarrow.Table) -> pyarrow.Table:
+    def transform_arrow(
+        self, pa_table: pyarrow.Table, features: List[Field]
+    ) -> pyarrow.Table:
         raise Exception(
             'OnDemandFeatureView mode "python" not supported for offline processing.'
         )

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -343,17 +343,23 @@ class UniversalFeatureViews:
 def construct_universal_feature_views(
     data_sources: UniversalDataSources,
     with_odfv: bool = True,
+    use_substrait_odfv: bool = False,
 ) -> UniversalFeatureViews:
     driver_hourly_stats = create_driver_hourly_stats_feature_view(data_sources.driver)
     driver_hourly_stats_base_feature_view = (
         create_driver_hourly_stats_batch_feature_view(data_sources.driver)
     )
+
     return UniversalFeatureViews(
         customer=create_customer_daily_profile_feature_view(data_sources.customer),
         global_fv=create_global_stats_feature_view(data_sources.global_ds),
         driver=driver_hourly_stats,
         driver_odfv=conv_rate_plus_100_feature_view(
-            [driver_hourly_stats_base_feature_view, create_conv_rate_request_source()]
+            [
+                driver_hourly_stats_base_feature_view[["conv_rate"]],
+                create_conv_rate_request_source(),
+            ],
+            use_substrait_odfv=use_substrait_odfv,
         )
         if with_odfv
         else None,

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -41,12 +41,19 @@ np.random.seed(0)
 @pytest.mark.integration
 @pytest.mark.universal_offline_stores
 @pytest.mark.parametrize("full_feature_names", [True, False], ids=lambda v: f"full:{v}")
-def test_historical_features(environment, universal_data_sources, full_feature_names):
+@pytest.mark.parametrize(
+    "use_substrait_odfv", [True, False], ids=lambda v: f"substrait:{v}"
+)
+def test_historical_features(
+    environment, universal_data_sources, full_feature_names, use_substrait_odfv
+):
     store = environment.feature_store
 
     (entities, datasets, data_sources) = universal_data_sources
 
-    feature_views = construct_universal_feature_views(data_sources)
+    feature_views = construct_universal_feature_views(
+        data_sources, use_substrait_odfv=use_substrait_odfv
+    )
 
     entity_df_with_request_data = datasets.entity_df.copy(deep=True)
     entity_df_with_request_data["val_to_add"] = [

--- a/sdk/python/tests/unit/test_substrait_transformation.py
+++ b/sdk/python/tests/unit/test_substrait_transformation.py
@@ -75,10 +75,8 @@ def test_ibis_pandas_parity():
             mode="substrait",
         )
         def substrait_view(inputs: Table) -> Table:
-            return inputs.select(
-                (inputs["conv_rate"] + inputs["acc_rate"]).name(
-                    "conv_rate_plus_acc_substrait"
-                )
+            return inputs.mutate(
+                conv_rate_plus_acc_substrait=inputs["conv_rate"] + inputs["acc_rate"]
             )
 
         store.apply(


### PR DESCRIPTION
# What this PR does / why we need it:
This PR changes the offline flow for ODFV execution in ibis-based offline stores (currently only duckdb). Instead of collecting raw offline store output into a pyarrow table and applying a substrait transformation with acero, ibis-based offline stores now get ibis functions and directly extend ibis logical plan, meaning ODFVs will be executed by the offline store engine itself.

The feature necessitated a couple of underlying changes in `substrait` ODFVs:
1. `substrait` ODVS now also store ibis python functions in protos to directly apply these functions in `transform_ibis`. This can probably be avoided in the future if there's a good substrait to ibis compiler in place, but currently is the simplest solution. Note: there are other problems here as well, substrait plans need to know precisely what input columns they will consume, this is problematic in the offline flow as there's no way to know beforehand which features the user will request in `get_historical_features` call. To correctly apply ODFVs, one would need to apply each ODFV to a relevant subset of columns and then join all tables back together (kind of like how it's done in the online flow), which is a horrible waste of resources. 
2. Unlike pandas transformations, ibis functions must now return all the columns that are passed as an input to the function (in addition to on demand features) as opposed to returning only the on demand features that they generate. This is to avoid an extra join back to the main table after ibis functions are applied to the output. This way multiple ODFVs can easily be chained, each mutating the offline store output to append the relevant columns. 

With this PR, all of the planned ibis/substrait features will now be in place in python sdk. The next steps will be to enable native substrait ODFV execution in non-python sdks as well.

# Which issue(s) this PR fixes:
Fixes #3979 
