### PR TITLE
fix: Bigquery dataset create table disposition

### DIFF
--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -575,9 +575,9 @@ def construct_test_environment(
     }
 
     if not isinstance(offline_creator, RemoteOfflineOidcAuthStoreDataSourceCreator):
-        environment = Environment(**environment_params)
+        environment = Environment(**environment_params)  # type: ignore
     else:
-        environment = OfflineServerPermissionsEnvironment(**environment_params)
+        environment = OfflineServerPermissionsEnvironment(**environment_params)  # type: ignore
     return environment
 
 

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -61,5 +61,6 @@ class DataSourceCreator(ABC):
     def teardown(self):
         raise NotImplementedError
 
-    def xdist_groups(self) -> list[str]:
+    @staticmethod
+    def xdist_groups() -> list[str]:
         return []

--- a/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_source_creator.py
@@ -61,5 +61,5 @@ class DataSourceCreator(ABC):
     def teardown(self):
         raise NotImplementedError
 
-    def xdist_groups() -> list[str]:
+    def xdist_groups(self) -> list[str]:
         return []

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -451,7 +451,8 @@ auth:
         self.server_port: int = 0
         self.proc = None
 
-    def xdist_groups(self) -> list[str]:
+    @staticmethod
+    def xdist_groups() -> list[str]:
         return ["keycloak"]
 
     def setup(self, registry: RegistryConfig):

--- a/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
+++ b/sdk/python/tests/integration/feature_repos/universal/data_sources/file.py
@@ -451,7 +451,7 @@ auth:
         self.server_port: int = 0
         self.proc = None
 
-    def xdist_groups() -> list[str]:
+    def xdist_groups(self) -> list[str]:
         return ["keycloak"]
 
     def setup(self, registry: RegistryConfig):
@@ -464,10 +464,10 @@ auth:
             entity_key_serialization_version=2,
         )
 
-        repo_path = Path(tempfile.mkdtemp())
-        with open(repo_path / "feature_store.yaml", "w") as outfile:
+        repo_base_path = Path(tempfile.mkdtemp())
+        with open(repo_base_path / "feature_store.yaml", "w") as outfile:
             yaml.dump(config.model_dump(by_alias=True), outfile)
-        repo_path = str(repo_path.resolve())
+        repo_path = str(repo_base_path.resolve())
 
         include_auth_config(
             file_path=f"{repo_path}/feature_store.yaml", auth_config=self.auth_config
@@ -486,7 +486,7 @@ auth:
         ]
         self.proc = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
-        )
+        )  # type: ignore
 
         _time_out_sec: int = 60
         # Wait for server to start

--- a/sdk/python/tests/utils/auth_permissions_util.py
+++ b/sdk/python/tests/utils/auth_permissions_util.py
@@ -49,7 +49,7 @@ def default_store(
 
     fs = FeatureStore(repo_path=repo_path)
 
-    fs.apply(permissions)
+    fs.apply(permissions)  # type: ignore
 
     return fs
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
* Updates `get_historical_features` to not create a BigQuery dataset when `create_table_disposition` is set to `CREATE_NEVER`.
* Cleans up or ignores some linting issues preventing pushing due to pre-commit checks.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #4648 

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
This PR brings BigQuery dataset creation in line with table creation - this will hopefully be useful to orgs (such as mine!) that have stricter requirements over what can/cannot make infrastructure/warehouse changes in production environments. In our case `get_historical_features` is expected to be read only operation.