### PR TITLE
feat: Allow feast snowflake to read in byte string for private-key authentication

### DIFF
--- a/sdk/python/feast/infra/materialization/snowflake_engine.py
+++ b/sdk/python/feast/infra/materialization/snowflake_engine.py
@@ -67,7 +67,7 @@ class SnowflakeMaterializationEngineConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[str | bytes] = None
+    private_key: Optional[Union[str,bytes]] = None
     """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None

--- a/sdk/python/feast/infra/materialization/snowflake_engine.py
+++ b/sdk/python/feast/infra/materialization/snowflake_engine.py
@@ -67,7 +67,7 @@ class SnowflakeMaterializationEngineConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[Union[str,bytes]] = None
+    private_key: Optional[Union[str, bytes]] = None
     """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None

--- a/sdk/python/feast/infra/materialization/snowflake_engine.py
+++ b/sdk/python/feast/infra/materialization/snowflake_engine.py
@@ -67,8 +67,11 @@ class SnowflakeMaterializationEngineConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[Union[str, bytes]] = None
-    """ Snowflake private key stored as bytes or file path"""
+    private_key: Optional[str] = None
+    """ Snowflake private key file path"""
+
+    private_key_content: Optional[bytes] = None
+    """ Snowflake private key stored as bytes"""
 
     private_key_passphrase: Optional[str] = None
     """ Snowflake private key file passphrase"""

--- a/sdk/python/feast/infra/materialization/snowflake_engine.py
+++ b/sdk/python/feast/infra/materialization/snowflake_engine.py
@@ -67,8 +67,8 @@ class SnowflakeMaterializationEngineConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[str] = None
-    """ Snowflake private key file path"""
+    private_key: Optional[str | bytes] = None
+    """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None
     """ Snowflake private key file passphrase"""

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -104,7 +104,7 @@ class SnowflakeOfflineStoreConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[Union[str,bytes]] = None
+    private_key: Optional[Union[str, bytes]] = None
     """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -104,8 +104,11 @@ class SnowflakeOfflineStoreConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[Union[str, bytes]] = None
-    """ Snowflake private key stored as bytes or file path"""
+    private_key: Optional[str] = None
+    """ Snowflake private key file path"""
+
+    private_key_content: Optional[bytes] = None
+    """ Snowflake private key stored as bytes"""
 
     private_key_passphrase: Optional[str] = None
     """ Snowflake private key file passphrase"""

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -104,7 +104,7 @@ class SnowflakeOfflineStoreConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[str | bytes] = None
+    private_key: Optional[Union[str,bytes]] = None
     """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -104,8 +104,8 @@ class SnowflakeOfflineStoreConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[str] = None
-    """ Snowflake private key file path"""
+    private_key: Optional[str | bytes] = None
+    """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None
     """ Snowflake private key file passphrase"""

--- a/sdk/python/feast/infra/online_stores/snowflake.py
+++ b/sdk/python/feast/infra/online_stores/snowflake.py
@@ -50,7 +50,7 @@ class SnowflakeOnlineStoreConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[Union[str,bytes]] = None
+    private_key: Optional[Union[str, bytes]] = None
     """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None

--- a/sdk/python/feast/infra/online_stores/snowflake.py
+++ b/sdk/python/feast/infra/online_stores/snowflake.py
@@ -50,8 +50,8 @@ class SnowflakeOnlineStoreConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[str] = None
-    """ Snowflake private key file path"""
+    private_key: Optional[str | bytes] = None
+    """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None
     """ Snowflake private key file passphrase"""

--- a/sdk/python/feast/infra/online_stores/snowflake.py
+++ b/sdk/python/feast/infra/online_stores/snowflake.py
@@ -2,7 +2,7 @@ import itertools
 import os
 from binascii import hexlify
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple
 
 import pandas as pd
 from pydantic import ConfigDict, Field, StrictStr

--- a/sdk/python/feast/infra/online_stores/snowflake.py
+++ b/sdk/python/feast/infra/online_stores/snowflake.py
@@ -50,8 +50,11 @@ class SnowflakeOnlineStoreConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[Union[str, bytes]] = None
-    """ Snowflake private key stored as bytes or file path"""
+    private_key: Optional[str] = None
+    """ Snowflake private key file path"""
+
+    private_key_content: Optional[bytes] = None
+    """ Snowflake private key stored as bytes"""
 
     private_key_passphrase: Optional[str] = None
     """ Snowflake private key file passphrase"""

--- a/sdk/python/feast/infra/online_stores/snowflake.py
+++ b/sdk/python/feast/infra/online_stores/snowflake.py
@@ -2,7 +2,7 @@ import itertools
 import os
 from binascii import hexlify
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union
 
 import pandas as pd
 from pydantic import ConfigDict, Field, StrictStr
