### PR TITLE
fix: Resolve Operator CRD bloat due to long field descriptions

### DIFF
--- a/infra/feast-operator/Makefile
+++ b/infra/feast-operator/Makefile
@@ -97,7 +97,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=0 webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/infra/feast-operator/config/crd/bases/feast.dev_featurestores.yaml
+++ b/infra/feast-operator/config/crd/bases/feast.dev_featurestores.yaml
@@ -26,69 +26,30 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: FeatureStore is the Schema for the featurestores API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: FeatureStoreSpec defines the desired state of FeatureStore
             properties:
               authz:
-                description: AuthzConfig defines the authorization settings for the
-                  deployed Feast services.
                 properties:
                   kubernetes:
-                    description: |-
-                      KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.
-                      https://kubernetes.io/docs/reference/access-authn-authz/rbac/
                     properties:
                       roles:
-                        description: |-
-                          The Kubernetes RBAC roles to be deployed in the same namespace of the FeatureStore.
-                          Roles are managed by the operator and created with an empty list of rules.
-                          See the Feast permission model at https://docs.feast.dev/getting-started/concepts/permission
-                          The feature store admin is not obligated to manage roles using the Feast operator, roles can be managed independently.
-                          This configuration option is only providing a way to automate this procedure.
-                          Important note: the operator cannot ensure that these roles will match the ones used in the configured Feast permissions.
                         items:
                           type: string
                         type: array
                     type: object
                   oidc:
-                    description: |-
-                      OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.
-                      https://auth0.com/docs/authenticate/protocols/openid-connect-protocol
                     properties:
                       secretRef:
-                        description: |-
-                          LocalObjectReference contains enough information to let you locate the
-                          referenced object inside the same namespace.
                         properties:
                           name:
                             default: ""
-                            description: |-
-                              Name of the referent.
-                              This field is effectively required, but due to backwards compatibility is
-                              allowed to be empty. Instances of this type with an empty value here are
-                              almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -100,186 +61,88 @@ spec:
                 - message: One selection required between kubernetes or oidc.
                   rule: '[has(self.kubernetes), has(self.oidc)].exists_one(c, c)'
               feastProject:
-                description: FeastProject is the Feast project id. This can be any
-                  alphanumeric string with underscores, but it cannot start with an
-                  underscore. Required.
                 pattern: ^[A-Za-z0-9][A-Za-z0-9_]*$
                 type: string
               services:
-                description: FeatureStoreServices defines the desired feast services.
-                  An ephemeral registry is deployed by default.
                 properties:
                   deploymentStrategy:
-                    description: DeploymentStrategy describes how to replace existing
-                      pods with new ones.
                     properties:
                       rollingUpdate:
-                        description: |-
-                          Rolling update config params. Present only if DeploymentStrategyType =
-                          RollingUpdate.
-                          ---
-                          TODO: Update this to follow our convention for oneOf, whatever we decide it
-                          to be.
                         properties:
                           maxSurge:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              The maximum number of pods that can be scheduled above the desired number of
-                              pods.
-                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                              This can not be 0 if MaxUnavailable is 0.
-                              Absolute number is calculated from percentage by rounding up.
-                              Defaults to 25%.
-                              Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
-                              the rolling update starts, such that the total number of old and new pods do not exceed
-                              130% of desired pods. Once old pods have been killed,
-                              new ReplicaSet can be scaled up further, ensuring that total number of pods running
-                              at any time during the update is at most 130% of desired pods.
                             x-kubernetes-int-or-string: true
                           maxUnavailable:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              The maximum number of pods that can be unavailable during the update.
-                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                              Absolute number is calculated from percentage by rounding down.
-                              This can not be 0 if MaxSurge is 0.
-                              Defaults to 25%.
-                              Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
-                              immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
-                              can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
-                              that the total number of pods available at all times during the update is at
-                              least 70% of desired pods.
                             x-kubernetes-int-or-string: true
                         type: object
                       type:
-                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
-                          Default is RollingUpdate.
                         type: string
                     type: object
                   disableInitContainers:
-                    description: Disable the 'feast repo initialization' initContainer
                     type: boolean
                   offlineStore:
-                    description: OfflineStore configures the deployed offline store
-                      service
                     properties:
                       env:
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                Escaped references will never be expanded, regardless of whether the variable
-                                exists or not.
-                                Defaults to "".
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -292,50 +155,24 @@ spec:
                         type: array
                       envFrom:
                         items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
                           properties:
                             configMapRef:
-                              description: The ConfigMap to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
-                              description: The Secret to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret must be
-                                    defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
@@ -344,13 +181,8 @@ spec:
                       image:
                         type: string
                       imagePullPolicy:
-                        description: PullPolicy describes a policy for if/when to
-                          pull a container image
                         type: string
                       logLevel:
-                        description: |-
-                          LogLevel sets the logging level for the offline store service
-                          Allowed values: "debug", "info", "warning", "error", "critical".
                         enum:
                         - debug
                         - info
@@ -359,34 +191,18 @@ spec:
                         - critical
                         type: string
                       persistence:
-                        description: OfflineStorePersistence configures the persistence
-                          settings for the offline store service
                         properties:
                           file:
-                            description: OfflineStoreFilePersistence configures the
-                              file-based persistence for the offline store service
                             properties:
                               pvc:
-                                description: |-
-                                  PvcConfig defines the settings for a persistent file store based on PVCs.
-                                  We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                 properties:
                                   create:
-                                    description: Settings for creating a new PVC
                                     properties:
                                       accessModes:
-                                        description: AccessModes k8s persistent volume
-                                          access modes. Defaults to ["ReadWriteOnce"].
                                         items:
                                           type: string
                                         type: array
                                       resources:
-                                        description: |-
-                                          Resources describes the storage resource requirements for a volume.
-                                          Default requested storage size depends on the associated service:
-                                          - 10Gi for offline store
-                                          - 5Gi for online store
-                                          - 5Gi for registry
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -395,9 +211,6 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Limits describes the maximum amount of compute resources allowed.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -406,40 +219,20 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Requests describes the minimum amount of compute resources required.
-                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                         type: object
                                       storageClassName:
-                                        description: |-
-                                          StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                          means that this volume does not belong to any StorageClass and the cluster default will be used.
                                         type: string
                                     type: object
                                     x-kubernetes-validations:
                                     - message: PvcCreate is immutable
                                       rule: self == oldSelf
                                   mountPath:
-                                    description: |-
-                                      MountPath within the container at which the volume should be mounted.
-                                      Must start by "/" and cannot contain ':'.
                                     type: string
                                   ref:
-                                    description: Reference to an existing field
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -462,28 +255,13 @@ spec:
                                 type: string
                             type: object
                           store:
-                            description: OfflineStoreDBStorePersistence configures
-                              the DB store persistence for the offline store service
                             properties:
                               secretKeyName:
-                                description: By default, the selected store "type"
-                                  is used as the SecretKeyName
                                 type: string
                               secretRef:
-                                description: Data store parameters should be placed
-                                  as-is from the "feature_store.yaml" under the secret
-                                  key. "registry_type" & "type" fields should be removed.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -508,28 +286,11 @@ spec:
                         - message: One selection required between file or store.
                           rule: '[has(self.file), has(self.store)].exists_one(c, c)'
                       resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                               required:
                               - name
@@ -545,9 +306,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -556,48 +314,23 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tls:
-                        description: TlsConfigs configures server TLS for a feast
-                          service. in an openshift cluster, this is configured by
-                          default using service serving certificates.
                         properties:
                           disable:
-                            description: will disable TLS for the feast service. useful
-                              in an openshift cluster, for example, where TLS is configured
-                              by default
                             type: boolean
                           secretKeyNames:
-                            description: SecretKeyNames defines the secret key names
-                              for the TLS key and cert.
                             properties:
                               tlsCrt:
-                                description: defaults to "tls.crt"
                                 type: string
                               tlsKey:
-                                description: defaults to "tls.key"
                                 type: string
                             type: object
                           secretRef:
-                            description: references the local k8s secret where the
-                              TLS key and cert reside
                             properties:
                               name:
                                 default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -608,122 +341,63 @@ spec:
                             : true'
                     type: object
                   onlineStore:
-                    description: OnlineStore configures the deployed online store
-                      service
                     properties:
                       env:
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                Escaped references will never be expanded, regardless of whether the variable
-                                exists or not.
-                                Defaults to "".
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -736,50 +410,24 @@ spec:
                         type: array
                       envFrom:
                         items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
                           properties:
                             configMapRef:
-                              description: The ConfigMap to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
-                              description: The Secret to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret must be
-                                    defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
@@ -788,13 +436,8 @@ spec:
                       image:
                         type: string
                       imagePullPolicy:
-                        description: PullPolicy describes a policy for if/when to
-                          pull a container image
                         type: string
                       logLevel:
-                        description: |-
-                          LogLevel sets the logging level for the online store service
-                          Allowed values: "debug", "info", "warning", "error", "critical".
                         enum:
                         - debug
                         - info
@@ -803,36 +446,20 @@ spec:
                         - critical
                         type: string
                       persistence:
-                        description: OnlineStorePersistence configures the persistence
-                          settings for the online store service
                         properties:
                           file:
-                            description: OnlineStoreFilePersistence configures the
-                              file-based persistence for the offline store service
                             properties:
                               path:
                                 type: string
                               pvc:
-                                description: |-
-                                  PvcConfig defines the settings for a persistent file store based on PVCs.
-                                  We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                 properties:
                                   create:
-                                    description: Settings for creating a new PVC
                                     properties:
                                       accessModes:
-                                        description: AccessModes k8s persistent volume
-                                          access modes. Defaults to ["ReadWriteOnce"].
                                         items:
                                           type: string
                                         type: array
                                       resources:
-                                        description: |-
-                                          Resources describes the storage resource requirements for a volume.
-                                          Default requested storage size depends on the associated service:
-                                          - 10Gi for offline store
-                                          - 5Gi for online store
-                                          - 5Gi for registry
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -841,9 +468,6 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Limits describes the maximum amount of compute resources allowed.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -852,40 +476,20 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Requests describes the minimum amount of compute resources required.
-                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                         type: object
                                       storageClassName:
