### PR TITLE
chore: Ignore generated protos.js file in ESLint (Feast UI)

### DIFF
--- a/ui/.eslintignore
+++ b/ui/.eslintignore
@@ -1,0 +1,1 @@
+src/protos.js


### PR DESCRIPTION
# What this PR does / why we need it:

We see lots of ESLint warnings from the generated protos.js file when running `yarn start` in the `ui` directory. No need to lint generated files, so add that file to ESLint's ignore list.

# Which issue(s) this PR fixes:

At the end of `yarn start` output, you currently see these warnings:
```sh
WARNING in src/protos.js
  Line 2:1:        'use strict' is unnecessary inside of modules                                                 strict
  Line 779:44:     Unexpected mix of '&&' and '||'. Use parentheses to clarify the intended order of operations  no-mixed-operators
  Line 779:91:     Unexpected mix of '&&' and '||'. Use parentheses to clarify the intended order of operations  no-mixed-operators
  Line 835:21:     Nested block is redundant                                                                     no-lone-blocks
  Line 845:21:     Nested block is redundant                                                                     no-lone-blocks
  Line 855:21:     Nested block is redundant                                                                     no-lone-blocks
  Line 865:21:     Nested block is redundant                                                                     no-lone-blocks
  Line 875:21:     Nested block is redundant                                                                     no-lone-blocks
  Line 885:21:     Nested block is redundant                                                                     no-lone-blocks
  Line 895:21:     Nested block is redundant                                                                     no-lone-blocks
  Line 905:21:     Nested block is redundant                                                                     no-lone-blocks
[...]
  Line 47563:41:   Unexpected mix of '&&' and '||'. Use parentheses to clarify the intended order of operations  no-mixed-operators
  Line 47563:85:   Unexpected mix of '&&' and '||'. Use parentheses to clarify the intended order of operations  no-mixed-operators

webpack 5.94.0 compiled with 1 warning in 21989 ms
No issues found.
```

After this change, there are no warnings:
```sh
webpack 5.94.0 compiled successfully in 5783 ms
```