### PR TITLE
chore: Updated tests to confirm behavior of inconsistent offline/online return values

### DIFF
--- a/sdk/python/tests/unit/test_on_demand_python_transformation.py
+++ b/sdk/python/tests/unit/test_on_demand_python_transformation.py
@@ -228,6 +228,7 @@ class TestOnDemandPythonTransformation(unittest.TestCase):
                     python_view,
                     python_demo_view,
                     driver_stats_entity_less_fv,
+                    python_stored_writes_feature_view,
                 ]
             )
             self.store.write_to_online_store(

--- a/sdk/python/tests/unit/test_on_demand_python_transformation.py
+++ b/sdk/python/tests/unit/test_on_demand_python_transformation.py
@@ -228,7 +228,6 @@ class TestOnDemandPythonTransformation(unittest.TestCase):
                     python_view,
                     python_demo_view,
                     driver_stats_entity_less_fv,
-                    python_stored_writes_feature_view,
                 ]
             )
             self.store.write_to_online_store(
@@ -425,6 +424,13 @@ class TestOnDemandPythonTransformationAllDataTypes(unittest.TestCase):
                     Field(name="avg_daily_trip_rank_names", dtype=Array(String)),
                 ],
             )
+            input_request = RequestSource(
+                name="vals_to_add",
+                schema=[
+                    Field(name="val_to_add", dtype=Int64),
+                    Field(name="val_to_add_2", dtype=Int64),
+                ],
+            )
 
             @on_demand_feature_view(
                 sources=[request_source, driver_stats_fv],
@@ -476,8 +482,37 @@ class TestOnDemandPythonTransformationAllDataTypes(unittest.TestCase):
                 output["achieved_ranks"] = ranks
                 return output
 
+            @on_demand_feature_view(
+                sources=[
+                    driver_stats_fv,
+                    input_request,
+                ],
+                schema=[
+                    Field(name="conv_rate_plus_val1", dtype=Float64),
+                    Field(name="conv_rate_plus_val2", dtype=Float64),
+                ],
+                mode="pandas",
+            )
+            def pandas_view(features_df: pd.DataFrame) -> pd.DataFrame:
+                df = pd.DataFrame()
+                df["conv_rate_plus_val1"] = (
+                    features_df["conv_rate"] + features_df["val_to_add"]
+                )
+                df["conv_rate_plus_val2"] = (
+                    features_df["conv_rate"] + features_df["val_to_add_2"]
+                )
+                return df
+
             self.store.apply(
-                [driver, driver_stats_source, driver_stats_fv, python_view]
+                [
+                    driver,
+                    driver_stats_source,
+                    driver_stats_fv,
+                    python_view,
+                    pandas_view,
+                    input_request,
+                    request_source,
+                ]
             )
             fv_applied = self.store.get_feature_view("driver_hourly_stats")
             assert fv_applied.entities == [driver.name]
@@ -487,6 +522,98 @@ class TestOnDemandPythonTransformationAllDataTypes(unittest.TestCase):
             self.store.write_to_online_store(
                 feature_view_name="driver_hourly_stats", df=driver_df
             )
+
+            batch_sample = pd.DataFrame(driver_entities, columns=["driver_id"])
+            batch_sample["val_to_add"] = 0
+            batch_sample["val_to_add_2"] = 1
+            batch_sample["event_timestamp"] = start_date
+            batch_sample["created"] = start_date
+
+            resp = self.store.get_historical_features(
+                entity_df=pd.DataFrame(batch_sample),
+                features=[
+                    "driver_hourly_stats:conv_rate",
+                    "driver_hourly_stats:acc_rate",
+                    "driver_hourly_stats:avg_daily_trips",
+                    "pandas_view:conv_rate_plus_val1",
+                    "pandas_view:conv_rate_plus_val2",
+                ],
+            ).to_df()
+            assert resp is not None
+            assert resp["conv_rate_plus_val1"].isnull().sum() == 0
+
+            # Now testing feature retrieval for driver ids not in the dataset
+            missing_batch_sample = pd.DataFrame([1234567890], columns=["driver_id"])
+            missing_batch_sample["val_to_add"] = 0
+            missing_batch_sample["val_to_add_2"] = 1
+            missing_batch_sample["event_timestamp"] = start_date
+            missing_batch_sample["created"] = start_date
+            resp_offline = self.store.get_historical_features(
+                entity_df=pd.DataFrame(missing_batch_sample),
+                features=[
+                    "driver_hourly_stats:conv_rate",
+                    "driver_hourly_stats:acc_rate",
+                    "driver_hourly_stats:avg_daily_trips",
+                    "pandas_view:conv_rate_plus_val1",
+                    "pandas_view:conv_rate_plus_val2",
+                ],
+            ).to_df()
+            assert resp_offline is not None
+            assert resp_offline["conv_rate_plus_val1"].isnull().sum() == 1
+            assert sorted(resp_offline.columns) == [
+                "acc_rate",
+                "avg_daily_trips",
+                "conv_rate",
+                "conv_rate_plus_val1",
+                "conv_rate_plus_val2",
+                "created__",
+                "driver_id",
+                "event_timestamp",
+                # It should not have the items below
+                "val_to_add",
+                "val_to_add_2",
+            ]
+            with pytest.raises(TypeError):
+                _ = self.store.get_online_features(
+                    entity_rows=[
+                        {"driver_id": 1234567890, "val_to_add": 0, "val_to_add_2": 1}
+                    ],
+                    features=[
+                        "driver_hourly_stats:conv_rate",
+                        "driver_hourly_stats:acc_rate",
+                        "driver_hourly_stats:avg_daily_trips",
+                        "pandas_view:conv_rate_plus_val1",
+                        "pandas_view:conv_rate_plus_val2",
+                    ],
+                )
+            resp_online = self.store.get_online_features(
+                entity_rows=[{"driver_id": 1001, "val_to_add": 0, "val_to_add_2": 1}],
+                features=[
+                    "driver_hourly_stats:conv_rate",
+                    "driver_hourly_stats:acc_rate",
+                    "driver_hourly_stats:avg_daily_trips",
+                    "pandas_view:conv_rate_plus_val1",
+                    "pandas_view:conv_rate_plus_val2",
+                ],
+            ).to_df()
+            assert resp_online is not None
+            assert sorted(resp_online.columns) == [
+                "acc_rate",
+                "avg_daily_trips",
+                "conv_rate",
+                "conv_rate_plus_val1",
+                "conv_rate_plus_val2",
+                "driver_id",
+                # It does not have the items below
+                # "created__",
+                # "event_timestamp",
+                # "val_to_add",
+                # "val_to_add_2",
+            ]
+            assert sorted(resp_online.columns) != sorted(resp_offline.columns)
+
+    def test_setup(self):
+        pass
 
     def test_python_transformation_returning_all_data_types(self):
         entity_rows = [

--- a/sdk/python/tests/unit/test_on_demand_python_transformation.py
+++ b/sdk/python/tests/unit/test_on_demand_python_transformation.py
@@ -566,12 +566,12 @@ class TestOnDemandPythonTransformationAllDataTypes(unittest.TestCase):
                 "conv_rate",
                 "conv_rate_plus_val1",
                 "conv_rate_plus_val2",
-                "created__",
-                "driver_id",
-                "event_timestamp",
                 # It should not have the items below
-                "val_to_add",
-                "val_to_add_2",
+                # "created__",
+                # "driver_id",
+                # "event_timestamp",
+                # "val_to_add",
+                # "val_to_add_2",
             ]
             with pytest.raises(TypeError):
                 _ = self.store.get_online_features(
@@ -610,7 +610,7 @@ class TestOnDemandPythonTransformationAllDataTypes(unittest.TestCase):
                 # "val_to_add",
                 # "val_to_add_2",
             ]
-            assert sorted(resp_online.columns) != sorted(resp_offline.columns)
+            assert sorted(resp_online.columns) == sorted(resp_offline.columns)
 
     def test_setup(self):
         pass


### PR DESCRIPTION
# What this PR does / why we need it:
This PR updates `get_historical_features` to return the requested set of features when ODFVs are called as `get_online_features`. 

As outlined in https://github.com/feast-dev/feast/issues/4479, `get_historical_features` returns more features than what is requested when an ODFV is requested. 

This PR updates:
1. The tests to verify that `get_historical_features` when calling an ODFV returns only the fields requested
2. The tests to verify that an ODFV will result in an error when `get_historical_features` is called with an entity that does not have data to calculate an ODFV
3. The code to properly return only the requested features in `get_historical_features`

# Which issue(s) this PR fixes:
https://github.com/feast-dev/feast/issues/4479

# Misc
N/A