### PR TITLE
feat: Add date support when converting from python to feast types

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -164,6 +164,7 @@ def python_type_to_feast_value_type(
         "datetime64[ns]": ValueType.UNIX_TIMESTAMP,
         "datetime64[ns, tz]": ValueType.UNIX_TIMESTAMP,  # special dtype of pandas
         "datetime64[ns, utc]": ValueType.UNIX_TIMESTAMP,
+        "date": ValueType.UNIX_TIMESTAMP,
         "category": ValueType.STRING,
     }
 


### PR DESCRIPTION
# What this PR does / why we need it:
Add date support when converting from python to feast types. This is a follow up to https://github.com/feast-dev/feast/pull/4913

# Which issue(s) this PR fixes:
None