### PR TITLE
refactor: Making username and password fields in OidcAuthModel as mandatory onl…

### DIFF
--- a/docs/getting-started/components/authz_manager.md
+++ b/docs/getting-started/components/authz_manager.md
@@ -61,24 +61,36 @@ For example, the access token for a client `app` of a user with `reader` role sh
 }
 ```
 
-An example of OIDC authorization configuration is the following: 
+An example of feast OIDC authorization configuration on the server side is the following: 
 ```yaml
 project: my-project
 auth:
   type: oidc
   client_id: _CLIENT_ID__
-  client_secret: _CLIENT_SECRET__
-  realm: _REALM__  
   auth_discovery_url: _OIDC_SERVER_URL_/realms/master/.well-known/openid-configuration
 ...
 ```
 
-In case of client configuration, the following settings must be added to specify the current user:
+In case of client configuration, the following settings username, password and client_secret must be added to specify the current user:
 ```yaml
 auth:
+  type: oidc
   ...
   username: _USERNAME_
   password: _PASSWORD_
+  client_secret: _CLIENT_SECRET__
+```
+
+Below is an example of feast full OIDC client auth configuration:
+```yaml
+project: my-project
+auth:
+  type: oidc
+  client_id: test_client_id
+  client_secret: test_client_secret
+  username: test_user_name
+  password: test_password
+  auth_discovery_url: http://localhost:8080/realms/master/.well-known/openid-configuration
 ```
 
 ### Kubernetes RBAC Authorization

--- a/sdk/python/feast/permissions/auth_model.py
+++ b/sdk/python/feast/permissions/auth_model.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional
+from typing import Literal
 
 from feast.repo_config import FeastConfigBaseModel
 
@@ -10,10 +10,12 @@ class AuthConfig(FeastConfigBaseModel):
 class OidcAuthConfig(AuthConfig):
     auth_discovery_url: str
     client_id: str
-    client_secret: Optional[str] = None
+
+
+class OidcClientAuthConfig(OidcAuthConfig):
     username: str
     password: str
-    realm: str = "master"
+    client_secret: str
 
 
 class NoAuthConfig(AuthConfig):

--- a/sdk/python/feast/permissions/client/auth_client_manager_factory.py
+++ b/sdk/python/feast/permissions/client/auth_client_manager_factory.py
@@ -2,7 +2,7 @@ from feast.permissions.auth.auth_type import AuthType
 from feast.permissions.auth_model import (
     AuthConfig,
     KubernetesAuthConfig,
-    OidcAuthConfig,
+    OidcClientAuthConfig,
 )
 from feast.permissions.client.auth_client_manager import AuthenticationClientManager
 from feast.permissions.client.kubernetes_auth_client_manager import (
@@ -15,7 +15,7 @@ from feast.permissions.client.oidc_authentication_client_manager import (
 
 def get_auth_client_manager(auth_config: AuthConfig) -> AuthenticationClientManager:
     if auth_config.type == AuthType.OIDC.value:
-        assert isinstance(auth_config, OidcAuthConfig)
+        assert isinstance(auth_config, OidcClientAuthConfig)
         return OidcAuthClientManager(auth_config)
     elif auth_config.type == AuthType.KUBERNETES.value:
         assert isinstance(auth_config, KubernetesAuthConfig)

--- a/sdk/python/feast/permissions/client/oidc_authentication_client_manager.py
+++ b/sdk/python/feast/permissions/client/oidc_authentication_client_manager.py
@@ -4,7 +4,7 @@ import os
 import jwt
 import requests
 
-from feast.permissions.auth_model import OidcAuthConfig
+from feast.permissions.auth_model import OidcClientAuthConfig
 from feast.permissions.client.auth_client_manager import AuthenticationClientManager
 from feast.permissions.oidc_service import OIDCDiscoveryService
 
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class OidcAuthClientManager(AuthenticationClientManager):
-    def __init__(self, auth_config: OidcAuthConfig):
+    def __init__(self, auth_config: OidcClientAuthConfig):
         self.auth_config = auth_config
 
     def get_token(self):

--- a/sdk/python/feast/permissions/server/utils.py
+++ b/sdk/python/feast/permissions/server/utils.py
@@ -15,7 +15,10 @@ from feast.permissions.auth.kubernetes_token_parser import KubernetesTokenParser
 from feast.permissions.auth.oidc_token_parser import OidcTokenParser
 from feast.permissions.auth.token_extractor import TokenExtractor
 from feast.permissions.auth.token_parser import TokenParser
-from feast.permissions.auth_model import AuthConfig, OidcAuthConfig
+from feast.permissions.auth_model import (
+    AuthConfig,
+    OidcAuthConfig,
+)
 from feast.permissions.security_manager import (
     SecurityManager,
     no_security_manager,

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -298,6 +298,7 @@ class RepoConfig(FeastBaseModel):
                     self.auth.get("type") == AuthType.OIDC.value
                     and "username" in self.auth
                     and "password" in self.auth
+                    and "client_secret" in self.auth
                 )
                 self._auth = get_auth_config_from_type(
                     "oidc_client" if is_oidc_client else self.auth.get("type")

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -302,6 +302,10 @@ class RepoConfig(FeastBaseModel):
                 self._auth = get_auth_config_from_type(
                     "oidc_client" if is_oidc_client else self.auth.get("type")
                 )(**self.auth)
+            elif isinstance(self.auth, str):
+                self._auth = get_auth_config_from_type(self.auth)()
+            elif self.auth:
+                self._auth = self.auth
 
         return self._auth
 

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -87,10 +87,13 @@ FEATURE_SERVER_CONFIG_CLASS_FOR_TYPE = {
     "local": "feast.infra.feature_servers.local_process.config.LocalFeatureServerConfig",
 }
 
+ALLOWED_AUTH_TYPES = ["no_auth", "kubernetes", "oidc"]
+
 AUTH_CONFIGS_CLASS_FOR_TYPE = {
     "no_auth": "feast.permissions.auth_model.NoAuthConfig",
     "kubernetes": "feast.permissions.auth_model.KubernetesAuthConfig",
     "oidc": "feast.permissions.auth_model.OidcAuthConfig",
+    "oidc_client": "feast.permissions.auth_model.OidcClientAuthConfig",
 }
 
 
@@ -291,13 +294,14 @@ class RepoConfig(FeastBaseModel):
     def auth_config(self):
         if not self._auth:
             if isinstance(self.auth, Dict):
-                self._auth = get_auth_config_from_type(self.auth.get("type"))(
-                    **self.auth
+                is_oidc_client = (
+                    self.auth.get("type") == AuthType.OIDC.value
+                    and "username" in self.auth
+                    and "password" in self.auth
                 )
-            elif isinstance(self.auth, str):
-                self._auth = get_auth_config_from_type(self.auth.get("type"))()
-            elif self.auth:
-                self._auth = self.auth
+                self._auth = get_auth_config_from_type(
+                    "oidc_client" if is_oidc_client else self.auth.get("type")
+                )(**self.auth)
 
         return self._auth
 
@@ -336,22 +340,21 @@ class RepoConfig(FeastBaseModel):
         from feast.permissions.auth_model import AuthConfig
 
         if "auth" in values:
-            allowed_auth_types = AUTH_CONFIGS_CLASS_FOR_TYPE.keys()
             if isinstance(values["auth"], Dict):
                 if values["auth"].get("type") is None:
                     raise ValueError(
-                        f"auth configuration is missing authentication type. Possible values={allowed_auth_types}"
+                        f"auth configuration is missing authentication type. Possible values={ALLOWED_AUTH_TYPES}"
                     )
-                elif values["auth"]["type"] not in allowed_auth_types:
+                elif values["auth"]["type"] not in ALLOWED_AUTH_TYPES:
                     raise ValueError(
                         f'auth configuration has invalid authentication type={values["auth"]["type"]}. Possible '
-                        f'values={allowed_auth_types}'
+                        f'values={ALLOWED_AUTH_TYPES}'
                     )
             elif isinstance(values["auth"], AuthConfig):
-                if values["auth"].type not in allowed_auth_types:
+                if values["auth"].type not in ALLOWED_AUTH_TYPES:
                     raise ValueError(
                         f'auth configuration has invalid authentication type={values["auth"].type}. Possible '
-                        f'values={allowed_auth_types}'
+                        f'values={ALLOWED_AUTH_TYPES}'
                     )
         return values
 

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -466,7 +466,6 @@ def is_integration_test(all_markers_from_module):
             client_secret: feast-integration-client-secret
             username: reader_writer
             password: password
-            realm: master
             auth_discovery_url: KEYCLOAK_URL_PLACE_HOLDER/realms/master/.well-known/openid-configuration
         """),
     ],

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -449,8 +449,6 @@ class OfflineServerPermissionsEnvironment(Environment):
         keycloak_url = self.data_source_creator.get_keycloak_url()
         auth_config = OidcAuthConfig(
             client_id="feast-integration-client",
-            client_secret="feast-integration-client-secret",
-            realm="master",
             type="oidc",
             auth_discovery_url=f"{keycloak_url}/realms/master/.well-known"
             f"/openid-configuration",

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -450,8 +450,6 @@ class OfflineServerPermissionsEnvironment(Environment):
         auth_config = OidcAuthConfig(
             client_id="feast-integration-client",
             client_secret="feast-integration-client-secret",
-            username="reader_writer",
-            password="password",
             realm="master",
             type="oidc",
             auth_discovery_url=f"{keycloak_url}/realms/master/.well-known"

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -28,7 +28,7 @@ from feast.infra.feature_servers.base_config import (
 )
 from feast.infra.feature_servers.local_process.config import LocalFeatureServerConfig
 from feast.permissions.action import AuthzedAction
-from feast.permissions.auth_model import OidcAuthConfig
+from feast.permissions.auth_model import OidcClientAuthConfig
 from feast.permissions.permission import Permission
 from feast.permissions.policy import RoleBasedPolicy
 from feast.repo_config import RegistryConfig, RepoConfig
@@ -447,11 +447,14 @@ class OfflineServerPermissionsEnvironment(Environment):
     def setup(self):
         self.data_source_creator.setup(self.registry)
         keycloak_url = self.data_source_creator.get_keycloak_url()
-        auth_config = OidcAuthConfig(
+        auth_config = OidcClientAuthConfig(
             client_id="feast-integration-client",
             type="oidc",
             auth_discovery_url=f"{keycloak_url}/realms/master/.well-known"
             f"/openid-configuration",
+            client_secret="feast-integration-client-secret",
+            username="reader_writer",
+            password="password",
         )
         self.config = RepoConfig(
             registry=self.registry,

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -448,7 +448,6 @@ auth:
   client_secret: feast-integration-client-secret
   username: reader_writer
   password: password
-  realm: master
   auth_discovery_url: {keycloak_url}/realms/master/.well-known/openid-configuration
 """
         self.auth_config = auth_config_template.format(keycloak_url=self.keycloak_url)

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -445,9 +445,6 @@ class RemoteOfflineOidcAuthStoreDataSourceCreator(FileDataSourceCreator):
 auth:
   type: oidc
   client_id: feast-integration-client
-  client_secret: feast-integration-client-secret
-  username: reader_writer
-  password: password
   auth_discovery_url: {keycloak_url}/realms/master/.well-known/openid-configuration
 """
         self.auth_config = auth_config_template.format(keycloak_url=self.keycloak_url)

--- a/sdk/python/tests/unit/infra/scaffolding/test_repo_config.py
+++ b/sdk/python/tests/unit/infra/scaffolding/test_repo_config.py
@@ -9,6 +9,7 @@ from feast.permissions.auth_model import (
     KubernetesAuthConfig,
     NoAuthConfig,
     OidcAuthConfig,
+    OidcClientAuthConfig,
 )
 from feast.repo_config import FeastConfigError, load_repo_config
 
@@ -213,7 +214,6 @@ def test_auth_config():
             client_secret: test_client_secret
             username: test_user_name
             password: test_password
-            realm: master
             auth_discovery_url: http://localhost:8080/realms/master/.well-known/openid-configuration
         registry: "registry.db"
         provider: local
@@ -235,7 +235,6 @@ def test_auth_config():
             client_secret: test_client_secret
             username: test_user_name
             password: test_password
-            realm: master
             auth_discovery_url: http://localhost:8080/realms/master/.well-known/openid-configuration
         registry: "registry.db"
         provider: local
@@ -247,17 +246,13 @@ def test_auth_config():
         expect_error="invalid authentication type=not_valid_auth_type",
     )
 
-    oidc_repo_config = _test_config(
+    oidc_server_repo_config = _test_config(
         dedent(
             """
         project: foo
         auth:
             type: oidc
             client_id: test_client_id
-            client_secret: test_client_secret
-            username: test_user_name
-            password: test_password
-            realm: master
             auth_discovery_url: http://localhost:8080/realms/master/.well-known/openid-configuration
         registry: "registry.db"
         provider: local
@@ -268,15 +263,42 @@ def test_auth_config():
         ),
         expect_error=None,
     )
-    assert oidc_repo_config.auth["type"] == AuthType.OIDC.value
-    assert isinstance(oidc_repo_config.auth_config, OidcAuthConfig)
-    assert oidc_repo_config.auth_config.client_id == "test_client_id"
-    assert oidc_repo_config.auth_config.client_secret == "test_client_secret"
-    assert oidc_repo_config.auth_config.username == "test_user_name"
-    assert oidc_repo_config.auth_config.password == "test_password"
-    assert oidc_repo_config.auth_config.realm == "master"
+    assert oidc_server_repo_config.auth["type"] == AuthType.OIDC.value
+    assert isinstance(oidc_server_repo_config.auth_config, OidcAuthConfig)
+    assert oidc_server_repo_config.auth_config.client_id == "test_client_id"
     assert (
-        oidc_repo_config.auth_config.auth_discovery_url
+        oidc_server_repo_config.auth_config.auth_discovery_url
+        == "http://localhost:8080/realms/master/.well-known/openid-configuration"
+    )
+
+    oidc_client_repo_config = _test_config(
+        dedent(
+            """
+        project: foo
+        auth:
+            type: oidc
+            client_id: test_client_id
+            client_secret: test_client_secret
+            username: test_user_name
+            password: test_password
+            auth_discovery_url: http://localhost:8080/realms/master/.well-known/openid-configuration
+        registry: "registry.db"
+        provider: local
+        online_store:
+            path: foo
+        entity_key_serialization_version: 2
+        """
+        ),
+        expect_error=None,
+    )
+    assert oidc_client_repo_config.auth["type"] == AuthType.OIDC.value
+    assert isinstance(oidc_client_repo_config.auth_config, OidcClientAuthConfig)
+    assert oidc_client_repo_config.auth_config.client_id == "test_client_id"
+    assert oidc_client_repo_config.auth_config.client_secret == "test_client_secret"
+    assert oidc_client_repo_config.auth_config.username == "test_user_name"
+    assert oidc_client_repo_config.auth_config.password == "test_password"
+    assert (
+        oidc_client_repo_config.auth_config.auth_discovery_url
         == "http://localhost:8080/realms/master/.well-known/openid-configuration"
     )
 

--- a/sdk/python/tests/unit/permissions/auth/conftest.py
+++ b/sdk/python/tests/unit/permissions/auth/conftest.py
@@ -75,8 +75,7 @@ def oidc_config() -> OidcAuthConfig:
     return OidcAuthConfig(
         auth_discovery_url="https://localhost:8080/realms/master/.well-known/openid-configuration",
         client_id=_CLIENT_ID,
-        client_secret="",
-        realm="",
+        type="oidc",
     )
 
 

--- a/sdk/python/tests/unit/permissions/auth/conftest.py
+++ b/sdk/python/tests/unit/permissions/auth/conftest.py
@@ -76,8 +76,6 @@ def oidc_config() -> OidcAuthConfig:
         auth_discovery_url="https://localhost:8080/realms/master/.well-known/openid-configuration",
         client_id=_CLIENT_ID,
         client_secret="",
-        username="",
-        password="",
         realm="",
     )
 

--- a/sdk/python/tests/unit/permissions/test_oidc_auth_client.py
+++ b/sdk/python/tests/unit/permissions/test_oidc_auth_client.py
@@ -5,7 +5,7 @@ from requests import Session
 from feast.permissions.auth_model import (
     KubernetesAuthConfig,
     NoAuthConfig,
-    OidcAuthConfig,
+    OidcClientAuthConfig,
 )
 from feast.permissions.client.http_auth_requests_wrapper import (
     AuthenticatedRequestsSession,
@@ -21,8 +21,8 @@ from feast.permissions.client.oidc_authentication_client_manager import (
 MOCKED_TOKEN_VALUE: str = "dummy_token"
 
 
-def _get_dummy_oidc_auth_type() -> OidcAuthConfig:
-    oidc_config = OidcAuthConfig(
+def _get_dummy_oidc_auth_type() -> OidcClientAuthConfig:
+    oidc_config = OidcClientAuthConfig(
         auth_discovery_url="http://localhost:8080/realms/master/.well-known/openid-configuration",
         type="oidc",
         username="admin_test",

--- a/sdk/python/tests/unit/permissions/test_oidc_auth_client.py
+++ b/sdk/python/tests/unit/permissions/test_oidc_auth_client.py
@@ -28,6 +28,7 @@ def _get_dummy_oidc_auth_type() -> OidcClientAuthConfig:
         username="admin_test",
         password="password_test",
         client_id="dummy_client_id",
+        client_secret="client_secret",
     )
     return oidc_config
 


### PR DESCRIPTION
Added separate model for OidcClient side so that username and password is not required for server side.


# What this PR does / why we need it:
class [OidcAuthConfig](https://github.com/feast-dev/feast/blob/master/sdk/python/feast/permissions/auth_model.py) is having username and password as mandatory. OIDC server side code is not using username and password so it is forcing server side code to pass the values. One of the proposal is to create separate model for oidc server and client. We need to evaluate all the util methods if it is going to impact in any other way.


# Which issue(s) this PR fixes:
https://github.com/feast-dev/feast/issues/4457