@@ -50,7 +50,7 @@ class SnowflakeOnlineStoreConfig(FeastConfigBaseModel):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[str | bytes] = None
+    private_key: Optional[Union[str,bytes]] = None
     """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None

--- a/sdk/python/feast/infra/registry/snowflake.py
+++ b/sdk/python/feast/infra/registry/snowflake.py
@@ -93,8 +93,8 @@ class SnowflakeRegistryConfig(RegistryConfig):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[str] = None
-    """ Snowflake private key file path"""
+    private_key: Optional[str | bytes] = None
+    """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None
     """ Snowflake private key file passphrase"""

--- a/sdk/python/feast/infra/registry/snowflake.py
+++ b/sdk/python/feast/infra/registry/snowflake.py
@@ -93,8 +93,11 @@ class SnowflakeRegistryConfig(RegistryConfig):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[Union[str, bytes]] = None
-    """ Snowflake private key stored as bytes or file path"""
+    private_key: Optional[str] = None
+    """ Snowflake private key file path"""
+
+    private_key_content: Optional[bytes] = None
+    """ Snowflake private key stored as bytes"""
 
     private_key_passphrase: Optional[str] = None
     """ Snowflake private key file passphrase"""

--- a/sdk/python/feast/infra/registry/snowflake.py
+++ b/sdk/python/feast/infra/registry/snowflake.py
@@ -93,7 +93,7 @@ class SnowflakeRegistryConfig(RegistryConfig):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[Union[str,bytes]] = None
+    private_key: Optional[Union[str, bytes]] = None
     """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None

--- a/sdk/python/feast/infra/registry/snowflake.py
+++ b/sdk/python/feast/infra/registry/snowflake.py
@@ -93,7 +93,7 @@ class SnowflakeRegistryConfig(RegistryConfig):
     authenticator: Optional[str] = None
     """ Snowflake authenticator name """
 
-    private_key: Optional[str | bytes] = None
+    private_key: Optional[Union[str,bytes]] = None
     """ Snowflake private key stored as bytes or file path"""
 
     private_key_passphrase: Optional[str] = None

--- a/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
+++ b/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
@@ -86,7 +86,9 @@ class GetSnowflakeConnection:
             # https://docs.snowflake.com/en/user-guide/key-pair-auth.html#configuring-key-pair-authentication
             if "private_key" in kwargs or "private_key_content" in kwargs:
                 kwargs["private_key"] = parse_private_key_path(
-                    kwargs.get("private_key_passphrase"), kwargs.get("private_key"), kwargs.get("private_key_content")
+                    kwargs.get("private_key_passphrase"),
+                    kwargs.get("private_key"),
+                    kwargs.get("private_key_content"),
                 )
 
             try:
@@ -511,7 +513,9 @@ def chunk_helper(lst: pd.DataFrame, n: int) -> Iterator[Tuple[int, pd.DataFrame]
 
 
 def parse_private_key_path(
-    private_key_passphrase: str, key_path: Optional[str] = None, private_key_content: Optional[bytes] = None
+    private_key_passphrase: str,
+    key_path: Optional[str] = None,
+    private_key_content: Optional[bytes] = None,
 ) -> bytes:
     """Returns snowflake pkb by parsing and reading either from key path or private_key_content as byte string."""
     if private_key_content:

--- a/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
+++ b/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
@@ -6,7 +6,7 @@ import string
 from logging import getLogger
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Tuple, cast
 
 import pandas as pd
 import pyarrow

--- a/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
+++ b/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
@@ -511,7 +511,7 @@ def chunk_helper(lst: pd.DataFrame, n: int) -> Iterator[Tuple[int, pd.DataFrame]
 
 
 def parse_private_key_path(
-    private_key: Union[bytes | str], private_key_passphrase: str
+    private_key: Union[str, bytes], private_key_passphrase: str
 ) -> bytes:
     """Returns snowflake pkb by parsing and reading either from private key path or as byte string."""
     if isinstance(private_key, str):

--- a/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
+++ b/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
@@ -511,7 +511,7 @@ def chunk_helper(lst: pd.DataFrame, n: int) -> Iterator[Tuple[int, pd.DataFrame]
 
 
 def parse_private_key_path(
-    private_key_passphrase: str, key_path: str = None, private_key_content: bytes = None
+    private_key_passphrase: str, key_path: Optional[str] = None, private_key_content: Optional[bytes] = None
 ) -> bytes:
     """Returns snowflake pkb by parsing and reading either from key path or private_key_content as byte string."""
     if private_key_content:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [description] vs feat: [description])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Allows the user to pass private_key as a byte string for Snowflake key-pair authentication rather than only limiting the ability to refer to the file path where the private key is stored. 
Gives the ability to pass in `private_key` from a Secret Manager service (i.e: Google Cloud Secret Manager) 

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Fixes