### PR TITLE
fix: Changed feast operator to set status of featurestore cr to ready based on deployment.status = available

### DIFF
--- a/infra/feast-operator/api/v1alpha1/featurestore_types.go
+++ b/infra/feast-operator/api/v1alpha1/featurestore_types.go
@@ -38,23 +38,25 @@ const (
 	AuthorizationReadyType = "Authorization"
 
 	// Feast condition reasons:
-	ReadyReason                 = "Ready"
-	FailedReason                = "FeatureStoreFailed"
-	OfflineStoreFailedReason    = "OfflineStoreDeploymentFailed"
-	OnlineStoreFailedReason     = "OnlineStoreDeploymentFailed"
-	RegistryFailedReason        = "RegistryDeploymentFailed"
-	UIFailedReason              = "UIDeploymentFailed"
-	ClientFailedReason          = "ClientDeploymentFailed"
-	KubernetesAuthzFailedReason = "KubernetesAuthorizationDeploymentFailed"
+	ReadyReason                  = "Ready"
+	FailedReason                 = "FeatureStoreFailed"
+	DeploymentNotAvailableReason = "DeploymentNotAvailable"
+	OfflineStoreFailedReason     = "OfflineStoreDeploymentFailed"
+	OnlineStoreFailedReason      = "OnlineStoreDeploymentFailed"
+	RegistryFailedReason         = "RegistryDeploymentFailed"
+	UIFailedReason               = "UIDeploymentFailed"
+	ClientFailedReason           = "ClientDeploymentFailed"
+	KubernetesAuthzFailedReason  = "KubernetesAuthorizationDeploymentFailed"
 
 	// Feast condition messages:
-	ReadyMessage                = "FeatureStore installation complete"
-	OfflineStoreReadyMessage    = "Offline Store installation complete"
-	OnlineStoreReadyMessage     = "Online Store installation complete"
-	RegistryReadyMessage        = "Registry installation complete"
-	UIReadyMessage              = "UI installation complete"
-	ClientReadyMessage          = "Client installation complete"
-	KubernetesAuthzReadyMessage = "Kubernetes authorization installation complete"
+	ReadyMessage                  = "FeatureStore installation complete"
+	OfflineStoreReadyMessage      = "Offline Store installation complete"
+	OnlineStoreReadyMessage       = "Online Store installation complete"
+	RegistryReadyMessage          = "Registry installation complete"
+	UIReadyMessage                = "UI installation complete"
+	ClientReadyMessage            = "Client installation complete"
+	KubernetesAuthzReadyMessage   = "Kubernetes authorization installation complete"
+	DeploymentNotAvailableMessage = "Deployment is not available"
 
 	// entity_key_serialization_version
 	SerializationVersion = 3

--- a/infra/feast-operator/internal/controller/featurestore_controller.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller.go
@@ -138,6 +138,30 @@ func (r *FeatureStoreReconciler) deployFeast(ctx context.Context, cr *feastdevv1
 			Reason:  feastdevv1alpha1.FailedReason,
 			Message: "Error: " + err.Error(),
 		}
+	} else {
+		deployment, deploymentErr := feast.GetDeployment()
+		if deploymentErr != nil {
+			condition = metav1.Condition{
+				Type:    feastdevv1alpha1.ReadyType,
+				Status:  metav1.ConditionUnknown,
+				Reason:  feastdevv1alpha1.DeploymentNotAvailableReason,
+				Message: feastdevv1alpha1.DeploymentNotAvailableMessage,
+			}
+
+			result = errResult
+		} else {
+			isDeployAvailable := services.IsDeploymentAvailable(deployment.Status.Conditions)
+			if !isDeployAvailable {
+				condition = metav1.Condition{
+					Type:    feastdevv1alpha1.ReadyType,
+					Status:  metav1.ConditionUnknown,
+					Reason:  feastdevv1alpha1.DeploymentNotAvailableReason,
+					Message: feastdevv1alpha1.DeploymentNotAvailableMessage,
+				}
+
+				result = errResult
+			}
+		}
 	}
 
 	logger.Info(condition.Message)

