### PR TITLE
fix: Feast UI importlib change

### DIFF
--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -51,7 +51,7 @@ def get_app(
 
     async_refresh()
 
-    ui_dir_ref = importlib_resources.files(__name__) / "ui/build/"
+    ui_dir_ref = importlib_resources.files(__spec__.parent) / "ui/build/"  # type: ignore[name-defined]
     with importlib_resources.as_file(ui_dir_ref) as ui_dir:
         # Initialize with the projects-list.json file
         with ui_dir.joinpath("projects-list.json").open(mode="w") as f:


### PR DESCRIPTION
# What this PR does / why we need it:
Starting the UI fails when using the builtin `importlib.resources.files` function; it works with the one from the library `importlib-resources`. 

## The error
> TypeError: 'feast.ui_server' is not a package

## Proposed solution
Using the reference to the module's parent (its package) through __spec__ ([docs](https://docs.python.org/3/library/importlib.html#importlib.machinery.ModuleSpec.parent)). We're using `__spec__.parent` as opposed to `__package__` because `__package__` does not seem to be the way according [to this](https://docs.python.org/3/reference/import.html#package__).

According to the python-docs, the function should work with both modules and packages, but that does not seem to be the case ([link to docs](https://docs.python.org/3.11/library/importlib.resources.html#importlib.resources.files)).

# Which issue(s) this PR fixes:
Fixes [4241](https://github.com/feast-dev/feast/issues/4241).