### PR TITLE
fix: Ignore the type check as both functions calls are not belonging to Feast code.

### DIFF
--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -51,7 +51,7 @@ def get_app(
 
     async_refresh()
 
-    ui_dir_ref = importlib_resources.files(__spec__.parent) / "ui/build/"  # type: ignore[name-defined]
+    ui_dir_ref = importlib_resources.files(__spec__.parent) / "ui/build/"  # type: ignore[name-defined, arg-type]
     with importlib_resources.as_file(ui_dir_ref) as ui_dir:
         # Initialize with the projects-list.json file
         with ui_dir.joinpath("projects-list.json").open(mode="w") as f:


### PR DESCRIPTION
Fix #4462 


If "mypy>=1.11", it will show the following error:
`feast/ui_server.py:54: error: Argument 1 to "files" has incompatible type "str | None"; expected "str | Module"  [arg-type]`

