### PR TITLE
fix: Validate entities when running get_online_features

### DIFF
--- a/sdk/python/tests/unit/online_store/test_online_retrieval.py
+++ b/sdk/python/tests/unit/online_store/test_online_retrieval.py
@@ -137,6 +137,21 @@ def test_get_online_features() -> None:
 
         assert "trips" in result
 
+        with pytest.raises(KeyError) as excinfo:
+            _ = store.get_online_features(
+                features=["driver_locations:lon"],
+                entity_rows=[{"customer_id": 0}],
+                full_feature_names=False,
+            ).to_dict()
+
+        error_message = str(excinfo.value)
+        assert "Missing join key values for keys:" in error_message
+        assert (
+            "Missing join key values for keys: ['customer_id', 'driver_id', 'item_id']."
+            in error_message
+        )
+        assert "Provided join_key_values: ['customer_id']" in error_message
+
         result = store.get_online_features(
             features=["customer_profile_pandas_odfv:on_demand_age"],
             entity_rows=[{"driver_id": 1, "customer_id": "5"}],

--- a/sdk/python/tests/unit/test_unit_feature_store.py
+++ b/sdk/python/tests/unit/test_unit_feature_store.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Dict, List
 
+import pytest
+
 from feast import utils
 from feast.protos.feast.types.Value_pb2 import Value
 
@@ -17,7 +19,7 @@ class MockFeatureView:
     projection: MockFeatureViewProjection
 
 
-def test_get_unique_entities():
+def test_get_unique_entities_success():
     entity_values = {
         "entity_1": [Value(int64_val=1), Value(int64_val=2), Value(int64_val=1)],
         "entity_2": [
@@ -41,9 +43,87 @@ def test_get_unique_entities():
         join_key_values=entity_values,
         entity_name_to_join_key_map=entity_name_to_join_key_map,
     )
-
-    assert unique_entities == (
+    expected_entities = (
         {"entity_1": Value(int64_val=1), "entity_2": Value(string_val="1")},
         {"entity_1": Value(int64_val=2), "entity_2": Value(string_val="2")},
     )
-    assert indexes == ([0, 2], [1])
+    expected_indexes = ([0, 2], [1])
+
+    assert unique_entities == expected_entities
+    assert indexes == expected_indexes
+
+
+def test_get_unique_entities_missing_join_key_success():
+    """
+    Tests that _get_unique_entities raises a KeyError when a required join key is missing.
+    """
+    # Here, we omit the required key for "entity_1"
+    entity_values = {
+        "entity_2": [
+            Value(string_val="1"),
+            Value(string_val="2"),
+            Value(string_val="1"),
+        ],
+    }
+
+    entity_name_to_join_key_map = {"entity_1": "entity_1", "entity_2": "entity_2"}
+
+    fv = MockFeatureView(
+        name="fv_1",
+        entities=["entity_1", "entity_2"],
+        projection=MockFeatureViewProjection(join_key_map={}),
+    )
+
+    unique_entities, indexes = utils._get_unique_entities(
+        table=fv,
+        join_key_values=entity_values,
+        entity_name_to_join_key_map=entity_name_to_join_key_map,
+    )
+    expected_entities = (
+        {"entity_2": Value(string_val="1")},
+        {"entity_2": Value(string_val="2")},
+    )
+    expected_indexes = ([0, 2], [1])
+
+    assert unique_entities == expected_entities
+    assert indexes == expected_indexes
+    # We're not say anything about the entity_1 missing from the unique_entities list
+    assert "entity_1" not in [entity.keys() for entity in unique_entities]
+
+
+def test_get_unique_entities_missing_all_join_keys_error():
+    """
+    Tests that _get_unique_entities raises a KeyError when all required join keys are missing.
+    """
+    entity_values_not_in_feature_view = {
+        "entity_3": [Value(string_val="3")],
+    }
+    entity_name_to_join_key_map = {
+        "entity_1": "entity_1",
+        "entity_2": "entity_2",
+        "entity_3": "entity_3",
+    }
+
+    fv = MockFeatureView(
+        name="fv_1",
+        entities=["entity_1", "entity_2"],
+        projection=MockFeatureViewProjection(join_key_map={}),
+    )
+
+    with pytest.raises(KeyError) as excinfo:
+        utils._get_unique_entities(
+            table=fv,
+            join_key_values=entity_values_not_in_feature_view,
+            entity_name_to_join_key_map=entity_name_to_join_key_map,
+        )
+
+    error_message = str(excinfo.value)
+    assert (
+        "Missing join key values for keys: ['entity_1', 'entity_2', 'entity_3']"
+        in error_message
+    )
+    assert (
+        "No values provided for keys: ['entity_1', 'entity_2', 'entity_3']"
+        in error_message
+    )
+    assert "Provided join_key_values: ['entity_3']" in error_message


### PR DESCRIPTION
# What this PR does / why we need it:

This PR addresses the issue of unexpected crashes when using feature_store.get_online_features with incorrect or missing join keys. 

Specifically, it introduces validation logic in the `_get_unique_entities` function to ensure that all expected join keys are present and non-empty before proceeding. 

**If any required join keys are missing** or have empty values, a KeyError is raised with a descriptive error message. Additionally, new unit tests have been added to cover various edge cases, ensuring that the function behaves as expected under different scenarios.

Changes:
- `sdk/python/feast/utils.py`:
    - Added validation for missing and empty join keys in `_get_unique_entities`.
    - Updated the logic to convert column-oriented `table_entity_values` into row-wise data and handle edge cases.
- `sdk/python/tests/unit/online_store/test_online_retrieval.py`:
    - Added a test case to verify that a `KeyError` is raised when required join keys are missing.
- `sdk/python/tests/unit/test_unit_feature_store.py`:
    - Imported pytest for testing.
    - Renamed `test_get_unique_entities` to `test_get_unique_entities_success` for clarity.
    - Added test cases for missing join keys and handling errors appropriately.


# Which issue(s) this PR fixes:
https://github.com/feast-dev/feast/issues/3270

# Misc

It's worth noting, when one key is present and one is not, the retrieval will still succeed as this is expected behavior.