### PR TITLE
fix: Specify version instead of latest macOS runner version for unit test actions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,9 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.9", "3.10" ]
-        os: [ ubuntu-latest, macOS-latest ]
+        os: [ ubuntu-latest, macOS-12 ]
         exclude:
-          - os: macOS-latest
+          - os: macOS-12
             python-version: "3.9"
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
Attempt pinning a version for MacOS action runner in unit tests as I suspect macos-latest (resolving to 14) is causing issues for dependency libs such as seen [here](https://github.com/feast-dev/feast/actions/runs/8789249143/job/24119321935).
