### PR TITLE
chore: Mark tests using keycloak with xdist_group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test-python-unit:
 	python -m pytest -n 8 --color=yes sdk/python/tests
 
 test-python-integration:
-	python -m pytest -n 4 --integration --color=yes --durations=10 --timeout=1200 --timeout_method=thread \
+	python -m pytest -n 8 --integration --color=yes --durations=10 --timeout=1200 --timeout_method=thread --dist loadgroup \
 		-k "(not snowflake or not test_historical_features_main)" \
 		sdk/python/tests
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test-python-integration:
 test-python-integration-local:
 	FEAST_IS_LOCAL_TEST=True \
 	FEAST_LOCAL_ONLINE_CONTAINER=True \
-	python -m pytest -n 4 --color=yes --integration --durations=10 --timeout=1200 --timeout_method=thread --dist loadgroup \
+	python -m pytest -n 8 --color=yes --integration --durations=10 --timeout=1200 --timeout_method=thread --dist loadgroup \
 		-k "not test_lambda_materialization and not test_snowflake_materialization" \
 		sdk/python/tests
 

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -279,7 +279,11 @@ def pytest_generate_tests(metafunc: pytest.Metafunc):
                         c = IntegrationTestRepoConfig(**config)
 
                         if c not in _config_cache:
-                            _config_cache[c] = c
+                            marks = [
+                                pytest.mark.xdist_group(name=m)
+                                for m in c.offline_store_creator.xdist_groups()
+                            ]
+                            _config_cache[c] = pytest.param(c, marks=marks)
 
                         configs.append(_config_cache[c])
         else:

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -60,3 +60,6 @@ class DataSourceCreator(ABC):
     @abstractmethod
     def teardown(self):
         raise NotImplementedError
+
+    def xdist_groups() -> list[str]:
+        return []

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -456,6 +456,9 @@ auth:
         self.server_port: int = 0
         self.proc = None
 
+    def xdist_groups() -> list[str]:
+        return ["keycloak"]
+
     def setup(self, registry: RegistryConfig):
         parent_offline_config = super().create_offline_store_config()
         config = RepoConfig(


### PR DESCRIPTION
- Adds a workaround to mark tests with xdist markers using new static method on `DataSourceCreator`
- Increases the number of workers for integration tests back to 8