### PR TITLE
fix: Removed version func from feature_store.py

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -88,7 +88,6 @@ from feast.repo_contents import RepoContents
 from feast.saved_dataset import SavedDataset, SavedDatasetStorage, ValidationReference
 from feast.stream_feature_view import StreamFeatureView
 from feast.utils import _utc_now
-from feast.version import get_version
 
 warnings.simplefilter("once", DeprecationWarning)
 
@@ -170,10 +169,6 @@ class FeatureStore:
             )
 
         self._provider = get_provider(self.config)
-
-    def version(self) -> str:
-        """Returns the version of the current Feast SDK/CLI."""
-        return get_version()
 
     def __repr__(self) -> str:
         return (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

This PR removes the `version` function from `feature_store.py`, which is a method to the `FeatureStore` class. The `version` method was unused, un-needed, and confusing. See issue #4747 for more details.
 
I categorized this as a "fix" because I see an unused/un-needed function as a bug, but I understand that this could merit a different categorization.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#4747 