### PR TITLE
feat: Feast/IKV datetime edgecase errors

### DIFF
--- a/sdk/python/feast/infra/online_stores/contrib/ikv_online_store/ikv.py
+++ b/sdk/python/feast/infra/online_stores/contrib/ikv_online_store/ikv.py
@@ -265,7 +265,8 @@ class IKVOnlineStore(OnlineStore):
             IKVDocumentBuilder()
             .put_string_field(PRIMARY_KEY_FIELD_NAME, entity_id)
             .put_bytes_field(
-                EVENT_CREATION_TIMESTAMP_FIELD_NAME, event_timestamp_seconds_proto.SerializeToString()
+                EVENT_CREATION_TIMESTAMP_FIELD_NAME,
+                event_timestamp_seconds_proto.SerializeToString(),
             )
         )
 

--- a/sdk/python/feast/infra/online_stores/contrib/ikv_online_store/ikv.py
+++ b/sdk/python/feast/infra/online_stores/contrib/ikv_online_store/ikv.py
@@ -11,6 +11,8 @@ from typing import (
     Tuple,
 )
 
+import pytz
+from google.protobuf.timestamp_pb2 import Timestamp
 from ikvpy.client import IKVReader, IKVWriter
 from ikvpy.clientoptions import ClientOptions, ClientOptionsBuilder
 from ikvpy.document import IKVDocument, IKVDocumentBuilder
@@ -24,9 +26,6 @@ from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
 from feast.usage import log_exceptions_and_usage
-
-import pytz
-from google.protobuf.timestamp_pb2 import Timestamp
 
 PRIMARY_KEY_FIELD_NAME: str = "_entity_key"
 EVENT_CREATION_TIMESTAMP_FIELD_NAME: str = "_event_timestamp"


### PR DESCRIPTION
# What this PR does / why we need it:
Some date-time inputs had decoding errors while running benchmark (<1%)

# Testing
make format-python && make lint-python
