### PR TITLE
fix: Check for snowflake functions when setting up materialization engine

### DIFF
--- a/sdk/python/feast/infra/materialization/snowflake_engine.py
+++ b/sdk/python/feast/infra/materialization/snowflake_engine.py
@@ -130,14 +130,14 @@ class SnowflakeMaterializationEngine(BatchMaterializationEngine):
         with GetSnowflakeConnection(self.repo_config.batch_engine) as conn:
             query = f"SHOW USER FUNCTIONS LIKE 'FEAST_{project.upper()}%' IN SCHEMA {stage_context}"
             cursor = execute_snowflake_statement(conn, query)
-            stage_list = pd.DataFrame(
+            function_list = pd.DataFrame(
                 cursor.fetchall(),
                 columns=[column.name for column in cursor.description],
             )
 
             # if the SHOW FUNCTIONS query returns results,
             # assumes that the materialization functions have been deployed
-            if len(stage_list.index) > 0:
+            if len(function_list.index) > 0:
                 click.echo(
                     f"Materialization functions for {Style.BRIGHT + Fore.GREEN}{project}{Style.RESET_ALL} already detected."
                 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
When running `feast apply` using the snowflake materialization engine, feast only checks if the stage in snowflake exists and assumes the functions have been created.  This allows a case where if anything goes wrong during function creation, such as permission issues, a stage can be created while the functions are not. Following attempts to `feast apply` see the created stage and tell the user that the functions exist without creating them. This leads to materialization on snowflake to fail down the line due to missing functions.

This PR aims to change the apply logic to instead check for snowflake functions before deciding if action is required.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
A current workaround for this is to delete the stage in Snowflake before running the next `feast apply`.