### PR TITLE
chore: Update go targets in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ scratch*
 
 ### Local Environment ###
 *local*.env
+tools
 
 ### Secret ###
 **/service_account.json
@@ -101,6 +102,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.out
 *.cover
 .hypothesis/
 .pytest_cache/

--- a/sdk/python/requirements/protoc-requirements.txt
+++ b/sdk/python/requirements/protoc-requirements.txt
@@ -1,0 +1,3 @@
+protobuf>=4.24.0,<5.0.0
+grpcio-tools>=1.56.2,<2
+mypy-protobuf>=3.1

--- a/sdk/python/requirements/protoc-requirements.txt
+++ b/sdk/python/requirements/protoc-requirements.txt
@@ -1,3 +1,0 @@
-protobuf>=4.24.0,<5.0.0
-grpcio-tools>=1.56.2,<2
-mypy-protobuf>=3.1


### PR DESCRIPTION
# What this PR does / why we need it:
This PR fixes or updates some of the go-related targets, specifically addresses the following:
- incorrectly defined dependency targets
- protobuf/GRPC go tools installed globally, thus potentially messing up existing installations
- pip used instead of uv pip
- .PHONY targets not declared
- moved inline python/grpc requirements to separate file

# Which issue(s) this PR fixes:
N/A

# Misc
target `build-go` builds a binary in the root directory, it should be moved under `dist/`  (follow-up PR)