### PR TITLE
fix: Make Java gRPC client use timeouts as expected

### DIFF
--- a/java/serving-client/src/test/java/dev/feast/FeastClientTest.java
+++ b/java/serving-client/src/test/java/dev/feast/FeastClientTest.java
@@ -38,7 +38,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,7 +45,7 @@ import org.junit.Test;
 
 public class FeastClientTest {
   private final String AUTH_TOKEN = "test token";
-  private final Deadline DEADLINE = Deadline.after(2, TimeUnit.SECONDS);
+  private final long TIMEOUT_MILLIS = 300;
 
   @Rule public GrpcCleanupRule grpcRule;
   private AtomicBoolean isAuthenticated;
@@ -88,7 +87,7 @@ public class FeastClientTest {
     ManagedChannel channel =
         this.grpcRule.register(
             InProcessChannelBuilder.forName(serverName).directExecutor().build());
-    this.client = new FeastClient(channel, Optional.empty(), Optional.of(DEADLINE));
+    this.client = new FeastClient(channel, Optional.empty(), TIMEOUT_MILLIS);
   }
 
   @Test


### PR DESCRIPTION
# What this PR does / why we need it:
In my previous [PR](https://github.com/feast-dev/feast/pull/4217) I added deadlines to the gRPC stub used in Java `FeastClient`, however deadlines in gRPC don't behave like timeouts and in that PR are only set once when the client is constructed, causing requests after construction to fail with deadline exceeded even though the time they took was was within the deadline the used thought they had set up; here's an example of the issue:

```java
// Create the client, deadline starts counting from the moment client is instantiated
FeastClient client = new FeastClient(channel, Optional.empty(), Optional.of(Deadline.after(200, TimeUnit.MILLISECONDS)));
Thread.sleep(200);
client.getOnlineFeatures(...); // throws a StatusRuntimeException: DEADLINE_EXCEEDED
```
The `getOnlineFeatures(...)` call would exceed the deadline even if it took 1ms.

The official gRPC examples show the correct usage for adding timeouts is to create a copy stub with a new deadline setup for every new request as shown [here](https://github.com/grpc/grpc-java/blob/5c6b80881deb188586346f2cbbf2f35dd7f5f6f6/examples/src/main/java/io/grpc/examples/deadline/DeadlineClient.java#L56C31-L56C48), which is what is included in this PR.

# Which issue(s) this PR fixes:
N/A

# Fixes
N/A