### PR TITLE
fix: Fixing failure of protos during ODFV transformations for missing entities

### DIFF
--- a/sdk/python/feast/utils.py
+++ b/sdk/python/feast/utils.py
@@ -552,13 +552,19 @@ def _augment_response_with_on_demand_transforms(
         selected_subset = [f for f in transformed_columns if f in _feature_refs]
 
         proto_values = []
+        schema_dict = {k.name: k.dtype for k in odfv.schema}
         for selected_feature in selected_subset:
             feature_vector = transformed_features[selected_feature]
+            feature_type = schema_dict.get(selected_feature, None)
+            feature_type = (
+                feature_type.to_value_type() if feature_type else ValueType.UNKNOWN
+            )
             proto_values.append(
-                python_values_to_proto_values(feature_vector, ValueType.UNKNOWN)
-                if odfv.mode == "python"
-                else python_values_to_proto_values(
-                    feature_vector.to_numpy(), ValueType.UNKNOWN
+                python_values_to_proto_values(
+                    feature_vector
+                    if odfv.mode == "python"
+                    else feature_vector.to_numpy(),
+                    feature_type,
                 )
             )
 

--- a/sdk/python/tests/unit/test_on_demand_python_transformation.py
+++ b/sdk/python/tests/unit/test_on_demand_python_transformation.py
@@ -609,19 +609,19 @@ class TestOnDemandPythonTransformationAllDataTypes(unittest.TestCase):
                 "val_to_add",
                 "val_to_add_2",
             ]
-            with pytest.raises(TypeError):
-                _ = self.store.get_online_features(
-                    entity_rows=[
-                        {"driver_id": 1234567890, "val_to_add": 0, "val_to_add_2": 1}
-                    ],
-                    features=[
-                        "driver_hourly_stats:conv_rate",
-                        "driver_hourly_stats:acc_rate",
-                        "driver_hourly_stats:avg_daily_trips",
-                        "pandas_view:conv_rate_plus_val1",
-                        "pandas_view:conv_rate_plus_val2",
-                    ],
-                )
+            resp_online_missing_entity = self.store.get_online_features(
+                entity_rows=[
+                    {"driver_id": 1234567890, "val_to_add": 0, "val_to_add_2": 1}
+                ],
+                features=[
+                    "driver_hourly_stats:conv_rate",
+                    "driver_hourly_stats:acc_rate",
+                    "driver_hourly_stats:avg_daily_trips",
+                    "pandas_view:conv_rate_plus_val1",
+                    "pandas_view:conv_rate_plus_val2",
+                ],
+            )
+            assert resp_online_missing_entity is not None
             resp_online = self.store.get_online_features(
                 entity_rows=[{"driver_id": 1001, "val_to_add": 0, "val_to_add_2": 1}],
                 features=[


### PR DESCRIPTION
# What this PR does / why we need it:

This PR fixes failure of proto type adjustment during ODFV transformations for missing entities

# Which issue(s) this PR fixes:
https://github.com/feast-dev/feast/issues/4473

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
