### PR TITLE
chore: Set router basename to simplify paths in /ui

### DIFF
--- a/ui/src/FeastUI.tsx
+++ b/ui/src/FeastUI.tsx
@@ -15,10 +15,14 @@ const defaultQueryClient = new QueryClient();
 
 const FeastUI = ({ reactQueryClient, feastUIConfigs }: FeastUIProps) => {
   const queryClient = reactQueryClient || defaultQueryClient;
+  const basename = process.env.PUBLIC_URL ?? '';
 
   return (
     // Disable v7_relativeSplatPath: custom tab routes don't currently work with it
-    <BrowserRouter future={{ v7_relativeSplatPath: false, v7_startTransition: true }}>
+    <BrowserRouter
+      basename={basename}
+      future={{ v7_relativeSplatPath: false, v7_startTransition: true }}
+    >
       <QueryClientProvider client={queryClient}>
         <QueryParamProvider adapter={ReactRouter6Adapter}>
           <FeastUISansProviders feastUIConfigs={feastUIConfigs} />

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -62,8 +62,6 @@ const FeastUISansProviders = ({
           isCustom: true,
         }
       : { projectsListPromise: defaultProjectListPromise(), isCustom: false };
-    
-  const BASE_URL = process.env.PUBLIC_URL || ""
 
   return (
     <EuiProvider colorMode="light">
@@ -76,9 +74,9 @@ const FeastUISansProviders = ({
           >
             <ProjectListContext.Provider value={projectListContext}>
               <Routes>
-                <Route path={BASE_URL + "/"} element={<Layout />}>
+                <Route path="/" element={<Layout />}>
                   <Route index element={<RootProjectSelectionPage />} />
-                  <Route path={BASE_URL + "/p/:projectName/*"} element={<NoProjectGuard />}>
+                  <Route path="/p/:projectName/*" element={<NoProjectGuard />}>
                     <Route index element={<ProjectOverviewPage />} />
                     <Route path="data-source/" element={<DatasourceIndex />} />
                     <Route

--- a/ui/src/components/FeaturesInServiceDisplay.tsx
+++ b/ui/src/components/FeaturesInServiceDisplay.tsx
@@ -28,9 +28,7 @@ const FeaturesInServiceList = ({ featureViews }: FeatureViewsListInterace) => {
       field: "featureViewName",
       render: (name: string) => {
         return (
-          <EuiCustomLink
-            to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view/${name}`}
-          >
+          <EuiCustomLink to={`/p/${projectName}/feature-view/${name}`}>
             {name}
           </EuiCustomLink>
         );

--- a/ui/src/components/FeaturesListDisplay.tsx
+++ b/ui/src/components/FeaturesListDisplay.tsx
@@ -21,7 +21,7 @@ const FeaturesList = ({
       field: "name",
       render: (item: string) => (
         <EuiCustomLink
-          to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view/${featureViewName}/feature/${item}`}
+          to={`/p/${projectName}/feature-view/${featureViewName}/feature/${item}`}
         >
           {item}
         </EuiCustomLink>

--- a/ui/src/components/ObjectsCountStats.tsx
+++ b/ui/src/components/ObjectsCountStats.tsx
@@ -55,7 +55,7 @@ const ObjectsCountStats = () => {
             <EuiFlexItem>
               <EuiStat
                 style={statStyle}
-                onClick={() => navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-service`)}
+                onClick={() => navigate(`/p/${projectName}/feature-service`)}
                 description="Feature Services→"
                 title={data.featureServices}
                 reverse
@@ -65,7 +65,7 @@ const ObjectsCountStats = () => {
               <EuiStat
                 style={statStyle}
                 description="Feature Views→"
-                onClick={() => navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view`)}
+                onClick={() => navigate(`/p/${projectName}/feature-view`)}
                 title={data.featureViews}
                 reverse
               />
@@ -74,7 +74,7 @@ const ObjectsCountStats = () => {
               <EuiStat
                 style={statStyle}
                 description="Entities→"
-                onClick={() => navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/entity`)}
+                onClick={() => navigate(`/p/${projectName}/entity`)}
                 title={data.entities}
                 reverse
               />
@@ -83,7 +83,7 @@ const ObjectsCountStats = () => {
               <EuiStat
                 style={statStyle}
                 description="Data Sources→"
-                onClick={() => navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/data-source`)}
+                onClick={() => navigate(`/p/${projectName}/data-source`)}
                 title={data.dataSources}
                 reverse
               />

--- a/ui/src/components/ProjectSelector.tsx
+++ b/ui/src/components/ProjectSelector.tsx
@@ -22,7 +22,7 @@ const ProjectSelector = () => {
 
   const basicSelectId = useGeneratedHtmlId({ prefix: "basicSelect" });
   const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    navigate(`${process.env.PUBLIC_URL || ""}/p/${e.target.value}`);
+    navigate(`/p/${e.target.value}`);
   };
 
   return (

--- a/ui/src/pages/RootProjectSelectionPage.tsx
+++ b/ui/src/pages/RootProjectSelectionPage.tsx
@@ -21,12 +21,12 @@ const RootProjectSelectionPage = () => {
   useEffect(() => {
     if (data && data.default) {
       // If a default is set, redirect there.
-      navigate(`${process.env.PUBLIC_URL || ""}/p/${data.default}`);
+      navigate(`/p/${data.default}`);
     }
 
     if (data && data.projects.length === 1) {
       // If there is only one project, redirect there.
-      navigate(`${process.env.PUBLIC_URL || ""}/p/${data.projects[0].id}`);
+      navigate(`/p/${data.projects[0].id}`);
     }
   }, [data, navigate]);
 
@@ -38,7 +38,7 @@ const RootProjectSelectionPage = () => {
           title={`${item.name}`}
           description={item?.description || ""}
           onClick={() => {
-            navigate(`${process.env.PUBLIC_URL || ""}/p/${item.id}`);
+            navigate(`/p/${item.id}`);
           }}
         />
       </EuiFlexItem>

--- a/ui/src/pages/Sidebar.tsx
+++ b/ui/src/pages/Sidebar.tsx
@@ -53,7 +53,7 @@ const SideNav = () => {
       : ""
   }`;
 
-  const baseUrl = `${process.env.PUBLIC_URL || ""}/p/${projectName}`;
+  const baseUrl = `/p/${projectName}`;
 
   const sideNav: React.ComponentProps<typeof EuiSideNav>['items'] = [
     {

--- a/ui/src/pages/data-sources/DataSourcesListingTable.tsx
+++ b/ui/src/pages/data-sources/DataSourcesListingTable.tsx
@@ -20,9 +20,7 @@ const DatasourcesListingTable = ({
       sortable: true,
       render: (name: string) => {
         return (
-          <EuiCustomLink
-            to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/data-source/${name}`}
-          >
+          <EuiCustomLink to={`/p/${projectName}/data-source/${name}`}>
             {name}
           </EuiCustomLink>
         );

--- a/ui/src/pages/entities/EntitiesListingTable.tsx
+++ b/ui/src/pages/entities/EntitiesListingTable.tsx
@@ -20,9 +20,7 @@ const EntitiesListingTable = ({ entities }: EntitiesListingTableProps) => {
       sortable: true,
       render: (name: string) => {
         return (
-          <EuiCustomLink
-            to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/entity/${name}`}
-          >
+          <EuiCustomLink to={`/p/${projectName}/entity/${name}`}>
             {name}
           </EuiCustomLink>
         );

--- a/ui/src/pages/entities/FeatureViewEdgesList.tsx
+++ b/ui/src/pages/entities/FeatureViewEdgesList.tsx
@@ -53,9 +53,7 @@ const FeatureViewEdgesList = ({ fvNames }: FeatureViewEdgesListInterace) => {
       field: "",
       render: ({ name }: { name: string }) => {
         return (
-          <EuiCustomLink
-            to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view/${name}`}
-          >
+          <EuiCustomLink to={`/p/${projectName}/feature-view/${name}`}>
             {name}
           </EuiCustomLink>
         );

--- a/ui/src/pages/feature-services/FeatureServiceListingTable.tsx
+++ b/ui/src/pages/feature-services/FeatureServiceListingTable.tsx
@@ -30,9 +30,7 @@ const FeatureServiceListingTable = ({
       field: "spec.name",
       render: (name: string) => {
         return (
-          <EuiCustomLink
-            to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-service/${name}`}
-          >
+          <EuiCustomLink to={`/p/${projectName}/feature-service/${name}`}>
             {name}
           </EuiCustomLink>
         );

--- a/ui/src/pages/feature-services/FeatureServiceOverviewTab.tsx
+++ b/ui/src/pages/feature-services/FeatureServiceOverviewTab.tsx
@@ -109,7 +109,7 @@ const FeatureServiceOverviewTab = () => {
                     tags={data.spec.tags}
                     createLink={(key, value) => {
                       return (
-                        `${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-service?` +
+                        `/p/${projectName}/feature-service?` +
                         encodeSearchQueryString(`${key}:${value}`)
                       );
                     }}
@@ -133,7 +133,7 @@ const FeatureServiceOverviewTab = () => {
                             color="primary"
                             onClick={() => {
                               navigate(
-                                `${process.env.PUBLIC_URL || ""}/p/${projectName}/entity/${entity.name}`
+                                `/p/${projectName}/entity/${entity.name}`
                               );
                             }}
                             onClickAriaLabel={entity.name}

--- a/ui/src/pages/feature-views/ConsumingFeatureServicesList.tsx
+++ b/ui/src/pages/feature-views/ConsumingFeatureServicesList.tsx
@@ -18,9 +18,7 @@ const ConsumingFeatureServicesList = ({
       field: "",
       render: ({ name }: { name: string }) => {
         return (
-          <EuiCustomLink
-            to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-service/${name}`}
-          >
+          <EuiCustomLink to={`/p/${projectName}/feature-service/${name}`}>
             {name}
           </EuiCustomLink>
         );

--- a/ui/src/pages/feature-views/FeatureViewListingTable.tsx
+++ b/ui/src/pages/feature-views/FeatureViewListingTable.tsx
@@ -31,9 +31,7 @@ const FeatureViewListingTable = ({
       sortable: true,
       render: (name: string, item: genericFVType) => {
         return (
-          <EuiCustomLink
-            to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view/${name}`}
-          >
+          <EuiCustomLink to={`/p/${projectName}/feature-view/${name}`}>
             {name} {(item.type === "ondemand" && <EuiBadge>ondemand</EuiBadge>) || (item.type === "stream" && <EuiBadge>stream</EuiBadge>)}
           </EuiCustomLink>
         );

--- a/ui/src/pages/feature-views/RegularFeatureViewOverviewTab.tsx
+++ b/ui/src/pages/feature-views/RegularFeatureViewOverviewTab.tsx
@@ -96,7 +96,7 @@ const RegularFeatureViewOverviewTab = ({
                       <EuiBadge
                         color="primary"
                         onClick={() => {
-                          navigate(`${process.env.PUBLIC_URL || ""}/p/${projectName}/entity/${entity}`);
+                          navigate(`/p/${projectName}/entity/${entity}`);
                         }}
                         onClickAriaLabel={entity}
                         data-test-sub="testExample1"
@@ -134,7 +134,7 @@ const RegularFeatureViewOverviewTab = ({
                 tags={data.spec.tags}
                 createLink={(key, value) => {
                   return (
-                    `${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view?` +
+                    `/p/${projectName}/feature-view?` +
                     encodeSearchQueryString(`${key}:${value}`)
                   );
                 }}

--- a/ui/src/pages/feature-views/StreamFeatureViewOverviewTab.tsx
+++ b/ui/src/pages/feature-views/StreamFeatureViewOverviewTab.tsx
@@ -96,7 +96,7 @@ const StreamFeatureViewOverviewTab = ({
                     </EuiText>
                     <EuiTitle size="s">
                       <EuiCustomLink
-                        to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/data-source/${inputGroup?.name}`}
+                        to={`/p/${projectName}/data-source/${inputGroup?.name}`}
                       >
                         {inputGroup?.name}
                       </EuiCustomLink>

--- a/ui/src/pages/feature-views/components/FeatureViewProjectionDisplayPanel.tsx
+++ b/ui/src/pages/feature-views/components/FeatureViewProjectionDisplayPanel.tsx
@@ -31,7 +31,7 @@ const FeatureViewProjectionDisplayPanel = (featureViewProjection: RequestDataDis
       <EuiSpacer size="xs" />
       <EuiTitle size="s">
         <EuiCustomLink
-          to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view/${featureViewProjection.featureViewName}`}
+          to={`/p/${projectName}/feature-view/${featureViewProjection.featureViewName}`}
         >
           {featureViewProjection?.featureViewName}
         </EuiCustomLink>

--- a/ui/src/pages/feature-views/components/RequestDataDisplayPanel.tsx
+++ b/ui/src/pages/feature-views/components/RequestDataDisplayPanel.tsx
@@ -39,7 +39,7 @@ const RequestDataDisplayPanel = ({
       <EuiSpacer size="xs" />
       <EuiTitle size="s">
         <EuiCustomLink
-          to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/data-source/${requestDataSource?.name}`}
+          to={`/p/${projectName}/data-source/${requestDataSource?.name}`}
         >
           {requestDataSource?.name}
         </EuiCustomLink>

--- a/ui/src/pages/features/FeatureOverviewTab.tsx
+++ b/ui/src/pages/features/FeatureOverviewTab.tsx
@@ -63,7 +63,7 @@ const FeatureOverviewTab = () => {
                   <EuiDescriptionListTitle>FeatureView</EuiDescriptionListTitle>
                   <EuiDescriptionListDescription>
                     <EuiCustomLink
-                      to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/feature-view/${FeatureViewName}`}
+                      to={`/p/${projectName}/feature-view/${FeatureViewName}`}
                     >
                       {FeatureViewName}
                     </EuiCustomLink>

--- a/ui/src/pages/saved-data-sets/DatasetsListingTable.tsx
+++ b/ui/src/pages/saved-data-sets/DatasetsListingTable.tsx
@@ -19,9 +19,7 @@ const DatasetsListingTable = ({ datasets }: DatasetsListingTableProps) => {
       sortable: true,
       render: (name: string) => {
         return (
-          <EuiCustomLink
-            to={`${process.env.PUBLIC_URL || ""}/p/${projectName}/data-set/${name}`}
-          >
+          <EuiCustomLink to={`/p/${projectName}/data-set/${name}`}>
             {name}
           </EuiCustomLink>
         );


### PR DESCRIPTION
# What this PR does / why we need it:

Sets the React Router [basename](https://reactrouter.com/6.28.2/router-components/browser-router#basename) to avoid repeating the `PUBLIC_URL` environment variable.

# Which issue(s) this PR fixes:

This is pretty much a re-do of https://github.com/feast-dev/feast/pull/3541 but with only internal changes. Related short discussion started in https://github.com/feast-dev/feast/pull/3514#issuecomment-1472661945.

# Misc

I verified that the environment variable still works by starting the app with `PUBLIC_URL=/feast-ui yarn start` (also `PUBLIC_URL=http://localhost:3000/feast-ui yarn start` somehow works):
<img width="1214" alt="feast-ui-prefix" src="https://github.com/user-attachments/assets/44a4298c-ac30-4293-9f25-b4bcf166a52e" />

**Note:** I originally included some changes that affected the behavior (see discussion below), but eventually decided to keep this as purely refactoring, and make other kinds of improvements separately.