### PR TITLE
fix: Fixed example materialize-incremental and improved explanation

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -493,19 +493,14 @@ print(training_df.head())
 {% endtabs %}
 ### Step 6: Ingest batch features into your online store
 
-We now serialize the latest values of features since the beginning of time to prepare for serving (note: 
-`materialize-incremental` serializes all new features since the last `materialize` call).
+We now serialize the latest values of features since the beginning of time to prepare for serving. Note, `materialize_incremental` serializes all new features since the last `materialize` call, or since the time provided minus the `ttl` timedelta. In this case, this will be `CURRENT_TIME - 1 day` (`ttl` was set on the `FeatureView` instances in [feature_repo/feature_repo/example_repo.py](feature_repo/feature_repo/example_repo.py)).
 
 {% tabs %}
 {% tab title="Bash" %}
 ```bash
 CURRENT_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S")
-# For mac
-LAST_YEAR=$(date -u -v -1y +"%Y-%m-%dT%H:%M:%S")
-# For Linux
-# LAST_YEAR=$(date -u -d "last year" +"%Y-%m-%dT%H:%M:%S")
 
-feast materialize-incremental $LAST_YEAR $CURRENT_TIME
+feast materialize-incremental $CURRENT_TIME
 ```
 {% endtab %}
 {% endtabs %}

--- a/examples/quickstart/quickstart.ipynb
+++ b/examples/quickstart/quickstart.ipynb
@@ -758,14 +758,14 @@
       "source": [
         "### Step 5a: Using `materialize_incremental`\n",
         "\n",
-        "We now serialize the latest values of features since the beginning of time to prepare for serving (note: `materialize_incremental` serializes all new features since the last `materialize` call).\n",
-        "\n",
-        "An alternative to using the CLI command is to use Python:\n",
+        "We now serialize the latest values of features since the beginning of time to prepare for serving. Note, `materialize_incremental` serializes all new features since the last `materialize` call, or since the time provided minus the `ttl` timedelta. In this case, this will be `CURRENT_TIME - 1 day` (`ttl` was set on the `FeatureView` instances in [feature_repo/feature_repo/example_repo.py](feature_repo/feature_repo/example_repo.py)). \n",
         "\n",
         "```bash\n",
         "CURRENT_TIME=$(date -u +\"%Y-%m-%dT%H:%M:%S\")\n",
         "feast materialize-incremental $CURRENT_TIME\n",
-        "```"
+        "```\n",
+        "\n",
+        "An alternative to using the CLI command is to use Python:"
       ]
     },
     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

In the [quickstart documentation](https://docs.feast.dev/getting-started/quickstart#step-6-ingest-batch-features-into-your-online-store), step 6 mistakenly provides both start and end date parameters to the `feast materialize-incremental` command (which only takes an end date). This was probably just confused with the parameters for the `feast materialize` command. Running the command as is results in an error.

In addition, the docs explain that `materialize-incremental` "serializes all new features since the last materialize call", but this is confusing since no `materialize` call has been run in the quickstart.

In this PR, I fixed the parameter input, and improved the documentation to include a mention of when the ttl is used.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->

To reproduce the issue:
1. Initialize the quickstart repo: `feast init feature_repo`  # run in examples/quickstart
2. Apply the repo config: `feast apply`
3. Try running the command from step 6 in the [quickstart documentation](https://docs.feast.dev/getting-started/quickstart#step-6-ingest-batch-features-into-your-online-store):
```CURRENT_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S")
LAST_YEAR=$(date -u -v -1y +"%Y-%m-%dT%H:%M:%S")

feast materialize-incremental $LAST_YEAR $CURRENT_TIME
```

Error Output:

```feast materialize-incremental $LAST_YEAR $CURRENT_TIME
Usage: feast materialize-incremental [OPTIONS] END_TS
Try 'feast materialize-incremental --help' for help.

Error: Got unexpected extra argument (2024-11-04T17:42:12)
```

