### PR TITLE
feat: Add delta format to `FileSource`, add support for it in ibis/duckdb

### DIFF
--- a/protos/feast/core/DataFormat.proto
+++ b/protos/feast/core/DataFormat.proto
@@ -27,8 +27,12 @@ message FileFormat {
   // Defines options for the Parquet data format
   message ParquetFormat {}
 
+  // Defines options for delta data format
+  message DeltaFormat {}
+
   oneof format {
     ParquetFormat parquet_format = 1;
+    DeltaFormat delta_format = 2;
   }
 }
 

--- a/sdk/python/feast/data_format.py
+++ b/sdk/python/feast/data_format.py
@@ -43,6 +43,8 @@ class FileFormat(ABC):
         fmt = proto.WhichOneof("format")
         if fmt == "parquet_format":
             return ParquetFormat()
+        elif fmt == "delta_format":
+            return DeltaFormat()
         if fmt is None:
             return None
         raise NotImplementedError(f"FileFormat is unsupported: {fmt}")
@@ -64,6 +66,18 @@ class ParquetFormat(FileFormat):
 
     def __str__(self):
         return "parquet"
+
+
+class DeltaFormat(FileFormat):
+    """
+    Defines delta data format
+    """
+
+    def to_proto(self):
+        return FileFormatProto(delta_format=FileFormatProto.DeltaFormat())
+
+    def __str__(self):
+        return "delta"
 
 
 class StreamFormat(ABC):

--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -59,11 +59,11 @@ bidict==0.23.1
     # via ibis-framework
 bleach==6.1.0
     # via nbconvert
-boto3==1.34.85
+boto3==1.34.88
     # via
     #   feast (setup.py)
     #   moto
-botocore==1.34.85
+botocore==1.34.88
     # via
     #   boto3
     #   moto
@@ -134,11 +134,11 @@ cryptography==42.0.5
     #   snowflake-connector-python
     #   types-pyopenssl
     #   types-redis
-dask[array,dataframe]==2024.4.1
+dask[array,dataframe]==2024.4.2
     # via
     #   dask-expr
     #   feast (setup.py)
-dask-expr==1.0.11
+dask-expr==1.0.12
     # via dask
 db-dtypes==1.2.0
     # via google-cloud-bigquery
@@ -148,6 +148,8 @@ decorator==5.1.1
     # via ipython
 defusedxml==0.7.1
     # via nbconvert
+deltalake==0.16.4
+    # via feast (setup.py)
 dill==0.3.8
     # via feast (setup.py)
 distlib==0.3.8
@@ -158,7 +160,7 @@ docker==7.0.0
     #   testcontainers
 docutils==0.19
     # via sphinx
-duckdb==0.10.1
+duckdb==0.10.2
     # via
     #   duckdb-engine
     #   ibis-framework
@@ -166,7 +168,7 @@ duckdb-engine==0.11.5
     # via ibis-framework
 entrypoints==0.4
     # via altair
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   anyio
     #   ipython
@@ -175,7 +177,7 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.110.1
+fastapi==0.110.2
     # via feast (setup.py)
 fastjsonschema==2.19.1
     # via nbformat
@@ -263,7 +265,7 @@ greenlet==3.0.3
     # via sqlalchemy
 grpc-google-iam-v1==0.13.0
     # via google-cloud-bigtable
-grpcio==1.62.1
+grpcio==1.62.2
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -275,15 +277,15 @@ grpcio==1.62.1
     #   grpcio-status
     #   grpcio-testing
     #   grpcio-tools
-grpcio-health-checking==1.62.1
+grpcio-health-checking==1.62.2
     # via feast (setup.py)
-grpcio-reflection==1.62.1
+grpcio-reflection==1.62.2
     # via feast (setup.py)
-grpcio-status==1.62.1
+grpcio-status==1.62.2
     # via google-api-core
-grpcio-testing==1.62.1
+grpcio-testing==1.62.2
     # via feast (setup.py)
-grpcio-tools==1.62.1
+grpcio-tools==1.62.2
     # via feast (setup.py)
 gunicorn==22.0.0 ; platform_system != "Windows"
     # via feast (setup.py)
