### PR TITLE
chore: Adjusting the file version validation for minor releases

### DIFF
--- a/infra/scripts/release/bump_file_versions.py
+++ b/infra/scripts/release/bump_file_versions.py
@@ -1,5 +1,6 @@
 # This script will bump the versions found in files (charts, pom.xml) during the Feast release process.
 
+import re
 import pathlib
 import sys
 
@@ -73,10 +74,19 @@ def validate_files_to_bump(current_version, files_to_bump, repo_root):
         with open(repo_root.joinpath(file_path), "r") as f:
             file_contents = f.readlines()
             for line in lines:
-                assert current_version in file_contents[int(line) - 1], (
+                new_version = _get_semantic_version(file_contents[int(line) - 1])
+                current_major_minor_version = '.'.join(current_version.split(".")[0:1])
+                assert current_version in new_version or current_major_minor_version in new_version, (
                     f"File `{file_path}` line `{line}` didn't contain version {current_version}. "
                     f"Contents: {file_contents[int(line) - 1]}"
                 )
+
+
+
+def _get_semantic_version(input_string: str) -> str:
+    semver_pattern = r'\bv?(\d+\.\d+\.\d+)\b'
+    match = re.search(semver_pattern, input_string)
+    return match.group(1)
 
 
 if __name__ == "__main__":

--- a/infra/scripts/release/bump_file_versions.py
+++ b/infra/scripts/release/bump_file_versions.py
@@ -46,7 +46,9 @@ def main() -> None:
         with open(repo_root.joinpath(file_path), "r") as f:
             file_contents = f.readlines()
             for line in lines:
-                file_contents[int(line) - 1] = file_contents[int(line) - 1].replace(current_version, new_version)
+                # note we validate the version above already
+                current_parsed_version = _get_semantic_version(file_contents[int(line) - 1])
+                file_contents[int(line) - 1] = file_contents[int(line) - 1].replace(current_parsed_version, new_version)
 
         with open(repo_root.joinpath(file_path), "w") as f:
             f.write(''.join(file_contents))
@@ -80,7 +82,6 @@ def validate_files_to_bump(current_version, files_to_bump, repo_root):
                     f"File `{file_path}` line `{line}` didn't contain version {current_version}. "
                     f"Contents: {file_contents[int(line) - 1]}"
                 )
-
 
 
 def _get_semantic_version(input_string: str) -> str:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
This is changing the validation to ignore patch version changes. So the CI should trigger correctly for increments from `0.37.1` -> `0.38.0`.

```bash
python infra/scripts/release/bump_file_versions.py 0.37.0 0.38.0
Updated 16 files with new version 0.38.0
```

Previously this failed as `0.37.1` wasn't recognized as a tag.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Fixes
