### PR TITLE
chore: Update document test to add other feature data types and fix feature logging

### DIFF
--- a/sdk/python/tests/data/data_creator.py
+++ b/sdk/python/tests/data/data_creator.py
@@ -84,6 +84,8 @@ def get_feature_values_for_dtype(
 def create_document_dataset() -> pd.DataFrame:
     data = {
         "item_id": [1, 2, 3],
+        "string_feature": ["a", "b", "c"],
+        "float_feature": [1.0, 2.0, 3.0],
         "embedding_float": [[4.0, 5.0], [1.0, 2.0], [3.0, 4.0]],
         "embedding_double": [[4.0, 5.0], [1.0, 2.0], [3.0, 4.0]],
         "ts": [

--- a/sdk/python/tests/integration/feature_repos/universal/feature_views.py
+++ b/sdk/python/tests/integration/feature_repos/universal/feature_views.py
@@ -17,7 +17,7 @@ from feast import (
 from feast.data_source import DataSource, RequestSource
 from feast.feature_view_projection import FeatureViewProjection
 from feast.on_demand_feature_view import PandasTransformation, SubstraitTransformation
-from feast.types import Array, FeastType, Float32, Float64, Int32, Int64
+from feast.types import Array, FeastType, Float32, Float64, Int32, Int64, String
 from tests.integration.feature_repos.universal.entities import (
     customer,
     driver,
@@ -160,8 +160,20 @@ def create_item_embeddings_feature_view(source, infer_features: bool = False):
         schema=None
         if infer_features
         else [
-            Field(name="embedding_double", dtype=Array(Float64)),
-            Field(name="embedding_float", dtype=Array(Float32)),
+            Field(
+                name="embedding_double",
+                dtype=Array(Float64),
+                vector_index=True,
+                vector_search_metric="L2",
+            ),
+            Field(
+                name="embedding_float",
+                dtype=Array(Float32),
+                vector_index=True,
+                vector_search_metric="L2",
+            ),
+            Field(name="string_feature", dtype=String),
+            Field(name="float_feature", dtype=Float32),
         ],
         source=source,
         ttl=timedelta(hours=2),

--- a/sdk/python/tests/integration/offline_store/test_feature_logging.py
+++ b/sdk/python/tests/integration/offline_store/test_feature_logging.py
@@ -106,7 +106,15 @@ def test_feature_service_logging(environment, universal_data_sources, pass_as_pa
     )
 
     persisted_logs = persisted_logs[expected_columns]
+
     logs_df = logs_df[expected_columns]
+
+    # Convert timezone-aware datetime values to naive datetime values
+    logs_df[LOG_TIMESTAMP_FIELD] = logs_df[LOG_TIMESTAMP_FIELD].dt.tz_localize(None)
+    persisted_logs[LOG_TIMESTAMP_FIELD] = persisted_logs[
+        LOG_TIMESTAMP_FIELD
+    ].dt.tz_localize(None)
+
     pd.testing.assert_frame_equal(
         logs_df.sort_values(REQUEST_ID_FIELD).reset_index(drop=True),
         persisted_logs.sort_values(REQUEST_ID_FIELD).reset_index(drop=True),


### PR DESCRIPTION
# What this PR does / why we need it:

This pull request introduces several enhancements and updates to the `feast` repository. The changes are focused on adding new features and improving existing functionalities in the Python SDK. Below are the detailed changes:

#### Changes in `sdk/python/tests/data/data_creator.py`
- Added new fields to the `create_document_dataset` function:
  - `string_feature`: A list of strings `["a", "b", "c"]`.
  - `float_feature`: A list of floats `[1.0, 2.0, 3.0]`.

#### Changes in `sdk/python/tests/integration/feature_repos/universal/feature_views.py`
- Updated imports to include `String` from `feast.types`.
- Enhanced the `create_item_embeddings_feature_view` function:
  - Added `vector_index` and `vector_search_metric="L2"` attributes to `embedding_double` and `embedding_float` fields.
  - Added new fields `string_feature` of type `String` and `float_feature` of type `Float32`.

#### Changes in `sdk/python/tests/integration/offline_store/test_feature_logging.py`
- Modified the `retrieve` function to handle timezone-aware datetime values:
  - Converted timezone-aware datetime values to naive datetime values for `LOG_TIMESTAMP_FIELD` in both `logs_df` and `persisted_logs`.
  - Ensured the comparison of `logs_df` and `persisted_logs` is done with naive datetime values.

These changes aim to enhance the data handling capabilities of the Feast SDK, particularly in the areas of feature retrieval and logging. The added vector indexing support and new field types will allow for more advanced data processing and analysis.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
Pulled out of https://github.com/feast-dev/feast/pull/4872