### PR TITLE
chore: Remove sqlite_vec assertion in test_online_retrieval.py

### DIFF
--- a/sdk/python/tests/unit/online_store/test_online_retrieval.py
+++ b/sdk/python/tests/unit/online_store/test_online_retrieval.py
@@ -548,7 +548,6 @@ def test_sqlite_vec_import() -> None:
     sqlite_version, vec_version = db.execute(
         "select sqlite_version(), vec_version()"
     ).fetchone()
-    assert vec_version == "v0.1.1"
     print(f"sqlite_version={sqlite_version}, vec_version={vec_version}")
 
     result = db.execute("""


### PR DESCRIPTION
# What this PR does / why we need it:
Remove sqlite Vec version assertion

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
