### PR TITLE
chore: Minor precommit fixes on import ordering

### DIFF
--- a/sdk/python/feast/driver_test_data.py
+++ b/sdk/python/feast/driver_test_data.py
@@ -2,10 +2,10 @@
 import itertools
 from datetime import timedelta, timezone
 from enum import Enum
-from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
+from zoneinfo import ZoneInfo
 
 from feast.infra.offline_stores.offline_utils import (
     DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,

--- a/sdk/python/tests/data/data_creator.py
+++ b/sdk/python/tests/data/data_creator.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
-from zoneinfo import ZoneInfo
 
 import pandas as pd
+from zoneinfo import ZoneInfo
 
 from feast.types import FeastType, Float32, Int32, Int64, String
 from feast.utils import _utc_now


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Precommit was failing I believe due to a third party Python library (`zoneinfo`) being grouped with the builtin Python libraries. This is a very minor change re-ordering the library import statements so that precommit formatting checks succeed, and the import lines meet the style requirements.

Note that this is merely a style change (not functionality), but it makes a difference because it will keep developers from getting stuck on precommit issues that they either have to manually ignore, or address in some other way.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