--- a/infra/feast-operator/internal/controller/featurestore_controller_db_store_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_db_store_test.go
@@ -398,10 +398,10 @@ var _ = Describe("FeatureStore Controller - db storage services", func() {
 			Expect(resource.Status.Conditions).NotTo(BeEmpty())
 			cond := apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.ReadyType)
 			Expect(cond).ToNot(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(feastdevv1alpha1.ReadyReason))
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal(feastdevv1alpha1.DeploymentNotAvailableReason))
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.ReadyType))
-			Expect(cond.Message).To(Equal(feastdevv1alpha1.ReadyMessage))
+			Expect(cond.Message).To(Equal(feastdevv1alpha1.DeploymentNotAvailableMessage))
 
 			cond = apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.RegistryReadyType)
 			Expect(cond).ToNot(BeNil())
@@ -431,7 +431,7 @@ var _ = Describe("FeatureStore Controller - db storage services", func() {
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.OnlineStoreReadyType))
 			Expect(cond.Message).To(Equal(feastdevv1alpha1.OnlineStoreReadyMessage))
 
-			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.ReadyPhase))
+			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.PendingPhase))
 
 			// check deployment
 			deploy := &appsv1.Deployment{}

--- a/infra/feast-operator/internal/controller/featurestore_controller_ephemeral_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_ephemeral_test.go
@@ -164,10 +164,10 @@ var _ = Describe("FeatureStore Controller-Ephemeral services", func() {
 			Expect(resource.Status.Conditions).NotTo(BeEmpty())
 			cond := apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.ReadyType)
 			Expect(cond).ToNot(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(feastdevv1alpha1.ReadyReason))
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal(feastdevv1alpha1.DeploymentNotAvailableReason))
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.ReadyType))
-			Expect(cond.Message).To(Equal(feastdevv1alpha1.ReadyMessage))
+			Expect(cond.Message).To(Equal(feastdevv1alpha1.DeploymentNotAvailableMessage))
 
 			cond = apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.AuthorizationReadyType)
 			Expect(cond).To(BeNil())
@@ -200,7 +200,7 @@ var _ = Describe("FeatureStore Controller-Ephemeral services", func() {
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.OnlineStoreReadyType))
 			Expect(cond.Message).To(Equal(feastdevv1alpha1.OnlineStoreReadyMessage))
 
-			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.ReadyPhase))
+			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.PendingPhase))
 
 			// check deployment
 			deploy := &appsv1.Deployment{}

--- a/infra/feast-operator/internal/controller/featurestore_controller_kubernetes_auth_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_kubernetes_auth_test.go
@@ -150,10 +150,10 @@ var _ = Describe("FeatureStore Controller-Kubernetes authorization", func() {
 			Expect(resource.Status.Conditions).NotTo(BeEmpty())
 			cond := apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.ReadyType)
 			Expect(cond).ToNot(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(feastdevv1alpha1.ReadyReason))
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal(feastdevv1alpha1.DeploymentNotAvailableReason))
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.ReadyType))
-			Expect(cond.Message).To(Equal(feastdevv1alpha1.ReadyMessage))
+			Expect(cond.Message).To(Equal(feastdevv1alpha1.DeploymentNotAvailableMessage))
 
 			cond = apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.AuthorizationReadyType)
 			Expect(cond).ToNot(BeNil())
@@ -190,7 +190,7 @@ var _ = Describe("FeatureStore Controller-Kubernetes authorization", func() {
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.OnlineStoreReadyType))
 			Expect(cond.Message).To(Equal(feastdevv1alpha1.OnlineStoreReadyMessage))
 
-			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.ReadyPhase))
+			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.PendingPhase))
 
 			// check deployment
 			deploy := &appsv1.Deployment{}

