### PR TITLE
feat: Add SQLite retrieve_online_documents_v2

### DIFF
--- a/docs/reference/alpha-vector-database.md
+++ b/docs/reference/alpha-vector-database.md
@@ -7,14 +7,14 @@ Vector database allows user to store and retrieve embeddings. Feast provides gen
 ## Integration
 Below are supported vector databases and implemented features:
 
-| Vector Database | Retrieval | Indexing | V2 Support* | 
-|-----------------|-----------|----------|-------------|
-| Pgvector        | [x]       | [ ]      | []          |
-| Elasticsearch   | [x]       | [x]      | []          |
-| Milvus          | [x]       | [x]      | [x]         |
-| Faiss           | [ ]       | [ ]      | []          |
-| SQLite          | [x]       | [ ]      | []          |
-| Qdrant          | [x]       | [x]      | []          |
+| Vector Database | Retrieval | Indexing | V2 Support* | Online Read |
+|-----------------|-----------|----------|-------------|-------------|
+| Pgvector        | [x]       | [ ]      | []          | []          |
+| Elasticsearch   | [x]       | [x]      | []          | []          |
+| Milvus          | [x]       | [x]      | [x]         | [x]         |
+| Faiss           | [ ]       | [ ]      | []          | []          |
+| SQLite          | [x]       | [ ]      | [x]         | [x]         |
+| Qdrant          | [x]       | [x]      | []          | []          |
 
 *Note: V2 Support means the SDK supports retrieval of features along with vector embeddings from vector similarity search.
 
