### PR TITLE
refactor: Replace deprecated lifespan event

### DIFF
--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -47,8 +47,8 @@ class MaterializeIncrementalRequest(BaseModel):
 
 
 def get_app(
-        store: "feast.FeatureStore",
-        registry_ttl_sec: int = DEFAULT_FEATURE_SERVER_REGISTRY_TTL,
+    store: "feast.FeatureStore",
+    registry_ttl_sec: int = DEFAULT_FEATURE_SERVER_REGISTRY_TTL,
 ):
     proto_json.patch()
     # Asynchronously refresh registry, notifying shutdown and canceling the active timer if the app is shutting down
@@ -203,7 +203,6 @@ def get_app(
 if sys.platform != "win32":
     import gunicorn.app.base
 
-
     class FeastServeApplication(gunicorn.app.base.BaseApplication):
         def __init__(self, store: "feast.FeatureStore", **options):
             self._app = get_app(
@@ -225,13 +224,13 @@ if sys.platform != "win32":
 
 
 def start_server(
-        store: "feast.FeatureStore",
-        host: str,
-        port: int,
-        no_access_log: bool,
-        workers: int,
-        keep_alive_timeout: int,
-        registry_ttl_sec: int,
+    store: "feast.FeatureStore",
+    host: str,
+    port: int,
+    no_access_log: bool,
+    workers: int,
+    keep_alive_timeout: int,
+    registry_ttl_sec: int,
 ):
     if sys.platform != "win32":
         FeastServeApplication(

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -6,18 +6,19 @@ import warnings
 from contextlib import asynccontextmanager
 from typing import List, Optional
 
-import feast
 import pandas as pd
 from dateutil import parser
 from fastapi import FastAPI, HTTPException, Request, Response, status
 from fastapi.logger import logger
 from fastapi.params import Depends
+from google.protobuf.json_format import MessageToDict
+from pydantic import BaseModel
+
+import feast
 from feast import proto_json, utils
 from feast.constants import DEFAULT_FEATURE_SERVER_REGISTRY_TTL
 from feast.data_source import PushMode
 from feast.errors import PushSourceNotFoundException
-from google.protobuf.json_format import MessageToDict
-from pydantic import BaseModel
 
 
 # TODO: deprecate this in favor of push features


### PR DESCRIPTION
# What this PR does / why we need it:

Change fastapi's deprecated lifespan code to async context manager.

``` text 
[FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  @app.on_event("shutdown")                                                                                                                                                                                                                                                                                                                                              
/app/.local/lib/python3.10/site-packages/fastapi/applications.py:4495: DeprecationWarning: on_event is deprecated, use lifespan event handlers instead.                                                                                                                                                                                                                                                                                                     
Read more about it in the [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
```

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Fixes
