### PR TITLE
feat: Add api contract to fastapi docs

### DIFF
--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -118,7 +118,7 @@ def get_app(
         "/get-online-features",
         dependencies=[Depends(inject_user_details)],
     )
-    async def get_online_features(request: GetOnlineFeaturesRequest):
+    async def get_online_features(request: GetOnlineFeaturesRequest) -> Dict[str, Any]:
         # Initialize parameters for FeatureStore.get_online_features(...) call
         if request.feature_service:
             feature_service = store.get_feature_service(
@@ -167,7 +167,7 @@ def get_app(
         )
 
     @app.post("/push", dependencies=[Depends(inject_user_details)])
-    async def push(request: PushFeaturesRequest):
+    async def push(request: PushFeaturesRequest) -> None:
         df = pd.DataFrame(request.df)
         actions = []
         if request.to == "offline":
@@ -219,7 +219,7 @@ def get_app(
             store.push(**push_params)
 
     @app.post("/write-to-online-store", dependencies=[Depends(inject_user_details)])
-    def write_to_online_store(request: WriteToFeatureStoreRequest):
+    def write_to_online_store(request: WriteToFeatureStoreRequest) -> None:
         df = pd.DataFrame(request.df)
         feature_view_name = request.feature_view_name
         allow_registry_cache = request.allow_registry_cache
@@ -248,7 +248,7 @@ def get_app(
         )
 
     @app.post("/materialize", dependencies=[Depends(inject_user_details)])
-    def materialize(request: MaterializeRequest):
+    def materialize(request: MaterializeRequest) -> None:
         for feature_view in request.feature_views or []:
             # TODO: receives a str for resource but isn't in the Union. is str actually allowed?
             assert_permissions(
@@ -262,7 +262,7 @@ def get_app(
         )
 
     @app.post("/materialize-incremental", dependencies=[Depends(inject_user_details)])
-    def materialize_incremental(request: MaterializeIncrementalRequest):
+    def materialize_incremental(request: MaterializeIncrementalRequest) -> None:
         for feature_view in request.feature_views or []:
             # TODO: receives a str for resource but isn't in the Union. is str actually allowed?
             assert_permissions(

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -127,7 +127,7 @@ def get_app(
             assert_permissions(
                 resource=feature_service, actions=[AuthzedAction.READ_ONLINE]
             )
-            features = request.feature_service  # type: ignore
+            features = feature_service  # type: ignore
         else:
             all_feature_views, all_on_demand_feature_views = (
                 utils._get_feature_views_to_use(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

* FastApi by default creates an openapi docs page which lists out endpoints
* the python feature server doesn't use pydantic models for request bodies, so the sample inputs for the endpoints aren't populated and schema unknown
* remove json request body parsing and replace it w pydantic models
* this mr does _not_ define a robust response schema for `/get-online-features`
  * simply specifies it as dict[str, any]
  * should come up w something better but as a follow up

```
feast serve --port 8080
```
generates the following at [http://localhost:8080/docs](http://localhost:8080/docs)

<img width="911" alt="image" src="https://github.com/user-attachments/assets/70e1b9ad-39d5-45db-9ff1-35718be5aeb1">

<img width="597" alt="image" src="https://github.com/user-attachments/assets/b52d2a0e-7c0a-430f-bcb9-c1559a815554">


# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #4720 

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