--- a/infra/feast-operator/internal/controller/featurestore_controller_loglevel_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_loglevel_test.go
@@ -129,10 +129,10 @@ var _ = Describe("FeatureStore Controller - Feast service LogLevel", func() {
 			Expect(resource.Status.Conditions).NotTo(BeEmpty())
 			cond := apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.ReadyType)
 			Expect(cond).ToNot(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(feastdevv1alpha1.ReadyReason))
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal(feastdevv1alpha1.DeploymentNotAvailableReason))
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.ReadyType))
-			Expect(cond.Message).To(Equal(feastdevv1alpha1.ReadyMessage))
+			Expect(cond.Message).To(Equal(feastdevv1alpha1.DeploymentNotAvailableMessage))
 
 			cond = apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.RegistryReadyType)
 			Expect(cond).ToNot(BeNil())
@@ -161,7 +161,7 @@ var _ = Describe("FeatureStore Controller - Feast service LogLevel", func() {
 			Expect(cond.Reason).To(Equal(feastdevv1alpha1.ReadyReason))
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.OnlineStoreReadyType))
 			Expect(cond.Message).To(Equal(feastdevv1alpha1.OnlineStoreReadyMessage))
-			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.ReadyPhase))
+			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.PendingPhase))
 
 			// check deployment
 			deploy := &appsv1.Deployment{}

--- a/infra/feast-operator/internal/controller/featurestore_controller_objectstore_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_objectstore_test.go
@@ -148,10 +148,10 @@ var _ = Describe("FeatureStore Controller-Ephemeral services", func() {
 			Expect(resource.Status.Conditions).NotTo(BeEmpty())
 			cond := apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.ReadyType)
 			Expect(cond).ToNot(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(feastdevv1alpha1.ReadyReason))
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal(feastdevv1alpha1.DeploymentNotAvailableReason))
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.ReadyType))
-			Expect(cond.Message).To(Equal(feastdevv1alpha1.ReadyMessage))
+			Expect(cond.Message).To(Equal(feastdevv1alpha1.DeploymentNotAvailableMessage))
 
 			cond = apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.AuthorizationReadyType)
 			Expect(cond).To(BeNil())
@@ -176,7 +176,7 @@ var _ = Describe("FeatureStore Controller-Ephemeral services", func() {
 			cond = apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.OnlineStoreReadyType)
 			Expect(cond).To(BeNil())
 
-			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.ReadyPhase))
+			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.PendingPhase))
 
 			// check deployment
 			deploy := &appsv1.Deployment{}

--- a/infra/feast-operator/internal/controller/featurestore_controller_oidc_auth_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_oidc_auth_test.go
@@ -173,10 +173,10 @@ var _ = Describe("FeatureStore Controller-OIDC authorization", func() {
 			Expect(resource.Status.Conditions).NotTo(BeEmpty())
 			cond := apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.ReadyType)
 			Expect(cond).ToNot(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(feastdevv1alpha1.ReadyReason))
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal(feastdevv1alpha1.DeploymentNotAvailableReason))
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.ReadyType))
-			Expect(cond.Message).To(Equal(feastdevv1alpha1.ReadyMessage))
+			Expect(cond.Message).To(Equal(feastdevv1alpha1.DeploymentNotAvailableMessage))
 
 			cond = apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.AuthorizationReadyType)
 			Expect(cond).To(BeNil())
@@ -209,7 +209,7 @@ var _ = Describe("FeatureStore Controller-OIDC authorization", func() {
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.OnlineStoreReadyType))
 			Expect(cond.Message).To(Equal(feastdevv1alpha1.OnlineStoreReadyMessage))
 
-			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.ReadyPhase))
+			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.PendingPhase))
 
 			// check deployment
 			deploy := &appsv1.Deployment{}

