### PR TITLE
fix: Remote apply using offline store

### DIFF
--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -15,7 +15,16 @@ import warnings
 from abc import ABC
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import pandas as pd
 import pyarrow
@@ -352,8 +361,8 @@ class OfflineStore(ABC):
         """
         raise NotImplementedError
 
-    @staticmethod
     def validate_data_source(
+        self,
         config: RepoConfig,
         data_source: DataSource,
     ):
@@ -365,3 +374,17 @@ class OfflineStore(ABC):
             data_source: DataSource object that needs to be validated
         """
         data_source.validate(config=config)
+
+    def get_table_column_names_and_types_from_data_source(
+        self,
+        config: RepoConfig,
+        data_source: DataSource,
+    ) -> Iterable[Tuple[str, str]]:
+        """
+        Returns the list of column names and raw column types for a DataSource.
+
+        Args:
+            config: Configuration object used to configure a feature store.
+            data_source: DataSource object
+        """
+        return data_source.get_table_column_names_and_types(config=config)

--- a/sdk/python/feast/infra/offline_stores/remote.py
+++ b/sdk/python/feast/infra/offline_stores/remote.py
@@ -340,7 +340,7 @@ class RemoteOfflineStore(OfflineStore):
         )
 
         api_parameters = {
-            "data_source_name": data_source.name,
+            "data_source_proto": str(data_source),
         }
         logger.debug(f"validating DataSource {data_source.name}")
         _call_put(

--- a/sdk/python/feast/infra/offline_stores/remote.py
+++ b/sdk/python/feast/infra/offline_stores/remote.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -327,6 +327,54 @@ class RemoteOfflineStore(OfflineStore):
             table=table,
             entity_df=None,
         )
+
+    def validate_data_source(
+        self,
+        config: RepoConfig,
+        data_source: DataSource,
+    ):
+        assert isinstance(config.offline_store, RemoteOfflineStoreConfig)
+
+        client = build_arrow_flight_client(
+            config.offline_store.host, config.offline_store.port, config.auth_config
+        )
+
+        api_parameters = {
+            "data_source_name": data_source.name,
+        }
+        logger.debug(f"validating DataSource {data_source.name}")
+        _call_put(
+            api=OfflineStore.validate_data_source.__name__,
+            api_parameters=api_parameters,
+            client=client,
+            table=None,
+            entity_df=None,
+        )
+
+    def get_table_column_names_and_types_from_data_source(
+        self, config: RepoConfig, data_source: DataSource
+    ) -> Iterable[Tuple[str, str]]:
+        assert isinstance(config.offline_store, RemoteOfflineStoreConfig)
+
+        client = build_arrow_flight_client(
+            config.offline_store.host, config.offline_store.port, config.auth_config
+        )
+
+        api_parameters = {
+            "data_source_name": data_source.name,
+        }
+        table = _send_retrieve_remote(
+            api=OfflineStore.get_table_column_names_and_types_from_data_source.__name__,
+            api_parameters=api_parameters,
+            client=client,
+            table=None,
+            entity_df=None,
+        )
+
+        logger.debug(
+            f"get_table_column_names_and_types_from_data_source for {data_source.name}: {table}"
+        )
+        return zip(table.column("name").to_pylist(), table.column("type").to_pylist())
 
 
 def _create_retrieval_metadata(feature_refs: List[str], entity_df: pd.DataFrame):

--- a/sdk/python/feast/infra/offline_stores/remote.py
+++ b/sdk/python/feast/infra/offline_stores/remote.py
@@ -361,8 +361,11 @@ class RemoteOfflineStore(OfflineStore):
         )
 
         api_parameters = {
-            "data_source_name": data_source.name,
+            "data_source_proto": str(data_source),
         }
