### PR TITLE
fix: Resolving syntax error while querying a feature view with column name starting with a number and BigQuery as data source

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -898,10 +898,14 @@ CREATE TEMP TABLE {{ featureview.name }}__cleaned AS (
     {{ featureview.name }}__subquery AS (
         SELECT
             {{ featureview.timestamp_field }} as event_timestamp,
-            {{ featureview.created_timestamp_column ~ ' as created_timestamp,' if featureview.created_timestamp_column else '' }}
+            {{ featureview.created_timestamp_column ~ ' as created_timestamp,' if featureview.created_timestamp_column 
+            else '' }}
             {{ featureview.entity_selections | join(', ')}}{% if featureview.entity_selections %},{% else %}{% endif %}
             {% for feature in featureview.features %}
-                {{ feature | backticks }} as {% if full_feature_names %}{{ featureview.name }}__{{featureview.field_mapping.get(feature, feature)}}{% else %}{{ featureview.field_mapping.get(feature, feature) | backticks }}{% endif %}{% if loop.last %}{% else %}, {% endif %}
+                {{ feature | backticks }} as {% if full_feature_names %}
+                {{ featureview.name }}__{{featureview.field_mapping.get(feature, feature)}}{% else %}
+                {{ featureview.field_mapping.get(feature, feature) | backticks }}{% endif %}
+                {% if loop.last %}{% else %}, {% endif %}
             {% endfor %}
         FROM {{ featureview.table_subquery }}
         WHERE {{ featureview.timestamp_field }} <= '{{ featureview.max_event_timestamp }}'

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -901,7 +901,7 @@ CREATE TEMP TABLE {{ featureview.name }}__cleaned AS (
             {{ featureview.created_timestamp_column ~ ' as created_timestamp,' if featureview.created_timestamp_column else '' }}
             {{ featureview.entity_selections | join(', ')}}{% if featureview.entity_selections %},{% else %}{% endif %}
             {% for feature in featureview.features %}
-                {{ feature }} as {% if full_feature_names %}{{ featureview.name }}__{{featureview.field_mapping.get(feature, feature)}}{% else %}{{ featureview.field_mapping.get(feature, feature) }}{% endif %}{% if loop.last %}{% else %}, {% endif %}
+                {{ feature | backticks }} as {% if full_feature_names %}{{ featureview.name }}__{{featureview.field_mapping.get(feature, feature)}}{% else %}{{ featureview.field_mapping.get(feature, feature) | backticks }}{% endif %}{% if loop.last %}{% else %}, {% endif %}
             {% endfor %}
         FROM {{ featureview.table_subquery }}
         WHERE {{ featureview.timestamp_field }} <= '{{ featureview.max_event_timestamp }}'
@@ -995,14 +995,14 @@ CREATE TEMP TABLE {{ featureview.name }}__cleaned AS (
  The entity_dataframe dataset being our source of truth here.
  */
 
-SELECT {{ final_output_feature_names | join(', ')}}
+SELECT {{ final_output_feature_names | backticks | join(', ')}}
 FROM entity_dataframe
 {% for featureview in featureviews %}
 LEFT JOIN (
     SELECT
         {{featureview.name}}__entity_row_unique_id
         {% for feature in featureview.features %}
-            ,{% if full_feature_names %}{{ featureview.name }}__{{featureview.field_mapping.get(feature, feature)}}{% else %}{{ featureview.field_mapping.get(feature, feature) }}{% endif %}
+            ,{% if full_feature_names %}{{ featureview.name }}__{{featureview.field_mapping.get(feature, feature)}}{% else %}{{ featureview.field_mapping.get(feature, feature) | backticks }}{% endif %}
         {% endfor %}
     FROM {{ featureview.name }}__cleaned
 ) USING ({{featureview.name}}__entity_row_unique_id)

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -898,8 +898,7 @@ CREATE TEMP TABLE {{ featureview.name }}__cleaned AS (
     {{ featureview.name }}__subquery AS (
         SELECT
             {{ featureview.timestamp_field }} as event_timestamp,
-            {{ featureview.created_timestamp_column ~ ' as created_timestamp,' if featureview.created_timestamp_column 
-            else '' }}
+            {{ featureview.created_timestamp_column ~ ' as created_timestamp,' if featureview.created_timestamp_column else '' }}
             {{ featureview.entity_selections | join(', ')}}{% if featureview.entity_selections %},{% else %}{% endif %}
             {% for feature in featureview.features %}
                 {{ feature | backticks }} as {% if full_feature_names %}

--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -262,3 +262,4 @@ def enclose_in_backticks(value):
         return [f'`{v}`' for v in value]
     else:
         return f'`{value}`'
+

--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -186,7 +186,9 @@ def build_point_in_time_query(
     full_feature_names: bool = False,
 ) -> str:
     """Build point-in-time query between each feature view table and the entity dataframe for Bigquery and Redshift"""
-    template = Environment(loader=BaseLoader()).from_string(source=query_template)
+    env = Environment(loader=BaseLoader())
+    env.filters['backticks'] = enclose_in_backticks
+    template = env.from_string(source=query_template)
 
     final_output_feature_names = list(entity_df_columns)
     final_output_feature_names.extend(
@@ -252,3 +254,11 @@ def get_pyarrow_schema_from_batch_source(
         column_names.append(column_name)
 
     return pa.schema(pa_schema), column_names
+
+
+def enclose_in_backticks(value):
+    # Check if the input is a list
+    if isinstance(value, list):
+        return [f'`{v}`' for v in value]
+    else:
+        return f'`{value}`'

--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -262,4 +262,3 @@ def enclose_in_backticks(value):
         return [f'`{v}`' for v in value]
     else:
         return f'`{value}`'
-

--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -187,7 +187,7 @@ def build_point_in_time_query(
 ) -> str:
     """Build point-in-time query between each feature view table and the entity dataframe for Bigquery and Redshift"""
     env = Environment(loader=BaseLoader())
-    env.filters['backticks'] = enclose_in_backticks
+    env.filters["backticks"] = enclose_in_backticks
     template = env.from_string(source=query_template)
 
     final_output_feature_names = list(entity_df_columns)
@@ -259,6 +259,6 @@ def get_pyarrow_schema_from_batch_source(
 def enclose_in_backticks(value):
     # Check if the input is a list
     if isinstance(value, list):
-        return [f'`{v}`' for v in value]
+        return [f"`{v}`" for v in value]
     else:
-        return f'`{value}`'
+        return f"`{value}`"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
This PR addresses a syntax error that occurs when querying a feature view with a column name starting with a number, specifically when using the BigQuery data source. To resolve this issue, the PR wraps all BigQuery feature view column names in backticks (`).
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
Fixes #4688
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Misc
This issue was closed by the PR https://github.com/feast-dev/feast/pull/4713, however the bug was not resolved with 4713. 
The current PR fixes bugs mentioned in #4688
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->