### PR TITLE
feat: Adding first feast operator e2e test.

### DIFF
--- a/infra/feast-operator/Makefile
+++ b/infra/feast-operator/Makefile
@@ -145,9 +145,9 @@ docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMG} .
 
 ## Build feast docker image.
-.PHONY: feast-docker-build
-feast-image-build:
-	cd ./../.. && VERSION=operator.v0 REGISTRY=example.com make build-feature-transformation-server-docker
+.PHONY: feast-ci-dev-docker-img
+feast-ci-dev-docker-img:
+	cd ./../.. && make build-feature-server-dev
 
 
 .PHONY: docker-push

--- a/infra/feast-operator/README.md
+++ b/infra/feast-operator/README.md
@@ -131,3 +131,28 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+
+
+## Running End-to-End integration tests on local(dev) environment
+You need a kind cluster to run the e2e tests on local(dev) environment.
+
+```shell
+# Default kind cluster configuration is not enough to run all the pods. In my case i was using docker with colima. kind uses the cpi and memory assigned to docker.
+# below memory configuration worked well but if you are using other docker runtime then please increase the cpu and memory.
+colima start --cpu 10 --memory 15 --disk 100
+
+# create the kind cluster
+kind create cluster
+
+# set kubernetes context to the recently created kind cluster
+kubectl cluster-info --context kind-kind
+
+# run the command from operator directory to run e2e tests.
+make test-e2e
+
+# delete cluster once you are done.
+kind delete cluster
+```
+
+
+

