### PR TITLE
fix: Make sure schema is used when calling `get_table_query_string` method for Snowflake datasource

### DIFF
--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -191,8 +191,10 @@ class SnowflakeSource(DataSource):
 
     def get_table_query_string(self) -> str:
         """Returns a string that can directly be used to reference this table in SQL."""
-        if self.database and self.table:
+        if self.database and self.schema and self.table:
             return f'"{self.database}"."{self.schema}"."{self.table}"'
+        elif self.schema and self.table:
+            return f'"{self.schema}.{self.table}"'
         elif self.table:
             return f'"{self.table}"'
         else:

--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -194,7 +194,7 @@ class SnowflakeSource(DataSource):
         if self.database and self.schema and self.table:
             return f'"{self.database}"."{self.schema}"."{self.table}"'
         elif self.schema and self.table:
-            return f'"{self.schema}.{self.table}"'
+            return f'"{self.schema}"."{self.table}"'
         elif self.table:
             return f'"{self.table}"'
         else:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

If I pass `schema="my_schema"` and `table="my_table"` when creating a `SnowflakeSource`, I would expect that `SnowflakeSource.get_table_query_string` outputs `'"my_schema"."my_table"'`. However, currently, `SnowflakeSource.get_table_query_string` outputs `"my_table"`.

This PR fixes that by extending the `get_table_query_string` method with an additional branch for when both `schema` and `table` are specified on the `SnowflakeSource` class.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

https://github.com/feast-dev/feast/issues/4130
