### PR TITLE
fix: Move pre-release image builds to quay.io, retire gcr.io pushes

### DIFF
--- a/.github/workflows/java_master_only.yml
+++ b/.github/workflows/java_master_only.yml
@@ -16,7 +16,7 @@ jobs:
         component: [feature-server-java]
     env:
       MAVEN_CACHE: gs://feast-templocation-kf-feast/.m2.2020-08-19.tar
-      REGISTRY: gcr.io/kf-feast
+      REGISTRY: quay.io/feastdev-ci
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/java_pr.yml
+++ b/.github/workflows/java_pr.yml
@@ -84,7 +84,7 @@ jobs:
         component: [ feature-server-java ]
     env:
       MAVEN_CACHE: gs://feast-templocation-kf-feast/.m2.2020-08-19.tar
-      REGISTRY: gcr.io/kf-feast
+      REGISTRY: quay.io/feastdev-ci
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -97,7 +97,7 @@ jobs:
         component: [ feature-server, feature-server-java, feature-transformation-server, feast-operator ]
     env:
       MAVEN_CACHE: gs://feast-templocation-kf-feast/.m2.2020-08-19.tar
-      REGISTRY: gcr.io/kf-feast
+      REGISTRY: quay.io/feastdev-ci
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -106,11 +106,12 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           install: true
-      - name: Login to DockerHub
+      - name: Login to Quay.io
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: quay.io
+          username: ${{ secrets.QUAYIO_CI_USERNAME }}
+          password: ${{ secrets.QUAYIO_CI_TOKEN }}
       - name: Authenticate to Google Cloud
         uses: 'google-github-actions/auth@v1'
         with:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
The gcr.io image registry is being decommissioned and we can no longer add new repos to it. Because of this, we have a failing GH workflow.
