### PR TITLE
feat: Force absolute paths in file based registries

### DIFF
--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -210,6 +210,14 @@ class FeastRegistryTypeInvalidError(FeastError):
         )
 
 
+class FeastFileRegistryPathNotAbsoluteError(FeastError):
+    def __init__(self, path: str):
+        super().__init__(
+            f"File registry path was set to {path}, which is a relative path. "
+            "Please, specify the absolute path of the registry file in the feature_store.yaml"
+        )
+
+
 class FeastModuleImportError(FeastError):
     def __init__(self, module_name: str, class_name: str):
         super().__init__(

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -20,6 +20,7 @@ from pydantic import (
 
 from feast.errors import (
     FeastFeatureServerTypeInvalidError,
+    FeastFileRegistryPathNotAbsoluteError,
     FeastInvalidAuthConfigClass,
     FeastOfflineStoreInvalidName,
     FeastOnlineStoreInvalidName,
@@ -166,6 +167,15 @@ class RegistryConfig(FeastBaseModel):
                     "explicitely to `path`."
                 )
                 return path.replace("postgresql://", "postgresql+psycopg://")
+
+        if values.data.get("registry_type") == "file":
+            is_local_file_registry = not (
+                path.startswith("s3://") or path.startswith("gs://")
+            )
+            is_relative_path = not os.path.isabs(path)
+            if is_local_file_registry and is_relative_path:
+                raise FeastFileRegistryPathNotAbsoluteError(str(path))
+
         return path
 
 

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -486,9 +486,26 @@ def init_repo(repo_name: str, template: str):
         os.remove(bootstrap_path)
 
     # Template the feature_store.yaml file
-    feature_store_yaml_path = repo_path / "feature_repo" / "feature_store.yaml"
+    feature_repo_path = repo_path / "feature_repo"
+    feature_store_yaml_path = feature_repo_path / "feature_store.yaml"
+
+    # user-defined project name
     replace_str_in_file(
         feature_store_yaml_path, "project: my_project", f"project: {repo_name}"
+    )
+
+    # registry: replace relative path from template with absolute path
+    replace_str_in_file(
+        feature_store_yaml_path,
+        "registry: data/registry.db",
+        f"registry: {feature_repo_path}/data/registry.db",
+    )
+
+    # online store: replace relative path from template with absolute path
+    replace_str_in_file(
+        feature_store_yaml_path,
+        "path: data/online_store.db",
+        f"path: {feature_repo_path}/data/online_store.db",
     )
 
     # Remove the __pycache__ folder if it exists


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
While I was working on https://github.com/feast-dev/feast/pull/4772, I discovered an issue related to the Feast CLI and how `FileRegistryStore` instances are populated when running a CLI command using the `-f` argument. Assume a really simple setup made with the `feast init` command, i.e. the Feature Store is backed by file stores both in the registry and in the online store.

When the registry is set to `file` in the `feature_store.yaml`, `RegistryConfig`'s `path` attribute is filled with the same exact value provided in the YAML, and at some point, the `Registry` is instantiated. This is not the same for the `FileRegistryStore` that is instantiated later, however - in that class, paths from the `RegistryConfig` are processed to turn them into absolute paths in the event they are relative:

```py
class FileRegistryStore(RegistryStore):
    def __init__(self, registry_config: RegistryConfig, repo_path: Path):
        registry_path = Path(registry_config.path)
        if registry_path.is_absolute():
            self._filepath = registry_path
        else:
            self._filepath = repo_path.joinpath(registry_path)

    [...]
```

The problem here is that the tool used to build the CLI injects the current working directory in its context's `CHDIR` key, and that `CHDIR` is passed down the successive calls as the `repo_path` until the `FileRegistryStore` is finally built, which results in a malformed absolute path. Consequently, things like the UI cannot load (the landing page just claims there was an issue while loading the project list due to a malformed `feature_store.yaml`, but that's actually misleading).

Besides these issues, there's another one related to the env var `FEATURE_STORE_YAML_BASE64`. When the YAML is base-64 encoded and passed to the CLI with a file-based registry configured using a relative path, the final path built in `FileRegistryStore` takes as prefix a subfolder of `/tmp`, hence assuming that the file registry is stored in that subfolder (which is impossible, as it is created on the fly just to store the decoded env var as an actual file somewhere). Once again, the `FileRegistryStore` ends up in a weird state.

To mitigate these issues, I propose enforcing the usage of absolute paths while configuring the `feature_store.yaml`, be it a file or an env var. The onus is on the user then, and I am aware this can be a breaking change for people currently using file-based registries on their Feature Store setups, but the odds of using registries like these in production environments are very low IMHO.

Aside from that constraint, I also updated the logic behind the `feast init` command to replace the default values of the `feature_store.yaml` template with absolute paths built according to the dir from which the command was issued.

# Which issue(s) this PR fixes:

# Misc
