### PR TITLE
chore: Add Kustomize structure for Feast Operator with environment-specific …

### DIFF
--- a/infra/feast-operator/config/overlays/odh/delete-namespace.yaml
+++ b/infra/feast-operator/config/overlays/odh/delete-namespace.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system

--- a/infra/feast-operator/config/overlays/odh/kustomization.yaml
+++ b/infra/feast-operator/config/overlays/odh/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opendatahub
+
+
+resources:
+- ../../default
+
+
+patches:
+  # patch to remove default `system` namespace in ../../manager/manager.yaml
+  - path: delete-namespace.yaml
+
+configMapGenerator:
+  - name:  feast-operator-parameters
+    envs:
+      - params.env
+
+configurations:
+  - params.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: feast-operator-parameters
+      version: v1
+      fieldPath: data.odh-feast-operator-controller-image
+    targets:
+      - select:
+          kind: Deployment
+          name: controller-manager
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].image
+

--- a/infra/feast-operator/config/overlays/odh/params.env
+++ b/infra/feast-operator/config/overlays/odh/params.env
@@ -1,0 +1,1 @@
+odh-feast-operator-controller-image=docker.io/feastdev/feast-operator:0.42.0

--- a/infra/feast-operator/config/overlays/odh/params.yaml
+++ b/infra/feast-operator/config/overlays/odh/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment

--- a/infra/scripts/release/files_to_bump.txt
+++ b/infra/scripts/release/files_to_bump.txt
@@ -14,6 +14,7 @@ infra/feast-helm-operator/Makefile 6
 infra/feast-helm-operator/config/manager/kustomization.yaml 8
 infra/feast-operator/Makefile 6
 infra/feast-operator/config/manager/kustomization.yaml 8
+infra/feast-operator/config/overlays/odh/params.env 1
 infra/feast-operator/api/feastversion/version.go 20
 java/pom.xml 38
 ui/package.json 3


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])


-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
The Feast Operator currently requires the manifest path to be specified for installation in odh. To support environment-specific configurations, we need to create a proper Kustomize structure, including overlay support for rhoai and odh environments.


# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
