### PR TITLE
feat: add `real`(float32) type for trino offline store

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_type_map.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_type_map.py
@@ -74,6 +74,7 @@ _TRINO_TO_PA_TYPE_MAP = {
     "double": pa.float64(),
     "binary": pa.binary(),
     "char": pa.string(),
+    "real": pa.float32()
 }
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
I used Trino as offline store. And feast supports a various data types by Trino-supported data types([docs](https://trino.io/docs/current/language/types.html)) 
But feast doesn't support Trino-based `real` type. the type means `float32`. I just add the mapping `real` to `float32`. 

# Which issue(s) this PR fixes:
A float32 type is supported in the trino as offline store


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
