### PR TITLE
chore: Issue warning announcing entity's value_type as mandatory 

### DIFF
--- a/sdk/python/feast/entity.py
+++ b/sdk/python/feast/entity.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import warnings
 from datetime import datetime
 from typing import Dict, List, Optional
-import warnings
 
 from google.protobuf.json_format import MessageToJson
 from typeguard import typechecked

--- a/sdk/python/feast/entity.py
+++ b/sdk/python/feast/entity.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from datetime import datetime
 from typing import Dict, List, Optional
+import warnings
 
 from google.protobuf.json_format import MessageToJson
 from typeguard import typechecked
@@ -79,6 +80,13 @@ class Entity:
             ValueError: Parameters are specified incorrectly.
         """
         self.name = name
+        if value_type is None:
+            warnings.warn(
+                "Entity value_type will be mandatory in the next release. "
+                "Please specify a value_type for entity '%s'." % name,
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.value_type = value_type or ValueType.UNKNOWN
 
         if join_keys and len(join_keys) > 1:

--- a/sdk/python/tests/unit/test_entity.py
+++ b/sdk/python/tests/unit/test_entity.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import warnings
+
 import assertpy
 import pytest
-import warnings
 
 from feast.entity import Entity
 from feast.value_type import ValueType

--- a/sdk/python/tests/unit/test_entity.py
+++ b/sdk/python/tests/unit/test_entity.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import assertpy
 import pytest
+import warnings
 
 from feast.entity import Entity
 from feast.value_type import ValueType
@@ -73,3 +74,16 @@ def test_hash():
 
     s4 = {entity1, entity2, entity3, entity4}
     assert len(s4) == 3
+
+
+def test_entity_without_value_type_warns():
+    with pytest.warns(DeprecationWarning, match="Entity value_type will be mandatory"):
+        entity = Entity(name="my-entity")
+    assert entity.value_type == ValueType.UNKNOWN
+
+
+def test_entity_with_value_type_no_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        entity = Entity(name="my-entity", value_type=ValueType.STRING)
+    assert entity.value_type == ValueType.STRING


### PR DESCRIPTION
# What this PR does / why we need it:
Make value_type for Entity issue a warning if not set. Next release we'll make it mandatory.

# Which issue(s) this PR fixes:
https://github.com/feast-dev/feast/issues/4670

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