+        logger.debug(
+            f"Calling {OfflineStore.get_table_column_names_and_types_from_data_source.__name__} with {api_parameters}"
+        )
         table = _send_retrieve_remote(
             api=OfflineStore.get_table_column_names_and_types_from_data_source.__name__,
             api_parameters=api_parameters,

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -471,8 +471,6 @@ class PassthroughProvider(Provider):
     def get_table_column_names_and_types_from_data_source(
         self, config: RepoConfig, data_source: DataSource
     ) -> Iterable[Tuple[str, str]]:
-        if isinstance(data_source, FileSource):
-            return data_source.get_table_column_names_and_types(config=config)
         return self.offline_store.get_table_column_names_and_types_from_data_source(
             config=config, data_source=data_source
         )

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -30,7 +30,6 @@ from feast.infra.materialization.batch_materialization_engine import (
     MaterializationJobStatus,
     MaterializationTask,
 )
-from feast.infra.offline_stores.file_source import FileSource
 from feast.infra.offline_stores.offline_store import RetrievalJob
 from feast.infra.offline_stores.offline_utils import get_offline_store_from_config
 from feast.infra.online_stores.helpers import get_online_store_from_config

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -1,5 +1,16 @@
 from datetime import datetime, timedelta
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import pandas as pd
 import pyarrow as pa
@@ -19,6 +30,7 @@ from feast.infra.materialization.batch_materialization_engine import (
     MaterializationJobStatus,
     MaterializationTask,
 )
+from feast.infra.offline_stores.file_source import FileSource
 from feast.infra.offline_stores.offline_store import RetrievalJob
 from feast.infra.offline_stores.offline_utils import get_offline_store_from_config
 from feast.infra.online_stores.helpers import get_online_store_from_config
@@ -455,3 +467,12 @@ class PassthroughProvider(Provider):
         data_source: DataSource,
     ):
         self.offline_store.validate_data_source(config=config, data_source=data_source)
+
+    def get_table_column_names_and_types_from_data_source(
+        self, config: RepoConfig, data_source: DataSource
+    ) -> Iterable[Tuple[str, str]]:
+        if isinstance(data_source, FileSource):
+            return data_source.get_table_column_names_and_types(config=config)
+        return self.offline_store.get_table_column_names_and_types_from_data_source(
+            config=config, data_source=data_source
+        )

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -1,7 +1,18 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import pandas as pd
 import pyarrow
@@ -402,6 +413,19 @@ class Provider(ABC):
         Args:
             config: Configuration object used to configure a feature store.
             data_source: DataSource object that needs to be validated
