### PR TITLE
feat: Add boto3 session based auth for dynamodb online store for cross account access

### DIFF
--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -473,6 +473,7 @@ def _initialize_dynamodb_client(
     endpoint_url: Optional[str] = None,
     session_based_auth: Optional[bool] = False,
 ):
+
     if session_based_auth:
         return boto3.Session().client(
             "dynamodb",

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -473,7 +473,6 @@ def _initialize_dynamodb_client(
     endpoint_url: Optional[str] = None,
     session_based_auth: Optional[bool] = False,
 ):
-
     if session_based_auth:
         return boto3.Session().client(
             "dynamodb",

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -73,6 +73,7 @@ class DynamoDBOnlineStoreConfig(FeastConfigBaseModel):
     session_based_auth: bool = False
     """AWS session based client authentication"""
 
+
 class DynamoDBOnlineStore(OnlineStore):
     """
     AWS DynamoDB implementation of the online store interface.
@@ -106,10 +107,14 @@ class DynamoDBOnlineStore(OnlineStore):
         online_config = config.online_store
         assert isinstance(online_config, DynamoDBOnlineStoreConfig)
         dynamodb_client = self._get_dynamodb_client(
-            online_config.region, online_config.endpoint_url, online_config.session_based_auth
+            online_config.region,
+            online_config.endpoint_url,
+            online_config.session_based_auth,
         )
         dynamodb_resource = self._get_dynamodb_resource(
-            online_config.region, online_config.endpoint_url, online_config.session_based_auth
+            online_config.region,
+            online_config.endpoint_url,
+            online_config.session_based_auth,
         )
         # Add Tags attribute to creation request only if configured to prevent
         # TagResource permission issues, even with an empty Tags array.
@@ -168,7 +173,9 @@ class DynamoDBOnlineStore(OnlineStore):
         online_config = config.online_store
         assert isinstance(online_config, DynamoDBOnlineStoreConfig)
         dynamodb_resource = self._get_dynamodb_resource(
-            online_config.region, online_config.endpoint_url, online_config.session_based_auth
+            online_config.region,
+            online_config.endpoint_url,
+            online_config.session_based_auth,
         )
 
         for table in tables:
@@ -203,7 +210,9 @@ class DynamoDBOnlineStore(OnlineStore):
         online_config = config.online_store
         assert isinstance(online_config, DynamoDBOnlineStoreConfig)
         dynamodb_resource = self._get_dynamodb_resource(
-            online_config.region, online_config.endpoint_url, online_config.session_based_auth
+            online_config.region,
+            online_config.endpoint_url,
+            online_config.session_based_auth,
         )
 
         table_instance = dynamodb_resource.Table(
@@ -230,7 +239,9 @@ class DynamoDBOnlineStore(OnlineStore):
         assert isinstance(online_config, DynamoDBOnlineStoreConfig)
 
         dynamodb_resource = self._get_dynamodb_resource(
-            online_config.region, online_config.endpoint_url, online_config.session_based_auth
+            online_config.region,
+            online_config.endpoint_url,
+            online_config.session_based_auth,
         )
         table_instance = dynamodb_resource.Table(
             _get_table_name(online_config, config, table)
@@ -325,12 +336,24 @@ class DynamoDBOnlineStore(OnlineStore):
     def _get_aiodynamodb_client(self, region: str):
         return self._get_aioboto_session().create_client("dynamodb", region_name=region)
 
-    def _get_dynamodb_client(self, region: str, endpoint_url: Optional[str] = None, session_based_auth: Optional[bool] = False):
+    def _get_dynamodb_client(
+        self,
+        region: str,
+        endpoint_url: Optional[str] = None,
+        session_based_auth: Optional[bool] = False,
+    ):
         if self._dynamodb_client is None:
-            self._dynamodb_client = _initialize_dynamodb_client(region, endpoint_url, session_based_auth)
+            self._dynamodb_client = _initialize_dynamodb_client(
+                region, endpoint_url, session_based_auth
+            )
         return self._dynamodb_client
 
-    def _get_dynamodb_resource(self, region: str, endpoint_url: Optional[str] = None, session_based_auth: Optional[bool] = False):
+    def _get_dynamodb_resource(
+        self,
+        region: str,
+        endpoint_url: Optional[str] = None,
+        session_based_auth: Optional[bool] = False,
+    ):
         if self._dynamodb_resource is None:
             self._dynamodb_resource = _initialize_dynamodb_resource(
                 region, endpoint_url, session_based_auth
@@ -445,8 +468,11 @@ class DynamoDBOnlineStore(OnlineStore):
         }
 
 
-def _initialize_dynamodb_client(region: str, endpoint_url: Optional[str] = None, session_based_auth: Optional[bool] = False):
-
+def _initialize_dynamodb_client(
+    region: str,
+    endpoint_url: Optional[str] = None,
+    session_based_auth: Optional[bool] = False,
+):
     if session_based_auth is True:
         return boto3.Session().client(
             "dynamodb",
@@ -459,18 +485,21 @@ def _initialize_dynamodb_client(region: str, endpoint_url: Optional[str] = None,
             "dynamodb",
             region_name=region,
             endpoint_url=endpoint_url,
-            config=Config(user_agent=get_user_agent())
-
+            config=Config(user_agent=get_user_agent()),
         )
 
 
-def _initialize_dynamodb_resource(region: str, endpoint_url: Optional[str] = None, session_based_auth: Optional[bool] = False):
+def _initialize_dynamodb_resource(
+    region: str,
+    endpoint_url: Optional[str] = None,
+    session_based_auth: Optional[bool] = False,
+):
     if session_based_auth is True:
-        return boto3.Session().resource("dynamodb", region_name=region, endpoint_url=endpoint_url)
+        return boto3.Session().resource(
+            "dynamodb", region_name=region, endpoint_url=endpoint_url
+        )
     else:
         return boto3.resource("dynamodb", region_name=region, endpoint_url=endpoint_url)
-
-
 
 
 # TODO(achals): This form of user-facing templating is experimental.

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -70,6 +70,8 @@ class DynamoDBOnlineStoreConfig(FeastConfigBaseModel):
     tags: Union[Dict[str, str], None] = None
     """AWS resource tags added to each table"""
 
+    session_based_auth: bool = False
+    """AWS session based client authentication"""
 
 class DynamoDBOnlineStore(OnlineStore):
     """
@@ -104,10 +106,10 @@ class DynamoDBOnlineStore(OnlineStore):
         online_config = config.online_store
         assert isinstance(online_config, DynamoDBOnlineStoreConfig)
         dynamodb_client = self._get_dynamodb_client(
-            online_config.region, online_config.endpoint_url
+            online_config.region, online_config.endpoint_url, online_config.session_based_auth
         )
         dynamodb_resource = self._get_dynamodb_resource(
-            online_config.region, online_config.endpoint_url
+            online_config.region, online_config.endpoint_url, online_config.session_based_auth
         )
         # Add Tags attribute to creation request only if configured to prevent
         # TagResource permission issues, even with an empty Tags array.
@@ -166,7 +168,7 @@ class DynamoDBOnlineStore(OnlineStore):
         online_config = config.online_store
         assert isinstance(online_config, DynamoDBOnlineStoreConfig)
         dynamodb_resource = self._get_dynamodb_resource(
-            online_config.region, online_config.endpoint_url
+            online_config.region, online_config.endpoint_url, online_config.session_based_auth
         )
 
         for table in tables:
@@ -201,7 +203,7 @@ class DynamoDBOnlineStore(OnlineStore):
         online_config = config.online_store
         assert isinstance(online_config, DynamoDBOnlineStoreConfig)
         dynamodb_resource = self._get_dynamodb_resource(
-            online_config.region, online_config.endpoint_url
+            online_config.region, online_config.endpoint_url, online_config.session_based_auth
         )
 
         table_instance = dynamodb_resource.Table(
@@ -228,7 +230,7 @@ class DynamoDBOnlineStore(OnlineStore):
         assert isinstance(online_config, DynamoDBOnlineStoreConfig)
 
         dynamodb_resource = self._get_dynamodb_resource(
-            online_config.region, online_config.endpoint_url
+            online_config.region, online_config.endpoint_url, online_config.session_based_auth
         )
         table_instance = dynamodb_resource.Table(
             _get_table_name(online_config, config, table)
@@ -323,15 +325,15 @@ class DynamoDBOnlineStore(OnlineStore):
     def _get_aiodynamodb_client(self, region: str):
         return self._get_aioboto_session().create_client("dynamodb", region_name=region)
 
-    def _get_dynamodb_client(self, region: str, endpoint_url: Optional[str] = None):
+    def _get_dynamodb_client(self, region: str, endpoint_url: Optional[str] = None, session_based_auth: Optional[bool] = False):
         if self._dynamodb_client is None:
-            self._dynamodb_client = _initialize_dynamodb_client(region, endpoint_url)
+            self._dynamodb_client = _initialize_dynamodb_client(region, endpoint_url, session_based_auth)
         return self._dynamodb_client
 
-    def _get_dynamodb_resource(self, region: str, endpoint_url: Optional[str] = None):
+    def _get_dynamodb_resource(self, region: str, endpoint_url: Optional[str] = None, session_based_auth: Optional[bool] = False):
         if self._dynamodb_resource is None:
             self._dynamodb_resource = _initialize_dynamodb_resource(
-                region, endpoint_url
+                region, endpoint_url, session_based_auth
             )
         return self._dynamodb_resource
 
@@ -443,17 +445,32 @@ class DynamoDBOnlineStore(OnlineStore):
         }
 
 
-def _initialize_dynamodb_client(region: str, endpoint_url: Optional[str] = None):
-    return boto3.client(
-        "dynamodb",
-        region_name=region,
-        endpoint_url=endpoint_url,
-        config=Config(user_agent=get_user_agent()),
-    )
+def _initialize_dynamodb_client(region: str, endpoint_url: Optional[str] = None, session_based_auth: Optional[bool] = False):
+
+    if session_based_auth is True:
+        return boto3.Session().client(
+            "dynamodb",
+            region_name=region,
+            endpoint_url=endpoint_url,
+            config=Config(user_agent=get_user_agent()),
+        )
+    else:
+        return boto3.client(
+            "dynamodb",
+            region_name=region,
+            endpoint_url=endpoint_url,
+            config=Config(user_agent=get_user_agent())
+
+        )
 
 
-def _initialize_dynamodb_resource(region: str, endpoint_url: Optional[str] = None):
-    return boto3.resource("dynamodb", region_name=region, endpoint_url=endpoint_url)
+def _initialize_dynamodb_resource(region: str, endpoint_url: Optional[str] = None, session_based_auth: Optional[bool] = False):
+    if session_based_auth is True:
+        return boto3.Session().resource("dynamodb", region_name=region, endpoint_url=endpoint_url)
+    else:
+        return boto3.resource("dynamodb", region_name=region, endpoint_url=endpoint_url)
+
+
 
 
 # TODO(achals): This form of user-facing templating is experimental.

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -473,7 +473,7 @@ def _initialize_dynamodb_client(
     endpoint_url: Optional[str] = None,
     session_based_auth: Optional[bool] = False,
 ):
-    if session_based_auth is True:
+    if session_based_auth:
         return boto3.Session().client(
             "dynamodb",
             region_name=region,

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -494,7 +494,7 @@ def _initialize_dynamodb_resource(
     endpoint_url: Optional[str] = None,
     session_based_auth: Optional[bool] = False,
 ):
-    if session_based_auth is True:
+    if session_based_auth:
         return boto3.Session().resource(
             "dynamodb", region_name=region, endpoint_url=endpoint_url
         )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Hi Team,

This PR enables feast to create aws client from either current session or using default boto3.client. This will enable feast to use dynamodb in a cross account setup i.e if feast is running in account A and want to use dynamodb in account B, right now it dosen't offers that and creates a default client which is limits the usage of feast.

# Which issue(s) this PR fixes:
https://github.com/feast-dev/feast/issues/4605


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
