### PR TITLE
fix: Fix showing selected navigation item in UI sidebar

### DIFF
--- a/ui/src/pages/Sidebar.tsx
+++ b/ui/src/pages/Sidebar.tsx
@@ -55,12 +55,14 @@ const SideNav = () => {
       : ""
   }`;
 
+  const baseUrl = `${process.env.PUBLIC_URL || ""}/p/${projectName}`;
+
   const sideNav = [
     {
       name: "Home",
       id: htmlIdGenerator("basicExample")(),
       onClick: () => {
-        navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/`);
+        navigate(`${baseUrl}/`);
       },
       items: [
         {
@@ -68,45 +70,45 @@ const SideNav = () => {
           id: htmlIdGenerator("dataSources")(),
           icon: <EuiIcon type={DataSourceIcon} />,
           onClick: () => {
-            navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/data-source`);
+            navigate(`${baseUrl}/data-source`);
           },
-          isSelected: useMatchSubpath("data-source"),
+          isSelected: useMatchSubpath(`${baseUrl}/data-source`),
         },
         {
           name: entitiesLabel,
           id: htmlIdGenerator("entities")(),
           icon: <EuiIcon type={EntityIcon} />,
           onClick: () => {
-            navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/entity`);
+            navigate(`${baseUrl}/entity`);
           },
-          isSelected: useMatchSubpath("entity"),
+          isSelected: useMatchSubpath(`${baseUrl}/entity`),
         },
         {
           name: featureViewsLabel,
           id: htmlIdGenerator("featureView")(),
           icon: <EuiIcon type={FeatureViewIcon} />,
           onClick: () => {
-            navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view`);
+            navigate(`${baseUrl}/feature-view`);
           },
-          isSelected: useMatchSubpath("feature-view"),
+          isSelected: useMatchSubpath(`${baseUrl}/feature-view`),
         },
         {
           name: featureServicesLabel,
           id: htmlIdGenerator("featureService")(),
           icon: <EuiIcon type={FeatureServiceIcon} />,
           onClick: () => {
-            navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-service`);
+            navigate(`${baseUrl}/feature-service`);
           },
-          isSelected: useMatchSubpath("feature-service"),
+          isSelected: useMatchSubpath(`${baseUrl}/feature-service`),
         },
         {
           name: savedDatasetsLabel,
           id: htmlIdGenerator("savedDatasets")(),
           icon: <EuiIcon type={DatasetIcon} />,
           onClick: () => {
-            navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/data-set`);
+            navigate(`${baseUrl}/data-set`);
           },
-          isSelected: useMatchSubpath("data-set"),
+          isSelected: useMatchSubpath(`${baseUrl}/data-set`),
         },
       ],
     },


### PR DESCRIPTION
# What this PR does / why we need it:

Fixes showing the currently active/selected navigation item in the sidebar.

## Before

<img width="1213" alt="feast-ui-nav-items-before" src="https://github.com/user-attachments/assets/f2fd2eb1-2084-4dba-ab37-09b252387f32" />

## After

<img width="1213" alt="feast-ui-nav-items-after" src="https://github.com/user-attachments/assets/0a94cc60-16ce-425d-93d9-8da73e7df7cb" />

# Which issue(s) this PR fixes:

No related issues as far as I know, just something I happened to notice.

# Misc

Our [`useMatchSubpath`](https://github.com/feast-dev/feast/blob/dc2c1dc67c8e191c29155ced3334244351f312c7/ui/src/hooks/useMatchSubpath.ts#L3) hook uses these two react-router-dom hooks:

1. [`useResolvedPath`](https://reactrouter.com/6.28.2/hooks/use-resolved-path)
2. [`useMatch`](https://reactrouter.com/6.28.2/hooks/use-match)

After some investigation, I found that `useMatch` [doesn't work with relative or partial paths](https://github.com/remix-run/react-router/issues/8684#issuecomment-1050521422). Furthermore, in our Sidebar `useResolvedPath` doesn't include any parts of the current page pathname in the result, resulting in just e.g. `/data-source`, and thus `useMatch` never returns a match.

Not sure exactly why this happens, since we get a full resolved path when [calling `useMatchSubpath`](https://github.com/feast-dev/feast/blob/dc2c1dc67c8e191c29155ced3334244351f312c7/ui/src/pages/feature-views/RegularFeatureViewInstance.tsx#L36) in at least `RegularFeatureInstance.tsx`, but it's probably related to where we render the components in the component tree, and Sidebar is rendered outside the React Router Outlet component.

I found out these differences with some `console.log`s in `useMatchSubpath`.

The fix is to include the full path when calling `useMatchSubpath` in Sidebar, so that it fully matches the current location used by `useMatch`.