### PR TITLE
feat: Publish TypeScript types in Feast UI package

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -6,6 +6,7 @@
     "dist"
   ],
   "main": "./dist/feast-ui.cjs",
+  "types": "./dist/FeastUI.d.ts",
   "module": "./dist/feast-ui.module.js",
   "peerDependencies": {
     "@elastic/datemath": "^5.0.3",
@@ -54,8 +55,8 @@
   "scripts": {
     "start": "npm run generate-protos && react-scripts start",
     "build": "npm run generate-protos && react-scripts build",
-    "build:lib": "npm run generate-protos && rimraf ./dist && tsc && rollup -c",
-    "build:lib-dev": "npm run generate-protos && rimraf ./dist && tsc && rollup -c && yalc publish -f",
+    "build:lib": "npm run generate-protos && rimraf ./dist && tsc --project ./tsconfig.build-lib.json && rollup -c",
+    "build:lib-dev": "npm run build:lib && yalc publish -f",
     "test": "npm run generate-protos && react-scripts test",
     "eject": "react-scripts eject",
     "generate-protos": "pbjs --no-encode -o src/protos.js -w commonjs -t static-module `find ../protos/feast/ -iname *.proto` && pbts -n protos -o src/protos.d.ts src/protos.js"

--- a/ui/tsconfig.build-lib.json
+++ b/ui/tsconfig.build-lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  }
+}


### PR DESCRIPTION
# What this PR does / why we need it:

Makes Feast UI TypeScript declarations available in TypeScript projects that use Feast UI as a module.

# Which issue(s) this PR fixes:

Fixes #4539.

# Misc

I tested this by running `yarn build:lib-dev` in this repository (after installing [`yalc`](https://www.npmjs.com/package/yalc)), then linking it in my test app with `yalc add @feast-dev/feast-ui`.

## Before

No type declarations available:

![feast-ui-no-types](https://github.com/user-attachments/assets/81fb8d06-c70a-4266-94bb-1516e9982e70)

Only "import FeastUI" shown on hover:

![feast-ui-plain-import](https://github.com/user-attachments/assets/81ae1890-ef3e-438f-a7ac-3d74a0aa2650)

## After

Type declarations available and shown on hover:

![feast-ui-typed](https://github.com/user-attachments/assets/dfed7fd7-6044-4a70-8c07-94a301c30339)

You can also easily navigate to the type declaration file:

![feast-ui-type-declarations](https://github.com/user-attachments/assets/ff826031-d079-4170-9f1f-82c9aba73b8f)

