### PR TITLE
docs: Operator readme fix

### DIFF
--- a/infra/feast-operator/README.md
+++ b/infra/feast-operator/README.md
@@ -21,7 +21,7 @@ kind: FeastFeatureServer
 metadata:
   name: example
 spec:
-  feature_store_yaml_base64: $(cat feature_store.yaml | base64)
+  feature_store_yaml_base64: $(cat feature_store.yaml | base64 | tr -d '\n\r')
 EOF
 ```
 Ensure it was successfully created on the cluster and that the `feature_store_yaml_base64` field was properly set. The following command should return output which is identical to your `feature_store.yaml`:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->
Fixes the operator readme docs.

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Fixes an issue when operator docs are followed on a linux machine. This change improves cross-platform documentation.