--- a/infra/feast-operator/test/e2e/e2e_test.go
+++ b/infra/feast-operator/test/e2e/e2e_test.go
@@ -102,7 +102,8 @@ var _ = Describe("controller", Ordered, func() {
 
 			namespace := "default"
 
-			deploymentNames := [3]string{"feast-simple-feast-setup-registry", "feast-simple-feast-setup-online", "feast-simple-feast-setup-offline"}
+			deploymentNames := [3]string{"feast-simple-feast-setup-registry", "feast-simple-feast-setup-online",
+				"feast-simple-feast-setup-offline"}
 			for _, deploymentName := range deploymentNames {
 				By(fmt.Sprintf("validate the feast deployment: %s is up and in availability state.", deploymentName))
 				err = checkIfDeploymentExistsAndAvailable(namespace, deploymentName, timeout)
@@ -122,7 +123,8 @@ var _ = Describe("controller", Ordered, func() {
 			))
 			fmt.Printf("Feast Deployment %s is available\n", configMapName)
 
-			serviceAccountNames := [3]string{"feast-simple-feast-setup-registry", "feast-simple-feast-setup-online", "feast-simple-feast-setup-offline"}
+			serviceAccountNames := [3]string{"feast-simple-feast-setup-registry", "feast-simple-feast-setup-online",
+				"feast-simple-feast-setup-offline"}
 			for _, serviceAccountName := range serviceAccountNames {
 				By(fmt.Sprintf("validate the feast service account: %s is available.", serviceAccountName))
 				err = checkIfServiceAccountExists(namespace, serviceAccountName)
@@ -133,7 +135,8 @@ var _ = Describe("controller", Ordered, func() {
 				fmt.Printf("Service account %s exists in namespace %s\n", serviceAccountName, namespace)
 			}
 
-			serviceNames := [3]string{"feast-simple-feast-setup-registry", "feast-simple-feast-setup-online", "feast-simple-feast-setup-offline"}
+			serviceNames := [3]string{"feast-simple-feast-setup-registry", "feast-simple-feast-setup-online",
+				"feast-simple-feast-setup-offline"}
 			for _, serviceName := range serviceNames {
 				By(fmt.Sprintf("validate the kubernetes service name: %s is available.", serviceName))
 				err = checkIfKubernetesServiceExists(namespace, serviceName)

--- a/infra/feast-operator/test/e2e/e2e_test.go
+++ b/infra/feast-operator/test/e2e/e2e_test.go
@@ -144,6 +144,14 @@ var _ = Describe("controller", Ordered, func() {
 				fmt.Printf("kubernetes service %s is available\n", serviceName)
 			}
 
+			By(fmt.Sprintf("Checking FeatureStore customer resource: %s is in Ready Status.", "simple-feast-setup"))
+			err = checkIfFeatureStoreCustomResourceConditionsInReady("simple-feast-setup", namespace)
+			Expect(err).To(BeNil(), fmt.Sprintf(
+				"FeatureStore custom resource %s all conditions are not in ready state. \nError: %v\n",
+				"simple-feast-setup", err,
+			))
+			fmt.Printf("FeatureStore customer resource %s conditions are in Ready State\n", "simple-feast-setup")
+
 			By("deleting the feast deployment")
 			cmd = exec.Command("kubectl", "delete", "-f",
 				"test/testdata/feast_integration_test_crs/v1alpha1_default_featurestore.yaml")

--- a/infra/feast-operator/test/e2e/e2e_test.go
+++ b/infra/feast-operator/test/e2e/e2e_test.go
@@ -46,7 +46,7 @@ var _ = Describe("controller", Ordered, func() {
 			var err error
 
 			// projectimage stores the name of the image used in the example
-			var projectimage = "example.com/feast-operator:v0.0.1"
+			var projectimage = "localhost/feast-operator:v0.0.1"
 
 			By("building the manager(Operator) image")
 			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
@@ -61,6 +61,7 @@ var _ = Describe("controller", Ordered, func() {
 			cmd = exec.Command("make", "feast-ci-dev-docker-img")
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			// this image will be built in above make target.
 			var feastImage = "feastdev/feature-server:dev"
 			var feastLocalImage = "localhost/feastdev/feature-server:dev"
 

--- a/infra/feast-operator/test/e2e/test_util.go
+++ b/infra/feast-operator/test/e2e/test_util.go
@@ -1,0 +1,133 @@
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// validates if a deployment exists and also in the availability state as True.
+func checkIfDeploymentExistsAndAvailable(namespace string, deploymentName string, timeout time.Duration) error {
+	var output, errOutput bytes.Buffer
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	timeoutChan := time.After(timeout)
+
+	for {
+		select {
+		case <-timeoutChan:
+			return fmt.Errorf("timed out waiting for deployment %s to become available", deploymentName)
+		case <-ticker.C:
+			// Run kubectl command
+			cmd := exec.Command("kubectl", "get", "deployment", deploymentName, "-n", namespace, "-o", "json")
+			cmd.Stdout = &output
+			cmd.Stderr = &errOutput
+
+			if err := cmd.Run(); err != nil {
+				// Log error and retry
+				fmt.Printf("Error running command: %s\n", errOutput.String())
+				continue
+			}
+
+			// Parse the JSON output into a map
+			var result map[string]interface{}
+			if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+				return fmt.Errorf("failed to parse deployment JSON: %v", err)
+			}
+
+			// Navigate to status.conditions
+			status, ok := result["status"].(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("failed to get status field from deployment JSON")
+			}
+
+			conditions, ok := status["conditions"].([]interface{})
+			if !ok {
+				return fmt.Errorf("failed to get conditions field from deployment JSON")
+			}
+
+			// Check for Available condition
+			for _, condition := range conditions {
+				cond, ok := condition.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if cond["type"] == "Available" && cond["status"] == "True" {
+					return nil // Deployment is available
+				}
+			}
+
+			// Reset buffers for the next loop iteration
+			output.Reset()
+			errOutput.Reset()
+		}
+	}
+}
+
+// validates if a service account exists using the kubectl CLI.
+func checkIfServiceAccountExists(namespace, saName string) error {
+	cmd := exec.Command("kubectl", "get", "sa", saName, "-n", namespace)
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to find service account %s in namespace %s. Error: %v. Stderr: %s", saName, namespace, err, stderr.String())
+	}
+
+	// Check the output to confirm presence
+	if !strings.Contains(out.String(), saName) {
+		return fmt.Errorf("service account %s not found in namespace %s", saName, namespace)
+	}
+
+	return nil
+}
+
+// validates if a config map exists using the kubectl CLI.
+func checkIfConfigMapExists(namespace, configMapName string) error {
+	cmd := exec.Command("kubectl", "get", "cm", configMapName, "-n", namespace)
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to find config map %s in namespace %s. Error: %v. Stderr: %s", configMapName, namespace, err, stderr.String())
+	}
+
+	// Check the output to confirm presence
+	if !strings.Contains(out.String(), configMapName) {
+		return fmt.Errorf("config map %s not found in namespace %s", configMapName, namespace)
+	}
+
+	return nil
+}
+
+// validates if a kubernetes service exists using the kubectl CLI.
+func checkIfKubernetesServiceExists(namespace, serviceName string) error {
+	cmd := exec.Command("kubectl", "get", "service", serviceName, "-n", namespace)
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to find kubernetes service %s in namespace %s. Error: %v. Stderr: %s", serviceName, namespace, err, stderr.String())
+	}
+
+	// Check the output to confirm presence
+	if !strings.Contains(out.String(), serviceName) {
+		return fmt.Errorf("kubernetes service %s not found in namespace %s", serviceName, namespace)
+	}
+
+	return nil
+}

--- a/infra/feast-operator/test/e2e/test_util.go
+++ b/infra/feast-operator/test/e2e/test_util.go
@@ -19,7 +19,8 @@ func checkIfFeatureStoreCustomResourceConditionsInReady(featureStoreName, namesp
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to get resource %s in namespace %s. Error: %v. Stderr: %s", featureStoreName, namespace, err, stderr.String())
+		return fmt.Errorf("failed to get resource %s in namespace %s. Error: %v. Stderr: %s",
+			featureStoreName, namespace, err, stderr.String())
 	}
 
 	// Parse the JSON into a generic map
@@ -50,7 +51,8 @@ func checkIfFeatureStoreCustomResourceConditionsInReady(featureStoreName, namesp
 		conditionStatus := conditionMap["status"].(string)
 
 		if conditionStatus != "True" {
-			return fmt.Errorf(" FeatureStore=%s condition '%s' is not in 'Ready' state. Status: %s", featureStoreName, conditionType, conditionStatus)
+			return fmt.Errorf(" FeatureStore=%s condition '%s' is not in 'Ready' state. Status: %s",
+				featureStoreName, conditionType, conditionStatus)
 		}
 	}
 
@@ -127,7 +129,8 @@ func checkIfServiceAccountExists(namespace, saName string) error {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to find service account %s in namespace %s. Error: %v. Stderr: %s", saName, namespace, err, stderr.String())
+		return fmt.Errorf("failed to find service account %s in namespace %s. Error: %v. Stderr: %s",
+			saName, namespace, err, stderr.String())
 	}
 
 	// Check the output to confirm presence
@@ -148,7 +151,8 @@ func checkIfConfigMapExists(namespace, configMapName string) error {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to find config map %s in namespace %s. Error: %v. Stderr: %s", configMapName, namespace, err, stderr.String())
+		return fmt.Errorf("failed to find config map %s in namespace %s. Error: %v. Stderr: %s",
+			configMapName, namespace, err, stderr.String())
 	}
 
 	// Check the output to confirm presence
@@ -169,7 +173,8 @@ func checkIfKubernetesServiceExists(namespace, serviceName string) error {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to find kubernetes service %s in namespace %s. Error: %v. Stderr: %s", serviceName, namespace, err, stderr.String())
+		return fmt.Errorf("failed to find kubernetes service %s in namespace %s. Error: %v. Stderr: %s",
+			serviceName, namespace, err, stderr.String())
 	}
 
 	// Check the output to confirm presence

--- a/infra/feast-operator/test/e2e/test_util.go
+++ b/infra/feast-operator/test/e2e/test_util.go
@@ -30,7 +30,7 @@ func checkIfDeploymentExistsAndAvailable(namespace string, deploymentName string
 
 			if err := cmd.Run(); err != nil {
 				// Log error and retry
-				fmt.Printf("Error running command: %s\n", errOutput.String())
+				fmt.Printf("Deployment not yet found, we may try again to find the updated status: %s\n", errOutput.String())
 				continue
 			}
 

--- a/infra/feast-operator/test/testdata/feast_integration_test_crs/v1alpha1_default_featurestore.yaml
+++ b/infra/feast-operator/test/testdata/feast_integration_test_crs/v1alpha1_default_featurestore.yaml
@@ -1,0 +1,14 @@
+apiVersion: feast.dev/v1alpha1
+kind: FeatureStore
+metadata:
+  name: simple-feast-setup
+spec:
+  feastProject: my_project
+  services:
+    onlineStore:
+      image: 'localhost/feastdev/feature-server:dev'
+    offlineStore:
+      image: 'localhost/feastdev/feature-server:dev'
+    registry:
+      local:
+        image: 'localhost/feastdev/feature-server:dev'


### PR DESCRIPTION
Adding first basic feast operator e2e test.

Planing to address following scenarios as part of the test in this PR:

1. Kubernetes FeatureStore CR should spin up all the necessary services required  in our case it will be registry, online and offline services.
2. Assert `FeatureStore` CR status should be in ready state.
3. Assert registry, online and offline service Deployments are in Running and available state.
4. Assert feast client ConfigMap is existing.
5. Assert registry, online and offline services are having associated Kubernetes service objects defined.
6. Assert registry, online and offline services are having associated Kubernetes service account objects defined.

Issue we are fixing: [4792](https://github.com/feast-dev/feast/issues/4792)
