### PR TITLE
chore: Moving Milvus client to PyMilvus

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1757,7 +1757,7 @@ class FeatureStore:
         query: Union[str, List[float]],
         top_k: int,
         features: Optional[List[str]] = None,
-        distance_metric: Optional[str] = None,
+        distance_metric: Optional[str] = "L2",
     ) -> OnlineResponse:
         """
         Retrieves the top k closest document features. Note, embeddings are a subset of features.

--- a/sdk/python/feast/infra/online_stores/milvus_online_store/milvus.py
+++ b/sdk/python/feast/infra/online_stores/milvus_online_store/milvus.py
@@ -114,9 +114,6 @@ class MilvusOnlineStore(OnlineStore):
                 if config.online_store.username and config.online_store.password
                 else "",
             )
-            print(
-                f"Connected to Milvus at {config.online_store.host}:{config.online_store.port}"
-            )
         return self.client
 
     def _get_collection(self, config: RepoConfig, table: FeatureView) -> Dict[str, Any]:
@@ -168,13 +165,10 @@ class MilvusOnlineStore(OnlineStore):
             schema = CollectionSchema(
                 fields=fields, description="Feast feature view data"
             )
-            self.client.drop_collection(collection_name)
             collection_exists = self.client.has_collection(
                 collection_name=collection_name
             )
-            print(f"Collection {collection_name} exists: {collection_exists}")
             if not collection_exists:
-                print("Creating collection")
                 self.client.create_collection(
                     collection_name=collection_name,
                     dimension=config.online_store.embedding_dim,
@@ -199,7 +193,6 @@ class MilvusOnlineStore(OnlineStore):
                     index_params=index_params,
                 )
             else:
-                print(f"Loading collection {collection_name}")
                 self.client.load_collection(collection_name)
             self._collections[collection_name] = self.client.describe_collection(
                 collection_name
@@ -345,7 +338,6 @@ class MilvusOnlineStore(OnlineStore):
             + (requested_features if requested_features else [])
             + ["created_ts", "event_ts"]
         )
-        print(output_fields, collection)
         assert all(
             field in [f["name"] for f in collection["fields"]]
             for field in output_fields
@@ -360,7 +352,6 @@ class MilvusOnlineStore(OnlineStore):
                 ann_search_field = field["name"]
                 break
 
-        # print("\n****\n", collection, collection_name, ann_search_field, search_params, top_k)
         self.client.load_collection(collection_name)
         results = self.client.search(
             collection_name=collection_name,

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/milvus.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/milvus.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict
 
-from testcontainers.milvus import MilvusContainer
+import docker
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_for_logs
 
 from tests.integration.feature_repos.universal.online_store_creator import (
     OnlineStoreCreator,
@@ -11,13 +13,19 @@ class MilvusOnlineStoreCreator(OnlineStoreCreator):
     def __init__(self, project_name: str, **kwargs):
         super().__init__(project_name)
         self.fixed_port = 19530
-        self.container = MilvusContainer("milvusdb/milvus:v2.4.4").with_exposed_ports(
+        self.container = DockerContainer("milvusdb/milvus:v2.4.4").with_exposed_ports(
             self.fixed_port
         )
+        self.client = docker.from_env()
 
     def create_online_store(self) -> Dict[str, Any]:
         self.container.start()
         # Wait for Milvus server to be ready
+        # log_string_to_wait_for = "Ready to accept connections"
+        log_string_to_wait_for = ""
+        wait_for_logs(
+            container=self.container, predicate=log_string_to_wait_for, timeout=30
+        )
         host = "localhost"
         port = self.container.get_exposed_port(self.fixed_port)
         return {

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -897,26 +897,26 @@ def test_retrieve_online_documents(environment, fake_document_data):
         ).to_dict()
 
 
-# @pytest.mark.integration
-# @pytest.mark.universal_online_stores(only=["milvus"])
-# def test_retrieve_online_milvus_documents(environment, fake_document_data):
-#     fs = environment.feature_store
-#     df, data_source = fake_document_data
-#     item_embeddings_feature_view = create_item_embeddings_feature_view(data_source)
-#     fs.apply([item_embeddings_feature_view, item()])
-#     fs.write_to_online_store("item_embeddings", df)
-#     documents = fs.retrieve_online_documents(
-#         feature=None,
-#         features=[
-#             "item_embeddings:embedding_float",
-#             "item_embeddings:item_id",
-#             "item_embeddings:string_feature",
-#         ],
-#         query=[1.0, 2.0],
-#         top_k=2,
-#         distance_metric="L2",
-#     ).to_dict()
-#     assert len(documents["embedding_float"]) == 2
-#
-#     assert len(documents["item_id"]) == 2
-#     assert documents["item_id"] == [2, 3]
+@pytest.mark.integration
+@pytest.mark.universal_online_stores(only=["milvus"])
+def test_retrieve_online_milvus_documents(environment, fake_document_data):
+    fs = environment.feature_store
+    df, data_source = fake_document_data
+    item_embeddings_feature_view = create_item_embeddings_feature_view(data_source)
+    fs.apply([item_embeddings_feature_view, item()])
+    fs.write_to_online_store("item_embeddings", df)
+    documents = fs.retrieve_online_documents(
+        feature=None,
+        features=[
+            "item_embeddings:embedding_float",
+            "item_embeddings:item_id",
+            "item_embeddings:string_feature",
+        ],
+        query=[1.0, 2.0],
+        top_k=2,
+        distance_metric="L2",
+    ).to_dict()
+    assert len(documents["embedding_float"]) == 2
+
+    assert len(documents["item_id"]) == 2
+    assert documents["item_id"] == [2, 3]


### PR DESCRIPTION
# What this PR does / why we need it:

This PR moves the Milvus Online Store implementation to the PyMilvus Client instead of using Connections, in addition to some other minor changes. 

More specifically:
1. `sdk/python/feast/feature_store.py`:
    - Changed the default value of the `distance_metric` parameter in the `retrieve_online_documents` method to "L2".
2. `sdk/python/feast/infra/online_stores/milvus_online_store/milvus.py`:
    - Replaced the usage of `pymilvus.orm.connections` with `MilvusClient` for managing Milvus connections.
    - Added support for `username` and `password` configurations in `MilvusOnlineStoreConfig`.
    - Updated the `MilvusOnlineStore` class to use `MilvusClient` for creating and managing collections, including:
      - Creating collections with a composite key.
      - Preparing and creating indexes for vector fields.
      - Handling authentication and connection establishment using `username` and `password`.
      - Refactoring methods like `_connect`, `_get_collection`, `online_write_batch`, `update`, `teardown`, and `retrieve_online_documents` to use the new client-based approach.
3. `sdk/python/tests/integration/feature_repos/universal/online_store/milvus.py`:
    - Replaced `MilvusContainer` with `DockerContainer` from `testcontainers.core`.
    - Added Docker client initialization and log waiting utility for Milvus container readiness.
4. `sdk/python/tests/integration/online_store/test_universal_online.py`:
     - Re-enabled the previously commented-out integration test for retrieving online documents using Milvus.

# Which issue(s) this PR fixes:
Another one in service of https://github.com/feast-dev/feast/issues/4364

# Misc
N/A 