### PR TITLE
feat: Allow tag updates to Feast objects

### DIFF
--- a/docs/reference/feast-cli-commands.md
+++ b/docs/reference/feast-cli-commands.md
@@ -12,32 +12,61 @@ Usage: feast [OPTIONS] COMMAND [ARGS]...
   For more information, see our public docs at https://docs.feast.dev/
 
 Options:
-  -c, --chdir TEXT  Switch to a different feature repository directory before
-                    executing the given subcommand.
-
-  --help            Show this message and exit.
+  -c, --chdir TEXT               Switch to a different feature repository
+                                 directory before executing the given
+                                 subcommand.
+  --log-level TEXT               The logging level. One of DEBUG, INFO,
+                                 WARNING, ERROR, and CRITICAL (case-
+                                 insensitive).
+  -f, --feature-store-yaml TEXT  Override the directory where the CLI should
+                                 look for the feature_store.yaml file.
+  --help                         Show this message and exit.
 
 Commands:
   apply                    Create or update a feature store deployment
+  data-sources             Access data sources
+  endpoint                 Display feature server endpoints
   entities                 Access entities
+  feature-services         Access feature services
   feature-views            Access feature views
   init                     Create a new Feast repository
+  listen                   Start a gRPC feature server to ingest...
   materialize              Run a (non-incremental) materialization job to...
-  materialize-incremental  Run an incremental materialization job to ingest...
+  materialize-incremental  Run an incremental materialization job to...
+  on-demand-feature-views  [Experimental] Access on demand feature views
   permissions              Access permissions
+  plan                     Create or update a feature store deployment
+  projects                 Access projects
   registry-dump            Print contents of the metadata registry
+  saved-datasets           [Experimental] Access saved datasets
+  serve                    Start a feature server locally on a given port.
+  serve_offline            Start a remote server locally on a given host,...
+  serve_registry           Start a registry server locally on a given port.
+  serve_transformations    [Experimental] Start a feature consumption...
+  stream-feature-views     [Experimental] Access stream feature views
+  tag                      [Experimental] Tag objects
   teardown                 Tear down deployed feature store infrastructure
+  ui                       Shows the Feast UI over the current directory
+  validate                 Perform validation of logged features...
+  validation-references    [Experimental] Access validation references
   version                  Display Feast SDK version
 ```
 
 ## Global Options
 
-The Feast CLI provides one global top-level option that can be used with other commands
+The Feast CLI provides three global top-level options that can be used with other commands
 
 **chdir \(-c, --chdir\)**
 
 This command allows users to run Feast CLI commands in a different folder from the current working directory.
 
+**log-level \(--log-level\)**
+
+This command allows users to change the logging level.
+
+**feature-store-yaml \(-f, --feature-store-yaml\)**
+
+This command allows users to override the directory where the CLI should look for the `feature_store.yaml` file.
 ```text
 feast -c path/to/my/feature/repo apply
 ```
@@ -292,6 +321,47 @@ reader             driver_hourly_stats_fresh   FeatureView      DESCRIBE
 ...
 ```
 
+## Tag
+Update tags for the following objects types:
+- data-source
+- entity
+- feature-service
+- feature-view
+- on-demand-feature-view
+- permission
+- project
+- saved-dataset
+- stream-feature-view
+- validation-reference
+
+```text
+% feast tag --help
+Usage: feast tag [OPTIONS] OBJECT_TYPE NAME TAGS...
+
+  [Experimental] Tag objects
+
+  *  A tag key and value must begin with a letter or number, and may contain
+  letters, numbers, hyphens, dots, and underscores, up to 63 characters each.
+
+  *  Optionally, the key can begin with a DNS subdomain prefix and a single
+  '/', like example.com/my-app. The 'feast.dev/' prefix is reserved.
+
+  Examples:
+
+      # Update data source 'foo' with the tag 'test' and the value 'true'.
+
+      feast tag data-source foo test:true
+
+      # Update feature view 'foo' by removing a tag named 'bar' if it exists.
+      Does not require the --overwrite flag.
+
+      feast tag feature-view foo bar-
+
+Options:
+  --overwrite  If true, allow tags to be overwritten, otherwise reject tag
+               updates that overwrite existing tags.
+  --help       Show this message and exit.
+```
 
 ## Teardown
 

