### PR TITLE
feat: Added OWNERS file for OpenshiftCI

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,5 @@
+# This file is being used by RedHat for running e2e CI
+
 approvers:
 - redhathameed
 - tmihalac

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,13 @@
+approvers:
+- redhathameed
+- tmihalac
+- accorvin
+- amsharma3
+- franciscojavierarceo
+options: {}
+reviewers:
+- redhathameed
+- tmihalac
+- accorvin
+- amsharma3
+- franciscojavierarceo


### PR DESCRIPTION
Added OWNERS file for OpenshiftCI

# What this PR does / why we need it:
Used by openshiftCI infrastructure