@@ -482,13 +484,13 @@ nest-asyncio==1.6.0
     # via ipykernel
 nodeenv==1.8.0
     # via pre-commit
-notebook==7.1.2
+notebook==7.1.3
     # via great-expectations
 notebook-shim==0.2.4
     # via
     #   jupyterlab
     #   notebook
-numpy==1.24.4
+numpy==1.26.4
     # via
     #   altair
     #   dask
@@ -615,12 +617,15 @@ pyarrow==15.0.2
     # via
     #   dask-expr
     #   db-dtypes
+    #   deltalake
     #   feast (setup.py)
     #   google-cloud-bigquery
     #   ibis-framework
     #   snowflake-connector-python
 pyarrow-hotfix==0.6
-    # via ibis-framework
+    # via
+    #   deltalake
+    #   ibis-framework
 pyasn1==0.6.0
     # via
     #   pyasn1-modules
@@ -692,7 +697,7 @@ pytest-ordering==0.6
     # via feast (setup.py)
 pytest-timeout==1.4.2
     # via feast (setup.py)
-pytest-xdist==3.5.0
+pytest-xdist==3.6.0
     # via feast (setup.py)
 python-dateutil==2.9.0.post0
     # via
@@ -728,7 +733,7 @@ pyyaml==6.0.1
     #   pre-commit
     #   responses
     #   uvicorn
-pyzmq==26.0.0
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -785,7 +790,7 @@ rsa==4.9
     # via google-auth
 ruamel-yaml==0.17.17
     # via great-expectations
-ruff==0.3.7
+ruff==0.4.1
     # via feast (setup.py)
 s3transfer==0.10.1
     # via boto3
@@ -812,7 +817,7 @@ sniffio==1.3.1
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python[pandas]==3.8.1
+snowflake-connector-python[pandas]==3.9.0
     # via feast (setup.py)
 sortedcontainers==2.4.0
     # via snowflake-connector-python
@@ -895,7 +900,7 @@ tqdm==4.66.2
     # via
     #   feast (setup.py)
     #   great-expectations
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel

--- a/sdk/python/requirements/py3.10-requirements.txt
+++ b/sdk/python/requirements/py3.10-requirements.txt
@@ -34,17 +34,17 @@ cloudpickle==3.0.0
     # via dask
 colorama==0.4.6
     # via feast (setup.py)
-dask[array,dataframe]==2024.4.1
+dask[array,dataframe]==2024.4.2
     # via
     #   dask-expr
     #   feast (setup.py)
-dask-expr==1.0.11
+dask-expr==1.0.12
     # via dask
 dill==0.3.8
     # via feast (setup.py)
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via anyio
-fastapi==0.110.1
+fastapi==0.110.2
     # via feast (setup.py)
 fissix==21.11.13
     # via bowler
@@ -84,7 +84,7 @@ mypy-extensions==1.0.0
     # via mypy
 mypy-protobuf==3.6.0
     # via feast (setup.py)
-numpy==1.24.4
+numpy==1.26.4
     # via
     #   dask
     #   feast (setup.py)
@@ -164,7 +164,7 @@ tqdm==4.66.2
     # via feast (setup.py)
 typeguard==4.2.1
     # via feast (setup.py)
-types-protobuf==4.25.0.20240417
+types-protobuf==5.26.0.20240420
     # via mypy-protobuf
 typing-extensions==4.11.0
     # via

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -59,11 +59,11 @@ bidict==0.23.1
     # via ibis-framework
 bleach==6.1.0
     # via nbconvert
-boto3==1.34.85
+boto3==1.34.88
     # via
     #   feast (setup.py)
     #   moto
-botocore==1.34.85
+botocore==1.34.88
     # via
     #   boto3
     #   moto
@@ -134,11 +134,11 @@ cryptography==42.0.5
     #   snowflake-connector-python
     #   types-pyopenssl
     #   types-redis
-dask[array,dataframe]==2024.4.1
+dask[array,dataframe]==2024.4.2
     # via
     #   dask-expr
     #   feast (setup.py)
-dask-expr==1.0.11
+dask-expr==1.0.12
     # via dask
 db-dtypes==1.2.0
     # via google-cloud-bigquery
