### PR TITLE
fix: Added Offline Store Arrow client errors handler

### DIFF
--- a/sdk/python/feast/arrow_error_handler.py
+++ b/sdk/python/feast/arrow_error_handler.py
@@ -1,0 +1,49 @@
+import logging
+from functools import wraps
+
+import pyarrow.flight as fl
+
+from feast.errors import FeastError
+
+logger = logging.getLogger(__name__)
+
+
+def arrow_client_error_handling_decorator(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            mapped_error = FeastError.from_error_detail(_get_exception_data(e.args[0]))
+            if mapped_error is not None:
+                raise mapped_error
+            raise e
+
+    return wrapper
+
+
+def arrow_server_error_handling_decorator(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            if isinstance(e, FeastError):
+                raise fl.FlightError(e.to_error_detail())
+
+    return wrapper
+
+
+def _get_exception_data(except_str) -> str:
+    substring = "Flight error: "
+
+    # Find the starting index of the substring
+    position = except_str.find(substring)
+    end_json_index = except_str.find("}")
+
+    if position != -1 and end_json_index != -1:
+        # Extract the part of the string after the substring
+        result = except_str[position + len(substring) : end_json_index + 1]
+        return result
+
+    return ""

--- a/sdk/python/feast/permissions/client/arrow_flight_auth_interceptor.py
+++ b/sdk/python/feast/permissions/client/arrow_flight_auth_interceptor.py
@@ -1,6 +1,5 @@
 import pyarrow.flight as fl
 
-from feast.permissions.auth.auth_type import AuthType
 from feast.permissions.auth_model import AuthConfig
 from feast.permissions.client.client_auth_token import get_auth_token
 
@@ -28,11 +27,3 @@ class FlightAuthInterceptorFactory(fl.ClientMiddlewareFactory):
 
     def start_call(self, info):
         return FlightBearerTokenInterceptor(self.auth_config)
-
-
-def build_arrow_flight_client(host: str, port, auth_config: AuthConfig):
-    if auth_config.type != AuthType.NONE.value:
-        middleware_factory = FlightAuthInterceptorFactory(auth_config)
-        return fl.FlightClient(f"grpc://{host}:{port}", middleware=[middleware_factory])
-    else:
-        return fl.FlightClient(f"grpc://{host}:{port}")

--- a/sdk/python/feast/permissions/server/arrow.py
+++ b/sdk/python/feast/permissions/server/arrow.py
@@ -5,7 +5,7 @@ A module with utility functions and classes to support authorizing the Arrow Fli
 import asyncio
 import functools
 import logging
-from typing import Optional, cast
+from typing import cast
 
 import pyarrow.flight as fl
 from pyarrow.flight import ServerCallContext
@@ -14,32 +14,10 @@ from feast.permissions.auth.auth_manager import (
     get_auth_manager,
 )
 from feast.permissions.security_manager import get_security_manager
-from feast.permissions.server.utils import (
-    AuthManagerType,
-)
 from feast.permissions.user import User
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-
-
-def arrowflight_middleware(
-    auth_type: AuthManagerType,
-) -> Optional[dict[str, fl.ServerMiddlewareFactory]]:
-    """
-    A dictionary with the configured middlewares to support extracting the user details when the authorization manager is defined.
-    The authorization middleware key is `auth`.
-
-    Returns:
-        dict[str, fl.ServerMiddlewareFactory]: Optional dictionary of middlewares. If the authorization type is set to `NONE`, it returns `None`.
-    """
-
-    if auth_type == AuthManagerType.NONE:
-        return None
-
-    return {
-        "auth": AuthorizationMiddlewareFactory(),
-    }
 
 
 class AuthorizationMiddlewareFactory(fl.ServerMiddlewareFactory):
@@ -47,8 +25,8 @@ class AuthorizationMiddlewareFactory(fl.ServerMiddlewareFactory):
     A middleware factory to intercept the authorization header and propagate it to the authorization middleware.
     """
 
-    def __init__(self):
-        pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def start_call(self, info, headers):
         """
@@ -65,7 +43,8 @@ class AuthorizationMiddleware(fl.ServerMiddleware):
     A server middleware holding the authorization header and offering a method to extract the user credentials.
     """
 
-    def __init__(self, access_token: str):
+    def __init__(self, access_token: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.access_token = access_token
 
     def call_completed(self, exception):

--- a/sdk/python/tests/unit/test_arrow_error_decorator.py
+++ b/sdk/python/tests/unit/test_arrow_error_decorator.py
@@ -1,0 +1,33 @@
+import pyarrow.flight as fl
+import pytest
+
+from feast.arrow_error_handler import arrow_client_error_handling_decorator
+from feast.errors import PermissionNotFoundException
+
+permissionError = PermissionNotFoundException("dummy_name", "dummy_project")
+
+
+@arrow_client_error_handling_decorator
+def decorated_method(error):
+    raise error
+
+
+@pytest.mark.parametrize(
+    "error, expected_raised_error",
+    [
+        (fl.FlightError("Flight error: "), fl.FlightError("Flight error: ")),
+        (
+            fl.FlightError(f"Flight error: {permissionError.to_error_detail()}"),
+            permissionError,
+        ),
+        (fl.FlightError("Test Error"), fl.FlightError("Test Error")),
+        (RuntimeError("Flight error: "), RuntimeError("Flight error: ")),
+        (permissionError, permissionError),
+    ],
+)
+def test_rest_error_handling_with_feast_exception(error, expected_raised_error):
+    with pytest.raises(
+        type(expected_raised_error),
+        match=str(expected_raised_error),
+    ):
+        decorated_method(error)


### PR DESCRIPTION
# What this PR does / why we need it:
Added a decorator for arrow calls to remote offline server failures and adds an additional message to the response with the failure status and details.
The proxy client then rebuilds the original error from the status data.

# Which issue(s) this PR fixes:
Fixes https://github.com/feast-dev/feast/issues/4523