### PR TITLE
fix: Optimize SQL Registry proto() method

### DIFF
--- a/protos/feast/core/Registry.proto
+++ b/protos/feast/core/Registry.proto
@@ -56,4 +56,5 @@ message Registry {
 message ProjectMetadata {
     string project = 1;
     string project_uuid = 2;
+    google.protobuf.Timestamp last_updated_timestamp = 3;
 }

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -423,7 +423,7 @@ class FeatureView(BaseFeatureView):
 
         if len(feature_view.entities) != len(feature_view.entity_columns):
             warnings.warn(
-                f"There are some mismatches in your feature view's registered entities. Please check if you have applied your entities correctly."
+                f"There are some mismatches in your feature view: {feature_view.name} registered entities. Please check if you have applied your entities correctly."
                 f"Entities: {feature_view.entities} vs Entity Columns: {feature_view.entity_columns}"
             )
 

--- a/sdk/python/feast/project_metadata.py
+++ b/sdk/python/feast/project_metadata.py
@@ -98,8 +98,8 @@ class ProjectMetadata:
         project_metadata = cls(
             project_name=project_metadata_proto.project,
             project_uuid=project_metadata_proto.project_uuid,
-            last_updated_timestamp=project_metadata_proto.last_updated_timestamp.ToDatetime().astimezone(
-                tz=timezone.utc
+            last_updated_timestamp=project_metadata_proto.last_updated_timestamp.ToDatetime().replace(
+                tzinfo=timezone.utc
             ),
         )
 

--- a/sdk/python/feast/project_metadata.py
+++ b/sdk/python/feast/project_metadata.py
@@ -98,8 +98,8 @@ class ProjectMetadata:
         project_metadata = cls(
             project_name=project_metadata_proto.project,
             project_uuid=project_metadata_proto.project_uuid,
-            last_updated_timestamp=project_metadata_proto.last_updated_timestamp.ToDatetime(
-                tzinfo=timezone.utc
+            last_updated_timestamp=project_metadata_proto.last_updated_timestamp.ToDatetime().astimezone(
+                tz=timezone.utc
             ),
         )
 

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -128,6 +128,9 @@ class RegistryConfig(FeastBaseModel):
     cache_mode: StrictStr = "sync"
     """ str: Cache mode type, Possible options are sync and thread(asynchronous caching using threading library)"""
 
+    thread_pool_executor_worker_count: StrictInt = 0
+    """ int: Number of worker threads to use for asynchronous caching in SQL Registry. If set to 0, it doesn't use ThreadPoolExecutor. """
+
     @field_validator("path")
     def validate_path(cls, path: str, values: ValidationInfo) -> str:
         if values.data.get("registry_type") == "sql":

--- a/sdk/python/tests/unit/test_on_demand_feature_view.py
+++ b/sdk/python/tests/unit/test_on_demand_feature_view.py
@@ -251,11 +251,9 @@ def test_from_proto_backwards_compatible_udf():
         proto.spec.feature_transformation.user_defined_function.body_text
     )
 
-    # And now we're going to null the feature_transformation proto object before reserializing the entire proto
-    # proto.spec.user_defined_function.body_text = on_demand_feature_view.transformation.udf_string
-    proto.spec.feature_transformation.user_defined_function.name = ""
-    proto.spec.feature_transformation.user_defined_function.body = b""
-    proto.spec.feature_transformation.user_defined_function.body_text = ""
+    # For objects that are already registered, feature_transformation and mode is not set
+    proto.spec.feature_transformation.Clear()
+    proto.spec.ClearField("mode")
 
     # And now we expect the to get the same object back under feature_transformation
     reserialized_proto = OnDemandFeatureView.from_proto(proto)
@@ -263,3 +261,4 @@ def test_from_proto_backwards_compatible_udf():
         reserialized_proto.feature_transformation.udf_string
         == on_demand_feature_view.feature_transformation.udf_string
     )
+    assert reserialized_proto.mode == "pandas"

--- a/sdk/python/tests/unit/test_project_metadata.py
+++ b/sdk/python/tests/unit/test_project_metadata.py
@@ -1,0 +1,99 @@
+import unittest
+from datetime import datetime, timezone
+
+from feast.project_metadata import ProjectMetadata
+from feast.protos.feast.core.Registry_pb2 import ProjectMetadata as ProjectMetadataProto
+
+
+class TestProjectMetadata(unittest.TestCase):
+    def setUp(self):
+        self.project_name = "test_project"
+        self.project_uuid = "123e4567-e89b-12d3-a456-426614174000"
+        self.timestamp = datetime(2021, 1, 1, tzinfo=timezone.utc)
+
+    def test_initialization(self):
+        metadata = ProjectMetadata(
+            project_name=self.project_name,
+            project_uuid=self.project_uuid,
+            last_updated_timestamp=self.timestamp,
+        )
+        self.assertEqual(metadata.project_name, self.project_name)
+        self.assertEqual(metadata.project_uuid, self.project_uuid)
+        self.assertEqual(metadata.last_updated_timestamp, self.timestamp)
+
+    def test_initialization_with_default_last_updated_timestamp(self):
+        metadata = ProjectMetadata(
+            project_name=self.project_name,
+            project_uuid=self.project_uuid,
+        )
+        self.assertEqual(metadata.project_name, self.project_name)
+        self.assertEqual(metadata.project_uuid, self.project_uuid)
+        self.assertEqual(
+            metadata.last_updated_timestamp, datetime.fromtimestamp(1, tz=timezone.utc)
+        )
+
+    def test_initialization_without_project_name(self):
+        with self.assertRaises(ValueError):
+            ProjectMetadata()
+
+    def test_equality(self):
+        metadata1 = ProjectMetadata(
+            project_name=self.project_name,
+            project_uuid=self.project_uuid,
+            last_updated_timestamp=self.timestamp,
+        )
+        metadata2 = ProjectMetadata(
+            project_name=self.project_name,
+            project_uuid=self.project_uuid,
+            last_updated_timestamp=self.timestamp,
+        )
+        self.assertEqual(metadata1, metadata2)
+
+    def test_hash(self):
+        metadata = ProjectMetadata(
+            project_name=self.project_name,
+            project_uuid=self.project_uuid,
+            last_updated_timestamp=self.timestamp,
+        )
+        self.assertEqual(
+            hash(metadata), hash((self.project_name, self.project_uuid, self.timestamp))
+        )
+
+    def test_from_proto(self):
+        proto = ProjectMetadataProto(
+            project=self.project_name,
+            project_uuid=self.project_uuid,
+        )
+        proto.last_updated_timestamp.FromDatetime(self.timestamp)
+        metadata = ProjectMetadata.from_proto(proto)
+        self.assertEqual(metadata.project_name, self.project_name)
+        self.assertEqual(metadata.project_uuid, self.project_uuid)
+        self.assertEqual(metadata.last_updated_timestamp, self.timestamp)
+
+    def test_to_proto(self):
+        metadata = ProjectMetadata(
+            project_name=self.project_name,
+            project_uuid=self.project_uuid,
+            last_updated_timestamp=self.timestamp,
+        )
+        proto = metadata.to_proto()
+        self.assertEqual(proto.project, self.project_name)
+        self.assertEqual(proto.project_uuid, self.project_uuid)
+        self.assertEqual(
+            proto.last_updated_timestamp.ToDatetime().replace(tzinfo=timezone.utc),
+            self.timestamp,
+        )
+
+    def test_conversion_to_proto_and_back(self):
+        metadata = ProjectMetadata(
+            project_name=self.project_name,
+            project_uuid=self.project_uuid,
+            last_updated_timestamp=self.timestamp,
+        )
+        proto = metadata.to_proto()
+        metadata_from_proto = ProjectMetadata.from_proto(proto)
+        self.assertEqual(metadata, metadata_from_proto)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
**Problem Summary:** We are using SQL Registry with 150+ projects and ~600 feature views at the moment. They are going to grow in future. 
1 . Starting up a Remote registry service is taking longer than expected due to proto() call during Registry initialization. This has to refresh all 150 projects metadata on start up.  
2 . Refreshing the cache on a regular interval with cache_mode = thread taking longer even though most of the projects object (like entities, FVs, ODFVs) doesn't change so often. 

**Fixes:**
1. Running the proto() method using ThreadPoolExecutor to run in parallel with 5 default workers. This doesn't fully solve the problem. We may need to look into the lazy caching options which reduces the start up times and load only the projects for which it's serving the calls rather than loading all projects into the cache. Along with that we may need to control the size of cache_registry_proto object with some eviction policy for the cache. 
2. Leveraging the previously cached RegistryProto if the last_updated_timestamp of the project hasn't changed in the feast_metadata table. Reduces the number of database calls we make. 
3. Adding last_updated_timestamp column to ProjectMetadata table
4. Added Indexes to the tables
5. _maybe_init_project_metadata is called multiple times (Ex: In get, list and apply). Proto() method depends on list calls (~10 calls per project. With 150 projects, it just makes the function call 1500 times which is not needed)
6. _get_all_projects() method is using individual tables to get the projects list instead of using feast_metadata table
7. Added get_all_projects(), get_project_metadata() and delete_project() methods to SQL Registry. 
8. Updated test case for ODFV backward compatibility issue
9. Added tests cases to ProjectMetadata object
10. Added integration tests for the changes
11. Switched sqlite fixture scope to "function". sqlite is not thread safe so added `thread_pool_executor_worker_count` configuration. If its 0, doesn't use ThreadPoolExecutor. 


**Questions:**
1. It make sense to refresh the proto() with all projects for remote registry service if SQL registry is the proxy. If users pass the project_name as part of Repo Config, proto() can only refresh the project passed. I'm not sure how to make the distinction when registry is a Proxy registry for Registry Service vs Regular Registry. Appreciate any thoughts on this. 

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
