### PR TITLE
fix: Update the base image for feature-server.

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3.11
-
+FROM debian:11-slim
 RUN apt update && \
         apt install -y \
         jq \
+        python3 \
+        python3-pip \
         python3-dev \
         build-essential
 
@@ -18,4 +19,4 @@ RUN apt update
 RUN apt -y install libarrow-dev
 # modify permissions to support running with a random uid
 RUN mkdir -m 775 /.cache
-RUN chmod g+w $(python -c "import feast.ui as _; print(_.__path__)" | tr -d "[']")/build/projects-list.json
+RUN chmod g+w $(python3 -c "import feast.ui as _; print(_.__path__)" | tr -d "[']")/build/projects-list.json

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -1,8 +1,10 @@
-FROM python:3.11
+FROM debian:11-slim
 
 RUN apt update && \
         apt install -y \
         jq \
+        python3 \
+        python3-pip \
         python3-dev \
         build-essential
 
@@ -19,4 +21,4 @@ RUN apt update
 RUN apt -y install libarrow-dev
 # modify permissions to support running with a random uid
 RUN mkdir -m 775 /.cache
-RUN chmod g+w $(python -c "import feast.ui as _; print(_.__path__)" | tr -d "[']")/build/projects-list.json
+RUN chmod g+w $(python3 -c "import feast.ui as _; print(_.__path__)" | tr -d "[']")/build/projects-list.json


### PR DESCRIPTION


# What this PR does / why we need it:
the previous base image (Python:3.11) for feature-server has vulnerabilities issue. 
It is changed to Debian:11-slim and manually install python, python-pip that have default python version 3.9.

# Which issue(s) this PR fixes:
Fix #4506