-                                        description: |-
-                                          StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                          means that this volume does not belong to any StorageClass and the cluster default will be used.
                                         type: string
                                     type: object
                                     x-kubernetes-validations:
                                     - message: PvcCreate is immutable
                                       rule: self == oldSelf
                                   mountPath:
-                                    description: |-
-                                      MountPath within the container at which the volume should be mounted.
-                                      Must start by "/" and cannot contain ':'.
                                     type: string
                                   ref:
-                                    description: Reference to an existing field
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -913,28 +517,13 @@ spec:
                               rule: 'has(self.path) ? !(self.path.startsWith(''s3://'')
                                 || self.path.startsWith(''gs://'')) : true'
                           store:
-                            description: OnlineStoreDBStorePersistence configures
-                              the DB store persistence for the offline store service
                             properties:
                               secretKeyName:
-                                description: By default, the selected store "type"
-                                  is used as the SecretKeyName
                                 type: string
                               secretRef:
-                                description: Data store parameters should be placed
-                                  as-is from the "feature_store.yaml" under the secret
-                                  key. "registry_type" & "type" fields should be removed.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -966,28 +555,11 @@ spec:
                         - message: One selection required between file or store.
                           rule: '[has(self.file), has(self.store)].exists_one(c, c)'
                       resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                               required:
                               - name
@@ -1003,9 +575,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1014,48 +583,23 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tls:
-                        description: TlsConfigs configures server TLS for a feast
-                          service. in an openshift cluster, this is configured by
-                          default using service serving certificates.
                         properties:
                           disable:
-                            description: will disable TLS for the feast service. useful
-                              in an openshift cluster, for example, where TLS is configured
-                              by default
                             type: boolean
                           secretKeyNames:
-                            description: SecretKeyNames defines the secret key names
-                              for the TLS key and cert.
                             properties:
                               tlsCrt:
-                                description: defaults to "tls.crt"
                                 type: string
                               tlsKey:
-                                description: defaults to "tls.key"
                                 type: string
                             type: object
                           secretRef:
-                            description: references the local k8s secret where the
-                              TLS key and cert reside
                             properties:
                               name:
                                 default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1066,127 +610,65 @@ spec:
                             : true'
                     type: object
                   registry:
-                    description: Registry configures the registry service. One selection
-                      is required. Local is the default setting.
                     properties:
                       local:
-                        description: LocalRegistryConfig configures the deployed registry
-                          service
                         properties:
                           env:
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -1199,50 +681,24 @@ spec:
                             type: array
                           envFrom:
                             items:
-                              description: EnvFromSource represents the source of
-                                a set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1251,13 +707,8 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
-                            description: PullPolicy describes a policy for if/when
-                              to pull a container image
                             type: string
                           logLevel:
-                            description: |-
-                              LogLevel sets the logging level for the registry service
-                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -1266,36 +717,20 @@ spec:
                             - critical
                             type: string
                           persistence:
-                            description: RegistryPersistence configures the persistence
-                              settings for the registry service
                             properties:
                               file:
-                                description: RegistryFilePersistence configures the
-                                  file-based persistence for the registry service
                                 properties:
                                   path:
                                     type: string
                                   pvc:
-                                    description: |-
-                                      PvcConfig defines the settings for a persistent file store based on PVCs.
-                                      We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                     properties:
                                       create:
-                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
-                                            description: AccessModes k8s persistent
-                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
-                                            description: |-
-                                              Resources describes the storage resource requirements for a volume.
-                                              Default requested storage size depends on the associated service:
-                                              - 10Gi for offline store
-                                              - 5Gi for online store
-                                              - 5Gi for registry
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -1304,9 +739,6 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Limits describes the maximum amount of compute resources allowed.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -1315,40 +747,20 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Requests describes the minimum amount of compute resources required.
-                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                             type: object
                                           storageClassName:
-                                            description: |-
-                                              StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                              means that this volume does not belong to any StorageClass and the cluster default will be used.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
-                                        description: |-
-                                          MountPath within the container at which the volume should be mounted.
-                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
-                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -1388,29 +800,13 @@ spec:
                                   rule: '(has(self.s3_additional_kwargs) && has(self.path))
                                     ? self.path.startsWith(''s3://'') : true'
                               store:
-                                description: RegistryDBStorePersistence configures
-                                  the DB store persistence for the registry service
                                 properties:
                                   secretKeyName:
-                                    description: By default, the selected store "type"
-                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
-                                    description: Data store parameters should be placed
-                                      as-is from the "feature_store.yaml" under the
-                                      secret key. "registry_type" & "type" fields
-                                      should be removed.
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -1429,29 +825,11 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
                             properties:
                               claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-
-                                  This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate.
-
-
-                                  This field is immutable. It can only be set for containers.
                                 items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
                                       type: string
                                   required:
                                   - name
@@ -1467,9 +845,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1478,48 +853,23 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           tls:
-                            description: TlsConfigs configures server TLS for a feast
-                              service. in an openshift cluster, this is configured
-                              by default using service serving certificates.
                             properties:
                               disable:
-                                description: will disable TLS for the feast service.
-                                  useful in an openshift cluster, for example, where
-                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
-                                description: SecretKeyNames defines the secret key
-                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
-                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
-                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
-                                description: references the local k8s secret where
-                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -1530,51 +880,26 @@ spec:
                                 : true'
                         type: object
                       remote:
-                        description: |-
-                          RemoteRegistryConfig points to a remote feast registry server. When set, the operator will not deploy a registry for this FeatureStore CR.
-                          Instead, this FeatureStore CR's online/offline services will use a remote registry. One selection is required.
                         properties:
                           feastRef:
-                            description: Reference to an existing `FeatureStore` CR
-                              in the same k8s cluster.
                             properties:
                               name:
-                                description: Name of the FeatureStore
                                 type: string
                               namespace:
-                                description: Namespace of the FeatureStore
                                 type: string
                             required:
                             - name
                             type: object
                           hostname:
-                            description: Host address of the remote registry service
-                              - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`
                             type: string
                           tls:
-                            description: TlsRemoteRegistryConfigs configures client
-                              TLS for a remote feast registry. in an openshift cluster,
-                              this is configured by default when the remote feast
-                              registry is using service serving certificates.
                             properties:
                               certName:
-                                description: defines the configmap key name for the
-                                  client TLS cert.
                                 type: string
                               configMapRef:
-                                description: references the local k8s configmap where
-                                  the TLS cert resides
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -1592,121 +917,63 @@ spec:
                     - message: One selection required.
                       rule: '[has(self.local), has(self.remote)].exists_one(c, c)'
                   ui:
-                    description: UIService configures the deployed Feast UI service
                     properties:
                       env:
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                Escaped references will never be expanded, regardless of whether the variable
-                                exists or not.
-                                Defaults to "".
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -1719,50 +986,24 @@ spec:
                         type: array
                       envFrom:
                         items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
                           properties:
                             configMapRef:
-                              description: The ConfigMap to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
-                              description: The Secret to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret must be
-                                    defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
@@ -1771,13 +1012,8 @@ spec:
                       image:
                         type: string
                       imagePullPolicy:
-                        description: PullPolicy describes a policy for if/when to
-                          pull a container image
                         type: string
                       logLevel:
-                        description: |-
-                          LogLevel sets the logging level for the UI service
-                          Allowed values: "debug", "info", "warning", "error", "critical".
                         enum:
                         - debug
                         - info
@@ -1786,28 +1022,11 @@ spec:
                         - critical
                         type: string
                       resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                               required:
                               - name
@@ -1823,9 +1042,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1834,48 +1050,23 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tls:
-                        description: TlsConfigs configures server TLS for a feast
-                          service. in an openshift cluster, this is configured by
-                          default using service serving certificates.
                         properties:
                           disable:
-                            description: will disable TLS for the feast service. useful
-                              in an openshift cluster, for example, where TLS is configured
-                              by default
                             type: boolean
                           secretKeyNames:
-                            description: SecretKeyNames defines the secret key names
-                              for the TLS key and cert.
                             properties:
                               tlsCrt:
-                                description: defaults to "tls.crt"
                                 type: string
                               tlsKey:
-                                description: defaults to "tls.key"
                                 type: string
                             type: object
                           secretRef:
-                            description: references the local k8s secret where the
-                              TLS key and cert reside
                             properties:
                               name:
                                 default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1890,53 +1081,24 @@ spec:
             - feastProject
             type: object
           status:
-            description: FeatureStoreStatus defines the observed state of FeatureStore
             properties:
               applied:
-                description: Shows the currently applied feast configuration, including
-                  any pertinent defaults
                 properties:
                   authz:
-                    description: AuthzConfig defines the authorization settings for
-                      the deployed Feast services.
                     properties:
                       kubernetes:
-                        description: |-
-                          KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.
-                          https://kubernetes.io/docs/reference/access-authn-authz/rbac/
                         properties:
                           roles:
-                            description: |-
-                              The Kubernetes RBAC roles to be deployed in the same namespace of the FeatureStore.
-                              Roles are managed by the operator and created with an empty list of rules.
-                              See the Feast permission model at https://docs.feast.dev/getting-started/concepts/permission
-                              The feature store admin is not obligated to manage roles using the Feast operator, roles can be managed independently.
-                              This configuration option is only providing a way to automate this procedure.
-                              Important note: the operator cannot ensure that these roles will match the ones used in the configured Feast permissions.
                             items:
                               type: string
                             type: array
                         type: object
                       oidc:
-                        description: |-
-                          OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.
-                          https://auth0.com/docs/authenticate/protocols/openid-connect-protocol
                         properties:
                           secretRef:
-                            description: |-
-                              LocalObjectReference contains enough information to let you locate the
-                              referenced object inside the same namespace.
                             properties:
                               name:
                                 default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1949,187 +1111,88 @@ spec:
                       rule: '[has(self.kubernetes), has(self.oidc)].exists_one(c,
                         c)'
                   feastProject:
-                    description: FeastProject is the Feast project id. This can be
-                      any alphanumeric string with underscores, but it cannot start
-                      with an underscore. Required.
                     pattern: ^[A-Za-z0-9][A-Za-z0-9_]*$
                     type: string
                   services:
-                    description: FeatureStoreServices defines the desired feast services.
-                      An ephemeral registry is deployed by default.
                     properties:
                       deploymentStrategy:
-                        description: DeploymentStrategy describes how to replace existing
-                          pods with new ones.
                         properties:
                           rollingUpdate:
-                            description: |-
-                              Rolling update config params. Present only if DeploymentStrategyType =
-                              RollingUpdate.
-                              ---
-                              TODO: Update this to follow our convention for oneOf, whatever we decide it
-                              to be.
                             properties:
                               maxSurge:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of pods that can be scheduled above the desired number of
-                                  pods.
-                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                                  This can not be 0 if MaxUnavailable is 0.
-                                  Absolute number is calculated from percentage by rounding up.
-                                  Defaults to 25%.
-                                  Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
-                                  the rolling update starts, such that the total number of old and new pods do not exceed
-                                  130% of desired pods. Once old pods have been killed,
-                                  new ReplicaSet can be scaled up further, ensuring that total number of pods running
-                                  at any time during the update is at most 130% of desired pods.
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of pods that can be unavailable during the update.
-                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                                  Absolute number is calculated from percentage by rounding down.
-                                  This can not be 0 if MaxSurge is 0.
-                                  Defaults to 25%.
-                                  Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
-                                  immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
-                                  can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
-                                  that the total number of pods available at all times during the update is at
-                                  least 70% of desired pods.
                                 x-kubernetes-int-or-string: true
                             type: object
                           type:
-                            description: Type of deployment. Can be "Recreate" or
-                              "RollingUpdate". Default is RollingUpdate.
                             type: string
                         type: object
                       disableInitContainers:
-                        description: Disable the 'feast repo initialization' initContainer
                         type: boolean
                       offlineStore:
-                        description: OfflineStore configures the deployed offline
-                          store service
                         properties:
                           env:
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -2142,50 +1205,24 @@ spec:
                             type: array
                           envFrom:
                             items:
-                              description: EnvFromSource represents the source of
-                                a set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -2194,13 +1231,8 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
-                            description: PullPolicy describes a policy for if/when
-                              to pull a container image
                             type: string
                           logLevel:
-                            description: |-
-                              LogLevel sets the logging level for the offline store service
-                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -2209,35 +1241,18 @@ spec:
                             - critical
                             type: string
                           persistence:
-                            description: OfflineStorePersistence configures the persistence
-                              settings for the offline store service
                             properties:
                               file:
-                                description: OfflineStoreFilePersistence configures
-                                  the file-based persistence for the offline store
-                                  service
                                 properties:
                                   pvc:
-                                    description: |-
-                                      PvcConfig defines the settings for a persistent file store based on PVCs.
-                                      We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                     properties:
                                       create:
-                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
-                                            description: AccessModes k8s persistent
-                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
-                                            description: |-
-                                              Resources describes the storage resource requirements for a volume.
-                                              Default requested storage size depends on the associated service:
-                                              - 10Gi for offline store
-                                              - 5Gi for online store
-                                              - 5Gi for registry
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -2246,9 +1261,6 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Limits describes the maximum amount of compute resources allowed.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -2257,40 +1269,20 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Requests describes the minimum amount of compute resources required.
-                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                             type: object
                                           storageClassName:
-                                            description: |-
-                                              StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                              means that this volume does not belong to any StorageClass and the cluster default will be used.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
-                                        description: |-
-                                          MountPath within the container at which the volume should be mounted.
-                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
-                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -2313,29 +1305,13 @@ spec:
                                     type: string
                                 type: object
                               store:
-                                description: OfflineStoreDBStorePersistence configures
-                                  the DB store persistence for the offline store service
                                 properties:
                                   secretKeyName:
-                                    description: By default, the selected store "type"
-                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
-                                    description: Data store parameters should be placed
-                                      as-is from the "feature_store.yaml" under the
-                                      secret key. "registry_type" & "type" fields
-                                      should be removed.
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2361,29 +1337,11 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
                             properties:
                               claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-
-                                  This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate.
-
-
-                                  This field is immutable. It can only be set for containers.
                                 items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
                                       type: string
                                   required:
                                   - name
@@ -2399,9 +1357,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -2410,48 +1365,23 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           tls:
-                            description: TlsConfigs configures server TLS for a feast
-                              service. in an openshift cluster, this is configured
-                              by default using service serving certificates.
                             properties:
                               disable:
-                                description: will disable TLS for the feast service.
-                                  useful in an openshift cluster, for example, where
-                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
-                                description: SecretKeyNames defines the secret key
-                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
-                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
-                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
-                                description: references the local k8s secret where
-                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -2462,123 +1392,63 @@ spec:
                                 : true'
                         type: object
                       onlineStore:
-                        description: OnlineStore configures the deployed online store
-                          service
                         properties:
                           env:
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -2591,50 +1461,24 @@ spec:
                             type: array
                           envFrom:
                             items:
-                              description: EnvFromSource represents the source of
-                                a set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -2643,13 +1487,8 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
-                            description: PullPolicy describes a policy for if/when
-                              to pull a container image
                             type: string
                           logLevel:
-                            description: |-
-                              LogLevel sets the logging level for the online store service
-                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -2658,37 +1497,20 @@ spec:
                             - critical
                             type: string
                           persistence:
-                            description: OnlineStorePersistence configures the persistence
-                              settings for the online store service
                             properties:
                               file:
-                                description: OnlineStoreFilePersistence configures
-                                  the file-based persistence for the offline store
-                                  service
                                 properties:
                                   path:
                                     type: string
                                   pvc:
-                                    description: |-
-                                      PvcConfig defines the settings for a persistent file store based on PVCs.
-                                      We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                     properties:
                                       create:
-                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
-                                            description: AccessModes k8s persistent
-                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
-                                            description: |-
-                                              Resources describes the storage resource requirements for a volume.
-                                              Default requested storage size depends on the associated service:
-                                              - 10Gi for offline store
-                                              - 5Gi for online store
-                                              - 5Gi for registry
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -2697,9 +1519,6 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Limits describes the maximum amount of compute resources allowed.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -2708,40 +1527,20 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Requests describes the minimum amount of compute resources required.
-                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                             type: object
                                           storageClassName:
-                                            description: |-
-                                              StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                              means that this volume does not belong to any StorageClass and the cluster default will be used.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
-                                        description: |-
-                                          MountPath within the container at which the volume should be mounted.
-                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
-                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -2770,29 +1569,13 @@ spec:
                                   rule: 'has(self.path) ? !(self.path.startsWith(''s3://'')
                                     || self.path.startsWith(''gs://'')) : true'
                               store:
-                                description: OnlineStoreDBStorePersistence configures
-                                  the DB store persistence for the offline store service
                                 properties:
                                   secretKeyName:
-                                    description: By default, the selected store "type"
-                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
-                                    description: Data store parameters should be placed
-                                      as-is from the "feature_store.yaml" under the
-                                      secret key. "registry_type" & "type" fields
-                                      should be removed.
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2825,29 +1608,11 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
                             properties:
                               claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-
-                                  This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate.
-
-
-                                  This field is immutable. It can only be set for containers.
                                 items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
                                       type: string
                                   required:
                                   - name
@@ -2863,9 +1628,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -2874,48 +1636,23 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           tls:
-                            description: TlsConfigs configures server TLS for a feast
-                              service. in an openshift cluster, this is configured
-                              by default using service serving certificates.
                             properties:
                               disable:
-                                description: will disable TLS for the feast service.
-                                  useful in an openshift cluster, for example, where
-                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
-                                description: SecretKeyNames defines the secret key
-                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
-                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
-                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
-                                description: references the local k8s secret where
-                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -2926,130 +1663,65 @@ spec:
                                 : true'
                         type: object
                       registry:
-                        description: Registry configures the registry service. One
-                          selection is required. Local is the default setting.
                         properties:
                           local:
-                            description: LocalRegistryConfig configures the deployed
-                              registry service
                             properties:
                               env:
                                 items:
-                                  description: EnvVar represents an environment variable
-                                    present in a Container.
                                   properties:
                                     name:
-                                      description: Name of the environment variable.
-                                        Must be a C_IDENTIFIER.
                                       type: string
                                     value:
-                                      description: |-
-                                        Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any service environment variables. If a variable cannot be resolved,
-                                        the reference in the input string will be unchanged. Double $$ are reduced
-                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                        Escaped references will never be expanded, regardless of whether the variable
-                                        exists or not.
-                                        Defaults to "".
                                       type: string
                                     valueFrom:
-                                      description: Source for the environment variable's
-                                        value. Cannot be used if value is not empty.
                                       properties:
                                         configMapKeyRef:
-                                          description: Selects a key of a ConfigMap.
                                           properties:
                                             key:
-                                              description: The key to select.
                                               type: string
                                             name:
                                               default: ""
-                                              description: |-
-                                                Name of the referent.
-                                                This field is effectively required, but due to backwards compatibility is
-                                                allowed to be empty. Instances of this type with an empty value here are
-                                                almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap
-                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
-                                          description: |-
-                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         secretKeyRef:
-                                          description: Selects a key of a secret in
-                                            the pod's namespace
                                           properties:
                                             key:
-                                              description: The key of the secret to
-                                                select from.  Must be a valid secret
-                                                key.
                                               type: string
                                             name:
                                               default: ""
-                                              description: |-
-                                                Name of the referent.
-                                                This field is effectively required, but due to backwards compatibility is
-                                                allowed to be empty. Instances of this type with an empty value here are
-                                                almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret
-                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
@@ -3062,50 +1734,24 @@ spec:
                                 type: array
                               envFrom:
                                 items:
-                                  description: EnvFromSource represents the source
-                                    of a set of ConfigMaps
                                   properties:
                                     configMapRef:
-                                      description: The ConfigMap to select from
                                       properties:
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: An optional identifier to prepend
-                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
-                                      description: The Secret to select from
                                       properties:
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret
-                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -3114,13 +1760,8 @@ spec:
                               image:
                                 type: string
                               imagePullPolicy:
-                                description: PullPolicy describes a policy for if/when
-                                  to pull a container image
                                 type: string
                               logLevel:
-                                description: |-
-                                  LogLevel sets the logging level for the registry service
-                                  Allowed values: "debug", "info", "warning", "error", "critical".
                                 enum:
                                 - debug
                                 - info
@@ -3129,39 +1770,20 @@ spec:
                                 - critical
                                 type: string
                               persistence:
-                                description: RegistryPersistence configures the persistence
-                                  settings for the registry service
                                 properties:
                                   file:
-                                    description: RegistryFilePersistence configures
-                                      the file-based persistence for the registry
-                                      service
                                     properties:
                                       path:
                                         type: string
                                       pvc:
-                                        description: |-
-                                          PvcConfig defines the settings for a persistent file store based on PVCs.
-                                          We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                         properties:
                                           create:
-                                            description: Settings for creating a new
-                                              PVC
                                             properties:
                                               accessModes:
-                                                description: AccessModes k8s persistent
-                                                  volume access modes. Defaults to
-                                                  ["ReadWriteOnce"].
                                                 items:
                                                   type: string
                                                 type: array
                                               resources:
-                                                description: |-
-                                                  Resources describes the storage resource requirements for a volume.
-                                                  Default requested storage size depends on the associated service:
-                                                  - 10Gi for offline store
-                                                  - 5Gi for online store
-                                                  - 5Gi for registry
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -3170,9 +1792,6 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: |-
-                                                      Limits describes the maximum amount of compute resources allowed.
-                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -3181,41 +1800,20 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: |-
-                                                      Requests describes the minimum amount of compute resources required.
-                                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                 type: object
                                               storageClassName:
-                                                description: |-
-                                                  StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                                  means that this volume does not belong to any StorageClass and the cluster default will be used.
                                                 type: string
                                             type: object
                                             x-kubernetes-validations:
                                             - message: PvcCreate is immutable
                                               rule: self == oldSelf
                                           mountPath:
-                                            description: |-
-                                              MountPath within the container at which the volume should be mounted.
-                                              Must start by "/" and cannot contain ':'.
                                             type: string
                                           ref:
-                                            description: Reference to an existing
-                                              field
                                             properties:
                                               name:
                                                 default: ""
-                                                description: |-
-                                                  Name of the referent.
-                                                  This field is effectively required, but due to backwards compatibility is
-                                                  allowed to be empty. Instances of this type with an empty value here are
-                                                  almost certainly wrong.
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
@@ -3255,29 +1853,13 @@ spec:
                                       rule: '(has(self.s3_additional_kwargs) && has(self.path))
                                         ? self.path.startsWith(''s3://'') : true'
                                   store:
-                                    description: RegistryDBStorePersistence configures
-                                      the DB store persistence for the registry service
                                     properties:
                                       secretKeyName:
-                                        description: By default, the selected store
-                                          "type" is used as the SecretKeyName
                                         type: string
                                       secretRef:
-                                        description: Data store parameters should
-                                          be placed as-is from the "feature_store.yaml"
-                                          under the secret key. "registry_type" &
-                                          "type" fields should be removed.
                                         properties:
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -3297,29 +1879,11 @@ spec:
                                   rule: '[has(self.file), has(self.store)].exists_one(c,
                                     c)'
                               resources:
-                                description: ResourceRequirements describes the compute
-                                  resource requirements.
                                 properties:
                                   claims:
-                                    description: |-
-                                      Claims lists the names of resources, defined in spec.resourceClaims,
-                                      that are used by this container.
-
-
-                                      This is an alpha field and requires enabling the
-                                      DynamicResourceAllocation feature gate.
-
-
-                                      This field is immutable. It can only be set for containers.
                                     items:
-                                      description: ResourceClaim references one entry
-                                        in PodSpec.ResourceClaims.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name must match the name of one entry in pod.spec.resourceClaims of
-                                            the Pod where this field is used. It makes that resource available
-                                            inside a container.
                                           type: string
                                       required:
                                       - name
@@ -3335,9 +1899,6 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: |-
-                                      Limits describes the maximum amount of compute resources allowed.
-                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -3346,48 +1907,23 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: |-
-                                      Requests describes the minimum amount of compute resources required.
-                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     type: object
                                 type: object
                               tls:
-                                description: TlsConfigs configures server TLS for
-                                  a feast service. in an openshift cluster, this is
-                                  configured by default using service serving certificates.
                                 properties:
                                   disable:
-                                    description: will disable TLS for the feast service.
-                                      useful in an openshift cluster, for example,
-                                      where TLS is configured by default
                                     type: boolean
                                   secretKeyNames:
-                                    description: SecretKeyNames defines the secret
-                                      key names for the TLS key and cert.
                                     properties:
                                       tlsCrt:
-                                        description: defaults to "tls.crt"
                                         type: string
                                       tlsKey:
-                                        description: defaults to "tls.key"
                                         type: string
                                     type: object
                                   secretRef:
-                                    description: references the local k8s secret where
-                                      the TLS key and cert reside
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -3398,51 +1934,26 @@ spec:
                                     : true'
                             type: object
                           remote:
-                            description: |-
-                              RemoteRegistryConfig points to a remote feast registry server. When set, the operator will not deploy a registry for this FeatureStore CR.
-                              Instead, this FeatureStore CR's online/offline services will use a remote registry. One selection is required.
                             properties:
                               feastRef:
-                                description: Reference to an existing `FeatureStore`
-                                  CR in the same k8s cluster.
                                 properties:
                                   name:
-                                    description: Name of the FeatureStore
                                     type: string
                                   namespace:
-                                    description: Namespace of the FeatureStore
                                     type: string
                                 required:
                                 - name
                                 type: object
                               hostname:
-                                description: Host address of the remote registry service
-                                  - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`
                                 type: string
                               tls:
-                                description: TlsRemoteRegistryConfigs configures client
-                                  TLS for a remote feast registry. in an openshift
-                                  cluster, this is configured by default when the
-                                  remote feast registry is using service serving certificates.
                                 properties:
                                   certName:
-                                    description: defines the configmap key name for
-                                      the client TLS cert.
                                     type: string
                                   configMapRef:
-                                    description: references the local k8s configmap
-                                      where the TLS cert resides
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -3461,122 +1972,63 @@ spec:
                           rule: '[has(self.local), has(self.remote)].exists_one(c,
                             c)'
                       ui:
-                        description: UIService configures the deployed Feast UI service
                         properties:
                           env:
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -3589,50 +2041,24 @@ spec:
                             type: array
                           envFrom:
                             items:
-                              description: EnvFromSource represents the source of
-                                a set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3641,13 +2067,8 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
-                            description: PullPolicy describes a policy for if/when
-                              to pull a container image
                             type: string
                           logLevel:
-                            description: |-
-                              LogLevel sets the logging level for the UI service
-                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -3656,29 +2077,11 @@ spec:
                             - critical
                             type: string
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
                             properties:
                               claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-
-                                  This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate.
-
-
-                                  This field is immutable. It can only be set for containers.
                                 items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
                                       type: string
                                   required:
                                   - name
@@ -3694,9 +2097,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3705,48 +2105,23 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           tls:
-                            description: TlsConfigs configures server TLS for a feast
-                              service. in an openshift cluster, this is configured
-                              by default using service serving certificates.
                             properties:
                               disable:
-                                description: will disable TLS for the feast service.
-                                  useful in an openshift cluster, for example, where
-                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
-                                description: SecretKeyNames defines the secret key
-                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
-                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
-                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
-                                description: references the local k8s secret where
-                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -3761,67 +2136,32 @@ spec:
                 - feastProject
                 type: object
               clientConfigMap:
-                description: ConfigMap in this namespace containing a client `feature_store.yaml`
-                  for this feast deployment
                 type: string
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -3838,8 +2178,6 @@ spec:
               phase:
                 type: string
               serviceHostnames:
-                description: ServiceHostnames defines the service hostnames in the
-                  format of <domain>:<port>, e.g. example.svc.cluster.local:80
                 properties:
                   offlineStore:
                     type: string

--- a/infra/feast-operator/dist/install.yaml
+++ b/infra/feast-operator/dist/install.yaml
@@ -34,69 +34,30 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: FeatureStore is the Schema for the featurestores API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: FeatureStoreSpec defines the desired state of FeatureStore
             properties:
               authz:
-                description: AuthzConfig defines the authorization settings for the
-                  deployed Feast services.
                 properties:
                   kubernetes:
-                    description: |-
-                      KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.
-                      https://kubernetes.io/docs/reference/access-authn-authz/rbac/
                     properties:
                       roles:
-                        description: |-
-                          The Kubernetes RBAC roles to be deployed in the same namespace of the FeatureStore.
-                          Roles are managed by the operator and created with an empty list of rules.
-                          See the Feast permission model at https://docs.feast.dev/getting-started/concepts/permission
-                          The feature store admin is not obligated to manage roles using the Feast operator, roles can be managed independently.
-                          This configuration option is only providing a way to automate this procedure.
-                          Important note: the operator cannot ensure that these roles will match the ones used in the configured Feast permissions.
                         items:
                           type: string
                         type: array
                     type: object
                   oidc:
-                    description: |-
-                      OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.
-                      https://auth0.com/docs/authenticate/protocols/openid-connect-protocol
                     properties:
                       secretRef:
-                        description: |-
-                          LocalObjectReference contains enough information to let you locate the
-                          referenced object inside the same namespace.
                         properties:
                           name:
                             default: ""
-                            description: |-
-                              Name of the referent.
-                              This field is effectively required, but due to backwards compatibility is
-                              allowed to be empty. Instances of this type with an empty value here are
-                              almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
-                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -108,186 +69,88 @@ spec:
                 - message: One selection required between kubernetes or oidc.
                   rule: '[has(self.kubernetes), has(self.oidc)].exists_one(c, c)'
               feastProject:
-                description: FeastProject is the Feast project id. This can be any
-                  alphanumeric string with underscores, but it cannot start with an
-                  underscore. Required.
                 pattern: ^[A-Za-z0-9][A-Za-z0-9_]*$
                 type: string
               services:
-                description: FeatureStoreServices defines the desired feast services.
-                  An ephemeral registry is deployed by default.
                 properties:
                   deploymentStrategy:
-                    description: DeploymentStrategy describes how to replace existing
-                      pods with new ones.
                     properties:
                       rollingUpdate:
-                        description: |-
-                          Rolling update config params. Present only if DeploymentStrategyType =
-                          RollingUpdate.
-                          ---
-                          TODO: Update this to follow our convention for oneOf, whatever we decide it
-                          to be.
                         properties:
                           maxSurge:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              The maximum number of pods that can be scheduled above the desired number of
-                              pods.
-                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                              This can not be 0 if MaxUnavailable is 0.
-                              Absolute number is calculated from percentage by rounding up.
-                              Defaults to 25%.
-                              Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
-                              the rolling update starts, such that the total number of old and new pods do not exceed
-                              130% of desired pods. Once old pods have been killed,
-                              new ReplicaSet can be scaled up further, ensuring that total number of pods running
-                              at any time during the update is at most 130% of desired pods.
                             x-kubernetes-int-or-string: true
                           maxUnavailable:
                             anyOf:
                             - type: integer
                             - type: string
-                            description: |-
-                              The maximum number of pods that can be unavailable during the update.
-                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                              Absolute number is calculated from percentage by rounding down.
-                              This can not be 0 if MaxSurge is 0.
-                              Defaults to 25%.
-                              Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
-                              immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
-                              can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
-                              that the total number of pods available at all times during the update is at
-                              least 70% of desired pods.
                             x-kubernetes-int-or-string: true
                         type: object
                       type:
-                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
-                          Default is RollingUpdate.
                         type: string
                     type: object
                   disableInitContainers:
-                    description: Disable the 'feast repo initialization' initContainer
                     type: boolean
                   offlineStore:
-                    description: OfflineStore configures the deployed offline store
-                      service
                     properties:
                       env:
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                Escaped references will never be expanded, regardless of whether the variable
-                                exists or not.
-                                Defaults to "".
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -300,50 +163,24 @@ spec:
                         type: array
                       envFrom:
                         items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
                           properties:
                             configMapRef:
-                              description: The ConfigMap to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
-                              description: The Secret to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret must be
-                                    defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
@@ -352,13 +189,8 @@ spec:
                       image:
                         type: string
                       imagePullPolicy:
-                        description: PullPolicy describes a policy for if/when to
-                          pull a container image
                         type: string
                       logLevel:
-                        description: |-
-                          LogLevel sets the logging level for the offline store service
-                          Allowed values: "debug", "info", "warning", "error", "critical".
                         enum:
                         - debug
                         - info
@@ -367,34 +199,18 @@ spec:
                         - critical
                         type: string
                       persistence:
-                        description: OfflineStorePersistence configures the persistence
-                          settings for the offline store service
                         properties:
                           file:
-                            description: OfflineStoreFilePersistence configures the
-                              file-based persistence for the offline store service
                             properties:
                               pvc:
-                                description: |-
-                                  PvcConfig defines the settings for a persistent file store based on PVCs.
-                                  We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                 properties:
                                   create:
-                                    description: Settings for creating a new PVC
                                     properties:
                                       accessModes:
-                                        description: AccessModes k8s persistent volume
-                                          access modes. Defaults to ["ReadWriteOnce"].
                                         items:
                                           type: string
                                         type: array
                                       resources:
-                                        description: |-
-                                          Resources describes the storage resource requirements for a volume.
-                                          Default requested storage size depends on the associated service:
-                                          - 10Gi for offline store
-                                          - 5Gi for online store
-                                          - 5Gi for registry
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -403,9 +219,6 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Limits describes the maximum amount of compute resources allowed.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -414,40 +227,20 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Requests describes the minimum amount of compute resources required.
-                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                         type: object
                                       storageClassName:
-                                        description: |-
-                                          StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                          means that this volume does not belong to any StorageClass and the cluster default will be used.
                                         type: string
                                     type: object
                                     x-kubernetes-validations:
                                     - message: PvcCreate is immutable
                                       rule: self == oldSelf
                                   mountPath:
-                                    description: |-
-                                      MountPath within the container at which the volume should be mounted.
-                                      Must start by "/" and cannot contain ':'.
                                     type: string
                                   ref:
-                                    description: Reference to an existing field
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -470,28 +263,13 @@ spec:
                                 type: string
                             type: object
                           store:
-                            description: OfflineStoreDBStorePersistence configures
-                              the DB store persistence for the offline store service
                             properties:
                               secretKeyName:
-                                description: By default, the selected store "type"
-                                  is used as the SecretKeyName
                                 type: string
                               secretRef:
-                                description: Data store parameters should be placed
-                                  as-is from the "feature_store.yaml" under the secret
-                                  key. "registry_type" & "type" fields should be removed.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -516,28 +294,11 @@ spec:
                         - message: One selection required between file or store.
                           rule: '[has(self.file), has(self.store)].exists_one(c, c)'
                       resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                               required:
                               - name
@@ -553,9 +314,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -564,48 +322,23 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tls:
-                        description: TlsConfigs configures server TLS for a feast
-                          service. in an openshift cluster, this is configured by
-                          default using service serving certificates.
                         properties:
                           disable:
-                            description: will disable TLS for the feast service. useful
-                              in an openshift cluster, for example, where TLS is configured
-                              by default
                             type: boolean
                           secretKeyNames:
-                            description: SecretKeyNames defines the secret key names
-                              for the TLS key and cert.
                             properties:
                               tlsCrt:
-                                description: defaults to "tls.crt"
                                 type: string
                               tlsKey:
-                                description: defaults to "tls.key"
                                 type: string
                             type: object
                           secretRef:
-                            description: references the local k8s secret where the
-                              TLS key and cert reside
                             properties:
                               name:
                                 default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -616,122 +349,63 @@ spec:
                             : true'
                     type: object
                   onlineStore:
-                    description: OnlineStore configures the deployed online store
-                      service
                     properties:
                       env:
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                Escaped references will never be expanded, regardless of whether the variable
-                                exists or not.
-                                Defaults to "".
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -744,50 +418,24 @@ spec:
                         type: array
                       envFrom:
                         items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
                           properties:
                             configMapRef:
-                              description: The ConfigMap to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
-                              description: The Secret to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret must be
-                                    defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
@@ -796,13 +444,8 @@ spec:
                       image:
                         type: string
                       imagePullPolicy:
-                        description: PullPolicy describes a policy for if/when to
-                          pull a container image
                         type: string
                       logLevel:
-                        description: |-
-                          LogLevel sets the logging level for the online store service
-                          Allowed values: "debug", "info", "warning", "error", "critical".
                         enum:
                         - debug
                         - info
@@ -811,36 +454,20 @@ spec:
                         - critical
                         type: string
                       persistence:
-                        description: OnlineStorePersistence configures the persistence
-                          settings for the online store service
                         properties:
                           file:
-                            description: OnlineStoreFilePersistence configures the
-                              file-based persistence for the offline store service
                             properties:
                               path:
                                 type: string
                               pvc:
-                                description: |-
-                                  PvcConfig defines the settings for a persistent file store based on PVCs.
-                                  We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                 properties:
                                   create:
-                                    description: Settings for creating a new PVC
                                     properties:
                                       accessModes:
-                                        description: AccessModes k8s persistent volume
-                                          access modes. Defaults to ["ReadWriteOnce"].
                                         items:
                                           type: string
                                         type: array
                                       resources:
-                                        description: |-
-                                          Resources describes the storage resource requirements for a volume.
-                                          Default requested storage size depends on the associated service:
-                                          - 10Gi for offline store
-                                          - 5Gi for online store
-                                          - 5Gi for registry
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -849,9 +476,6 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Limits describes the maximum amount of compute resources allowed.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -860,40 +484,20 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            description: |-
-                                              Requests describes the minimum amount of compute resources required.
-                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                             type: object
                                         type: object
                                       storageClassName:
-                                        description: |-
-                                          StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                          means that this volume does not belong to any StorageClass and the cluster default will be used.
                                         type: string
                                     type: object
                                     x-kubernetes-validations:
                                     - message: PvcCreate is immutable
                                       rule: self == oldSelf
                                   mountPath:
-                                    description: |-
-                                      MountPath within the container at which the volume should be mounted.
-                                      Must start by "/" and cannot contain ':'.
                                     type: string
                                   ref:
-                                    description: Reference to an existing field
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -921,28 +525,13 @@ spec:
                               rule: 'has(self.path) ? !(self.path.startsWith(''s3://'')
                                 || self.path.startsWith(''gs://'')) : true'
                           store:
-                            description: OnlineStoreDBStorePersistence configures
-                              the DB store persistence for the offline store service
                             properties:
                               secretKeyName:
-                                description: By default, the selected store "type"
-                                  is used as the SecretKeyName
                                 type: string
                               secretRef:
-                                description: Data store parameters should be placed
-                                  as-is from the "feature_store.yaml" under the secret
-                                  key. "registry_type" & "type" fields should be removed.
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -974,28 +563,11 @@ spec:
                         - message: One selection required between file or store.
                           rule: '[has(self.file), has(self.store)].exists_one(c, c)'
                       resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                               required:
                               - name
@@ -1011,9 +583,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1022,48 +591,23 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tls:
-                        description: TlsConfigs configures server TLS for a feast
-                          service. in an openshift cluster, this is configured by
-                          default using service serving certificates.
                         properties:
                           disable:
-                            description: will disable TLS for the feast service. useful
-                              in an openshift cluster, for example, where TLS is configured
-                              by default
                             type: boolean
                           secretKeyNames:
-                            description: SecretKeyNames defines the secret key names
-                              for the TLS key and cert.
                             properties:
                               tlsCrt:
-                                description: defaults to "tls.crt"
                                 type: string
                               tlsKey:
-                                description: defaults to "tls.key"
                                 type: string
                             type: object
                           secretRef:
-                            description: references the local k8s secret where the
-                              TLS key and cert reside
                             properties:
                               name:
                                 default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1074,127 +618,65 @@ spec:
                             : true'
                     type: object
                   registry:
-                    description: Registry configures the registry service. One selection
-                      is required. Local is the default setting.
                     properties:
                       local:
-                        description: LocalRegistryConfig configures the deployed registry
-                          service
                         properties:
                           env:
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -1207,50 +689,24 @@ spec:
                             type: array
                           envFrom:
                             items:
-                              description: EnvFromSource represents the source of
-                                a set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1259,13 +715,8 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
-                            description: PullPolicy describes a policy for if/when
-                              to pull a container image
                             type: string
                           logLevel:
-                            description: |-
-                              LogLevel sets the logging level for the registry service
-                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -1274,36 +725,20 @@ spec:
                             - critical
                             type: string
                           persistence:
-                            description: RegistryPersistence configures the persistence
-                              settings for the registry service
                             properties:
                               file:
-                                description: RegistryFilePersistence configures the
-                                  file-based persistence for the registry service
                                 properties:
                                   path:
                                     type: string
                                   pvc:
-                                    description: |-
-                                      PvcConfig defines the settings for a persistent file store based on PVCs.
-                                      We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                     properties:
                                       create:
-                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
-                                            description: AccessModes k8s persistent
-                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
-                                            description: |-
-                                              Resources describes the storage resource requirements for a volume.
-                                              Default requested storage size depends on the associated service:
-                                              - 10Gi for offline store
-                                              - 5Gi for online store
-                                              - 5Gi for registry
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -1312,9 +747,6 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Limits describes the maximum amount of compute resources allowed.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -1323,40 +755,20 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Requests describes the minimum amount of compute resources required.
-                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                             type: object
                                           storageClassName:
-                                            description: |-
-                                              StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                              means that this volume does not belong to any StorageClass and the cluster default will be used.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
-                                        description: |-
-                                          MountPath within the container at which the volume should be mounted.
-                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
-                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -1396,29 +808,13 @@ spec:
                                   rule: '(has(self.s3_additional_kwargs) && has(self.path))
                                     ? self.path.startsWith(''s3://'') : true'
                               store:
-                                description: RegistryDBStorePersistence configures
-                                  the DB store persistence for the registry service
                                 properties:
                                   secretKeyName:
-                                    description: By default, the selected store "type"
-                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
-                                    description: Data store parameters should be placed
-                                      as-is from the "feature_store.yaml" under the
-                                      secret key. "registry_type" & "type" fields
-                                      should be removed.
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -1437,29 +833,11 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
                             properties:
                               claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-
-                                  This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate.
-
-
-                                  This field is immutable. It can only be set for containers.
                                 items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
                                       type: string
                                   required:
                                   - name
@@ -1475,9 +853,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1486,48 +861,23 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           tls:
-                            description: TlsConfigs configures server TLS for a feast
-                              service. in an openshift cluster, this is configured
-                              by default using service serving certificates.
                             properties:
                               disable:
-                                description: will disable TLS for the feast service.
-                                  useful in an openshift cluster, for example, where
-                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
-                                description: SecretKeyNames defines the secret key
-                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
-                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
-                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
-                                description: references the local k8s secret where
-                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -1538,51 +888,26 @@ spec:
                                 : true'
                         type: object
                       remote:
-                        description: |-
-                          RemoteRegistryConfig points to a remote feast registry server. When set, the operator will not deploy a registry for this FeatureStore CR.
-                          Instead, this FeatureStore CR's online/offline services will use a remote registry. One selection is required.
                         properties:
                           feastRef:
-                            description: Reference to an existing `FeatureStore` CR
-                              in the same k8s cluster.
                             properties:
                               name:
-                                description: Name of the FeatureStore
                                 type: string
                               namespace:
-                                description: Namespace of the FeatureStore
                                 type: string
                             required:
                             - name
                             type: object
                           hostname:
-                            description: Host address of the remote registry service
-                              - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`
                             type: string
                           tls:
-                            description: TlsRemoteRegistryConfigs configures client
-                              TLS for a remote feast registry. in an openshift cluster,
-                              this is configured by default when the remote feast
-                              registry is using service serving certificates.
                             properties:
                               certName:
-                                description: defines the configmap key name for the
-                                  client TLS cert.
                                 type: string
                               configMapRef:
-                                description: references the local k8s configmap where
-                                  the TLS cert resides
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -1600,121 +925,63 @@ spec:
                     - message: One selection required.
                       rule: '[has(self.local), has(self.remote)].exists_one(c, c)'
                   ui:
-                    description: UIService configures the deployed Feast UI service
                     properties:
                       env:
                         items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
                               type: string
                             value:
-                              description: |-
-                                Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any service environment variables. If a variable cannot be resolved,
-                                the reference in the input string will be unchanged. Double $$ are reduced
-                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                Escaped references will never be expanded, regardless of whether the variable
-                                exists or not.
-                                Defaults to "".
                               type: string
                             valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
-                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: |-
-                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: |-
-                                    Selects a resource of the container: only resources limits and requests
-                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
-                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -1727,50 +994,24 @@ spec:
                         type: array
                       envFrom:
                         items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
                           properties:
                             configMapRef:
-                              description: The ConfigMap to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
-                              description: The Secret to select from
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret must be
-                                    defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
@@ -1779,13 +1020,8 @@ spec:
                       image:
                         type: string
                       imagePullPolicy:
-                        description: PullPolicy describes a policy for if/when to
-                          pull a container image
                         type: string
                       logLevel:
-                        description: |-
-                          LogLevel sets the logging level for the UI service
-                          Allowed values: "debug", "info", "warning", "error", "critical".
                         enum:
                         - debug
                         - info
@@ -1794,28 +1030,11 @@ spec:
                         - critical
                         type: string
                       resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
                         properties:
                           claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-
-                              This field is immutable. It can only be set for containers.
                             items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
                                   type: string
                               required:
                               - name
@@ -1831,9 +1050,6 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Limits describes the maximum amount of compute resources allowed.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -1842,48 +1058,23 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: |-
-                              Requests describes the minimum amount of compute resources required.
-                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       tls:
-                        description: TlsConfigs configures server TLS for a feast
-                          service. in an openshift cluster, this is configured by
-                          default using service serving certificates.
                         properties:
                           disable:
-                            description: will disable TLS for the feast service. useful
-                              in an openshift cluster, for example, where TLS is configured
-                              by default
                             type: boolean
                           secretKeyNames:
-                            description: SecretKeyNames defines the secret key names
-                              for the TLS key and cert.
                             properties:
                               tlsCrt:
-                                description: defaults to "tls.crt"
                                 type: string
                               tlsKey:
-                                description: defaults to "tls.key"
                                 type: string
                             type: object
                           secretRef:
-                            description: references the local k8s secret where the
-                              TLS key and cert reside
                             properties:
                               name:
                                 default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1898,53 +1089,24 @@ spec:
             - feastProject
             type: object
           status:
-            description: FeatureStoreStatus defines the observed state of FeatureStore
             properties:
               applied:
-                description: Shows the currently applied feast configuration, including
-                  any pertinent defaults
                 properties:
                   authz:
-                    description: AuthzConfig defines the authorization settings for
-                      the deployed Feast services.
                     properties:
                       kubernetes:
-                        description: |-
-                          KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.
-                          https://kubernetes.io/docs/reference/access-authn-authz/rbac/
                         properties:
                           roles:
-                            description: |-
-                              The Kubernetes RBAC roles to be deployed in the same namespace of the FeatureStore.
-                              Roles are managed by the operator and created with an empty list of rules.
-                              See the Feast permission model at https://docs.feast.dev/getting-started/concepts/permission
-                              The feature store admin is not obligated to manage roles using the Feast operator, roles can be managed independently.
-                              This configuration option is only providing a way to automate this procedure.
-                              Important note: the operator cannot ensure that these roles will match the ones used in the configured Feast permissions.
                             items:
                               type: string
                             type: array
                         type: object
                       oidc:
-                        description: |-
-                          OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.
-                          https://auth0.com/docs/authenticate/protocols/openid-connect-protocol
                         properties:
                           secretRef:
-                            description: |-
-                              LocalObjectReference contains enough information to let you locate the
-                              referenced object inside the same namespace.
                             properties:
                               name:
                                 default: ""
-                                description: |-
-                                  Name of the referent.
-                                  This field is effectively required, but due to backwards compatibility is
-                                  allowed to be empty. Instances of this type with an empty value here are
-                                  almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
-                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1957,187 +1119,88 @@ spec:
                       rule: '[has(self.kubernetes), has(self.oidc)].exists_one(c,
                         c)'
                   feastProject:
-                    description: FeastProject is the Feast project id. This can be
-                      any alphanumeric string with underscores, but it cannot start
-                      with an underscore. Required.
                     pattern: ^[A-Za-z0-9][A-Za-z0-9_]*$
                     type: string
                   services:
-                    description: FeatureStoreServices defines the desired feast services.
-                      An ephemeral registry is deployed by default.
                     properties:
                       deploymentStrategy:
-                        description: DeploymentStrategy describes how to replace existing
-                          pods with new ones.
                         properties:
                           rollingUpdate:
-                            description: |-
-                              Rolling update config params. Present only if DeploymentStrategyType =
-                              RollingUpdate.
-                              ---
-                              TODO: Update this to follow our convention for oneOf, whatever we decide it
-                              to be.
                             properties:
                               maxSurge:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of pods that can be scheduled above the desired number of
-                                  pods.
-                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                                  This can not be 0 if MaxUnavailable is 0.
-                                  Absolute number is calculated from percentage by rounding up.
-                                  Defaults to 25%.
-                                  Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
-                                  the rolling update starts, such that the total number of old and new pods do not exceed
-                                  130% of desired pods. Once old pods have been killed,
-                                  new ReplicaSet can be scaled up further, ensuring that total number of pods running
-                                  at any time during the update is at most 130% of desired pods.
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: |-
-                                  The maximum number of pods that can be unavailable during the update.
-                                  Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
-                                  Absolute number is calculated from percentage by rounding down.
-                                  This can not be 0 if MaxSurge is 0.
-                                  Defaults to 25%.
-                                  Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
-                                  immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
-                                  can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
-                                  that the total number of pods available at all times during the update is at
-                                  least 70% of desired pods.
                                 x-kubernetes-int-or-string: true
                             type: object
                           type:
-                            description: Type of deployment. Can be "Recreate" or
-                              "RollingUpdate". Default is RollingUpdate.
                             type: string
                         type: object
                       disableInitContainers:
-                        description: Disable the 'feast repo initialization' initContainer
                         type: boolean
                       offlineStore:
-                        description: OfflineStore configures the deployed offline
-                          store service
                         properties:
                           env:
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -2150,50 +1213,24 @@ spec:
                             type: array
                           envFrom:
                             items:
-                              description: EnvFromSource represents the source of
-                                a set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -2202,13 +1239,8 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
-                            description: PullPolicy describes a policy for if/when
-                              to pull a container image
                             type: string
                           logLevel:
-                            description: |-
-                              LogLevel sets the logging level for the offline store service
-                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -2217,35 +1249,18 @@ spec:
                             - critical
                             type: string
                           persistence:
-                            description: OfflineStorePersistence configures the persistence
-                              settings for the offline store service
                             properties:
                               file:
-                                description: OfflineStoreFilePersistence configures
-                                  the file-based persistence for the offline store
-                                  service
                                 properties:
                                   pvc:
-                                    description: |-
-                                      PvcConfig defines the settings for a persistent file store based on PVCs.
-                                      We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                     properties:
                                       create:
-                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
-                                            description: AccessModes k8s persistent
-                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
-                                            description: |-
-                                              Resources describes the storage resource requirements for a volume.
-                                              Default requested storage size depends on the associated service:
-                                              - 10Gi for offline store
-                                              - 5Gi for online store
-                                              - 5Gi for registry
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -2254,9 +1269,6 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Limits describes the maximum amount of compute resources allowed.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -2265,40 +1277,20 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Requests describes the minimum amount of compute resources required.
-                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                             type: object
                                           storageClassName:
-                                            description: |-
-                                              StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                              means that this volume does not belong to any StorageClass and the cluster default will be used.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
-                                        description: |-
-                                          MountPath within the container at which the volume should be mounted.
-                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
-                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -2321,29 +1313,13 @@ spec:
                                     type: string
                                 type: object
                               store:
-                                description: OfflineStoreDBStorePersistence configures
-                                  the DB store persistence for the offline store service
                                 properties:
                                   secretKeyName:
-                                    description: By default, the selected store "type"
-                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
-                                    description: Data store parameters should be placed
-                                      as-is from the "feature_store.yaml" under the
-                                      secret key. "registry_type" & "type" fields
-                                      should be removed.
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2369,29 +1345,11 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
                             properties:
                               claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-
-                                  This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate.
-
-
-                                  This field is immutable. It can only be set for containers.
                                 items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
                                       type: string
                                   required:
                                   - name
@@ -2407,9 +1365,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -2418,48 +1373,23 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           tls:
-                            description: TlsConfigs configures server TLS for a feast
-                              service. in an openshift cluster, this is configured
-                              by default using service serving certificates.
                             properties:
                               disable:
-                                description: will disable TLS for the feast service.
-                                  useful in an openshift cluster, for example, where
-                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
-                                description: SecretKeyNames defines the secret key
-                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
-                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
-                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
-                                description: references the local k8s secret where
-                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -2470,123 +1400,63 @@ spec:
                                 : true'
                         type: object
                       onlineStore:
-                        description: OnlineStore configures the deployed online store
-                          service
                         properties:
                           env:
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -2599,50 +1469,24 @@ spec:
                             type: array
                           envFrom:
                             items:
-                              description: EnvFromSource represents the source of
-                                a set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -2651,13 +1495,8 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
-                            description: PullPolicy describes a policy for if/when
-                              to pull a container image
                             type: string
                           logLevel:
-                            description: |-
-                              LogLevel sets the logging level for the online store service
-                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -2666,37 +1505,20 @@ spec:
                             - critical
                             type: string
                           persistence:
-                            description: OnlineStorePersistence configures the persistence
-                              settings for the online store service
                             properties:
                               file:
-                                description: OnlineStoreFilePersistence configures
-                                  the file-based persistence for the offline store
-                                  service
                                 properties:
                                   path:
                                     type: string
                                   pvc:
-                                    description: |-
-                                      PvcConfig defines the settings for a persistent file store based on PVCs.
-                                      We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                     properties:
                                       create:
-                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
-                                            description: AccessModes k8s persistent
-                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
-                                            description: |-
-                                              Resources describes the storage resource requirements for a volume.
-                                              Default requested storage size depends on the associated service:
-                                              - 10Gi for offline store
-                                              - 5Gi for online store
-                                              - 5Gi for registry
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -2705,9 +1527,6 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Limits describes the maximum amount of compute resources allowed.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -2716,40 +1535,20 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: |-
-                                                  Requests describes the minimum amount of compute resources required.
-                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                             type: object
                                           storageClassName:
-                                            description: |-
-                                              StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                              means that this volume does not belong to any StorageClass and the cluster default will be used.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
-                                        description: |-
-                                          MountPath within the container at which the volume should be mounted.
-                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
-                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -2778,29 +1577,13 @@ spec:
                                   rule: 'has(self.path) ? !(self.path.startsWith(''s3://'')
                                     || self.path.startsWith(''gs://'')) : true'
                               store:
-                                description: OnlineStoreDBStorePersistence configures
-                                  the DB store persistence for the offline store service
                                 properties:
                                   secretKeyName:
-                                    description: By default, the selected store "type"
-                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
-                                    description: Data store parameters should be placed
-                                      as-is from the "feature_store.yaml" under the
-                                      secret key. "registry_type" & "type" fields
-                                      should be removed.
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2833,29 +1616,11 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
                             properties:
                               claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-
-                                  This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate.
-
-
-                                  This field is immutable. It can only be set for containers.
                                 items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
                                       type: string
                                   required:
                                   - name
@@ -2871,9 +1636,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -2882,48 +1644,23 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           tls:
-                            description: TlsConfigs configures server TLS for a feast
-                              service. in an openshift cluster, this is configured
-                              by default using service serving certificates.
                             properties:
                               disable:
-                                description: will disable TLS for the feast service.
-                                  useful in an openshift cluster, for example, where
-                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
-                                description: SecretKeyNames defines the secret key
-                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
-                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
-                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
-                                description: references the local k8s secret where
-                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -2934,130 +1671,65 @@ spec:
                                 : true'
                         type: object
                       registry:
-                        description: Registry configures the registry service. One
-                          selection is required. Local is the default setting.
                         properties:
                           local:
-                            description: LocalRegistryConfig configures the deployed
-                              registry service
                             properties:
                               env:
                                 items:
-                                  description: EnvVar represents an environment variable
-                                    present in a Container.
                                   properties:
                                     name:
-                                      description: Name of the environment variable.
-                                        Must be a C_IDENTIFIER.
                                       type: string
                                     value:
-                                      description: |-
-                                        Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any service environment variables. If a variable cannot be resolved,
-                                        the reference in the input string will be unchanged. Double $$ are reduced
-                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                        Escaped references will never be expanded, regardless of whether the variable
-                                        exists or not.
-                                        Defaults to "".
                                       type: string
                                     valueFrom:
-                                      description: Source for the environment variable's
-                                        value. Cannot be used if value is not empty.
                                       properties:
                                         configMapKeyRef:
-                                          description: Selects a key of a ConfigMap.
                                           properties:
                                             key:
-                                              description: The key to select.
                                               type: string
                                             name:
                                               default: ""
-                                              description: |-
-                                                Name of the referent.
-                                                This field is effectively required, but due to backwards compatibility is
-                                                allowed to be empty. Instances of this type with an empty value here are
-                                                almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap
-                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
-                                          description: |-
-                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         resourceFieldRef:
-                                          description: |-
-                                            Selects a resource of the container: only resources limits and requests
-                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to
-                                                select'
                                               type: string
                                           required:
                                           - resource
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         secretKeyRef:
-                                          description: Selects a key of a secret in
-                                            the pod's namespace
                                           properties:
                                             key:
-                                              description: The key of the secret to
-                                                select from.  Must be a valid secret
-                                                key.
                                               type: string
                                             name:
                                               default: ""
-                                              description: |-
-                                                Name of the referent.
-                                                This field is effectively required, but due to backwards compatibility is
-                                                allowed to be empty. Instances of this type with an empty value here are
-                                                almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret
-                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
@@ -3070,50 +1742,24 @@ spec:
                                 type: array
                               envFrom:
                                 items:
-                                  description: EnvFromSource represents the source
-                                    of a set of ConfigMaps
                                   properties:
                                     configMapRef:
-                                      description: The ConfigMap to select from
                                       properties:
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: An optional identifier to prepend
-                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
-                                      description: The Secret to select from
                                       properties:
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret
-                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -3122,13 +1768,8 @@ spec:
                               image:
                                 type: string
                               imagePullPolicy:
-                                description: PullPolicy describes a policy for if/when
-                                  to pull a container image
                                 type: string
                               logLevel:
-                                description: |-
-                                  LogLevel sets the logging level for the registry service
-                                  Allowed values: "debug", "info", "warning", "error", "critical".
                                 enum:
                                 - debug
                                 - info
@@ -3137,39 +1778,20 @@ spec:
                                 - critical
                                 type: string
                               persistence:
-                                description: RegistryPersistence configures the persistence
-                                  settings for the registry service
                                 properties:
                                   file:
-                                    description: RegistryFilePersistence configures
-                                      the file-based persistence for the registry
-                                      service
                                     properties:
                                       path:
                                         type: string
                                       pvc:
-                                        description: |-
-                                          PvcConfig defines the settings for a persistent file store based on PVCs.
-                                          We can refer to an existing PVC using the `Ref` field, or create a new one using the `Create` field.
                                         properties:
                                           create:
-                                            description: Settings for creating a new
-                                              PVC
                                             properties:
                                               accessModes:
-                                                description: AccessModes k8s persistent
-                                                  volume access modes. Defaults to
-                                                  ["ReadWriteOnce"].
                                                 items:
                                                   type: string
                                                 type: array
                                               resources:
-                                                description: |-
-                                                  Resources describes the storage resource requirements for a volume.
-                                                  Default requested storage size depends on the associated service:
-                                                  - 10Gi for offline store
-                                                  - 5Gi for online store
-                                                  - 5Gi for registry
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -3178,9 +1800,6 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: |-
-                                                      Limits describes the maximum amount of compute resources allowed.
-                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -3189,41 +1808,20 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
-                                                    description: |-
-                                                      Requests describes the minimum amount of compute resources required.
-                                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                     type: object
                                                 type: object
                                               storageClassName:
-                                                description: |-
-                                                  StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
-                                                  means that this volume does not belong to any StorageClass and the cluster default will be used.
                                                 type: string
                                             type: object
                                             x-kubernetes-validations:
                                             - message: PvcCreate is immutable
                                               rule: self == oldSelf
                                           mountPath:
-                                            description: |-
-                                              MountPath within the container at which the volume should be mounted.
-                                              Must start by "/" and cannot contain ':'.
                                             type: string
                                           ref:
-                                            description: Reference to an existing
-                                              field
                                             properties:
                                               name:
                                                 default: ""
-                                                description: |-
-                                                  Name of the referent.
-                                                  This field is effectively required, but due to backwards compatibility is
-                                                  allowed to be empty. Instances of this type with an empty value here are
-                                                  almost certainly wrong.
-                                                  TODO: Add other useful fields. apiVersion, kind, uid?
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
@@ -3263,29 +1861,13 @@ spec:
                                       rule: '(has(self.s3_additional_kwargs) && has(self.path))
                                         ? self.path.startsWith(''s3://'') : true'
                                   store:
-                                    description: RegistryDBStorePersistence configures
-                                      the DB store persistence for the registry service
                                     properties:
                                       secretKeyName:
-                                        description: By default, the selected store
-                                          "type" is used as the SecretKeyName
                                         type: string
                                       secretRef:
-                                        description: Data store parameters should
-                                          be placed as-is from the "feature_store.yaml"
-                                          under the secret key. "registry_type" &
-                                          "type" fields should be removed.
                                         properties:
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              TODO: Add other useful fields. apiVersion, kind, uid?
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -3305,29 +1887,11 @@ spec:
                                   rule: '[has(self.file), has(self.store)].exists_one(c,
                                     c)'
                               resources:
-                                description: ResourceRequirements describes the compute
-                                  resource requirements.
                                 properties:
                                   claims:
-                                    description: |-
-                                      Claims lists the names of resources, defined in spec.resourceClaims,
-                                      that are used by this container.
-
-
-                                      This is an alpha field and requires enabling the
-                                      DynamicResourceAllocation feature gate.
-
-
-                                      This field is immutable. It can only be set for containers.
                                     items:
-                                      description: ResourceClaim references one entry
-                                        in PodSpec.ResourceClaims.
                                       properties:
                                         name:
-                                          description: |-
-                                            Name must match the name of one entry in pod.spec.resourceClaims of
-                                            the Pod where this field is used. It makes that resource available
-                                            inside a container.
                                           type: string
                                       required:
                                       - name
@@ -3343,9 +1907,6 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: |-
-                                      Limits describes the maximum amount of compute resources allowed.
-                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -3354,48 +1915,23 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: |-
-                                      Requests describes the minimum amount of compute resources required.
-                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     type: object
                                 type: object
                               tls:
-                                description: TlsConfigs configures server TLS for
-                                  a feast service. in an openshift cluster, this is
-                                  configured by default using service serving certificates.
                                 properties:
                                   disable:
-                                    description: will disable TLS for the feast service.
-                                      useful in an openshift cluster, for example,
-                                      where TLS is configured by default
                                     type: boolean
                                   secretKeyNames:
-                                    description: SecretKeyNames defines the secret
-                                      key names for the TLS key and cert.
                                     properties:
                                       tlsCrt:
-                                        description: defaults to "tls.crt"
                                         type: string
                                       tlsKey:
-                                        description: defaults to "tls.key"
                                         type: string
                                     type: object
                                   secretRef:
-                                    description: references the local k8s secret where
-                                      the TLS key and cert reside
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -3406,51 +1942,26 @@ spec:
                                     : true'
                             type: object
                           remote:
-                            description: |-
-                              RemoteRegistryConfig points to a remote feast registry server. When set, the operator will not deploy a registry for this FeatureStore CR.
-                              Instead, this FeatureStore CR's online/offline services will use a remote registry. One selection is required.
                             properties:
                               feastRef:
-                                description: Reference to an existing `FeatureStore`
-                                  CR in the same k8s cluster.
                                 properties:
                                   name:
-                                    description: Name of the FeatureStore
                                     type: string
                                   namespace:
-                                    description: Namespace of the FeatureStore
                                     type: string
                                 required:
                                 - name
                                 type: object
                               hostname:
-                                description: Host address of the remote registry service
-                                  - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`
                                 type: string
                               tls:
-                                description: TlsRemoteRegistryConfigs configures client
-                                  TLS for a remote feast registry. in an openshift
-                                  cluster, this is configured by default when the
-                                  remote feast registry is using service serving certificates.
                                 properties:
                                   certName:
-                                    description: defines the configmap key name for
-                                      the client TLS cert.
                                     type: string
                                   configMapRef:
-                                    description: references the local k8s configmap
-                                      where the TLS cert resides
                                     properties:
                                       name:
                                         default: ""
-                                        description: |-
-                                          Name of the referent.
-                                          This field is effectively required, but due to backwards compatibility is
-                                          allowed to be empty. Instances of this type with an empty value here are
-                                          almost certainly wrong.
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
-                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -3469,122 +1980,63 @@ spec:
                           rule: '[has(self.local), has(self.remote)].exists_one(c,
                             c)'
                       ui:
-                        description: UIService configures the deployed Feast UI service
                         properties:
                           env:
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: |-
-                                    Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any service environment variables. If a variable cannot be resolved,
-                                    the reference in the input string will be unchanged. Double $$ are reduced
-                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                                    Escaped references will never be expanded, regardless of whether the variable
-                                    exists or not.
-                                    Defaults to "".
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
-                                      description: |-
-                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
-                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
-                                      description: |-
-                                        Selects a resource of the container: only resources limits and requests
-                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
-                                          description: |-
-                                            Name of the referent.
-                                            This field is effectively required, but due to backwards compatibility is
-                                            allowed to be empty. Instances of this type with an empty value here are
-                                            almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
-                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -3597,50 +2049,24 @@ spec:
                             type: array
                           envFrom:
                             items:
-                              description: EnvFromSource represents the source of
-                                a set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
-                                      description: |-
-                                        Name of the referent.
-                                        This field is effectively required, but due to backwards compatibility is
-                                        allowed to be empty. Instances of this type with an empty value here are
-                                        almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
-                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must
-                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3649,13 +2075,8 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
-                            description: PullPolicy describes a policy for if/when
-                              to pull a container image
                             type: string
                           logLevel:
-                            description: |-
-                              LogLevel sets the logging level for the UI service
-                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -3664,29 +2085,11 @@ spec:
                             - critical
                             type: string
                           resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
                             properties:
                               claims:
-                                description: |-
-                                  Claims lists the names of resources, defined in spec.resourceClaims,
-                                  that are used by this container.
-
-
-                                  This is an alpha field and requires enabling the
-                                  DynamicResourceAllocation feature gate.
-
-
-                                  This field is immutable. It can only be set for containers.
                                 items:
-                                  description: ResourceClaim references one entry
-                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
-                                      description: |-
-                                        Name must match the name of one entry in pod.spec.resourceClaims of
-                                        the Pod where this field is used. It makes that resource available
-                                        inside a container.
                                       type: string
                                   required:
                                   - name
@@ -3702,9 +2105,6 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Limits describes the maximum amount of compute resources allowed.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3713,48 +2113,23 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: |-
-                                  Requests describes the minimum amount of compute resources required.
-                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
-                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
-                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           tls:
-                            description: TlsConfigs configures server TLS for a feast
-                              service. in an openshift cluster, this is configured
-                              by default using service serving certificates.
                             properties:
                               disable:
-                                description: will disable TLS for the feast service.
-                                  useful in an openshift cluster, for example, where
-                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
-                                description: SecretKeyNames defines the secret key
-                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
-                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
-                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
-                                description: references the local k8s secret where
-                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
-                                    description: |-
-                                      Name of the referent.
-                                      This field is effectively required, but due to backwards compatibility is
-                                      allowed to be empty. Instances of this type with an empty value here are
-                                      almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
-                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -3769,67 +2144,32 @@ spec:
                 - feastProject
                 type: object
               clientConfigMap:
-                description: ConfigMap in this namespace containing a client `feature_store.yaml`
-                  for this feast deployment
                 type: string
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -3846,8 +2186,6 @@ spec:
               phase:
                 type: string
               serviceHostnames:
-                description: ServiceHostnames defines the service hostnames in the
-                  format of <domain>:<port>, e.g. example.svc.cluster.local:80
                 properties:
                   offlineStore:
                     type: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
We're experiencing some CRD bloat due to large field descriptions. Going forward, we'll want to point users to our API reference doc instead.
https://github.com/feast-dev/feast/blob/v0.43-branch/infra/feast-operator/docs/api/markdown/ref.md



# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/feast-dev/feast/issues/4984

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
https://developers.redhat.com/articles/2022/12/23/configuring-kubernetes-operands-through-custom-resources