### PR TITLE
feat: Make arrow primary interchange for online ODFV execution

### DIFF
--- a/sdk/python/feast/online_response.py
+++ b/sdk/python/feast/online_response.py
@@ -15,6 +15,7 @@
 from typing import Any, Dict, List
 
 import pandas as pd
+import pyarrow as pa
 
 from feast.feature_view import DUMMY_ENTITY_ID
 from feast.protos.feast.serving.ServingService_pb2 import GetOnlineFeaturesResponse
@@ -77,3 +78,13 @@ class OnlineResponse:
         """
 
         return pd.DataFrame(self.to_dict(include_event_timestamps))
+
+    def to_arrow(self, include_event_timestamps: bool = False) -> pa.Table:
+        """
+        Converts GetOnlineFeaturesResponse features into pyarrow Table.
+
+        Args:
+        is_with_event_timestamps: bool Optionally include feature timestamps in the table
+        """
+
+        return pa.Table.from_pydict(self.to_dict(include_event_timestamps))

--- a/sdk/python/feast/transformation/python_transformation.py
+++ b/sdk/python/feast/transformation/python_transformation.py
@@ -64,9 +64,6 @@ class PythonTransformation:
                 "Comparisons should only involve PythonTransformation class objects."
             )
 
-        if not super().__eq__(other):
-            return False
-
         if (
             self.udf_string != other.udf_string
             or self.udf.__code__.co_code != other.udf.__code__.co_code

--- a/sdk/python/feast/transformation/substrait_transformation.py
+++ b/sdk/python/feast/transformation/substrait_transformation.py
@@ -77,9 +77,6 @@ class SubstraitTransformation:
                 "Comparisons should only involve SubstraitTransformation class objects."
             )
 
-        if not super().__eq__(other):
-            return False
-
         return (
             self.substrait_plan == other.substrait_plan
             and self.ibis_function.__code__.co_code

--- a/sdk/python/feast/transformation_server.py
+++ b/sdk/python/feast/transformation_server.py
@@ -45,15 +45,14 @@ class TransformationServer(TransformationServiceServicer):
             context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
             raise
 
-        df = pa.ipc.open_file(request.transformation_input.arrow_value).read_pandas()
+        df = pa.ipc.open_file(request.transformation_input.arrow_value).read_all()
 
         if odfv.mode != "pandas":
             raise Exception(
                 f'OnDemandFeatureView mode "{odfv.mode}" not supported by TransformationServer.'
             )
 
-        result_df = odfv.get_transformed_features_df(df, True)
-        result_arrow = pa.Table.from_pandas(result_df)
+        result_arrow = odfv.transform_arrow(df, True)
         sink = pa.BufferOutputStream()
         writer = pa.ipc.new_file(sink, result_arrow.schema)
         writer.write_table(result_arrow)

--- a/sdk/python/tests/unit/test_on_demand_feature_view.py
+++ b/sdk/python/tests/unit/test_on_demand_feature_view.py
@@ -204,7 +204,7 @@ def test_python_native_transformation_mode():
             }
         )
 
-    assert on_demand_feature_view_python_native.get_transformed_features(
+    assert on_demand_feature_view_python_native.transform_dict(
         {
             "feature1": 0,
             "feature2": 1,


### PR DESCRIPTION
# What this PR does / why we need it:
This PR is an online counterpart of #4083. online response object no longer needs to be converted to pandas for substrait transformations to be executed. Also cleans up some leftover unused code from `on_demand_feature_view.py`.