### PR TITLE
fix: Issue of DataSource subclasses using parent abstract class docstrings

### DIFF
--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -343,6 +343,8 @@ class DataSource(ABC):
 
 @typechecked
 class KafkaSource(DataSource):
+    """A KafkaSource allow users to register Kafka streams as data sources."""
+
     def __init__(
         self,
         *,
@@ -616,6 +618,8 @@ class RequestSource(DataSource):
 
 @typechecked
 class KinesisSource(DataSource):
+    """A KinesisSource allows users to register Kinesis streams as data sources."""
+
     def validate(self, config: RepoConfig):
         raise NotImplementedError
 
@@ -666,6 +670,25 @@ class KinesisSource(DataSource):
         owner: Optional[str] = "",
         batch_source: Optional[DataSource] = None,
     ):
+        """
+        Args:
+            name: The unique name of the Kinesis source.
+            record_format: The record format of the Kinesis stream.
+            region: The AWS region of the Kinesis stream.
+            stream_name: The name of the Kinesis stream.
+            timestamp_field: Event timestamp field used for point-in-time joins of
+            feature values.
+            created_timestamp_column:  Timestamp column indicating when the row
+            was created, used for deduplicating rows.
+            field_mapping: A dictionary mapping of column names in this data
+            source to feature names in a feature table or view. Only used for feature
+            columns, not entity or timestamp columns.
+            description: A human-readable description.
+            tags: A dictionary of key-value pairs to store arbitrary metadata.
+            owner: The owner of the Kinesis source, typically the email of the primary
+            maintainer.
+            batch_source: A DataSource backing the Kinesis stream (used for retrieving historical features).
+        """
         if record_format is None:
             raise ValueError("Record format must be specified for kinesis source")
 

--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -21,6 +21,8 @@ from feast.value_type import ValueType
 
 @typechecked
 class BigQuerySource(DataSource):
+    """A BigQuerySource object defines a data source that a BigQueryOfflineStore class can use."""
+
     def __init__(
         self,
         *,

--- a/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssqlserver_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssqlserver_source.py
@@ -111,6 +111,8 @@ class MsSqlServerOptions:
 
 
 class MsSqlServerSource(DataSource):
+    """A MsSqlServerSource object defines a data source that a MsSqlServerOfflineStore class can use."""
+
     def __init__(
         self,
         name: str,
@@ -124,6 +126,23 @@ class MsSqlServerSource(DataSource):
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = None,
     ):
+        """Creates a MsSqlServerSource object.
+
+        Args:
+            name: Name of the source, which should be unique within a project.
+            table_ref: The table reference.
+            event_timestamp_column: The event timestamp column (used for point-in-time joins of feature values).
+            created_timestamp_column: Timestamp column indicating when the row was created
+                (used for deduplicating rows).
+            field_mapping: A dictionary mapping of column names in this data
+            source to feature names in a feature table or view.
+                Only used for feature columns, not entity or timestamp columns.
+            date_partition_column: The date partition column.
+            connection_str: The connection string.
+            description: A human-readable description.
+            tags: A dictionary of key-value pairs to store arbitrary metadata.
+            owner: The owner of the data source, typically the email of the primary maintainer.
+        """
         # warnings.warn(
         #     "The Azure Synapse + Azure SQL data source is an experimental feature in alpha development. "
         #     "Some functionality may still be unstable so functionality can change in the future.",

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres_source.py
@@ -18,6 +18,8 @@ from feast.value_type import ValueType
 
 @typechecked
 class PostgreSQLSource(DataSource):
+    """A PostgreSQLSource object defines a data source that a PostgreSQLOfflineStore class can use."""
+
     def __init__(
         self,
         name: Optional[str] = None,
@@ -30,6 +32,24 @@ class PostgreSQLSource(DataSource):
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
     ):
+        """Creates a PostgreSQLSource object.
+
+        Args:
+            name: Name of PostgreSQLSource, which should be unique within a project.
+            query: SQL query that will be used to fetch the data.
+            table: Table name.
+            timestamp_field (optional): Event timestamp field used for point-in-time joins of
+                feature values.
+            created_timestamp_column (optional): Timestamp column indicating when the row
+                was created, used for deduplicating rows.
+            field_mapping (optional): A dictionary mapping of column names in this data
+                source to feature names in a feature table or view. Only used for feature
+                columns, not entity or timestamp columns.
+            description (optional): A human-readable description.
+            tags (optional): A dictionary of key-value pairs to store arbitrary metadata.
+            owner (optional): The owner of the data source, typically the email of the primary
+                maintainer.
+        """
         self._postgres_options = PostgreSQLOptions(name=name, query=query, table=table)
 
         # If no name, use the table as the default name.

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_source.py
@@ -84,6 +84,8 @@ class TrinoOptions:
 
 
 class TrinoSource(DataSource):
+    """A TrinoSource object defines a data source that a TrinoOfflineStore class can use."""
+
     def __init__(
         self,
         *,

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -26,6 +26,8 @@ from feast.value_type import ValueType
 
 @typechecked
 class FileSource(DataSource):
+    """A FileSource object defines a data source that a DaskOfflineStore or DuckDBOfflineStore class can use."""
+
     def __init__(
         self,
         *,

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -24,6 +24,8 @@ from feast.value_type import ValueType
 
 @typechecked
 class RedshiftSource(DataSource):
+    """A RedshiftSource object defines a data source that a RedshiftOfflineStore class can use."""
+
     def __init__(
         self,
         *,

--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -21,6 +21,8 @@ from feast.value_type import ValueType
 
 @typechecked
 class SnowflakeSource(DataSource):
+    """A SnowflakeSource object defines a data source that a SnowflakeOfflineStore class can use."""
+
     def __init__(
         self,
         *,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

This is a natural continuation of the work done in this PR: [[PR](fix: Fixed SparkSource docstrings so it wouldn't used inhereted class docstrings)](https://github.com/feast-dev/feast/pull/4722).

There were other DataSource subclasses that had the same issue--using the abstract class docstring (and `__init__` docstring, which did not accurately describe the parameters and functionality of the specialized subclasses.

I have added class docstrings and class `__init__` docstrings where they were missing for subclasses of the `DataSource` class.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
