### PR TITLE
fix: Deprecated the datetime.utcfromtimestamp().

### DIFF
--- a/sdk/python/feast/infra/registry/snowflake.py
+++ b/sdk/python/feast/infra/registry/snowflake.py
@@ -2,7 +2,7 @@ import logging
 import os
 import uuid
 from binascii import hexlify
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from threading import Lock
 from typing import Any, Callable, List, Literal, Optional, Set, Union
@@ -994,7 +994,7 @@ class SnowflakeRegistry(BaseRegistry):
         if df.empty:
             return None
 
-        return datetime.utcfromtimestamp(int(df.squeeze()))
+        return datetime.fromtimestamp(int(df.squeeze()), tz=timezone.utc)
 
     def _infer_fv_classes(self, feature_view):
         if isinstance(feature_view, StreamFeatureView):

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Union
@@ -903,7 +903,7 @@ class SqlRegistry(CachingRegistry):
                 return None
             update_time = int(row._mapping["last_updated_timestamp"])
 
-            return datetime.utcfromtimestamp(update_time)
+            return datetime.fromtimestamp(update_time, tz=timezone.utc)
 
     def _get_all_projects(self) -> Set[str]:
         projects = set()


### PR DESCRIPTION

# What this PR does / why we need it:

Change from
```
>>> dt_now = datetime.utcnow()
>>> dt_ts = datetime.utcfromtimestamp(1571595618.0)
```
to
```
>>> from datetime import timezone
>>> dt_now = datetime.now(tz=timezone.utc)
>>> dt_ts = datetime.fromtimestamp(1571595618.0, tz=timezone.utc)
```

Reference: https://blog.ganssle.io/articles/2019/11/utcnow.html

# Which issue(s) this PR fixes:

# Partial Fixes #4240 
