### PR TITLE
chore: Add packageManager to ui/package.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -107,5 +107,6 @@
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/feast-dev/feast/issues"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
# What this PR does / why we need it:

Newest Node.js versions include a tool called [Corepack](https://nodejs.org/docs/latest-v20.x/api/corepack.html), and if you enable it and run `yarn install`, the `packageManager` field gets automatically added to `package.json` with this message:

> ! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e.
> ! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager

Corepack is an experimental feature but can be quite useful, and having this field doesn't affect people who don't use it, so I propose to add it permanently. From the Corepack docs linked above:

> This feature simplifies two core workflows:
> - It eases new contributor onboarding, since they won't have to follow system-specific installation processes anymore just to have the package manager you want them to.
>- It allows you to ensure that everyone in your team will use exactly the package manager version you intend them to, without them having to manually synchronize it each time you need to make an update.

Personally I don't have `yarn` installed globally, but using it in this project with Corepack is a breeze:
```sh
# Corepack not enabled yet
% yarn
zsh: command not found: yarn
# Enable Corepack, the `corepack` binary is installed automatically with Node.js 
% corepack enable
# Now Yarn is available, you will be prompted to install it if you haven't done it before
% yarn
yarn install v1.22.22
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.54s.
```