@@ -148,6 +148,8 @@ decorator==5.1.1
     # via ipython
 defusedxml==0.7.1
     # via nbconvert
+deltalake==0.16.4
+    # via feast (setup.py)
 dill==0.3.8
     # via feast (setup.py)
 distlib==0.3.8
@@ -158,7 +160,7 @@ docker==7.0.0
     #   testcontainers
 docutils==0.19
     # via sphinx
-duckdb==0.10.1
+duckdb==0.10.2
     # via
     #   duckdb-engine
     #   ibis-framework
@@ -166,7 +168,7 @@ duckdb-engine==0.11.5
     # via ibis-framework
 entrypoints==0.4
     # via altair
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via
     #   anyio
     #   ipython
@@ -175,7 +177,7 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.0.1
     # via stack-data
-fastapi==0.110.1
+fastapi==0.110.2
     # via feast (setup.py)
 fastjsonschema==2.19.1
     # via nbformat
@@ -263,7 +265,7 @@ greenlet==3.0.3
     # via sqlalchemy
 grpc-google-iam-v1==0.13.0
     # via google-cloud-bigtable
-grpcio==1.62.1
+grpcio==1.62.2
     # via
     #   feast (setup.py)
     #   google-api-core
@@ -275,15 +277,15 @@ grpcio==1.62.1
     #   grpcio-status
     #   grpcio-testing
     #   grpcio-tools
-grpcio-health-checking==1.62.1
+grpcio-health-checking==1.62.2
     # via feast (setup.py)
-grpcio-reflection==1.62.1
+grpcio-reflection==1.62.2
     # via feast (setup.py)
-grpcio-status==1.62.1
+grpcio-status==1.62.2
     # via google-api-core
-grpcio-testing==1.62.1
+grpcio-testing==1.62.2
     # via feast (setup.py)
-grpcio-tools==1.62.1
+grpcio-tools==1.62.2
     # via feast (setup.py)
 gunicorn==22.0.0 ; platform_system != "Windows"
     # via feast (setup.py)
@@ -491,13 +493,13 @@ nest-asyncio==1.6.0
     # via ipykernel
 nodeenv==1.8.0
     # via pre-commit
-notebook==7.1.2
+notebook==7.1.3
     # via great-expectations
 notebook-shim==0.2.4
     # via
     #   jupyterlab
     #   notebook
-numpy==1.24.4
+numpy==1.26.4
     # via
     #   altair
     #   dask
@@ -624,12 +626,15 @@ pyarrow==15.0.2
     # via
     #   dask-expr
     #   db-dtypes
+    #   deltalake
     #   feast (setup.py)
     #   google-cloud-bigquery
     #   ibis-framework
     #   snowflake-connector-python
 pyarrow-hotfix==0.6
-    # via ibis-framework
+    # via
+    #   deltalake
+    #   ibis-framework
 pyasn1==0.6.0
     # via
     #   pyasn1-modules
@@ -701,7 +706,7 @@ pytest-ordering==0.6
     # via feast (setup.py)
 pytest-timeout==1.4.2
     # via feast (setup.py)
-pytest-xdist==3.5.0
+pytest-xdist==3.6.0
     # via feast (setup.py)
 python-dateutil==2.9.0.post0
     # via
@@ -737,7 +742,7 @@ pyyaml==6.0.1
     #   pre-commit
     #   responses
     #   uvicorn
-pyzmq==26.0.0
+pyzmq==26.0.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -796,7 +801,7 @@ ruamel-yaml==0.17.17
     # via great-expectations
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
-ruff==0.3.7
+ruff==0.4.1
     # via feast (setup.py)
 s3transfer==0.10.1
     # via boto3
@@ -823,7 +828,7 @@ sniffio==1.3.1
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
-snowflake-connector-python[pandas]==3.8.1
+snowflake-connector-python[pandas]==3.9.0
     # via feast (setup.py)
 sortedcontainers==2.4.0
     # via snowflake-connector-python
@@ -906,7 +911,7 @@ tqdm==4.66.2
     # via
     #   feast (setup.py)
     #   great-expectations
