### PR TITLE
chore: Move feast install to docker build in java it tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,10 +7,7 @@
     },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.9"
-    },
-    "ghcr.io/meaningful-ooo/devcontainer-features/homebrew:2": {
-      "version": "latest"
     }
   },
-  "postCreateCommand": "brew install mysql && pip install -e '.[dev]' && make compile-protos-python"
+  "postCreateCommand": "pip install -e '.[dev]' && make compile-protos-python"
 }

--- a/.github/fork_workflows/fork_pr_integration_tests_aws.yml
+++ b/.github/fork_workflows/fork_pr_integration_tests_aws.yml
@@ -138,7 +138,7 @@ jobs:
             sudo apt update
             sudo apt install -y -V libarrow-dev
       - name: Install apache-arrow on macos
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macos-12'
         run: |
             brew install apache-arrow
             brew install pkg-config

--- a/.github/fork_workflows/fork_pr_integration_tests_gcp.yml
+++ b/.github/fork_workflows/fork_pr_integration_tests_gcp.yml
@@ -82,7 +82,7 @@ jobs:
             sudo apt update
             sudo apt install -y -V libarrow-dev
       - name: Install apache-arrow on macos
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macOS-12'
         run: |
             brew install apache-arrow
             brew install pkg-config

--- a/.github/fork_workflows/fork_pr_integration_tests_snowflake.yml
+++ b/.github/fork_workflows/fork_pr_integration_tests_snowflake.yml
@@ -72,7 +72,7 @@ jobs:
             sudo apt update
             sudo apt install -y -V libarrow-dev
       - name: Install apache-arrow on macos
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macos-12'
         run: |
             brew install apache-arrow
             brew install pkg-config

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -79,7 +79,7 @@ jobs:
 
   build-source-distribution:
     name: Build source distribution
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -136,7 +136,7 @@ jobs:
     needs: [build-python-wheel, build-source-distribution, get-version]
     strategy:
       matrix:
-        os: [ubuntu-latest,  macos-latest ]
+        os: [ubuntu-latest,  macos-12 ]
         python-version: ["3.9", "3.10"]
         from-source: [ True, False ]
     env:
@@ -165,7 +165,7 @@ jobs:
           name: wheels
           path: dist
       - name: Install OS X dependencies
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-12'
         run: brew install coreutils
       - name: Install wheel
         if: ${{ !matrix.from-source }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -202,7 +202,7 @@ jobs:
             sudo apt update
             sudo apt install -y -V libarrow-dev
       - name: Install apache-arrow on macos
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macos-12'
         run: brew install apache-arrow
       - name: Install dependencies
         run: make install-python-ci-dependencies

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,9 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.9", "3.10" ]
-        os: [ ubuntu-latest, macOS-latest ]
+        os: [ ubuntu-latest, macos-12 ]
         exclude:
-          - os: macOS-latest
+          - os: macos-12
             python-version: "3.9"
     env:
       OS: ${{ matrix.os }}
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Python
         id: setup-python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
+++ b/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
@@ -62,11 +62,8 @@ abstract class ServingEnvironment {
             .withExposedService("redis", 6379)
             .withExposedService(
                 "feast", 8080, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(180)))
-            .withTailChildContainers(true);
-
-    if (System.getenv("FEAST_TESTCONTAINERS_LOCAL_COMPOSE") != null) {
-      environment = environment.withLocalCompose(true);
-    }
+            .withTailChildContainers(true)
+            .withLocalCompose(true);
 
     environment.start();
   }

--- a/java/serving/src/test/resources/docker-compose/docker-compose-redis-it.yml
+++ b/java/serving/src/test/resources/docker-compose/docker-compose-redis-it.yml
@@ -12,6 +12,3 @@ services:
       - "8080"
     links:
       - redis
-    # volumes:
-    #   - $PWD/../../../../../../:/mnt/feast
-

--- a/java/serving/src/test/resources/docker-compose/docker-compose-redis-it.yml
+++ b/java/serving/src/test/resources/docker-compose/docker-compose-redis-it.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   redis:
     image: redis:6.2
@@ -7,11 +5,13 @@ services:
     ports:
       - "6379"
   feast:
