### PR TITLE
fix: Update react-router-dom to 6.3.0 and restrict its version in Feast UI

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-query": "^3.34.12",
-    "react-router-dom": "6",
+    "react-router-dom": "<6.4.0",
     "react-scripts": "^5.0.0",
     "use-query-params": "^1.2.3",
     "zod": "^3.11.6"
@@ -37,7 +37,7 @@
     "query-string": "^7.1.1",
     "react-code-blocks": "^0.0.9-0",
     "react-query": "^3.34.12",
-    "react-router-dom": "6",
+    "react-router-dom": "<6.4.0",
     "react-scripts": "^5.0.0",
     "tslib": "^2.3.1",
     "use-query-params": "^1.2.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9345,18 +9345,18 @@ react-remove-scroll@^2.5.2:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
-react-router-dom@6:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.2.1.tgz#32ec81829152fbb8a7b045bf593a22eadf019bec"
-  integrity sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==
+react-router-dom@<6.4.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
+  integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
   dependencies:
     history "^5.2.0"
-    react-router "6.2.1"
+    react-router "6.3.0"
 
-react-router@6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.2.1.tgz#be2a97a6006ce1d9123c28934e604faef51448a3"
-  integrity sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==
+react-router@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
+  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
   dependencies:
     history "^5.2.0"
 


### PR DESCRIPTION
# What this PR does / why we need it:

As noted in #3794, Feast UI is not compatible with the latest react-router-dom versions, more precisely [from 6.4.0 onwards](https://stackoverflow.com/a/74252839/305436). Limit react-router-dom version to a compatible range to avoid the runtime errors mentioned in the issue when installing app dependencies without specifying exact versions.

After setting the restricted versions in `package.json`, running `yarn install` updated `react-router-dom` to the latest compatible version 6.3.0. It should be a minor upgrade (https://github.com/remix-run/react-router/blob/main/CHANGELOG.md#v630), and I didn't notice anything not working in the UI after it.

# Which issue(s) this PR fixes:

#3794 has already been closed since there was another way to resolve it, but otherwise this should have fixed it too.

# Misc

I've noticed that regardless of which versions you define in `peerDependencies`, at least Yarn 1 (Classic) installs the latest versions of those packages in the app project with `yarn add`. But the peer dependency versions still have an impact:

- If I keep the react-router-dom version as `6` in `peerDependencies`, Yarn installs the latest version in the root `node_modules` and uses only that, and I get the error in #3794
- If I restrict react-router-dom version to `<6.4.0` in `peerDependencies`, Yarn installs the latest version in the root `node_modules` and version 6.3.0 in `@feast-dev/feast-ui/node_modules`, so Feast UI uses 6.3.0 and the rest of the app the latest version, and I don't get errors (using different versions of react-router-dom **might** introduce some other problems, but limiting the version in `peerDependencies` is the best we can do to influence the app dependency version)  

There are differences in how different package managers (and their different versions) handle peer dependency versions, and you can sometime influence that with command line arguments. But the main point here was to verify that we indeed should update the version in `peerDependencies` too. 😄