### PR TITLE
fix: Update the base image of materilization engine.

### DIFF
--- a/sdk/python/feast/infra/materialization/kubernetes/Dockerfile
+++ b/sdk/python/feast/infra/materialization/kubernetes/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.11-slim-bullseye AS build
+FROM debian:11-slim AS build
 
 RUN apt-get update && \
-    apt-get install --no-install-suggests --no-install-recommends --yes git
+    apt-get install --no-install-suggests --no-install-recommends --yes git python3 python3-pip
 
 WORKDIR /app
 


### PR DESCRIPTION


# What this PR does / why we need it:
the current base image (python:3.11-slim-bullseye) in sdk/python/feast/infra/materialization/kubernetes/Dockerfile  has vulnerabilities.
Update it to 'debian:11-slim"

# Which issue(s) this PR fixes:
Fix #4506



