### PR TITLE
Added grpcio extras to default feature-server image

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && \
         build-essential
 
 RUN pip install pip --upgrade
-RUN pip install "feast[aws,gcp,snowflake,redis,go,mysql,postgres,opentelemetry]"
+RUN pip install "feast[aws,gcp,snowflake,redis,go,mysql,postgres,opentelemetry,grpcio]"
 
 
 RUN apt update

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -11,7 +11,7 @@ RUN apt update && \
 RUN pip install pip --upgrade
 COPY . .
 
-RUN pip install "feast[aws,gcp,snowflake,redis,go,mysql,postgres,opentelemetry]"
+RUN pip install "feast[aws,gcp,snowflake,redis,go,mysql,postgres,opentelemetry,grpcio]"
 
 RUN apt update
 RUN apt install -y -V ca-certificates lsb-release wget


### PR DESCRIPTION
# What this PR does / why we need it:
Adds `grpcio` extras to the default `feature-server` image.

# Which issue(s) this PR fixes:
Fixes #4729 
