### PR TITLE
fix: Replaced ClusterRoles with local RoleBindings

### DIFF
--- a/docs/getting-started/components/authz_manager.md
+++ b/docs/getting-started/components/authz_manager.md
@@ -115,3 +115,13 @@ auth:
 In case the client cannot run on the same cluster as the servers, the client token can be injected using the `LOCAL_K8S_TOKEN` 
 environment variable on the client side. The value must refer to the token of a service account created on the servers cluster
 and linked to the desired RBAC roles.
+
+#### Setting Up Kubernetes RBAC for Feast
+
+To ensure the Kubernetes RBAC environment aligns with Feast's RBAC configuration, follow these guidelines:
+* The roles defined in Feast `Permission` instances must have corresponding Kubernetes RBAC `Role` names.
+* The Kubernetes RBAC `Role` must reside in the same namespace as the Feast service.
+* The client application can run in a different namespace, using its own dedicated `ServiceAccount`.
+* Finally, the `RoleBinding` that links the client `ServiceAccount` to the RBAC `Role` must be defined in the namespace of the Feast service.
+
+If the above rules are satisfied, the Feast service must be  granted permissions to fetch `RoleBinding` instances from the local namespace.

--- a/examples/rbac-remote/server/k8s/server_resources.yaml
+++ b/examples/rbac-remote/server/k8s/server_resources.yaml
@@ -5,23 +5,23 @@ metadata:
   namespace: feast-dev
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: feast-cluster-role
+  name: feast-role
 rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["roles", "rolebindings", "clusterrolebindings"]
+    resources: ["roles", "rolebindings"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: feast-cluster-rolebinding
+  name: feast-rolebinding
 subjects:
   - kind: ServiceAccount
     name: feast-sa
     namespace: feast-dev
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: feast-cluster-role
+  kind: Role
+  name: feast-role

--- a/examples/rbac-remote/server/k8s/server_resources.yaml
+++ b/examples/rbac-remote/server/k8s/server_resources.yaml
@@ -8,6 +8,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: feast-role
+  namespace: feast-dev
 rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]
@@ -17,6 +18,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: feast-rolebinding
+  namespace: feast-dev
 subjects:
   - kind: ServiceAccount
     name: feast-sa

--- a/sdk/python/tests/unit/permissions/auth/conftest.py
+++ b/sdk/python/tests/unit/permissions/auth/conftest.py
@@ -20,46 +20,28 @@ def sa_name():
 
 
 @pytest.fixture
-def namespace():
+def my_namespace():
     return "my-ns"
 
 
 @pytest.fixture
-def rolebindings(sa_name, namespace) -> dict:
+def sa_namespace():
+    return "sa-ns"
+
+
+@pytest.fixture
+def rolebindings(my_namespace, sa_name, sa_namespace) -> dict:
     roles = ["reader", "writer"]
     items = []
     for r in roles:
         items.append(
             client.V1RoleBinding(
-                metadata=client.V1ObjectMeta(name=r, namespace=namespace),
+                metadata=client.V1ObjectMeta(name=r, namespace=my_namespace),
                 subjects=[
                     client.V1Subject(
                         kind="ServiceAccount",
                         name=sa_name,
-                        api_group="rbac.authorization.k8s.io",
-                    )
-                ],
-                role_ref=client.V1RoleRef(
-                    kind="Role", name=r, api_group="rbac.authorization.k8s.io"
-                ),
-            )
-        )
-    return {"items": client.V1RoleBindingList(items=items), "roles": roles}
-
-
-@pytest.fixture
-def clusterrolebindings(sa_name, namespace) -> dict:
-    roles = ["updater"]
-    items = []
-    for r in roles:
-        items.append(
-            client.V1ClusterRoleBinding(
-                metadata=client.V1ObjectMeta(name=r, namespace=namespace),
-                subjects=[
-                    client.V1Subject(
-                        kind="ServiceAccount",
-                        name=sa_name,
-                        namespace=namespace,
+                        namespace=sa_namespace,
                         api_group="rbac.authorization.k8s.io",
                     )
                 ],

--- a/sdk/python/tests/unit/permissions/auth/server/mock_utils.py
+++ b/sdk/python/tests/unit/permissions/auth/server/mock_utils.py
@@ -53,11 +53,11 @@ def mock_oidc(request, monkeypatch, client_id):
 
 
 def mock_kubernetes(request, monkeypatch):
+    my_namespace = request.getfixturevalue("my_namespace")
     sa_name = request.getfixturevalue("sa_name")
-    namespace = request.getfixturevalue("namespace")
-    subject = f"system:serviceaccount:{namespace}:{sa_name}"
+    sa_namespace = request.getfixturevalue("sa_namespace")
+    subject = f"system:serviceaccount:{sa_namespace}:{sa_name}"
     rolebindings = request.getfixturevalue("rolebindings")
-    clusterrolebindings = request.getfixturevalue("clusterrolebindings")
 
     monkeypatch.setattr(
         "feast.permissions.auth.kubernetes_token_parser.config.load_incluster_config",
@@ -72,10 +72,10 @@ def mock_kubernetes(request, monkeypatch):
         lambda *args, **kwargs: rolebindings["items"],
     )
     monkeypatch.setattr(
-        "feast.permissions.auth.kubernetes_token_parser.client.RbacAuthorizationV1Api.list_cluster_role_binding",
-        lambda *args, **kwargs: clusterrolebindings["items"],
-    )
-    monkeypatch.setattr(
         "feast.permissions.client.kubernetes_auth_client_manager.KubernetesAuthClientManager.get_token",
         lambda self: "my-token",
+    )
+    monkeypatch.setattr(
+        "feast.permissions.auth.kubernetes_token_parser.KubernetesTokenParser._read_namespace_from_file",
+        lambda self: my_namespace,
     )


### PR DESCRIPTION
# What this PR does / why we need it:
Avoid assigning cluster-wide privileges to Feast services to handle RBAC enforcement.

# Which issue(s) this PR fixes:
Foxes #4623 

# Misc
Tested on cluster with existing "rbac_remote" example (which IMO needs some review)