### PR TITLE
chore!: Update @elastic/eui and @emotion/react in Feast UI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '17.x'
+          node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Install yarn dependencies
         working-directory: ./ui

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,8 +9,8 @@
   "types": "./dist/FeastUI.d.ts",
   "module": "./dist/feast-ui.module.js",
   "peerDependencies": {
-    "@elastic/eui": "^55.0.1",
-    "@emotion/react": "^11.7.1",
+    "@elastic/eui": "^95.12.0",
+    "@emotion/react": "^11.13.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
@@ -24,12 +24,12 @@
   },
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
-    "@elastic/eui": "^55.0.1",
-    "@emotion/react": "^11.7.1",
+    "@elastic/eui": "^95.12.0",
+    "@emotion/css": "^11.13.0",
+    "@emotion/react": "^11.13.3",
     "d3": "^7.3.0",
     "inter-ui": "^3.19.3",
     "moment": "^2.29.1",
-    "prop-types": "^15.8.1",
     "protobufjs": "^7.1.1",
     "query-string": "^7.1.1",
     "react-code-blocks": "^0.0.9-0",
@@ -57,6 +57,7 @@
   },
   "jest": {
     "moduleNameMapper": {
+      "chroma-js": "<rootDir>/node_modules/chroma-js/dist/chroma.min.cjs",
       "d3": "<rootDir>/node_modules/d3/dist/d3.min.js"
     }
   },
@@ -100,7 +101,7 @@
     "rollup-plugin-svg": "^2.0.0",
     "rollup-plugin-svgo": "^1.1.0",
     "rollup-plugin-terser": "^7.0.2",
