### PR TITLE
feat: Add s3 remote storage export for duckdb

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -179,7 +179,15 @@ class FileSource(DataSource):
         elif isinstance(self.file_format, DeltaFormat):
             from deltalake import DeltaTable
 
-            schema = DeltaTable(self.path).schema().to_pyarrow()
+            storage_options = {
+                "AWS_ENDPOINT_URL": str(self.s3_endpoint_override),
+            }
+
+            schema = (
+                DeltaTable(self.path, storage_options=storage_options)
+                .schema()
+                .to_pyarrow()
+            )
         else:
             raise Exception(f"Unknown FileFormat -> {self.file_format}")
 

--- a/sdk/python/pytest.ini
+++ b/sdk/python/pytest.ini
@@ -6,3 +6,9 @@ markers =
 env =
     FEAST_USAGE=False
     IS_TEST=True
+
+filterwarnings =
+    ignore::DeprecationWarning:pyspark.sql.pandas.*:
+    ignore::DeprecationWarning:pyspark.sql.connect.*:
+    ignore::DeprecationWarning:httpx.*:
+    ignore::FutureWarning:ibis_substrait.compiler.*:

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 import logging
 import multiprocessing
+import os
 import random
 from datetime import datetime, timedelta
 from multiprocessing import Process
 from sys import platform
 from typing import Any, Dict, List, Tuple, no_type_check
+from unittest import mock
 
 import pandas as pd
 import pytest
@@ -180,7 +182,11 @@ def environment(request, worker_id):
         request.param, worker_id=worker_id, fixture_request=request
     )
 
-    yield e
+    if hasattr(e.data_source_creator, "mock_environ"):
+        with mock.patch.dict(os.environ, e.data_source_creator.mock_environ):
+            yield e
+    else:
+        yield e
 
     e.feature_store.teardown()
     e.data_source_creator.teardown()

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -33,6 +33,7 @@ from tests.integration.feature_repos.universal.data_sources.bigquery import (
 from tests.integration.feature_repos.universal.data_sources.file import (
     DuckDBDataSourceCreator,
     DuckDBDeltaDataSourceCreator,
+    DuckDBDeltaS3DataSourceCreator,
     FileDataSourceCreator,
 )
 from tests.integration.feature_repos.universal.data_sources.redshift import (
@@ -121,6 +122,14 @@ AVAILABLE_OFFLINE_STORES: List[Tuple[str, Type[DataSourceCreator]]] = [
     ("local", DuckDBDataSourceCreator),
     ("local", DuckDBDeltaDataSourceCreator),
 ]
+
+if os.getenv("FEAST_IS_LOCAL_TEST", "False") == "True":
+    AVAILABLE_OFFLINE_STORES.extend(
+        [
+            ("local", DuckDBDeltaS3DataSourceCreator),
+        ]
+    )
+
 
 AVAILABLE_ONLINE_STORES: Dict[
     str, Tuple[Union[str, Dict[Any, Any]], Optional[Type[OnlineStoreCreator]]]

--- a/sdk/python/tests/integration/materialization/contrib/spark/test_spark.py
+++ b/sdk/python/tests/integration/materialization/contrib/spark/test_spark.py
@@ -31,7 +31,7 @@ def test_spark_materialization_consistency():
         batch_engine={"type": "spark.engine", "partitions": 10},
     )
     spark_environment = construct_test_environment(
-        spark_config, None, entity_key_serialization_version=1
+        spark_config, None, entity_key_serialization_version=2
     )
 
     df = create_basic_driver_dataset()

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -139,8 +139,7 @@ def test_historical_features(
 
     if job_from_df.supports_remote_storage_export():
         files = job_from_df.to_remote_storage()
-        print(files)
-        assert len(files) > 0  # This test should be way more detailed
+        assert len(files)  # 0  # This test should be way more detailed
 
     start_time = datetime.utcnow()
     actual_df_from_df_entities = job_from_df.to_df()


### PR DESCRIPTION
# What this PR does / why we need it:
- Adds tests and some missed functionality to access delta tables stored in s3 with duckdb offline store.
- Adds ability to export the output of duckdb retrieval job to s3.