### PR TITLE
fix: Helm chart `feast-feature-server`, improve Service template name

### DIFF
--- a/examples/python-helm-demo/README.md
+++ b/examples/python-helm-demo/README.md
@@ -72,11 +72,11 @@ We use the Feast CLI to register and materialize features, and then retrieving v
    3. `helm install feast-release ../../../infra/charts/feast-feature-server --set image.tag=dev --set feature_store_yaml_base64=$(base64 feature_store.yaml)`
 5. (Optional): check logs of the server to make sure it’s working
    ```bash
-   kubectl logs svc/feast-feature-server
+   kubectl logs svc/feast-release-feast-feature-server
    ```
 6. Port forward to expose the grpc endpoint:
    ```bash
-   kubectl port-forward svc/feast-feature-server 6566:80
+   kubectl port-forward svc/feast-release-feast-feature-server 6566:80
    ```
 7. Run test fetches for online features:8. 
     - First: change back the Redis connection string to allow localhost connections to Redis

--- a/infra/charts/feast-feature-server/templates/service.yaml
+++ b/infra/charts/feast-feature-server/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "feast-feature-server.name" . }}
+  name: {{ include "feast-feature-server.fullname" . }}
   labels:
     {{- include "feast-feature-server.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Changes metadata.name in service.yaml template to use `"feast-feature-server.fullname"`, like the deployment template already does. This ensures the service name for each helm install will be unique to the namespace.

Of note, the service template in the [java helm chart](/feast-dev/feast/tree/master/infra/charts/feast/charts/feature-server) is already configured this way -
https://github.com/feast-dev/feast/blob/2b493e0457cea19a9b3faa163f099d6b32fde30d/infra/charts/feast/charts/feature-server/templates/service.yaml#L4

An example of the fix working -
```bash
$ helm install example1 infra/charts/feast-feature-server --set feature_store_yaml_base64=$(base64 feature_store.yaml)
NAME: example1
LAST DEPLOYED: Mon Apr 29 14:16:09 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None

$ helm install example2 infra/charts/feast-feature-server --set feature_store_yaml_base64=$(base64 feature_store.yaml)
NAME: example2
LAST DEPLOYED: Mon Apr 29 14:16:14 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/feast-dev/feast/issues/4160