### PR TITLE
introduce string_json value type

### DIFF
--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -680,6 +680,7 @@ class OnDemandFeatureView(BaseFeatureView):
             ValueType.FLOAT_LIST: [[1.0]],
             ValueType.BOOL_LIST: [[True]],
             ValueType.UNIX_TIMESTAMP_LIST: [[_utc_now()]],
+            ValueType.STRING_JSON: [{"0": "hello world"}],
         }
         if singleton:
             rand_dict_value = {k: rand_dict_value[k][0] for k in rand_dict_value}

--- a/sdk/python/feast/value_type.py
+++ b/sdk/python/feast/value_type.py
@@ -48,6 +48,7 @@ class ValueType(enum.Enum):
     BOOL_LIST = 17
     UNIX_TIMESTAMP_LIST = 18
     NULL = 19
+    STRING_JSON = 20
 
 
 ListType = Union[


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
On-demand feature views are very powerful, but we can extend their functionality further by allowing a string of JSON as a type.

Consider a feature with `Field(name='value_array', dtype=String_JSON)`. 
An example feature would be `{'0': 127.5433, '1': 183.2108, '2': 157.525, '3': 170.2931, '4': 186.0841, '5': 141.6574, '6': 146.1895, '7': 148.6707, '8': 146.0211, '9': 196.4125, '10': 132.7219, '11': 154.1899, '12': 132.3854}`

The on-demand feature view now can be defined as:

```
@on_demand_feature_view(
    sources=[driver_hourly_stats_view, input_request],
    schema=[
        Field(name="value_array_modified", dtype=Float64)
    ],
)
def array_modified(inputs: pd.DataFrame) -> pd.DataFrame:
    df = pd.DataFrame()
    df['value_array_modified'] = 0.0
    for index, row in inputs.iterrows():
        x1 = eval(row['value_array']).get('1')
        x1 = x1 if x1 is not None else 0.0
        x2 = eval(row['value_array']).get('2')
        x2 = x2 if x2 is not None else 0.0
        x3 = eval(row['value_array']).get('3')
        x3 = x3 if x3 is not None else 0.0
        df.at[index, 'value_array_modified'] = x1 + x2 + x3

    return df
```

Upon requested this feature, the response would be `511.0289`

<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
