### PR TITLE
fix: Reduce feast-server container image size & fix dev image build

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -1,22 +1,18 @@
-FROM debian:11-slim
-RUN apt update && \
-        apt install -y \
-        jq \
-        python3 \
-        python3-pip \
-        python3-dev \
-        build-essential
+FROM python:3.11-slim-bullseye
 
-RUN pip install pip --upgrade
-RUN pip install "feast[aws,gcp,snowflake,redis,go,mysql,postgres,opentelemetry,grpcio]"
+RUN pip install --no-cache-dir pip --upgrade
+RUN pip install --no-cache-dir "feast[aws,gcp,snowflake,redis,go,mysql,postgres,opentelemetry,grpcio]"
 
 
-RUN apt update
-RUN apt install -y -V ca-certificates lsb-release wget
-RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-RUN apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-RUN apt update
-RUN apt -y install libarrow-dev
+RUN apt update && apt install -y -V ca-certificates lsb-release wget && \
+    wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+    apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && apt update && \
+    apt install -y \
+    jq \
+    libarrow-dev && \
+    apt remove -y lsb-release wget && \
+    apt-get clean && rm -rf /var/cache/apt/lists
+
 # modify permissions to support running with a random uid
 RUN mkdir -m 775 /.cache
 RUN chmod g+w $(python3 -c "import feast.ui as _; print(_.__path__)" | tr -d "[']")/build/projects-list.json

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -1,24 +1,28 @@
-FROM debian:11-slim
+FROM python:3.11-slim-bullseye
 
-RUN apt update && \
-        apt install -y \
-        jq \
-        python3 \
-        python3-pip \
-        python3-dev \
-        build-essential
+RUN pip install --no-cache-dir pip --upgrade
+RUN pip install --no-cache-dir pip-tools
 
-RUN pip install pip --upgrade
-COPY . .
+RUN apt update && apt install -y -V ca-certificates lsb-release wget make git curl gcc && \
+    curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
+    wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+    apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && apt update && \
+    apt install -y \
+    jq \
+    nodejs \
+    libarrow-dev && \
+    npm install -g yarn && \
+    apt remove -y lsb-release wget && \
+    apt-get clean && rm -rf /var/cache/apt/lists
 
-RUN pip install "feast[aws,gcp,snowflake,redis,go,mysql,postgres,opentelemetry,grpcio]"
+COPY . /feast
+WORKDIR /feast
+RUN make install-python-ci-dependencies && pip cache purge
+ENV NPM_TOKEN '//registry.npmjs.org/:_authToken'
+RUN make build-ui && yarn cache clean
 
-RUN apt update
-RUN apt install -y -V ca-certificates lsb-release wget
-RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-RUN apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-RUN apt update
-RUN apt -y install libarrow-dev
+WORKDIR /
+
 # modify permissions to support running with a random uid
 RUN mkdir -m 775 /.cache
 RUN chmod g+w $(python3 -c "import feast.ui as _; print(_.__path__)" | tr -d "[']")/build/projects-list.json


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Improve the Dockerfile to remove unnecessary packages and do some cleanup. This will reduce the current image size by over 300mb.
```shell
$ podman images
REPOSITORY                         TAG         IMAGE ID      CREATED        SIZE
quay.io/tchughesiv/feature-server  0.41.3      84dc7acaad64  2 minutes ago  1.04 GB
docker.io/feastdev/feature-server  0.41.3      1bbf34c192d9  3 weeks ago    1.37 GB
```

This is done by switching to the official python3 debian 11 slim image (`python:3.11-slim-bullseye`) which handles some of cleanup around python installation. We also tell pip install not to use cache and remove the `build-essential` package. Finally, we do some additional cleanup around apt.

Additionally, this PR fixes `Dockerfile.dev` so that it builds local dev changes into a functional container image, as was its intent.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/feast-dev/feast/issues/4784
