### PR TITLE
chore: Added uvicorn-worker dependency

### DIFF
--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -307,7 +307,7 @@ if sys.platform != "win32":
                 if key.lower() in self.cfg.settings and value is not None:
                     self.cfg.set(key.lower(), value)
 
-            self.cfg.set("worker_class", "uvicorn.workers.UvicornWorker")
+            self.cfg.set("worker_class", "uvicorn_worker.UvicornWorker")
 
         def load(self):
             return self._app

--- a/sdk/python/requirements/py3.10-ci-requirements.txt
+++ b/sdk/python/requirements/py3.10-ci-requirements.txt
@@ -167,7 +167,7 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.1.0
     # via stack-data
-fastapi==0.115.0
+fastapi==0.115.2
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
@@ -889,6 +889,7 @@ urllib3==2.2.3
     #   responses
     #   testcontainers
 uvicorn[standard]==0.30.6
+uvicorn-worker
 uvloop==0.20.0
     # via uvicorn
 virtualenv==20.23.0

--- a/sdk/python/requirements/py3.10-requirements.txt
+++ b/sdk/python/requirements/py3.10-requirements.txt
@@ -29,7 +29,7 @@ dask-expr==1.1.14
 dill==0.3.8
 exceptiongroup==1.2.2
     # via anyio
-fastapi==0.115.0
+fastapi==0.115.2
 fsspec==2024.9.0
     # via dask
 greenlet==3.1.0
@@ -136,6 +136,7 @@ tzdata==2024.1
 urllib3==2.2.3
     # via requests
 uvicorn[standard]==0.30.6
+uvicorn-worker
 uvloop==0.20.0
     # via uvicorn
 watchfiles==0.24.0

--- a/sdk/python/requirements/py3.11-ci-requirements.txt
+++ b/sdk/python/requirements/py3.11-ci-requirements.txt
@@ -160,7 +160,7 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.1.0
     # via stack-data
-fastapi==0.115.0
+fastapi==0.115.2
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
@@ -866,6 +866,7 @@ urllib3==2.2.3
     #   responses
     #   testcontainers
 uvicorn[standard]==0.30.6
+uvicorn-worker
 uvloop==0.20.0
     # via uvicorn
 virtualenv==20.23.0

--- a/sdk/python/requirements/py3.11-requirements.txt
+++ b/sdk/python/requirements/py3.11-requirements.txt
@@ -27,7 +27,7 @@ dask[dataframe]==2024.9.0
 dask-expr==1.1.14
     # via dask
 dill==0.3.8
-fastapi==0.115.0
+fastapi==0.115.2
 fsspec==2024.9.0
     # via dask
 greenlet==3.1.0
@@ -130,6 +130,7 @@ tzdata==2024.1
 urllib3==2.2.3
     # via requests
 uvicorn[standard]==0.30.6
+uvicorn-worker
 uvloop==0.20.0
     # via uvicorn
 watchfiles==0.24.0

--- a/sdk/python/requirements/py3.9-ci-requirements.txt
+++ b/sdk/python/requirements/py3.9-ci-requirements.txt
@@ -169,7 +169,7 @@ execnet==2.1.1
     # via pytest-xdist
 executing==2.1.0
     # via stack-data
-fastapi==0.115.0
+fastapi==0.115.2
 fastjsonschema==2.20.0
     # via nbformat
 filelock==3.16.1
@@ -900,6 +900,7 @@ urllib3==1.26.20
     #   snowflake-connector-python
     #   testcontainers
 uvicorn[standard]==0.30.6
+uvicorn-worker
 uvloop==0.20.0
     # via uvicorn
 virtualenv==20.23.0

--- a/sdk/python/requirements/py3.9-requirements.txt
+++ b/sdk/python/requirements/py3.9-requirements.txt
@@ -29,7 +29,7 @@ dask-expr==1.1.10
 dill==0.3.8
 exceptiongroup==1.2.2
     # via anyio
-fastapi==0.115.0
+fastapi==0.115.2
 fsspec==2024.9.0
     # via dask
 greenlet==3.1.0
@@ -139,6 +139,7 @@ tzdata==2024.1
 urllib3==2.2.3
     # via requests
 uvicorn[standard]==0.30.6
+uvicorn-worker
 uvloop==0.20.0
     # via uvicorn
 watchfiles==0.24.0

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ REQUIRED = [
     "typeguard>=4.0.0",
     "fastapi>=0.68.0",
     "uvicorn[standard]>=0.14.0,<1",
+    "uvicorn-worker",
     "gunicorn; platform_system != 'Windows'",
     "dask[dataframe]>=2024.2.1",
     "prometheus_client",


### PR DESCRIPTION
# What this PR does / why we need it:
Removes the deprecation warning: for `uvicorn.workers`.
The `uvicorn.workers` module is deprecated, they refer using `uvicorn-worker` package instead.

# Which issue(s) this PR fixes:
Fixes https://github.com/feast-dev/feast/issues/4638
