### PR TITLE
fix: Update java testcontainers to use Compose V2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.9-buster
+
+USER vscode
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN curl -fsSL https://pixi.sh/install.sh | bash
+ENV PATH=$PATH:/home/vscode/.cargo/bin
+ENV PYTHON=3.9
+RUN uv venv ~/.local
+ENV VIRTUAL_ENV=~/.local
+ENV PATH=$VIRTUAL_ENV/bin:$PATH
+USER root
+    
+    

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
-  "name": "feast-devcontainer",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-  "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "version": "latest"
-    },
-    "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.9"
-    }
-  },
-  "postCreateCommand": "pip install -e '.[dev]' && make compile-protos-python"
+	"name": "feast-devcontainer",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers-contrib/features/maven-sdkman:2": {
+			"jdkVersion": "11.0.24-amzn"
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	"postCreateCommand": "make install-python-ci-dependencies-uv-venv"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
 }

--- a/java/serving/pom.xml
+++ b/java/serving/pom.xml
@@ -348,14 +348,20 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.16.2</version>
+      <version>1.20.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>1.16.2</version>
+      <version>1.20.1</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.10.3</version>
+        <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>

--- a/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
+++ b/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
@@ -62,8 +62,7 @@ abstract class ServingEnvironment {
             .withExposedService("redis", 6379)
             .withExposedService(
                 "feast", 8080, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(180)))
-            .withTailChildContainers(true)
-            .withLocalCompose(true);
+            .withTailChildContainers(true);
 
     environment.start();
   }

--- a/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
+++ b/java/serving/src/test/java/feast/serving/it/ServingEnvironment.java
@@ -39,13 +39,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.ComposeContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 abstract class ServingEnvironment {
-  static DockerComposeContainer environment;
+  static ComposeContainer environment;
   static int serverPort = getFreePort();
   ServingServiceGrpc.ServingServiceBlockingStub servingStub;
   Injector injector;
@@ -57,12 +57,13 @@ abstract class ServingEnvironment {
   @BeforeAll
   static void globalSetup() {
     environment =
-        new DockerComposeContainer(
+        new ComposeContainer(
                 new File("src/test/resources/docker-compose/docker-compose-redis-it.yml"))
             .withExposedService("redis", 6379)
             .withExposedService(
                 "feast", 8080, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(180)))
-            .withTailChildContainers(true);
+            .withTailChildContainers(true)
+            .withLocalCompose(true);
 
     environment.start();
   }


### PR DESCRIPTION
`ubuntu-latest` runner image updated docker compose plugin to v2 which broke java integration tests that rely on `docker-compose` being in PATH instead of `docker compose`. This PR temporarily updates java testcontainers to use Compose V2.