### PR TITLE
feat: Set optional full-scan for deletion

### DIFF
--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -77,7 +77,7 @@ class RedisOnlineStoreConfig(FeastConfigBaseModel):
     key_ttl_seconds: Optional[int] = None
     """(Optional) redis key bin ttl (in seconds) for expiring entities"""
 
-    full_scan_for_deletion: Optional[bool] = False
+    full_scan_for_deletion: Optional[bool] = True
     """(Optional) whether to scan for deletion of features"""
 
 

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -77,6 +77,9 @@ class RedisOnlineStoreConfig(FeastConfigBaseModel):
     key_ttl_seconds: Optional[int] = None
     """(Optional) redis key bin ttl (in seconds) for expiring entities"""
 
+    full_scan_for_deletion: Optional[bool] = False
+    """(Optional) whether to scan for deletion of features"""
+
 
 class RedisOnlineStore(OnlineStore):
     """
@@ -160,9 +163,13 @@ class RedisOnlineStore(OnlineStore):
             entities_to_keep: Entities to keep
             partial: Whether to do a partial update
         """
+        online_store_config = config.online_store
 
-        for table in tables_to_delete:
-            self.delete_table(config, table)
+        assert isinstance(online_store_config, RedisOnlineStoreConfig)
+
+        if online_store_config.full_scan_for_deletion:
+            for table in tables_to_delete:
+                self.delete_table(config, table)
 
     def teardown(
         self,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

In this link (https://github.com/feast-dev/feast/pull/3857), I added function to perform a full-scan and delete data to save Redis memory. However, full-scan in Redis does not work beautifully, takes too long at production scale, and often fails in CI that performs feast-apply. So, I think it would be a good idea to add the 'full_scan_for_deletion' option in redis so that the user can select and delete it.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Fixes
