### PR TITLE
feat: Add date field support to spark

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -825,6 +825,7 @@ def spark_to_feast_value_type(spark_type_as_str: str) -> ValueType:
         "array<float>": ValueType.FLOAT_LIST,
         "array<boolean>": ValueType.BOOL_LIST,
         "array<timestamp>": ValueType.UNIX_TIMESTAMP_LIST,
+        "array<date>": ValueType.UNIX_TIMESTAMP_LIST,
     }
     if spark_type_as_str.startswith("decimal"):
         spark_type_as_str = "decimal"


### PR DESCRIPTION
# What this PR does / why we need it:
Add support for both date and list of date columns/fields for data loaded with spark.

This is done by adding the appropriate mapping. The same convention is used for other backends like snowflake and postgres

# Which issue(s) this PR fixes:
Addresses https://github.com/feast-dev/feast/issues/4912


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
