### PR TITLE
fix: Get container host addresses from testcontainers (java)

### DIFF
--- a/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
+++ b/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
@@ -63,6 +63,11 @@ abstract class ServingEnvironment {
             .withExposedService(
                 "feast", 8080, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(180)))
             .withTailChildContainers(true);
+
+    if (System.getenv("FEAST_TESTCONTAINERS_LOCAL_COMPOSE") != null) {
+      environment = environment.withLocalCompose(true);
+    }
+
     environment.start();
   }
 
@@ -136,7 +141,7 @@ abstract class ServingEnvironment {
     server = injector.getInstance(Server.class);
     server.start();
 
-    channel = ManagedChannelBuilder.forAddress("localhost", serverPort).usePlaintext().build();
+    channel = ManagedChannelBuilder.forAddress("127.0.0.1", serverPort).usePlaintext().build();
 
     servingStub =
         ServingServiceGrpc.newBlockingStub(channel)

--- a/java/serving/src/test/java/feast/serving/it/ServingRedisAzureRegistryIT.java
+++ b/java/serving/src/test/java/feast/serving/it/ServingRedisAzureRegistryIT.java
@@ -50,8 +50,10 @@ public class ServingRedisAzureRegistryIT extends ServingBaseTests {
     return new BlobServiceClientBuilder()
         .endpoint(
             String.format(
-                "http://localhost:%d/%s",
-                azureBlobMock.getMappedPort(BLOB_STORAGE_PORT), TEST_ACCOUNT_NAME))
+                "http://%s:%d/%s",
+                azureBlobMock.getHost(),
+                azureBlobMock.getMappedPort(BLOB_STORAGE_PORT),
+                TEST_ACCOUNT_NAME))
         .credential(CREDENTIAL)
         .buildClient();
   }
@@ -95,8 +97,10 @@ public class ServingRedisAzureRegistryIT extends ServingBaseTests {
         return new BlobServiceClientBuilder()
             .endpoint(
                 String.format(
-                    "http://localhost:%d/%s",
-                    azureBlobMock.getMappedPort(BLOB_STORAGE_PORT), TEST_ACCOUNT_NAME))
+                    "http://%s:%d/%s",
+                    azureBlobMock.getHost(),
+                    azureBlobMock.getMappedPort(BLOB_STORAGE_PORT),
+                    TEST_ACCOUNT_NAME))
             .credential(CREDENTIAL)
             .buildClient();
       }

--- a/java/serving/src/test/java/feast/serving/it/ServingRedisGSRegistryIT.java
+++ b/java/serving/src/test/java/feast/serving/it/ServingRedisGSRegistryIT.java
@@ -61,7 +61,7 @@ public class ServingRedisGSRegistryIT extends ServingBaseTests {
     return StorageOptions.newBuilder()
         .setProjectId(TEST_PROJECT)
         .setCredentials(ServiceAccountCredentials.create(credential))
-        .setHost("http://localhost:" + gcsMock.getMappedPort(GCS_PORT))
+        .setHost(String.format("http://%s:%d", gcsMock.getHost(), gcsMock.getMappedPort(GCS_PORT)))
         .build()
         .getService();
   }
@@ -89,7 +89,8 @@ public class ServingRedisGSRegistryIT extends ServingBaseTests {
         return StorageOptions.newBuilder()
             .setProjectId(TEST_PROJECT)
             .setCredentials(ServiceAccountCredentials.create(credential))
-            .setHost("http://localhost:" + gcsMock.getMappedPort(GCS_PORT))
+            .setHost(
+                String.format("http://%s:%d", gcsMock.getHost(), gcsMock.getMappedPort(GCS_PORT)))
             .build()
             .getService();
       }

--- a/java/serving/src/test/java/feast/serving/it/ServingRedisS3RegistryIT.java
+++ b/java/serving/src/test/java/feast/serving/it/ServingRedisS3RegistryIT.java
@@ -42,7 +42,8 @@ public class ServingRedisS3RegistryIT extends ServingBaseTests {
     return AmazonS3ClientBuilder.standard()
         .withEndpointConfiguration(
             new AwsClientBuilder.EndpointConfiguration(
-                String.format("http://localhost:%d", s3Mock.getHttpServerPort()), TEST_REGION))
+                String.format("http://%s:%d", s3Mock.getHost(), s3Mock.getHttpServerPort()),
+                TEST_REGION))
         .withCredentials(credentials)
         .enablePathStyleAccess()
         .build();
@@ -89,7 +90,8 @@ public class ServingRedisS3RegistryIT extends ServingBaseTests {
         return AmazonS3ClientBuilder.standard()
             .withEndpointConfiguration(
                 new AwsClientBuilder.EndpointConfiguration(
-                    String.format("http://localhost:%d", s3Mock.getHttpServerPort()), TEST_REGION))
+                    String.format("http://%s:%d", s3Mock.getHost(), s3Mock.getHttpServerPort()),
+                    TEST_REGION))
             .withCredentials(credentials)
             .enablePathStyleAccess()
             .build();


### PR DESCRIPTION
# What this PR does / why we need it:
This PR makes similar changes to java integration tests as #3946 did to python ones. Changes are necessary for the tests to be runnable from inside a container.

- Resolves container address by calling `getHost()` instead of hardcoding `localhost`. The user will usually have to also set `TESTCONTAINERS_HOST_OVERRIDE` env variable to `host.docker.internal`
- `DockerComposeContainer` by default works by first running another container with `docker-compose` inside and mounting build context and running `docker-compose up` from there. This doesn't really work if you're already inside a container as volume mounts and `docker-in-docker` don't really get along well. This PR introduces an environment variable `FEAST_TESTCONTAINERS_LOCAL_COMPOSE` which if set changes the default behavior to running docker-compose locally (`docker-compose` needs to be in PATH).