### PR TITLE
perf: Parallelize read calls by table and batch

### DIFF
--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import asyncio
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
@@ -240,7 +240,7 @@ class OnlineStore(ABC):
             native_entity_values=True,
         )
 
-        for table, requested_features in grouped_refs:
+        async def query_table(table, requested_features):
             # Get the correct set of entity values with the correct join keys.
             table_entity_values, idxs = utils._get_unique_entities(
                 table,
@@ -258,6 +258,14 @@ class OnlineStore(ABC):
                 requested_features=requested_features,
             )
 
+            return idxs, read_rows
+
+        all_responses = await asyncio.gather(*[
+            query_table(table, requested_features)
+            for table, requested_features in grouped_refs
+        ])
+
+        for (idxs, read_rows), (table, requested_features) in zip(all_responses, grouped_refs):
             feature_data = utils._convert_rows_to_protobuf(
                 requested_features, read_rows
             )

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -260,12 +260,16 @@ class OnlineStore(ABC):
 
             return idxs, read_rows
 
-        all_responses = await asyncio.gather(*[
-            query_table(table, requested_features)
-            for table, requested_features in grouped_refs
-        ])
+        all_responses = await asyncio.gather(
+            *[
+                query_table(table, requested_features)
+                for table, requested_features in grouped_refs
+            ]
+        )
 
-        for (idxs, read_rows), (table, requested_features) in zip(all_responses, grouped_refs):
+        for (idxs, read_rows), (table, requested_features) in zip(
+            all_responses, grouped_refs
+        ):
             feature_data = utils._convert_rows_to_protobuf(
                 requested_features, read_rows
             )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

Improve the use of async batch calls to dynamo db for `get_online_features_async`

* tested on a feature service w 3 feature views and 11 features
* compared to the sync method, the async method was
  * 50% faster w 5 entities retrieved
  * 75% faster w 80 entities retrieved

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
