### PR TITLE
fix: Ensure Postgres queries are committed or autocommit is used

### DIFF
--- a/sdk/python/feast/infra/online_stores/postgres_online_store/postgres.py
+++ b/sdk/python/feast/infra/online_stores/postgres_online_store/postgres.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import (
     Any,
     AsyncGenerator,
+    Bool,
     Callable,
     Dict,
     Generator,
@@ -58,7 +59,7 @@ class PostgreSQLOnlineStore(OnlineStore):
     _conn_pool_async: Optional[AsyncConnectionPool] = None
 
     @contextlib.contextmanager
-    def _get_conn(self, config: RepoConfig) -> Generator[Connection, Any, Any]:
+    def _get_conn(self, config: RepoConfig, autocommit: Bool = False) -> Generator[Connection, Any, Any]:
         assert config.online_store.type == "postgres"
 
         if config.online_store.conn_type == ConnectionType.pool:
@@ -66,16 +67,18 @@ class PostgreSQLOnlineStore(OnlineStore):
                 self._conn_pool = _get_connection_pool(config.online_store)
                 self._conn_pool.open()
             connection = self._conn_pool.getconn()
+            connection.set_autocommit(autocommit)
             yield connection
             self._conn_pool.putconn(connection)
         else:
             if not self._conn:
                 self._conn = _get_conn(config.online_store)
+            self._conn .set_autocommit(autocommit)
             yield self._conn
 
     @contextlib.asynccontextmanager
     async def _get_conn_async(
-        self, config: RepoConfig
+        self, config: RepoConfig, autocommit: Bool = False
     ) -> AsyncGenerator[AsyncConnection, Any]:
         if config.online_store.conn_type == ConnectionType.pool:
             if not self._conn_pool_async:
@@ -84,11 +87,13 @@ class PostgreSQLOnlineStore(OnlineStore):
                 )
                 await self._conn_pool_async.open()
             connection = await self._conn_pool_async.getconn()
+            await connection.set_autocommit(autocommit)
             yield connection
             await self._conn_pool_async.putconn(connection)
         else:
             if not self._conn_async:
                 self._conn_async = await _get_conn_async(config.online_store)
+            await self._conn_async.set_autocommit(autocommit)
             yield self._conn_async
 
     def online_write_batch(
@@ -161,7 +166,7 @@ class PostgreSQLOnlineStore(OnlineStore):
             config, table, keys, requested_features
         )
 
-        with self._get_conn(config) as conn, conn.cursor() as cur:
+        with self._get_conn(config, autocommit=True) as conn, conn.cursor() as cur:
             cur.execute(query, params)
             rows = cur.fetchall()
 
@@ -179,7 +184,7 @@ class PostgreSQLOnlineStore(OnlineStore):
             config, table, keys, requested_features
         )
 
-        async with self._get_conn_async(config) as conn:
+        async with self._get_conn_async(config, autocommit=True) as conn:
             async with conn.cursor() as cur:
                 await cur.execute(query, params)
                 rows = await cur.fetchall()
@@ -398,7 +403,7 @@ class PostgreSQLOnlineStore(OnlineStore):
                 Optional[ValueProto],
             ]
         ] = []
-        with self._get_conn(config) as conn, conn.cursor() as cur:
+        with self._get_conn(config, autocommit=True) as conn, conn.cursor() as cur:
             table_name = _table_id(project, table)
 
             # Search query template to find the top k items that are closest to the given embedding

--- a/sdk/python/feast/infra/online_stores/postgres_online_store/postgres.py
+++ b/sdk/python/feast/infra/online_stores/postgres_online_store/postgres.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from typing import (
     Any,
     AsyncGenerator,
-    Bool,
     Callable,
     Dict,
     Generator,
@@ -59,7 +58,9 @@ class PostgreSQLOnlineStore(OnlineStore):
     _conn_pool_async: Optional[AsyncConnectionPool] = None
 
     @contextlib.contextmanager
-    def _get_conn(self, config: RepoConfig, autocommit: Bool = False) -> Generator[Connection, Any, Any]:
+    def _get_conn(
+        self, config: RepoConfig, autocommit: bool = False
+    ) -> Generator[Connection, Any, Any]:
         assert config.online_store.type == "postgres"
 
         if config.online_store.conn_type == ConnectionType.pool:
@@ -73,12 +74,12 @@ class PostgreSQLOnlineStore(OnlineStore):
         else:
             if not self._conn:
                 self._conn = _get_conn(config.online_store)
-            self._conn .set_autocommit(autocommit)
+            self._conn.set_autocommit(autocommit)
             yield self._conn
 
     @contextlib.asynccontextmanager
     async def _get_conn_async(
-        self, config: RepoConfig, autocommit: Bool = False
+        self, config: RepoConfig, autocommit: bool = False
     ) -> AsyncGenerator[AsyncConnection, Any]:
         if config.online_store.conn_type == ConnectionType.pool:
             if not self._conn_pool_async:

--- a/sdk/python/feast/infra/online_stores/postgres_online_store/postgres.py
+++ b/sdk/python/feast/infra/online_stores/postgres_online_store/postgres.py
@@ -345,6 +345,7 @@ class PostgreSQLOnlineStore(OnlineStore):
                 for table in tables:
                     table_name = _table_id(project, table)
                     cur.execute(_drop_table_and_index(table_name))
+                conn.commit()
         except Exception:
             logging.exception("Teardown failed")
             raise


### PR DESCRIPTION
# What this PR does / why we need it:

We are using `psycopg3` in case we use Postgres for the online store. If you create connections with `psycopg3` using a context manager (i.e. a `with ...` block), it will automatically commit the transaction once you exit the context. However, in `feast` we are manually creating (and in the case of connection pools, putting) connections, so we need to ensure that we also explicitly call `commit` after firing queries to the database. 

The `commit` statements were missing for (async) read methods of the `PostgresOnlineStore` and the `teardown` method. For the read statements, this wasn't an issue as we just do a `SELECT`. However, it does add warning statements and quite a bit of latency as transactions needed to be rolled back. 

Hence, for those read methods, I introduced an optional `autocommit` to the `_get_conn` and `_get_conn_async` methods that defaults to `False`. We are setting it to `True` in our read methods, so that prevents us from having to call `commit` and further optimizes the performance. In my local tests, `online_read_async` performance improved by 20-30% when calling explicitly commit, and **40-70%** when enabling autocommit (depending on feature view).


# Which issue(s) this PR fixes:

Fixes https://github.com/feast-dev/feast/issues/5038