### PR TITLE
chore: Added component_metadata file to show Feast latest release in ODH operator [stable]

### DIFF
--- a/infra/feast-operator/config/component_metadata.yaml
+++ b/infra/feast-operator/config/component_metadata.yaml
@@ -1,0 +1,5 @@
+# This file is required to configure Feast release information for ODH/RHOAI Operator
+releases:
+  - name: Feast
+    version: 0.45.0
+    repoUrl: https://github.com/feast-dev/feast

--- a/infra/scripts/release/files_to_bump.txt
+++ b/infra/scripts/release/files_to_bump.txt
@@ -14,6 +14,7 @@ infra/feast-helm-operator/Makefile 6
 infra/feast-helm-operator/config/manager/kustomization.yaml 8
 infra/feast-operator/Makefile 6
 infra/feast-operator/config/manager/kustomization.yaml 8
+infra/feast-operator/config/component_metadata.yaml 4
 infra/feast-operator/config/overlays/odh/params.env 1 2
 infra/feast-operator/api/feastversion/version.go 20
 java/pom.xml 38


### PR DESCRIPTION


added component_metadata file to show feast latest release in ODH operator

same PR moving to stable branch #5021

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
