### PR TITLE
docs: Adding the missed documentation for the RBAC

### DIFF
--- a/docs/getting-started/components/authz_manager.md
+++ b/docs/getting-started/components/authz_manager.md
@@ -44,9 +44,9 @@ The server, in turn, uses the same OIDC server to validate the token and extract
 
 Some assumptions are made in the OIDC server configuration:
 * The OIDC token refers to a client with roles matching the RBAC roles of the configured `Permission`s (*)
-* The roles are exposed in the access token passed to the server 
-* JWT token is expected to have verified signature and not expired. Feast oidc token parser logic validates for `verify_signature` and `verify_exp` so make sure that given OIDC provider is configured to meet this requirement.
-* preferred_username should be part of the jwt token claim.
+* The roles are exposed in the access token that is passed to the server
+* The JWT token is expected to have a verified signature and not be expired. The Feast OIDC token parser logic validates for `verify_signature` and `verify_exp` so make sure that the given OIDC provider is configured to meet these requirements.
+* The preferred_username should be part of the JWT token claim.
 
 
 (*) Please note that **the role match is case-sensitive**, e.g. the name of the role in the OIDC server and in the `Permission` configuration

--- a/docs/getting-started/components/authz_manager.md
+++ b/docs/getting-started/components/authz_manager.md
@@ -1,5 +1,5 @@
 # Authorization Manager
-An Authorization Manager is an instance of the `AuthManager` class that is plugged into one of the Feast servers to extract user details from the current request and inject them into the [permissions](../../getting-started/concepts/permissions.md) framework.
+An Authorization Manager is an instance of the `AuthManager` class that is plugged into one of the Feast servers to extract user details from the current request and inject them into the [permission](../../getting-started/concepts/permission.md) framework.
 
 {% hint style="info" %}
 **Note**: Feast does not provide authentication capabilities; it is the client's responsibility to manage the authentication token and pass it to
@@ -44,7 +44,10 @@ The server, in turn, uses the same OIDC server to validate the token and extract
 
 Some assumptions are made in the OIDC server configuration:
 * The OIDC token refers to a client with roles matching the RBAC roles of the configured `Permission`s (*)
-* The roles are exposed in the access token passed to the server
+* The roles are exposed in the access token passed to the server 
+* JWT token is expected to have verified signature and not expired. Feast oidc token parser logic validates for `verify_signature` and `verify_exp` so make sure that given OIDC provider is configured to meet this requirement.
+* preferred_username should be part of the jwt token claim.
+
 
 (*) Please note that **the role match is case-sensitive**, e.g. the name of the role in the OIDC server and in the `Permission` configuration
 must be exactly the same.
@@ -57,7 +60,8 @@ For example, the access token for a client `app` of a user with `reader` role sh
       "roles": [
         "reader"
       ]
-    },
+    }
+  }
 }
 ```
 

--- a/docs/reference/feast-cli-commands.md
+++ b/docs/reference/feast-cli-commands.md
@@ -224,6 +224,48 @@ tags:
   key2: value2
 
 ```
+### Permission check
+The `permissions check` command is used to identify resources that lack the appropriate permissions based on their type, name, or tags.
+
+This command is particularly useful for administrators when roles, actions, or permissions have been modified or newly configured. By running this command, administrators can easily verify which resources and actions are not protected by any permission configuration, ensuring that proper security measures are in place.
+
+```text
+> feast permissions check
+
+
+The following resources are not secured by any permission configuration:
+NAME                         TYPE
+driver                       Entity
+driver_hourly_stats_fresh    FeatureView
+The following actions are not secured by any permission configuration (Note: this might not be a security concern, depending on the used APIs):
+NAME                         TYPE                 UNSECURED ACTIONS
+driver                       Entity               CREATE
+                                                  DESCRIBE
+                                                  UPDATE
+                                                  DELETE
+                                                  READ_ONLINE
+                                                  READ_OFFLINE
+                                                  WRITE_ONLINE
+                                                  WRITE_OFFLINE
+driver_hourly_stats_fresh    FeatureView          CREATE
+                                                  DESCRIBE
+                                                  UPDATE
+                                                  DELETE
+                                                  READ_ONLINE
+                                                  READ_OFFLINE
+                                                  WRITE_ONLINE
+                                                  WRITE_OFFLINE
+
+Based on the above results, the administrator can reassess the permissions configuration and make any necessary adjustments to meet their security requirements.
+
+If no resources are accessible publicly, the permissions check command will return the following response:
+> feast permissions check
+The following resources are not secured by any permission configuration:
+NAME    TYPE
+The following actions are not secured by any permission configuration (Note: this might not be a security concern, depending on the used APIs):
+NAME    TYPE    UNSECURED ACTIONS
+```
+
 
 ### List of the configured roles
 List all the configured roles


### PR DESCRIPTION
Adding the missed documentation for - 
* OIDC Token requirement or assumptions
* Added `feast permissions check` cli command documentation.