-    "typescript": "^4.4.2"
+    "typescript": "^4.9.5"
   },
   "description": "Web UI for the [Feast Feature Store](https://feast.dev/)",
   "repository": {

--- a/ui/src/components/ExplorePanel.tsx
+++ b/ui/src/components/ExplorePanel.tsx
@@ -5,7 +5,7 @@ import {
   EuiPanel,
   EuiTitle,
   EuiBadge,
-  EuiLoadingContent,
+  EuiSkeletonText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -25,7 +25,7 @@ const ExplorePanel = () => {
         <h3>Explore this Project</h3>
       </EuiTitle>
       <EuiHorizontalRule margin="xs" />
-      {isLoading && <EuiLoadingContent lines={3} />}
+      {isLoading && <EuiSkeletonText lines={3} />}
       {isSuccess &&
         data &&
         data.map((suggestionGroup, i) => {

--- a/ui/src/components/NoProjectGuard.tsx
+++ b/ui/src/components/NoProjectGuard.tsx
@@ -1,4 +1,4 @@
-import { EuiEmptyPrompt, EuiLoadingContent } from "@elastic/eui";
+import { EuiEmptyPrompt, EuiSkeletonText } from "@elastic/eui";
 import React, { useContext } from "react";
 import { Outlet, useParams } from "react-router-dom";
 import {
@@ -14,7 +14,7 @@ const NoProjectGuard = () => {
   const projectListContext = useContext(ProjectListContext);
 
   if (isLoading && !data) {
-    return <EuiLoadingContent lines={3} />;
+    return <EuiSkeletonText lines={3} />;
   }
 
   if (isError) {

--- a/ui/src/custom-tabs/data-source-demo-tab/DemoCustomTab.tsx
+++ b/ui/src/custom-tabs/data-source-demo-tab/DemoCustomTab.tsx
@@ -6,7 +6,7 @@ import {
 } from "../types";
 
 import {
-  EuiLoadingContent,
+  EuiSkeletonText,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -29,7 +29,7 @@ const DemoCustomTab = ({ id, feastObjectQuery }: DataSourceCustomTabProps) => {
   if (isLoading) {
     // Handle Loading State
     // https://elastic.github.io/eui/#/display/loading
-    return <EuiLoadingContent lines={3} />;
+    return <EuiSkeletonText lines={3} />;
   }
 
   if (isError) {

--- a/ui/src/custom-tabs/dataset-demo-tab/DemoCustomTab.tsx
+++ b/ui/src/custom-tabs/dataset-demo-tab/DemoCustomTab.tsx
@@ -6,7 +6,7 @@ import {
 } from "../types";
 
 import {
-  EuiLoadingContent,
+  EuiSkeletonText,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -29,7 +29,7 @@ const DemoCustomTab = ({ id, feastObjectQuery }: DatasetCustomTabProps) => {
   if (isLoading) {
     // Handle Loading State
     // https://elastic.github.io/eui/#/display/loading
-    return <EuiLoadingContent lines={3} />;
+    return <EuiSkeletonText lines={3} />;
   }
 
   if (isError) {

--- a/ui/src/custom-tabs/entity-demo-tab/DemoCustomTab.tsx
+++ b/ui/src/custom-tabs/entity-demo-tab/DemoCustomTab.tsx
@@ -6,7 +6,7 @@ import {
 } from "../types";
 
 import {
-  EuiLoadingContent,
+  EuiSkeletonText,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -29,7 +29,7 @@ const DemoCustomTab = ({ id, feastObjectQuery }: EntityCustomTabProps) => {
   if (isLoading) {
     // Handle Loading State
     // https://elastic.github.io/eui/#/display/loading
-    return <EuiLoadingContent lines={3} />;
+    return <EuiSkeletonText lines={3} />;
   }
 
   if (isError) {

--- a/ui/src/custom-tabs/feature-demo-tab/DemoCustomTab.tsx
+++ b/ui/src/custom-tabs/feature-demo-tab/DemoCustomTab.tsx
@@ -6,7 +6,7 @@ import {
 } from "../types";
 
 import {
-  EuiLoadingContent,
+  EuiSkeletonText,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -30,7 +30,7 @@ const DemoCustomTab = ({ id, feastObjectQuery }: FeatureCustomTabProps) => {
   if (isLoading) {
     // Handle Loading State
     // https://elastic.github.io/eui/#/display/loading
-    return <EuiLoadingContent lines={3} />;
+    return <EuiSkeletonText lines={3} />;
   }
 
   if (isError) {

--- a/ui/src/custom-tabs/feature-service-demo-tab/DemoCustomTab.tsx
+++ b/ui/src/custom-tabs/feature-service-demo-tab/DemoCustomTab.tsx
@@ -6,7 +6,7 @@ import {
 } from "../types";
 
 import {
-  EuiLoadingContent,
+  EuiSkeletonText,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -32,7 +32,7 @@ const DemoCustomTab = ({
   if (isLoading) {
     // Handle Loading State
     // https://elastic.github.io/eui/#/display/loading
-    return <EuiLoadingContent lines={3} />;
+    return <EuiSkeletonText lines={3} />;
   }
 
   if (isError) {

--- a/ui/src/custom-tabs/ondemand-fv-demo-tab/DemoCustomTab.tsx
+++ b/ui/src/custom-tabs/ondemand-fv-demo-tab/DemoCustomTab.tsx
@@ -6,7 +6,7 @@ import {
 } from "../types";
 
 import {
-  EuiLoadingContent,
+  EuiSkeletonText,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -32,7 +32,7 @@ const DemoCustomTab = ({
   if (isLoading) {
     // Handle Loading State
     // https://elastic.github.io/eui/#/display/loading
-    return <EuiLoadingContent lines={3} />;
+    return <EuiSkeletonText lines={3} />;
   }
 
   if (isError) {

--- a/ui/src/custom-tabs/reguar-fv-demo-tab/DemoCustomTab.tsx
+++ b/ui/src/custom-tabs/reguar-fv-demo-tab/DemoCustomTab.tsx
@@ -6,7 +6,7 @@ import {
 } from "../types";
 
 import {
-  EuiLoadingContent,
+  EuiSkeletonText,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -32,7 +32,7 @@ const DemoCustomTab = ({
   if (isLoading) {
     // Handle Loading State
     // https://elastic.github.io/eui/#/display/loading
-    return <EuiLoadingContent lines={3} />;
+    return <EuiSkeletonText lines={3} />;
   }
 
   if (isError) {

--- a/ui/src/custom-tabs/stream-fv-demo-tab/DemoCustomTab.tsx
+++ b/ui/src/custom-tabs/stream-fv-demo-tab/DemoCustomTab.tsx
@@ -6,7 +6,7 @@ import {
 } from "../types";
 
 import {
-  EuiLoadingContent,
+  EuiSkeletonText,
   EuiEmptyPrompt,
   EuiFlexGroup,
   EuiFlexItem,
@@ -32,7 +32,7 @@ const DemoCustomTab = ({
   if (isLoading) {
     // Handle Loading State
     // https://elastic.github.io/eui/#/display/loading
-    return <EuiLoadingContent lines={3} />;
+    return <EuiSkeletonText lines={3} />;
   }
 
   if (isError) {

--- a/ui/src/graphics/DataSourceIcon.tsx
+++ b/ui/src/graphics/DataSourceIcon.tsx
@@ -1,17 +1,9 @@
 import React from "react";
 
-const DataSourceIcon = ({
-  size,
-  className,
-}: {
-  size: number;
-  className?: string;
-}) => {
+const DataSourceIcon = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      className={className}
-      width={size}
-      height={size}
+      {...props}
       viewBox="0 0 32 32"
       fill="none"
     >
@@ -27,17 +19,4 @@ const DataSourceIcon = ({
   );
 };
 
-const DataSourceIcon16 = () => {
-  return <DataSourceIcon size={16} className="euiSideNavItemButton__icon" />;
-};
-
-const DataSourceIcon32 = () => {
-  return (
-    <DataSourceIcon
-      size={32}
-      className="euiIcon euiIcon--xLarge euiPageHeaderContent__titleIcon"
-    />
-  );
-};
-
-export { DataSourceIcon, DataSourceIcon16, DataSourceIcon32 };
+export { DataSourceIcon };

--- a/ui/src/graphics/DatasetIcon.tsx
+++ b/ui/src/graphics/DatasetIcon.tsx
@@ -1,17 +1,9 @@
 import React from "react";
 
-const DatasetIcon = ({
-  size,
-  className,
-}: {
-  size: number;
-  className?: string;
-}) => {
+const DatasetIcon = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      className={className}
-      width={size}
-      height={size}
+      {...props}
       viewBox="0 0 32 32"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
@@ -36,17 +28,4 @@ const DatasetIcon = ({
   );
 };
 
-const DatasetIcon16 = () => {
-  return <DatasetIcon size={16} className="euiSideNavItemButton__icon" />;
-};
-
-const DatasetIcon32 = () => {
-  return (
-    <DatasetIcon
-      size={32}
-      className="euiIcon euiIcon--xLarge euiPageHeaderContent__titleIcon"
-    />
-  );
-};
-
-export { DatasetIcon, DatasetIcon16, DatasetIcon32 };
+export { DatasetIcon };

--- a/ui/src/graphics/EntityIcon.tsx
+++ b/ui/src/graphics/EntityIcon.tsx
@@ -1,17 +1,9 @@
 import React from "react";
 
-const EntityIcon = ({
-  size,
-  className,
-}: {
-  size: number;
-  className?: string;
-}) => {
+const EntityIcon = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      className={className}
-      width={size}
-      height={size}
+      {...props}
       viewBox="0 0 32 32"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
@@ -30,17 +22,4 @@ const EntityIcon = ({
   );
 };
 
-const EntityIcon16 = () => {
-  return <EntityIcon size={16} className="euiSideNavItemButton__icon" />;
-};
-
-const EntityIcon32 = () => {
-  return (
-    <EntityIcon
-      size={32}
-      className="euiIcon euiIcon--xLarge euiPageHeaderContent__titleIcon"
-    />
-  );
-};
-
-export { EntityIcon, EntityIcon16, EntityIcon32 };
+export { EntityIcon };

--- a/ui/src/graphics/FeatureIcon.tsx
+++ b/ui/src/graphics/FeatureIcon.tsx
@@ -1,17 +1,9 @@
 import React from "react";
 
-const FeatureIcon = ({
-  size,
-  className,
-}: {
-  size: number;
-  className?: string;
-}) => {
+const FeatureIcon = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      className={className}
-      width={size}
-      height={size}
+      {...props}
       viewBox="0 0 32 32"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
@@ -36,17 +28,4 @@ const FeatureIcon = ({
   );
 };
 
-const FeatureIcon16 = () => {
-  return <FeatureIcon size={16} className="euiSideNavItemButton__icon" />;
-};
-
-const FeatureIcon32 = () => {
-  return (
-    <FeatureIcon
-      size={32}
-      className="euiIcon euiIcon--xLarge euiPageHeaderContent__titleIcon"
-    />
-  );
-};
-
-export { FeatureIcon, FeatureIcon16, FeatureIcon32 };
+export { FeatureIcon };

--- a/ui/src/graphics/FeatureServiceIcon.tsx
+++ b/ui/src/graphics/FeatureServiceIcon.tsx
@@ -1,17 +1,9 @@
 import React from "react";
 
-const FeatureServiceIcon = ({
-  size,
-  className,
-}: {
-  size: number;
-  className?: string;
-}) => {
+const FeatureServiceIcon = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      className={className}
-      width={size}
-      height={size}
+      {...props}
       viewBox="0 0 32 32"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
@@ -24,19 +16,4 @@ const FeatureServiceIcon = ({
   );
 };
 
-const FeatureServiceIcon16 = () => {
-  return (
-    <FeatureServiceIcon size={16} className="euiSideNavItemButton__icon" />
-  );
-};
-
-const FeatureServiceIcon32 = () => {
-  return (
-    <FeatureServiceIcon
-      size={32}
-      className="euiIcon euiIcon--xLarge euiPageHeaderContent__titleIcon"
-    />
-  );
-};
-
-export { FeatureServiceIcon, FeatureServiceIcon16, FeatureServiceIcon32 };
+export { FeatureServiceIcon };

--- a/ui/src/graphics/FeatureViewIcon.tsx
+++ b/ui/src/graphics/FeatureViewIcon.tsx
@@ -1,17 +1,9 @@
 import React from "react";
 
-const FeatureViewIcon = ({
-  size,
-  className,
-}: {
-  size: number;
-  className?: string;
-}) => {
+const FeatureViewIcon = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg
-      className={className}
-      width={size}
-      height={size}
+      {...props}
       viewBox="0 0 32 32"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
@@ -38,17 +30,4 @@ const FeatureViewIcon = ({
   );
 };
 
-const FeatureViewIcon16 = () => {
-  return <FeatureViewIcon size={16} className="euiSideNavItemButton__icon" />;
-};
-
-const FeatureViewIcon32 = () => {
-  return (
-    <FeatureViewIcon
-      size={32}
-      className="euiIcon euiIcon--xLarge euiPageHeaderContent__titleIcon"
-    />
-  );
-};
-
-export { FeatureViewIcon, FeatureViewIcon16, FeatureViewIcon32 };
+export { FeatureViewIcon };

--- a/ui/src/pages/Layout.tsx
+++ b/ui/src/pages/Layout.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import {
   EuiPage,
-  EuiPageSideBar,
+  EuiPageSidebar,
   EuiPageBody,
   EuiErrorBoundary,
   EuiHorizontalRule,
@@ -35,9 +35,9 @@ const Layout = () => {
   return (
     <RegistryPathContext.Provider value={registryPath}>
       <EuiPage paddingSize="none" style={{ background: "transparent" }}>
-        <EuiPageSideBar
+        <EuiPageSidebar
           paddingSize="l"
-          sticky
+          sticky={{ offset: 0 }}
           role={"navigation"}
           aria-label={"Top Level"}
         >
@@ -50,9 +50,9 @@ const Layout = () => {
               <Sidebar />
             </React.Fragment>
           )}
-        </EuiPageSideBar>
+        </EuiPageSidebar>
 
-        <EuiPageBody panelled>
+        <EuiPageBody>
           <EuiErrorBoundary>
             <Outlet />
           </EuiErrorBoundary>

--- a/ui/src/pages/ProjectOverviewPage.tsx
+++ b/ui/src/pages/ProjectOverviewPage.tsx
@@ -1,14 +1,13 @@
 import React, { useContext } from "react";
 
 import {
-  EuiPageContent,
-  EuiPageContentBody,
+  EuiPageTemplate,
   EuiText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiTitle,
   EuiSpacer,
-  EuiLoadingContent,
+  EuiSkeletonText,
   EuiEmptyPrompt,
 } from "@elastic/eui";
 
@@ -24,17 +23,11 @@ const ProjectOverviewPage = () => {
   const { isLoading, isSuccess, isError, data } = useLoadRegistry(registryUrl);
 
   return (
-    <EuiPageContent
-      hasBorder={false}
-      hasShadow={false}
-      paddingSize="none"
-      color="transparent"
-      borderRadius="none"
-    >
-      <EuiPageContentBody>
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Section>
         <EuiTitle size="l">
           <h1>
-            {isLoading && <EuiLoadingContent lines={1} />}
+            {isLoading && <EuiSkeletonText lines={1} />}
             {isSuccess && data?.project && `Project: ${data.project}`}
           </h1>
         </EuiTitle>
@@ -42,7 +35,7 @@ const ProjectOverviewPage = () => {
 
         <EuiFlexGroup>
           <EuiFlexItem grow={2}>
-            {isLoading && <EuiLoadingContent lines={4} />}
+            {isLoading && <EuiSkeletonText lines={4} />}
             {isError && (
               <EuiEmptyPrompt
                 iconType="alert"
@@ -91,8 +84,8 @@ const ProjectOverviewPage = () => {
             <ExplorePanel />
           </EuiFlexItem>
         </EuiFlexGroup>
-      </EuiPageContentBody>
-    </EuiPageContent>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/RootProjectSelectionPage.tsx
+++ b/ui/src/pages/RootProjectSelectionPage.tsx
@@ -4,9 +4,8 @@ import {
   EuiFlexGrid,
   EuiFlexItem,
   EuiIcon,
-  EuiLoadingContent,
-  EuiPageContent,
-  EuiPageContentBody,
+  EuiSkeletonText,
+  EuiPageTemplate,
   EuiText,
   EuiTitle,
   EuiHorizontalRule,
@@ -47,14 +46,8 @@ const RootProjectSelectionPage = () => {
   });
 
   return (
-    <EuiPageContent
-      hasBorder={false}
-      hasShadow={false}
-      paddingSize="none"
-      color="transparent"
-      borderRadius="none"
-    >
-      <EuiPageContentBody>
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Section>
         <EuiTitle size="s">
           <h1>Welcome to Feast</h1>
         </EuiTitle>
@@ -62,14 +55,14 @@ const RootProjectSelectionPage = () => {
           <p>Select one of the projects.</p>
         </EuiText>
         <EuiHorizontalRule margin="m" />
-        {isLoading && <EuiLoadingContent lines={1} />}
+        {isLoading && <EuiSkeletonText lines={1} />}
         {isSuccess && data?.projects && (
           <EuiFlexGrid columns={3} gutterSize="l">
             {projectCards}
           </EuiFlexGrid>
         )}
-      </EuiPageContentBody>
-    </EuiPageContent>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/Sidebar.tsx
+++ b/ui/src/pages/Sidebar.tsx
@@ -6,11 +6,11 @@ import { useMatchSubpath } from "../hooks/useMatchSubpath";
 import useLoadRegistry from "../queries/useLoadRegistry";
 import RegistryPathContext from "../contexts/RegistryPathContext";
 
-import { DataSourceIcon16 } from "../graphics/DataSourceIcon";
-import { EntityIcon16 } from "../graphics/EntityIcon";
-import { FeatureViewIcon16 } from "../graphics/FeatureViewIcon";
-import { FeatureServiceIcon16 } from "../graphics/FeatureServiceIcon";
-import { DatasetIcon16 } from "../graphics/DatasetIcon";
+import { DataSourceIcon } from "../graphics/DataSourceIcon";
+import { EntityIcon } from "../graphics/EntityIcon";
+import { FeatureViewIcon } from "../graphics/FeatureViewIcon";
+import { FeatureServiceIcon } from "../graphics/FeatureServiceIcon";
+import { DatasetIcon } from "../graphics/DatasetIcon";
 
 const SideNav = () => {
   const registryUrl = useContext(RegistryPathContext);
@@ -66,7 +66,7 @@ const SideNav = () => {
         {
           name: dataSourcesLabel,
           id: htmlIdGenerator("dataSources")(),
-          icon: <EuiIcon type={DataSourceIcon16} />,
+          icon: <EuiIcon type={DataSourceIcon} />,
           onClick: () => {
             navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/data-source`);
           },
@@ -75,7 +75,7 @@ const SideNav = () => {
         {
           name: entitiesLabel,
           id: htmlIdGenerator("entities")(),
-          icon: <EuiIcon type={EntityIcon16} />,
+          icon: <EuiIcon type={EntityIcon} />,
           onClick: () => {
             navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/entity`);
           },
@@ -84,7 +84,7 @@ const SideNav = () => {
         {
           name: featureViewsLabel,
           id: htmlIdGenerator("featureView")(),
-          icon: <EuiIcon type={FeatureViewIcon16} />,
+          icon: <EuiIcon type={FeatureViewIcon} />,
           onClick: () => {
             navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view`);
           },
@@ -93,7 +93,7 @@ const SideNav = () => {
         {
           name: featureServicesLabel,
           id: htmlIdGenerator("featureService")(),
-          icon: <EuiIcon type={FeatureServiceIcon16} />,
+          icon: <EuiIcon type={FeatureServiceIcon} />,
           onClick: () => {
             navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-service`);
           },
@@ -102,7 +102,7 @@ const SideNav = () => {
         {
           name: savedDatasetsLabel,
           id: htmlIdGenerator("savedDatasets")(),
-          icon: <EuiIcon type={DatasetIcon16} />,
+          icon: <EuiIcon type={DatasetIcon} />,
           onClick: () => {
             navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/data-set`);
           },
@@ -118,7 +118,6 @@ const SideNav = () => {
       mobileTitle="Feast"
       toggleOpenOnMobile={() => toggleOpenOnMobile()}
       isOpenOnMobile={isSideNavOpenOnMobile}
-      style={{ width: 192 }}
       items={sideNav}
     />
   );

--- a/ui/src/pages/data-sources/DataSourceInstance.tsx
+++ b/ui/src/pages/data-sources/DataSourceInstance.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import { Route, Routes, useNavigate, useParams } from "react-router-dom";
-import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
-} from "@elastic/eui";
+import { EuiPageTemplate } from "@elastic/eui";
 
-import { DataSourceIcon32 } from "../../graphics/DataSourceIcon";
+import { DataSourceIcon } from "../../graphics/DataSourceIcon";
 import { useMatchExact } from "../../hooks/useMatchSubpath";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import DataSourceRawData from "./DataSourceRawData";
@@ -39,29 +35,21 @@ const DataSourceInstance = () => {
   const CustomTabRoutes = useDataSourceCustomTabRoutes();
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={DataSourceIcon32}
+        iconType={DataSourceIcon}
         pageTitle={`Data Source: ${dataSourceName}`}
         tabs={tabs}
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          <Routes>
-            <Route path="/" element={<DataSourceOverviewTab />} />
-            <Route path="/raw-data" element={<DataSourceRawData />} />
-            {CustomTabRoutes}
-          </Routes>
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        <Routes>
+          <Route path="/" element={<DataSourceOverviewTab />} />
+          <Route path="/raw-data" element={<DataSourceRawData />} />
+          {CustomTabRoutes}
+        </Routes>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/data-sources/Index.tsx
+++ b/ui/src/pages/data-sources/Index.tsx
@@ -1,10 +1,13 @@
 import React, { useContext } from "react";
 
 import {
-    EuiPageHeader,
-    EuiPageContent,
-    EuiPageContentBody,
-    EuiLoadingSpinner, EuiFlexGroup, EuiFlexItem, EuiTitle, EuiFieldSearch, EuiSpacer,
+  EuiPageTemplate,
+  EuiLoadingSpinner,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiTitle,
+  EuiFieldSearch,
+  EuiSpacer,
 } from "@elastic/eui";
 
 import useLoadRegistry from "../../queries/useLoadRegistry";
@@ -12,8 +15,8 @@ import DatasourcesListingTable from "./DataSourcesListingTable";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import RegistryPathContext from "../../contexts/RegistryPathContext";
 import DataSourceIndexEmptyState from "./DataSourceIndexEmptyState";
-import { DataSourceIcon32 } from "../../graphics/DataSourceIcon";
-import { useSearchQuery} from "../../hooks/useSearchInputWithTags";
+import { DataSourceIcon } from "../../graphics/DataSourceIcon";
+import { useSearchQuery } from "../../hooks/useSearchInputWithTags";
 import { feast } from "../../protos";
 
 const useLoadDatasources = () => {
@@ -52,56 +55,48 @@ const Index = () => {
 
   const { searchString, searchTokens, setSearchString } = useSearchQuery();
 
-    const filterResult = data
+  const filterResult = data
     ? filterFn(data, searchTokens)
     : data;
 
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={DataSourceIcon32}
+        iconType={DataSourceIcon}
         pageTitle="Data Sources"
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          {isLoading && (
-            <p>
-              <EuiLoadingSpinner size="m" /> Loading
-            </p>
-          )}
-          {isError && <p>We encountered an error while loading.</p>}
-          {isSuccess && !data && <DataSourceIndexEmptyState />}
-          {isSuccess && data && data.length > 0 && filterResult && (
-            <React.Fragment>
-              <EuiFlexGroup>
-                <EuiFlexItem grow={2}>
-                  <EuiTitle size="xs">
-                    <h2>Search</h2>
-                  </EuiTitle>
-                  <EuiFieldSearch
-                    value={searchString}
-                    fullWidth={true}
-                    onChange={(e) => {
-                      setSearchString(e.target.value);
-                    }}
-                  />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-              <EuiSpacer size="m" />
-              <DatasourcesListingTable dataSources={filterResult} />
-            </React.Fragment>
-          )}
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        {isLoading && (
+          <p>
+            <EuiLoadingSpinner size="m" /> Loading
+          </p>
+        )}
+        {isError && <p>We encountered an error while loading.</p>}
+        {isSuccess && !data && <DataSourceIndexEmptyState />}
+        {isSuccess && data && data.length > 0 && filterResult && (
+          <React.Fragment>
+            <EuiFlexGroup>
+              <EuiFlexItem grow={2}>
+                <EuiTitle size="xs">
+                  <h2>Search</h2>
+                </EuiTitle>
+                <EuiFieldSearch
+                  value={searchString}
+                  fullWidth={true}
+                  onChange={(e) => {
+                    setSearchString(e.target.value);
+                  }}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="m" />
+            <DatasourcesListingTable dataSources={filterResult} />
+          </React.Fragment>
+        )}
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/entities/EntityInstance.tsx
+++ b/ui/src/pages/entities/EntityInstance.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import { Route, Routes, useNavigate, useParams } from "react-router-dom";
-import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
-} from "@elastic/eui";
+import { EuiPageTemplate } from "@elastic/eui";
 
-import { EntityIcon32 } from "../../graphics/EntityIcon";
+import { EntityIcon } from "../../graphics/EntityIcon";
 import { useMatchExact } from "../../hooks/useMatchSubpath";
 import EntityOverviewTab from "./EntityOverviewTab";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
@@ -25,10 +21,10 @@ const EntityInstance = () => {
   useDocumentTitle(`${entityName} | Entity | Feast`);
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={EntityIcon32}
+        iconType={EntityIcon}
         pageTitle={`Entity: ${entityName}`}
         tabs={[
           {
@@ -41,21 +37,13 @@ const EntityInstance = () => {
           ...customNavigationTabs,
         ]}
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          <Routes>
-            <Route path="/" element={<EntityOverviewTab />} />
-            {CustomTabRoutes}
-          </Routes>
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        <Routes>
+          <Route path="/" element={<EntityOverviewTab />} />
+          {CustomTabRoutes}
+        </Routes>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/entities/FeatureViewEdgesList.tsx
+++ b/ui/src/pages/entities/FeatureViewEdgesList.tsx
@@ -51,7 +51,7 @@ const FeatureViewEdgesList = ({ fvNames }: FeatureViewEdgesListInterace) => {
     {
       name: "Name",
       field: "",
-      render: (name: string) => {
+      render: ({ name }: { name: string }) => {
         return (
           <EuiCustomLink
             href={`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view/${name}`}
@@ -64,7 +64,8 @@ const FeatureViewEdgesList = ({ fvNames }: FeatureViewEdgesListInterace) => {
     },
     {
       name: "FS Consumers",
-      render: (name: string) => {
+      field: "",
+      render: ({ name }: { name: string }) => {
         return (
           <React.Fragment>
             {isLoading && <EuiLoadingSpinner size="s" />}
@@ -82,7 +83,7 @@ const FeatureViewEdgesList = ({ fvNames }: FeatureViewEdgesListInterace) => {
   };
 
   return (
-    <EuiBasicTable columns={columns} items={fvNames} rowProps={getRowProps} />
+    <EuiBasicTable columns={columns} items={fvNames.map(name => ({ name }))} rowProps={getRowProps} />
   );
 };
 

--- a/ui/src/pages/entities/Index.tsx
+++ b/ui/src/pages/entities/Index.tsx
@@ -1,13 +1,8 @@
 import React, { useContext } from "react";
 
-import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
-  EuiLoadingSpinner,
-} from "@elastic/eui";
+import { EuiPageTemplate, EuiLoadingSpinner } from "@elastic/eui";
 
-import { EntityIcon32 } from "../../graphics/EntityIcon";
+import { EntityIcon } from "../../graphics/EntityIcon";
 
 import useLoadRegistry from "../../queries/useLoadRegistry";
 import EntitiesListingTable from "./EntitiesListingTable";
@@ -36,31 +31,23 @@ const Index = () => {
   useDocumentTitle(`Entities | Feast`);
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={EntityIcon32}
+        iconType={EntityIcon}
         pageTitle="Entities"
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          {isLoading && (
-            <p>
-              <EuiLoadingSpinner size="m" /> Loading
-            </p>
-          )}
-          {isError && <p>We encountered an error while loading.</p>}
-          {isSuccess && !data && <EntityIndexEmptyState />}
-          {isSuccess && data && <EntitiesListingTable entities={data} />}
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        {isLoading && (
+          <p>
+            <EuiLoadingSpinner size="m" /> Loading
+          </p>
+        )}
+        {isError && <p>We encountered an error while loading.</p>}
+        {isSuccess && !data && <EntityIndexEmptyState />}
+        {isSuccess && data && <EntitiesListingTable entities={data} />}
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/feature-services/FeatureServiceInstance.tsx
+++ b/ui/src/pages/feature-services/FeatureServiceInstance.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import { Route, Routes, useNavigate, useParams } from "react-router-dom";
-import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
-} from "@elastic/eui";
+import { EuiPageTemplate } from "@elastic/eui";
 
-import { FeatureServiceIcon32 } from "../../graphics/FeatureServiceIcon";
+import { FeatureServiceIcon } from "../../graphics/FeatureServiceIcon";
 import { useMatchExact } from "../../hooks/useMatchSubpath";
 import FeatureServiceOverviewTab from "./FeatureServiceOverviewTab";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
@@ -26,10 +22,10 @@ const FeatureServiceInstance = () => {
   const CustomTabRoutes = useFeatureServiceCustomTabRoutes();
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={FeatureServiceIcon32}
+        iconType={FeatureServiceIcon}
         pageTitle={`Feature Service: ${featureServiceName}`}
         tabs={[
           {
@@ -42,21 +38,13 @@ const FeatureServiceInstance = () => {
           ...customNavigationTabs,
         ]}
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          <Routes>
-            <Route path="/" element={<FeatureServiceOverviewTab />} />
-            {CustomTabRoutes}
-          </Routes>
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        <Routes>
+          <Route path="/" element={<FeatureServiceOverviewTab />} />
+          {CustomTabRoutes}
+        </Routes>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/feature-services/FeatureServiceOverviewTab.tsx
+++ b/ui/src/pages/feature-services/FeatureServiceOverviewTab.tsx
@@ -51,7 +51,7 @@ const FeatureServiceOverviewTab = () => {
       {isEmpty && <p>No feature service with name: {featureServiceName}</p>}
       {isError && <p>Error loading feature service: {featureServiceName}</p>}
       {isSuccess && data && (
-        <React.Fragment>
+        <EuiFlexGroup direction="column">
           <EuiFlexGroup alignItems="center">
             <EuiFlexItem grow={false}>
               <EuiStat title={`${numFeatures}`} description="Total Features" />
@@ -167,7 +167,7 @@ const FeatureServiceOverviewTab = () => {
               </EuiPanel>
             </EuiFlexItem>
           </EuiFlexGroup>
-        </React.Fragment>
+        </EuiFlexGroup>
       )}
     </React.Fragment>
   );

--- a/ui/src/pages/feature-services/Index.tsx
+++ b/ui/src/pages/feature-services/Index.tsx
@@ -1,9 +1,7 @@
 import React, { useContext } from "react";
 
 import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
+  EuiPageTemplate,
   EuiLoadingSpinner,
   EuiTitle,
   EuiSpacer,
@@ -12,7 +10,7 @@ import {
   EuiFieldSearch,
 } from "@elastic/eui";
 
-import { FeatureServiceIcon32 } from "../../graphics/FeatureServiceIcon";
+import { FeatureServiceIcon } from "../../graphics/FeatureServiceIcon";
 
 import useLoadRegistry from "../../queries/useLoadRegistry";
 import FeatureServiceListingTable from "./FeatureServiceListingTable";
@@ -112,64 +110,56 @@ const Index = () => {
     : data;
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={FeatureServiceIcon32}
+        iconType={FeatureServiceIcon}
         pageTitle="Feature Services"
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          {isLoading && (
-            <p>
-              <EuiLoadingSpinner size="m" /> Loading
-            </p>
-          )}
-          {isError && <p>We encountered an error while loading.</p>}
-          {isSuccess && !data && <FeatureServiceIndexEmptyState />}
-          {isSuccess && filterResult && (
-            <React.Fragment>
-              <EuiFlexGroup>
-                <EuiFlexItem grow={2}>
-                  <EuiTitle size="xs">
-                    <h2>Search</h2>
-                  </EuiTitle>
-                  <EuiFieldSearch
-                    value={searchString}
-                    fullWidth={true}
-                    onChange={(e) => {
-                      setSearchString(e.target.value);
-                    }}
-                  />
-                </EuiFlexItem>
-                <EuiFlexItem grow={3}>
-                  <TagSearch
-                    currentTag={currentTag}
-                    tagsString={tagsString}
-                    setTagsString={setTagsString}
-                    acceptSuggestion={acceptSuggestion}
-                    tagSuggestions={tagSuggestions}
-                    suggestionMode={suggestionMode}
-                    setCursorPosition={setCursorPosition}
-                  />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-              <EuiSpacer size="m" />
-              <FeatureServiceListingTable
-                featureServices={filterResult}
-                tagKeysSet={tagKeysSet}
-              />
-            </React.Fragment>
-          )}
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        {isLoading && (
+          <p>
+            <EuiLoadingSpinner size="m" /> Loading
+          </p>
+        )}
+        {isError && <p>We encountered an error while loading.</p>}
+        {isSuccess && !data && <FeatureServiceIndexEmptyState />}
+        {isSuccess && filterResult && (
+          <React.Fragment>
+            <EuiFlexGroup>
+              <EuiFlexItem grow={2}>
+                <EuiTitle size="xs">
+                  <h2>Search</h2>
+                </EuiTitle>
+                <EuiFieldSearch
+                  value={searchString}
+                  fullWidth={true}
+                  onChange={(e) => {
+                    setSearchString(e.target.value);
+                  }}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={3}>
+                <TagSearch
+                  currentTag={currentTag}
+                  tagsString={tagsString}
+                  setTagsString={setTagsString}
+                  acceptSuggestion={acceptSuggestion}
+                  tagSuggestions={tagSuggestions}
+                  suggestionMode={suggestionMode}
+                  setCursorPosition={setCursorPosition}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="m" />
+            <FeatureServiceListingTable
+              featureServices={filterResult}
+              tagKeysSet={tagKeysSet}
+            />
+          </React.Fragment>
+        )}
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/feature-views/ConsumingFeatureServicesList.tsx
+++ b/ui/src/pages/feature-views/ConsumingFeatureServicesList.tsx
@@ -16,7 +16,7 @@ const ConsumingFeatureServicesList = ({
     {
       name: "Name",
       field: "",
-      render: (name: string) => {
+      render: ({ name }: { name: string }) => {
         return (
           <EuiCustomLink
             href={`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-service/${name}`}
@@ -36,7 +36,7 @@ const ConsumingFeatureServicesList = ({
   };
 
   return (
-    <EuiBasicTable columns={columns} items={fsNames} rowProps={getRowProps} />
+    <EuiBasicTable columns={columns} items={fsNames.map(name => ({ name }))} rowProps={getRowProps} />
   );
 };
 

--- a/ui/src/pages/feature-views/Index.tsx
+++ b/ui/src/pages/feature-views/Index.tsx
@@ -1,9 +1,7 @@
 import React, { useContext } from "react";
 
 import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
+  EuiPageTemplate,
   EuiLoadingSpinner,
   EuiSpacer,
   EuiTitle,
@@ -12,7 +10,7 @@ import {
   EuiFlexItem,
 } from "@elastic/eui";
 
-import { FeatureViewIcon32 } from "../../graphics/FeatureViewIcon";
+import { FeatureViewIcon } from "../../graphics/FeatureViewIcon";
 
 import useLoadRegistry from "../../queries/useLoadRegistry";
 import FeatureViewListingTable from "./FeatureViewListingTable";
@@ -114,64 +112,56 @@ const Index = () => {
     : data;
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={FeatureViewIcon32}
+        iconType={FeatureViewIcon}
         pageTitle="Feature Views"
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          {isLoading && (
-            <p>
-              <EuiLoadingSpinner size="m" /> Loading
-            </p>
-          )}
-          {isError && <p>We encountered an error while loading.</p>}
-          {isSuccess && data?.length === 0 && <FeatureViewIndexEmptyState />}
-          {isSuccess && data && data.length > 0 && filterResult && (
-            <React.Fragment>
-              <EuiFlexGroup>
-                <EuiFlexItem grow={2}>
-                  <EuiTitle size="xs">
-                    <h2>Search</h2>
-                  </EuiTitle>
-                  <EuiFieldSearch
-                    value={searchString}
-                    fullWidth={true}
-                    onChange={(e) => {
-                      setSearchString(e.target.value);
-                    }}
-                  />
-                </EuiFlexItem>
-                <EuiFlexItem grow={3}>
-                  <TagSearch
-                    currentTag={currentTag}
-                    tagsString={tagsString}
-                    setTagsString={setTagsString}
-                    acceptSuggestion={acceptSuggestion}
-                    tagSuggestions={tagSuggestions}
-                    suggestionMode={suggestionMode}
-                    setCursorPosition={setCursorPosition}
-                  />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-              <EuiSpacer size="m" />
-              <FeatureViewListingTable
-                tagKeysSet={tagKeysSet}
-                featureViews={filterResult}
-              />
-            </React.Fragment>
-          )}
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        {isLoading && (
+          <p>
+            <EuiLoadingSpinner size="m" /> Loading
+          </p>
+        )}
+        {isError && <p>We encountered an error while loading.</p>}
+        {isSuccess && data?.length === 0 && <FeatureViewIndexEmptyState />}
+        {isSuccess && data && data.length > 0 && filterResult && (
+          <React.Fragment>
+            <EuiFlexGroup>
+              <EuiFlexItem grow={2}>
+                <EuiTitle size="xs">
+                  <h2>Search</h2>
+                </EuiTitle>
+                <EuiFieldSearch
+                  value={searchString}
+                  fullWidth={true}
+                  onChange={(e) => {
+                    setSearchString(e.target.value);
+                  }}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={3}>
+                <TagSearch
+                  currentTag={currentTag}
+                  tagsString={tagsString}
+                  setTagsString={setTagsString}
+                  acceptSuggestion={acceptSuggestion}
+                  tagSuggestions={tagSuggestions}
+                  suggestionMode={suggestionMode}
+                  setCursorPosition={setCursorPosition}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="m" />
+            <FeatureViewListingTable
+              tagKeysSet={tagKeysSet}
+              featureViews={filterResult}
+            />
+          </React.Fragment>
+        )}
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/feature-views/OnDemandFeatureViewInstance.tsx
+++ b/ui/src/pages/feature-views/OnDemandFeatureViewInstance.tsx
@@ -1,13 +1,9 @@
 import React from "react";
 import { Route, Routes, useNavigate } from "react-router-dom";
 import { useParams } from "react-router-dom";
-import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
-} from "@elastic/eui";
+import { EuiPageTemplate } from "@elastic/eui";
 
-import { FeatureViewIcon32 } from "../../graphics/FeatureViewIcon";
+import { FeatureViewIcon } from "../../graphics/FeatureViewIcon";
 import { useMatchExact } from "../../hooks/useMatchSubpath";
 import OnDemandFeatureViewOverviewTab from "./OnDemandFeatureViewOverviewTab";
 
@@ -29,10 +25,10 @@ const OnDemandFeatureInstance = ({ data }: OnDemandFeatureInstanceProps) => {
   const CustomTabRoutes = useOnDemandFeatureViewCustomTabRoutes();
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={FeatureViewIcon32}
+        iconType={FeatureViewIcon}
         pageTitle={`${featureViewName}`}
         tabs={[
           {
@@ -45,24 +41,16 @@ const OnDemandFeatureInstance = ({ data }: OnDemandFeatureInstanceProps) => {
           ...customNavigationTabs,
         ]}
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          <Routes>
-            <Route
-              path="/"
-              element={<OnDemandFeatureViewOverviewTab data={data} />}
-            />
-            {CustomTabRoutes}
-          </Routes>
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        <Routes>
+          <Route
+            path="/"
+            element={<OnDemandFeatureViewOverviewTab data={data} />}
+          />
+          {CustomTabRoutes}
+        </Routes>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/feature-views/OnDemandFeatureViewOverviewTab.tsx
+++ b/ui/src/pages/feature-views/OnDemandFeatureViewOverviewTab.tsx
@@ -48,7 +48,7 @@ const OnDemandFeatureViewOverviewTab = ({
     : [];
 
   return (
-    <React.Fragment>
+    <EuiFlexGroup direction="column">
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiPanel hasBorder={true}>
@@ -138,7 +138,7 @@ const OnDemandFeatureViewOverviewTab = ({
           </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGroup>
-    </React.Fragment>
+    </EuiFlexGroup>
   );
 };
 

--- a/ui/src/pages/feature-views/RegularFeatureViewInstance.tsx
+++ b/ui/src/pages/feature-views/RegularFeatureViewInstance.tsx
@@ -1,12 +1,8 @@
 import React, { useContext } from "react";
 import { Route, Routes, useNavigate } from "react-router-dom";
-import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
-} from "@elastic/eui";
+import { EuiPageTemplate } from "@elastic/eui";
 
-import { FeatureViewIcon32 } from "../../graphics/FeatureViewIcon";
+import { FeatureViewIcon } from "../../graphics/FeatureViewIcon";
 
 import { useMatchExact, useMatchSubpath } from "../../hooks/useMatchSubpath";
 import RegularFeatureViewOverviewTab from "./RegularFeatureViewOverviewTab";
@@ -53,31 +49,23 @@ const RegularFeatureInstance = ({ data }: RegularFeatureInstanceProps) => {
   const TabRoutes = useRegularFeatureViewCustomTabRoutes();
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={FeatureViewIcon32}
+        iconType={FeatureViewIcon}
         pageTitle={`${data?.spec?.name}`}
         tabs={tabs}
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          <Routes>
-            <Route
-              path="/"
-              element={<RegularFeatureViewOverviewTab data={data} />}
-            />
-            {TabRoutes}
-          </Routes>
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        <Routes>
+          <Route
+            path="/"
+            element={<RegularFeatureViewOverviewTab data={data} />}
+          />
+          {TabRoutes}
+        </Routes>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/feature-views/StreamFeatureViewInstance.tsx
+++ b/ui/src/pages/feature-views/StreamFeatureViewInstance.tsx
@@ -1,13 +1,9 @@
 import React from "react";
 import { Route, Routes, useNavigate } from "react-router-dom";
 import { useParams } from "react-router-dom";
-import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
-} from "@elastic/eui";
+import { EuiPageTemplate } from "@elastic/eui";
 
-import { FeatureViewIcon32 } from "../../graphics/FeatureViewIcon";
+import { FeatureViewIcon } from "../../graphics/FeatureViewIcon";
 import { useMatchExact } from "../../hooks/useMatchSubpath";
 import StreamFeatureViewOverviewTab from "./StreamFeatureViewOverviewTab";
 
@@ -29,10 +25,11 @@ const StreamFeatureInstance = ({ data }: StreamFeatureInstanceProps) => {
   const CustomTabRoutes = useStreamFeatureViewCustomTabRoutes();
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={FeatureViewIcon32}
+        paddingSize="l"
+        iconType={FeatureViewIcon}
         pageTitle={`${featureViewName}`}
         tabs={[
           {
@@ -45,24 +42,16 @@ const StreamFeatureInstance = ({ data }: StreamFeatureInstanceProps) => {
           ...customNavigationTabs,
         ]}
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          <Routes>
-            <Route
-              path="/"
-              element={<StreamFeatureViewOverviewTab data={data} />}
-            />
-            {CustomTabRoutes}
-          </Routes>
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        <Routes>
+          <Route
+            path="/"
+            element={<StreamFeatureViewOverviewTab data={data} />}
+          />
+          {CustomTabRoutes}
+        </Routes>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/feature-views/StreamFeatureViewOverviewTab.tsx
+++ b/ui/src/pages/feature-views/StreamFeatureViewOverviewTab.tsx
@@ -47,7 +47,7 @@ const StreamFeatureViewOverviewTab = ({
     : [];
 
   return (
-    <React.Fragment>
+    <EuiFlexGroup direction="column">
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiPanel hasBorder={true}>
@@ -126,7 +126,7 @@ const StreamFeatureViewOverviewTab = ({
           </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGroup>
-    </React.Fragment>
+    </EuiFlexGroup>
   );
 };
 

--- a/ui/src/pages/feature-views/components/FeatureViewProjectionDisplayPanel.tsx
+++ b/ui/src/pages/feature-views/components/FeatureViewProjectionDisplayPanel.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { EuiBasicTable, EuiPanel, EuiText, EuiTitle } from "@elastic/eui";
-
+import { EuiBasicTable, EuiPanel, EuiSpacer, EuiText, EuiTitle } from "@elastic/eui";
 import { useParams } from "react-router-dom";
 import EuiCustomLink from "../../../components/EuiCustomLink";
 import { feast } from "../../../protos";
@@ -29,6 +28,7 @@ const FeatureViewProjectionDisplayPanel = (featureViewProjection: RequestDataDis
       <EuiText size="xs">
         <span>Feature View</span>
       </EuiText>
+      <EuiSpacer size="xs" />
       <EuiTitle size="s">
         <EuiCustomLink
           href={`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view/${featureViewProjection.featureViewName}`}
@@ -37,6 +37,7 @@ const FeatureViewProjectionDisplayPanel = (featureViewProjection: RequestDataDis
           {featureViewProjection?.featureViewName}
         </EuiCustomLink>
       </EuiTitle>
+      <EuiSpacer size="s" />
       <EuiBasicTable
         columns={columns}
         items={featureViewProjection?.featureColumns!}

--- a/ui/src/pages/feature-views/components/RequestDataDisplayPanel.tsx
+++ b/ui/src/pages/feature-views/components/RequestDataDisplayPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { EuiBasicTable, EuiPanel, EuiText, EuiTitle } from "@elastic/eui";
+import { EuiBasicTable, EuiPanel, EuiSpacer, EuiText, EuiTitle } from "@elastic/eui";
 import { useParams } from "react-router-dom";
 import EuiCustomLink from "../../../components/EuiCustomLink";
 import { feast } from "../../../protos";
@@ -36,6 +36,7 @@ const RequestDataDisplayPanel = ({
       <EuiText size="xs">
         <span>Request Data</span>
       </EuiText>
+      <EuiSpacer size="xs" />
       <EuiTitle size="s">
         <EuiCustomLink
           href={`${process.env.PUBLIC_URL || ""}/p/${projectName}/data-source/${requestDataSource?.name}`}
@@ -44,6 +45,7 @@ const RequestDataDisplayPanel = ({
           {requestDataSource?.name}
         </EuiCustomLink>
       </EuiTitle>
+      <EuiSpacer size="s" />
       <EuiBasicTable columns={columns} items={items} />
     </EuiPanel>
   );

--- a/ui/src/pages/features/FeatureInstance.tsx
+++ b/ui/src/pages/features/FeatureInstance.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import { Route, Routes, useNavigate, useParams } from "react-router-dom";
-import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
-} from "@elastic/eui";
+import { EuiPageTemplate } from "@elastic/eui";
 
-import { FeatureIcon32 } from "../../graphics/FeatureIcon";
+import { FeatureIcon } from "../../graphics/FeatureIcon";
 import { useMatchExact } from "../../hooks/useMatchSubpath";
 import FeatureOverviewTab from "./FeatureOverviewTab";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
@@ -25,10 +21,10 @@ const FeatureInstance = () => {
   useDocumentTitle(`${FeatureName} | ${FeatureViewName} | Feast`);
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={FeatureIcon32}
+        iconType={FeatureIcon}
         pageTitle={`Feature: ${FeatureName}`}
         tabs={[
           {
@@ -41,21 +37,13 @@ const FeatureInstance = () => {
           ...customNavigationTabs,
         ]}
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          <Routes>
-            <Route path="/" element={<FeatureOverviewTab />} />
-            {CustomTabRoutes}
-          </Routes>
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        <Routes>
+          <Route path="/" element={<FeatureOverviewTab />} />
+          {CustomTabRoutes}
+        </Routes>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/saved-data-sets/DatasetInstance.tsx
+++ b/ui/src/pages/saved-data-sets/DatasetInstance.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import { Route, Routes, useNavigate, useParams } from "react-router-dom";
-import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
-} from "@elastic/eui";
+import { EuiPageTemplate } from "@elastic/eui";
 
-import { DatasetIcon32 } from "../../graphics/DatasetIcon";
+import { DatasetIcon } from "../../graphics/DatasetIcon";
 
 import { useMatchExact, useMatchSubpath } from "../../hooks/useMatchSubpath";
 import DatasetOverviewTab from "./DatasetOverviewTab";
@@ -27,10 +23,10 @@ const DatasetInstance = () => {
   const CustomTabRoutes = useDataSourceCustomTabRoutes();
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={DatasetIcon32}
+        iconType={DatasetIcon}
         pageTitle={`Entity: ${datasetName}`}
         tabs={[
           {
@@ -50,22 +46,14 @@ const DatasetInstance = () => {
           ...customNavigationTabs,
         ]}
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          <Routes>
-            <Route path="/" element={<DatasetOverviewTab />} />
-            <Route path="/expectations" element={<DatasetExpectationsTab />} />
-            {CustomTabRoutes}
-          </Routes>
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        <Routes>
+          <Route path="/" element={<DatasetOverviewTab />} />
+          <Route path="/expectations" element={<DatasetExpectationsTab />} />
+          {CustomTabRoutes}
+        </Routes>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/src/pages/saved-data-sets/Index.tsx
+++ b/ui/src/pages/saved-data-sets/Index.tsx
@@ -1,13 +1,8 @@
 import React, { useContext } from "react";
 
-import {
-  EuiPageHeader,
-  EuiPageContent,
-  EuiPageContentBody,
-  EuiLoadingSpinner,
-} from "@elastic/eui";
+import { EuiPageTemplate, EuiLoadingSpinner } from "@elastic/eui";
 
-import { DatasetIcon32 } from "../../graphics/DatasetIcon";
+import { DatasetIcon } from "../../graphics/DatasetIcon";
 
 import useLoadRegistry from "../../queries/useLoadRegistry";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
@@ -36,31 +31,23 @@ const Index = () => {
   useDocumentTitle(`Saved Datasets | Feast`);
 
   return (
-    <React.Fragment>
-      <EuiPageHeader
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
         restrictWidth
-        iconType={DatasetIcon32}
+        iconType={DatasetIcon}
         pageTitle="Datasets"
       />
-      <EuiPageContent
-        hasBorder={false}
-        hasShadow={false}
-        paddingSize="none"
-        color="transparent"
-        borderRadius="none"
-      >
-        <EuiPageContentBody>
-          {isLoading && (
-            <p>
-              <EuiLoadingSpinner size="m" /> Loading
-            </p>
-          )}
-          {isError && <p>We encountered an error while loading.</p>}
-          {isSuccess && data && <DatasetsListingTable datasets={data} />}
-          {isSuccess && !data && <DatasetsIndexEmptyState />}
-        </EuiPageContentBody>
-      </EuiPageContent>
-    </React.Fragment>
+      <EuiPageTemplate.Section>
+        {isLoading && (
+          <p>
+            <EuiLoadingSpinner size="m" /> Loading
+          </p>
+        )}
+        {isError && <p>We encountered an error while loading.</p>}
+        {isSuccess && data && <DatasetsListingTable datasets={data} />}
+        {isSuccess && !data && <DatasetsIndexEmptyState />}
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
   );
 };
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1164,7 +1164,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
   integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
@@ -1177,6 +1177,13 @@
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
   dependencies:
     regenerator-runtime "^0.13.11"
+
+"@babel/runtime@^7.12.1", "@babel/runtime@^7.18.3", "@babel/runtime@^7.24.1":
+  version "7.25.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.6.tgz#9afc3289f7184d8d7f98b099884c26317b9264d2"
+  integrity sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
 
 "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
@@ -1268,66 +1275,88 @@
   dependencies:
     tslib "^1.9.3"
 
-"@elastic/eui@^55.0.1":
-  version "55.1.2"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-55.1.2.tgz#dd0b42f5b26c5800d6a9cb2d4c2fe1afce9d3f07"
-  integrity sha512-wwZz5KxMIMFlqEsoCRiQBJDc4CrluS1d0sCOmQ5lhIzKhYc91MdxnqCk2i6YkhL4sSDf2Y9KAEuMXa+uweOWUA==
+"@elastic/eui@^95.12.0":
+  version "95.12.0"
+  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-95.12.0.tgz#862f2be8b72248a62b40704b9e62f2f5d7d43853"
+  integrity sha512-SW4ru97FY2VitSqyCgURrM5OMk1W+Ww12b6S+VZN5ex50aNT296DfED/ByidlYaAoVihqjZuoB3HlQBBXydFpA==
   dependencies:
-    "@types/chroma-js" "^2.0.0"
-    "@types/lodash" "^4.14.160"
-    "@types/numeral" "^0.0.28"
-    "@types/react-beautiful-dnd" "^13.1.2"
-    "@types/react-input-autosize" "^2.2.1"
-    "@types/react-virtualized-auto-sizer" "^1.0.1"
-    "@types/react-window" "^1.8.5"
-    "@types/refractor" "^3.0.0"
-    "@types/resize-observer-browser" "^0.1.5"
-    "@types/vfile-message" "^2.0.0"
-    chroma-js "^2.1.0"
-    classnames "^2.2.6"
+    "@hello-pangea/dnd" "^16.6.0"
+    "@types/lodash" "^4.14.202"
+    "@types/numeral" "^2.0.5"
+    "@types/react-window" "^1.8.8"
+    "@types/refractor" "^3.4.0"
+    chroma-js "^2.4.2"
+    classnames "^2.5.1"
     lodash "^4.17.21"
-    mdast-util-to-hast "^10.0.0"
+    mdast-util-to-hast "^10.2.0"
     numeral "^2.0.6"
-    prop-types "^15.6.0"
-    react-beautiful-dnd "^13.1.0"
-    react-dropzone "^11.5.3"
-    react-element-to-jsx-string "^14.3.4"
-    react-focus-on "^3.5.4"
-    react-input-autosize "^3.0.0"
+    prop-types "^15.8.1"
+    react-dropzone "^11.7.1"
+    react-element-to-jsx-string "^15.0.0"
+    react-focus-on "^3.9.1"
     react-is "^17.0.2"
-    react-virtualized-auto-sizer "^1.0.6"
-    react-window "^1.8.6"
-    refractor "^3.5.0"
-    rehype-raw "^5.0.0"
-    rehype-react "^6.0.0"
+    react-remove-scroll-bar "^2.3.4"
+    react-virtualized-auto-sizer "^1.0.24"
+    react-window "^1.8.10"
+    refractor "^3.6.0"
+    rehype-raw "^5.1.0"
+    rehype-react "^6.2.1"
     rehype-stringify "^8.0.0"
     remark-breaks "^2.0.2"
     remark-emoji "^2.1.0"
-    remark-parse "^8.0.3"
-    remark-rehype "^8.0.0"
-    tabbable "^5.2.1"
+    remark-parse-no-trim "^8.0.4"
+    remark-rehype "^8.1.0"
+    tabbable "^5.3.3"
     text-diff "^1.0.1"
-    unified "^9.2.0"
+    unified "^9.2.2"
     unist-util-visit "^2.0.3"
     url-parse "^1.5.10"
     uuid "^8.3.0"
-    vfile "^4.2.0"
+    vfile "^4.2.1"
 
-"@emotion/cache@^11.7.1":
-  version "11.7.1"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.7.1.tgz#08d080e396a42e0037848214e8aa7bf879065539"
-  integrity sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==
+"@emotion/babel-plugin@^11.12.0":
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz#7b43debb250c313101b3f885eba634f1d723fcc2"
+  integrity sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==
   dependencies:
-    "@emotion/memoize" "^0.7.4"
-    "@emotion/sheet" "^1.1.0"
-    "@emotion/utils" "^1.0.0"
-    "@emotion/weak-memoize" "^0.2.5"
-    stylis "4.0.13"
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/serialize" "^1.2.0"
+    babel-plugin-macros "^3.1.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.2.0"
 
-"@emotion/hash@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
-  integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
+"@emotion/cache@^11.13.0":
+  version "11.13.1"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.13.1.tgz#fecfc54d51810beebf05bf2a161271a1a91895d7"
+  integrity sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==
+  dependencies:
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/sheet" "^1.4.0"
+    "@emotion/utils" "^1.4.0"
+    "@emotion/weak-memoize" "^0.4.0"
+    stylis "4.2.0"
+
+"@emotion/css@^11.13.0":
+  version "11.13.0"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.13.0.tgz#3b44f008ce782dafa7cecff75b263af174d0c702"
+  integrity sha512-BUk99ylT+YHl+W/HN7nv1RCTkDYmKKqa1qbvM/qLSQEg61gipuBF5Hptk/2/ERmX2DCv0ccuFGhz9i0KSZOqPg==
+  dependencies:
+    "@emotion/babel-plugin" "^11.12.0"
+    "@emotion/cache" "^11.13.0"
+    "@emotion/serialize" "^1.3.0"
+    "@emotion/sheet" "^1.4.0"
+    "@emotion/utils" "^1.4.0"
+
+"@emotion/hash@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
+  integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
 
 "@emotion/is-prop-valid@^1.1.0":
   version "1.2.0"
@@ -1336,64 +1365,75 @@
   dependencies:
     "@emotion/memoize" "^0.8.0"
 
-"@emotion/memoize@^0.7.4":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
-  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
-
 "@emotion/memoize@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
   integrity sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==
 
-"@emotion/react@^11.7.1":
-  version "11.7.1"
-  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.7.1.tgz#3f800ce9b20317c13e77b8489ac4a0b922b2fe07"
-  integrity sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==
+"@emotion/memoize@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.9.0.tgz#745969d649977776b43fc7648c556aaa462b4102"
+  integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
+
+"@emotion/react@^11.13.3":
+  version "11.13.3"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.13.3.tgz#a69d0de2a23f5b48e0acf210416638010e4bd2e4"
+  integrity sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==
   dependencies:
-    "@babel/runtime" "^7.13.10"
-    "@emotion/cache" "^11.7.1"
-    "@emotion/serialize" "^1.0.2"
-    "@emotion/sheet" "^1.1.0"
-    "@emotion/utils" "^1.0.0"
-    "@emotion/weak-memoize" "^0.2.5"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.12.0"
+    "@emotion/cache" "^11.13.0"
+    "@emotion/serialize" "^1.3.1"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.1.0"
+    "@emotion/utils" "^1.4.0"
+    "@emotion/weak-memoize" "^0.4.0"
     hoist-non-react-statics "^3.3.1"
 
-"@emotion/serialize@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
-  integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==
+"@emotion/serialize@^1.2.0", "@emotion/serialize@^1.3.0", "@emotion/serialize@^1.3.1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.3.2.tgz#e1c1a2e90708d5d85d81ccaee2dfeb3cc0cccf7a"
+  integrity sha512-grVnMvVPK9yUVE6rkKfAJlYZgo0cu3l9iMC77V7DW6E1DUIrU68pSEXRmFZFOFB1QFo57TncmOcvcbMDWsL4yA==
   dependencies:
-    "@emotion/hash" "^0.8.0"
-    "@emotion/memoize" "^0.7.4"
-    "@emotion/unitless" "^0.7.5"
-    "@emotion/utils" "^1.0.0"
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/unitless" "^0.10.0"
+    "@emotion/utils" "^1.4.1"
     csstype "^3.0.2"
 
-"@emotion/sheet@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
-  integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
+"@emotion/sheet@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.4.0.tgz#c9299c34d248bc26e82563735f78953d2efca83c"
+  integrity sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
 
 "@emotion/stylis@^0.8.4":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@^0.7.4", "@emotion/unitless@^0.7.5":
+"@emotion/unitless@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
+  integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
+
+"@emotion/unitless@^0.7.4":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
-"@emotion/utils@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
-  integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
+"@emotion/use-insertion-effect-with-fallbacks@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz#1a818a0b2c481efba0cf34e5ab1e0cb2dcb9dfaf"
+  integrity sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==
 
-"@emotion/weak-memoize@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
-  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
+"@emotion/utils@^1.4.0", "@emotion/utils@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.4.1.tgz#b3adbb43de12ee2149541c4f1337d2eb7774f0ad"
+  integrity sha512-BymCXzCG3r72VKJxaYVwOXATqXIZ85cuvg0YOUDxMGNrKc1DJRZk8MgV5wyXRyEayIMd4FuXJIUgTBXvDNW5cA==
+
+"@emotion/weak-memoize@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
+  integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
 "@eslint/eslintrc@^1.0.5":
   version "1.0.5"
@@ -1409,6 +1449,19 @@
     js-yaml "^4.1.0"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
+
+"@hello-pangea/dnd@^16.6.0":
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/@hello-pangea/dnd/-/dnd-16.6.0.tgz#7509639c7bd13f55e537b65a9dcfcd54e7c99ac7"
+  integrity sha512-vfZ4GydqbtUPXSLfAvKvXQ6xwRzIjUSjVU0Sx+70VOhc2xx6CdmJXJ8YhH70RpbTUGjxctslQTHul9sIOxCfFQ==
+  dependencies:
+    "@babel/runtime" "^7.24.1"
+    css-box-model "^1.2.1"
+    memoize-one "^6.0.0"
+    raf-schd "^4.0.3"
+    react-redux "^8.1.3"
+    redux "^4.2.1"
+    use-memo-one "^1.1.3"
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.3"
@@ -2167,11 +2220,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/chroma-js@^2.0.0":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@types/chroma-js/-/chroma-js-2.1.3.tgz#0b03d737ff28fad10eb884e0c6cedd5ffdc4ba0a"
-  integrity sha512-1xGPhoSGY1CPmXLCBcjVZSQinFjL26vlR8ZqprsBWiFyED4JacJJ9zHhh5aaUXqbY9B37mKQ73nlydVAXmr1+g==
-
 "@types/connect-history-api-fallback@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae"
@@ -2478,10 +2526,10 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/hoist-non-react-statics@^3.3.0":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
-  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz#dab7867ef789d87e2b4b0003c9d65c49cc44a494"
+  integrity sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==
   dependencies:
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
@@ -2553,10 +2601,10 @@
   resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
   integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
 
-"@types/lodash@^4.14.160":
-  version "4.14.178"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
-  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
+"@types/lodash@^4.14.202":
+  version "4.17.9"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.9.tgz#0dc4902c229f6b8e2ac5456522104d7b1a230290"
+  integrity sha512-w9iWudx1XWOHW5lQRS9iKpK/XuRhnN+0T7HvdCCd802FYkT1AMTnxndJHGrNJwRoRHkslGr4S29tjm1cT7x/7w==
 
 "@types/markdown-it@^12.2.3":
   version "12.2.3"
@@ -2598,10 +2646,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.21.tgz#474d7589a30afcf5291f59bd49cca9ad171ffde4"
   integrity sha512-Pf8M1XD9i1ksZEcCP8vuSNwooJ/bZapNmIzpmsMaL+jMI+8mEYU3PKvs+xDNuQcJWF/x24WzY4qxLtB0zNow9A==
 
-"@types/numeral@^0.0.28":
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/@types/numeral/-/numeral-0.0.28.tgz#e43928f0bda10b169b6f7ecf99e3ddf836b8ebe4"
-  integrity sha512-Sjsy10w6XFHDktJJdXzBJmoondAKW+LcGpRFH+9+zXEDj0cOH8BxJuZA9vUDSMAzU1YRJlsPKmZEEiTYDlICLw==
+"@types/numeral@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/numeral/-/numeral-2.0.5.tgz#388e5c4ff4b0e1787f130753cbbe83d3ba770858"
+  integrity sha512-kH8I7OSSwQu9DS9JYdFWbuvhVzvFRoCPCkGxNwoGgaPeDfEPJlcxNvEOypZhQ3XXHsGbfIuYcxcJxKUfJHnRfw==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -2643,13 +2691,6 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-beautiful-dnd@^13.1.2":
-  version "13.1.2"
-  resolved "https://registry.yarnpkg.com/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.2.tgz#510405abb09f493afdfd898bf83995dc6385c130"
-  integrity sha512-+OvPkB8CdE/bGdXKyIhc/Lm2U7UAYCCJgsqmopFmh9gbAudmslkI8eOrPDjg4JhwSE6wytz4a3/wRjKtovHVJg==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-dom@^17.0.9":
   version "17.0.11"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
@@ -2657,34 +2698,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-input-autosize@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@types/react-input-autosize/-/react-input-autosize-2.2.1.tgz#6a335212e7fce1e1a4da56ae2095c8c5c35fbfe6"
-  integrity sha512-RxzEjd4gbLAAdLQ92Q68/AC+TfsAKTc4evsArUH1aIShIMqQMIMjsxoSnwyjtbFTO/AGIW/RQI94XSdvOxCz/w==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-redux@^7.1.20":
-  version "7.1.22"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.22.tgz#0eab76a37ef477cc4b53665aeaf29cb60631b72a"
-  integrity sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==
-  dependencies:
-    "@types/hoist-non-react-statics" "^3.3.0"
-    "@types/react" "*"
-    hoist-non-react-statics "^3.3.0"
-    redux "^4.0.0"
-
-"@types/react-virtualized-auto-sizer@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz#b3187dae1dfc4c15880c9cfc5b45f2719ea6ebd4"
-  integrity sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-window@^1.8.5":
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.5.tgz#285fcc5cea703eef78d90f499e1457e9b5c02fc1"
-  integrity sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==
+"@types/react-window@^1.8.8":
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.8.tgz#c20645414d142364fbe735818e1c1e0a145696e3"
+  integrity sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==
   dependencies:
     "@types/react" "*"
 
@@ -2697,17 +2714,12 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/refractor@^3.0.0":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@types/refractor/-/refractor-3.0.2.tgz#2d42128d59f78f84d2c799ffc5ab5cadbcba2d82"
-  integrity sha512-2HMXuwGuOqzUG+KUTm9GDJCHl0LCBKsB5cg28ujEmVi/0qgTb6jOmkVSO5K48qXksyl2Fr3C0Q2VrgD4zbwyXg==
+"@types/refractor@^3.4.0":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@types/refractor/-/refractor-3.4.1.tgz#8b109804f77b3da8fad543d3f575fef1ece8835a"
+  integrity sha512-wYuorIiCTSuvRT9srwt+taF6mH/ww+SyN2psM0sjef2qW+sS8GmshgDGTEDgWB1sTVGgYVE6EK7dBA2MxQxibg==
   dependencies:
     "@types/prismjs" "*"
-
-"@types/resize-observer-browser@^0.1.5":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.6.tgz#d8e6c2f830e2650dc06fe74464472ff64b54a302"
-  integrity sha512-61IfTac0s9jvNtBCpyo86QeaN8qqpMGHdK0uGKCCIy2dt5/Yk84VduHIdWAcmkC5QvdkPL0p5eWYgUZtHKKUVg==
 
 "@types/resolve@1.17.1":
   version "1.17.1"
@@ -2784,12 +2796,10 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@types/vfile-message@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-2.0.0.tgz#690e46af0fdfc1f9faae00cd049cc888957927d5"
-  integrity sha512-GpTIuDpb9u4zIO165fUy9+fXcULdD8HFRNli04GehoMVbeNq7D6OBnqSmg3lxZnC+UvgUhEWKxdKiwYUkGltIw==
-  dependencies:
-    vfile-message "*"
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@types/ws@^8.2.2":
   version "8.2.2"
@@ -3236,12 +3246,12 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aria-hidden@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.1.3.tgz#bb48de18dc84787a3c6eee113709c473c64ec254"
-  integrity sha512-RhVWFtKH5BiGMycI72q2RAFMLQi8JP9bLuQXgR5a8Znp7P5KOIADSJeyfI8PCVxLEp067B2HbP5JIiI/PXIZeA==
+aria-hidden@^1.2.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.4.tgz#b78e383fdbc04d05762c78b4a25a501e736c4522"
+  integrity sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==
   dependencies:
-    tslib "^1.0.0"
+    tslib "^2.0.0"
 
 aria-query@^4.2.2:
   version "4.2.2"
@@ -3885,10 +3895,10 @@ chokidar@^3.4.2, chokidar@^3.5.2, chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chroma-js@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.3.0.tgz#fdf68a18d8f97ce006422338044218ccbffb9ecb"
-  integrity sha512-dRgAp9FHHy+VfE7e3/I5HHU0+zZlUHBODcjvXUXinsR/NnHCO+kfv68ofzrAqFI80q2IWvDSAmHAqHh93TGgKg==
+chroma-js@^2.4.2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.6.0.tgz#578743dd359698a75067a19fa5571dec54d0b70b"
+  integrity sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==
 
 chrome-trace-event@^1.0.2:
   version "1.0.3"
@@ -3905,10 +3915,10 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-classnames@^2.2.6:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
-  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+classnames@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
 
 clean-css@^5.2.2:
   version "5.2.4"
@@ -4126,6 +4136,11 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+convert-source-map@^1.5.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
+  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -4207,7 +4222,7 @@ css-blank-pseudo@^3.0.2:
   dependencies:
     postcss-selector-parser "^6.0.8"
 
-css-box-model@^1.2.0:
+css-box-model@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
   integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
@@ -5704,6 +5719,11 @@ find-cache-dir@^3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
 find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -5747,10 +5767,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-focus-lock@^0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.11.2.tgz#aeef3caf1cea757797ac8afdebaec8fd9ab243ed"
-  integrity sha512-pZ2bO++NWLHhiKkgP1bEXHhR1/OjVcSvlCJ98aNJDFeb7H5OOQaO+SKOZle6041O9rv2tmbrO4JzClAvDUHf0g==
+focus-lock@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-1.3.5.tgz#aa644576e5ec47d227b57eb14e1efb2abf33914c"
+  integrity sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==
   dependencies:
     tslib "^2.0.3"
 
@@ -7743,7 +7763,7 @@ mdast-util-definitions@^4.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
-mdast-util-to-hast@^10.0.0, mdast-util-to-hast@^10.2.0:
+mdast-util-to-hast@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz#61875526a017d8857b71abc9333942700b2d3604"
   integrity sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==
@@ -7796,10 +7816,15 @@ memfs@^3.4.3:
   dependencies:
     fs-monkey "^1.0.4"
 
-"memoize-one@>=3.1.1 <6", memoize-one@^5.1.1:
+"memoize-one@>=3.1.1 <6":
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -9068,10 +9093,10 @@ prismjs@~1.17.0:
   optionalDependencies:
     clipboard "^2.0.0"
 
-prismjs@~1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.25.0.tgz#6f822df1bdad965734b310b315a23315cf999756"
-  integrity sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==
+prismjs@~1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
+  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -9093,7 +9118,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -9198,7 +9223,7 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-raf-schd@^4.0.2:
+raf-schd@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
   integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
@@ -9243,19 +9268,6 @@ react-app-polyfill@^3.0.0:
     raf "^3.4.1"
     regenerator-runtime "^0.13.9"
     whatwg-fetch "^3.6.2"
-
-react-beautiful-dnd@^13.1.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.0.tgz#ec97c81093593526454b0de69852ae433783844d"
-  integrity sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-    css-box-model "^1.2.0"
-    memoize-one "^5.1.1"
-    raf-schd "^4.0.2"
-    react-redux "^7.2.0"
-    redux "^4.0.4"
-    use-memo-one "^1.1.1"
 
 react-clientside-effect@^1.2.6:
   version "1.2.6"
@@ -9313,7 +9325,7 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-dropzone@^11.5.3:
+react-dropzone@^11.7.1:
   version "11.7.1"
   resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.7.1.tgz#3851bb75b26af0bf1b17ce1449fd980e643b9356"
   integrity sha512-zxCMwhfPy1olUEbw3FLNPLhAm/HnaYH5aELIEglRbqabizKAdHs0h+WuyOpmA+v1JXn0++fpQDdNfUagWt5hJQ==
@@ -9322,61 +9334,63 @@ react-dropzone@^11.5.3:
     file-selector "^0.4.0"
     prop-types "^15.8.1"
 
-react-element-to-jsx-string@^14.3.4:
-  version "14.3.4"
-  resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.4.tgz#709125bc72f06800b68f9f4db485f2c7d31218a8"
-  integrity sha512-t4ZwvV6vwNxzujDQ+37bspnLwA4JlgUPWhLjBJWsNIDceAf6ZKUTCjdm08cN6WeZ5pTMKiCJkmAYnpmR4Bm+dg==
+react-element-to-jsx-string@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-15.0.0.tgz#1cafd5b6ad41946ffc8755e254da3fc752a01ac6"
+  integrity sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==
   dependencies:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
-    react-is "17.0.2"
+    react-is "18.1.0"
 
 react-error-overlay@^6.0.10:
   version "6.0.10"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.10.tgz#0fe26db4fa85d9dbb8624729580e90e7159a59a6"
   integrity sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==
 
-react-focus-lock@^2.9.0:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.1.tgz#094cfc19b4f334122c73bb0bff65d77a0c92dd16"
-  integrity sha512-pSWOQrUmiKLkffPO6BpMXN7SNKXMsuOakl652IBuALAu1esk+IcpJyM+ALcYzPTTFz1rD0R54aB9A4HuP5t1Wg==
+react-focus-lock@^2.11.3:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.13.2.tgz#e1addac2f8b9550bc0581f3c416755ba0f81f5ef"
+  integrity sha512-T/7bsofxYqnod2xadvuwjGKHOoL5GH7/EIPI5UyEvaU/c2CcphvGI371opFtuY/SYdbMsNiuF4HsHQ50nA/TKQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    focus-lock "^0.11.2"
+    focus-lock "^1.3.5"
     prop-types "^15.6.2"
     react-clientside-effect "^1.2.6"
-    use-callback-ref "^1.3.0"
+    use-callback-ref "^1.3.2"
     use-sidecar "^1.1.2"
 
-react-focus-on@^3.5.4:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.6.0.tgz#159e13082dad4ea1f07abe11254f0e981d5a7b79"
-  integrity sha512-onIRjpd9trAUenXNdDcvjc8KJUSklty4X/Gr7hAm/MzM7ekSF2pg9D8KBKL7ipige22IAPxLRRf/EmJji9KD6Q==
+react-focus-on@^3.9.1:
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/react-focus-on/-/react-focus-on-3.9.4.tgz#0b6c13273d86243c330d1aa53af39290f543da7b"
+  integrity sha512-NFKmeH6++wu8e7LJcbwV8TTd4L5w/U5LMXTMOdUcXhCcZ7F5VOvgeTHd4XN1PD7TNmdvldDu/ENROOykUQ4yQg==
   dependencies:
-    aria-hidden "^1.1.3"
-    react-focus-lock "^2.9.0"
-    react-remove-scroll "^2.5.2"
-    react-style-singleton "^2.2.0"
+    aria-hidden "^1.2.2"
+    react-focus-lock "^2.11.3"
+    react-remove-scroll "^2.6.0"
+    react-style-singleton "^2.2.1"
     tslib "^2.3.1"
-    use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
-react-input-autosize@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
-  integrity sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==
-  dependencies:
-    prop-types "^15.5.8"
-
-react-is@17.0.2, react-is@^17.0.1, react-is@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
-  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+react-is@18.1.0:
+  version "18.1.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.1.0.tgz#61aaed3096d30eacf2a2127118b5b41387d32a67"
+  integrity sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1, react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 react-query@^3.34.12:
   version "3.34.12"
@@ -9387,39 +9401,39 @@ react-query@^3.34.12:
     broadcast-channel "^3.4.1"
     match-sorter "^6.0.2"
 
-react-redux@^7.2.0:
-  version "7.2.6"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
-  integrity sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==
+react-redux@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.1.3.tgz#4fdc0462d0acb59af29a13c27ffef6f49ab4df46"
+  integrity sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==
   dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@types/react-redux" "^7.1.20"
+    "@babel/runtime" "^7.12.1"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/use-sync-external-store" "^0.0.3"
     hoist-non-react-statics "^3.3.2"
-    loose-envify "^1.4.0"
-    prop-types "^15.7.2"
-    react-is "^17.0.2"
+    react-is "^18.0.0"
+    use-sync-external-store "^1.0.0"
 
 react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-remove-scroll-bar@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.1.tgz#9f13b05b249eaa57c8d646c1ebb83006b3581f5f"
-  integrity sha512-IvGX3mJclEF7+hga8APZczve1UyGMkMG+tjS0o/U1iLgvZRpjFAQEUBJ4JETfvbNlfNnZnoDyWJCICkA15Mghg==
+react-remove-scroll-bar@^2.3.4, react-remove-scroll-bar@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz#3e585e9d163be84a010180b18721e851ac81a29c"
+  integrity sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==
   dependencies:
-    react-style-singleton "^2.2.0"
+    react-style-singleton "^2.2.1"
     tslib "^2.0.0"
 
-react-remove-scroll@^2.5.2:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.3.tgz#a152196e710e8e5811be39dc352fd8a90b05c961"
-  integrity sha512-NQ1bXrxKrnK5pFo/GhLkXeo3CrK5steI+5L+jynwwIemvZyfXqaL0L5BzwJd7CSwNCU723DZaccvjuyOdoy3Xw==
+react-remove-scroll@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz#fb03a0845d7768a4f1519a99fdb84983b793dc07"
+  integrity sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==
   dependencies:
-    react-remove-scroll-bar "^2.3.1"
-    react-style-singleton "^2.2.0"
-    tslib "^2.0.0"
+    react-remove-scroll-bar "^2.3.6"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
@@ -9493,10 +9507,10 @@ react-scripts@^5.0.0:
   optionalDependencies:
     fsevents "^2.3.2"
 
-react-style-singleton@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.0.tgz#70f45f5fef97fdb9a52eed98d1839fa6b9032b22"
-  integrity sha512-nK7mN92DMYZEu3cQcAhfwE48NpzO5RpxjG4okbSqRRbfal9Pk+fG2RdQXTMp+f6all1hB9LIJSt+j7dCYrU11g==
+react-style-singleton@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
+  integrity sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==
   dependencies:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
@@ -9513,15 +9527,15 @@ react-syntax-highlighter@^12.2.1:
     prismjs "^1.8.4"
     refractor "^2.4.1"
 
-react-virtualized-auto-sizer@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz#66c5b1c9278064c5ef1699ed40a29c11518f97ca"
-  integrity sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==
+react-virtualized-auto-sizer@^1.0.24:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.24.tgz#3ebdc92f4b05ad65693b3cc8e7d8dd54924c0227"
+  integrity sha512-3kCn7N9NEb3FlvJrSHWGQ4iVl+ydQObq2fHMn12i5wbtm74zHOPhz/i64OL3c1S1vi9i2GXtZqNqUJTQ+BnNfg==
 
-react-window@^1.8.6:
-  version "1.8.7"
-  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.7.tgz#5e9fd0d23f48f432d7022cdb327219353a15f0d4"
-  integrity sha512-JHEZbPXBpKMmoNO1bNhoXOOLg/ujhL/BU4IqVU9r8eQPcy5KQnGHIHDRkJ0ns9IM5+Aq5LNwt3j8t3tIrePQzA==
+react-window@^1.8.10:
+  version "1.8.10"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.10.tgz#9e6b08548316814b443f7002b1cf8fd3a1bdde03"
+  integrity sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
@@ -9578,10 +9592,10 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redux@^4.0.0, redux@^4.0.4:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
-  integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+redux@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
+  integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==
   dependencies:
     "@babel/runtime" "^7.9.2"
 
@@ -9594,14 +9608,14 @@ refractor@^2.4.1:
     parse-entities "^1.1.2"
     prismjs "~1.17.0"
 
-refractor@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.5.0.tgz#334586f352dda4beaf354099b48c2d18e0819aec"
-  integrity sha512-QwPJd3ferTZ4cSPPjdP5bsYHMytwWYnAN5EEnLtGvkqp/FCCnGsBgxrm9EuIDnjUC3Uc/kETtvVi7fSIVC74Dg==
+refractor@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-3.6.0.tgz#ac318f5a0715ead790fcfb0c71f4dd83d977935a"
+  integrity sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==
   dependencies:
     hastscript "^6.0.0"
     parse-entities "^2.0.0"
-    prismjs "~1.25.0"
+    prismjs "~1.27.0"
 
 regenerate-unicode-properties@^9.0.0:
   version "9.0.0"
@@ -9624,6 +9638,11 @@ regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
+  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regenerator-transform@^0.14.2:
   version "0.14.5"
@@ -9674,14 +9693,14 @@ regjsparser@^0.7.0:
   dependencies:
     jsesc "~0.5.0"
 
-rehype-raw@^5.0.0:
+rehype-raw@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-5.1.0.tgz#66d5e8d7188ada2d31bc137bc19a1000cf2c6b7e"
   integrity sha512-MDvHAb/5mUnif2R+0IPCYJU8WjHa9UzGtM/F4AVy5GixPlDZ1z3HacYy4xojDU+uBa+0X/3PIfyQI26/2ljJNA==
   dependencies:
     hast-util-raw "^6.1.0"
 
-rehype-react@^6.0.0:
+rehype-react@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/rehype-react/-/rehype-react-6.2.1.tgz#9b9bf188451ad6f63796b784fe1f51165c67b73a"
   integrity sha512-f9KIrjktvLvmbGc7si25HepocOg4z0MuNOtweigKzBcDjiGSTGhyz6VSgaV5K421Cq1O+z4/oxRJ5G9owo0KVg==
@@ -9717,10 +9736,10 @@ remark-emoji@^2.1.0:
     node-emoji "^1.10.0"
     unist-util-visit "^2.0.3"
 
-remark-parse@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-8.0.3.tgz#9c62aa3b35b79a486454c690472906075f40c7e1"
-  integrity sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==
+remark-parse-no-trim@^8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/remark-parse-no-trim/-/remark-parse-no-trim-8.0.4.tgz#f5c9531644284071d4a57a49e19a42ad4e8040bd"
+  integrity sha512-WtqeHNTZ0LSdyemmY1/G6y9WoEFblTtgckfKF5/NUnri919/0/dEu8RCDfvXtJvu96soMvT+mLWWgYVUaiHoag==
   dependencies:
     ccount "^1.0.0"
     collapse-white-space "^1.0.2"
@@ -9732,14 +9751,13 @@ remark-parse@^8.0.3:
     parse-entities "^2.0.0"
     repeat-string "^1.5.4"
     state-toggle "^1.0.0"
-    trim "0.0.1"
     trim-trailing-lines "^1.0.0"
     unherit "^1.0.4"
     unist-util-remove-position "^2.0.0"
     vfile-location "^3.0.0"
     xtend "^4.0.1"
 
-remark-rehype@^8.0.0:
+remark-rehype@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/remark-rehype/-/remark-rehype-8.1.0.tgz#610509a043484c1e697437fa5eb3fd992617c945"
   integrity sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==
@@ -10266,7 +10284,7 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, sourc
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.5.0, source-map@^0.5.3:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -10544,10 +10562,10 @@ stylehacks@^5.0.2:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
 
-stylis@4.0.13:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
-  integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
+stylis@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
+  integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
@@ -10644,10 +10662,10 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tabbable@^5.2.1:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.2.tgz#66d6119ee8a533634c3f17deb0caa1c379e36ac7"
-  integrity sha512-6G/8EWRFx8CiSe2++/xHhXkmCRq2rHtDtZbQFHx34cvDfZzIBfvwG9zGUNTWMXWLCYvDj3aQqOzdl3oCxKuBkQ==
+tabbable@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.3.tgz#aac0ff88c73b22d6c3c5a50b1586310006b47fbf"
+  integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
 
 taffydb@2.6.2:
   version "2.6.2"
@@ -10874,11 +10892,6 @@ trim-trailing-lines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
-  integrity sha1-WFhUf2spB1fulczMZm+1AITEYN0=
-
 trough@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
@@ -10899,7 +10912,7 @@ tsconfig-paths@^3.12.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.0.0, tslib@^1.8.1, tslib@^1.9.3:
+tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -10975,10 +10988,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.4.2:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -11036,7 +11049,7 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
   integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
 
-unified@^9.2.0:
+unified@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
   integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==
@@ -11093,13 +11106,6 @@ unist-util-stringify-position@^2.0.0:
   integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
   dependencies:
     "@types/unist" "^2.0.2"
-
-unist-util-stringify-position@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz#d517d2883d74d0daa0b565adc3d10a02b4a8cde9"
-  integrity sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==
-  dependencies:
-    "@types/unist" "^2.0.0"
 
 unist-util-visit-parents@^2.0.0:
   version "2.1.2"
@@ -11200,10 +11206,17 @@ use-callback-ref@^1.3.0:
   dependencies:
     tslib "^2.0.0"
 
-use-memo-one@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.2.tgz#0c8203a329f76e040047a35a1197defe342fab20"
-  integrity sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==
+use-callback-ref@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.2.tgz#6134c7f6ff76e2be0b56c809b17a650c942b1693"
+  integrity sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==
+  dependencies:
+    tslib "^2.0.0"
+
+use-memo-one@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
+  integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
 use-query-params@^1.2.3:
   version "1.2.3"
@@ -11219,6 +11232,11 @@ use-sidecar@^1.1.2:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+use-sync-external-store@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
+  integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
@@ -11274,14 +11292,6 @@ vfile-location@^3.0.0, vfile-location@^3.2.0:
   resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-3.2.0.tgz#d8e41fbcbd406063669ebf6c33d56ae8721d0f3c"
   integrity sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==
 
-vfile-message@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-3.1.0.tgz#5437035aa43185ff4b9210d32fada6c640e59143"
-  integrity sha512-4QJbBk+DkPEhBXq3f260xSaWtjE4gPKOfulzfMFF8ZNwaPZieWsg3iVlcmF04+eebzpcpeXOOFMfrYzJHVYg+g==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-stringify-position "^3.0.0"
-
 vfile-message@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.4.tgz#5b43b88171d409eae58477d13f23dd41d52c371a"
@@ -11290,7 +11300,7 @@ vfile-message@^2.0.0:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^2.0.0"
 
-vfile@^4.0.0, vfile@^4.2.0:
+vfile@^4.0.0, vfile@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.2.1.tgz#03f1dce28fc625c625bc6514350fbdb00fa9e624"
   integrity sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==


### PR DESCRIPTION
# What this PR does / why we need it:

Updates the Elastic UI framework to almost its latest version 95.12.0. The current version 55.0.1 is over 2 years old and doesn't support React 18, which the latest versions do. Good to update its peer dependency @emotion/react to the latest version at the same time.

Note: 95.12.0 was the latest version when I started doing the upgrade, but I noticed version 96 was just released the other day. But when I tried updating to that, I got some mysterious TypeScript errors and decided to leave it; this has already been quite an effort so I just want to get it done. 😅

The UI looks mostly the same as before. The most notable change is that the main content panel now stretches to the bottom of the page. It's possible to avoid that, but it's the default and personally I prefer it. There are some changes in the spacing too, and in how the tag-like elements look. I tried checking all possible pages, but please click around and report anything that looks off.

One notable difference: In on-demand feature views, we have title elements that are also links, and they lost their blue link color in the update due to it being overridden with the title styles. Overriding that would require some extra effort with theme providers etc., and is doable but might not be worth the effort. Here's what I'm talking about:

<details>
<summary>Before/after screenshots of on-demand feature view</summary>

**Before**
![on-demand-feature-view-before](https://github.com/user-attachments/assets/09ef92f4-58ec-4710-bfe0-bdcf6dbeb1eb)
**After**
<img width="1505" alt="on-demand-feature-view-after" src="https://github.com/user-attachments/assets/5ac4b780-e77b-4778-b8ec-a33bb6567f64">
</details>

## More before/after screenshots

<details>
<summary>Landing page</summary>

**Before**
![landing-page-before](https://github.com/user-attachments/assets/afa5c0f1-d083-42a9-9ef0-6f1869ffd58e)
**After**
![landing-page-after](https://github.com/user-attachments/assets/f959eb48-6669-47cd-bbc9-6e6d0ac986a7)
</details>

<details>
<summary>Project overview</summary>

**Before**
![project-overview-before](https://github.com/user-attachments/assets/85c5efad-5371-4cdb-b0cd-0e8abadfda0b)
**After**
![project-overview-after](https://github.com/user-attachments/assets/a4f9ba98-7926-47ac-8a0d-6342152acb29)
</details>

<details>
<summary>Loading state</summary>

**Before**
![loading-state-before](https://github.com/user-attachments/assets/ec7402f6-83dd-4b36-9c1d-058c3cbc623f)
**After**
![loading-state-after](https://github.com/user-attachments/assets/42ec4873-22ac-45f9-95d0-f05477dfead9)
</details>

<details>
<summary>Data source</summary>

**Before**
<img width="1505" alt="data-source-before" src="https://github.com/user-attachments/assets/581e5b8d-ad08-4633-b590-622abe412c77">
**After**
<img width="1505" alt="data-source-after" src="https://github.com/user-attachments/assets/ab0c9694-7242-4174-be7a-648f0d51d92b">
</details>


<details>
<summary>Feature service</summary>

**Before**
![feature-service-before](https://github.com/user-attachments/assets/01efe3ff-1d44-4d7f-b24f-92ca88ba44b1)
**After**
![feature-service-after](https://github.com/user-attachments/assets/75661999-df50-4aa6-85c6-df9d61398a4d)
</details>

# Which issue(s) this PR fixes:

There's a related issue #3784 about upgrading to React 18, this is one step towards enabling it.

# Misc

This is a potentially breaking change: If you are using @feast-dev/feast-ui as module in a React app that also uses @elastic/eui, you should update it to a compatible version. If you use @elastic/eui components that have been renamed or replaced with others, you'll need to update your code accordingly. I tested this with my example React app, and didn't notice any problems with the new version.

There are many kinds of changes, so below is a summary to help with the review. I took initial inspiration from https://github.com/elastic/kibana/issues/161418 and then went through the [Elastic UI docs](https://eui.elastic.co/#/) when needed.

## Other dependency changes

- @emotion/css is now a peer dependency of @elastic/eui, so we need to add it to our dependencies.
- prop-types is no longer a peer dependency of @elastic/eui, so we can remove it from our dependencies.
- typescript needed an upgrade for TypeScript compilation to work in the `build:lib` script; it failed due to a syntax error in @types/lodash (dependency of @elastic/eui). Unfortunately this typescript version isn't within the version range of @elastic/eui's peer dependencies, but that one seems overly strict, especially since this version seems to work. Unfortunately this also introduces a temporarily-visible warning in the `yarn start` output about the typescript version being newer than what ESLint supports, but again, everything seems fine. And to be honest, I don't know what else to do, this has been quite a challenge to get somehow working. 😓

## Code changes

- EuiLoadingContent has been replaced with EuiSkeletonText.
- EuiPageContent and EuiPageContentBody have been replaced with EuiPageTemplate, EuiPageTemplate.Header and EuiPageTemplate.Section.
- EuiSideNav no longer takes a style prop, so it is dropped; the width seems fine without it.
- EuiBasicTable now requires the field prop in its columns, and only takes objects in its items.
- The `panelled` prop has been moved from Layout's EuiPageBody to each page's EuiPageTemplate, so that the page template's header gets the wanted background color.
- The `sticky` prop passed to Layout's EuiPageSidebar needs to be an object with an offset, otherwise the offset is read from --euiFixedHeadersOffset that is unset if there is no fixed EuiHeader on the page.
- Icons: Static class names no longer work for proper styling, we need to pass at least the className prop to the svg element. Passing all props allows possible other props to work too. Also, we no longer need separate components for differently sized icons (16, 32).
- Some overview tab contents are wrapped in an additional EuiFlexGroup to add gaps between sections; they previously appeared through some component margins but not anymore.
- Jest failed to parse chroma-js sources, probably something to do with it being an ES module (its support in Jest is limited: https://jest-archive-august-2023.netlify.app/docs/27.x/ecmascript-modules), so we use the build version of chroma-js with Jest, similarly to d3.