### PR TITLE
feat: Make RegistryServer writable

### DIFF
--- a/protos/feast/core/Transformation.proto
+++ b/protos/feast/core/Transformation.proto
@@ -5,8 +5,6 @@ option go_package = "github.com/feast-dev/feast/go/protos/feast/core";
 option java_outer_classname = "FeatureTransformationProto";
 option java_package = "feast.proto.core";
 
-import "google/protobuf/duration.proto";
-
 // Serialized representation of python function.
 message UserDefinedFunctionV2 {
     // The function name

--- a/protos/feast/registry/RegistryServer.proto
+++ b/protos/feast/registry/RegistryServer.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package feast.registry;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 import "feast/core/Registry.proto";
 import "feast/core/Entity.proto";
 import "feast/core/DataSource.proto";
@@ -16,16 +17,22 @@ import "feast/core/InfraObject.proto";
 
 service RegistryServer{
   // Entity RPCs
+  rpc ApplyEntity (ApplyEntityRequest) returns (google.protobuf.Empty) {}
   rpc GetEntity (GetEntityRequest) returns (feast.core.Entity) {}
   rpc ListEntities (ListEntitiesRequest) returns (ListEntitiesResponse) {}
+  rpc DeleteEntity (DeleteEntityRequest) returns (google.protobuf.Empty) {}
   
   // DataSource RPCs
+  rpc ApplyDataSource (ApplyDataSourceRequest) returns (google.protobuf.Empty) {}
   rpc GetDataSource (GetDataSourceRequest) returns (feast.core.DataSource) {}
   rpc ListDataSources (ListDataSourcesRequest) returns (ListDataSourcesResponse) {}
+  rpc DeleteDataSource (DeleteDataSourceRequest) returns (google.protobuf.Empty) {}
 
   // FeatureView RPCs
+  rpc ApplyFeatureView (ApplyFeatureViewRequest) returns (google.protobuf.Empty) {}
   rpc GetFeatureView (GetFeatureViewRequest) returns (feast.core.FeatureView) {}
   rpc ListFeatureViews (ListFeatureViewsRequest) returns (ListFeatureViewsResponse) {}
+  rpc DeleteFeatureView (DeleteFeatureViewRequest) returns (google.protobuf.Empty) {}
 
   // StreamFeatureView RPCs
   rpc GetStreamFeatureView (GetStreamFeatureViewRequest) returns (feast.core.StreamFeatureView) {}
@@ -36,19 +43,28 @@ service RegistryServer{
   rpc ListOnDemandFeatureViews (ListOnDemandFeatureViewsRequest) returns (ListOnDemandFeatureViewsResponse) {}
 
   // FeatureService RPCs
+  rpc ApplyFeatureService (ApplyFeatureServiceRequest) returns (google.protobuf.Empty) {}
   rpc GetFeatureService (GetFeatureServiceRequest) returns (feast.core.FeatureService) {}
   rpc ListFeatureServices (ListFeatureServicesRequest) returns (ListFeatureServicesResponse) {}
+  rpc DeleteFeatureService (DeleteFeatureServiceRequest) returns (google.protobuf.Empty) {}
 
   // SavedDataset RPCs
+  rpc ApplySavedDataset (ApplySavedDatasetRequest) returns (google.protobuf.Empty) {}
   rpc GetSavedDataset (GetSavedDatasetRequest) returns (feast.core.SavedDataset) {}
   rpc ListSavedDatasets (ListSavedDatasetsRequest) returns (ListSavedDatasetsResponse) {}
+  rpc DeleteSavedDataset (DeleteSavedDatasetRequest) returns (google.protobuf.Empty) {}
 
   // ValidationReference RPCs
+  rpc ApplyValidationReference (ApplyValidationReferenceRequest) returns (google.protobuf.Empty) {}
   rpc GetValidationReference (GetValidationReferenceRequest) returns (feast.core.ValidationReference) {}
   rpc ListValidationReferences (ListValidationReferencesRequest) returns (ListValidationReferencesResponse) {}
-
+  rpc DeleteValidationReference (DeleteValidationReferenceRequest) returns (google.protobuf.Empty) {}
+  
+  rpc ApplyMaterialization (ApplyMaterializationRequest) returns (google.protobuf.Empty) {}
   rpc ListProjectMetadata (ListProjectMetadataRequest) returns (ListProjectMetadataResponse) {}
+  rpc UpdateInfra (UpdateInfraRequest) returns (google.protobuf.Empty) {}
   rpc GetInfra (GetInfraRequest) returns (feast.core.Infra) {}
+  rpc Commit (google.protobuf.Empty) returns (google.protobuf.Empty) {}
   rpc Refresh (RefreshRequest) returns (google.protobuf.Empty) {}
   rpc Proto (google.protobuf.Empty) returns (feast.core.Registry) {}
 
@@ -56,6 +72,12 @@ service RegistryServer{
 
 message RefreshRequest {
   string project = 1;
+}
+
+message UpdateInfraRequest {
+  feast.core.Infra infra = 1;
+  string project = 2;
+  bool commit = 3;
 }
 
 message GetInfraRequest {
@@ -70,6 +92,20 @@ message ListProjectMetadataRequest {
 
 message ListProjectMetadataResponse {
   repeated feast.core.ProjectMetadata project_metadata = 1;     
+}
+
+message ApplyMaterializationRequest {
+  feast.core.FeatureView feature_view = 1;
+  string project = 2;
+  google.protobuf.Timestamp start_date = 3;
+  google.protobuf.Timestamp end_date = 4;
+  bool commit = 5;
+}
+
+message ApplyEntityRequest {
+  feast.core.Entity entity = 1;
+  string project = 2;
+  bool commit = 3;
 }
 
 message GetEntityRequest {
@@ -87,7 +123,19 @@ message ListEntitiesResponse {
     repeated feast.core.Entity entities = 1;
 }
 
+message DeleteEntityRequest {
+    string name = 1;
+    string project = 2;
+    bool commit = 3;
+}
+
 // DataSources
+
+message ApplyDataSourceRequest {
+  feast.core.DataSource data_source = 1;
+  string project = 2;
+  bool commit = 3;
+}
 
 message GetDataSourceRequest {
     string name = 1;
@@ -104,7 +152,23 @@ message ListDataSourcesResponse {
     repeated feast.core.DataSource data_sources = 1;
 }
 
+message DeleteDataSourceRequest {
+    string name = 1;
+    string project = 2;
+    bool commit = 3;
+}
+
 // FeatureViews
+
+message ApplyFeatureViewRequest {
+  oneof base_feature_view {
+    feast.core.FeatureView feature_view = 1;
+    feast.core.OnDemandFeatureView on_demand_feature_view = 2;
+    feast.core.StreamFeatureView stream_feature_view = 3;
+  }
+  string project = 4;
+  bool commit = 5;
+}
 
 message GetFeatureViewRequest {
     string name = 1;
@@ -119,6 +183,12 @@ message ListFeatureViewsRequest {
 
 message ListFeatureViewsResponse {
     repeated feast.core.FeatureView feature_views = 1;
+}
+
+message DeleteFeatureViewRequest {
+    string name = 1;
+    string project = 2;
+    bool commit = 3;
 }
 
 // StreamFeatureView
@@ -157,6 +227,12 @@ message ListOnDemandFeatureViewsResponse {
 
 // FeatureServices
 
+message ApplyFeatureServiceRequest {
+  feast.core.FeatureService feature_service = 1;
+  string project = 2;
+  bool commit = 3;
+}
+
 message GetFeatureServiceRequest {
     string name = 1;
     string project = 2;
@@ -172,7 +248,19 @@ message ListFeatureServicesResponse {
     repeated feast.core.FeatureService feature_services = 1;
 }
 
+message DeleteFeatureServiceRequest {
+    string name = 1;
+    string project = 2;
+    bool commit = 3;
+}
+
 // SavedDataset
+
+message ApplySavedDatasetRequest {
+  feast.core.SavedDataset saved_dataset = 1;
+  string project = 2;
+  bool commit = 3;
+}
 
 message GetSavedDatasetRequest {
     string name = 1;
@@ -189,7 +277,19 @@ message ListSavedDatasetsResponse {
     repeated feast.core.SavedDataset saved_datasets = 1;
 }
 
+message DeleteSavedDatasetRequest {
+    string name = 1;
+    string project = 2;
+    bool commit = 3;
+}
+
 // ValidationReference
+
+message ApplyValidationReferenceRequest {
+  feast.core.ValidationReference validation_reference = 1;
+  string project = 2;
+  bool commit = 3;
+}
 
 message GetValidationReferenceRequest {
     string name = 1;
@@ -204,4 +304,10 @@ message ListValidationReferencesRequest {
 
 message ListValidationReferencesResponse {
     repeated feast.core.ValidationReference validation_references = 1;
+}
+
+message DeleteValidationReferenceRequest {
+    string name = 1;
+    string project = 2;
+    bool commit = 3;
 }

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -406,18 +406,14 @@ class BaseRegistry(ABC):
         """
         raise NotImplementedError
 
-    def delete_saved_dataset(self, name: str, project: str, allow_cache: bool = False):
+    def delete_saved_dataset(self, name: str, project: str, commit: bool = True):
         """
         Delete a saved dataset.
 
         Args:
             name: Name of dataset
             project: Feast project that this dataset belongs to
-            allow_cache: Whether to allow returning this dataset from a cached registry
-
-        Returns:
-            Returns either the specified SavedDataset, or raises an exception if
-            none is found
+            commit: Whether the change should be persisted immediately
         """
         raise NotImplementedError
 

--- a/sdk/python/feast/registry_server.py
+++ b/sdk/python/feast/registry_server.py
@@ -1,16 +1,34 @@
 from concurrent import futures
+from datetime import datetime
 
 import grpc
 from google.protobuf.empty_pb2 import Empty
 
 from feast import FeatureStore
+from feast.data_source import DataSource
+from feast.entity import Entity
+from feast.feature_service import FeatureService
+from feast.feature_view import FeatureView
+from feast.infra.infra_object import Infra
+from feast.infra.registry.base_registry import BaseRegistry
+from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.protos.feast.registry import RegistryServer_pb2, RegistryServer_pb2_grpc
+from feast.saved_dataset import SavedDataset, ValidationReference
+from feast.stream_feature_view import StreamFeatureView
 
 
 class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
-    def __init__(self, store: FeatureStore) -> None:
+    def __init__(self, registry: BaseRegistry) -> None:
         super().__init__()
-        self.proxied_registry = store.registry
+        self.proxied_registry = registry
+
+    def ApplyEntity(self, request: RegistryServer_pb2.ApplyEntityRequest, context):
+        self.proxied_registry.apply_entity(
+            entity=Entity.from_proto(request.entity),
+            project=request.project,
+            commit=request.commit,
+        )
+        return Empty()
 
     def GetEntity(self, request: RegistryServer_pb2.GetEntityRequest, context):
         return self.proxied_registry.get_entity(
@@ -27,6 +45,22 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             ]
         )
 
+    def DeleteEntity(self, request: RegistryServer_pb2.DeleteEntityRequest, context):
+        self.proxied_registry.delete_entity(
+            name=request.name, project=request.project, commit=request.commit
+        )
+        return Empty()
+
+    def ApplyDataSource(
+        self, request: RegistryServer_pb2.ApplyDataSourceRequest, context
+    ):
+        self.proxied_registry.apply_data_source(
+            data_source=DataSource.from_proto(request.data_source),
+            project=request.project,
+            commit=request.commit,
+        )
+        return Empty()
+
     def GetDataSource(self, request: RegistryServer_pb2.GetDataSourceRequest, context):
         return self.proxied_registry.get_data_source(
             name=request.name, project=request.project, allow_cache=request.allow_cache
@@ -42,12 +76,38 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             ]
         )
 
+    def DeleteDataSource(
+        self, request: RegistryServer_pb2.DeleteDataSourceRequest, context
+    ):
+        self.proxied_registry.delete_data_source(
+            name=request.name, project=request.project, commit=request.commit
+        )
+        return Empty()
+
     def GetFeatureView(
         self, request: RegistryServer_pb2.GetFeatureViewRequest, context
     ):
         return self.proxied_registry.get_feature_view(
             name=request.name, project=request.project, allow_cache=request.allow_cache
         ).to_proto()
+
+    def ApplyFeatureView(
+        self, request: RegistryServer_pb2.ApplyFeatureViewRequest, context
+    ):
+        feature_view_type = request.WhichOneof("base_feature_view")
+        if feature_view_type == "feature_view":
+            feature_view = FeatureView.from_proto(request.feature_view)
+        elif feature_view_type == "on_demand_feature_view":
+            feature_view = OnDemandFeatureView.from_proto(
+                request.on_demand_feature_view
+            )
+        elif feature_view_type == "stream_feature_view":
+            feature_view = StreamFeatureView.from_proto(request.stream_feature_view)
+
+        self.proxied_registry.apply_feature_view(
+            feature_view=feature_view, project=request.project, commit=request.commit
+        )
+        return Empty()
 
     def ListFeatureViews(self, request, context):
         return RegistryServer_pb2.ListFeatureViewsResponse(
@@ -58,6 +118,14 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
                 )
             ]
         )
+
+    def DeleteFeatureView(
+        self, request: RegistryServer_pb2.DeleteFeatureViewRequest, context
+    ):
+        self.proxied_registry.delete_feature_view(
+            name=request.name, project=request.project, commit=request.commit
+        )
+        return Empty()
 
     def GetStreamFeatureView(
         self, request: RegistryServer_pb2.GetStreamFeatureViewRequest, context
@@ -93,6 +161,16 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             ]
         )
 
+    def ApplyFeatureService(
+        self, request: RegistryServer_pb2.ApplyFeatureServiceRequest, context
+    ):
+        self.proxied_registry.apply_feature_service(
+            feature_service=FeatureService.from_proto(request.feature_service),
+            project=request.project,
+            commit=request.commit,
+        )
+        return Empty()
+
     def GetFeatureService(
         self, request: RegistryServer_pb2.GetFeatureServiceRequest, context
     ):
@@ -111,6 +189,24 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
                 )
             ]
         )
+
+    def DeleteFeatureService(
+        self, request: RegistryServer_pb2.DeleteFeatureServiceRequest, context
+    ):
+        self.proxied_registry.delete_feature_service(
+            name=request.name, project=request.project, commit=request.commit
+        )
+        return Empty()
+
+    def ApplySavedDataset(
+        self, request: RegistryServer_pb2.ApplySavedDatasetRequest, context
+    ):
+        self.proxied_registry.apply_saved_dataset(
+            saved_dataset=SavedDataset.from_proto(request.saved_dataset),
+            project=request.project,
+            commit=request.commit,
+        )
+        return Empty()
 
     def GetSavedDataset(
         self, request: RegistryServer_pb2.GetSavedDatasetRequest, context
@@ -131,6 +227,26 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             ]
         )
 
+    def DeleteSavedDataset(
+        self, request: RegistryServer_pb2.DeleteSavedDatasetRequest, context
+    ):
+        self.proxied_registry.delete_saved_dataset(
+            name=request.name, project=request.project, commit=request.commit
+        )
+        return Empty()
+
+    def ApplyValidationReference(
+        self, request: RegistryServer_pb2.ApplyValidationReferenceRequest, context
+    ):
+        self.proxied_registry.apply_validation_reference(
+            validation_reference=ValidationReference.from_proto(
+                request.validation_reference
+            ),
+            project=request.project,
+            commit=request.commit,
+        )
+        return Empty()
+
     def GetValidationReference(
         self, request: RegistryServer_pb2.GetValidationReferenceRequest, context
     ):
@@ -150,6 +266,14 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             ]
         )
 
+    def DeleteValidationReference(
+        self, request: RegistryServer_pb2.DeleteValidationReferenceRequest, context
+    ):
+        self.proxied_registry.delete_validation_reference(
+            name=request.name, project=request.project, commit=request.commit
+        )
+        return Empty()
+
     def ListProjectMetadata(
         self, request: RegistryServer_pb2.ListProjectMetadataRequest, context
     ):
@@ -162,10 +286,38 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             ]
         )
 
+    def ApplyMaterialization(
+        self, request: RegistryServer_pb2.ApplyMaterializationRequest, context
+    ):
+        self.proxied_registry.apply_materialization(
+            feature_view=FeatureView.from_proto(request.feature_view),
+            project=request.project,
+            start_date=datetime.fromtimestamp(
+                request.start_date.seconds + request.start_date.nanos / 1e9
+            ),
+            end_date=datetime.fromtimestamp(
+                request.end_date.seconds + request.end_date.nanos / 1e9
+            ),
+            commit=request.commit,
+        )
+        return Empty()
+
+    def UpdateInfra(self, request: RegistryServer_pb2.UpdateInfraRequest, context):
+        self.proxied_registry.update_infra(
+            infra=Infra.from_proto(request.infra),
+            project=request.project,
+            commit=request.commit,
+        )
+        return Empty()
+
     def GetInfra(self, request: RegistryServer_pb2.GetInfraRequest, context):
         return self.proxied_registry.get_infra(
             project=request.project, allow_cache=request.allow_cache
         ).to_proto()
+
+    def Commit(self, request, context):
+        self.proxied_registry.commit()
+        return Empty()
 
     def Refresh(self, request, context):
         self.proxied_registry.refresh(request.project)
@@ -178,7 +330,7 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
 def start_server(store: FeatureStore, port: int):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     RegistryServer_pb2_grpc.add_RegistryServerServicer_to_server(
-        RegistryServer(store), server
+        RegistryServer(store.registry), server
     )
     server.add_insecure_port(f"[::]:{port}")
     server.start()

--- a/sdk/python/tests/unit/infra/registry/test_remote.py
+++ b/sdk/python/tests/unit/infra/registry/test_remote.py
@@ -41,7 +41,7 @@ def mock_remote_registry(environment):
     )
     mock_channel = GrpcMockChannel(
         RegistryServer_pb2.DESCRIPTOR.services_by_name["RegistryServer"],
-        RegistryServer(store=store),
+        RegistryServer(registry=store._registry),
     )
     registry.stub = RegistryServer_pb2_grpc.RegistryServerStub(mock_channel)
     return registry

--- a/sdk/python/tests/unit/test_registry_server.py
+++ b/sdk/python/tests/unit/test_registry_server.py
@@ -21,7 +21,7 @@ def call_registry_server(server, method: str, request=None):
 def registry_server(environment):
     store: FeatureStore = environment.feature_store
 
-    servicer = RegistryServer(store=store)
+    servicer = RegistryServer(registry=store._registry)
 
     return grpc_testing.server_from_dictionary(
         {RegistryServer_pb2.DESCRIPTOR.services_by_name["RegistryServer"]: servicer},


### PR DESCRIPTION
# What this PR does / why we need it:
- This PR adds apply/delete endpoints to the grpc registry server, also makes necessary changes in `remote` registry that call those endpoints.

# Which issue(s) this PR fixes:
Fixes #4216 
