### PR TITLE
chore: Drop dependency on non-standard importlib libraries

### DIFF
--- a/sdk/python/feast/__init__.py
+++ b/sdk/python/feast/__init__.py
@@ -1,9 +1,5 @@
-try:
-    from importlib.metadata import PackageNotFoundError
-    from importlib.metadata import version as _version
-except ModuleNotFoundError:
-    from importlib_metadata import PackageNotFoundError  # type: ignore
-    from importlib_metadata import version as _version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
 
 from feast.infra.offline_stores.bigquery_source import BigQuerySource
 from feast.infra.offline_stores.contrib.athena_offline_store.athena_source import (

--- a/sdk/python/feast/cli.py
+++ b/sdk/python/feast/cli.py
@@ -14,6 +14,7 @@
 import json
 import logging
 from datetime import datetime
+from importlib.metadata import version as importlib_version
 from pathlib import Path
 from typing import List, Optional
 
@@ -21,7 +22,6 @@ import click
 import yaml
 from colorama import Fore, Style
 from dateutil import parser
-from importlib_metadata import version as importlib_version
 from pygments import formatters, highlight, lexers
 
 from feast import utils

--- a/sdk/python/feast/proto_json.py
+++ b/sdk/python/feast/proto_json.py
@@ -1,4 +1,5 @@
 import uuid
+from importlib.metadata import version as importlib_version
 from typing import Any, Callable, Type
 
 from google.protobuf.json_format import (  # type: ignore
@@ -7,7 +8,6 @@ from google.protobuf.json_format import (  # type: ignore
     _Parser,
     _Printer,
 )
-from importlib_metadata import version as importlib_version
 from packaging import version
 
 from feast.protos.feast.serving.ServingService_pb2 import FeatureList

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -1,8 +1,8 @@
 import json
 import threading
+from importlib import resources as importlib_resources
 from typing import Callable, Optional
 
-import importlib_resources
 import uvicorn
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware

--- a/sdk/python/feast/version.py
+++ b/sdk/python/feast/version.py
@@ -1,7 +1,4 @@
-try:
-    from importlib.metadata import PackageNotFoundError, version
-except ModuleNotFoundError:
-    from importlib_metadata import PackageNotFoundError, version  # type: ignore
+from importlib.metadata import PackageNotFoundError, version
 
 
 def get_version():

--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -45,7 +45,7 @@ azure-core==1.30.1
     # via
     #   azure-identity
     #   azure-storage-blob
-azure-identity==1.15.0
+azure-identity==1.16.0
     # via feast (setup.py)
 azure-storage-blob==12.19.1
     # via feast (setup.py)
@@ -59,11 +59,11 @@ bidict==0.23.1
     # via ibis-framework
 bleach==6.1.0
     # via nbconvert
-boto3==1.34.80
+boto3==1.34.85
     # via
     #   feast (setup.py)
     #   moto
-botocore==1.34.80
+botocore==1.34.85
     # via
     #   boto3
     #   moto
@@ -138,7 +138,7 @@ dask[array,dataframe]==2024.4.1
     # via
     #   dask-expr
     #   feast (setup.py)
-dask-expr==1.0.10
+dask-expr==1.0.11
     # via dask
 db-dtypes==1.2.0
     # via google-cloud-bigquery
@@ -148,12 +148,8 @@ decorator==5.1.1
     # via ipython
 defusedxml==0.7.1
     # via nbconvert
-deprecation==2.1.0
-    # via testcontainers
 dill==0.3.8
-    # via
-    #   feast (setup.py)
-    #   multiprocess
+    # via feast (setup.py)
 distlib==0.3.8
     # via virtualenv
 docker==7.0.0
@@ -166,7 +162,7 @@ duckdb==0.10.1
     # via
     #   duckdb-engine
     #   ibis-framework
-duckdb-engine==0.11.4
+duckdb-engine==0.11.5
     # via ibis-framework
 entrypoints==0.4
     # via altair
@@ -183,7 +179,7 @@ fastapi==0.110.1
     # via feast (setup.py)
 fastjsonschema==2.19.1
     # via nbformat
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   snowflake-connector-python
     #   virtualenv
@@ -213,7 +209,7 @@ google-api-core[grpc]==2.18.0
     #   google-cloud-datastore
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.125.0
+google-api-python-client==2.126.0
     # via firebase-admin
 google-auth==2.29.0
     # via
@@ -230,7 +226,7 @@ google-cloud-bigquery[pandas]==3.12.0
     # via feast (setup.py)
 google-cloud-bigquery-storage==2.24.0
     # via feast (setup.py)
-google-cloud-bigtable==2.23.0
+google-cloud-bigtable==2.23.1
     # via feast (setup.py)
 google-cloud-core==2.4.1
     # via
@@ -289,7 +285,7 @@ grpcio-testing==1.62.1
     # via feast (setup.py)
 grpcio-tools==1.62.1
     # via feast (setup.py)
-gunicorn==21.2.0 ; platform_system != "Windows"
+gunicorn==22.0.0 ; platform_system != "Windows"
     # via feast (setup.py)
 h11==0.14.0
     # via
@@ -330,12 +326,8 @@ idna==3.7
     #   snowflake-connector-python
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.11.0
-    # via
-    #   dask
-    #   feast (setup.py)
-importlib-resources==6.4.0
-    # via feast (setup.py)
+importlib-metadata==7.1.0
+    # via dask
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.4
@@ -368,7 +360,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-json5==0.9.24
+json5==0.9.25
     # via jupyterlab-server
 jsonpatch==1.33
     # via great-expectations
@@ -402,9 +394,9 @@ jupyter-core==5.7.2
     #   nbformat
 jupyter-events==0.10.0
     # via jupyter-server
-jupyter-lsp==2.2.4
+jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.13.0
+jupyter-server==2.14.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -438,7 +430,7 @@ markupsafe==2.1.5
     #   werkzeug
 marshmallow==3.21.1
     # via great-expectations
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -511,12 +503,11 @@ oauthlib==3.2.2
     # via requests-oauthlib
 overrides==7.7.0
     # via jupyter-server
-packaging==21.3
+packaging==24.0
     # via
     #   build
     #   dask
     #   db-dtypes
-    #   deprecation
     #   docker
     #   duckdb-engine
     #   google-cloud-bigquery
@@ -533,7 +524,7 @@ packaging==21.3
     #   pytest
     #   snowflake-connector-python
     #   sphinx
-pandas==2.2.1
+pandas==2.2.2
     # via
     #   altair
     #   dask
@@ -640,12 +631,12 @@ pybindgen==0.22.1
     # via feast (setup.py)
 pycparser==2.22
     # via cffi
-pydantic==2.6.4
+pydantic==2.7.0
     # via
     #   fastapi
     #   feast (setup.py)
     #   great-expectations
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 pygments==2.17.2
     # via
@@ -670,7 +661,6 @@ pyparsing==3.1.2
     # via
     #   great-expectations
     #   httplib2
-    #   packaging
 pyproject-hooks==1.0.0
     # via
     #   build
@@ -738,7 +728,7 @@ pyyaml==6.0.1
     #   pre-commit
     #   responses
     #   uvicorn
-pyzmq==25.1.2
+pyzmq==26.0.0
     # via
     #   ipykernel
     #   jupyter-client
@@ -750,7 +740,7 @@ referencing==0.34.0
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-regex==2023.12.25
+regex==2024.4.16
     # via feast (setup.py)
 requests==2.31.0
     # via
@@ -795,7 +785,7 @@ rsa==4.9
     # via google-auth
 ruamel-yaml==0.17.17
     # via great-expectations
-ruff==0.3.5
+ruff==0.3.7
     # via feast (setup.py)
 s3transfer==0.10.1
     # via boto3
@@ -822,7 +812,7 @@ sniffio==1.3.1
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python[pandas]==3.7.1
+snowflake-connector-python[pandas]==3.8.1
     # via feast (setup.py)
 sortedcontainers==2.4.0
     # via snowflake-connector-python
@@ -857,7 +847,7 @@ stack-data==0.6.3
     # via ipython
 starlette==0.37.2
     # via fastapi
-substrait==0.15.0
+substrait==0.16.0
     # via ibis-substrait
 tabulate==0.9.0
     # via feast (setup.py)
@@ -867,7 +857,7 @@ terminado==0.18.1
     # via
     #   jupyter-server
     #   jupyter-server-terminals
-testcontainers==3.7.1
+testcontainers==4.3.3
     # via feast (setup.py)
 thriftpy2==0.4.20
     # via happybase
@@ -924,28 +914,32 @@ trino==0.328.0
     # via feast (setup.py)
 typeguard==4.2.1
     # via feast (setup.py)
+types-cffi==1.16.0.20240331
+    # via types-pyopenssl
 types-protobuf==3.19.22
     # via
     #   feast (setup.py)
     #   mypy-protobuf
 types-pymysql==1.1.0.1
     # via feast (setup.py)
-types-pyopenssl==24.0.0.20240311
+types-pyopenssl==24.0.0.20240417
     # via types-redis
 types-python-dateutil==2.9.0.20240316
     # via
     #   arrow
     #   feast (setup.py)
-types-pytz==2024.1.0.20240203
+types-pytz==2024.1.0.20240417
     # via feast (setup.py)
 types-pyyaml==6.0.12.20240311
     # via feast (setup.py)
-types-redis==4.6.0.20240409
+types-redis==4.6.0.20240417
     # via feast (setup.py)
 types-requests==2.30.0.0
     # via feast (setup.py)
-types-setuptools==69.2.0.20240317
-    # via feast (setup.py)
+types-setuptools==69.5.0.20240415
+    # via
+    #   feast (setup.py)
+    #   types-cffi
 types-tabulate==0.9.0.20240106
     # via feast (setup.py)
 types-urllib3==1.26.25.14
@@ -965,6 +959,7 @@ typing-extensions==4.11.0
     #   pydantic-core
     #   snowflake-connector-python
     #   sqlalchemy
+    #   testcontainers
     #   typeguard
     #   uvicorn
 tzdata==2024.1
@@ -988,6 +983,7 @@ urllib3==1.26.18
     #   requests
     #   responses
     #   rockset
+    #   testcontainers
 uvicorn[standard]==0.29.0
     # via feast (setup.py)
 uvloop==0.19.0

--- a/sdk/python/requirements/py3.10-requirements.txt
+++ b/sdk/python/requirements/py3.10-requirements.txt
@@ -38,7 +38,7 @@ dask[array,dataframe]==2024.4.1
     # via
     #   dask-expr
     #   feast (setup.py)
-dask-expr==1.0.10
+dask-expr==1.0.11
     # via dask
 dill==0.3.8
     # via feast (setup.py)
@@ -52,7 +52,7 @@ fsspec==2024.3.1
     # via dask
 greenlet==3.0.3
     # via sqlalchemy
-gunicorn==21.2.0 ; platform_system != "Windows"
+gunicorn==22.0.0 ; platform_system != "Windows"
     # via feast (setup.py)
 h11==0.14.0
     # via uvicorn
@@ -62,12 +62,8 @@ idna==3.7
     # via
     #   anyio
     #   requests
-importlib-metadata==6.11.0
-    # via
-    #   dask
-    #   feast (setup.py)
-importlib-resources==6.4.0
-    # via feast (setup.py)
+importlib-metadata==7.1.0
+    # via dask
 jinja2==3.1.3
     # via feast (setup.py)
 jsonschema==4.21.1
@@ -98,7 +94,7 @@ packaging==24.0
     # via
     #   dask
     #   gunicorn
-pandas==2.2.1
+pandas==2.2.2
     # via
     #   dask
     #   dask-expr
@@ -113,11 +109,11 @@ pyarrow==15.0.2
     # via
     #   dask-expr
     #   feast (setup.py)
-pydantic==2.6.4
+pydantic==2.7.0
     # via
     #   fastapi
     #   feast (setup.py)
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 pygments==2.17.2
     # via feast (setup.py)
@@ -168,7 +164,7 @@ tqdm==4.66.2
     # via feast (setup.py)
 typeguard==4.2.1
     # via feast (setup.py)
-types-protobuf==4.24.0.20240408
+types-protobuf==4.25.0.20240417
     # via mypy-protobuf
 typing-extensions==4.11.0
     # via

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -45,7 +45,7 @@ azure-core==1.30.1
     # via
     #   azure-identity
     #   azure-storage-blob
-azure-identity==1.15.0
+azure-identity==1.16.0
     # via feast (setup.py)
 azure-storage-blob==12.19.1
     # via feast (setup.py)
@@ -59,11 +59,11 @@ bidict==0.23.1
     # via ibis-framework
 bleach==6.1.0
     # via nbconvert
-boto3==1.34.80
+boto3==1.34.85
     # via
     #   feast (setup.py)
     #   moto
-botocore==1.34.80
+botocore==1.34.85
     # via
     #   boto3
     #   moto
@@ -138,7 +138,7 @@ dask[array,dataframe]==2024.4.1
     # via
     #   dask-expr
     #   feast (setup.py)
-dask-expr==1.0.10
+dask-expr==1.0.11
     # via dask
 db-dtypes==1.2.0
     # via google-cloud-bigquery
@@ -148,12 +148,8 @@ decorator==5.1.1
     # via ipython
 defusedxml==0.7.1
     # via nbconvert
-deprecation==2.1.0
-    # via testcontainers
 dill==0.3.8
-    # via
-    #   feast (setup.py)
-    #   multiprocess
+    # via feast (setup.py)
 distlib==0.3.8
     # via virtualenv
 docker==7.0.0
@@ -166,7 +162,7 @@ duckdb==0.10.1
     # via
     #   duckdb-engine
     #   ibis-framework
-duckdb-engine==0.11.4
+duckdb-engine==0.11.5
     # via ibis-framework
 entrypoints==0.4
     # via altair
@@ -183,7 +179,7 @@ fastapi==0.110.1
     # via feast (setup.py)
 fastjsonschema==2.19.1
     # via nbformat
-filelock==3.13.3
+filelock==3.13.4
     # via
     #   snowflake-connector-python
     #   virtualenv
@@ -213,7 +209,7 @@ google-api-core[grpc]==2.18.0
     #   google-cloud-datastore
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.125.0
+google-api-python-client==2.126.0
     # via firebase-admin
 google-auth==2.29.0
     # via
@@ -230,7 +226,7 @@ google-cloud-bigquery[pandas]==3.12.0
     # via feast (setup.py)
 google-cloud-bigquery-storage==2.24.0
     # via feast (setup.py)
-google-cloud-bigtable==2.23.0
+google-cloud-bigtable==2.23.1
     # via feast (setup.py)
 google-cloud-core==2.4.1
     # via
@@ -289,7 +285,7 @@ grpcio-testing==1.62.1
     # via feast (setup.py)
 grpcio-tools==1.62.1
     # via feast (setup.py)
-gunicorn==21.2.0 ; platform_system != "Windows"
+gunicorn==22.0.0 ; platform_system != "Windows"
     # via feast (setup.py)
 h11==0.14.0
     # via
@@ -330,11 +326,10 @@ idna==3.7
     #   snowflake-connector-python
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.11.0
+importlib-metadata==7.1.0
     # via
     #   build
     #   dask
-    #   feast (setup.py)
     #   jupyter-client
     #   jupyter-lsp
     #   jupyterlab
@@ -342,8 +337,6 @@ importlib-metadata==6.11.0
     #   nbconvert
     #   sphinx
     #   typeguard
-importlib-resources==6.4.0
-    # via feast (setup.py)
 iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.4
@@ -376,7 +369,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-json5==0.9.24
+json5==0.9.25
     # via jupyterlab-server
 jsonpatch==1.33
     # via great-expectations
@@ -410,9 +403,9 @@ jupyter-core==5.7.2
     #   nbformat
 jupyter-events==0.10.0
     # via jupyter-server
-jupyter-lsp==2.2.4
+jupyter-lsp==2.2.5
     # via jupyterlab
-jupyter-server==2.13.0
+jupyter-server==2.14.0
     # via
     #   jupyter-lsp
     #   jupyterlab
@@ -446,7 +439,7 @@ markupsafe==2.1.5
     #   werkzeug
 marshmallow==3.21.1
     # via great-expectations
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
@@ -519,12 +512,11 @@ oauthlib==3.2.2
     # via requests-oauthlib
 overrides==7.7.0
     # via jupyter-server
-packaging==21.3
+packaging==24.0
     # via
     #   build
     #   dask
     #   db-dtypes
-    #   deprecation
     #   docker
     #   duckdb-engine
     #   google-cloud-bigquery
@@ -541,7 +533,7 @@ packaging==21.3
     #   pytest
     #   snowflake-connector-python
     #   sphinx
-pandas==2.2.1
+pandas==2.2.2
     # via
     #   altair
     #   dask
@@ -648,12 +640,12 @@ pybindgen==0.22.1
     # via feast (setup.py)
 pycparser==2.22
     # via cffi
-pydantic==2.6.4
+pydantic==2.7.0
     # via
     #   fastapi
     #   feast (setup.py)
     #   great-expectations
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 pygments==2.17.2
     # via
@@ -678,7 +670,6 @@ pyparsing==3.1.2
     # via
     #   great-expectations
     #   httplib2
-    #   packaging
 pyproject-hooks==1.0.0
     # via
     #   build
@@ -746,7 +737,7 @@ pyyaml==6.0.1
     #   pre-commit
     #   responses
     #   uvicorn
-pyzmq==25.1.2
+pyzmq==26.0.0
     # via
     #   ipykernel
     #   jupyter-client
@@ -758,7 +749,7 @@ referencing==0.34.0
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-regex==2023.12.25
+regex==2024.4.16
     # via feast (setup.py)
 requests==2.31.0
     # via
@@ -805,7 +796,7 @@ ruamel-yaml==0.17.17
     # via great-expectations
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.3.5
+ruff==0.3.7
     # via feast (setup.py)
 s3transfer==0.10.1
     # via boto3
@@ -832,7 +823,7 @@ sniffio==1.3.1
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python[pandas]==3.7.1
+snowflake-connector-python[pandas]==3.8.1
     # via feast (setup.py)
 sortedcontainers==2.4.0
     # via snowflake-connector-python
@@ -867,7 +858,7 @@ stack-data==0.6.3
     # via ipython
 starlette==0.37.2
     # via fastapi
-substrait==0.15.0
+substrait==0.16.0
     # via ibis-substrait
 tabulate==0.9.0
     # via feast (setup.py)
@@ -877,7 +868,7 @@ terminado==0.18.1
     # via
     #   jupyter-server
     #   jupyter-server-terminals
-testcontainers==3.7.1
+testcontainers==4.3.3
     # via feast (setup.py)
 thriftpy2==0.4.20
     # via happybase
@@ -934,28 +925,32 @@ trino==0.328.0
     # via feast (setup.py)
 typeguard==4.2.1
     # via feast (setup.py)
+types-cffi==1.16.0.20240331
+    # via types-pyopenssl
 types-protobuf==3.19.22
     # via
     #   feast (setup.py)
     #   mypy-protobuf
 types-pymysql==1.1.0.1
     # via feast (setup.py)
-types-pyopenssl==24.0.0.20240311
+types-pyopenssl==24.0.0.20240417
     # via types-redis
 types-python-dateutil==2.9.0.20240316
     # via
     #   arrow
     #   feast (setup.py)
-types-pytz==2024.1.0.20240203
+types-pytz==2024.1.0.20240417
     # via feast (setup.py)
 types-pyyaml==6.0.12.20240311
     # via feast (setup.py)
-types-redis==4.6.0.20240409
+types-redis==4.6.0.20240417
     # via feast (setup.py)
 types-requests==2.30.0.0
     # via feast (setup.py)
-types-setuptools==69.2.0.20240317
-    # via feast (setup.py)
+types-setuptools==69.5.0.20240415
+    # via
+    #   feast (setup.py)
+    #   types-cffi
 types-tabulate==0.9.0.20240106
     # via feast (setup.py)
 types-urllib3==1.26.25.14
@@ -976,6 +971,7 @@ typing-extensions==4.11.0
     #   snowflake-connector-python
     #   sqlalchemy
     #   starlette
+    #   testcontainers
     #   typeguard
     #   uvicorn
 tzdata==2024.1
@@ -1000,6 +996,7 @@ urllib3==1.26.18
     #   responses
     #   rockset
     #   snowflake-connector-python
+    #   testcontainers
 uvicorn[standard]==0.29.0
     # via feast (setup.py)
 uvloop==0.19.0
@@ -1037,9 +1034,7 @@ wrapt==1.16.0
 xmltodict==0.13.0
     # via moto
 zipp==3.18.1
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/sdk/python/requirements/py3.9-requirements.txt
+++ b/sdk/python/requirements/py3.9-requirements.txt
@@ -38,7 +38,7 @@ dask[array,dataframe]==2024.4.1
     # via
     #   dask-expr
     #   feast (setup.py)
-dask-expr==1.0.10
+dask-expr==1.0.11
     # via dask
 dill==0.3.8
     # via feast (setup.py)
@@ -52,7 +52,7 @@ fsspec==2024.3.1
     # via dask
 greenlet==3.0.3
     # via sqlalchemy
-gunicorn==21.2.0 ; platform_system != "Windows"
+gunicorn==22.0.0 ; platform_system != "Windows"
     # via feast (setup.py)
 h11==0.14.0
     # via uvicorn
@@ -62,13 +62,10 @@ idna==3.7
     # via
     #   anyio
     #   requests
-importlib-metadata==6.11.0
+importlib-metadata==7.1.0
     # via
     #   dask
-    #   feast (setup.py)
     #   typeguard
-importlib-resources==6.4.0
-    # via feast (setup.py)
 jinja2==3.1.3
     # via feast (setup.py)
 jsonschema==4.21.1
@@ -99,7 +96,7 @@ packaging==24.0
     # via
     #   dask
     #   gunicorn
-pandas==2.2.1
+pandas==2.2.2
     # via
     #   dask
     #   dask-expr
@@ -114,11 +111,11 @@ pyarrow==15.0.2
     # via
     #   dask-expr
     #   feast (setup.py)
-pydantic==2.6.4
+pydantic==2.7.0
     # via
     #   fastapi
     #   feast (setup.py)
-pydantic-core==2.16.3
+pydantic-core==2.18.1
     # via pydantic
 pygments==2.17.2
     # via feast (setup.py)
@@ -169,7 +166,7 @@ tqdm==4.66.2
     # via feast (setup.py)
 typeguard==4.2.1
     # via feast (setup.py)
-types-protobuf==4.24.0.20240408
+types-protobuf==4.25.0.20240417
     # via mypy-protobuf
 typing-extensions==4.11.0
     # via
@@ -197,6 +194,4 @@ watchfiles==0.21.0
 websockets==12.0
     # via uvicorn
 zipp==3.18.1
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,6 @@ REQUIRED = [
     "gunicorn; platform_system != 'Windows'",
     "dask[dataframe]>=2021.1.0",
     "bowler",  # Needed for automatic repo upgrades
-    "importlib-resources>=6.0.0,<7",
-    "importlib_metadata>=6.8.0,<7",
 ]
 
 GCP_REQUIRED = [


### PR DESCRIPTION
# What this PR does / why we need it:
Explicit dependency on non-standard importlib libraries (`importlib-resources` and `importlib_metadata`) is no longer required after dropping 3.8. This PR switches to use alternatives from standard library.