### PR TITLE
docs: Add missing unpacking operator in Permission objects docs

### DIFF
--- a/docs/getting-started/concepts/permission.md
+++ b/docs/getting-started/concepts/permission.md
@@ -69,7 +69,7 @@ Permission(
     name="feature-reader",
     types=[FeatureView, FeatureService],
     policy=RoleBasedPolicy(roles=["super-reader"]),
-    actions=[AuthzedAction.DESCRIBE, READ],
+    actions=[AuthzedAction.DESCRIBE, *READ],
 )
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:

The current example for setting up a `Permission` object with the `READ` action, which serves as a composition of multiple read actions (`READ_OFFLINE` and `READ_ONLINE`), makes Feast crash when running `feast apply`.

It is documented like this at the moment:

```py
from feast.permissions.action import AuthzedAction, READ

Permission(
    name="feature-reader",
    types=[FeatureView, FeatureService],
    policy=RoleBasedPolicy(roles=["super-reader"]),
    actions=[AuthzedAction.DESCRIBE, READ],
)
```

So `actions` ultimately ends up resolving `READ` and looking like this:

```py
from feast.permissions.action import AuthzedAction, READ

Permission(
    name="feature-reader",
    types=[FeatureView, FeatureService],
    policy=RoleBasedPolicy(roles=["super-reader"]),
    actions=[AuthzedAction.DESCRIBE, [AuthzedAction.READ_OFFLINE, AuthzedAction.READ_ONLINE]],
)
```

And `feast apply` yields the following exception when trying to persist that permission to the Registry:

```bash
$ feast apply

Applying changes for project feast-demo

Traceback (most recent call last):
  File "/usr/local/bin/feast", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/feast/cli.py", line 760, in apply_total_command
    apply_total(repo_config, repo, skip_source_validation)
  File "/usr/local/lib/python3.11/site-packages/feast/repo_operations.py", line 404, in apply_total
    apply_total_with_repo_instance(
  File "/usr/local/lib/python3.11/site-packages/feast/repo_operations.py", line 351, in apply_total_with_repo_instance
    store.apply(all_to_apply, objects_to_delete=all_to_delete, partial=False)
  File "/usr/local/lib/python3.11/site-packages/feast/feature_store.py", line 960, in apply
    self._registry.apply_permission(
  File "/usr/local/lib/python3.11/site-packages/feast/infra/registry/sql.py", line 1176, in apply_permission
    return self._apply_object(
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/feast/infra/registry/sql.py", line 969, in _apply_object
    proto_field_name: obj.to_proto().SerializeToString(),
                      ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/feast/permissions/permission.py", line 218, in to_proto
    actions = [
              ^
  File "/usr/local/lib/python3.11/site-packages/feast/permissions/permission.py", line 219, in <listcomp>
    PermissionSpecProto.AuthzedAction.Value(action.name)
                                            ^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'name'
```

We need the unpacking operator (`*`) to flatten the `READ` list and make the `Permission` look like this at the end:

```py
from feast.permissions.action import AuthzedAction, READ

Permission(
    name="feature-reader",
    types=[FeatureView, FeatureService],
    policy=RoleBasedPolicy(roles=["super-reader"]),
    actions=[AuthzedAction.DESCRIBE, *READ],
)
```

Which resolves as:

```py
from feast.permissions.action import AuthzedAction, READ

Permission(
    name="feature-reader",
    types=[FeatureView, FeatureService],
    policy=RoleBasedPolicy(roles=["super-reader"]),
    actions=[AuthzedAction.DESCRIBE, AuthzedAction.READ_OFFLINE, AuthzedAction.READ_ONLINE],
)
```