### PR TITLE
fix: Update master-only benchmark bucket name due to credential update

### DIFF
--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -142,7 +142,7 @@ jobs:
           SNOWFLAKE_CI_WAREHOUSE: ${{ secrets.SNOWFLAKE_CI_WAREHOUSE }}
         run: pytest --verbose --color=yes sdk/python/tests --integration --benchmark --benchmark-autosave --benchmark-save-data --durations=5
       - name: Upload Benchmark Artifact to S3
-        run: aws s3 cp --recursive .benchmarks s3://feast-ci-pytest-benchmarks
+        run: aws s3 cp --recursive .benchmarks s3://feast-ci-pytest-benchmark
 
   build-all-docker-images:
     if: github.repository == 'feast-dev/feast'


### PR DESCRIPTION
# What this PR does / why we need it:

Update bucket name due to global resource name collisions with old AWS acct. in order to fix master-only test runs failing as seen [here](https://github.com/feast-dev/feast/actions/runs/8989121663/job/24693009473#step:17:29).

