### PR TITLE
fix: Remove redundant batching in PostgreSQLOnlineStore.online_write_batch and fix progress bar

### DIFF
--- a/sdk/python/feast/infra/online_stores/contrib/postgres.py
+++ b/sdk/python/feast/infra/online_stores/contrib/postgres.py
@@ -124,8 +124,18 @@ class PostgreSQLOnlineStore(OnlineStore):
             cur.executemany(sql_query, insert_values)
             conn.commit()
 
-            if progress:
-                progress(len(data))
+        # At the moment, looping over many execute statements is still faster than a
+        # single executemany statement. Use a pipeline and a prepared statement to
+        # speed things up further.
+        # with self._get_conn(config) as conn:
+        #     with conn.pipeline():
+        #         with conn.cursor() as cur:
+        #             for value in insert_values:
+        #                 cur.execute(sql_query, value, prepare=True)
+        #     conn.commit()
+
+        if progress:
+            progress(len(data))
 
     def online_read(
         self,

--- a/sdk/python/feast/infra/online_stores/contrib/postgres.py
+++ b/sdk/python/feast/infra/online_stores/contrib/postgres.py
@@ -119,20 +119,8 @@ class PostgreSQLOnlineStore(OnlineStore):
 
         # Push data in batches to online store
         with self._get_conn(config) as conn, conn.cursor() as cur:
-            # XXX: Instead try to loop `execute` commands with prepared statements in a
-            #  pipeline, since `executemany` seems to be slow according to docs.
             cur.executemany(sql_query, insert_values)
             conn.commit()
-
-        # At the moment, looping over many execute statements is still faster than a
-        # single executemany statement. Use a pipeline and a prepared statement to
-        # speed things up further.
-        # with self._get_conn(config) as conn:
-        #     with conn.pipeline():
-        #         with conn.cursor() as cur:
-        #             for value in insert_values:
-        #                 cur.execute(sql_query, value, prepare=True)
-        #     conn.commit()
 
         if progress:
             progress(len(data))

--- a/sdk/python/feast/infra/online_stores/contrib/postgres.py
+++ b/sdk/python/feast/infra/online_stores/contrib/postgres.py
@@ -117,7 +117,7 @@ class PostgreSQLOnlineStore(OnlineStore):
         """
         ).format(sql.Identifier(_table_id(config.project, table)))
 
-        # Push data in batches to online store
+        # Push data into the online store
         with self._get_conn(config) as conn, conn.cursor() as cur:
             cur.executemany(sql_query, insert_values)
             conn.commit()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:

Since the materialization engine already batches the data and calls the `online_write_batch` method of the online store for each batch, we can get rid of the additional batching in the `PostgreSQLOnlineStore.online_write_batch` method, which will speed up materialization logic for Postgres. 

While there, fix the progress bar by updating it with the number of entities in the batch, instead of the number of entity * feature pairs.

# Which issue(s) this PR fixes:

https://github.com/feast-dev/feast/issues/4309