@@ -30,7 +30,7 @@ Beyond that, we will then have `retrieve_online_documents` and `retrieve_online_
 backwards compatibility and the adopt industry standard naming conventions.
 {% endhint %}
 
-**Note**: Milvus implements the v2 `retrieve_online_documents_v2` method in the SDK. This will be the longer-term solution so that Data Scientists can easily enable vector similarity search by just flipping a flag.
+**Note**: Milvus and SQLite implement the v2 `retrieve_online_documents_v2` method in the SDK. This will be the longer-term solution so that Data Scientists can easily enable vector similarity search by just flipping a flag.
 
 ## Examples
 

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -372,7 +372,7 @@ class SqliteOnlineStore(OnlineStore):
 
         cur.execute(
             f"""
-            CREATE VIRTUAL TABLE vec_example using vec0(
+            CREATE VIRTUAL TABLE vec_table using vec0(
                 vector_value float[{config.online_store.vector_len}]
         );
         """
@@ -381,13 +381,13 @@ class SqliteOnlineStore(OnlineStore):
         # Currently I can only insert the embedding value without crashing SQLite, will report a bug
         cur.execute(
             f"""
-            INSERT INTO vec_example(rowid, vector_value)
+            INSERT INTO vec_table(rowid, vector_value)
             select rowid, vector_value from {table_name}
         """
         )
         cur.execute(
             """
-            INSERT INTO vec_example(rowid, vector_value)
+            INSERT INTO vec_table(rowid, vector_value)
                 VALUES (?, ?)
         """,
             (0, query_embedding_bin),
@@ -408,7 +408,7 @@ class SqliteOnlineStore(OnlineStore):
                     rowid,
                     vector_value,
                     distance
-                from vec_example
+                from vec_table
                 where vector_value match ?
                 order by distance
                 limit ?
@@ -492,7 +492,7 @@ class SqliteOnlineStore(OnlineStore):
 
         cur.execute(
             f"""
-            CREATE VIRTUAL TABLE IF NOT EXISTS vec_example using vec0(
+            CREATE VIRTUAL TABLE IF NOT EXISTS vec_table using vec0(
                 vector_value float[{online_store.vector_len}]
             );
             """
@@ -500,17 +500,9 @@ class SqliteOnlineStore(OnlineStore):
 
         cur.execute(
             f"""
-            INSERT INTO vec_example(rowid, vector_value)
+            INSERT INTO vec_table(rowid, vector_value)
             select rowid, vector_value from {table_name}
             """
-        )
-
-        cur.execute(
-            """
-            INSERT INTO vec_example(rowid, vector_value)
-            VALUES (?, ?)
-            """,
-            (0, query_embedding_bin),
         )
 
         cur.execute(
@@ -527,13 +519,13 @@ class SqliteOnlineStore(OnlineStore):
                     rowid,
                     vector_value,
                     distance
-                from vec_example
+                from vec_table
                 where vector_value match ?
                 order by distance
                 limit ?
             ) f
             left join {table_name} fv
-            on f.rowid = fv.rowid
+                on f.rowid = fv.rowid
             where fv.feature_name in ({",".join(["?" for _ in requested_features])})
             """,
             (

--- a/sdk/python/tests/integration/registration/test_universal_registry.py
+++ b/sdk/python/tests/integration/registration/test_universal_registry.py
@@ -1164,7 +1164,7 @@ def test_registry_cache_thread_async(test_registry):
     test_registry.teardown()
 
 
-# @pytest.mark.integration
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "test_registry",
     all_fixtures,

--- a/sdk/python/tests/integration/registration/test_universal_registry.py
+++ b/sdk/python/tests/integration/registration/test_universal_registry.py
@@ -1164,7 +1164,7 @@ def test_registry_cache_thread_async(test_registry):
     test_registry.teardown()
 
 
-@pytest.mark.integration
+# @pytest.mark.integration
 @pytest.mark.parametrize(
     "test_registry",
     all_fixtures,

--- a/sdk/python/tests/unit/online_store/test_online_retrieval.py
+++ b/sdk/python/tests/unit/online_store/test_online_retrieval.py
@@ -738,6 +738,68 @@ def test_sqlite_vec_import() -> None:
     assert result == [(2, 2.39), (1, 2.39)]
 
 
+@pytest.mark.skipif(
+    sys.version_info[0:2] != (3, 10),
+    reason="Only works on Python 3.10",
+)
+def test_sqlite_get_online_documents_v2() -> None:
+    """Test retrieving documents using v2 method with vector similarity search."""
+    n = 10
+    vector_length = 8
+    runner = CliRunner()
+    with runner.local_repo(
+        get_example_repo("example_feature_repo_1.py"), "file"
+    ) as store:
+        store.config.online_store.vector_enabled = True
+        store.config.online_store.vector_len = vector_length
+        document_embeddings_fv = store.get_feature_view(name="document_embeddings")
+
+        provider = store._get_provider()
+
+        # Create test data
+        item_keys = [
+            EntityKeyProto(
+                join_keys=["item_id"], entity_values=[ValueProto(int64_val=i)]
+            )
+            for i in range(n)
+        ]
+        data = []
+        for item_key in item_keys:
+            data.append(
+                (
+                    item_key,
+                    {
+                        "Embeddings": ValueProto(
+                            float_list_val=FloatListProto(
+                                val=[float(x) for x in np.random.random(vector_length)]
+                            )
+                        )
+                    },
+                    _utc_now(),
+                    _utc_now(),
+                )
+            )
+
+        provider.online_write_batch(
+            config=store.config,
+            table=document_embeddings_fv,
+            data=data,
+            progress=None,
+        )
+
+        # Test vector similarity search
+        query_embedding = [float(x) for x in np.random.random(vector_length)]
+        result = store.retrieve_online_documents_v2(
+            features=["document_embeddings:Embeddings"],
+            query=query_embedding,
+            top_k=3,
+        ).to_dict()
+
+        assert "Embeddings" in result
+        assert "distance" in result
+        assert len(result["distance"]) == 3
+
+
 @pytest.mark.skip(reason="Skipping this test as CI struggles with it")
 def test_local_milvus() -> None:
     import random

--- a/sdk/python/tests/unit/online_store/test_online_retrieval.py
+++ b/sdk/python/tests/unit/online_store/test_online_retrieval.py
@@ -752,6 +752,7 @@ def test_sqlite_get_online_documents_v2() -> None:
     ) as store:
         store.config.online_store.vector_enabled = True
         store.config.online_store.vector_len = vector_length
+        store.config.entity_key_serialization_version = 3
         document_embeddings_fv = store.get_feature_view(name="document_embeddings")
 
         provider = store._get_provider()


### PR DESCRIPTION
# What this PR does / why we need it:
Add  `retrieve_online_documents_v2` to sqlite-vec

- **docs/reference/alpha-vector-database.md**
  - Added a new column `Online Read` in the vector database support table.
  - Marked SQLite as supporting `retrieve_online_documents_v2`.
  - Noted that both Milvus and SQLite implement the `retrieve_online_documents_v2` method.

- **sdk/python/feast/infra/online_stores/sqlite.py**
  - Added new attributes to the `SqliteOnlineStoreConfig` class for vector search.
  - Modified `_get_conn` method to conditionally enable SQLite vector extension.
  - Refactored `retrieve_online_documents` to use `vec_table`.
  - Added a new method `retrieve_online_documents_v2` for vector similarity search.
  - Updated `_initialize_conn` method to handle the vector extension initialization.

- **sdk/python/tests/unit/online_store/test_online_retrieval.py**
  - Added a new test `test_sqlite_get_online_documents_v2` to ensure the new vector search functionality works as expected.

#### Notes:
- The new vector search functionality is only enabled for Python 3.10.
- Ensure the `sqlite_vec` extension is available in the environment to utilize the new vector search features.

# Which issue(s) this PR fixes:
N/A

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