-    build: feast10
+    build:
+      context: ../../../../../../
+      dockerfile: java/serving/src/test/resources/docker-compose/feast10/Dockerfile
     ports:
       - "8080"
     links:
       - redis
-    volumes:
-      - $PWD/../../../../../../:/mnt/feast
+    # volumes:
+    #   - $PWD/../../../../../../:/mnt/feast
 

--- a/java/serving/src/test/resources/docker-compose/docker-compose-redis-it.yml
+++ b/java/serving/src/test/resources/docker-compose/docker-compose-redis-it.yml
@@ -10,5 +10,5 @@ services:
       dockerfile: java/serving/src/test/resources/docker-compose/feast10/Dockerfile
     ports:
       - "8080"
-    links:
+    depends_on:
       - redis

--- a/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
+++ b/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
@@ -1,10 +1,5 @@
 FROM python:3.9
 
-WORKDIR /usr/src/
-
-COPY java/serving/src/test/resources/docker-compose/feast10/requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-
 WORKDIR /app
 COPY java/serving/src/test/resources/docker-compose/feast10/ .
 COPY sdk/python /mnt/feast/sdk/python

--- a/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
+++ b/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
@@ -2,11 +2,13 @@ FROM python:3.9
 
 WORKDIR /usr/src/
 
-COPY requirements.txt ./
+COPY java/serving/src/test/resources/docker-compose/feast10/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 WORKDIR /app
-COPY . .
+COPY java/serving/src/test/resources/docker-compose/feast10/ .
+COPY . /mnt/feast
+RUN cd /mnt/feast && pip install .[grpcio,redis]
 EXPOSE 8080
 
 CMD ["./entrypoint.sh"]

--- a/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
+++ b/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
@@ -7,8 +7,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 WORKDIR /app
 COPY java/serving/src/test/resources/docker-compose/feast10/ .
-COPY . /mnt/feast
-RUN cd /mnt/feast && pip install .[grpcio,redis]
+COPY sdk/python /mnt/feast/sdk/python
+COPY protos /mnt/feast/protos
+COPY setup.py /mnt/feast/setup.py
+COPY README.md /mnt/feast/README.md
+RUN cd /mnt/feast && SETUPTOOLS_SCM_PRETEND_VERSION="0.1.0" pip install .[grpcio,redis]
 EXPOSE 8080
 
 CMD ["./entrypoint.sh"]

--- a/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
+++ b/java/serving/src/test/resources/docker-compose/feast10/Dockerfile
@@ -5,6 +5,7 @@ COPY java/serving/src/test/resources/docker-compose/feast10/ .
 COPY sdk/python /mnt/feast/sdk/python
 COPY protos /mnt/feast/protos
 COPY setup.py /mnt/feast/setup.py
+COPY pyproject.toml /mnt/feast/pyproject.toml
 COPY README.md /mnt/feast/README.md
 RUN cd /mnt/feast && SETUPTOOLS_SCM_PRETEND_VERSION="0.1.0" pip install .[grpcio,redis]
 EXPOSE 8080

--- a/java/serving/src/test/resources/docker-compose/feast10/entrypoint.sh
+++ b/java/serving/src/test/resources/docker-compose/feast10/entrypoint.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-# feast root directory is expected to be mounted (eg, by docker compose)
-cd /mnt/feast
-pip install -e '.[grpcio,redis]'
-
 cd /app
 python materialize.py
 feast serve_transformations --port 8080

--- a/java/serving/src/test/resources/docker-compose/feast10/requirements.txt
+++ b/java/serving/src/test/resources/docker-compose/feast10/requirements.txt
@@ -1,6 +1,0 @@
-# for source generation
-pyarrow==14.0.1
-
-# temp fixes
-proto-plus
-Jinja2>=2.0.0


### PR DESCRIPTION
# What this PR does / why we need it:
In a docker-compose setup used in java integration tests, `pip install .` is part of an entrypoint.sh file, which effectively means that it's run once for each test (there are 6 tests as of now). This PR changes compose setup and moves feast pip install to a docker build step. This should noticeably speed up java integration tests.