### PR TITLE
chore: Limit integration runs back to a single python version due to rate limiting errors

### DIFF
--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11" ]
+        python-version: [ "3.11" ]
         os: [ ubuntu-latest ]
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
Even with recent workflow improvements, the recent change to increase scope of integration tests from only python v3.9 to v's 3.9-3.11 has caused us to begin hitting rate limiting errors with google cloud resources due to 3 simultaneous executions per action trigger. This PR reduces integration tests back to a single version scope using v3.11 so that actions won't require constant monitoring and re-triggers.