### PR TITLE
fix: Removed temporary directory creation and replaced with feature_repo

### DIFF
--- a/sdk/python/feast/infra/materialization/aws_lambda/app.py
+++ b/sdk/python/feast/infra/materialization/aws_lambda/app.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import sys
-import tempfile
 import traceback
 from pathlib import Path
 
@@ -27,8 +26,10 @@ def handler(event, context):
 
         config_bytes = base64.b64decode(config_base64)
 
-        # Create a new unique directory for writing feature_store.yaml
-        repo_path = Path(tempfile.mkdtemp())
+        # Create a directory for writing feature_store.yaml
+        repo_path = Path("/feature_repo")
+        if not repo_path.exists():
+            repo_path.mkdir(parents=True, exist_ok=True)
 
         with open(repo_path / "feature_store.yaml", "wb") as f:
             f.write(config_bytes)

--- a/sdk/python/feast/infra/transformation_servers/app.py
+++ b/sdk/python/feast/infra/transformation_servers/app.py
@@ -1,6 +1,5 @@
 import base64
 import os
-import tempfile
 import threading
 from pathlib import Path
 
@@ -20,8 +19,11 @@ from feast.infra.registry.registry import get_registry_store_class_from_scheme
 config_base64 = os.environ[FEATURE_STORE_YAML_ENV_NAME]
 config_bytes = base64.b64decode(config_base64)
 
-# Create a new unique directory for writing feature_store.yaml
-repo_path = Path(tempfile.mkdtemp())
+# Create a directory for writing feature_store.yaml
+repo_path = Path("/feature_repo")
+if not repo_path.exists():
+    repo_path.mkdir(parents=True, exist_ok=True)
+
 
 with open(repo_path / "feature_store.yaml", "wb") as f:
     f.write(config_bytes)

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -6,7 +6,6 @@ import os
 import random
 import re
 import sys
-import tempfile
 from importlib.abc import Loader
 from importlib.machinery import ModuleSpec
 from pathlib import Path
@@ -376,8 +375,10 @@ def create_feature_store(
     if config_base64:
         print("Received base64 encoded feature_store.yaml")
         config_bytes = base64.b64decode(config_base64)
-        # Create a new unique directory for writing feature_store.yaml
-        repo_path = Path(tempfile.mkdtemp())
+        # Create a directory for writing feature_store.yaml
+        repo_path = Path("/feature_repo")
+        if not repo_path.exists():
+            repo_path.mkdir(parents=True, exist_ok=True)
         with open(repo_path / "feature_store.yaml", "wb") as f:
             f.write(config_bytes)
         return FeatureStore(repo_path=str(repo_path.resolve()))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

As Feast takes the feature-store YAMLas Base64 environment variable, and stores it in a [temp directory](https://github.com/feast-dev/feast/blob/4a6b663f80bc91d6de35ed2ec428d34811d17a18/sdk/python/feast/repo_operations.py#L375-L383). Since it uses that temporary path and set feature store, and not way to to run `feast apply` on the remote server for example incase file base datasource used.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
