### PR TITLE
fix: Remove unnecessary peer dependencies from Feast UI

### DIFF
--- a/docs/reference/alpha-web-ui.md
+++ b/docs/reference/alpha-web-ui.md
@@ -45,11 +45,14 @@ Start with bootstrapping a React app with `create-react-app`
 npx create-react-app your-feast-ui
 ```
 
-Then, in your app folder, install Feast UI and its peer dependencies. Assuming you use yarn
+Then, in your app folder, install Feast UI and optionally its peer dependencies. Assuming you use yarn
 
 ```
 yarn add @feast-dev/feast-ui
-yarn add @elastic/eui @elastic/datemath @emotion/react moment prop-types inter-ui react-query react-router-dom use-query-params zod typescript query-string d3 @types/d3
+# For custom UI using the Elastic UI Framework (optional):
+yarn add @elastic/eui
+# For general custom styling (optional):
+yarn add @emotion/react
 ```
 
 Edit `index.js` in the React app to use Feast UI.

--- a/ui/README.md
+++ b/ui/README.md
@@ -21,11 +21,14 @@ Start with bootstrapping a React app with `create-react-app`
 npx create-react-app your-feast-ui
 ```
 
-Then, in your app folder, install Feast UI and its peer dependencies. Assuming you use yarn
+Then, in your app folder, install Feast UI and optionally its peer dependencies. Assuming you use yarn
 
 ```
 yarn add @feast-dev/feast-ui
-yarn add @elastic/eui @elastic/datemath @emotion/react moment prop-types inter-ui react-query react-router-dom use-query-params zod typescript query-string d3 @types/d3
+# For custom UI using the Elastic UI Framework (optional):
+yarn add @elastic/eui
+# For general custom styling (optional):
+yarn add @emotion/react
 ```
 
 Edit `index.js` in the React app to use Feast UI.

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,21 +9,18 @@
   "types": "./dist/FeastUI.d.ts",
   "module": "./dist/feast-ui.module.js",
   "peerDependencies": {
-    "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "^55.0.1",
     "@emotion/react": "^11.7.1",
-    "d3": "^7.3.0",
-    "inter-ui": "^3.19.3",
-    "moment": "^2.29.1",
-    "prop-types": "^15.8.1",
-    "query-string": "^7.1.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-query": "^3.34.12",
-    "react-router-dom": "<6.4.0",
-    "react-scripts": "^5.0.0",
-    "use-query-params": "^1.2.3",
-    "zod": "^3.11.6"
+    "react-dom": "^17.0.2"
+  },
+  "peerDependenciesMeta": {
+    "@elastic/eui": {
+      "optional": true
+    },
+    "@emotion/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",


### PR DESCRIPTION
# What this PR does / why we need it:
npm [peer dependencies](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#peerdependencies) in a consumed package are used for dependencies that should be installed by the consuming package/app and usually shared between the two. Most of Feast UI's current peer dependencies can be removed because installing them is not necessarily required in the consuming app when `@feast-dev/feast-ui` is used as a module.  The less we have peer dependencies, the easier it is to take Feast UI into use as a module.

# Which issue(s) this PR fixes:
Fixes #3785.

# Misc
Rationale for the new set of peer dependencies is given in https://github.com/feast-dev/feast/issues/3785#issuecomment-2373098965 and in the commit message) 