### PR TITLE
fix: Get rid of empty string `name_alias` during feature view projection deserialization 

### DIFF
--- a/sdk/python/feast/feature_view_projection.py
+++ b/sdk/python/feast/feature_view_projection.py
@@ -53,7 +53,7 @@ class FeatureViewProjection:
     def from_proto(proto: FeatureViewProjectionProto):
         feature_view_projection = FeatureViewProjection(
             name=proto.feature_view_name,
-            name_alias=proto.feature_view_name_alias,
+            name_alias=proto.feature_view_name_alias or None,
             features=[],
             join_key_map=dict(proto.join_key_map),
             desired_features=[],


### PR DESCRIPTION
# Which issue(s) this PR fixes:
* Fixes #4030 
