### PR TITLE
chore: Add ability to change default feature-server image during Operator deploy

### DIFF
--- a/infra/feast-operator/Makefile
+++ b/infra/feast-operator/Makefile
@@ -51,6 +51,7 @@ endif
 OPERATOR_SDK_VERSION ?= v1.38.0
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
+FS_IMG ?= docker.io/feastdev/feature-server:$(VERSION)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.30.0
 
@@ -172,7 +173,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	rm Dockerfile.cross
 
 .PHONY: build-installer
-build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
+build-installer: manifests generate related-image-fs kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install.yaml
@@ -192,7 +193,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: manifests kustomize related-image-fs ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 
@@ -213,12 +214,14 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+ENVSUBST = $(LOCALBIN)/envsubst
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.2
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 ENVTEST_VERSION ?= release-0.18
 GOLANGCI_LINT_VERSION ?= v1.59.1
+ENVSUBST_VERSION ?= v1.4.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -239,6 +242,11 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+.PHONY: envsubst
+envsubst: $(ENVSUBST) ## Download envsubst locally if necessary.
+$(ENVSUBST): $(LOCALBIN)
+	$(call go-install-tool,$(ENVSUBST),github.com/a8m/envsubst/cmd/envsubst,$(ENVSUBST_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)
@@ -275,7 +283,7 @@ endif
 endif
 
 .PHONY: bundle
-bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
+bundle: manifests kustomize related-image-fs operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
@@ -329,3 +337,7 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+.PHONY: related-image-fs
+related-image-fs: envsubst
+	FS_IMG=$(FS_IMG) $(ENVSUBST) < config/default/related_image_fs_patch.tmpl > config/default/related_image_fs_patch.yaml

--- a/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
+++ b/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-01-20T18:02:18Z"
+    createdAt: "2025-01-20T22:18:19Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: feast-operator.v0.43.0

--- a/infra/feast-operator/config/default/kustomization.yaml
+++ b/infra/feast-operator/config/default/kustomization.yaml
@@ -28,11 +28,15 @@ resources:
 # [METRICS] Expose the controller manager metrics service.
 - metrics_service.yaml
 
-# Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
+
 patches:
-- path: manager_related_images_patch.yaml
+- path: related_image_fs_patch.yaml
   target:
     kind: Deployment
+- path: related_image_grpc_patch.yaml
+  target:
+    kind: Deployment
+# Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
 # [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
 # More info: https://book.kubebuilder.io/reference/metrics
 - path: manager_metrics_patch.yaml

--- a/infra/feast-operator/config/default/related_image_fs_patch.tmpl
+++ b/infra/feast-operator/config/default/related_image_fs_patch.tmpl
@@ -1,0 +1,5 @@
+- op: replace
+  path: "/spec/template/spec/containers/0/env/0"
+  value:
+    name: RELATED_IMAGE_FEATURE_SERVER
+    value: ${FS_IMG}

--- a/infra/feast-operator/config/default/related_image_fs_patch.yaml
+++ b/infra/feast-operator/config/default/related_image_fs_patch.yaml
@@ -3,8 +3,3 @@
   value:
     name: RELATED_IMAGE_FEATURE_SERVER
     value: docker.io/feastdev/feature-server:0.43.0
-- op: replace
-  path: "/spec/template/spec/containers/0/env/1"
-  value:
-    name: RELATED_IMAGE_GRPC_CURL
-    value: docker.io/fullstorydev/grpcurl:v1.9.1-alpine

--- a/infra/feast-operator/config/default/related_image_grpc_patch.yaml
+++ b/infra/feast-operator/config/default/related_image_grpc_patch.yaml
@@ -1,0 +1,5 @@
+- op: replace
+  path: "/spec/template/spec/containers/0/env/1"
+  value:
+    name: RELATED_IMAGE_GRPC_CURL
+    value: docker.io/fullstorydev/grpcurl:v1.9.1-alpine

--- a/infra/feast-operator/internal/controller/services/services_types.go
+++ b/infra/feast-operator/internal/controller/services/services_types.go
@@ -25,6 +25,10 @@ import (
 )
 
 const (
+	feastServerImageVar = "RELATED_IMAGE_FEATURE_SERVER"
+	grpcCurlImageVar    = "RELATED_IMAGE_GRPC_CURL"
+	grpcCurlImage       = "fullstorydev/grpcurl:v1.9.1-alpine"
+
 	TmpFeatureStoreYamlEnvVar = "TMP_FEATURE_STORE_YAML_BASE64"
 	FeatureStoreYamlCmKey     = "feature_store.yaml"
 	EphemeralPath             = "/feast-data"

--- a/infra/feast-operator/internal/controller/services/util.go
+++ b/infra/feast-operator/internal/controller/services/util.go
@@ -172,17 +172,17 @@ func setServiceDefaultConfigs(defaultConfigs *feastdevv1alpha1.DefaultConfigs) {
 }
 
 func getFeatureServerImage() string {
-	if img, exists := os.LookupEnv("RELATED_IMAGE_FEATURE_SERVER"); exists {
+	if img, exists := os.LookupEnv(feastServerImageVar); exists {
 		return img
 	}
 	return DefaultImage
 }
 
 func getGrpcCurlImage() string {
-	if img, exists := os.LookupEnv("RELATED_IMAGE_GRPC_CURL"); exists {
+	if img, exists := os.LookupEnv(grpcCurlImageVar); exists {
 		return img
 	}
-	return "fullstorydev/grpcurl:v1.9.1-alpine"
+	return grpcCurlImage
 }
 
 func checkOfflineStoreFilePersistenceType(value string) error {

--- a/infra/feast-operator/test/e2e/e2e_test.go
+++ b/infra/feast-operator/test/e2e/e2e_test.go
@@ -75,7 +75,7 @@ var _ = Describe("controller", Ordered, func() {
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage))
+		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage), fmt.Sprintf("FS_IMG=%s", feastLocalImage))
 		_, err = utils.Run(cmd)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 

--- a/infra/scripts/release/files_to_bump.txt
+++ b/infra/scripts/release/files_to_bump.txt
@@ -14,7 +14,6 @@ infra/feast-helm-operator/Makefile 6
 infra/feast-helm-operator/config/manager/kustomization.yaml 8
 infra/feast-operator/Makefile 6
 infra/feast-operator/config/manager/kustomization.yaml 8
-infra/feast-operator/config/default/manager_related_images_patch.yaml 5
 infra/feast-operator/config/overlays/odh/params.env 1
 infra/feast-operator/api/feastversion/version.go 20
 java/pom.xml 38


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Related to https://github.com/feast-dev/feast/pull/4928

This allows a user to set the `FS_IMG` env variable during Operator manifest generation. The result will be a modified `RELATED_IMAGE_FEATURE_SERVER` env var in the Operator deployment object.

e.g.
```bash
$ make build-installer bundle FS_IMG=localhost/feastdev/feature-server:dev
```
```bash
$ make deploy FS_IMG=localhost/feastdev/feature-server:dev
```