### PR TITLE
chore: Bump macOS runners to macos-13

### DIFF
--- a/.github/fork_workflows/fork_pr_integration_tests_aws.yml
+++ b/.github/fork_workflows/fork_pr_integration_tests_aws.yml
@@ -137,11 +137,6 @@ jobs:
             sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
             sudo apt update
             sudo apt install -y -V libarrow-dev
-      - name: Install apache-arrow on macos
-        if: matrix.os == 'macos-12'
-        run: |
-            brew install apache-arrow
-            brew install pkg-config
       - name: Install dependencies
         run: make install-python-ci-dependencies
       - name: Setup Redis Cluster

--- a/.github/fork_workflows/fork_pr_integration_tests_gcp.yml
+++ b/.github/fork_workflows/fork_pr_integration_tests_gcp.yml
@@ -81,11 +81,6 @@ jobs:
             sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
             sudo apt update
             sudo apt install -y -V libarrow-dev
-      - name: Install apache-arrow on macos
-        if: matrix.os == 'macOS-12'
-        run: |
-            brew install apache-arrow
-            brew install pkg-config
       - name: Install dependencies
         run: make install-python-ci-dependencies
       - name: Setup Redis Cluster

--- a/.github/fork_workflows/fork_pr_integration_tests_snowflake.yml
+++ b/.github/fork_workflows/fork_pr_integration_tests_snowflake.yml
@@ -71,11 +71,6 @@ jobs:
             sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
             sudo apt update
             sudo apt install -y -V libarrow-dev
-      - name: Install apache-arrow on macos
-        if: matrix.os == 'macos-12'
-        run: |
-            brew install apache-arrow
-            brew install pkg-config
       - name: Install dependencies
         run: make install-python-ci-dependencies
       - name: Setup Redis Cluster

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -79,7 +79,7 @@ jobs:
 
   build-source-distribution:
     name: Build source distribution
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -136,7 +136,7 @@ jobs:
     needs: [build-python-wheel, build-source-distribution, get-version]
     strategy:
       matrix:
-        os: [ubuntu-latest,  macos-12 ]
+        os: [ubuntu-latest,  macos-13 ]
         python-version: ["3.9", "3.10"]
         from-source: [ True, False ]
     env:
@@ -165,7 +165,7 @@ jobs:
           name: wheels
           path: dist
       - name: Install OS X dependencies
-        if: matrix.os == 'macos-12'
+        if: matrix.os == 'macos-13'
         run: brew install coreutils
       - name: Install wheel
         if: ${{ !matrix.from-source }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -197,7 +197,7 @@ jobs:
             sudo apt update
             sudo apt install -y -V libarrow-dev
       - name: Install apache-arrow on macos
-        if: matrix.os == 'macos-12'
+        if: matrix.os == 'macos-13'
         run: brew install apache-arrow
       - name: Install dependencies
         run: make install-python-ci-dependencies

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,9 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.9", "3.10" ]
-        os: [ ubuntu-latest, macos-12 ]
+        os: [ ubuntu-latest, macos-13 ]
         exclude:
-          - os: macos-12
+          - os: macos-13
             python-version: "3.9"
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
# What this PR does / why we need it:
macos runners are obviously slower than linux ones in the ci. We are using `macos-12` which is (3CPU/14RAM) while `linux-latest` is (4CPU/16RAM). This PR bumps macos runner version to 13, which should be a similar image with [4 cores](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).