-traitlets==5.14.2
+traitlets==5.14.3
     # via
     #   comm
     #   ipykernel

--- a/sdk/python/requirements/py3.9-requirements.txt
+++ b/sdk/python/requirements/py3.9-requirements.txt
@@ -34,17 +34,17 @@ cloudpickle==3.0.0
     # via dask
 colorama==0.4.6
     # via feast (setup.py)
-dask[array,dataframe]==2024.4.1
+dask[array,dataframe]==2024.4.2
     # via
     #   dask-expr
     #   feast (setup.py)
-dask-expr==1.0.11
+dask-expr==1.0.12
     # via dask
 dill==0.3.8
     # via feast (setup.py)
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via anyio
-fastapi==0.110.1
+fastapi==0.110.2
     # via feast (setup.py)
 fissix==21.11.13
     # via bowler
@@ -86,7 +86,7 @@ mypy-extensions==1.0.0
     # via mypy
 mypy-protobuf==3.6.0
     # via feast (setup.py)
-numpy==1.24.4
+numpy==1.26.4
     # via
     #   dask
     #   feast (setup.py)
@@ -166,7 +166,7 @@ tqdm==4.66.2
     # via feast (setup.py)
 typeguard==4.2.1
     # via feast (setup.py)
-types-protobuf==4.25.0.20240417
+types-protobuf==5.26.0.20240420
     # via mypy-protobuf
 typing-extensions==4.11.0
     # via

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -32,6 +32,7 @@ from tests.integration.feature_repos.universal.data_sources.bigquery import (
 )
 from tests.integration.feature_repos.universal.data_sources.file import (
     DuckDBDataSourceCreator,
+    DuckDBDeltaDataSourceCreator,
     FileDataSourceCreator,
 )
 from tests.integration.feature_repos.universal.data_sources.redshift import (
@@ -118,6 +119,7 @@ OFFLINE_STORE_TO_PROVIDER_CONFIG: Dict[str, Tuple[str, Type[DataSourceCreator]]]
 AVAILABLE_OFFLINE_STORES: List[Tuple[str, Type[DataSourceCreator]]] = [
     ("local", FileDataSourceCreator),
     ("local", DuckDBDataSourceCreator),
+    ("local", DuckDBDeltaDataSourceCreator),
 ]
 
 AVAILABLE_ONLINE_STORES: Dict[

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -90,8 +90,6 @@ class FileDataSourceCreator(DataSourceCreator):
                 continue
             shutil.rmtree(d)
 
-        print(self.keep)
-
 
 class DeltaFileSourceCreator(FileDataSourceCreator):
     def create_data_source(

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ REQUIRED = [
     "mmh3",
     "numpy>=1.22,<2",
     "pandas>=1.4.3,<3",
-    # Higher than 4.23.4 seems to cause a seg fault
     "protobuf>=4.24.0,<5.0.0",
     "pyarrow>=4",
     "pydantic>=2.0.0",
@@ -150,6 +149,8 @@ GRPCIO_REQUIRED = [
 
 DUCKDB_REQUIRED = ["ibis-framework[duckdb]"]
 
+DELTA_REQUIRED = ["deltalake"]
+
 CI_REQUIRED = (
     [
         "build",
@@ -210,6 +211,7 @@ CI_REQUIRED = (
     + IBIS_REQUIRED
     + GRPCIO_REQUIRED
     + DUCKDB_REQUIRED
+    + DELTA_REQUIRED
 )
 
 DOCS_REQUIRED = CI_REQUIRED
@@ -374,7 +376,8 @@ setup(
         "rockset": ROCKSET_REQUIRED,
         "ibis": IBIS_REQUIRED,
         "duckdb": DUCKDB_REQUIRED,
-        "ikv": IKV_REQUIRED
+        "ikv": IKV_REQUIRED,
+        "delta": DELTA_REQUIRED,
     },
     include_package_data=True,
     license="Apache",


### PR DESCRIPTION
# What this PR does / why we need it:
This PR adds delta format to `FileSource` (only parquet was supported before), also implements logic for handling delta sources in ibis offline store. It also adds integration tests for duckdb offline store with delta sources, dukdb tests are effectively run twice, once for parquet and then for delta. 
