### PR TITLE
chore: Skip test_historical_features_main for Snowflake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test-python-unit:
 	python -m pytest -n 8 --color=yes sdk/python/tests
 
 test-python-integration:
-	python -m pytest -n 8 --integration -k "not minio_registry" --color=yes --durations=5 --timeout=1200 --timeout_method=thread sdk/python/tests
+	python -m pytest -n 8 --integration -k "(not snowflake or not test_historical_features_main) and not minio_registry" --color=yes --durations=5 --timeout=1200 --timeout_method=thread sdk/python/tests
 
 test-python-integration-local:
 	@(docker info > /dev/null 2>&1 && \

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -44,7 +44,7 @@ np.random.seed(0)
 @pytest.mark.parametrize(
     "use_substrait_odfv", [True, False], ids=lambda v: f"substrait:{v}"
 )
-def test_historical_features(
+def test_historical_features_main(
     environment, universal_data_sources, full_feature_names, use_substrait_odfv
 ):
     store = environment.feature_store


### PR DESCRIPTION
# What this PR does / why we need it:
Temporarily skips failing `test_historical_features_main` test (had to change the name to correctly apply a pytest expression) for snowflake.