### PR TITLE
doc: Added missing documentation for the registry server and remote client

### DIFF
--- a/docs/reference/feature-servers/README.md
+++ b/docs/reference/feature-servers/README.md
@@ -1,4 +1,4 @@
-# Feature servers
+# Feast servers
 
 Feast users can choose to retrieve features from a feature server, as opposed to through the Python SDK.
 
@@ -12,4 +12,8 @@ Feast users can choose to retrieve features from a feature server, as opposed to
 
 {% content-ref url="offline-feature-server.md" %}
 [offline-feature-server.md](offline-feature-server.md)
+{% endcontent-ref %}
+
+{% content-ref url="registry-server.md" %}
+[registry-server.md](registry-server.md)
 {% endcontent-ref %}

--- a/docs/reference/feature-servers/registry-server.md
+++ b/docs/reference/feature-servers/registry-server.md
@@ -1,0 +1,25 @@
+# Registry server
+
+## Description
+
+The Registry server uses the gRPC communication protocol to exchange data.
+This enables users to communicate with the server using any programming language that can make gRPC requests.
+
+## How to configure the server
+
+## CLI
+
+There is a CLI command that starts the Registry server: `feast serve_registry`. By default, remote Registry Server uses port 6570, the port can be overridden with a `--port` flag.
+To start the Registry Server in TLS mode, you need to provide the private and public keys using the `--key` and `--cert` arguments.
+
+## How to configure the client
+
+Please see the detail how to configure Remote Registry client [remote.md](../registries/remote.md)
+
+# Offline Feature Server Permissions and Access Control
+
+Please refer the [page](./../registry/registry-permissions.md) for more details on API Endpoints and Permissions.
+
+## How to configure Authentication and Authorization ?
+
+Please refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization.

--- a/docs/reference/registries/remote.md
+++ b/docs/reference/registries/remote.md
@@ -1,0 +1,28 @@
+# Remote Offline Store
+
+## Description
+
+The Remote Registry is a gRPC client for the registry that implements the `RemoteRegistry` class using the existing `BaseRegistry` interface.
+
+## How to configure the client
+
+User needs to create a client side `feature_store.yaml` file, set the `registry_type` to `remote` and provide the server connection configuration.
+The `path` parameter is a URL with a port (default is 6570) used by the client to connect with the Remote Registry server.
+
+The `cert` parameter is an optional configuration to the public certificate path when the Registry Server starts in SSL mode. This may be needed if the Registry Server is started with a self-signed certificate, typically this file ends with *.crt, *.cer, or *.pem.
+More info about the `cert` parameter can be found in [feast-client-connecting-to-remote-registry-sever-started-in-tls-mode](../../how-to-guides/starting-feast-servers-tls-mode.md#feast-client-connecting-to-remote-registry-sever-started-in-tls-mode)
+
+{% code title="feature_store.yaml" %}
+```yaml
+registry:
+  registry_type: remote
+  path: http://localhost:6570
+```
+{% endcode %}
+
+## How to configure the server
+
+Please see the detail how to configure offline feature server [registry-server.md](../feature-servers/registry-server.md)
+
+## How to configure Authentication and Authorization
+Please refer the [page](./../../../docs/getting-started/concepts/permission.md) for more details on how to configure authentication and authorization.


### PR DESCRIPTION
# What this PR does / why we need it:
Added missing documentation for the registry server and its remote client

# Which issue(s) this PR fixes:
Fixes https://github.com/feast-dev/feast/issues/4757