+        """
+        pass
+
+    @abstractmethod
+    def get_table_column_names_and_types_from_data_source(
+        self, config: RepoConfig, data_source: DataSource
+    ) -> Iterable[Tuple[str, str]]:
+        """
+        Returns the list of column names and raw column types for a DataSource.
+
+        Args:
+            config: Configuration object used to configure a feature store.
+            data_source: DataSource object
         """
         pass
 

--- a/sdk/python/feast/infra/registry/remote.py
+++ b/sdk/python/feast/infra/registry/remote.py
@@ -15,7 +15,6 @@ from feast.feature_view import FeatureView
 from feast.infra.infra_object import Infra
 from feast.infra.registry.base_registry import BaseRegistry
 from feast.on_demand_feature_view import OnDemandFeatureView
-from feast.permissions.auth.auth_type import AuthType
 from feast.permissions.auth_model import AuthConfig, NoAuthConfig
 from feast.permissions.client.grpc_client_auth_interceptor import (
     GrpcClientAuthHeaderInterceptor,
@@ -67,9 +66,8 @@ class RemoteRegistry(BaseRegistry):
     ):
         self.auth_config = auth_config
         self.channel = grpc.insecure_channel(registry_config.path)
-        if self.auth_config.type != AuthType.NONE.value:
-            auth_header_interceptor = GrpcClientAuthHeaderInterceptor(auth_config)
-            self.channel = grpc.intercept_channel(self.channel, auth_header_interceptor)
+        auth_header_interceptor = GrpcClientAuthHeaderInterceptor(auth_config)
+        self.channel = grpc.intercept_channel(self.channel, auth_header_interceptor)
         self.stub = RegistryServer_pb2_grpc.RegistryServerStub(self.channel)
 
     def close(self):

--- a/sdk/python/feast/offline_server.py
+++ b/sdk/python/feast/offline_server.py
@@ -10,6 +10,7 @@ import pyarrow.flight as fl
 
 from feast import FeatureStore, FeatureView, utils
 from feast.arrow_error_handler import arrow_server_error_handling_decorator
+from feast.errors import FeastObjectNotFoundException
 from feast.feature_logging import FeatureServiceLoggingSource
 from feast.feature_view import DUMMY_ENTITY_NAME
 from feast.infra.offline_stores.offline_utils import get_offline_store_from_config
@@ -138,6 +139,9 @@ class OfflineServer(fl.FlightServerBase):
             elif api == OfflineServer.persist.__name__:
                 self.persist(command, key)
                 remove_data = True
+            elif api == OfflineServer.validate_data_source.__name__:
+                self.validate_data_source(command)
+                remove_data = True
         except Exception as e:
             remove_data = True
             logger.exception(e)
@@ -224,6 +228,11 @@ class OfflineServer(fl.FlightServerBase):
                 table = self.pull_all_from_table_or_query(command).to_arrow()
             elif api == OfflineServer.pull_latest_from_table_or_query.__name__:
                 table = self.pull_latest_from_table_or_query(command).to_arrow()
+            elif (
+                api
+                == OfflineServer.get_table_column_names_and_types_from_data_source.__name__
+            ):
+                table = self.get_table_column_names_and_types_from_data_source(command)
             else:
                 raise NotImplementedError
         except Exception as e:
@@ -456,6 +465,43 @@ class OfflineServer(fl.FlightServerBase):
             logger.exception(e)
             traceback.print_exc()
             raise e
+
+    def validate_data_source(self, command: dict):
+        data_source_name = command["data_source_name"]
+        logger.debug(f"Validating data source {data_source_name}")
+        try:
+            data_source = self.store.registry.get_data_source(
+                name=data_source_name, project=self.store.config.project
+            )
+            self.offline_store.validate_data_source(
+                config=self.store.config,
+                data_source=data_source,
+            )
+        except FeastObjectNotFoundException:
+            logger.debug(f"DataSource {data_source_name} not found, validation skipped")
+
+    def get_table_column_names_and_types_from_data_source(self, command: dict):
+        data_source_name = command["data_source_name"]
+        logger.info(f"Fetching table columns metadata for {data_source_name}")
+        try:
+            data_source = self.store.registry.get_data_source(
+                name=data_source_name, project=self.store.config.project
+            )
+            column_names_and_types = data_source.get_table_column_names_and_types(
+                self.store.config
+            )
+
+            column_names, types = zip(*column_names_and_types)
+            logger.debug(
+                f"DataSource {data_source_name} has columns {column_names} with types {types}"
+            )
+        except FeastObjectNotFoundException:
+            logger.debug(
+                f"DataSource {data_source_name} not found, returning empty columns and no types"
+            )
+            column_names = tuple()
+            types = tuple()
+        return pa.table({"name": column_names, "type": types})
 
 
 def remove_dummies(fv: FeatureView) -> FeatureView:

--- a/sdk/python/feast/permissions/client/grpc_client_auth_interceptor.py
+++ b/sdk/python/feast/permissions/client/grpc_client_auth_interceptor.py
@@ -3,6 +3,7 @@ import logging
 import grpc
 
 from feast.errors import FeastError
+from feast.permissions.auth.auth_type import AuthType
 from feast.permissions.auth_model import AuthConfig
 from feast.permissions.client.client_auth_token import get_auth_token
 
@@ -15,8 +16,8 @@ class GrpcClientAuthHeaderInterceptor(
     grpc.StreamUnaryClientInterceptor,
     grpc.StreamStreamClientInterceptor,
 ):
-    def __init__(self, auth_type: AuthConfig):
-        self._auth_type = auth_type
+    def __init__(self, auth_config: AuthConfig):
+        self._auth_config = auth_config
 
     def intercept_unary_unary(
         self, continuation, client_call_details, request_iterator
@@ -39,7 +40,8 @@ class GrpcClientAuthHeaderInterceptor(
         return self._handle_call(continuation, client_call_details, request_iterator)
 
     def _handle_call(self, continuation, client_call_details, request_iterator):
-        client_call_details = self._append_auth_header_metadata(client_call_details)
+        if self._auth_config.type != AuthType.NONE.value:
+            client_call_details = self._append_auth_header_metadata(client_call_details)
         result = continuation(client_call_details, request_iterator)
         if result.exception() is not None:
             mapped_error = FeastError.from_error_detail(result.exception().details())
@@ -52,7 +54,7 @@ class GrpcClientAuthHeaderInterceptor(
             "Intercepted the grpc api method call to inject Authorization header "
         )
         metadata = client_call_details.metadata or []
-        access_token = get_auth_token(self._auth_type)
+        access_token = get_auth_token(self._auth_config)
         metadata.append((b"authorization", b"Bearer " + access_token.encode("utf-8")))
         client_call_details = client_call_details._replace(metadata=metadata)
         return client_call_details

--- a/sdk/python/tests/foo_provider.py
+++ b/sdk/python/tests/foo_provider.py
@@ -1,6 +1,17 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import pandas
 import pyarrow
@@ -140,6 +151,11 @@ class FooProvider(Provider):
         data_source: DataSource,
     ):
         pass
+
+    def get_table_column_names_and_types_from_data_source(
+        self, config: RepoConfig, data_source: DataSource
+    ) -> Iterable[Tuple[str, str]]:
+        return []
 
     def get_online_features(
         self,

--- a/sdk/python/tests/unit/infra/test_inference_unit_tests.py
+++ b/sdk/python/tests/unit/infra/test_inference_unit_tests.py
@@ -6,7 +6,10 @@ import pytest
 from feast import BigQuerySource, FileSource, RedshiftSource, SnowflakeSource
 from feast.data_source import RequestSource
 from feast.entity import Entity
-from feast.errors import DataSourceNoNameException, SpecifiedFeaturesNotPresentError
+from feast.errors import (
+    DataSourceNoNameException,
+    SpecifiedFeaturesNotPresentError,
+)
 from feast.feature_service import FeatureService
 from feast.feature_view import FeatureView
 from feast.field import Field
@@ -14,6 +17,7 @@ from feast.inference import update_feature_views_with_inferred_features_and_enti
 from feast.infra.offline_stores.contrib.spark_offline_store.spark_source import (
     SparkSource,
 )
+from feast.infra.provider import get_provider
 from feast.on_demand_feature_view import on_demand_feature_view
 from feast.repo_config import RepoConfig
 from feast.types import Float32, Float64, Int64, String, UnixTimestamp
@@ -253,15 +257,18 @@ def test_feature_view_inference_respects_basic_inference():
     assert len(feature_view_1.features) == 1
     assert len(feature_view_1.entity_columns) == 1
 
+    config = RepoConfig(
+        provider="local",
+        project="test",
+        entity_key_serialization_version=2,
+        registry="dummy_registry.pb",
+    )
+    provider = get_provider(config)
     update_feature_views_with_inferred_features_and_entities(
+        provider,
         [feature_view_1],
         [entity1],
-        RepoConfig(
-            provider="local",
-            project="test",
-            entity_key_serialization_version=2,
-            registry="dummy_registry.pb",
-        ),
+        config,
     )
     assert len(feature_view_1.schema) == 2
     assert len(feature_view_1.features) == 1
@@ -271,15 +278,18 @@ def test_feature_view_inference_respects_basic_inference():
     assert len(feature_view_2.features) == 1
     assert len(feature_view_2.entity_columns) == 2
 
+    config = RepoConfig(
+        provider="local",
+        project="test",
+        entity_key_serialization_version=2,
+        registry="dummy_registry.pb",
+    )
+    provider = get_provider(config)
     update_feature_views_with_inferred_features_and_entities(
+        provider,
         [feature_view_2],
         [entity1, entity2],
-        RepoConfig(
-            provider="local",
-            project="test",
-            entity_key_serialization_version=2,
-            registry="dummy_registry.pb",
-        ),
+        config,
     )
     assert len(feature_view_2.schema) == 3
     assert len(feature_view_2.features) == 1
@@ -305,15 +315,18 @@ def test_feature_view_inference_on_entity_value_types():
     assert len(feature_view_1.features) == 1
     assert len(feature_view_1.entity_columns) == 0
 
+    config = RepoConfig(
+        provider="local",
+        project="test",
+        entity_key_serialization_version=2,
+        registry="dummy_registry.pb",
+    )
+    provider = get_provider(config)
     update_feature_views_with_inferred_features_and_entities(
+        provider,
         [feature_view_1],
         [entity1],
-        RepoConfig(
-            provider="local",
-            project="test",
-            entity_key_serialization_version=2,
-            registry="dummy_registry.pb",
-        ),
+        config,
     )
 
     # The schema must be entity and features
@@ -378,15 +391,18 @@ def test_feature_view_inference_on_entity_columns(simple_dataset_1):
         assert len(feature_view_1.features) == 1
         assert len(feature_view_1.entity_columns) == 0
 
+        config = RepoConfig(
+            provider="local",
+            project="test",
+            entity_key_serialization_version=2,
+            registry="dummy_registry.pb",
+        )
+        provider = get_provider(config)
         update_feature_views_with_inferred_features_and_entities(
+            provider,
             [feature_view_1],
             [entity1],
-            RepoConfig(
-                provider="local",
-                project="test",
-                entity_key_serialization_version=2,
-                registry="dummy_registry.pb",
-            ),
+            config,
         )
 
         # Since there is already a feature specified, additional features are not inferred.
@@ -416,15 +432,18 @@ def test_feature_view_inference_on_feature_columns(simple_dataset_1):
         assert len(feature_view_1.features) == 0
         assert len(feature_view_1.entity_columns) == 1
 
+        config = RepoConfig(
+            provider="local",
+            project="test",
+            entity_key_serialization_version=2,
+            registry="dummy_registry.pb",
+        )
+        provider = get_provider(config)
         update_feature_views_with_inferred_features_and_entities(
+            provider,
             [feature_view_1],
             [entity1],
-            RepoConfig(
-                provider="local",
-                project="test",
-                entity_key_serialization_version=2,
-                registry="dummy_registry.pb",
-            ),
+            config,
         )
 
         # The schema is a property concatenating features and entity_columns
@@ -471,15 +490,18 @@ def test_update_feature_services_with_inferred_features(simple_dataset_1):
         assert len(feature_service.feature_view_projections[1].features) == 0
         assert len(feature_service.feature_view_projections[1].desired_features) == 0
 
+        config = RepoConfig(
+            provider="local",
+            project="test",
+            entity_key_serialization_version=2,
+            registry="dummy_registry.pb",
+        )
+        provider = get_provider(config)
         update_feature_views_with_inferred_features_and_entities(
+            provider,
             [feature_view_1, feature_view_2],
             [entity1],
-            RepoConfig(
-                provider="local",
-                project="test",
-                entity_key_serialization_version=2,
-                registry="dummy_registry.pb",
-            ),
+            config,
         )
         feature_service.infer_features(
             fvs_to_update={
@@ -531,15 +553,18 @@ def test_update_feature_services_with_specified_features(simple_dataset_1):
         assert len(feature_service.feature_view_projections[1].features) == 1
         assert len(feature_service.feature_view_projections[1].desired_features) == 0
 
+        config = RepoConfig(
+            provider="local",
+            project="test",
+            entity_key_serialization_version=2,
+            registry="dummy_registry.pb",
+        )
+        provider = get_provider(config)
         update_feature_views_with_inferred_features_and_entities(
+            provider,
             [feature_view_1, feature_view_2],
             [entity1],
-            RepoConfig(
-                provider="local",
-                project="test",
-                entity_key_serialization_version=2,
-                registry="dummy_registry.pb",
-            ),
+            config,
         )
         assert len(feature_view_1.features) == 1
         assert len(feature_view_2.features) == 1


### PR DESCRIPTION
# What this PR does / why we need it:
Moves methods used to run `feast apply` in the Offline Server.
E.g. `DataSource.get_column_names_and_types`

# Which issue(s) this PR fixes:
Fixes https://github.com/feast-dev/feast/issues/4529 and https://github.com/feast-dev/feast/issues/4542
