### PR TITLE
docs: Fix small typos in Feast UI projects list documentation

### DIFF
--- a/docs/reference/alpha-web-ui.md
+++ b/docs/reference/alpha-web-ui.md
@@ -70,7 +70,7 @@ ReactDOM.render(
 );
 ```
 
-When you start the React app, it will look for `project-list.json` to find a list of your projects. The JSON should looks something like this.
+When you start the React app, it will look for `projects-list.json` to find a list of your projects. The JSON should look something like this.
 
 ```json
 {

--- a/ui/README.md
+++ b/ui/README.md
@@ -46,7 +46,7 @@ ReactDOM.render(
 );
 ```
 
-When you start the React app, it will look for `projects-list.json` to find a list of your projects. The JSON should looks something like this.
+When you start the React app, it will look for `projects-list.json` to find a list of your projects. The JSON should look something like this.
 
 ```json
 {


### PR DESCRIPTION
# What this PR does / why we need it:

I initially created a `project-list.json` file following the web site docs, then found out it should be `projects-list.json`. Then spotted another tiny typo, so fixed it too.