--- a/infra/feast-operator/internal/controller/featurestore_controller_pvc_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_pvc_test.go
@@ -227,10 +227,10 @@ var _ = Describe("FeatureStore Controller-Ephemeral services", func() {
 			Expect(resource.Status.Conditions).NotTo(BeEmpty())
 			cond := apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.ReadyType)
 			Expect(cond).ToNot(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(feastdevv1alpha1.ReadyReason))
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal(feastdevv1alpha1.DeploymentNotAvailableReason))
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.ReadyType))
-			Expect(cond.Message).To(Equal(feastdevv1alpha1.ReadyMessage))
+			Expect(cond.Message).To(Equal(feastdevv1alpha1.DeploymentNotAvailableMessage))
 
 			cond = apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.AuthorizationReadyType)
 			Expect(cond).To(BeNil())
@@ -263,7 +263,7 @@ var _ = Describe("FeatureStore Controller-Ephemeral services", func() {
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.OnlineStoreReadyType))
 			Expect(cond.Message).To(Equal(feastdevv1alpha1.OnlineStoreReadyMessage))
 
-			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.ReadyPhase))
+			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.PendingPhase))
 
 			ephemeralName := "feast-data"
 			ephemeralVolume := corev1.Volume{

--- a/infra/feast-operator/internal/controller/featurestore_controller_tls_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_tls_test.go
@@ -145,10 +145,10 @@ var _ = Describe("FeatureStore Controller - Feast service TLS", func() {
 			Expect(resource.Status.Conditions).NotTo(BeEmpty())
 			cond := apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.ReadyType)
 			Expect(cond).ToNot(BeNil())
-			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-			Expect(cond.Reason).To(Equal(feastdevv1alpha1.ReadyReason))
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal(feastdevv1alpha1.DeploymentNotAvailableReason))
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.ReadyType))
-			Expect(cond.Message).To(Equal(feastdevv1alpha1.ReadyMessage))
+			Expect(cond.Message).To(Equal(feastdevv1alpha1.DeploymentNotAvailableMessage))
 
 			cond = apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1alpha1.RegistryReadyType)
 			Expect(cond).ToNot(BeNil())
@@ -178,7 +178,7 @@ var _ = Describe("FeatureStore Controller - Feast service TLS", func() {
 			Expect(cond.Type).To(Equal(feastdevv1alpha1.OnlineStoreReadyType))
 			Expect(cond.Message).To(Equal(feastdevv1alpha1.OnlineStoreReadyMessage))
 
-			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.ReadyPhase))
+			Expect(resource.Status.Phase).To(Equal(feastdevv1alpha1.PendingPhase))
 
 			// check deployment
 			deploy := &appsv1.Deployment{}

--- a/infra/feast-operator/internal/controller/services/services.go
+++ b/infra/feast-operator/internal/controller/services/services.go
@@ -614,6 +614,13 @@ func (feast *FeastServices) GetFeastServiceName(feastType FeastServiceType) stri
 	return GetFeastServiceName(feast.Handler.FeatureStore, feastType)
 }
 
+func (feast *FeastServices) GetDeployment() (appsv1.Deployment, error) {
+	deployment := appsv1.Deployment{}
+	obj := feast.GetObjectMeta()
+	err := feast.Handler.Get(feast.Handler.Context, client.ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}, &deployment)
+	return deployment, err
+}
+
 // GetFeastServiceName returns the feast service object name based on service type
 func GetFeastServiceName(featureStore *feastdevv1alpha1.FeatureStore, feastType FeastServiceType) string {
 	return GetFeastName(featureStore) + "-" + string(feastType)
@@ -916,4 +923,14 @@ func getProbeHandler(feastType FeastServiceType, tls *feastdevv1alpha1.TlsConfig
 			Port: intstr.FromInt(int(targetPort)),
 		},
 	}
+}
+
+func IsDeploymentAvailable(conditions []appsv1.DeploymentCondition) bool {
+	for _, condition := range conditions {
+		if condition.Type == appsv1.DeploymentAvailable {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
Changed feast Operator to update FeatureStore CR's status.conditions by checking resulting Deployment's status

# What this PR does / why we need it:
Now the status of the feast CR is more accurate
