### PR TITLE
fix: Invalid column names in get_historical_features when there are field mappings on join keys

### DIFF
--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -118,6 +118,10 @@ def get_feature_view_query_context(
 
     query_context = []
     for feature_view, features in feature_views_to_feature_map.items():
+        reverse_field_mapping = {
+            v: k for k, v in feature_view.batch_source.field_mapping.items()
+        }
+
         join_keys: List[str] = []
         entity_selections: List[str] = []
         for entity_column in feature_view.entity_columns:
@@ -125,16 +129,16 @@ def get_feature_view_query_context(
                 entity_column.name, entity_column.name
             )
             join_keys.append(join_key)
-            entity_selections.append(f"{entity_column.name} AS {join_key}")
+            entity_selections.append(
+                f"{reverse_field_mapping.get(entity_column.name, entity_column.name)} "
+                f"AS {join_key}"
+            )
 
         if isinstance(feature_view.ttl, timedelta):
             ttl_seconds = int(feature_view.ttl.total_seconds())
         else:
             ttl_seconds = 0
 
-        reverse_field_mapping = {
-            v: k for k, v in feature_view.batch_source.field_mapping.items()
-        }
         features = [reverse_field_mapping.get(feature, feature) for feature in features]
         timestamp_field = reverse_field_mapping.get(
             feature_view.batch_source.timestamp_field,

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -14,7 +14,7 @@ from feast.field import Field
 from feast.infra.offline_stores.offline_utils import (
     DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,
 )
-from feast.types import Float32, Int32
+from feast.types import Float32, Int32, String
 from feast.utils import _utc_now
 from tests.integration.feature_repos.repo_configuration import (
     construct_universal_feature_views,
@@ -615,6 +615,103 @@ def test_historical_features_containing_backfills(environment):
         name="driver_stats",
         entities=[driver],
         schema=[Field(name="avg_daily_trips", dtype=Int32)],
+        source=driver_stats_data_source,
+    )
+
+    store.apply([driver, driver_fv])
+
+    offline_job = store.get_historical_features(
+        entity_df=entity_df,
+        features=["driver_stats:avg_daily_trips"],
+        full_feature_names=False,
+    )
+
+    start_time = _utc_now()
+    actual_df = offline_job.to_df()
+
+    print(f"actual_df shape: {actual_df.shape}")
+    end_time = _utc_now()
+    print(str(f"Time to execute job_from_df.to_df() = '{(end_time - start_time)}'\n"))
+
+    assert sorted(expected_df.columns) == sorted(actual_df.columns)
+    validate_dataframes(
+        expected_df,
+        actual_df,
+        sort_by=["driver_id"],
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.universal_offline_stores
+@pytest.mark.parametrize("full_feature_names", [True, False], ids=lambda v: str(v))
+def test_historical_features_field_mapping(
+    environment, universal_data_sources, full_feature_names
+):
+    store = environment.feature_store
+
+    # (entities, datasets, data_sources) = universal_data_sources
+    # feature_views = construct_universal_feature_views(data_sources)
+
+    now = datetime.now().replace(microsecond=0, second=0, minute=0)
+    tomorrow = now + timedelta(days=1)
+    day_after_tomorrow = now + timedelta(days=2)
+
+    entity_df = pd.DataFrame(
+        data=[
+            {"driver_id": 1001, "event_timestamp": day_after_tomorrow},
+            {"driver_id": 1002, "event_timestamp": day_after_tomorrow},
+        ]
+    )
+
+    driver_stats_df = pd.DataFrame(
+        data=[
+            {
+                "id": 1001,
+                "avg_daily_trips": 20,
+                "event_timestamp": now,
+                "created": tomorrow,
+            },
+            {
+                "id": 1002,
+                "avg_daily_trips": 40,
+                "event_timestamp": tomorrow,
+                "created": now,
+            },
+        ]
+    )
+
+    expected_df = pd.DataFrame(
+        data=[
+            {
+                "driver_id": 1001,
+                "event_timestamp": day_after_tomorrow,
+                "avg_daily_trips": 20,
+            },
+            {
+                "driver_id": 1002,
+                "event_timestamp": day_after_tomorrow,
+                "avg_daily_trips": 40,
+            },
+        ]
+    )
+
+    driver_stats_data_source = environment.data_source_creator.create_data_source(
+        df=driver_stats_df,
+        destination_name=f"test_driver_stats_{int(time.time_ns())}_{random.randint(1000, 9999)}",
+        timestamp_field="event_timestamp",
+        created_timestamp_column="created",
+        # Map original "id" column to "driver_id" join key
+        field_mapping={"id": "driver_id"}
+    )
+
+    driver = Entity(name="driver", join_keys=["driver_id"])
+    driver_fv = FeatureView(
+        name="driver_stats",
+        entities=[driver],
+        schema=[
+            Field(name="driver_id", dtype=String),
+            Field(name="avg_daily_trips", dtype=Int32)
+        ],
         source=driver_stats_data_source,
     )
 

--- a/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
+++ b/sdk/python/tests/integration/offline_store/test_universal_historical_retrieval.py
@@ -701,7 +701,7 @@ def test_historical_features_field_mapping(
         timestamp_field="event_timestamp",
         created_timestamp_column="created",
         # Map original "id" column to "driver_id" join key
-        field_mapping={"id": "driver_id"}
+        field_mapping={"id": "driver_id"},
     )
 
     driver = Entity(name="driver", join_keys=["driver_id"])
@@ -710,7 +710,7 @@ def test_historical_features_field_mapping(
         entities=[driver],
         schema=[
             Field(name="driver_id", dtype=String),
-            Field(name="avg_daily_trips", dtype=Int32)
+            Field(name="avg_daily_trips", dtype=Int32),
         ],
         source=driver_stats_data_source,
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:

When there are field mappings on an entity's join keys, `get_historical_features()` fails because it does not use the original column name in the data source.

This is needed when the source data cannot be modified, and a field mapping is used to map the source data's column to the join key.

Example:

```python
from feast import Entity, Field, FeatureStore, FeatureView
from feast.types import Float32, String
from feast.infra.offline_stores.contrib.spark_offline_store.spark_source import SparkSource

# Initialize Feature Store.
store = FeatureStore(...)

# "driver_id" is used in the Feature Store.
driver = Entity(name="driver", join_keys=["driver_id"])

# Using SparkSource as an example, but this applies to other sources.
# Source data contains a primary key called "id". This is mapped to the join key "driver_id".
driver_stats_src = SparkSource(
    name="driver_stats",
    field_mapping={"id": "driver_id"},
    path=...,
    file_format=...,
)
driver_stats_fv = FeatureView(
    name="driver_stats",
    source= driver_stats_src,
    entities=[driver],
    schema=[
        # join key must be specified in the schema, else it is not included in driver_stats_fv.entity_columns
        Field(name="driver_id", dtype=String),
        Field(name="stat1", dtype=Float32),
        Field(name="stat2", dtype=Float32),
    ]
)

# Get historical features
store.get_historical_features(
    entity_df=...,
    features=[
        "driver_stats:stat1",
        "driver_stats:stat2",
    ]
```

Without this fix (Spark example):

```
pyspark.errors.exceptions.captured.AnalysisException: [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column or function parameter with name `driver_id` cannot be resolved. Did you mean one of the following? [`id`, `stat1`, `stat2`]
```

Underlying Spark query:

```sql
driver_stats__subquery AS (
    SELECT
        event_timestamp as event_timestamp,
        created as created_timestamp,

        -- Here is the problem.
        driver_id AS driver_id,

        stat1 as stat1, stat2 as stat2
    FROM `feast_entity_df_677a1a6fd13443c6b0e8ccc059b25f01`
    WHERE event_timestamp <= '2025-01-05T14:00:00'
)
```

With this fix, the field mapping is respected and the query becomes:

```sql
driver_stats__subquery AS (
    SELECT
        event_timestamp as event_timestamp,
        created as created_timestamp,

        id AS driver_id,
        
        stat1 as stat1, stat2 as stat2
    FROM `feast_entity_df_677a1a6fd13443c6b0e8ccc059b25f01`
    WHERE event_timestamp <= '2025-01-05T14:00:00'
)
```


# Which issue(s) this PR fixes:

#4889

# Misc

This only works if the entity join key is specified in the schema of the FeatureView (see above).