--- a/docs/tutorials/azure/deployment/fs_sqldb_azuredeploy.json
+++ b/docs/tutorials/azure/deployment/fs_sqldb_azuredeploy.json
@@ -179,7 +179,7 @@
                 "type": "SystemAssigned"
             },
             "tags": {
-                "displayName": "Azure ML Workspace"
+                "displayName": "Azure-ML-Workspace"
             },
             "dependsOn": [
                 "[variables('storageAccount')]",
@@ -224,7 +224,7 @@
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2021-04-01",
             "tags": {
-                "displayName": "Feast Registry Store"
+                "displayName": "Feast-Registry-Store"
             },
             "location": "[resourceGroup().location]",
             "kind": "StorageV2",
@@ -252,7 +252,7 @@
             "apiVersion": "2014-04-01",
             "location": "[resourceGroup().location]",
             "tags": {
-                "displayName": "Feast Offline Store Server"
+                "displayName": "Feast-Offline-Store-Server"
             },
             "properties": {
                 "administratorLogin": "[parameters('administratorLogin')]",
@@ -282,7 +282,7 @@
                         "name": "Basic"
                     },
                     "tags": {
-                        "displayName": "Feast Offline Store"
+                        "displayName": "Feast-Offline-Store"
                     },
                     "dependsOn": [
                         "[resourceId('Microsoft.Sql/servers', concat(parameters('sqlServerName')))]"
@@ -297,7 +297,7 @@
             "apiVersion": "2020-12-01",
             "location": "[resourceGroup().location]",
             "tags": {
-                "displayName": "Feast Online Store"
+                "displayName": "Feast-Online-Store"
             },
             "properties": {
                 "sku": {

--- a/docs/tutorials/azure/deployment/fs_synapse_azuredeploy.json
+++ b/docs/tutorials/azure/deployment/fs_synapse_azuredeploy.json
@@ -188,7 +188,7 @@
                 "type": "SystemAssigned"
             },
             "tags": {
-                "displayName": "Azure ML Workspace"
+                "displayName": "Azure-ML-Workspace"
             },
             "dependsOn": [
                 "[variables('storageAccount')]",
@@ -233,7 +233,7 @@
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2021-04-01",
             "tags": {
-                "displayName": "Feast Registry Store"
+                "displayName": "Feast-Registry-Store"
             },
             "location": "[resourceGroup().location]",
             "kind": "StorageV2",
@@ -261,7 +261,7 @@
             "apiVersion": "2020-12-01",
             "location": "[resourceGroup().location]",
             "tags": {
-                "displayName": "Feast Online Store"
+                "displayName": "Feast-Online-Store"
             },
             "properties": {
                 "sku": {

--- a/protos/feast/registry/RegistryServer.proto
+++ b/protos/feast/registry/RegistryServer.proto
@@ -21,12 +21,14 @@ service RegistryServer{
   // Entity RPCs
   rpc ApplyEntity (ApplyEntityRequest) returns (google.protobuf.Empty) {}
   rpc GetEntity (GetEntityRequest) returns (feast.core.Entity) {}
+  rpc TagEntity (TagEntityRequest) returns (google.protobuf.Empty) {}
   rpc ListEntities (ListEntitiesRequest) returns (ListEntitiesResponse) {}
   rpc DeleteEntity (DeleteEntityRequest) returns (google.protobuf.Empty) {}
   
   // DataSource RPCs
   rpc ApplyDataSource (ApplyDataSourceRequest) returns (google.protobuf.Empty) {}
   rpc GetDataSource (GetDataSourceRequest) returns (feast.core.DataSource) {}
+  rpc TagDataSource (TagDataSourceRequest) returns (google.protobuf.Empty) {}
   rpc ListDataSources (ListDataSourcesRequest) returns (ListDataSourcesResponse) {}
   rpc DeleteDataSource (DeleteDataSourceRequest) returns (google.protobuf.Empty) {}
 
@@ -38,43 +40,51 @@ service RegistryServer{
 
   // plain FeatureView RPCs
   rpc GetFeatureView (GetFeatureViewRequest) returns (feast.core.FeatureView) {}
+  rpc TagFeatureView (TagFeatureViewRequest) returns (google.protobuf.Empty) {}
   rpc ListFeatureViews (ListFeatureViewsRequest) returns (ListFeatureViewsResponse) {}
 
   // StreamFeatureView RPCs
   rpc GetStreamFeatureView (GetStreamFeatureViewRequest) returns (feast.core.StreamFeatureView) {}
+  rpc TagStreamFeatureView (TagStreamFeatureViewRequest) returns (google.protobuf.Empty) {}
   rpc ListStreamFeatureViews (ListStreamFeatureViewsRequest) returns (ListStreamFeatureViewsResponse) {}
 
   // OnDemandFeatureView RPCs
   rpc GetOnDemandFeatureView (GetOnDemandFeatureViewRequest) returns (feast.core.OnDemandFeatureView) {}
+  rpc TagOnDemandFeatureView (TagOnDemandFeatureViewRequest) returns (google.protobuf.Empty) {}
   rpc ListOnDemandFeatureViews (ListOnDemandFeatureViewsRequest) returns (ListOnDemandFeatureViewsResponse) {}
 
   // FeatureService RPCs
   rpc ApplyFeatureService (ApplyFeatureServiceRequest) returns (google.protobuf.Empty) {}
   rpc GetFeatureService (GetFeatureServiceRequest) returns (feast.core.FeatureService) {}
+  rpc TagFeatureService (TagFeatureServiceRequest) returns (google.protobuf.Empty) {}
   rpc ListFeatureServices (ListFeatureServicesRequest) returns (ListFeatureServicesResponse) {}
   rpc DeleteFeatureService (DeleteFeatureServiceRequest) returns (google.protobuf.Empty) {}
 
   // SavedDataset RPCs
   rpc ApplySavedDataset (ApplySavedDatasetRequest) returns (google.protobuf.Empty) {}
   rpc GetSavedDataset (GetSavedDatasetRequest) returns (feast.core.SavedDataset) {}
+  rpc TagSavedDataset (TagSavedDatasetRequest) returns (google.protobuf.Empty) {}
   rpc ListSavedDatasets (ListSavedDatasetsRequest) returns (ListSavedDatasetsResponse) {}
   rpc DeleteSavedDataset (DeleteSavedDatasetRequest) returns (google.protobuf.Empty) {}
 
   // ValidationReference RPCs
   rpc ApplyValidationReference (ApplyValidationReferenceRequest) returns (google.protobuf.Empty) {}
   rpc GetValidationReference (GetValidationReferenceRequest) returns (feast.core.ValidationReference) {}
+  rpc TagValidationReference (TagValidationReferenceRequest) returns (google.protobuf.Empty) {}
   rpc ListValidationReferences (ListValidationReferencesRequest) returns (ListValidationReferencesResponse) {}
   rpc DeleteValidationReference (DeleteValidationReferenceRequest) returns (google.protobuf.Empty) {}
 
   // Permission RPCs
   rpc ApplyPermission (ApplyPermissionRequest) returns (google.protobuf.Empty) {}
   rpc GetPermission (GetPermissionRequest) returns (feast.core.Permission) {}
+  rpc TagPermission (TagPermissionRequest) returns (google.protobuf.Empty) {}
   rpc ListPermissions (ListPermissionsRequest) returns (ListPermissionsResponse) {}
   rpc DeletePermission (DeletePermissionRequest) returns (google.protobuf.Empty) {}
 
   // Project RPCs
   rpc ApplyProject (ApplyProjectRequest) returns (google.protobuf.Empty) {}
   rpc GetProject (GetProjectRequest) returns (feast.core.Project) {}
+  rpc TagProject (TagProjectRequest) returns (google.protobuf.Empty) {}
   rpc ListProjects (ListProjectsRequest) returns (ListProjectsResponse) {}
   rpc DeleteProject (DeleteProjectRequest) returns (google.protobuf.Empty) {}
 
@@ -132,6 +142,13 @@ message GetEntityRequest {
     bool allow_cache = 3;
 }
 
+message TagEntityRequest {
+    string name = 1;
+    string project = 2;
+    map<string,string> tags = 3;
+    bool overwrite  = 4;
+}
+
 message ListEntitiesRequest {
     string project = 1;
     bool allow_cache = 2;
@@ -160,6 +177,13 @@ message GetDataSourceRequest {
     string name = 1;
     string project = 2;
     bool allow_cache = 3;
+}
+
+message TagDataSourceRequest {
+  string name = 1;
+  string project = 2;
+  map<string,string> tags = 3;
+  bool overwrite  = 4;
 }
 
 message ListDataSourcesRequest {
@@ -194,6 +218,13 @@ message GetFeatureViewRequest {
     string name = 1;
     string project = 2;
     bool allow_cache = 3;
+}
+
+message TagFeatureViewRequest {
+  string name = 1;
+  string project = 2;
+  map<string,string> tags = 3;
+  bool overwrite  = 4;
 }
 
 message ListFeatureViewsRequest {
@@ -249,6 +280,13 @@ message GetStreamFeatureViewRequest {
     bool allow_cache = 3;
 }
 
+message TagStreamFeatureViewRequest {
+  string name = 1;
+  string project = 2;
+  map<string,string> tags = 3;
+  bool overwrite  = 4;
+}
+
 message ListStreamFeatureViewsRequest {
     string project = 1;
     bool allow_cache = 2;
@@ -265,6 +303,13 @@ message GetOnDemandFeatureViewRequest {
     string name = 1;
     string project = 2;
     bool allow_cache = 3;
+}
+
+message TagOnDemandFeatureViewRequest {
+  string name = 1;
+  string project = 2;
+  map<string,string> tags = 3;
+  bool overwrite  = 4;
 }
 
 message ListOnDemandFeatureViewsRequest {
@@ -289,6 +334,13 @@ message GetFeatureServiceRequest {
     string name = 1;
     string project = 2;
     bool allow_cache = 3;
+}
+
+message TagFeatureServiceRequest {
+  string name = 1;
+  string project = 2;
+  map<string,string> tags = 3;
+  bool overwrite  = 4;
 }
 
 message ListFeatureServicesRequest {
@@ -321,6 +373,13 @@ message GetSavedDatasetRequest {
     bool allow_cache = 3;
 }
 
+message TagSavedDatasetRequest {
+  string name = 1;
+  string project = 2;
+  map<string,string> tags = 3;
+  bool overwrite  = 4;
+}
+
 message ListSavedDatasetsRequest {
     string project = 1;
     bool allow_cache = 2;
@@ -349,6 +408,13 @@ message GetValidationReferenceRequest {
     string name = 1;
     string project = 2;
     bool allow_cache = 3;
+}
+
+message TagValidationReferenceRequest {
+  string name = 1;
+  string project = 2;
+  map<string,string> tags = 3;
+  bool overwrite  = 4;
 }
 
 message ListValidationReferencesRequest {
@@ -381,6 +447,13 @@ message GetPermissionRequest {
   bool allow_cache = 3;
 }
 
+message TagPermissionRequest {
+  string name = 1;
+  string project = 2;
+  map<string,string> tags = 3;
+  bool overwrite  = 4;
+}
+
 message ListPermissionsRequest {
   string project = 1;
   bool allow_cache = 2;
@@ -407,6 +480,12 @@ message ApplyProjectRequest {
 message GetProjectRequest {
   string name = 1;
   bool allow_cache = 2;
+}
+
+message TagProjectRequest {
+  string name = 1;
+  map<string,string> tags = 3;
+  bool overwrite  = 4;
 }
 
 message ListProjectsRequest {

--- a/sdk/python/feast/base_feature_view.py
+++ b/sdk/python/feast/base_feature_view.py
@@ -27,6 +27,7 @@ from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
 from feast.protos.feast.core.StreamFeatureView_pb2 import (
     StreamFeatureView as StreamFeatureViewProto,
 )
+from feast.value_type import validate_tags
 
 
 class BaseFeatureView(ABC):
@@ -169,6 +170,8 @@ class BaseFeatureView(ABC):
         """
         if not self.name:
             raise ValueError("Feature view needs a name.")
+
+        validate_tags(self.tags)
 
     def with_name(self, name: str):
         """

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -27,7 +27,7 @@ from feast.field import Field
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
 from feast.repo_config import RepoConfig, get_data_source_class_from_type
 from feast.types import from_value_type
-from feast.value_type import ValueType
+from feast.value_type import ValueType, validate_tags
 
 
 class KafkaOptions:
@@ -269,6 +269,12 @@ class DataSource(ABC):
             return False
 
         return True
+
+    def is_valid(self):
+        """
+        Validates the state of this data source locally.
+        """
+        validate_tags(self.tags)
 
     @staticmethod
     @abstractmethod

--- a/sdk/python/feast/entity.py
+++ b/sdk/python/feast/entity.py
@@ -20,7 +20,7 @@ from typeguard import typechecked
 from feast.protos.feast.core.Entity_pb2 import Entity as EntityProto
 from feast.protos.feast.core.Entity_pb2 import EntityMeta as EntityMetaProto
 from feast.protos.feast.core.Entity_pb2 import EntitySpecV2 as EntitySpecProto
-from feast.value_type import ValueType
+from feast.value_type import ValueType, validate_tags
 
 
 @typechecked
@@ -136,6 +136,8 @@ class Entity:
 
         if not self.value_type:
             raise ValueError(f"The entity {self.name} does not have a type.")
+
+        validate_tags(self.tags)
 
     @classmethod
     def from_proto(cls, entity_proto: EntityProto):

--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -509,3 +509,25 @@ class FeastPermissionError(FeastError, PermissionError):
 
     def http_status_code(self) -> int:
         return HttpStatusCode.HTTP_403_FORBIDDEN
+
+
+class TagKeyAlreadyExists(Exception):
+    def __init__(self, key):
+        super().__init__(f"Tag '{key}' already exists")
+
+
+class TagRequestEmpty(Exception):
+    def __init__(self):
+        super().__init__("At least one tag update is required")
+
+
+class TagKeyNotFound(Exception):
+    def __init__(self, key):
+        super().__init__(f"Tag '{key}' not found")
+
+
+class TagKeyDel(Exception):
+    def __init__(self, key):
+        super().__init__(
+            f"Can not both modify and remove tag '{key}' in the same command"
+        )

--- a/sdk/python/feast/feature_service.py
+++ b/sdk/python/feast/feature_service.py
@@ -19,6 +19,7 @@ from feast.protos.feast.core.FeatureService_pb2 import (
 from feast.protos.feast.core.FeatureService_pb2 import (
     FeatureServiceSpec as FeatureServiceSpecProto,
 )
+from feast.value_type import validate_tags
 
 
 @typechecked
@@ -182,6 +183,12 @@ class FeatureService:
             return False
 
         return True
+
+    def is_valid(self):
+        """
+        Validates the state of this feature service locally.
+        """
+        validate_tags(self.tags)
 
     @classmethod
     def from_proto(cls, feature_service_proto: FeatureServiceProto):

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -408,6 +408,29 @@ class FeatureStore:
             name, self.project, allow_cache=allow_registry_cache
         )
 
+    def tag_entity(
+        self, name: str, tags: Optional[dict[str, str]] = None, overwrite: bool = False
+    ):
+        """
+        Updates tags of an entity.
+
+        Args:
+            name: Name of entity.
+            tags: Tags to update.
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags.
+
+        Raises:
+            EntityNotFoundException: The feast object could not be found.
+            TagKeyAlreadyExists: A tag with the same key already exists.
+            TagRequestEmpty: At least one tag update is required.
+            TagKeyDel: Can not both modify and remove a tag key in the same command.
+            TagKeyNotFound: Tag key not found.
+            ValueError: Invalid tag key or value, regex validation failed.
+        """
+        return self._registry.tag_entity(
+            name, self.project, tags=tags, overwrite=overwrite
+        )
+
     def get_feature_service(
         self, name: str, allow_cache: bool = False
     ) -> FeatureService:
@@ -425,6 +448,29 @@ class FeatureStore:
             FeatureServiceNotFoundException: The feature service could not be found.
         """
         return self._registry.get_feature_service(name, self.project, allow_cache)
+
+    def tag_feature_service(
+        self, name: str, tags: Optional[dict[str, str]] = None, overwrite: bool = False
+    ):
+        """
+        Updates tags of a feature service.
+
+        Args:
+            name: Name of feature service.
+            tags: Tags to update.
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags.
+
+        Raises:
+            FeatureServiceNotFoundException: The feast object could not be found.
+            TagKeyAlreadyExists: A tag with the same key already exists.
+            TagRequestEmpty: At least one tag update is required.
+            TagKeyDel: Can not both modify and remove a tag key in the same command.
+            TagKeyNotFound: Tag key not found.
+            ValueError: Invalid tag key or value, regex validation failed.
+        """
+        return self._registry.tag_feature_service(
+            name, self.project, tags=tags, overwrite=overwrite
+        )
 
     def get_feature_view(
         self, name: str, allow_registry_cache: bool = False
@@ -456,6 +502,29 @@ class FeatureStore:
         if hide_dummy_entity and feature_view.entities[0] == DUMMY_ENTITY_NAME:
             feature_view.entities = []
         return feature_view
+
+    def tag_feature_view(
+        self, name: str, tags: Optional[dict[str, str]] = None, overwrite: bool = False
+    ):
+        """
+        Updates tags of a feature view.
+
+        Args:
+            name: Name of feature view.
+            tags: Tags to update.
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags.
+
+        Raises:
+            FeatureViewNotFoundException: The feast object could not be found.
+            TagKeyAlreadyExists: A tag with the same key already exists.
+            TagRequestEmpty: At least one tag update is required.
+            TagKeyDel: Can not both modify and remove a tag key in the same command.
+            TagKeyNotFound: Tag key not found.
+            ValueError: Invalid tag key or value, regex validation failed.
+        """
+        return self._registry.tag_feature_view(
+            name, self.project, tags=tags, overwrite=overwrite
+        )
 
     def get_stream_feature_view(
         self, name: str, allow_registry_cache: bool = False
@@ -490,6 +559,29 @@ class FeatureStore:
             stream_feature_view.entities = []
         return stream_feature_view
 
+    def tag_stream_feature_view(
+        self, name: str, tags: Optional[dict[str, str]] = None, overwrite: bool = False
+    ):
+        """
+        Updates tags of an stream feature view.
+
+        Args:
+            name: Name of stream feature view.
+            tags: Tags to update.
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags.
+
+        Raises:
+            FeatureViewNotFoundException: The feast object could not be found.
+            TagKeyAlreadyExists: A tag with the same key already exists.
+            TagRequestEmpty: At least one tag update is required.
+            TagKeyDel: Can not both modify and remove a tag key in the same command.
+            TagKeyNotFound: Tag key not found.
+            ValueError: Invalid tag key or value, regex validation failed.
+        """
+        return self._registry.tag_stream_feature_view(
+            name, self.project, tags=tags, overwrite=overwrite
+        )
+
     def get_on_demand_feature_view(self, name: str) -> OnDemandFeatureView:
         """
         Retrieves a feature view.
@@ -505,6 +597,29 @@ class FeatureStore:
         """
         return self._registry.get_on_demand_feature_view(name, self.project)
 
+    def tag_on_demand_feature_view(
+        self, name: str, tags: Optional[dict[str, str]] = None, overwrite: bool = False
+    ):
+        """
+        Updates tags of an on demand feature view.
+
+        Args:
+            name: Name of on demand feature view.
+            tags: Tags to update.
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags.
+
+        Raises:
+            FeatureViewNotFoundException: The feast object could not be found.
+            TagKeyAlreadyExists: A tag with the same key already exists.
+            TagRequestEmpty: At least one tag update is required.
+            TagKeyDel: Can not both modify and remove a tag key in the same command.
+            TagKeyNotFound: Tag key not found.
+            ValueError: Invalid tag key or value, regex validation failed.
+        """
+        return self._registry.tag_on_demand_feature_view(
+            name, self.project, tags=tags, overwrite=overwrite
+        )
+
     def get_data_source(self, name: str) -> DataSource:
         """
         Retrieves the list of data sources from the registry.
@@ -519,6 +634,29 @@ class FeatureStore:
             DataSourceObjectNotFoundException: The data source could not be found.
         """
         return self._registry.get_data_source(name, self.project)
+
+    def tag_data_source(
+        self, name: str, tags: Optional[dict[str, str]] = None, overwrite: bool = False
+    ):
+        """
+        Updates tags of a data source.
+
+        Args:
+            name: Name of data source.
+            tags: Tags to update.
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags.
+
+        Raises:
+            DataSourceObjectNotFoundException: The feast object could not be found.
+            TagKeyAlreadyExists: A tag with the same key already exists.
+            TagRequestEmpty: At least one tag update is required.
+            TagKeyDel: Can not both modify and remove a tag key in the same command.
+            TagKeyNotFound: Tag key not found.
+            ValueError: Invalid tag key or value, regex validation failed.
+        """
+        return self._registry.tag_data_source(
+            name, self.project, tags=tags, overwrite=overwrite
+        )
 
     def delete_feature_view(self, name: str):
         """
@@ -1212,6 +1350,46 @@ class FeatureStore:
             config=self.config, dataset=dataset
         )
         return dataset.with_retrieval_job(retrieval_job)
+
+    def tag_saved_dataset(
+        self, name: str, tags: Optional[dict[str, str]] = None, overwrite: bool = False
+    ):
+        """
+        Updates tags of a saved dataset.
+
+        Args:
+            name: Name of saved dataset.
+            tags: Tags to update.
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags.
+
+        Raises:
+            SavedDatasetNotFound: The feast object could not be found.
+            TagKeyAlreadyExists: A tag with the same key already exists.
+            TagRequestEmpty: At least one tag update is required.
+            TagKeyDel: Can not both modify and remove a tag key in the same command.
+            TagKeyNotFound: Tag key not found.
+            ValueError: Invalid tag key or value, regex validation failed.
+        """
+        return self._registry.tag_saved_dataset(
+            name, self.project, tags=tags, overwrite=overwrite
+        )
+
+    def list_saved_datasets(
+        self, allow_cache: bool = False, tags: Optional[dict[str, str]] = None
+    ) -> List[SavedDataset]:
+        """
+        Retrieves the list of saved datasets from the registry.
+
+        Args:
+            allow_cache: Whether to allow returning saved datasets from a cached registry.
+            tags: Filter by tags.
+
+        Returns:
+            A list of saved datasets.
+        """
+        return self._registry.list_saved_datasets(
+            self.project, allow_cache=allow_cache, tags=tags
+        )
 
     def materialize_incremental(
         self,
@@ -1909,6 +2087,29 @@ class FeatureStore:
         ref._dataset = self.get_saved_dataset(ref.dataset_name)
         return ref
 
+    def tag_validation_reference(
+        self, name: str, tags: Optional[dict[str, str]] = None, overwrite: bool = False
+    ):
+        """
+        Updates tags of a validation reference.
+
+        Args:
+            name: Name of validation reference.
+            tags: Tags to update.
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags.
+
+        Raises:
+            ValidationReferenceNotFoundException: The feast object could not be found.
+            TagKeyAlreadyExists: A tag with the same key already exists.
+            TagRequestEmpty: At least one tag update is required.
+            TagKeyDel: Can not both modify and remove a tag key in the same command.
+            TagKeyNotFound: Tag key not found.
+            ValueError: Invalid tag key or value, regex validation failed.
+        """
+        return self._registry.tag_validation_reference(
+            name, self.project, tags=tags, overwrite=overwrite
+        )
+
     def list_validation_references(
         self, allow_cache: bool = False, tags: Optional[dict[str, str]] = None
     ) -> List[ValidationReference]:
@@ -1924,6 +2125,44 @@ class FeatureStore:
         """
         return self._registry.list_validation_references(
             self.project, allow_cache=allow_cache, tags=tags
+        )
+
+    def get_permission(self, name: str) -> Permission:
+        """
+        Retrieves a permission from the registry.
+
+        Args:
+            name: Name of the permission.
+
+        Returns:
+            The specified permission.
+
+        Raises:
+            PermissionObjectNotFoundException: The permission could not be found.
+        """
+        return self._registry.get_permission(name, self.project)
+
+    def tag_permission(
+        self, name: str, tags: Optional[dict[str, str]] = None, overwrite: bool = False
+    ):
+        """
+        Updates tags of a permission.
+
+        Args:
+            name: Name of permission.
+            tags: Tags to update.
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags.
+
+        Raises:
+            PermissionObjectNotFoundException: The feast object could not be found.
+            TagKeyAlreadyExists: A tag with the same key already exists.
+            TagRequestEmpty: At least one tag update is required.
+            TagKeyDel: Can not both modify and remove a tag key in the same command.
+            TagKeyNotFound: Tag key not found.
+            ValueError: Invalid tag key or value, regex validation failed.
+        """
+        return self._registry.tag_permission(
+            name, self.project, tags=tags, overwrite=overwrite
         )
 
     def list_permissions(
@@ -1943,36 +2182,6 @@ class FeatureStore:
             self.project, allow_cache=allow_cache, tags=tags
         )
 
-    def get_permission(self, name: str) -> Permission:
-        """
-        Retrieves a permission from the registry.
-
-        Args:
-            name: Name of the permission.
-
-        Returns:
-            The specified permission.
-
-        Raises:
-            PermissionObjectNotFoundException: The permission could not be found.
-        """
-        return self._registry.get_permission(name, self.project)
-
-    def list_projects(
-        self, allow_cache: bool = False, tags: Optional[dict[str, str]] = None
-    ) -> List[Project]:
-        """
-        Retrieves the list of projects from the registry.
-
-        Args:
-            allow_cache: Whether to allow returning projects from a cached registry.
-            tags: Filter by tags.
-
-        Returns:
-            A list of projects.
-        """
-        return self._registry.list_projects(allow_cache=allow_cache, tags=tags)
-
     def get_project(self, name: Optional[str]) -> Project:
         """
         Retrieves a project from the registry.
@@ -1988,22 +2197,41 @@ class FeatureStore:
         """
         return self._registry.get_project(name or self.project)
 
-    def list_saved_datasets(
-        self, allow_cache: bool = False, tags: Optional[dict[str, str]] = None
-    ) -> List[SavedDataset]:
+    def tag_project(
+        self, name: str, tags: Optional[dict[str, str]] = None, overwrite: bool = False
+    ):
         """
-        Retrieves the list of saved datasets from the registry.
+        Updates tags of a project.
 
         Args:
-            allow_cache: Whether to allow returning saved datasets from a cached registry.
+            name: Name of project.
+            tags: Tags to update.
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags.
+
+        Raises:
+            ProjectObjectNotFoundException: The feast object could not be found.
+            TagKeyAlreadyExists: A tag with the same key already exists.
+            TagRequestEmpty: At least one tag update is required.
+            TagKeyDel: Can not both modify and remove a tag key in the same command.
+            TagKeyNotFound: Tag key not found.
+            ValueError: Invalid tag key or value, regex validation failed.
+        """
+        return self._registry.tag_project(name, tags=tags, overwrite=overwrite)
+
+    def list_projects(
+        self, allow_cache: bool = False, tags: Optional[dict[str, str]] = None
+    ) -> List[Project]:
+        """
+        Retrieves the list of projects from the registry.
+
+        Args:
+            allow_cache: Whether to allow returning projects from a cached registry.
             tags: Filter by tags.
 
         Returns:
-            A list of saved datasets.
+            A list of projects.
         """
-        return self._registry.list_saved_datasets(
-            self.project, allow_cache=allow_cache, tags=tags
-        )
+        return self._registry.list_projects(allow_cache=allow_cache, tags=tags)
 
 
 def _print_materialization_log(

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -100,6 +100,28 @@ class BaseRegistry(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def tag_entity(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        """
+        Updates tags of an entity.
+
+        Args:
+            name: Name of entity
+            project: Feast project that this object belongs to
+            tags: Tags to update
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags
+
+        Returns:
+            Raises an exception if no object is found
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def list_entities(
         self,
         project: str,
@@ -164,6 +186,28 @@ class BaseRegistry(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def tag_data_source(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        """
+        Updates tags of a data source.
+
+        Args:
+            name: Name of data source
+            project: Feast project that this object belongs to
+            tags: Tags to update
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags
+
+        Returns:
+            Raises an exception if no object is found
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def list_data_sources(
         self,
         project: str,
@@ -224,6 +268,28 @@ class BaseRegistry(ABC):
         Returns:
             Returns either the specified feature service, or raises an exception if
             none is found
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def tag_feature_service(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        """
+        Updates tags of a feature service.
+
+        Args:
+            name: Name of feature service
+            project: Feast project that this object belongs to
+            tags: Tags to update
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags
+
+        Returns:
+            Raises an exception if no object is found
         """
         raise NotImplementedError
 
@@ -294,6 +360,28 @@ class BaseRegistry(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def tag_stream_feature_view(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        """
+        Updates tags of an stream feature view.
+
+        Args:
+            name: Name of stream feature view
+            project: Feast project that this object belongs to
+            tags: Tags to update
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags
+
+        Returns:
+            Raises an exception if no object is found
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def list_stream_feature_views(
         self,
         project: str,
@@ -333,6 +421,28 @@ class BaseRegistry(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def tag_on_demand_feature_view(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        """
+        Updates tags of an on demand feature view.
+
+        Args:
+            name: Name of on demand feature view
+            project: Feast project that this object belongs to
+            tags: Tags to update
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags
+
+        Returns:
+            Raises an exception if no object is found
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def list_on_demand_feature_views(
         self,
         project: str,
@@ -368,6 +478,28 @@ class BaseRegistry(ABC):
         Returns:
             Returns either the specified feature view, or raises an exception if
             none is found
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def tag_feature_view(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        """
+        Updates tags of a feature view.
+
+        Args:
+            name: Name of feature view
+            project: Feast project that this object belongs to
+            tags: Tags to update
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags
+
+        Returns:
+            Raises an exception if no object is found
         """
         raise NotImplementedError
 
@@ -486,6 +618,28 @@ class BaseRegistry(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def tag_saved_dataset(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        """
+        Updates tags of a saved dataset.
+
+        Args:
+            name: Name of saved dataset
+            project: Feast project that this object belongs to
+            tags: Tags to update
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags
+
+        Returns:
+            Raises an exception if no object is found
+        """
+        raise NotImplementedError
+
     def delete_saved_dataset(self, name: str, project: str, commit: bool = True):
         """
         Delete a saved dataset.
@@ -562,6 +716,28 @@ class BaseRegistry(ABC):
         Returns:
             Returns either the specified ValidationReference, or raises an exception if
             none is found
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def tag_validation_reference(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        """
+        Updates tags of a validation reference.
+
+        Args:
+            name: Name of validation reference
+            project: Feast project that this object belongs to
+            tags: Tags to update
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags
+
+        Returns:
+            Raises an exception if no object is found
         """
         raise NotImplementedError
 
@@ -685,6 +861,28 @@ class BaseRegistry(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def tag_permission(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        """
+        Updates tags of a permission.
+
+        Args:
+            name: Name of permission
+            project: Feast project that this object belongs to
+            tags: Tags to update
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags
+
+        Returns:
+            Raises an exception if no object is found
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def list_permissions(
         self,
         project: str,
@@ -744,10 +942,30 @@ class BaseRegistry(ABC):
 
         Args:
             name: Feast project name
-            allow_cache: Whether to allow returning this permission from a cached registry
+            allow_cache: Whether to allow returning this project from a cached registry
 
         Returns:
             Returns either the specified project, or raises ProjectObjectNotFoundException exception if none is found
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def tag_project(
+        self,
+        name: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        """
+        Updates tags of a project.
+
+        Args:
+            name: Name of project
+            tags: Tags to update
+            overwrite: If true, allow tags to be overwritten, otherwise reject tag updates that overwrite existing tags
+
+        Returns:
+            Raises an exception if no object is found
         """
         raise NotImplementedError
 
@@ -761,7 +979,7 @@ class BaseRegistry(ABC):
         Retrieve a list of projects from the registry
 
         Args:
-            allow_cache: Whether to allow returning permissions from a cached registry
+            allow_cache: Whether to allow returning projects from a cached registry
 
         Returns:
             List of project

--- a/sdk/python/feast/infra/registry/remote.py
+++ b/sdk/python/feast/infra/registry/remote.py
@@ -98,6 +98,22 @@ class RemoteRegistry(BaseRegistry):
         response = self.stub.GetEntity(request)
         return Entity.from_proto(response)
 
+    def tag_entity(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        request = RegistryServer_pb2.TagEntityRequest(
+            name=name,
+            project=project,
+            tags=tags,
+            overwrite=overwrite,
+        )
+
+        self.stub.TagEntity(request)
+
     def list_entities(
         self,
         project: str,
@@ -132,6 +148,22 @@ class RemoteRegistry(BaseRegistry):
         )
         response = self.stub.GetDataSource(request)
         return DataSource.from_proto(response)
+
+    def tag_data_source(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        request = RegistryServer_pb2.TagDataSourceRequest(
+            name=name,
+            project=project,
+            tags=tags,
+            overwrite=overwrite,
+        )
+
+        self.stub.TagDataSource(request)
 
     def list_data_sources(
         self,
@@ -169,6 +201,22 @@ class RemoteRegistry(BaseRegistry):
         )
         response = self.stub.GetFeatureService(request)
         return FeatureService.from_proto(response)
+
+    def tag_feature_service(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        request = RegistryServer_pb2.TagFeatureServiceRequest(
+            name=name,
+            project=project,
+            tags=tags,
+            overwrite=overwrite,
+        )
+
+        self.stub.TagFeatureService(request)
 
     def list_feature_services(
         self,
@@ -228,6 +276,22 @@ class RemoteRegistry(BaseRegistry):
         response = self.stub.GetStreamFeatureView(request)
         return StreamFeatureView.from_proto(response)
 
+    def tag_stream_feature_view(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        request = RegistryServer_pb2.TagStreamFeatureViewRequest(
+            name=name,
+            project=project,
+            tags=tags,
+            overwrite=overwrite,
+        )
+
+        self.stub.TagStreamFeatureView(request)
+
     def list_stream_feature_views(
         self,
         project: str,
@@ -251,6 +315,22 @@ class RemoteRegistry(BaseRegistry):
         )
         response = self.stub.GetOnDemandFeatureView(request)
         return OnDemandFeatureView.from_proto(response)
+
+    def tag_on_demand_feature_view(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        request = RegistryServer_pb2.TagOnDemandFeatureViewRequest(
+            name=name,
+            project=project,
+            tags=tags,
+            overwrite=overwrite,
+        )
+
+        self.stub.TagOnDemandFeatureView(request)
 
     def list_on_demand_feature_views(
         self,
@@ -306,6 +386,22 @@ class RemoteRegistry(BaseRegistry):
         )
         response = self.stub.GetFeatureView(request)
         return FeatureView.from_proto(response)
+
+    def tag_feature_view(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        request = RegistryServer_pb2.TagFeatureViewRequest(
+            name=name,
+            project=project,
+            tags=tags,
+            overwrite=overwrite,
+        )
+
+        self.stub.TagFeatureView(request)
 
     def list_feature_views(
         self,
@@ -372,6 +468,22 @@ class RemoteRegistry(BaseRegistry):
         response = self.stub.GetSavedDataset(request)
         return SavedDataset.from_proto(response)
 
+    def tag_saved_dataset(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        request = RegistryServer_pb2.TagSavedDatasetRequest(
+            name=name,
+            project=project,
+            tags=tags,
+            overwrite=overwrite,
+        )
+
+        self.stub.TagSavedDataset(request)
+
     def list_saved_datasets(
         self,
         project: str,
@@ -414,6 +526,22 @@ class RemoteRegistry(BaseRegistry):
         )
         response = self.stub.GetValidationReference(request)
         return ValidationReference.from_proto(response)
+
+    def tag_validation_reference(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        request = RegistryServer_pb2.TagValidationReferenceRequest(
+            name=name,
+            project=project,
+            tags=tags,
+            overwrite=overwrite,
+        )
+
+        self.stub.TagValidationReference(request)
 
     def list_validation_references(
         self,
@@ -492,6 +620,22 @@ class RemoteRegistry(BaseRegistry):
 
         return Permission.from_proto(response)
 
+    def tag_permission(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        request = RegistryServer_pb2.TagPermissionRequest(
+            name=name,
+            project=project,
+            tags=tags,
+            overwrite=overwrite,
+        )
+
+        self.stub.TagPermission(request)
+
     def list_permissions(
         self,
         project: str,
@@ -537,6 +681,20 @@ class RemoteRegistry(BaseRegistry):
         response = self.stub.GetProject(request)
 
         return Project.from_proto(response)
+
+    def tag_project(
+        self,
+        name: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        request = RegistryServer_pb2.TagProjectRequest(
+            name=name,
+            tags=tags,
+            overwrite=overwrite,
+        )
+
+        self.stub.TagProject(request)
 
     def list_projects(
         self,

--- a/sdk/python/feast/infra/registry/snowflake.py
+++ b/sdk/python/feast/infra/registry/snowflake.py
@@ -60,7 +60,8 @@ from feast.protos.feast.core.ValidationProfile_pb2 import (
 from feast.repo_config import RegistryConfig
 from feast.saved_dataset import SavedDataset, ValidationReference
 from feast.stream_feature_view import StreamFeatureView
-from feast.utils import _utc_now, has_all_tags
+from feast.utils import _utc_now, apply_tags, has_all_tags
+from feast.value_type import validate_tags
 
 logger = logging.getLogger(__name__)
 
@@ -334,6 +335,24 @@ class SnowflakeRegistry(BaseRegistry):
 
         name = name or (obj.name if hasattr(obj, "name") else None)
         assert name, f"name needs to be provided for {obj}"
+
+        if isinstance(
+            obj,
+            (
+                Project,
+                Permission,
+                FeatureService,
+                FeatureView,
+                OnDemandFeatureView,
+                StreamFeatureView,
+                ValidationReference,
+                DataSource,
+                Entity,
+                SavedDataset,
+                BaseFeatureView,
+            ),
+        ):
+            validate_tags(obj.tags)
 
         update_datetime = _utc_now()
         if hasattr(obj, "last_updated_timestamp"):
@@ -785,6 +804,116 @@ class SnowflakeRegistry(BaseRegistry):
             "PERMISSION_PROTO",
             PermissionNotFoundException,
         )
+
+    # tag operations
+    def tag_entity(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        obj = self.get_entity(name, project)
+        obj.tags = apply_tags(obj.tags, tags, overwrite)
+        self.apply_entity(obj, project)
+
+    def tag_feature_service(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        obj = self.get_feature_service(name, project)
+        obj.tags = apply_tags(obj.tags, tags, overwrite)
+        self.apply_feature_service(obj, project)
+
+    def tag_feature_view(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        obj = self.get_feature_view(name, project)
+        obj.tags = apply_tags(obj.tags, tags, overwrite)
+        self.apply_feature_view(obj, project)
+
+    def tag_on_demand_feature_view(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        obj = self.get_on_demand_feature_view(name, project)
+        obj.tags = apply_tags(obj.tags, tags, overwrite)
+        self.apply_feature_view(obj, project)
+
+    def tag_stream_feature_view(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        obj = self.get_stream_feature_view(name, project)
+        obj.tags = apply_tags(obj.tags, tags, overwrite)
+        self.apply_feature_view(obj, project)
+
+    def tag_data_source(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        obj = self.get_data_source(name, project)
+        obj.tags = apply_tags(obj.tags, tags, overwrite)
+        self.apply_data_source(obj, project)
+
+    def tag_saved_dataset(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        obj = self.get_saved_dataset(name, project)
+        obj.tags = apply_tags(obj.tags, tags, overwrite)
+        self.apply_saved_dataset(obj, project)
+
+    def tag_validation_reference(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        obj = self.get_validation_reference(name, project)
+        obj.tags = apply_tags(obj.tags, tags, overwrite)
+        self.apply_validation_reference(obj, project)
+
+    def tag_permission(
+        self,
+        name: str,
+        project: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        obj = self.get_permission(name, project)
+        obj._tags = apply_tags(obj.tags, tags, overwrite)
+        self.apply_permission(obj, project)
+
+    def tag_project(
+        self,
+        name: str,
+        tags: Optional[dict[str, str]] = None,
+        overwrite: bool = False,
+    ):
+        obj = self.get_project(name)
+        obj.tags = apply_tags(obj.tags, tags, overwrite)
+        self.apply_project(obj)
 
     # list operations
     def list_data_sources(

--- a/sdk/python/feast/permissions/permission.py
+++ b/sdk/python/feast/permissions/permission.py
@@ -13,6 +13,7 @@ from feast.permissions.policy import AllowAll, Policy
 from feast.protos.feast.core.Permission_pb2 import Permission as PermissionProto
 from feast.protos.feast.core.Permission_pb2 import PermissionMeta as PermissionMetaProto
 from feast.protos.feast.core.Permission_pb2 import PermissionSpec as PermissionSpecProto
+from feast.value_type import validate_tags
 
 if TYPE_CHECKING:
     from feast.feast_object import FeastObject
@@ -156,6 +157,13 @@ class Permission(ABC):
             allowed_actions=self.actions,
             requested_actions=requested_actions,
         )
+
+    def is_valid(self):
+        """
+        Validates the state of this permission locally.
+        """
+        validate_tags(self._tags)
+        validate_tags(self._required_tags)
 
     @staticmethod
     def from_proto(permission_proto: PermissionProto) -> Any:

--- a/sdk/python/feast/project.py
+++ b/sdk/python/feast/project.py
@@ -21,6 +21,7 @@ from feast.protos.feast.core.Project_pb2 import Project as ProjectProto
 from feast.protos.feast.core.Project_pb2 import ProjectMeta as ProjectMetaProto
 from feast.protos.feast.core.Project_pb2 import ProjectSpec as ProjectSpecProto
 from feast.utils import _utc_now
+from feast.value_type import validate_tags
 
 
 @typechecked
@@ -119,6 +120,8 @@ class Project:
                 f"Project name, {self.name}, should only have "
                 f"alphanumerical values and underscores but not start with an underscore."
             )
+
+        validate_tags(self.tags)
 
     @classmethod
     def from_proto(cls, project_proto: ProjectProto):

--- a/sdk/python/feast/registry_server.py
+++ b/sdk/python/feast/registry_server.py
@@ -37,6 +37,7 @@ from feast.project import Project
 from feast.protos.feast.registry import RegistryServer_pb2, RegistryServer_pb2_grpc
 from feast.saved_dataset import SavedDataset, ValidationReference
 from feast.stream_feature_view import StreamFeatureView
+from feast.utils import apply_tags
 
 
 def _build_any_feature_view_proto(feature_view: BaseFeatureView):
@@ -92,6 +93,27 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             ),
             actions=[AuthzedAction.DESCRIBE],
         ).to_proto()
+
+    def TagEntity(self, request: RegistryServer_pb2.TagEntityRequest, context):
+        getter = self.proxied_registry.get_entity
+        entity = cast(
+            Entity,
+            assert_permissions_to_update(
+                resource=getter(
+                    name=request.name,
+                    project=request.project,
+                ),
+                getter=getter,
+                project=request.project,
+            ),
+        )
+        entity.tags = apply_tags(entity.tags, dict(request.tags), request.overwrite)
+        self.proxied_registry.apply_entity(
+            entity=entity,
+            project=request.project,
+        )
+
+        return Empty()
 
     def ListEntities(self, request: RegistryServer_pb2.ListEntitiesRequest, context):
         return RegistryServer_pb2.ListEntitiesResponse(
@@ -152,6 +174,29 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             ),
             actions=AuthzedAction.DESCRIBE,
         ).to_proto()
+
+    def TagDataSource(self, request: RegistryServer_pb2.TagDataSourceRequest, context):
+        getter = self.proxied_registry.get_data_source
+        data_source = cast(
+            DataSource,
+            assert_permissions_to_update(
+                resource=getter(
+                    name=request.name,
+                    project=request.project,
+                ),
+                getter=getter,
+                project=request.project,
+            ),
+        )
+        data_source.tags = apply_tags(
+            data_source.tags, dict(request.tags), request.overwrite
+        )
+        self.proxied_registry.apply_data_source(
+            data_source=data_source,
+            project=request.project,
+        )
+
+        return Empty()
 
     def ListDataSources(
         self, request: RegistryServer_pb2.ListDataSourcesRequest, context
@@ -222,6 +267,31 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             )
         )
 
+    def TagFeatureView(
+        self, request: RegistryServer_pb2.TagFeatureViewRequest, context
+    ):
+        getter = self.proxied_registry.get_feature_view
+        feature_view = cast(
+            FeatureView,
+            assert_permissions_to_update(
+                resource=getter(
+                    name=request.name,
+                    project=request.project,
+                ),
+                getter=getter,
+                project=request.project,
+            ),
+        )
+        feature_view.tags = apply_tags(
+            feature_view.tags, dict(request.tags), request.overwrite
+        )
+        self.proxied_registry.apply_feature_view(
+            feature_view=feature_view,
+            project=request.project,
+        )
+
+        return Empty()
+
     def ApplyFeatureView(
         self, request: RegistryServer_pb2.ApplyFeatureViewRequest, context
     ):
@@ -241,7 +311,6 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             getter=self.proxied_registry.get_feature_view,
             project=request.project,
         )
-
         (
             self.proxied_registry.apply_feature_view(
                 feature_view=feature_view,
@@ -327,6 +396,31 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             actions=[AuthzedAction.DESCRIBE],
         ).to_proto()
 
+    def TagStreamFeatureView(
+        self, request: RegistryServer_pb2.TagStreamFeatureViewRequest, context
+    ):
+        getter = self.proxied_registry.get_stream_feature_view
+        stream_feature_view = cast(
+            StreamFeatureView,
+            assert_permissions_to_update(
+                resource=getter(
+                    name=request.name,
+                    project=request.project,
+                ),
+                getter=getter,
+                project=request.project,
+            ),
+        )
+        stream_feature_view.tags = apply_tags(
+            stream_feature_view.tags, dict(request.tags), request.overwrite
+        )
+        self.proxied_registry.apply_feature_view(
+            feature_view=stream_feature_view,
+            project=request.project,
+        )
+
+        return Empty()
+
     def ListStreamFeatureViews(
         self, request: RegistryServer_pb2.ListStreamFeatureViewsRequest, context
     ):
@@ -358,6 +452,31 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             ),
             actions=[AuthzedAction.DESCRIBE],
         ).to_proto()
+
+    def TagOnDemandFeatureView(
+        self, request: RegistryServer_pb2.TagOnDemandFeatureViewRequest, context
+    ):
+        getter = self.proxied_registry.get_on_demand_feature_view
+        on_demand_feature_view = cast(
+            OnDemandFeatureView,
+            assert_permissions_to_update(
+                resource=getter(
+                    name=request.name,
+                    project=request.project,
+                ),
+                getter=getter,
+                project=request.project,
+            ),
+        )
+        on_demand_feature_view.tags = apply_tags(
+            on_demand_feature_view.tags, dict(request.tags), request.overwrite
+        )
+        self.proxied_registry.apply_feature_view(
+            feature_view=on_demand_feature_view,
+            project=request.project,
+        )
+
+        return Empty()
 
     def ListOnDemandFeatureViews(
         self, request: RegistryServer_pb2.ListOnDemandFeatureViewsRequest, context
@@ -409,6 +528,31 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             ),
             actions=[AuthzedAction.DESCRIBE],
         ).to_proto()
+
+    def TagFeatureService(
+        self, request: RegistryServer_pb2.TagFeatureServiceRequest, context
+    ):
+        getter = self.proxied_registry.get_feature_service
+        feature_service = cast(
+            FeatureService,
+            assert_permissions_to_update(
+                resource=getter(
+                    name=request.name,
+                    project=request.project,
+                ),
+                getter=getter,
+                project=request.project,
+            ),
+        )
+        feature_service.tags = apply_tags(
+            feature_service.tags, dict(request.tags), request.overwrite
+        )
+        self.proxied_registry.apply_feature_service(
+            feature_service=feature_service,
+            project=request.project,
+        )
+
+        return Empty()
 
     def ListFeatureServices(
         self, request: RegistryServer_pb2.ListFeatureServicesRequest, context
@@ -478,6 +622,31 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             actions=[AuthzedAction.DESCRIBE],
         ).to_proto()
 
+    def TagSavedDataset(
+        self, request: RegistryServer_pb2.TagSavedDatasetRequest, context
+    ):
+        getter = self.proxied_registry.get_saved_dataset
+        saved_dataset = cast(
+            SavedDataset,
+            assert_permissions_to_update(
+                resource=getter(
+                    name=request.name,
+                    project=request.project,
+                ),
+                getter=getter,
+                project=request.project,
+            ),
+        )
+        saved_dataset.tags = apply_tags(
+            saved_dataset.tags, dict(request.tags), request.overwrite
+        )
+        self.proxied_registry.apply_saved_dataset(
+            saved_dataset=saved_dataset,
+            project=request.project,
+        )
+
+        return Empty()
+
     def ListSavedDatasets(
         self, request: RegistryServer_pb2.ListSavedDatasetsRequest, context
     ):
@@ -543,6 +712,31 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             ),
             actions=[AuthzedAction.DESCRIBE],
         ).to_proto()
+
+    def TagValidationReference(
+        self, request: RegistryServer_pb2.TagValidationReferenceRequest, context
+    ):
+        getter = self.proxied_registry.get_validation_reference
+        validation_reference = cast(
+            ValidationReference,
+            assert_permissions_to_update(
+                resource=getter(
+                    name=request.name,
+                    project=request.project,
+                ),
+                getter=getter,
+                project=request.project,
+            ),
+        )
+        validation_reference.tags = apply_tags(
+            validation_reference.tags, dict(request.tags), request.overwrite
+        )
+        self.proxied_registry.apply_validation_reference(
+            validation_reference=validation_reference,
+            project=request.project,
+        )
+
+        return Empty()
 
     def ListValidationReferences(
         self, request: RegistryServer_pb2.ListValidationReferencesRequest, context
@@ -655,6 +849,29 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
 
         return permission.to_proto()
 
+    def TagPermission(self, request: RegistryServer_pb2.TagPermissionRequest, context):
+        getter = self.proxied_registry.get_permission
+        permission = cast(
+            Permission,
+            assert_permissions_to_update(
+                resource=getter(
+                    name=request.name,
+                    project=request.project,
+                ),
+                getter=getter,
+                project=request.project,
+            ),
+        )
+        permission._tags = apply_tags(
+            permission.tags, dict(request.tags), request.overwrite
+        )
+        self.proxied_registry.apply_permission(
+            permission=permission,
+            project=request.project,
+        )
+
+        return Empty()
+
     def ListPermissions(
         self, request: RegistryServer_pb2.ListPermissionsRequest, context
     ):
@@ -713,6 +930,25 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             actions=[AuthzedAction.DESCRIBE],
         )
         return project.to_proto()
+
+    def TagProject(self, request: RegistryServer_pb2.TagProjectRequest, context):
+        getter = self.proxied_registry.get_project
+        project = cast(
+            Project,
+            assert_permissions_to_update(
+                resource=getter(
+                    name=request.name,
+                ),
+                getter=getter,
+                project=request.name,
+            ),
+        )
+        project.tags = apply_tags(project.tags, dict(request.tags), request.overwrite)
+        self.proxied_registry.apply_project(
+            project=project,
+        )
+
+        return Empty()
 
     def ListProjects(self, request: RegistryServer_pb2.ListProjectsRequest, context):
         return RegistryServer_pb2.ListProjectsResponse(

--- a/sdk/python/feast/saved_dataset.py
+++ b/sdk/python/feast/saved_dataset.py
@@ -17,6 +17,7 @@ from feast.protos.feast.core.SavedDataset_pb2 import (
 from feast.protos.feast.core.ValidationProfile_pb2 import (
     ValidationReference as ValidationReferenceProto,
 )
+from feast.value_type import validate_tags
 
 if TYPE_CHECKING:
     from feast.infra.offline_stores.offline_store import RetrievalJob
@@ -139,6 +140,12 @@ class SavedDataset:
             return False
 
         return True
+
+    def is_valid(self):
+        """
+        Validates the state of this saved dataset locally.
+        """
+        validate_tags(self.tags)
 
     @staticmethod
     def from_proto(saved_dataset_proto: SavedDatasetProto):
@@ -278,6 +285,12 @@ class ValidationReference:
         self.profiler = profiler
         self.description = description
         self.tags = tags or {}
+
+    def is_valid(self):
+        """
+        Validates the state of this saved dataset locally.
+        """
+        validate_tags(self.tags)
 
     @classmethod
     def from_saved_dataset(cls, name: str, dataset: SavedDataset, profiler: Profiler):

--- a/sdk/python/tests/integration/offline_store/test_validation.py
+++ b/sdk/python/tests/integration/offline_store/test_validation.py
@@ -322,6 +322,86 @@ def test_e2e_validation_via_cli(environment, universal_data_sources):
         )
         assert p.returncode == 0, p.stderr.decode()
 
+        # invalid tags should fail
+        p = runner.run(
+            ["tag", "saved-dataset", saved_dataset.name, "test?:wrong"],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 1, p.stderr.decode()
+
+        p = runner.run(
+            ["tag", "validation-reference", reference.name, "test?:wrong"],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 1, p.stderr.decode()
+
+        p = runner.run(
+            ["tag", "feature-service", feature_service.name, "test?:wrong"],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 1, p.stderr.decode()
+
+        p = runner.run(
+            [
+                "tag",
+                "feature-view",
+                feature_views.customer.name,
+                "test?:wrong",
+            ],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 1, p.stderr.decode()
+
+        # valid tag should succeed
+        p = runner.run(
+            ["tag", "saved-dataset", saved_dataset.name, "test:tag"],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+
+        p = runner.run(
+            ["tag", "validation-reference", reference.name, "test:tag"],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+
+        p = runner.run(
+            ["tag", "feature-service", feature_service.name, "test:tag"],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+
+        p = runner.run(
+            ["tag", "feature-view", feature_views.customer.name, "test:tag"],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+
+        # tag removal should succeed
+        p = runner.run(
+            ["tag", "saved-dataset", saved_dataset.name, "test-"],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+
+        p = runner.run(
+            ["tag", "validation-reference", reference.name, "test-"],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+
+        p = runner.run(
+            ["tag", "feature-service", feature_service.name, "test-"],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+
+        p = runner.run(
+            ["tag", "feature-view", feature_views.customer.name, "test-"],
+            cwd=local_repo.repo_path,
+        )
+        assert p.returncode == 0, p.stderr.decode()
+
         # make sure second validation will use cached profile
         shutil.rmtree(saved_dataset.storage.file_options.uri)
 

--- a/sdk/python/tests/unit/permissions/auth/server/test_utils.py
+++ b/sdk/python/tests/unit/permissions/auth/server/test_utils.py
@@ -57,6 +57,13 @@ invalid_list_entities_perm = Permission(
     actions=[AuthzedAction.DESCRIBE],
 )
 
+tag_entity_perm = Permission(
+    name="tag_entity_perm",
+    types=Entity,
+    policy=RoleBasedPolicy(roles=["reader", "updater"]),
+    actions=[AuthzedAction.DESCRIBE, AuthzedAction.UPDATE],
+)
+
 
 @pytest.mark.parametrize(
     "label, value",

--- a/sdk/python/tests/unit/test_types.py
+++ b/sdk/python/tests/unit/test_types.py
@@ -1,7 +1,7 @@
 import pytest
 
 from feast.types import Array, Float32, String, from_value_type
-from feast.value_type import ValueType
+from feast.value_type import ValueType, is_valid_tag_key, is_valid_tag_value
 
 
 def test_primitive_feast_type():
@@ -32,3 +32,92 @@ def test_all_value_types():
         # We do not support the NULL type.
         if value != ValueType.NULL:
             assert from_value_type(value).to_value_type() == value
+
+
+def test_valid_tag_key_cases():
+    # Valid cases
+    valid_cases = [
+        "app",  # Simple name
+        "APP",  # Simple name
+        "ap_.-p",  # Simple name w/ allowed special characters
+        "example.com/my-tag",  # Domain with tag
+        "a-b.c-m/d",  # Valid prefix and suffix
+        "a.b.c.d.e/f",  # More segments
+        "prefix/ta_.-g",  # Tag with a suffix and allowed special characters
+        "a/b",  # Valid prefix and suffix
+        "long-prefix-with-segments-allowed-in-dns-but-not-too-long/tag",  # Long prefix
+        "a/tag",  # Short valid prefix and tag
+        "a" * 63,  # 63 characters
+        "test.com/B",  # Valid suffix
+        "feast.dev",
+    ]
+
+    for case in valid_cases:
+        assert is_valid_tag_key(case)
+
+
+def test_invalid_tag_key_cases():
+    # Invalid cases
+    invalid_cases = [
+        "",  # Empty string
+        "a!d",  # Dissallowed special characters
+        "a-/b",  # Invalid prefix
+        "a.co_m/b",  # Invalid prefix
+        "a_b.com/b",  # Invalid prefix
+        "a.com.A/b",  # Invalid prefix
+        "A/b",  # Invalid prefix
+        "a/b-",  # Invalid suffix
+        "a/-b",  # Invalid suffix
+        "/missing",  # Missing prefix
+        "a/",  # Missing suffix
+        "feast.dev/",  # Forbidden prefix
+        "feast.dev/tag",  # Starts with forbidden prefix
+        "x" * 64,  # Name too long
+        "a." * 63 + "x",  # Name too long
+        "a" + "b." * 62 + "x",  # Name too long
+        "a/" + "x" * 62,  # Too long overall
+        "prefix/tag/extra",  # Too many segments
+        "a b c",  # Contains space
+        " ",  # Contains space
+    ]
+
+    for case in invalid_cases:
+        assert not is_valid_tag_key(case)
+
+
+def test_valid_tag_value_cases():
+    # Valid cases
+    valid_cases = [
+        "",  # Empty string
+        "a",  # Single alphanumeric character
+        "abc",  # Simple alphanumeric
+        "ABC",  # Simple alphanumeric
+        "abc123",  # Alphanumeric with numbers
+        "a.b.c",  # Valid with periods
+        "a_b_c",  # Valid with underscores
+        "a-b-c",  # Valid with dashes
+        "a.b_c-d",  # Combination of valid characters
+        "a" * 63,  # Maximum length allowed
+        "a.b_c-d" * 9,  # Length less than or equal to 63
+    ]
+
+    for case in valid_cases:
+        assert is_valid_tag_value(case)
+
+
+def test_invalid_tag_value_cases():
+    # Invalid cases
+    invalid_cases = [
+        "a" * 64,  # Too long
+        "-ab",  # Doesn't start w/ alphanumeric character
+        "ab.",  # Doesn't end w/ alphanumeric character
+        "a!b",  # Contains invalid character (!)
+        "abc@123",  # Contains invalid character (@)
+        "a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z",  # Too long
+        "a b c",  # Contains space
+        " ",  # Contains space
+        "abc/def",  # Contains invalid character (/)
+    ]
+
+    for case in invalid_cases:
+        assert not is_valid_tag_value(case)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
With this change we will be able to tag feast objects directly, similar to `kubectl label`. New registry endpoints were added, in addition to a new `feast tag` cli command. For this initial implementation users can -
1. Add new tags
2. Overwrite existing tags
3. Remove tags

```bash
$ feast tag --help
Usage: feast tag [OPTIONS] OBJECT_TYPE NAME TAGS...

  [Experimental] Tag objects

  *  A tag key and value must begin with a letter or number, and may contain
  letters, numbers, hyphens, dots, and underscores, up to 63 characters each.

  *  Optionally, the key can begin with a DNS subdomain prefix and a single
  '/', like example.com/my-app. The 'feast.dev/' prefix is reserved.

  Examples:

      # Update data source 'foo' with the tag 'test' and the value 'true'.

      feast tag data-source foo test:true

      # Update feature view 'foo' by removing a tag named 'bar' if it exists.
      # Does not require the --overwrite flag.

      feast tag feature-view foo bar-

Options:
  --overwrite  If true, allow tags to be overwritten, otherwise reject tag
               updates that overwrite existing tags.
  --help       Show this message and exit.
```

The following object types are supported for tagging:
- DataSource
- Entity
- FeatureService
- FeatureView
- OnDemandFeatureView
- Permission
- Project
- SavedDataset
- StreamFeatureView
- ValidationReference


# Which issue(s) this PR fixes:
Fixes https://github.com/feast-dev/feast/issues/4459

# Misc
Of note, this change will add regex validation for tag keys and values, which is nearly identical to kubernetes labels. In some environments, existing feast objects with "invalid" tags will break future tagging requests due to validation errors. This can be easily resolved by replacing the problematic tags. For example -
```bash
# here we see a pre-existing feature view with an invalid tag
$ feast feature-views describe driver_hourly_stats | yq .spec.tags
team?: driver_performance

# any attempts to add a new tag will fail due to the pre-existing invalid tag
$ feast tag feature-view driver_hourly_stats new:tag
Invalid tag key: 'team?': name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '^(?=.{1,63}$)(?!feast\.dev/)(?:(?:[a-z0-9]([-a-z0-9]*[a-z0-9])?\.)*[a-z0-9]([-a-z0-9]*[a-z0-9])?\/)?[a-z0-9A-Z]([a-z0-9A-Z._-]*[a-z0-9A-Z])?$'

# this can be resolved with a single command that will,
#  1) remove the invalid tag
#  2) replace it with a similar valid tag
#  3) add the new tag.
$ feast tag feature-view driver_hourly_stats 'team?-' team:driver_performance new:tag
feature-view 'driver_hourly_stats' tagged

# here we view the fixed feature view tags
$ feast feature-views describe driver_hourly_stats | yq .spec.tags
team: driver_performance
new: tag
```