### PR TITLE
fix: Add feast-operator files to semantic-release script (v0.40-branch)

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -66,6 +66,7 @@ module.exports = {
                     "CHANGELOG.md",
                     "java/pom.xml",
                     "infra/charts/**/*.*",
+                    "infra/feast-operator/**/*.*",
                     "ui/package.json",
                     "sdk/python/feast/ui/package.json",
                     "sdk/python/feast/ui/yarn.lock"

--- a/infra/feast-operator/Makefile
+++ b/infra/feast-operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.39.0
+VERSION ?= 0.40.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/infra/feast-operator/config/manager/kustomization.yaml
+++ b/infra/feast-operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: feastdev/feast-operator
-  newTag: 0.39.0
+  newTag: 0.40.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->
# Which issue(s) this PR fixes:
This fixes the issue where past releases are not properly versioning the feast-operator.