### PR TITLE
fix: Fixes validator field access for 'project_id' in BigQuery offline Store

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -114,7 +114,7 @@ class BigQueryOfflineStoreConfig(FeastConfigBaseModel):
 
     @field_validator("billing_project_id")
     def project_id_exists(cls, v, values, **kwargs):
-        if v and not values["project_id"]:
+        if v and not values.data["project_id"]:
             raise ValueError(
                 "please specify project_id if billing_project_id is specified"
             )


### PR DESCRIPTION
# What this PR does / why we need it:

Fixes a regression in BigQuery offline store due to newer pydantic version

# Which issue(s) this PR fixes:

Fixes https://github.com/feast-dev/feast/issues/4280

