### PR TITLE
chore: Remove unused `expectationsData` in Feast UI

### DIFF
--- a/ui/src/pages/saved-data-sets/DatasetExpectationsTab.tsx
+++ b/ui/src/pages/saved-data-sets/DatasetExpectationsTab.tsx
@@ -19,8 +19,6 @@ const DatasetExpectationsTab = () => {
     );
   }
 
-  let expectationsData;
-
   return isSuccess ? (
     <EuiPanel hasBorder={true} hasShadow={false}>
       <pre>{JSON.stringify(data.spec, null, 2)}</pre>


### PR DESCRIPTION
# What this PR does / why we need it:

Gets rid of this when running `yarn start`:

```sh
WARNING in src/pages/saved-data-sets/DatasetExpectationsTab.tsx
  Line 22:7:  'expectationsData' is defined but never used  @typescript-eslint/no-unused-vars

webpack 5.94.0 compiled with 1 warning in 20434 ms
```

I don't know how this has now come up, I saw no linter warnings in #4599 after my changes. 🤷 In any case, it's a clear case.