### PR TITLE
fix: Adapt project_id_exists validator for updated pydantic version

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -114,7 +114,7 @@ class BigQueryOfflineStoreConfig(FeastConfigBaseModel):
 
     @field_validator("billing_project_id")
     def project_id_exists(cls, v, values, **kwargs):
-        if v and not values["project_id"]:
+        if v and not (values.data and values.data["project_id"]):
             raise ValueError(
                 "please specify project_id if billing_project_id is specified"
             )

--- a/sdk/python/tests/unit/infra/offline_stores/test_bigquery.py
+++ b/sdk/python/tests/unit/infra/offline_stores/test_bigquery.py
@@ -107,3 +107,4 @@ class TestBigQueryRetrievalJobWithBillingProject:
                 full_feature_names=True,
                 on_demand_feature_views=[],
             )
+            retrieval_job.to_df()

--- a/sdk/python/tests/unit/infra/offline_stores/test_bigquery.py
+++ b/sdk/python/tests/unit/infra/offline_stores/test_bigquery.py
@@ -82,3 +82,28 @@ class TestBigQueryRetrievalJob:
             self.retrieval_job._execute_query.assert_called_once_with(
                 query=self.query, timeout=30
             )
+
+
+class TestBigQueryRetrievalJobWithBillingProject:
+    query = "SELECT * FROM bigquery"
+    client = Mock()
+
+    def test_project_id_exists(self):
+        with pytest.raises(ValueError):
+            retrieval_job = BigQueryRetrievalJob(
+                query=self.query,
+                client=self.client,
+                config=RepoConfig(
+                    registry="gs://ml-test/repo/registry.db",
+                    project="test",
+                    provider="gcp",
+                    online_store=SqliteOnlineStoreConfig(type="sqlite"),
+                    offline_store=BigQueryOfflineStoreConfig(
+                        type="bigquery",
+                        dataset="feast",
+                        billing_project_id="test-billing-project"
+                    ),
+                ),
+                full_feature_names=True,
+                on_demand_feature_views=[],
+            )

--- a/sdk/python/tests/unit/infra/offline_stores/test_bigquery.py
+++ b/sdk/python/tests/unit/infra/offline_stores/test_bigquery.py
@@ -101,7 +101,7 @@ class TestBigQueryRetrievalJobWithBillingProject:
                     offline_store=BigQueryOfflineStoreConfig(
                         type="bigquery",
                         dataset="feast",
-                        billing_project_id="test-billing-project"
+                        billing_project_id="test-billing-project",
                     ),
                 ),
                 full_feature_names=True,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
With pydantic version 2.9.2, values dict inside field validator will have all details like project_id, billing_project_id nested within data, this PR handles that and has one test case to validate.

# Which issue(s) this PR fixes:
Fixes #4678

