### PR TITLE
fix: Update release version in a pertinent Operator file

### DIFF
--- a/infra/feast-operator/dist/install.yaml
+++ b/infra/feast-operator/dist/install.yaml
@@ -349,7 +349,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: feastdev/feast-operator:0.40.0
+        image: feastdev/feast-operator:0.41.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/infra/scripts/release/files_to_bump.txt
+++ b/infra/scripts/release/files_to_bump.txt
@@ -14,5 +14,6 @@ infra/feast-helm-operator/Makefile 6
 infra/feast-helm-operator/config/manager/kustomization.yaml 8
 infra/feast-operator/Makefile 6
 infra/feast-operator/config/manager/kustomization.yaml 8
+infra/feast-operator/dist/install.yaml 352
 java/pom.xml 38
 ui/package.json 3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Updates the release version in a pertinent Operator file and adds said file to scripting. A followup PR will add additional release-specific CI for the operator so this doesn't happen again.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Operator CI is failing because of the recent 0.41.x release
