### PR TITLE
build: Set a proper build-system protobuf version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,14 @@
 [build-system]
-requires = ["setuptools>=60", "wheel", "setuptools_scm>=6.2", "grpcio", "grpcio-tools>=1.47.0", "mypy-protobuf==3.1", "sphinx!=4.0.0"]
+requires = [
+  "setuptools>=60",
+  "wheel",
+  "setuptools_scm>=6.2",
+  "grpcio",
+  "grpcio-tools>=1.47.0",
+  "mypy-protobuf==3.1",
+  "protobuf>=4.24.0,<5.0.0",
+  "sphinx!=4.0.0",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:

This PR enforces the protobuf version in the build system so that it is compatible with the runtime dependency

# Which issue(s) this PR fixes:
Fixes #4437

# Misc
The runtime version of protobuf is determined at:
https://github.com/feast-dev/feast/blob/0a48f7bb436febb0171c78a559a577eedeff421f/setup.py#L46

I have manually tested this PR with the following command

```
pip install git+https://github.com/Atry/feast.git@build-system-protobuf-version && python -m feast.protos.feast.types.Value_pb2
```
