### PR TITLE
fix: Use locally built feast-ui package in dev feature-server image

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -1,13 +1,30 @@
 FROM registry.access.redhat.com/ubi8/python-311:1
 
+USER 0
+RUN npm install -g yarn yalc && rm -rf .npm
+USER default
+
 COPY --chown=default . ${APP_ROOT}/src
+
+WORKDIR ${APP_ROOT}/src/ui
+RUN npm install && \
+    npm run build:lib-dev && \
+    rm -rf node_modules && \
+    npm cache clean --force
+
+WORKDIR ${APP_ROOT}/src/sdk/python/feast/ui
+RUN yalc add @feast-dev/feast-ui && \
+    git diff package.json && \
+    yarn install && \
+    npm run build --omit=dev && \
+    rm -rf node_modules && \
+    npm cache clean --force && \
+    yarn cache clean --all
+
+WORKDIR ${APP_ROOT}/src
 RUN pip install --no-cache-dir pip-tools && \
     make install-python-ci-dependencies && \
     pip uninstall -y pip-tools
-
-RUN npm install -S yarn
-ENV PATH ${PATH}:${APP_ROOT}/src/node_modules/yarn/bin
-RUN make build-ui && yarn cache clean --all
 
 # modify permissions to support running with a random uid
 RUN chmod g+w $(python -c "import feast.ui as ui; print(ui.__path__)" | tr -d "[']")/build/projects-list.json


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Our feature-server dev image builds aren't using the latest UI code. This PR resolves that.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Relates to https://github.com/feast-dev/feast/issues/4981