### PR TITLE
fix: Default value is not set in Redis connection string using environment variable

### DIFF
--- a/docs/how-to-guides/running-feast-in-production.md
+++ b/docs/how-to-guides/running-feast-in-production.md
@@ -257,17 +257,6 @@ online_store:
     connection_string: ${REDIS_CONNECTION_STRING}
 ```
 
-It is possible to set a default value if the environment variable is not set, with `${ENV_VAR:"default"}`. For instance:
-
-```yaml
-project: my_project
-registry: data/registry.db
-provider: local
-online_store:
-    type: redis
-    connection_string: ${REDIS_CONNECTION_STRING:"0.0.0.0:6379"}
-```
-
 ***
 
 ## Summary


### PR DESCRIPTION

# What this PR does / why we need it:
Removed documentation of Redis connection string supporting default values when using environment variables as it isn't supported

# Which issue(s) this PR fixes:
Fixes #3669