### PR TITLE
docs: Add docs for using `podman` on RHEL or Fedora machines

### DIFF
--- a/docs/project/development-guide.md
+++ b/docs/project/development-guide.md
@@ -123,6 +123,7 @@ Note that this means if you are midway through working through a PR and rebase, 
 Setting up your development environment for Feast Python SDK / CLI:
 1. Ensure that you have Docker installed in your environment. Docker is used to provision service dependencies during testing, and build images for feature servers and other components.
    - Please note that we use [Docker with BuiltKit](https://docs.docker.com/develop/develop-images/build_enhancements/).
+   - _Alternatively_ - To use [podman](https://podman.io/) on a Fedora or RHEL machine, follow this [guide](https://github.com/feast-dev/feast/issues/4190)
 2. Ensure that you have `make` and Python (3.9 or above) installed.
 3. _Recommended:_ Create a virtual environment to isolate development dependencies to be installed
   ```sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:
This shows users how to run tests locally with podman, instead of docker, on fedora and rhel machines.

The docs will point to https://github.com/feast-dev/feast/issues/4190 so we'll need someone to add the `keep-open` & 
`kind/process` labels to that issue. This is identical to https://github.com/feast-dev/feast/issues/2105, which is already similarly used.
