### PR TITLE
fix: _python_value_to_proto_value does not handle list values

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -372,11 +372,15 @@ def _python_value_to_proto_value(
                 if feast_value_type == ValueType.BYTES_LIST:
                     raise _type_err(sample, ValueType.BYTES_LIST)
 
-                json_value = json.loads(sample)
-                if isinstance(json_value, list):
+                json_sample = json.loads(sample)
+                if isinstance(json_sample, list):
+                    json_values = [json.loads(value) for value in values]
                     if feast_value_type == ValueType.BOOL_LIST:
-                        json_value = [bool(item) for item in json_value]
-                    return [ProtoValue(**{field_name: proto_type(val=json_value)})]  # type: ignore
+                        json_values = [bool(item) for item in json_values]
+                    return [
+                        ProtoValue(**{field_name: proto_type(val=v)})  # type: ignore
+                        for v in json_values
+                    ]
                 raise _type_err(sample, valid_types[0])
 
             if sample is not None and not all(
@@ -506,7 +510,14 @@ def python_values_to_proto_values(
     if value_type == ValueType.UNKNOWN:
         raise TypeError("Couldn't infer value type from empty value")
 
-    return _python_value_to_proto_value(value_type, values)
+    proto_values = _python_value_to_proto_value(value_type, values)
+
+    if len(proto_values) != len(values):
+        raise ValueError(
+            f"Number of proto values {len(proto_values)} does not match number of values {len(values)}"
+        )
+
+    return proto_values
 
 
 def _proto_value_to_value_type(proto_value: ProtoValue) -> ValueType:


### PR DESCRIPTION
# What this PR does / why we need it:

Currently, _python_value_to_proto_value does not properly handle lists. It will always return a list of values of length one, regardless of the number of input values.
