### PR TITLE
fix: Removed protobuf as a required dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,7 @@ lock-python-ci-dependencies:
 package-protos:
 	cp -r ${ROOT_DIR}/protos ${ROOT_DIR}/sdk/python/feast/protos
 
-install-protoc-dependencies:
-	pip install "grpcio-tools>=1.56.2,<2" "mypy-protobuf>=3.1"
-
-compile-protos-python: install-protoc-dependencies
+compile-protos-python:
 	python setup.py build_python_protos --inplace
 
 install-python:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,10 @@ lock-python-ci-dependencies:
 package-protos:
 	cp -r ${ROOT_DIR}/protos ${ROOT_DIR}/sdk/python/feast/protos
 
-compile-protos-python:
+install-protoc-dependencies:
+	pip install "grpcio-tools>=1.56.2,<2" "mypy-protobuf>=3.1"
+
+compile-protos-python: install-protoc-dependencies
 	python setup.py build_python_protos --inplace
 
 install-python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [build-system]
 requires = [
   "grpcio-tools>=1.56.2,<2",
-  "grpcio>=1.56.2,<2",
-  "mypy-protobuf==3.1",
-  "protobuf==4.24.0",
+  "mypy-protobuf>=3.1",
   "pybindgen==0.22.0",
   "setuptools>=60",
   "setuptools_scm>=6.2",

--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -572,7 +572,6 @@ proto-plus==1.24.0
     #   google-cloud-datastore
 protobuf==4.25.4
     # via
-    #   feast (setup.py)
     #   google-api-core
     #   google-cloud-bigquery-storage
     #   google-cloud-bigtable

--- a/sdk/python/requirements/py3.10-requirements.txt
+++ b/sdk/python/requirements/py3.10-requirements.txt
@@ -89,9 +89,7 @@ partd==1.4.2
 prometheus-client==0.20.0
     # via feast (setup.py)
 protobuf==4.25.4
-    # via
-    #   feast (setup.py)
-    #   mypy-protobuf
+    # via mypy-protobuf
 psutil==6.0.0
     # via feast (setup.py)
 pyarrow==17.0.0

--- a/sdk/python/requirements/py3.11-ci-requirements.txt
+++ b/sdk/python/requirements/py3.11-ci-requirements.txt
@@ -563,7 +563,6 @@ proto-plus==1.24.0
     #   google-cloud-datastore
 protobuf==4.25.4
     # via
-    #   feast (setup.py)
     #   google-api-core
     #   google-cloud-bigquery-storage
     #   google-cloud-bigtable

--- a/sdk/python/requirements/py3.11-requirements.txt
+++ b/sdk/python/requirements/py3.11-requirements.txt
@@ -87,9 +87,7 @@ partd==1.4.2
 prometheus-client==0.20.0
     # via feast (setup.py)
 protobuf==4.25.4
-    # via
-    #   feast (setup.py)
-    #   mypy-protobuf
+    # via mypy-protobuf
 psutil==6.0.0
     # via feast (setup.py)
 pyarrow==17.0.0

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -583,7 +583,6 @@ proto-plus==1.24.0
     #   google-cloud-datastore
 protobuf==4.25.4
     # via
-    #   feast (setup.py)
     #   google-api-core
     #   google-cloud-bigquery-storage
     #   google-cloud-bigtable

--- a/sdk/python/requirements/py3.9-requirements.txt
+++ b/sdk/python/requirements/py3.9-requirements.txt
@@ -91,9 +91,7 @@ partd==1.4.2
 prometheus-client==0.20.0
     # via feast (setup.py)
 protobuf==4.25.4
-    # via
-    #   feast (setup.py)
-    #   mypy-protobuf
+    # via mypy-protobuf
 psutil==6.0.0
     # via feast (setup.py)
 pyarrow==17.0.0

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,9 @@ import re
 import shutil
 import subprocess
 import sys
-
 from pathlib import Path
 
-from setuptools import find_packages, setup, Command
+from setuptools import Command, find_packages, setup
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
@@ -43,7 +42,6 @@ REQUIRED = [
     "mmh3",
     "numpy>=1.22,<2",
     "pandas>=1.4.3,<3",
-    "protobuf>=4.24.0,<5.0.0",
     "pyarrow>=4",
     "pydantic>=2.0.0",
     "pygments>=2.12.0,<3",
@@ -102,7 +100,7 @@ POSTGRES_REQUIRED = [
     "psycopg[binary,pool]>=3.0.0,<4",
 ]
 
-OPENTELEMETRY = ["prometheus_client","psutil"]
+OPENTELEMETRY = ["prometheus_client", "psutil"]
 
 MYSQL_REQUIRED = ["pymysql", "types-PyMySQL"]
 
@@ -139,7 +137,6 @@ IBIS_REQUIRED = [
 
 GRPCIO_REQUIRED = [
     "grpcio>=1.56.2,<2",
-    "grpcio-tools>=1.56.2,<2",
     "grpcio-reflection>=1.56.2,<2",
     "grpcio-health-checking>=1.56.2,<2",
 ]
@@ -160,6 +157,7 @@ CI_REQUIRED = (
         "virtualenv==20.23.0",
         "cryptography>=35.0,<43",
         "ruff>=0.3.3",
+        "grpcio-tools>=1.56.2,<2",
         "grpcio-testing>=1.56.2,<2",
         # FastAPI does not correctly pull starlette dependency on httpx see thread(https://github.com/tiangolo/fastapi/issues/5656).
         "httpx>=0.23.3",
@@ -403,9 +401,7 @@ setup(
     use_scm_version=use_scm_version,
     setup_requires=[
         "grpcio-tools>=1.56.2,<2",
-        "grpcio>=1.56.2,<2",
-        "mypy-protobuf==3.1",
-        "protobuf==4.24.0",
+        "mypy-protobuf>=3.1",
         "pybindgen==0.22.0",
         "setuptools_scm>=6.2",
     ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
1. Resolves the error when generating sdist. Current error is `pkg_resources.ContextualVersionConflict: (protobuf 4.24.0 (/feast/.eggs/protobuf-4.24.0-py3.8-macosx-14.4-arm64.egg), Requirement.parse('protobuf<6.0dev,>=5.26.1'), {'grpcio-tools'})`
2. Moved grpcio-tools as DEV dependency

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
