### PR TITLE
chore: Ignore `infra/feast-operator/bin` during release

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -68,6 +68,7 @@ module.exports = {
                     "infra/charts/**/*.*",
                     "infra/feast-helm-operator/**/*",
                     "infra/feast-operator/**/*",
+                    "!infra/feast-operator/bin/",
                     "ui/package.json",
                     "sdk/python/feast/ui/package.json",
                     "sdk/python/feast/ui/yarn.lock"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
The `bin/` dir for feast-operator is not needed.