### PR TITLE
docs: Deprecate Helm Operator - docs

### DIFF
--- a/docs/how-to-guides/running-feast-in-production.md
+++ b/docs/how-to-guides/running-feast-in-production.md
@@ -203,7 +203,7 @@ feature_vector = fs.get_online_features(
 ).to_dict()
 ```
 
-### 4.2. Deploy Feast feature servers on Kubernetes
+### 4.2. Deploy Feast feature servers on Kubernetes (Deprecated replaced by [feast-operator](../../infra/feast-operator/README.md))
 
 To deploy a Feast feature server on Kubernetes, you can use the included [helm chart + tutorial](https://github.com/feast-dev/feast/tree/master/infra/charts/feast-feature-server) (which also has detailed instructions and an example tutorial).
 

--- a/infra/feast-helm-operator/README.md
+++ b/infra/feast-helm-operator/README.md
@@ -1,4 +1,4 @@
-# Feast Feature Server Helm-based Operator
+# Feast Feature Server Helm-based Operator (Deprecated replaced by [feast-operator](../feast-operator/README.md))
 
 This Operator was built with the [operator-sdk](https://github.com/operator-framework/operator-sdk) and leverages the [feast-feature-server helm chart](/infra/charts/feast-feature-server).
 


### PR DESCRIPTION
Updated  Helm Operator to point out that the operator is deprecated and the new feast go operator should be used instead.

# What this PR does / why we need it:
The feast go operator is more powerful and allows a flexible deployment


