### PR TITLE
fix: FeastExtrasDependencyImportError when using SparkOfflineStore without S3

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -398,7 +398,6 @@ class SparkRetrievalJob(RetrievalJob):
 
                 return _list_files_in_folder(output_uri)
             elif self._config.offline_store.staging_location.startswith("s3://"):
-
                 from feast.infra.utils import aws_utils
 
                 spark_compatible_s3_staging_location = (

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -30,7 +30,6 @@ from feast.infra.offline_stores.offline_store import (
     RetrievalMetadata,
 )
 from feast.infra.registry.base_registry import BaseRegistry
-from feast.infra.utils import aws_utils
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
 from feast.type_map import spark_schema_to_np_dtypes
@@ -399,6 +398,9 @@ class SparkRetrievalJob(RetrievalJob):
 
                 return _list_files_in_folder(output_uri)
             elif self._config.offline_store.staging_location.startswith("s3://"):
+
+                from feast.infra.utils import aws_utils
+
                 spark_compatible_s3_staging_location = (
                     self._config.offline_store.staging_location.replace(
                         "s3://", "s3a://"


### PR DESCRIPTION
# What this PR does / why we need it:

When using `SparkOfflineStore` without S3, the following error is raised:

```shell
❯ python -c "from feast.infra.offline_stores.contrib.spark_offline_store.spark import SparkOfflineStore"

Traceback (most recent call last):
  File "[REDACTED]/python3.10/site-packages/feast/infra/utils/aws_utils.py", line 28, in <module>
    import boto3
ModuleNotFoundError: No module named 'boto3'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "[REDACTED]/python3.10/site-packages/feast/infra/offline_stores/contrib/spark_offline_store/spark.py", line 34, in <module>
    from feast.infra.utils import aws_utils
  File "[REDACTED]/python3.10/site-packages/feast/infra/utils/aws_utils.py", line 34, in <module>
    raise FeastExtrasDependencyImportError("aws", str(e))
feast.errors.FeastExtrasDependencyImportError: No module named 'boto3'
You may need run pip install 'feast[aws]'
```

Installing the AWS libraries should not be required when not using AWS, to avoid unnecessary bloat. Since Spark is commonly used in many different environments (e.g. GCS, Azure or on premise), this change allows `SparkOfflineStore` to be used without installing the AWS libraries.


