### PR TITLE
chore: Operator - increase maxDescLen to include some CRD descriptions

### DIFF
--- a/infra/feast-operator/Makefile
+++ b/infra/feast-operator/Makefile
@@ -97,7 +97,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=0 webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=120 webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/infra/feast-operator/config/crd/bases/feast.dev_featurestores.yaml
+++ b/infra/feast-operator/config/crd/bases/feast.dev_featurestores.yaml
@@ -26,30 +26,53 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: FeatureStore is the Schema for the featurestores API
         properties:
           apiVersion:
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
             type: string
           kind:
+            description: Kind is a string value representing the REST resource this
+              object represents.
             type: string
           metadata:
             type: object
           spec:
+            description: FeatureStoreSpec defines the desired state of FeatureStore
             properties:
               authz:
+                description: AuthzConfig defines the authorization settings for the
+                  deployed Feast services.
                 properties:
                   kubernetes:
+                    description: |-
+                      KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.
+                      https://kubernetes.
                     properties:
                       roles:
+                        description: The Kubernetes RBAC roles to be deployed in the
+                          same namespace of the FeatureStore.
                         items:
                           type: string
                         type: array
                     type: object
                   oidc:
+                    description: |-
+                      OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.
+                      https://auth0.
                     properties:
                       secretRef:
+                        description: |-
+                          LocalObjectReference contains enough information to let you locate the
+                          referenced object inside the same namespace.
                         properties:
                           name:
                             default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -61,45 +84,74 @@ spec:
                 - message: One selection required between kubernetes or oidc.
                   rule: '[has(self.kubernetes), has(self.oidc)].exists_one(c, c)'
               feastProject:
+                description: FeastProject is the Feast project id.
                 pattern: ^[A-Za-z0-9][A-Za-z0-9_]*$
                 type: string
               services:
+                description: FeatureStoreServices defines the desired feast services.
+                  An ephemeral registry is deployed by default.
                 properties:
                   deploymentStrategy:
+                    description: DeploymentStrategy describes how to replace existing
+                      pods with new ones.
                     properties:
                       rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if DeploymentStrategyType =
+                          RollingUpdate.
                         properties:
                           maxSurge:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              The maximum number of pods that can be scheduled above the desired number of
+                              pods.
                             x-kubernetes-int-or-string: true
                           maxUnavailable:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: The maximum number of pods that can be unavailable
+                              during the update.
                             x-kubernetes-int-or-string: true
                         type: object
                       type:
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                          Default is RollingUpdate.
                         type: string
                     type: object
                   disableInitContainers:
+                    description: Disable the 'feast repo initialization' initContainer
                     type: boolean
                   offlineStore:
+                    description: OfflineStore configures the deployed offline store
+                      service
                     properties:
                       persistence:
+                        description: OfflineStorePersistence configures the persistence
+                          settings for the offline store service
                         properties:
                           file:
+                            description: OfflineStoreFilePersistence configures the
+                              file-based persistence for the offline store service
                             properties:
                               pvc:
+                                description: PvcConfig defines the settings for a
+                                  persistent file store based on PVCs.
                                 properties:
                                   create:
+                                    description: Settings for creating a new PVC
                                     properties:
                                       accessModes:
+                                        description: AccessModes k8s persistent volume
+                                          access modes. Defaults to ["ReadWriteOnce"].
                                         items:
                                           type: string
                                         type: array
                                       resources:
+                                        description: Resources describes the storage
+                                          resource requirements for a volume.
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -108,6 +160,9 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -116,20 +171,33 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
+                                            description: Requests describes the minimum
+                                              amount of compute resources required.
                                             type: object
                                         type: object
                                       storageClassName:
+                                        description: StorageClassName is the name
+                                          of an existing StorageClass to which this
+                                          persistent volume belongs.
                                         type: string
                                     type: object
                                     x-kubernetes-validations:
                                     - message: PvcCreate is immutable
                                       rule: self == oldSelf
                                   mountPath:
+                                    description: |-
+                                      MountPath within the container at which the volume should be mounted.
+                                      Must start by "/" and cannot contain ':'.
                                     type: string
                                   ref:
+                                    description: Reference to an existing field
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -152,17 +220,30 @@ spec:
                                 type: string
                             type: object
                           store:
+                            description: OfflineStoreDBStorePersistence configures
+                              the DB store persistence for the offline store service
                             properties:
                               secretKeyName:
+                                description: By default, the selected store "type"
+                                  is used as the SecretKeyName
                                 type: string
                               secretRef:
+                                description: Data store parameters should be placed
+                                  as-is from the "feature_store.yaml" under the secret
+                                  key.
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type:
+                                description: Type of the persistence type you want
+                                  to use.
                                 enum:
                                 - snowflake.offline
                                 - bigquery
@@ -182,63 +263,108 @@ spec:
                         - message: One selection required between file or store.
                           rule: '[has(self.file), has(self.store)].exists_one(c, c)'
                       server:
+                        description: Creates a remote offline server container
                         properties:
                           env:
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -251,24 +377,42 @@ spec:
                             type: array
                           envFrom:
                             items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -277,8 +421,13 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
+                            description: PullPolicy describes a policy for if/when
+                              to pull a container image
                             type: string
                           logLevel:
+                            description: |-
+                              LogLevel sets the logging level for the server
+                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -287,11 +436,21 @@ spec:
                             - critical
                             type: string
                           resources:
+                            description: ResourceRequirements describes the compute
+                              resource requirements.
                             properties:
                               claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
                                 items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used.
                                       type: string
                                   required:
                                   - name
@@ -307,6 +466,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -315,23 +477,40 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           tls:
+                            description: TlsConfigs configures server TLS for a feast
+                              service.
                             properties:
                               disable:
+                                description: will disable TLS for the feast service.
+                                  useful in an openshift cluster, for example, where
+                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
+                                description: SecretKeyNames defines the secret key
+                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
+                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
+                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
+                                description: references the local k8s secret where
+                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -341,21 +520,43 @@ spec:
                               rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                 : true'
                           volumeMounts:
+                            description: VolumeMounts defines the list of volumes
+                              that should be mounted into the feast container.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
                                   type: boolean
                                 recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
                                   type: string
                                 subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
                                   type: string
                               required:
                               - mountPath
@@ -365,22 +566,35 @@ spec:
                         type: object
                     type: object
                   onlineStore:
+                    description: OnlineStore configures the deployed online store
+                      service
                     properties:
                       persistence:
+                        description: OnlineStorePersistence configures the persistence
+                          settings for the online store service
                         properties:
                           file:
+                            description: OnlineStoreFilePersistence configures the
+                              file-based persistence for the online store service
                             properties:
                               path:
                                 type: string
                               pvc:
+                                description: PvcConfig defines the settings for a
+                                  persistent file store based on PVCs.
                                 properties:
                                   create:
+                                    description: Settings for creating a new PVC
                                     properties:
                                       accessModes:
+                                        description: AccessModes k8s persistent volume
+                                          access modes. Defaults to ["ReadWriteOnce"].
                                         items:
                                           type: string
                                         type: array
                                       resources:
+                                        description: Resources describes the storage
+                                          resource requirements for a volume.
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -389,6 +603,9 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -397,20 +614,33 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
+                                            description: Requests describes the minimum
+                                              amount of compute resources required.
                                             type: object
                                         type: object
                                       storageClassName:
+                                        description: StorageClassName is the name
+                                          of an existing StorageClass to which this
+                                          persistent volume belongs.
                                         type: string
                                     type: object
                                     x-kubernetes-validations:
                                     - message: PvcCreate is immutable
                                       rule: self == oldSelf
                                   mountPath:
+                                    description: |-
+                                      MountPath within the container at which the volume should be mounted.
+                                      Must start by "/" and cannot contain ':'.
                                     type: string
                                   ref:
+                                    description: Reference to an existing field
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -438,17 +668,30 @@ spec:
                               rule: 'has(self.path) ? !(self.path.startsWith(''s3://'')
                                 || self.path.startsWith(''gs://'')) : true'
                           store:
+                            description: OnlineStoreDBStorePersistence configures
+                              the DB store persistence for the online store service
                             properties:
                               secretKeyName:
+                                description: By default, the selected store "type"
+                                  is used as the SecretKeyName
                                 type: string
                               secretRef:
+                                description: Data store parameters should be placed
+                                  as-is from the "feature_store.yaml" under the secret
+                                  key.
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type:
+                                description: Type of the persistence type you want
+                                  to use.
                                 enum:
                                 - snowflake.online
                                 - redis
@@ -476,63 +719,108 @@ spec:
                         - message: One selection required between file or store.
                           rule: '[has(self.file), has(self.store)].exists_one(c, c)'
                       server:
+                        description: Creates a feature server container
                         properties:
                           env:
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -545,24 +833,42 @@ spec:
                             type: array
                           envFrom:
                             items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -571,8 +877,13 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
+                            description: PullPolicy describes a policy for if/when
+                              to pull a container image
                             type: string
                           logLevel:
+                            description: |-
+                              LogLevel sets the logging level for the server
+                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -581,11 +892,21 @@ spec:
                             - critical
                             type: string
                           resources:
+                            description: ResourceRequirements describes the compute
+                              resource requirements.
                             properties:
                               claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
                                 items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used.
                                       type: string
                                   required:
                                   - name
@@ -601,6 +922,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -609,23 +933,40 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           tls:
+                            description: TlsConfigs configures server TLS for a feast
+                              service.
                             properties:
                               disable:
+                                description: will disable TLS for the feast service.
+                                  useful in an openshift cluster, for example, where
+                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
+                                description: SecretKeyNames defines the secret key
+                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
+                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
+                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
+                                description: references the local k8s secret where
+                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -635,21 +976,43 @@ spec:
                               rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                 : true'
                           volumeMounts:
+                            description: VolumeMounts defines the list of volumes
+                              that should be mounted into the feast container.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
                                   type: boolean
                                 recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
                                   type: string
                                 subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
                                   type: string
                               required:
                               - mountPath
@@ -659,24 +1022,39 @@ spec:
                         type: object
                     type: object
                   registry:
+                    description: Registry configures the registry service. One selection
+                      is required. Local is the default setting.
                     properties:
                       local:
+                        description: LocalRegistryConfig configures the deployed registry
+                          service
                         properties:
                           persistence:
+                            description: RegistryPersistence configures the persistence
+                              settings for the registry service
                             properties:
                               file:
+                                description: RegistryFilePersistence configures the
+                                  file-based persistence for the registry service
                                 properties:
                                   path:
                                     type: string
                                   pvc:
+                                    description: PvcConfig defines the settings for
+                                      a persistent file store based on PVCs.
                                     properties:
                                       create:
+                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
+                                            description: AccessModes k8s persistent
+                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
+                                            description: Resources describes the storage
+                                              resource requirements for a volume.
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -685,6 +1063,9 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -693,20 +1074,34 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: Requests describes the
+                                                  minimum amount of compute resources
+                                                  required.
                                                 type: object
                                             type: object
                                           storageClassName:
+                                            description: StorageClassName is the name
+                                              of an existing StorageClass to which
+                                              this persistent volume belongs.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
+                                        description: |-
+                                          MountPath within the container at which the volume should be mounted.
+                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
+                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -746,17 +1141,30 @@ spec:
                                   rule: '(has(self.s3_additional_kwargs) && has(self.path))
                                     ? self.path.startsWith(''s3://'') : true'
                               store:
+                                description: RegistryDBStorePersistence configures
+                                  the DB store persistence for the registry service
                                 properties:
                                   secretKeyName:
+                                    description: By default, the selected store "type"
+                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
+                                    description: Data store parameters should be placed
+                                      as-is from the "feature_store.yaml" under the
+                                      secret key.
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   type:
+                                    description: Type of the persistence type you
+                                      want to use.
                                     enum:
                                     - sql
                                     - snowflake.registry
@@ -771,63 +1179,111 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           server:
+                            description: Creates a registry server container
                             properties:
                               env:
                                 items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
                                   properties:
                                     name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
                                       type: string
                                     value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any
                                       type: string
                                     valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
                                       properties:
                                         configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
                                           properties:
                                             key:
+                                              description: The key to select.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
+                                          description: 'Selects a field of the pod:
+                                            supports metadata.name, metadata.namespace,
+                                            `metadata.labels[''<KEY>'']`, `metadata.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to
+                                                select'
                                               type: string
                                           required:
                                           - resource
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
                                           properties:
                                             key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
@@ -840,24 +1296,42 @@ spec:
                                 type: array
                               envFrom:
                                 items:
+                                  description: EnvFromSource represents the source
+                                    of a set of ConfigMaps
                                   properties:
                                     configMapRef:
+                                      description: The ConfigMap to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
+                                      description: An optional identifier to prepend
+                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
+                                      description: The Secret to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -866,8 +1340,13 @@ spec:
                               image:
                                 type: string
                               imagePullPolicy:
+                                description: PullPolicy describes a policy for if/when
+                                  to pull a container image
                                 type: string
                               logLevel:
+                                description: |-
+                                  LogLevel sets the logging level for the server
+                                  Allowed values: "debug", "info", "warning", "error", "critical".
                                 enum:
                                 - debug
                                 - info
@@ -876,11 +1355,21 @@ spec:
                                 - critical
                                 type: string
                               resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
                                 properties:
                                   claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
                                     items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
                                       properties:
                                         name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used.
                                           type: string
                                       required:
                                       - name
@@ -896,6 +1385,9 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -904,23 +1396,40 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: Requests describes the minimum amount
+                                      of compute resources required.
                                     type: object
                                 type: object
                               tls:
+                                description: TlsConfigs configures server TLS for
+                                  a feast service.
                                 properties:
                                   disable:
+                                    description: will disable TLS for the feast service.
+                                      useful in an openshift cluster, for example,
+                                      where TLS is configured by default
                                     type: boolean
                                   secretKeyNames:
+                                    description: SecretKeyNames defines the secret
+                                      key names for the TLS key and cert.
                                     properties:
                                       tlsCrt:
+                                        description: defaults to "tls.crt"
                                         type: string
                                       tlsKey:
+                                        description: defaults to "tls.key"
                                         type: string
                                     type: object
                                   secretRef:
+                                    description: references the local k8s secret where
+                                      the TLS key and cert reside
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -930,21 +1439,44 @@ spec:
                                   rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                     : true'
                               volumeMounts:
+                                description: VolumeMounts defines the list of volumes
+                                  that should be mounted into the feast container.
                                 items:
+                                  description: VolumeMount describes a mounting of
+                                    a Volume within a container.
                                   properties:
                                     mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
                                       type: string
                                     mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
                                       type: string
                                     name:
+                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
                                       type: boolean
                                     recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
                                       type: string
                                     subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
                                       type: string
                                     subPathExpr:
+                                      description: Expanded path within the volume
+                                        from which the container's volume should be
+                                        mounted.
                                       type: string
                                   required:
                                   - mountPath
@@ -954,26 +1486,44 @@ spec:
                             type: object
                         type: object
                       remote:
+                        description: RemoteRegistryConfig points to a remote feast
+                          registry server.
                         properties:
                           feastRef:
+                            description: Reference to an existing `FeatureStore` CR
+                              in the same k8s cluster.
                             properties:
                               name:
+                                description: Name of the FeatureStore
                                 type: string
                               namespace:
+                                description: Namespace of the FeatureStore
                                 type: string
                             required:
                             - name
                             type: object
                           hostname:
+                            description: Host address of the remote registry service
+                              - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`
                             type: string
                           tls:
+                            description: TlsRemoteRegistryConfigs configures client
+                              TLS for a remote feast registry.
                             properties:
                               certName:
+                                description: defines the configmap key name for the
+                                  client TLS cert.
                                 type: string
                               configMapRef:
+                                description: references the local k8s configmap where
+                                  the TLS cert resides
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -991,63 +1541,107 @@ spec:
                     - message: One selection required.
                       rule: '[has(self.local), has(self.remote)].exists_one(c, c)'
                   ui:
+                    description: Creates a UI server container
                     properties:
                       env:
                         items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
                           properties:
                             name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
                               type: string
                             value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any
                               type: string
                             valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
+                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.'
                                   properties:
                                     apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.
                                   properties:
                                     containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
+                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
                                   properties:
                                     key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -1060,24 +1654,42 @@ spec:
                         type: array
                       envFrom:
                         items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
                           properties:
                             configMapRef:
+                              description: The ConfigMap to select from
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
+                              description: The Secret to select from
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret must be
+                                    defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
@@ -1086,8 +1698,13 @@ spec:
                       image:
                         type: string
                       imagePullPolicy:
+                        description: PullPolicy describes a policy for if/when to
+                          pull a container image
                         type: string
                       logLevel:
+                        description: |-
+                          LogLevel sets the logging level for the server
+                          Allowed values: "debug", "info", "warning", "error", "critical".
                         enum:
                         - debug
                         - info
@@ -1096,11 +1713,20 @@ spec:
                         - critical
                         type: string
                       resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
                         properties:
                           claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
                             items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used.
                                   type: string
                               required:
                               - name
@@ -1116,6 +1742,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.
                             type: object
                           requests:
                             additionalProperties:
@@ -1124,23 +1753,40 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
+                            description: Requests describes the minimum amount of
+                              compute resources required.
                             type: object
                         type: object
                       tls:
+                        description: TlsConfigs configures server TLS for a feast
+                          service.
                         properties:
                           disable:
+                            description: will disable TLS for the feast service. useful
+                              in an openshift cluster, for example, where TLS is configured
+                              by default
                             type: boolean
                           secretKeyNames:
+                            description: SecretKeyNames defines the secret key names
+                              for the TLS key and cert.
                             properties:
                               tlsCrt:
+                                description: defaults to "tls.crt"
                                 type: string
                               tlsKey:
+                                description: defaults to "tls.key"
                                 type: string
                             type: object
                           secretRef:
+                            description: references the local k8s secret where the
+                              TLS key and cert reside
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1150,21 +1796,43 @@ spec:
                           rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                             : true'
                       volumeMounts:
+                        description: VolumeMounts defines the list of volumes that
+                          should be mounted into the feast container.
                         items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
                           properties:
                             mountPath:
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
                               type: string
                             mountPropagation:
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
                               type: string
                             name:
+                              description: This must match the Name of a Volume.
                               type: string
                             readOnly:
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
                               type: boolean
                             recursiveReadOnly:
+                              description: |-
+                                RecursiveReadOnly specifies whether read-only mounts should be handled
+                                recursively.
                               type: string
                             subPath:
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted.
                               type: string
                           required:
                           - mountPath
@@ -1173,109 +1841,209 @@ spec:
                         type: array
                     type: object
                   volumes:
+                    description: Volumes specifies the volumes to mount in the FeatureStore
+                      deployment.
                     items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
                       properties:
                         awsElasticBlockStore:
+                          description: |-
+                            awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                            kubelet's host machine and then exposed to th
                           properties:
                             fsType:
+                              description: fsType is the filesystem type of the volume
+                                that you want to mount.
                               type: string
                             partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
                               format: int32
                               type: integer
                             readOnly:
+                              description: |-
+                                readOnly value true will force the readOnly setting in VolumeMounts.
+                                More info: https://kubernetes.
                               type: boolean
                             volumeID:
+                              description: |-
+                                volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                More info: https://kubernetes.
                               type: string
                           required:
                           - volumeID
                           type: object
                         azureDisk:
+                          description: azureDisk represents an Azure Data Disk mount
+                            on the host and bind mount to the pod.
                           properties:
                             cachingMode:
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
                               type: string
                             diskName:
+                              description: diskName is the Name of the data disk in
+                                the blob storage
                               type: string
                             diskURI:
+                              description: diskURI is the URI of data disk in the
+                                blob storage
                               type: string
                             fsType:
+                              description: |-
+                                fsType is Filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             kind:
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage accoun'
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                           required:
                           - diskName
                           - diskURI
                           type: object
                         azureFile:
+                          description: azureFile represents an Azure File Service
+                            mount on the host and bind mount to the pod.
                           properties:
                             readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretName:
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
                               type: string
                             shareName:
+                              description: shareName is the azure share Name
                               type: string
                           required:
                           - secretName
                           - shareName
                           type: object
                         cephfs:
+                          description: cephFS represents a Ceph FS mount on the host
+                            that shares a pod's lifetime
                           properties:
                             monitors:
+                              description: |-
+                                monitors is Required: Monitors is a collection of Ceph monitors
+                                More info: https://examples.k8s.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretFile:
+                              description: 'secretFile is Optional: SecretFile is
+                                the path to key ring for User, default is /etc/ceph/user.'
                               type: string
                             secretRef:
+                              description: 'secretRef is Optional: SecretRef is reference
+                                to the authentication secret for User, default is
+                                empty.'
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             user:
+                              description: |-
+                                user is optional: User is the rados user name, default is admin
+                                More info: https://examples.k8s.
                               type: string
                           required:
                           - monitors
                           type: object
                         cinder:
+                          description: |-
+                            cinder represents a cinder volume attached and mounted on kubelets host machine.
+                            More info: https://examples.k8s.
                           properties:
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
+                              description: |-
+                                secretRef is optional: points to a secret object containing parameters used to connect
+                                to OpenStack.
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             volumeID:
+                              description: |-
+                                volumeID used to identify the volume in cinder.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               type: string
                           required:
                           - volumeID
                           type: object
                         configMap:
+                          description: configMap represents a configMap that should
+                            populate this volume
                           properties:
                             defaultMode:
+                              description: 'defaultMode is optional: mode bits used
+                                to set permissions on created files by default.'
                               format: int32
                               type: integer
                             items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                ConfigMap will be projected into the volum
                               items:
+                                description: Maps a string key to a path within a
+                                  volume.
                                 properties:
                                   key:
+                                    description: key is the key to project.
                                     type: string
                                   mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file.'
                                     format: int32
                                     type: integer
                                   path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
                                     type: string
                                 required:
                                 - key
@@ -1285,67 +2053,121 @@ spec:
                               x-kubernetes-list-type: atomic
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
                               type: boolean
                           type: object
                           x-kubernetes-map-type: atomic
                         csi:
+                          description: csi (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers (Beta fea
                           properties:
                             driver:
+                              description: driver is the name of the CSI driver that
+                                handles this volume.
                               type: string
                             fsType:
+                              description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
                               type: string
                             nodePublishSecretRef:
+                              description: |-
+                                nodePublishSecretRef is a reference to the secret object containing
+                                sensitive information to pass to the CSI driver to c
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             readOnly:
+                              description: |-
+                                readOnly specifies a read-only configuration for the volume.
+                                Defaults to false (read/write).
                               type: boolean
                             volumeAttributes:
                               additionalProperties:
                                 type: string
+                              description: |-
+                                volumeAttributes stores driver-specific properties that are passed to the CSI
+                                driver.
                               type: object
                           required:
                           - driver
                           type: object
                         downwardAPI:
+                          description: downwardAPI represents downward API about the
+                            pod that should populate this volume
                           properties:
                             defaultMode:
+                              description: 'Optional: mode bits to use on created
+                                files by default.'
                               format: int32
                               type: integer
                             items:
+                              description: Items is a list of downward API volume
+                                file
                               items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
                                 properties:
                                   fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name, namespace
+                                      and uid are supported.'
                                     properties:
                                       apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
                                         type: string
                                     required:
                                     - fieldPath
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   mode:
+                                    description: |-
+                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal valu
                                     format: int32
                                     type: integer
                                   path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path.'
                                     type: string
                                   resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, requests.
                                     properties:
                                       containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
+                                        description: 'Required: resource to select'
                                         type: string
                                     required:
                                     - resource
@@ -1358,36 +2180,63 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         emptyDir:
+                          description: |-
+                            emptyDir represents a temporary directory that shares a pod's lifetime.
+                            More info: https://kubernetes.
                           properties:
                             medium:
+                              description: medium represents what type of storage
+                                medium should back this directory.
                               type: string
                             sizeLimit:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: sizeLimit is the total amount of local
+                                storage required for this EmptyDir volume.
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
                         ephemeral:
+                          description: ephemeral represents a volume that is handled
+                            by a cluster storage driver.
                           properties:
                             volumeClaimTemplate:
+                              description: Will be used to create a stand-alone PVC
+                                to provision the volume.
                               properties:
                                 metadata:
+                                  description: |-
+                                    May contain labels and annotations that will be copied into the PVC
+                                    when creating it.
                                   type: object
                                 spec:
+                                  description: The specification for the PersistentVolumeClaim.
                                   properties:
                                     accessModes:
+                                      description: |-
+                                        accessModes contains the desired access modes the volume should have.
+                                        More info: https://kubernetes.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     dataSource:
+                                      description: |-
+                                        dataSource field can be used to specify either:
+                                        * An existing VolumeSnapshot object (snapshot.storage.k8s.
                                       properties:
                                         apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced.
                                           type: string
                                         kind:
+                                          description: Kind is the type of resource
+                                            being referenced
                                           type: string
                                         name:
+                                          description: Name is the name of resource
+                                            being referenced
                                           type: string
                                       required:
                                       - kind
@@ -1395,20 +2244,34 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                        volume is desired.
                                       properties:
                                         apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced.
                                           type: string
                                         kind:
+                                          description: Kind is the type of resource
+                                            being referenced
                                           type: string
                                         name:
+                                          description: Name is the name of resource
+                                            being referenced
                                           type: string
                                         namespace:
+                                          description: |-
+                                            Namespace is the namespace of resource being referenced
+                                            Note that when a namespace is specified, a gateway.networking.
                                           type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     resources:
+                                      description: resources represents the minimum
+                                        resources the volume should have.
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -1417,6 +2280,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -1425,18 +2291,36 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
+                                          description: Requests describes the minimum
+                                            amount of compute resources required.
                                           type: object
                                       type: object
                                     selector:
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1450,16 +2334,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     storageClassName:
+                                      description: |-
+                                        storageClassName is the name of the StorageClass required by the claim.
+                                        More info: https://kubernetes.
                                       type: string
                                     volumeAttributesClassName:
+                                      description: volumeAttributesClassName may be
+                                        used to set the VolumeAttributesClass used
+                                        by this claim.
                                       type: string
                                     volumeMode:
+                                      description: volumeMode defines what type of
+                                        volume is required by the claim.
                                       type: string
                                     volumeName:
+                                      description: volumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                               required:
@@ -1467,41 +2363,78 @@ spec:
                               type: object
                           type: object
                         fc:
+                          description: fc represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
                           properties:
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             lun:
+                              description: 'lun is Optional: FC target lun number'
                               format: int32
                               type: integer
                             readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             wwids:
+                              description: "wwids Optional: FC volume world wide identifiers
+                                (wwids)\nEither wwids or combination of targetWWNs
+                                and lun must be set, "
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         flexVolume:
+                          description: |-
+                            flexVolume represents a generic volume resource that is
+                            provisioned/attached using an exec based plugin.
                           properties:
                             driver:
+                              description: driver is the name of the driver to use
+                                for this volume.
                               type: string
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             options:
                               additionalProperties:
                                 type: string
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
                               type: object
                             readOnly:
+                              description: |-
+                                readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
+                              description: |-
+                                secretRef is Optional: secretRef is reference to the secret object containing
+                                sensitive information to pass to the plugi
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
@@ -1509,90 +2442,170 @@ spec:
                           - driver
                           type: object
                         flocker:
+                          description: flocker represents a Flocker volume attached
+                            to a kubelet's host machine.
                           properties:
                             datasetName:
+                              description: |-
+                                datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                should be considered as depreca
                               type: string
                             datasetUUID:
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
                               type: string
                           type: object
                         gcePersistentDisk:
+                          description: |-
+                            gcePersistentDisk represents a GCE Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the po
                           properties:
                             fsType:
+                              description: fsType is filesystem type of the volume
+                                that you want to mount.
                               type: string
                             partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
                               format: int32
                               type: integer
                             pdName:
+                              description: |-
+                                pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                More info: https://kubernetes.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://kubernetes.
                               type: boolean
                           required:
                           - pdName
                           type: object
                         gitRepo:
+                          description: |-
+                            gitRepo represents a git repository at a particular revision.
+                            DEPRECATED: GitRepo is deprecated.
                           properties:
                             directory:
+                              description: |-
+                                directory is the target directory name.
+                                Must not contain or start with '..'.  If '.
                               type: string
                             repository:
+                              description: repository is the URL
                               type: string
                             revision:
+                              description: revision is the commit hash for the specified
+                                revision.
                               type: string
                           required:
                           - repository
                           type: object
                         glusterfs:
+                          description: |-
+                            glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                            More info: https://examples.k8s.
                           properties:
                             endpoints:
+                              description: |-
+                                endpoints is the endpoint name that details Glusterfs topology.
+                                More info: https://examples.k8s.
                               type: string
                             path:
+                              description: |-
+                                path is the Glusterfs volume path.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                Defaults to false.
                               type: boolean
                           required:
                           - endpoints
                           - path
                           type: object
                         hostPath:
+                          description: |-
+                            hostPath represents a pre-existing file or directory on the host
+                            machine that is directly exposed to the container.
                           properties:
                             path:
+                              description: |-
+                                path of the directory on the host.
+                                If the path is a symlink, it will follow the link to the real path.
                               type: string
                             type:
+                              description: |-
+                                type for HostPath Volume
+                                Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                               type: string
                           required:
                           - path
                           type: object
                         iscsi:
+                          description: |-
+                            iscsi represents an ISCSI Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
                           properties:
                             chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
                               type: boolean
                             chapAuthSession:
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
                               type: boolean
                             fsType:
+                              description: fsType is the filesystem type of the volume
+                                that you want to mount.
                               type: string
                             initiatorName:
+                              description: initiatorName is the custom iSCSI Initiator
+                                Name.
                               type: string
                             iqn:
+                              description: iqn is the target iSCSI Qualified Name.
                               type: string
                             iscsiInterface:
+                              description: |-
+                                iscsiInterface is the interface Name that uses an iSCSI transport.
+                                Defaults to 'default' (tcp).
                               type: string
                             lun:
+                              description: lun represents iSCSI Target Lun number.
                               format: int32
                               type: integer
                             portals:
+                              description: portals is the iSCSI Target Portal List.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
                               type: boolean
                             secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             targetPortal:
+                              description: targetPortal is iSCSI Target Portal.
                               type: string
                           required:
                           - iqn
@@ -1600,68 +2613,138 @@ spec:
                           - targetPortal
                           type: object
                         name:
+                          description: |-
+                            name of the volume.
+                            Must be a DNS_LABEL and unique within the pod.
+                            More info: https://kubernetes.
                           type: string
                         nfs:
+                          description: |-
+                            nfs represents an NFS mount on the host that shares a pod's lifetime
+                            More info: https://kubernetes.
                           properties:
                             path:
+                              description: |-
+                                path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly here will force the NFS export to be mounted with read-only permissions.
+                                Defaults to false.
                               type: boolean
                             server:
+                              description: |-
+                                server is the hostname or IP address of the NFS server.
+                                More info: https://kubernetes.
                               type: string
                           required:
                           - path
                           - server
                           type: object
                         persistentVolumeClaim:
+                          description: |-
+                            persistentVolumeClaimVolumeSource represents a reference to a
+                            PersistentVolumeClaim in the same namespace.
                           properties:
                             claimName:
+                              description: claimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
                               type: boolean
                           required:
                           - claimName
                           type: object
                         photonPersistentDisk:
+                          description: photonPersistentDisk represents a PhotonController
+                            persistent disk attached and mounted on kubelets host
+                            machine
                           properties:
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             pdID:
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
                               type: string
                           required:
                           - pdID
                           type: object
                         portworxVolume:
+                          description: portworxVolume represents a portworx volume
+                            attached and mounted on kubelets host machine
                           properties:
                             fsType:
+                              description: |-
+                                fSType represents the filesystem type to mount
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             volumeID:
+                              description: volumeID uniquely identifies a Portworx
+                                volume
                               type: string
                           required:
                           - volumeID
                           type: object
                         projected:
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
                           properties:
                             defaultMode:
+                              description: defaultMode are the mode bits used to set
+                                permissions on created files by default.
                               format: int32
                               type: integer
                             sources:
+                              description: sources is the list of volume projections
                               items:
+                                description: Projection that may be projected along
+                                  with other supported volume types
                                 properties:
                                   clusterTrustBundle:
+                                    description: ClusterTrustBundle allows a pod to
+                                      access the `.spec.
                                     properties:
                                       labelSelector:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this label selector.  Only has
+                                          effect if signerName is set.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1675,31 +2758,58 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       name:
+                                        description: |-
+                                          Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                          with signerName and labelSelector.
                                         type: string
                                       optional:
+                                        description: |-
+                                          If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                          aren't available.
                                         type: boolean
                                       path:
+                                        description: Relative path from the volume
+                                          root to write the bundle.
                                         type: string
                                       signerName:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this signer name.
+                                          Mutually-exclusive with name.
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   configMap:
+                                    description: configMap information about the configMap
+                                      data to project
                                     properties:
                                       items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volum
                                         items:
+                                          description: Maps a string key to a path
+                                            within a volume.
                                           properties:
                                             key:
+                                              description: key is the key to project.
                                               type: string
                                             mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file.'
                                               format: int32
                                               type: integer
                                             path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
                                               type: string
                                           required:
                                           - key
@@ -1709,42 +2819,81 @@ spec:
                                         x-kubernetes-list-type: atomic
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                       optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   downwardAPI:
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
                                     properties:
                                       items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
                                         items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
                                           properties:
                                             fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name, namespace and uid are supported.'
                                               properties:
                                                 apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             mode:
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal valu
                                               format: int32
                                               type: integer
                                             path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path.'
                                               type: string
                                             resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.
                                               properties:
                                                 containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
@@ -1757,16 +2906,30 @@ spec:
                                         x-kubernetes-list-type: atomic
                                     type: object
                                   secret:
+                                    description: secret information about the secret
+                                      data to project
                                     properties:
                                       items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume a
                                         items:
+                                          description: Maps a string key to a path
+                                            within a volume.
                                           properties:
                                             key:
+                                              description: key is the key to project.
                                               type: string
                                             mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file.'
                                               format: int32
                                               type: integer
                                             path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
                                               type: string
                                           required:
                                           - key
@@ -1776,19 +2939,35 @@ spec:
                                         x-kubernetes-list-type: atomic
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                       optional:
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
                                         type: boolean
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   serviceAccountToken:
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
                                     properties:
                                       audience:
+                                        description: audience is the intended audience
+                                          of the token.
                                         type: string
                                       expirationSeconds:
+                                        description: |-
+                                          expirationSeconds is the requested duration of validity of the service
+                                          account token.
                                         format: int64
                                         type: integer
                                       path:
+                                        description: |-
+                                          path is the path relative to the mount point of the file to project the
+                                          token into.
                                         type: string
                                     required:
                                     - path
@@ -1798,79 +2977,164 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         quobyte:
+                          description: quobyte represents a Quobyte mount on the host
+                            that shares a pod's lifetime
                           properties:
                             group:
+                              description: |-
+                                group to map volume access to
+                                Default is no group
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                Defaults to false.
                               type: boolean
                             registry:
+                              description: |-
+                                registry represents a single or multiple Quobyte Registry services
+                                specified as a string as host:port pair (multiple ent
                               type: string
                             tenant:
+                              description: |-
+                                tenant owning the given Quobyte volume in the Backend
+                                Used with dynamically provisioned Quobyte volumes, value is set by
                               type: string
                             user:
+                              description: |-
+                                user to map volume access to
+                                Defaults to serivceaccount user
                               type: string
                             volume:
+                              description: volume is a string that references an already
+                                created Quobyte volume by name.
                               type: string
                           required:
                           - registry
                           - volume
                           type: object
                         rbd:
+                          description: |-
+                            rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                            More info: https://examples.k8s.
                           properties:
                             fsType:
+                              description: fsType is the filesystem type of the volume
+                                that you want to mount.
                               type: string
                             image:
+                              description: |-
+                                image is the rados image name.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                               type: string
                             keyring:
+                              description: |-
+                                keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring.
+                                More info: https://examples.k8s.
                               type: string
                             monitors:
+                              description: |-
+                                monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             pool:
+                              description: |-
+                                pool is the rados pool name.
+                                Default is rbd.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://examples.k8s.
                               type: boolean
                             secretRef:
+                              description: |-
+                                secretRef is name of the authentication secret for RBDUser. If provided
+                                overrides keyring.
+                                Default is nil.
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             user:
+                              description: |-
+                                user is the rados user name.
+                                Default is admin.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                               type: string
                           required:
                           - image
                           - monitors
                           type: object
                         scaleIO:
+                          description: scaleIO represents a ScaleIO persistent volume
+                            attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             gateway:
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
                               type: string
                             protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
+                              description: |-
+                                secretRef references to the secret for ScaleIO user and other
+                                sensitive information.
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication
+                                with Gateway, default false
                               type: boolean
                             storageMode:
+                              description: storageMode indicates whether the storage
+                                for a volume should be ThickProvisioned or ThinProvisioned.
                               type: string
                             storagePool:
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
                               type: string
                             system:
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
                               type: string
                             volumeName:
+                              description: |-
+                                volumeName is the name of a volume already created in the ScaleIO system
+                                that is associated with this volume source.
                               type: string
                           required:
                           - gateway
@@ -1878,19 +3142,35 @@ spec:
                           - system
                           type: object
                         secret:
+                          description: |-
+                            secret represents a secret that should populate this volume.
+                            More info: https://kubernetes.
                           properties:
                             defaultMode:
+                              description: 'defaultMode is Optional: mode bits used
+                                to set permissions on created files by default.'
                               format: int32
                               type: integer
                             items:
+                              description: |-
+                                items If unspecified, each key-value pair in the Data field of the referenced
+                                Secret will be projected into the volume a
                               items:
+                                description: Maps a string key to a path within a
+                                  volume.
                                 properties:
                                   key:
+                                    description: key is the key to project.
                                     type: string
                                   mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file.'
                                     format: int32
                                     type: integer
                                   path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
                                     type: string
                                 required:
                                 - key
@@ -1899,37 +3179,75 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             optional:
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
                               type: boolean
                             secretName:
+                              description: |-
+                                secretName is the name of the secret in the pod's namespace to use.
+                                More info: https://kubernetes.
                               type: string
                           type: object
                         storageos:
+                          description: storageOS represents a StorageOS volume attached
+                            and mounted on Kubernetes nodes.
                           properties:
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
+                              description: |-
+                                secretRef specifies the secret to use for obtaining the StorageOS API
+                                credentials.
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             volumeName:
+                              description: |-
+                                volumeName is the human-readable name of the StorageOS volume.  Volume
+                                names are only unique within a namespace.
                               type: string
                             volumeNamespace:
+                              description: volumeNamespace specifies the scope of
+                                the volume within StorageOS.
                               type: string
                           type: object
                         vsphereVolume:
+                          description: vsphereVolume represents a vSphere volume attached
+                            and mounted on kubelets host machine
                           properties:
                             fsType:
+                              description: |-
+                                fsType is filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
                               type: string
                             storagePolicyName:
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
                               type: string
                             volumePath:
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
                               type: string
                           required:
                           - volumePath
@@ -1943,24 +3261,44 @@ spec:
             - feastProject
             type: object
           status:
+            description: FeatureStoreStatus defines the observed state of FeatureStore
             properties:
               applied:
+                description: Shows the currently applied feast configuration, including
+                  any pertinent defaults
                 properties:
                   authz:
+                    description: AuthzConfig defines the authorization settings for
+                      the deployed Feast services.
                     properties:
                       kubernetes:
+                        description: |-
+                          KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.
+                          https://kubernetes.
                         properties:
                           roles:
+                            description: The Kubernetes RBAC roles to be deployed
+                              in the same namespace of the FeatureStore.
                             items:
                               type: string
                             type: array
                         type: object
                       oidc:
+                        description: |-
+                          OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.
+                          https://auth0.
                         properties:
                           secretRef:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1973,45 +3311,75 @@ spec:
                       rule: '[has(self.kubernetes), has(self.oidc)].exists_one(c,
                         c)'
                   feastProject:
+                    description: FeastProject is the Feast project id.
                     pattern: ^[A-Za-z0-9][A-Za-z0-9_]*$
                     type: string
                   services:
+                    description: FeatureStoreServices defines the desired feast services.
+                      An ephemeral registry is deployed by default.
                     properties:
                       deploymentStrategy:
+                        description: DeploymentStrategy describes how to replace existing
+                          pods with new ones.
                         properties:
                           rollingUpdate:
+                            description: |-
+                              Rolling update config params. Present only if DeploymentStrategyType =
+                              RollingUpdate.
                             properties:
                               maxSurge:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                description: |-
+                                  The maximum number of pods that can be scheduled above the desired number of
+                                  pods.
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                description: The maximum number of pods that can be
+                                  unavailable during the update.
                                 x-kubernetes-int-or-string: true
                             type: object
                           type:
+                            description: Type of deployment. Can be "Recreate" or
+                              "RollingUpdate". Default is RollingUpdate.
                             type: string
                         type: object
                       disableInitContainers:
+                        description: Disable the 'feast repo initialization' initContainer
                         type: boolean
                       offlineStore:
+                        description: OfflineStore configures the deployed offline
+                          store service
                         properties:
                           persistence:
+                            description: OfflineStorePersistence configures the persistence
+                              settings for the offline store service
                             properties:
                               file:
+                                description: OfflineStoreFilePersistence configures
+                                  the file-based persistence for the offline store
+                                  service
                                 properties:
                                   pvc:
+                                    description: PvcConfig defines the settings for
+                                      a persistent file store based on PVCs.
                                     properties:
                                       create:
+                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
+                                            description: AccessModes k8s persistent
+                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
+                                            description: Resources describes the storage
+                                              resource requirements for a volume.
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -2020,6 +3388,9 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -2028,20 +3399,34 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: Requests describes the
+                                                  minimum amount of compute resources
+                                                  required.
                                                 type: object
                                             type: object
                                           storageClassName:
+                                            description: StorageClassName is the name
+                                              of an existing StorageClass to which
+                                              this persistent volume belongs.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
+                                        description: |-
+                                          MountPath within the container at which the volume should be mounted.
+                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
+                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -2064,17 +3449,30 @@ spec:
                                     type: string
                                 type: object
                               store:
+                                description: OfflineStoreDBStorePersistence configures
+                                  the DB store persistence for the offline store service
                                 properties:
                                   secretKeyName:
+                                    description: By default, the selected store "type"
+                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
+                                    description: Data store parameters should be placed
+                                      as-is from the "feature_store.yaml" under the
+                                      secret key.
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   type:
+                                    description: Type of the persistence type you
+                                      want to use.
                                     enum:
                                     - snowflake.offline
                                     - bigquery
@@ -2095,63 +3493,111 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           server:
+                            description: Creates a remote offline server container
                             properties:
                               env:
                                 items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
                                   properties:
                                     name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
                                       type: string
                                     value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any
                                       type: string
                                     valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
                                       properties:
                                         configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
                                           properties:
                                             key:
+                                              description: The key to select.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
+                                          description: 'Selects a field of the pod:
+                                            supports metadata.name, metadata.namespace,
+                                            `metadata.labels[''<KEY>'']`, `metadata.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to
+                                                select'
                                               type: string
                                           required:
                                           - resource
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
                                           properties:
                                             key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
@@ -2164,24 +3610,42 @@ spec:
                                 type: array
                               envFrom:
                                 items:
+                                  description: EnvFromSource represents the source
+                                    of a set of ConfigMaps
                                   properties:
                                     configMapRef:
+                                      description: The ConfigMap to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
+                                      description: An optional identifier to prepend
+                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
+                                      description: The Secret to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -2190,8 +3654,13 @@ spec:
                               image:
                                 type: string
                               imagePullPolicy:
+                                description: PullPolicy describes a policy for if/when
+                                  to pull a container image
                                 type: string
                               logLevel:
+                                description: |-
+                                  LogLevel sets the logging level for the server
+                                  Allowed values: "debug", "info", "warning", "error", "critical".
                                 enum:
                                 - debug
                                 - info
@@ -2200,11 +3669,21 @@ spec:
                                 - critical
                                 type: string
                               resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
                                 properties:
                                   claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
                                     items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
                                       properties:
                                         name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used.
                                           type: string
                                       required:
                                       - name
@@ -2220,6 +3699,9 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -2228,23 +3710,40 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: Requests describes the minimum amount
+                                      of compute resources required.
                                     type: object
                                 type: object
                               tls:
+                                description: TlsConfigs configures server TLS for
+                                  a feast service.
                                 properties:
                                   disable:
+                                    description: will disable TLS for the feast service.
+                                      useful in an openshift cluster, for example,
+                                      where TLS is configured by default
                                     type: boolean
                                   secretKeyNames:
+                                    description: SecretKeyNames defines the secret
+                                      key names for the TLS key and cert.
                                     properties:
                                       tlsCrt:
+                                        description: defaults to "tls.crt"
                                         type: string
                                       tlsKey:
+                                        description: defaults to "tls.key"
                                         type: string
                                     type: object
                                   secretRef:
+                                    description: references the local k8s secret where
+                                      the TLS key and cert reside
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2254,21 +3753,44 @@ spec:
                                   rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                     : true'
                               volumeMounts:
+                                description: VolumeMounts defines the list of volumes
+                                  that should be mounted into the feast container.
                                 items:
+                                  description: VolumeMount describes a mounting of
+                                    a Volume within a container.
                                   properties:
                                     mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
                                       type: string
                                     mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
                                       type: string
                                     name:
+                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
                                       type: boolean
                                     recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
                                       type: string
                                     subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
                                       type: string
                                     subPathExpr:
+                                      description: Expanded path within the volume
+                                        from which the container's volume should be
+                                        mounted.
                                       type: string
                                   required:
                                   - mountPath
@@ -2278,22 +3800,36 @@ spec:
                             type: object
                         type: object
                       onlineStore:
+                        description: OnlineStore configures the deployed online store
+                          service
                         properties:
                           persistence:
+                            description: OnlineStorePersistence configures the persistence
+                              settings for the online store service
                             properties:
                               file:
+                                description: OnlineStoreFilePersistence configures
+                                  the file-based persistence for the online store
+                                  service
                                 properties:
                                   path:
                                     type: string
                                   pvc:
+                                    description: PvcConfig defines the settings for
+                                      a persistent file store based on PVCs.
                                     properties:
                                       create:
+                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
+                                            description: AccessModes k8s persistent
+                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
+                                            description: Resources describes the storage
+                                              resource requirements for a volume.
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -2302,6 +3838,9 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -2310,20 +3849,34 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: Requests describes the
+                                                  minimum amount of compute resources
+                                                  required.
                                                 type: object
                                             type: object
                                           storageClassName:
+                                            description: StorageClassName is the name
+                                              of an existing StorageClass to which
+                                              this persistent volume belongs.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
+                                        description: |-
+                                          MountPath within the container at which the volume should be mounted.
+                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
+                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -2352,17 +3905,30 @@ spec:
                                   rule: 'has(self.path) ? !(self.path.startsWith(''s3://'')
                                     || self.path.startsWith(''gs://'')) : true'
                               store:
+                                description: OnlineStoreDBStorePersistence configures
+                                  the DB store persistence for the online store service
                                 properties:
                                   secretKeyName:
+                                    description: By default, the selected store "type"
+                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
+                                    description: Data store parameters should be placed
+                                      as-is from the "feature_store.yaml" under the
+                                      secret key.
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   type:
+                                    description: Type of the persistence type you
+                                      want to use.
                                     enum:
                                     - snowflake.online
                                     - redis
@@ -2391,63 +3957,111 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           server:
+                            description: Creates a feature server container
                             properties:
                               env:
                                 items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
                                   properties:
                                     name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
                                       type: string
                                     value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any
                                       type: string
                                     valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
                                       properties:
                                         configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
                                           properties:
                                             key:
+                                              description: The key to select.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
+                                          description: 'Selects a field of the pod:
+                                            supports metadata.name, metadata.namespace,
+                                            `metadata.labels[''<KEY>'']`, `metadata.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to
+                                                select'
                                               type: string
                                           required:
                                           - resource
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
                                           properties:
                                             key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
@@ -2460,24 +4074,42 @@ spec:
                                 type: array
                               envFrom:
                                 items:
+                                  description: EnvFromSource represents the source
+                                    of a set of ConfigMaps
                                   properties:
                                     configMapRef:
+                                      description: The ConfigMap to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
+                                      description: An optional identifier to prepend
+                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
+                                      description: The Secret to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -2486,8 +4118,13 @@ spec:
                               image:
                                 type: string
                               imagePullPolicy:
+                                description: PullPolicy describes a policy for if/when
+                                  to pull a container image
                                 type: string
                               logLevel:
+                                description: |-
+                                  LogLevel sets the logging level for the server
+                                  Allowed values: "debug", "info", "warning", "error", "critical".
                                 enum:
                                 - debug
                                 - info
@@ -2496,11 +4133,21 @@ spec:
                                 - critical
                                 type: string
                               resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
                                 properties:
                                   claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
                                     items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
                                       properties:
                                         name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used.
                                           type: string
                                       required:
                                       - name
@@ -2516,6 +4163,9 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -2524,23 +4174,40 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: Requests describes the minimum amount
+                                      of compute resources required.
                                     type: object
                                 type: object
                               tls:
+                                description: TlsConfigs configures server TLS for
+                                  a feast service.
                                 properties:
                                   disable:
+                                    description: will disable TLS for the feast service.
+                                      useful in an openshift cluster, for example,
+                                      where TLS is configured by default
                                     type: boolean
                                   secretKeyNames:
+                                    description: SecretKeyNames defines the secret
+                                      key names for the TLS key and cert.
                                     properties:
                                       tlsCrt:
+                                        description: defaults to "tls.crt"
                                         type: string
                                       tlsKey:
+                                        description: defaults to "tls.key"
                                         type: string
                                     type: object
                                   secretRef:
+                                    description: references the local k8s secret where
+                                      the TLS key and cert reside
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2550,21 +4217,44 @@ spec:
                                   rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                     : true'
                               volumeMounts:
+                                description: VolumeMounts defines the list of volumes
+                                  that should be mounted into the feast container.
                                 items:
+                                  description: VolumeMount describes a mounting of
+                                    a Volume within a container.
                                   properties:
                                     mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
                                       type: string
                                     mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
                                       type: string
                                     name:
+                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
                                       type: boolean
                                     recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
                                       type: string
                                     subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
                                       type: string
                                     subPathExpr:
+                                      description: Expanded path within the volume
+                                        from which the container's volume should be
+                                        mounted.
                                       type: string
                                   required:
                                   - mountPath
@@ -2574,24 +4264,43 @@ spec:
                             type: object
                         type: object
                       registry:
+                        description: Registry configures the registry service. One
+                          selection is required. Local is the default setting.
                         properties:
                           local:
+                            description: LocalRegistryConfig configures the deployed
+                              registry service
                             properties:
                               persistence:
+                                description: RegistryPersistence configures the persistence
+                                  settings for the registry service
                                 properties:
                                   file:
+                                    description: RegistryFilePersistence configures
+                                      the file-based persistence for the registry
+                                      service
                                     properties:
                                       path:
                                         type: string
                                       pvc:
+                                        description: PvcConfig defines the settings
+                                          for a persistent file store based on PVCs.
                                         properties:
                                           create:
+                                            description: Settings for creating a new
+                                              PVC
                                             properties:
                                               accessModes:
+                                                description: AccessModes k8s persistent
+                                                  volume access modes. Defaults to
+                                                  ["ReadWriteOnce"].
                                                 items:
                                                   type: string
                                                 type: array
                                               resources:
+                                                description: Resources describes the
+                                                  storage resource requirements for
+                                                  a volume.
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -2600,6 +4309,9 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
+                                                    description: |-
+                                                      Limits describes the maximum amount of compute resources allowed.
+                                                      More info: https://kubernetes.
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -2608,20 +4320,36 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
+                                                    description: Requests describes
+                                                      the minimum amount of compute
+                                                      resources required.
                                                     type: object
                                                 type: object
                                               storageClassName:
+                                                description: StorageClassName is the
+                                                  name of an existing StorageClass
+                                                  to which this persistent volume
+                                                  belongs.
                                                 type: string
                                             type: object
                                             x-kubernetes-validations:
                                             - message: PvcCreate is immutable
                                               rule: self == oldSelf
                                           mountPath:
+                                            description: |-
+                                              MountPath within the container at which the volume should be mounted.
+                                              Must start by "/" and cannot contain ':'.
                                             type: string
                                           ref:
+                                            description: Reference to an existing
+                                              field
                                             properties:
                                               name:
                                                 default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty.
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
@@ -2661,17 +4389,30 @@ spec:
                                       rule: '(has(self.s3_additional_kwargs) && has(self.path))
                                         ? self.path.startsWith(''s3://'') : true'
                                   store:
+                                    description: RegistryDBStorePersistence configures
+                                      the DB store persistence for the registry service
                                     properties:
                                       secretKeyName:
+                                        description: By default, the selected store
+                                          "type" is used as the SecretKeyName
                                         type: string
                                       secretRef:
+                                        description: Data store parameters should
+                                          be placed as-is from the "feature_store.yaml"
+                                          under the secret key.
                                         properties:
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       type:
+                                        description: Type of the persistence type
+                                          you want to use.
                                         enum:
                                         - sql
                                         - snowflake.registry
@@ -2687,63 +4428,113 @@ spec:
                                   rule: '[has(self.file), has(self.store)].exists_one(c,
                                     c)'
                               server:
+                                description: Creates a registry server container
                                 properties:
                                   env:
                                     items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
                                       properties:
                                         name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any
                                           type: string
                                         valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
                                           properties:
                                             configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
+                                                  description: The key to select.
                                                   type: string
                                                 name:
                                                   default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty.
                                                   type: string
                                                 optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                `metadata.labels[''<KEY>'']`, `metadata.'
                                               properties:
                                                 apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.
                                               properties:
                                                 containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
                                               properties:
                                                 key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
                                                   type: string
                                                 name:
                                                   default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty.
                                                   type: string
                                                 optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -2756,24 +4547,43 @@ spec:
                                     type: array
                                   envFrom:
                                     items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
                                       properties:
                                         configMapRef:
+                                          description: The ConfigMap to select from
                                           properties:
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
                                               type: boolean
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
                                           type: string
                                         secretRef:
+                                          description: The Secret to select from
                                           properties:
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the Secret
+                                                must be defined
                                               type: boolean
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -2782,8 +4592,13 @@ spec:
                                   image:
                                     type: string
                                   imagePullPolicy:
+                                    description: PullPolicy describes a policy for
+                                      if/when to pull a container image
                                     type: string
                                   logLevel:
+                                    description: |-
+                                      LogLevel sets the logging level for the server
+                                      Allowed values: "debug", "info", "warning", "error", "critical".
                                     enum:
                                     - debug
                                     - info
@@ -2792,11 +4607,21 @@ spec:
                                     - critical
                                     type: string
                                   resources:
+                                    description: ResourceRequirements describes the
+                                      compute resource requirements.
                                     properties:
                                       claims:
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
                                         items:
+                                          description: ResourceClaim references one
+                                            entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used.
                                               type: string
                                           required:
                                           - name
@@ -2812,6 +4637,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2820,23 +4648,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: Requests describes the minimum
+                                          amount of compute resources required.
                                         type: object
                                     type: object
                                   tls:
+                                    description: TlsConfigs configures server TLS
+                                      for a feast service.
                                     properties:
                                       disable:
+                                        description: will disable TLS for the feast
+                                          service. useful in an openshift cluster,
+                                          for example, where TLS is configured by
+                                          default
                                         type: boolean
                                       secretKeyNames:
+                                        description: SecretKeyNames defines the secret
+                                          key names for the TLS key and cert.
                                         properties:
                                           tlsCrt:
+                                            description: defaults to "tls.crt"
                                             type: string
                                           tlsKey:
+                                            description: defaults to "tls.key"
                                             type: string
                                         type: object
                                       secretRef:
+                                        description: references the local k8s secret
+                                          where the TLS key and cert reside
                                         properties:
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -2847,21 +4693,46 @@ spec:
                                       rule: '(!has(self.disable) || !self.disable)
                                         ? has(self.secretRef) : true'
                                   volumeMounts:
+                                    description: VolumeMounts defines the list of
+                                      volumes that should be mounted into the feast
+                                      container.
                                     items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
                                       properties:
                                         mountPath:
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
+                                            not contain ':'.
                                           type: string
                                         mountPropagation:
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
+                                            to container and the other way around.
                                           type: string
                                         name:
+                                          description: This must match the Name of
+                                            a Volume.
                                           type: string
                                         readOnly:
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                                            Defaults to false.
                                           type: boolean
                                         recursiveReadOnly:
+                                          description: |-
+                                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                                            recursively.
                                           type: string
                                         subPath:
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted.
                                           type: string
                                       required:
                                       - mountPath
@@ -2871,26 +4742,44 @@ spec:
                                 type: object
                             type: object
                           remote:
+                            description: RemoteRegistryConfig points to a remote feast
+                              registry server.
                             properties:
                               feastRef:
+                                description: Reference to an existing `FeatureStore`
+                                  CR in the same k8s cluster.
                                 properties:
                                   name:
+                                    description: Name of the FeatureStore
                                     type: string
                                   namespace:
+                                    description: Namespace of the FeatureStore
                                     type: string
                                 required:
                                 - name
                                 type: object
                               hostname:
+                                description: Host address of the remote registry service
+                                  - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`
                                 type: string
                               tls:
+                                description: TlsRemoteRegistryConfigs configures client
+                                  TLS for a remote feast registry.
                                 properties:
                                   certName:
+                                    description: defines the configmap key name for
+                                      the client TLS cert.
                                     type: string
                                   configMapRef:
+                                    description: references the local k8s configmap
+                                      where the TLS cert resides
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2909,63 +4798,108 @@ spec:
                           rule: '[has(self.local), has(self.remote)].exists_one(c,
                             c)'
                       ui:
+                        description: Creates a UI server container
                         properties:
                           env:
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -2978,24 +4912,42 @@ spec:
                             type: array
                           envFrom:
                             items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3004,8 +4956,13 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
+                            description: PullPolicy describes a policy for if/when
+                              to pull a container image
                             type: string
                           logLevel:
+                            description: |-
+                              LogLevel sets the logging level for the server
+                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -3014,11 +4971,21 @@ spec:
                             - critical
                             type: string
                           resources:
+                            description: ResourceRequirements describes the compute
+                              resource requirements.
                             properties:
                               claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
                                 items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used.
                                       type: string
                                   required:
                                   - name
@@ -3034,6 +5001,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3042,23 +5012,40 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           tls:
+                            description: TlsConfigs configures server TLS for a feast
+                              service.
                             properties:
                               disable:
+                                description: will disable TLS for the feast service.
+                                  useful in an openshift cluster, for example, where
+                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
+                                description: SecretKeyNames defines the secret key
+                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
+                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
+                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
+                                description: references the local k8s secret where
+                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -3068,21 +5055,43 @@ spec:
                               rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                 : true'
                           volumeMounts:
+                            description: VolumeMounts defines the list of volumes
+                              that should be mounted into the feast container.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
                                   type: boolean
                                 recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
                                   type: string
                                 subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
                                   type: string
                               required:
                               - mountPath
@@ -3091,109 +5100,210 @@ spec:
                             type: array
                         type: object
                       volumes:
+                        description: Volumes specifies the volumes to mount in the
+                          FeatureStore deployment.
                         items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
+                              description: |-
+                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                kubelet's host machine and then exposed to th
                               properties:
                                 fsType:
+                                  description: fsType is the filesystem type of the
+                                    volume that you want to mount.
                                   type: string
                                 partition:
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
                                   format: int32
                                   type: integer
                                 readOnly:
+                                  description: |-
+                                    readOnly value true will force the readOnly setting in VolumeMounts.
+                                    More info: https://kubernetes.
                                   type: boolean
                                 volumeID:
+                                  description: |-
+                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                    More info: https://kubernetes.
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
+                              description: azureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
                                   type: string
                                 diskURI:
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
                                   type: string
                                 fsType:
+                                  description: |-
+                                    fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 kind:
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage accoun'
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
+                              description: azureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
+                              description: cephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
                               properties:
                                 monitors:
+                                  description: |-
+                                    monitors is Required: Monitors is a collection of Ceph monitors
+                                    More info: https://examples.k8s.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretFile:
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.'
                                   type: string
                                 secretRef:
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty.'
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
+                                  description: |-
+                                    user is optional: User is the rados user name, default is admin
+                                    More info: https://examples.k8s.
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
+                              description: |-
+                                cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                More info: https://examples.k8s.
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
+                                  description: |-
+                                    secretRef is optional: points to a secret object containing parameters used to connect
+                                    to OpenStack.
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
+                                  description: |-
+                                    volumeID used to identify the volume in cinder.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
+                              description: configMap represents a configMap that should
+                                populate this volume
                               properties:
                                 defaultMode:
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.'
                                   format: int32
                                   type: integer
                                 items:
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volum
                                   items:
+                                    description: Maps a string key to a path within
+                                      a volume.
                                     properties:
                                       key:
+                                        description: key is the key to project.
                                         type: string
                                       mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file.'
                                         format: int32
                                         type: integer
                                       path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
                                         type: string
                                     required:
                                     - key
@@ -3203,67 +5313,125 @@ spec:
                                   x-kubernetes-list-type: atomic
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers (Beta fea
                               properties:
                                 driver:
+                                  description: driver is the name of the CSI driver
+                                    that handles this volume.
                                   type: string
                                 fsType:
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs".
                                   type: string
                                 nodePublishSecretRef:
+                                  description: |-
+                                    nodePublishSecretRef is a reference to the secret object containing
+                                    sensitive information to pass to the CSI driver to c
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
+                                  description: |-
+                                    readOnly specifies a read-only configuration for the volume.
+                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
+                                  description: |-
+                                    volumeAttributes stores driver-specific properties that are passed to the CSI
+                                    driver.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
                               properties:
                                 defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default.'
                                   format: int32
                                   type: integer
                                 items:
+                                  description: Items is a list of downward API volume
+                                    file
                                   items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
                                     properties:
                                       fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name,
+                                          namespace and uid are supported.'
                                         properties:
                                           apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
                                             type: string
                                           fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
+                                        description: |-
+                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                          between 0000 and 0777 or a decimal valu
                                         format: int32
                                         type: integer
                                       path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.'
                                         type: string
                                       resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, requests.
                                         properties:
                                           containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
+                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -3276,36 +5444,63 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             emptyDir:
+                              description: |-
+                                emptyDir represents a temporary directory that shares a pod's lifetime.
+                                More info: https://kubernetes.
                               properties:
                                 medium:
+                                  description: medium represents what type of storage
+                                    medium should back this directory.
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
+                              description: ephemeral represents a volume that is handled
+                                by a cluster storage driver.
                               properties:
                                 volumeClaimTemplate:
+                                  description: Will be used to create a stand-alone
+                                    PVC to provision the volume.
                                   properties:
                                     metadata:
+                                      description: |-
+                                        May contain labels and annotations that will be copied into the PVC
+                                        when creating it.
                                       type: object
                                     spec:
+                                      description: The specification for the PersistentVolumeClaim.
                                       properties:
                                         accessModes:
+                                          description: |-
+                                            accessModes contains the desired access modes the volume should have.
+                                            More info: https://kubernetes.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         dataSource:
+                                          description: |-
+                                            dataSource field can be used to specify either:
+                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.
                                           properties:
                                             apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced.
                                               type: string
                                             kind:
+                                              description: Kind is the type of resource
+                                                being referenced
                                               type: string
                                             name:
+                                              description: Name is the name of resource
+                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -3313,20 +5508,34 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                            volume is desired.
                                           properties:
                                             apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced.
                                               type: string
                                             kind:
+                                              description: Kind is the type of resource
+                                                being referenced
                                               type: string
                                             name:
+                                              description: Name is the name of resource
+                                                being referenced
                                               type: string
                                             namespace:
+                                              description: |-
+                                                Namespace is the namespace of resource being referenced
+                                                Note that when a namespace is specified, a gateway.networking.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
+                                          description: resources represents the minimum
+                                            resources the volume should have.
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -3335,6 +5544,9 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
+                                              description: |-
+                                                Limits describes the maximum amount of compute resources allowed.
+                                                More info: https://kubernetes.
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -3343,18 +5555,38 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
+                                              description: Requests describes the
+                                                minimum amount of compute resources
+                                                required.
                                               type: object
                                           type: object
                                         selector:
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
                                               items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
                                                     type: string
                                                   operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3368,16 +5600,28 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
+                                          description: |-
+                                            storageClassName is the name of the StorageClass required by the claim.
+                                            More info: https://kubernetes.
                                           type: string
                                         volumeAttributesClassName:
+                                          description: volumeAttributesClassName may
+                                            be used to set the VolumeAttributesClass
+                                            used by this claim.
                                           type: string
                                         volumeMode:
+                                          description: volumeMode defines what type
+                                            of volume is required by the claim.
                                           type: string
                                         volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -3385,41 +5629,78 @@ spec:
                                   type: object
                               type: object
                             fc:
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 lun:
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 wwids:
+                                  description: "wwids Optional: FC volume world wide
+                                    identifiers (wwids)\nEither wwids or combination
+                                    of targetWWNs and lun must be set, "
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             flexVolume:
+                              description: |-
+                                flexVolume represents a generic volume resource that is
+                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
+                                  description: driver is the name of the driver to
+                                    use for this volume.
                                   type: string
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
                                   type: object
                                 readOnly:
+                                  description: |-
+                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
+                                  description: |-
+                                    secretRef is Optional: secretRef is reference to the secret object containing
+                                    sensitive information to pass to the plugi
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3427,90 +5708,171 @@ spec:
                               - driver
                               type: object
                             flocker:
+                              description: flocker represents a Flocker volume attached
+                                to a kubelet's host machine.
                               properties:
                                 datasetName:
+                                  description: |-
+                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                    should be considered as depreca
                                   type: string
                                 datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
+                              description: |-
+                                gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the po
                               properties:
                                 fsType:
+                                  description: fsType is filesystem type of the volume
+                                    that you want to mount.
                                   type: string
                                 partition:
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
                                   format: int32
                                   type: integer
                                 pdName:
+                                  description: |-
+                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                    More info: https://kubernetes.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://kubernetes.
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
+                              description: |-
+                                gitRepo represents a git repository at a particular revision.
+                                DEPRECATED: GitRepo is deprecated.
                               properties:
                                 directory:
+                                  description: |-
+                                    directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.
                                   type: string
                                 repository:
+                                  description: repository is the URL
                                   type: string
                                 revision:
+                                  description: revision is the commit hash for the
+                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
+                              description: |-
+                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.
                               properties:
                                 endpoints:
+                                  description: |-
+                                    endpoints is the endpoint name that details Glusterfs topology.
+                                    More info: https://examples.k8s.
                                   type: string
                                 path:
+                                  description: |-
+                                    path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                    Defaults to false.
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
+                              description: |-
+                                hostPath represents a pre-existing file or directory on the host
+                                machine that is directly exposed to the container.
                               properties:
                                 path:
+                                  description: |-
+                                    path of the directory on the host.
+                                    If the path is a symlink, it will follow the link to the real path.
                                   type: string
                                 type:
+                                  description: |-
+                                    type for HostPath Volume
+                                    Defaults to ""
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
+                              description: |-
+                                iscsi represents an ISCSI Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
                               properties:
                                 chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
+                                  description: fsType is the filesystem type of the
+                                    volume that you want to mount.
                                   type: string
                                 initiatorName:
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name.
                                   type: string
                                 iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
+                                  description: |-
+                                    iscsiInterface is the interface Name that uses an iSCSI transport.
+                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
+                                  description: portals is the iSCSI Target Portal
+                                    List.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
                                   type: boolean
                                 secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
+                                  description: targetPortal is iSCSI Target Portal.
                                   type: string
                               required:
                               - iqn
@@ -3518,68 +5880,139 @@ spec:
                               - targetPortal
                               type: object
                             name:
+                              description: |-
+                                name of the volume.
+                                Must be a DNS_LABEL and unique within the pod.
+                                More info: https://kubernetes.
                               type: string
                             nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.
                               properties:
                                 path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
                                   type: boolean
                                 server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
+                              description: |-
+                                persistentVolumeClaimVolumeSource represents a reference to a
+                                PersistentVolumeClaim in the same namespace.
                               properties:
                                 claimName:
+                                  description: claimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 pdID:
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
+                              description: portworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
+                                  description: |-
+                                    fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
                                   format: int32
                                   type: integer
                                 sources:
+                                  description: sources is the list of volume projections
                                   items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
+                                        description: ClusterTrustBundle allows a pod
+                                          to access the `.spec.
                                         properties:
                                           labelSelector:
+                                            description: |-
+                                              Select all ClusterTrustBundles that match this label selector.  Only has
+                                              effect if signerName is set.
                                             properties:
                                               matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
                                                 items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
                                                       type: string
                                                     operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty.
                                                       items:
                                                         type: string
                                                       type: array
@@ -3593,31 +6026,58 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
+                                            description: |-
+                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                              with signerName and labelSelector.
                                             type: string
                                           optional:
+                                            description: |-
+                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                              aren't available.
                                             type: boolean
                                           path:
+                                            description: Relative path from the volume
+                                              root to write the bundle.
                                             type: string
                                           signerName:
+                                            description: |-
+                                              Select all ClusterTrustBundles that match this signer name.
+                                              Mutually-exclusive with name.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
+                                        description: configMap information about the
+                                          configMap data to project
                                         properties:
                                           items:
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              ConfigMap will be projected into the volum
                                             items:
+                                              description: Maps a string key to a
+                                                path within a volume.
                                               properties:
                                                 key:
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
                                                   type: string
                                               required:
                                               - key
@@ -3627,42 +6087,83 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                           optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
                                         properties:
                                           items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
                                             items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
                                               properties:
                                                 fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name, namespace and uid
+                                                    are supported.'
                                                   properties:
                                                     apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
+                                                  description: |-
+                                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                                    between 0000 and 0777 or a decimal valu
                                                   format: int32
                                                   type: integer
                                                 path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path.'
                                                   type: string
                                                 resourceFieldRef:
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, requests.
                                                   properties:
                                                     containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
+                                                      description: 'Required: resource
+                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -3675,16 +6176,30 @@ spec:
                                             x-kubernetes-list-type: atomic
                                         type: object
                                       secret:
+                                        description: secret information about the
+                                          secret data to project
                                         properties:
                                           items:
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              Secret will be projected into the volume a
                                             items:
+                                              description: Maps a string key to a
+                                                path within a volume.
                                               properties:
                                                 key:
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
                                                   type: string
                                               required:
                                               - key
@@ -3694,19 +6209,35 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                           optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
+                                            description: audience is the intended
+                                              audience of the token.
                                             type: string
                                           expirationSeconds:
+                                            description: |-
+                                              expirationSeconds is the requested duration of validity of the service
+                                              account token.
                                             format: int64
                                             type: integer
                                           path:
+                                            description: |-
+                                              path is the path relative to the mount point of the file to project the
+                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -3716,79 +6247,164 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             quobyte:
+                              description: quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
                               properties:
                                 group:
+                                  description: |-
+                                    group to map volume access to
+                                    Default is no group
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                    Defaults to false.
                                   type: boolean
                                 registry:
+                                  description: |-
+                                    registry represents a single or multiple Quobyte Registry services
+                                    specified as a string as host:port pair (multiple ent
                                   type: string
                                 tenant:
+                                  description: |-
+                                    tenant owning the given Quobyte volume in the Backend
+                                    Used with dynamically provisioned Quobyte volumes, value is set by
                                   type: string
                                 user:
+                                  description: |-
+                                    user to map volume access to
+                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
+                              description: |-
+                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.
                               properties:
                                 fsType:
+                                  description: fsType is the filesystem type of the
+                                    volume that you want to mount.
                                   type: string
                                 image:
+                                  description: |-
+                                    image is the rados image name.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
+                                  description: |-
+                                    keyring is the path to key ring for RBDUser.
+                                    Default is /etc/ceph/keyring.
+                                    More info: https://examples.k8s.
                                   type: string
                                 monitors:
+                                  description: |-
+                                    monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 pool:
+                                  description: |-
+                                    pool is the rados pool name.
+                                    Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.
                                   type: boolean
                                 secretRef:
+                                  description: |-
+                                    secretRef is name of the authentication secret for RBDUser. If provided
+                                    overrides keyring.
+                                    Default is nil.
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
+                                  description: |-
+                                    user is the rados user name.
+                                    Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
+                              description: scaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 gateway:
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
+                                  description: |-
+                                    secretRef references to the secret for ScaleIO user and other
+                                    sensitive information.
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
                                   type: string
                                 storagePool:
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
                                   type: string
                                 system:
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
+                                  description: |-
+                                    volumeName is the name of a volume already created in the ScaleIO system
+                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -3796,19 +6412,35 @@ spec:
                               - system
                               type: object
                             secret:
+                              description: |-
+                                secret represents a secret that should populate this volume.
+                                More info: https://kubernetes.
                               properties:
                                 defaultMode:
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.'
                                   format: int32
                                   type: integer
                                 items:
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume a
                                   items:
+                                    description: Maps a string key to a path within
+                                      a volume.
                                     properties:
                                       key:
+                                        description: key is the key to project.
                                         type: string
                                       mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file.'
                                         format: int32
                                         type: integer
                                       path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
                                         type: string
                                     required:
                                     - key
@@ -3817,37 +6449,76 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.
                                   type: string
                               type: object
                             storageos:
+                              description: storageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
+                                  description: |-
+                                    secretRef specifies the secret to use for obtaining the StorageOS API
+                                    credentials.
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
+                                  description: |-
+                                    volumeName is the human-readable name of the StorageOS volume.  Volume
+                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
+                                  description: volumeNamespace specifies the scope
+                                    of the volume within StorageOS.
                                   type: string
                               type: object
                             vsphereVolume:
+                              description: vsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 storagePolicyID:
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -3861,32 +6532,51 @@ spec:
                 - feastProject
                 type: object
               clientConfigMap:
+                description: ConfigMap in this namespace containing a client `feature_store.yaml`
+                  for this feast deployment
                 type: string
               conditions:
                 items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
+                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -3903,6 +6593,8 @@ spec:
               phase:
                 type: string
               serviceHostnames:
+                description: ServiceHostnames defines the service hostnames in the
+                  format of <domain>:<port>, e.g. example.svc.cluster.local:80
                 properties:
                   offlineStore:
                     type: string

--- a/infra/feast-operator/dist/install.yaml
+++ b/infra/feast-operator/dist/install.yaml
@@ -34,30 +34,53 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: FeatureStore is the Schema for the featurestores API
         properties:
           apiVersion:
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
             type: string
           kind:
+            description: Kind is a string value representing the REST resource this
+              object represents.
             type: string
           metadata:
             type: object
           spec:
+            description: FeatureStoreSpec defines the desired state of FeatureStore
             properties:
               authz:
+                description: AuthzConfig defines the authorization settings for the
+                  deployed Feast services.
                 properties:
                   kubernetes:
+                    description: |-
+                      KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.
+                      https://kubernetes.
                     properties:
                       roles:
+                        description: The Kubernetes RBAC roles to be deployed in the
+                          same namespace of the FeatureStore.
                         items:
                           type: string
                         type: array
                     type: object
                   oidc:
+                    description: |-
+                      OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.
+                      https://auth0.
                     properties:
                       secretRef:
+                        description: |-
+                          LocalObjectReference contains enough information to let you locate the
+                          referenced object inside the same namespace.
                         properties:
                           name:
                             default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty.
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
@@ -69,45 +92,74 @@ spec:
                 - message: One selection required between kubernetes or oidc.
                   rule: '[has(self.kubernetes), has(self.oidc)].exists_one(c, c)'
               feastProject:
+                description: FeastProject is the Feast project id.
                 pattern: ^[A-Za-z0-9][A-Za-z0-9_]*$
                 type: string
               services:
+                description: FeatureStoreServices defines the desired feast services.
+                  An ephemeral registry is deployed by default.
                 properties:
                   deploymentStrategy:
+                    description: DeploymentStrategy describes how to replace existing
+                      pods with new ones.
                     properties:
                       rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if DeploymentStrategyType =
+                          RollingUpdate.
                         properties:
                           maxSurge:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              The maximum number of pods that can be scheduled above the desired number of
+                              pods.
                             x-kubernetes-int-or-string: true
                           maxUnavailable:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: The maximum number of pods that can be unavailable
+                              during the update.
                             x-kubernetes-int-or-string: true
                         type: object
                       type:
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                          Default is RollingUpdate.
                         type: string
                     type: object
                   disableInitContainers:
+                    description: Disable the 'feast repo initialization' initContainer
                     type: boolean
                   offlineStore:
+                    description: OfflineStore configures the deployed offline store
+                      service
                     properties:
                       persistence:
+                        description: OfflineStorePersistence configures the persistence
+                          settings for the offline store service
                         properties:
                           file:
+                            description: OfflineStoreFilePersistence configures the
+                              file-based persistence for the offline store service
                             properties:
                               pvc:
+                                description: PvcConfig defines the settings for a
+                                  persistent file store based on PVCs.
                                 properties:
                                   create:
+                                    description: Settings for creating a new PVC
                                     properties:
                                       accessModes:
+                                        description: AccessModes k8s persistent volume
+                                          access modes. Defaults to ["ReadWriteOnce"].
                                         items:
                                           type: string
                                         type: array
                                       resources:
+                                        description: Resources describes the storage
+                                          resource requirements for a volume.
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -116,6 +168,9 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -124,20 +179,33 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
+                                            description: Requests describes the minimum
+                                              amount of compute resources required.
                                             type: object
                                         type: object
                                       storageClassName:
+                                        description: StorageClassName is the name
+                                          of an existing StorageClass to which this
+                                          persistent volume belongs.
                                         type: string
                                     type: object
                                     x-kubernetes-validations:
                                     - message: PvcCreate is immutable
                                       rule: self == oldSelf
                                   mountPath:
+                                    description: |-
+                                      MountPath within the container at which the volume should be mounted.
+                                      Must start by "/" and cannot contain ':'.
                                     type: string
                                   ref:
+                                    description: Reference to an existing field
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -160,17 +228,30 @@ spec:
                                 type: string
                             type: object
                           store:
+                            description: OfflineStoreDBStorePersistence configures
+                              the DB store persistence for the offline store service
                             properties:
                               secretKeyName:
+                                description: By default, the selected store "type"
+                                  is used as the SecretKeyName
                                 type: string
                               secretRef:
+                                description: Data store parameters should be placed
+                                  as-is from the "feature_store.yaml" under the secret
+                                  key.
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type:
+                                description: Type of the persistence type you want
+                                  to use.
                                 enum:
                                 - snowflake.offline
                                 - bigquery
@@ -190,63 +271,108 @@ spec:
                         - message: One selection required between file or store.
                           rule: '[has(self.file), has(self.store)].exists_one(c, c)'
                       server:
+                        description: Creates a remote offline server container
                         properties:
                           env:
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -259,24 +385,42 @@ spec:
                             type: array
                           envFrom:
                             items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -285,8 +429,13 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
+                            description: PullPolicy describes a policy for if/when
+                              to pull a container image
                             type: string
                           logLevel:
+                            description: |-
+                              LogLevel sets the logging level for the server
+                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -295,11 +444,21 @@ spec:
                             - critical
                             type: string
                           resources:
+                            description: ResourceRequirements describes the compute
+                              resource requirements.
                             properties:
                               claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
                                 items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used.
                                       type: string
                                   required:
                                   - name
@@ -315,6 +474,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -323,23 +485,40 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           tls:
+                            description: TlsConfigs configures server TLS for a feast
+                              service.
                             properties:
                               disable:
+                                description: will disable TLS for the feast service.
+                                  useful in an openshift cluster, for example, where
+                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
+                                description: SecretKeyNames defines the secret key
+                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
+                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
+                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
+                                description: references the local k8s secret where
+                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -349,21 +528,43 @@ spec:
                               rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                 : true'
                           volumeMounts:
+                            description: VolumeMounts defines the list of volumes
+                              that should be mounted into the feast container.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
                                   type: boolean
                                 recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
                                   type: string
                                 subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
                                   type: string
                               required:
                               - mountPath
@@ -373,22 +574,35 @@ spec:
                         type: object
                     type: object
                   onlineStore:
+                    description: OnlineStore configures the deployed online store
+                      service
                     properties:
                       persistence:
+                        description: OnlineStorePersistence configures the persistence
+                          settings for the online store service
                         properties:
                           file:
+                            description: OnlineStoreFilePersistence configures the
+                              file-based persistence for the online store service
                             properties:
                               path:
                                 type: string
                               pvc:
+                                description: PvcConfig defines the settings for a
+                                  persistent file store based on PVCs.
                                 properties:
                                   create:
+                                    description: Settings for creating a new PVC
                                     properties:
                                       accessModes:
+                                        description: AccessModes k8s persistent volume
+                                          access modes. Defaults to ["ReadWriteOnce"].
                                         items:
                                           type: string
                                         type: array
                                       resources:
+                                        description: Resources describes the storage
+                                          resource requirements for a volume.
                                         properties:
                                           limits:
                                             additionalProperties:
@@ -397,6 +611,9 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
+                                            description: |-
+                                              Limits describes the maximum amount of compute resources allowed.
+                                              More info: https://kubernetes.
                                             type: object
                                           requests:
                                             additionalProperties:
@@ -405,20 +622,33 @@ spec:
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
+                                            description: Requests describes the minimum
+                                              amount of compute resources required.
                                             type: object
                                         type: object
                                       storageClassName:
+                                        description: StorageClassName is the name
+                                          of an existing StorageClass to which this
+                                          persistent volume belongs.
                                         type: string
                                     type: object
                                     x-kubernetes-validations:
                                     - message: PvcCreate is immutable
                                       rule: self == oldSelf
                                   mountPath:
+                                    description: |-
+                                      MountPath within the container at which the volume should be mounted.
+                                      Must start by "/" and cannot contain ':'.
                                     type: string
                                   ref:
+                                    description: Reference to an existing field
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -446,17 +676,30 @@ spec:
                               rule: 'has(self.path) ? !(self.path.startsWith(''s3://'')
                                 || self.path.startsWith(''gs://'')) : true'
                           store:
+                            description: OnlineStoreDBStorePersistence configures
+                              the DB store persistence for the online store service
                             properties:
                               secretKeyName:
+                                description: By default, the selected store "type"
+                                  is used as the SecretKeyName
                                 type: string
                               secretRef:
+                                description: Data store parameters should be placed
+                                  as-is from the "feature_store.yaml" under the secret
+                                  key.
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type:
+                                description: Type of the persistence type you want
+                                  to use.
                                 enum:
                                 - snowflake.online
                                 - redis
@@ -484,63 +727,108 @@ spec:
                         - message: One selection required between file or store.
                           rule: '[has(self.file), has(self.store)].exists_one(c, c)'
                       server:
+                        description: Creates a feature server container
                         properties:
                           env:
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -553,24 +841,42 @@ spec:
                             type: array
                           envFrom:
                             items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -579,8 +885,13 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
+                            description: PullPolicy describes a policy for if/when
+                              to pull a container image
                             type: string
                           logLevel:
+                            description: |-
+                              LogLevel sets the logging level for the server
+                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -589,11 +900,21 @@ spec:
                             - critical
                             type: string
                           resources:
+                            description: ResourceRequirements describes the compute
+                              resource requirements.
                             properties:
                               claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
                                 items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used.
                                       type: string
                                   required:
                                   - name
@@ -609,6 +930,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -617,23 +941,40 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           tls:
+                            description: TlsConfigs configures server TLS for a feast
+                              service.
                             properties:
                               disable:
+                                description: will disable TLS for the feast service.
+                                  useful in an openshift cluster, for example, where
+                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
+                                description: SecretKeyNames defines the secret key
+                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
+                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
+                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
+                                description: references the local k8s secret where
+                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -643,21 +984,43 @@ spec:
                               rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                 : true'
                           volumeMounts:
+                            description: VolumeMounts defines the list of volumes
+                              that should be mounted into the feast container.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
                                   type: boolean
                                 recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
                                   type: string
                                 subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
                                   type: string
                               required:
                               - mountPath
@@ -667,24 +1030,39 @@ spec:
                         type: object
                     type: object
                   registry:
+                    description: Registry configures the registry service. One selection
+                      is required. Local is the default setting.
                     properties:
                       local:
+                        description: LocalRegistryConfig configures the deployed registry
+                          service
                         properties:
                           persistence:
+                            description: RegistryPersistence configures the persistence
+                              settings for the registry service
                             properties:
                               file:
+                                description: RegistryFilePersistence configures the
+                                  file-based persistence for the registry service
                                 properties:
                                   path:
                                     type: string
                                   pvc:
+                                    description: PvcConfig defines the settings for
+                                      a persistent file store based on PVCs.
                                     properties:
                                       create:
+                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
+                                            description: AccessModes k8s persistent
+                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
+                                            description: Resources describes the storage
+                                              resource requirements for a volume.
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -693,6 +1071,9 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -701,20 +1082,34 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: Requests describes the
+                                                  minimum amount of compute resources
+                                                  required.
                                                 type: object
                                             type: object
                                           storageClassName:
+                                            description: StorageClassName is the name
+                                              of an existing StorageClass to which
+                                              this persistent volume belongs.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
+                                        description: |-
+                                          MountPath within the container at which the volume should be mounted.
+                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
+                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -754,17 +1149,30 @@ spec:
                                   rule: '(has(self.s3_additional_kwargs) && has(self.path))
                                     ? self.path.startsWith(''s3://'') : true'
                               store:
+                                description: RegistryDBStorePersistence configures
+                                  the DB store persistence for the registry service
                                 properties:
                                   secretKeyName:
+                                    description: By default, the selected store "type"
+                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
+                                    description: Data store parameters should be placed
+                                      as-is from the "feature_store.yaml" under the
+                                      secret key.
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   type:
+                                    description: Type of the persistence type you
+                                      want to use.
                                     enum:
                                     - sql
                                     - snowflake.registry
@@ -779,63 +1187,111 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           server:
+                            description: Creates a registry server container
                             properties:
                               env:
                                 items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
                                   properties:
                                     name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
                                       type: string
                                     value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any
                                       type: string
                                     valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
                                       properties:
                                         configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
                                           properties:
                                             key:
+                                              description: The key to select.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
+                                          description: 'Selects a field of the pod:
+                                            supports metadata.name, metadata.namespace,
+                                            `metadata.labels[''<KEY>'']`, `metadata.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to
+                                                select'
                                               type: string
                                           required:
                                           - resource
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
                                           properties:
                                             key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
@@ -848,24 +1304,42 @@ spec:
                                 type: array
                               envFrom:
                                 items:
+                                  description: EnvFromSource represents the source
+                                    of a set of ConfigMaps
                                   properties:
                                     configMapRef:
+                                      description: The ConfigMap to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
+                                      description: An optional identifier to prepend
+                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
+                                      description: The Secret to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -874,8 +1348,13 @@ spec:
                               image:
                                 type: string
                               imagePullPolicy:
+                                description: PullPolicy describes a policy for if/when
+                                  to pull a container image
                                 type: string
                               logLevel:
+                                description: |-
+                                  LogLevel sets the logging level for the server
+                                  Allowed values: "debug", "info", "warning", "error", "critical".
                                 enum:
                                 - debug
                                 - info
@@ -884,11 +1363,21 @@ spec:
                                 - critical
                                 type: string
                               resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
                                 properties:
                                   claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
                                     items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
                                       properties:
                                         name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used.
                                           type: string
                                       required:
                                       - name
@@ -904,6 +1393,9 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -912,23 +1404,40 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: Requests describes the minimum amount
+                                      of compute resources required.
                                     type: object
                                 type: object
                               tls:
+                                description: TlsConfigs configures server TLS for
+                                  a feast service.
                                 properties:
                                   disable:
+                                    description: will disable TLS for the feast service.
+                                      useful in an openshift cluster, for example,
+                                      where TLS is configured by default
                                     type: boolean
                                   secretKeyNames:
+                                    description: SecretKeyNames defines the secret
+                                      key names for the TLS key and cert.
                                     properties:
                                       tlsCrt:
+                                        description: defaults to "tls.crt"
                                         type: string
                                       tlsKey:
+                                        description: defaults to "tls.key"
                                         type: string
                                     type: object
                                   secretRef:
+                                    description: references the local k8s secret where
+                                      the TLS key and cert reside
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -938,21 +1447,44 @@ spec:
                                   rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                     : true'
                               volumeMounts:
+                                description: VolumeMounts defines the list of volumes
+                                  that should be mounted into the feast container.
                                 items:
+                                  description: VolumeMount describes a mounting of
+                                    a Volume within a container.
                                   properties:
                                     mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
                                       type: string
                                     mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
                                       type: string
                                     name:
+                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
                                       type: boolean
                                     recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
                                       type: string
                                     subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
                                       type: string
                                     subPathExpr:
+                                      description: Expanded path within the volume
+                                        from which the container's volume should be
+                                        mounted.
                                       type: string
                                   required:
                                   - mountPath
@@ -962,26 +1494,44 @@ spec:
                             type: object
                         type: object
                       remote:
+                        description: RemoteRegistryConfig points to a remote feast
+                          registry server.
                         properties:
                           feastRef:
+                            description: Reference to an existing `FeatureStore` CR
+                              in the same k8s cluster.
                             properties:
                               name:
+                                description: Name of the FeatureStore
                                 type: string
                               namespace:
+                                description: Namespace of the FeatureStore
                                 type: string
                             required:
                             - name
                             type: object
                           hostname:
+                            description: Host address of the remote registry service
+                              - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`
                             type: string
                           tls:
+                            description: TlsRemoteRegistryConfigs configures client
+                              TLS for a remote feast registry.
                             properties:
                               certName:
+                                description: defines the configmap key name for the
+                                  client TLS cert.
                                 type: string
                               configMapRef:
+                                description: references the local k8s configmap where
+                                  the TLS cert resides
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -999,63 +1549,107 @@ spec:
                     - message: One selection required.
                       rule: '[has(self.local), has(self.remote)].exists_one(c, c)'
                   ui:
+                    description: Creates a UI server container
                     properties:
                       env:
                         items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
                           properties:
                             name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
                               type: string
                             value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any
                               type: string
                             valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
                               properties:
                                 configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
                                   properties:
                                     key:
+                                      description: The key to select.
                                       type: string
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
                                       type: boolean
                                   required:
                                   - key
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.'
                                   properties:
                                     apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
                                       type: string
                                   required:
                                   - fieldPath
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.
                                   properties:
                                     containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
                                       type: string
                                     divisor:
                                       anyOf:
                                       - type: integer
                                       - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
+                                      description: 'Required: resource to select'
                                       type: string
                                   required:
                                   - resource
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
                                   properties:
                                     key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
                                       type: boolean
                                   required:
                                   - key
@@ -1068,24 +1662,42 @@ spec:
                         type: array
                       envFrom:
                         items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
                           properties:
                             configMapRef:
+                              description: The ConfigMap to select from
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
+                              description: The Secret to select from
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret must be
+                                    defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
@@ -1094,8 +1706,13 @@ spec:
                       image:
                         type: string
                       imagePullPolicy:
+                        description: PullPolicy describes a policy for if/when to
+                          pull a container image
                         type: string
                       logLevel:
+                        description: |-
+                          LogLevel sets the logging level for the server
+                          Allowed values: "debug", "info", "warning", "error", "critical".
                         enum:
                         - debug
                         - info
@@ -1104,11 +1721,20 @@ spec:
                         - critical
                         type: string
                       resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
                         properties:
                           claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
                             items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used.
                                   type: string
                               required:
                               - name
@@ -1124,6 +1750,9 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.
                             type: object
                           requests:
                             additionalProperties:
@@ -1132,23 +1761,40 @@ spec:
                               - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
+                            description: Requests describes the minimum amount of
+                              compute resources required.
                             type: object
                         type: object
                       tls:
+                        description: TlsConfigs configures server TLS for a feast
+                          service.
                         properties:
                           disable:
+                            description: will disable TLS for the feast service. useful
+                              in an openshift cluster, for example, where TLS is configured
+                              by default
                             type: boolean
                           secretKeyNames:
+                            description: SecretKeyNames defines the secret key names
+                              for the TLS key and cert.
                             properties:
                               tlsCrt:
+                                description: defaults to "tls.crt"
                                 type: string
                               tlsKey:
+                                description: defaults to "tls.key"
                                 type: string
                             type: object
                           secretRef:
+                            description: references the local k8s secret where the
+                              TLS key and cert reside
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1158,21 +1804,43 @@ spec:
                           rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                             : true'
                       volumeMounts:
+                        description: VolumeMounts defines the list of volumes that
+                          should be mounted into the feast container.
                         items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
                           properties:
                             mountPath:
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
                               type: string
                             mountPropagation:
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
                               type: string
                             name:
+                              description: This must match the Name of a Volume.
                               type: string
                             readOnly:
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
                               type: boolean
                             recursiveReadOnly:
+                              description: |-
+                                RecursiveReadOnly specifies whether read-only mounts should be handled
+                                recursively.
                               type: string
                             subPath:
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted.
                               type: string
                           required:
                           - mountPath
@@ -1181,109 +1849,209 @@ spec:
                         type: array
                     type: object
                   volumes:
+                    description: Volumes specifies the volumes to mount in the FeatureStore
+                      deployment.
                     items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
                       properties:
                         awsElasticBlockStore:
+                          description: |-
+                            awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                            kubelet's host machine and then exposed to th
                           properties:
                             fsType:
+                              description: fsType is the filesystem type of the volume
+                                that you want to mount.
                               type: string
                             partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
                               format: int32
                               type: integer
                             readOnly:
+                              description: |-
+                                readOnly value true will force the readOnly setting in VolumeMounts.
+                                More info: https://kubernetes.
                               type: boolean
                             volumeID:
+                              description: |-
+                                volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                More info: https://kubernetes.
                               type: string
                           required:
                           - volumeID
                           type: object
                         azureDisk:
+                          description: azureDisk represents an Azure Data Disk mount
+                            on the host and bind mount to the pod.
                           properties:
                             cachingMode:
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
                               type: string
                             diskName:
+                              description: diskName is the Name of the data disk in
+                                the blob storage
                               type: string
                             diskURI:
+                              description: diskURI is the URI of data disk in the
+                                blob storage
                               type: string
                             fsType:
+                              description: |-
+                                fsType is Filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             kind:
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage accoun'
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                           required:
                           - diskName
                           - diskURI
                           type: object
                         azureFile:
+                          description: azureFile represents an Azure File Service
+                            mount on the host and bind mount to the pod.
                           properties:
                             readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretName:
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
                               type: string
                             shareName:
+                              description: shareName is the azure share Name
                               type: string
                           required:
                           - secretName
                           - shareName
                           type: object
                         cephfs:
+                          description: cephFS represents a Ceph FS mount on the host
+                            that shares a pod's lifetime
                           properties:
                             monitors:
+                              description: |-
+                                monitors is Required: Monitors is a collection of Ceph monitors
+                                More info: https://examples.k8s.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretFile:
+                              description: 'secretFile is Optional: SecretFile is
+                                the path to key ring for User, default is /etc/ceph/user.'
                               type: string
                             secretRef:
+                              description: 'secretRef is Optional: SecretRef is reference
+                                to the authentication secret for User, default is
+                                empty.'
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             user:
+                              description: |-
+                                user is optional: User is the rados user name, default is admin
+                                More info: https://examples.k8s.
                               type: string
                           required:
                           - monitors
                           type: object
                         cinder:
+                          description: |-
+                            cinder represents a cinder volume attached and mounted on kubelets host machine.
+                            More info: https://examples.k8s.
                           properties:
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
+                              description: |-
+                                secretRef is optional: points to a secret object containing parameters used to connect
+                                to OpenStack.
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             volumeID:
+                              description: |-
+                                volumeID used to identify the volume in cinder.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                               type: string
                           required:
                           - volumeID
                           type: object
                         configMap:
+                          description: configMap represents a configMap that should
+                            populate this volume
                           properties:
                             defaultMode:
+                              description: 'defaultMode is optional: mode bits used
+                                to set permissions on created files by default.'
                               format: int32
                               type: integer
                             items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                ConfigMap will be projected into the volum
                               items:
+                                description: Maps a string key to a path within a
+                                  volume.
                                 properties:
                                   key:
+                                    description: key is the key to project.
                                     type: string
                                   mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file.'
                                     format: int32
                                     type: integer
                                   path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
                                     type: string
                                 required:
                                 - key
@@ -1293,67 +2061,121 @@ spec:
                               x-kubernetes-list-type: atomic
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
                               type: boolean
                           type: object
                           x-kubernetes-map-type: atomic
                         csi:
+                          description: csi (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers (Beta fea
                           properties:
                             driver:
+                              description: driver is the name of the CSI driver that
+                                handles this volume.
                               type: string
                             fsType:
+                              description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
                               type: string
                             nodePublishSecretRef:
+                              description: |-
+                                nodePublishSecretRef is a reference to the secret object containing
+                                sensitive information to pass to the CSI driver to c
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             readOnly:
+                              description: |-
+                                readOnly specifies a read-only configuration for the volume.
+                                Defaults to false (read/write).
                               type: boolean
                             volumeAttributes:
                               additionalProperties:
                                 type: string
+                              description: |-
+                                volumeAttributes stores driver-specific properties that are passed to the CSI
+                                driver.
                               type: object
                           required:
                           - driver
                           type: object
                         downwardAPI:
+                          description: downwardAPI represents downward API about the
+                            pod that should populate this volume
                           properties:
                             defaultMode:
+                              description: 'Optional: mode bits to use on created
+                                files by default.'
                               format: int32
                               type: integer
                             items:
+                              description: Items is a list of downward API volume
+                                file
                               items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
                                 properties:
                                   fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name, namespace
+                                      and uid are supported.'
                                     properties:
                                       apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
                                         type: string
                                     required:
                                     - fieldPath
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   mode:
+                                    description: |-
+                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal valu
                                     format: int32
                                     type: integer
                                   path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path.'
                                     type: string
                                   resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, requests.
                                     properties:
                                       containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                         - type: integer
                                         - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
+                                        description: 'Required: resource to select'
                                         type: string
                                     required:
                                     - resource
@@ -1366,36 +2188,63 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         emptyDir:
+                          description: |-
+                            emptyDir represents a temporary directory that shares a pod's lifetime.
+                            More info: https://kubernetes.
                           properties:
                             medium:
+                              description: medium represents what type of storage
+                                medium should back this directory.
                               type: string
                             sizeLimit:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: sizeLimit is the total amount of local
+                                storage required for this EmptyDir volume.
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
                         ephemeral:
+                          description: ephemeral represents a volume that is handled
+                            by a cluster storage driver.
                           properties:
                             volumeClaimTemplate:
+                              description: Will be used to create a stand-alone PVC
+                                to provision the volume.
                               properties:
                                 metadata:
+                                  description: |-
+                                    May contain labels and annotations that will be copied into the PVC
+                                    when creating it.
                                   type: object
                                 spec:
+                                  description: The specification for the PersistentVolumeClaim.
                                   properties:
                                     accessModes:
+                                      description: |-
+                                        accessModes contains the desired access modes the volume should have.
+                                        More info: https://kubernetes.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     dataSource:
+                                      description: |-
+                                        dataSource field can be used to specify either:
+                                        * An existing VolumeSnapshot object (snapshot.storage.k8s.
                                       properties:
                                         apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced.
                                           type: string
                                         kind:
+                                          description: Kind is the type of resource
+                                            being referenced
                                           type: string
                                         name:
+                                          description: Name is the name of resource
+                                            being referenced
                                           type: string
                                       required:
                                       - kind
@@ -1403,20 +2252,34 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                        volume is desired.
                                       properties:
                                         apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced.
                                           type: string
                                         kind:
+                                          description: Kind is the type of resource
+                                            being referenced
                                           type: string
                                         name:
+                                          description: Name is the name of resource
+                                            being referenced
                                           type: string
                                         namespace:
+                                          description: |-
+                                            Namespace is the namespace of resource being referenced
+                                            Note that when a namespace is specified, a gateway.networking.
                                           type: string
                                       required:
                                       - kind
                                       - name
                                       type: object
                                     resources:
+                                      description: resources represents the minimum
+                                        resources the volume should have.
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -1425,6 +2288,9 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.
                                           type: object
                                         requests:
                                           additionalProperties:
@@ -1433,18 +2299,36 @@ spec:
                                             - type: string
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
+                                          description: Requests describes the minimum
+                                            amount of compute resources required.
                                           type: object
                                       type: object
                                     selector:
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -1458,16 +2342,28 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     storageClassName:
+                                      description: |-
+                                        storageClassName is the name of the StorageClass required by the claim.
+                                        More info: https://kubernetes.
                                       type: string
                                     volumeAttributesClassName:
+                                      description: volumeAttributesClassName may be
+                                        used to set the VolumeAttributesClass used
+                                        by this claim.
                                       type: string
                                     volumeMode:
+                                      description: volumeMode defines what type of
+                                        volume is required by the claim.
                                       type: string
                                     volumeName:
+                                      description: volumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
                               required:
@@ -1475,41 +2371,78 @@ spec:
                               type: object
                           type: object
                         fc:
+                          description: fc represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
                           properties:
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             lun:
+                              description: 'lun is Optional: FC target lun number'
                               format: int32
                               type: integer
                             readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             wwids:
+                              description: "wwids Optional: FC volume world wide identifiers
+                                (wwids)\nEither wwids or combination of targetWWNs
+                                and lun must be set, "
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         flexVolume:
+                          description: |-
+                            flexVolume represents a generic volume resource that is
+                            provisioned/attached using an exec based plugin.
                           properties:
                             driver:
+                              description: driver is the name of the driver to use
+                                for this volume.
                               type: string
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             options:
                               additionalProperties:
                                 type: string
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
                               type: object
                             readOnly:
+                              description: |-
+                                readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
+                              description: |-
+                                secretRef is Optional: secretRef is reference to the secret object containing
+                                sensitive information to pass to the plugi
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
@@ -1517,90 +2450,170 @@ spec:
                           - driver
                           type: object
                         flocker:
+                          description: flocker represents a Flocker volume attached
+                            to a kubelet's host machine.
                           properties:
                             datasetName:
+                              description: |-
+                                datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                should be considered as depreca
                               type: string
                             datasetUUID:
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
                               type: string
                           type: object
                         gcePersistentDisk:
+                          description: |-
+                            gcePersistentDisk represents a GCE Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the po
                           properties:
                             fsType:
+                              description: fsType is filesystem type of the volume
+                                that you want to mount.
                               type: string
                             partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
                               format: int32
                               type: integer
                             pdName:
+                              description: |-
+                                pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                More info: https://kubernetes.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://kubernetes.
                               type: boolean
                           required:
                           - pdName
                           type: object
                         gitRepo:
+                          description: |-
+                            gitRepo represents a git repository at a particular revision.
+                            DEPRECATED: GitRepo is deprecated.
                           properties:
                             directory:
+                              description: |-
+                                directory is the target directory name.
+                                Must not contain or start with '..'.  If '.
                               type: string
                             repository:
+                              description: repository is the URL
                               type: string
                             revision:
+                              description: revision is the commit hash for the specified
+                                revision.
                               type: string
                           required:
                           - repository
                           type: object
                         glusterfs:
+                          description: |-
+                            glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                            More info: https://examples.k8s.
                           properties:
                             endpoints:
+                              description: |-
+                                endpoints is the endpoint name that details Glusterfs topology.
+                                More info: https://examples.k8s.
                               type: string
                             path:
+                              description: |-
+                                path is the Glusterfs volume path.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                Defaults to false.
                               type: boolean
                           required:
                           - endpoints
                           - path
                           type: object
                         hostPath:
+                          description: |-
+                            hostPath represents a pre-existing file or directory on the host
+                            machine that is directly exposed to the container.
                           properties:
                             path:
+                              description: |-
+                                path of the directory on the host.
+                                If the path is a symlink, it will follow the link to the real path.
                               type: string
                             type:
+                              description: |-
+                                type for HostPath Volume
+                                Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                               type: string
                           required:
                           - path
                           type: object
                         iscsi:
+                          description: |-
+                            iscsi represents an ISCSI Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
                           properties:
                             chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
                               type: boolean
                             chapAuthSession:
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
                               type: boolean
                             fsType:
+                              description: fsType is the filesystem type of the volume
+                                that you want to mount.
                               type: string
                             initiatorName:
+                              description: initiatorName is the custom iSCSI Initiator
+                                Name.
                               type: string
                             iqn:
+                              description: iqn is the target iSCSI Qualified Name.
                               type: string
                             iscsiInterface:
+                              description: |-
+                                iscsiInterface is the interface Name that uses an iSCSI transport.
+                                Defaults to 'default' (tcp).
                               type: string
                             lun:
+                              description: lun represents iSCSI Target Lun number.
                               format: int32
                               type: integer
                             portals:
+                              description: portals is the iSCSI Target Portal List.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
                               type: boolean
                             secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             targetPortal:
+                              description: targetPortal is iSCSI Target Portal.
                               type: string
                           required:
                           - iqn
@@ -1608,68 +2621,138 @@ spec:
                           - targetPortal
                           type: object
                         name:
+                          description: |-
+                            name of the volume.
+                            Must be a DNS_LABEL and unique within the pod.
+                            More info: https://kubernetes.
                           type: string
                         nfs:
+                          description: |-
+                            nfs represents an NFS mount on the host that shares a pod's lifetime
+                            More info: https://kubernetes.
                           properties:
                             path:
+                              description: |-
+                                path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly here will force the NFS export to be mounted with read-only permissions.
+                                Defaults to false.
                               type: boolean
                             server:
+                              description: |-
+                                server is the hostname or IP address of the NFS server.
+                                More info: https://kubernetes.
                               type: string
                           required:
                           - path
                           - server
                           type: object
                         persistentVolumeClaim:
+                          description: |-
+                            persistentVolumeClaimVolumeSource represents a reference to a
+                            PersistentVolumeClaim in the same namespace.
                           properties:
                             claimName:
+                              description: claimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
                               type: boolean
                           required:
                           - claimName
                           type: object
                         photonPersistentDisk:
+                          description: photonPersistentDisk represents a PhotonController
+                            persistent disk attached and mounted on kubelets host
+                            machine
                           properties:
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             pdID:
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
                               type: string
                           required:
                           - pdID
                           type: object
                         portworxVolume:
+                          description: portworxVolume represents a portworx volume
+                            attached and mounted on kubelets host machine
                           properties:
                             fsType:
+                              description: |-
+                                fSType represents the filesystem type to mount
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             volumeID:
+                              description: volumeID uniquely identifies a Portworx
+                                volume
                               type: string
                           required:
                           - volumeID
                           type: object
                         projected:
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
                           properties:
                             defaultMode:
+                              description: defaultMode are the mode bits used to set
+                                permissions on created files by default.
                               format: int32
                               type: integer
                             sources:
+                              description: sources is the list of volume projections
                               items:
+                                description: Projection that may be projected along
+                                  with other supported volume types
                                 properties:
                                   clusterTrustBundle:
+                                    description: ClusterTrustBundle allows a pod to
+                                      access the `.spec.
                                     properties:
                                       labelSelector:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this label selector.  Only has
+                                          effect if signerName is set.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
                                             items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1683,31 +2766,58 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs.
                                             type: object
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       name:
+                                        description: |-
+                                          Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                          with signerName and labelSelector.
                                         type: string
                                       optional:
+                                        description: |-
+                                          If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                          aren't available.
                                         type: boolean
                                       path:
+                                        description: Relative path from the volume
+                                          root to write the bundle.
                                         type: string
                                       signerName:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this signer name.
+                                          Mutually-exclusive with name.
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   configMap:
+                                    description: configMap information about the configMap
+                                      data to project
                                     properties:
                                       items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volum
                                         items:
+                                          description: Maps a string key to a path
+                                            within a volume.
                                           properties:
                                             key:
+                                              description: key is the key to project.
                                               type: string
                                             mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file.'
                                               format: int32
                                               type: integer
                                             path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
                                               type: string
                                           required:
                                           - key
@@ -1717,42 +2827,81 @@ spec:
                                         x-kubernetes-list-type: atomic
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                       optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   downwardAPI:
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
                                     properties:
                                       items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
                                         items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
                                           properties:
                                             fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name, namespace and uid are supported.'
                                               properties:
                                                 apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             mode:
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal valu
                                               format: int32
                                               type: integer
                                             path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path.'
                                               type: string
                                             resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.
                                               properties:
                                                 containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
@@ -1765,16 +2914,30 @@ spec:
                                         x-kubernetes-list-type: atomic
                                     type: object
                                   secret:
+                                    description: secret information about the secret
+                                      data to project
                                     properties:
                                       items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume a
                                         items:
+                                          description: Maps a string key to a path
+                                            within a volume.
                                           properties:
                                             key:
+                                              description: key is the key to project.
                                               type: string
                                             mode:
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file.'
                                               format: int32
                                               type: integer
                                             path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
                                               type: string
                                           required:
                                           - key
@@ -1784,19 +2947,35 @@ spec:
                                         x-kubernetes-list-type: atomic
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                       optional:
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
                                         type: boolean
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   serviceAccountToken:
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
                                     properties:
                                       audience:
+                                        description: audience is the intended audience
+                                          of the token.
                                         type: string
                                       expirationSeconds:
+                                        description: |-
+                                          expirationSeconds is the requested duration of validity of the service
+                                          account token.
                                         format: int64
                                         type: integer
                                       path:
+                                        description: |-
+                                          path is the path relative to the mount point of the file to project the
+                                          token into.
                                         type: string
                                     required:
                                     - path
@@ -1806,79 +2985,164 @@ spec:
                               x-kubernetes-list-type: atomic
                           type: object
                         quobyte:
+                          description: quobyte represents a Quobyte mount on the host
+                            that shares a pod's lifetime
                           properties:
                             group:
+                              description: |-
+                                group to map volume access to
+                                Default is no group
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                Defaults to false.
                               type: boolean
                             registry:
+                              description: |-
+                                registry represents a single or multiple Quobyte Registry services
+                                specified as a string as host:port pair (multiple ent
                               type: string
                             tenant:
+                              description: |-
+                                tenant owning the given Quobyte volume in the Backend
+                                Used with dynamically provisioned Quobyte volumes, value is set by
                               type: string
                             user:
+                              description: |-
+                                user to map volume access to
+                                Defaults to serivceaccount user
                               type: string
                             volume:
+                              description: volume is a string that references an already
+                                created Quobyte volume by name.
                               type: string
                           required:
                           - registry
                           - volume
                           type: object
                         rbd:
+                          description: |-
+                            rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                            More info: https://examples.k8s.
                           properties:
                             fsType:
+                              description: fsType is the filesystem type of the volume
+                                that you want to mount.
                               type: string
                             image:
+                              description: |-
+                                image is the rados image name.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                               type: string
                             keyring:
+                              description: |-
+                                keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring.
+                                More info: https://examples.k8s.
                               type: string
                             monitors:
+                              description: |-
+                                monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             pool:
+                              description: |-
+                                pool is the rados pool name.
+                                Default is rbd.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://examples.k8s.
                               type: boolean
                             secretRef:
+                              description: |-
+                                secretRef is name of the authentication secret for RBDUser. If provided
+                                overrides keyring.
+                                Default is nil.
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             user:
+                              description: |-
+                                user is the rados user name.
+                                Default is admin.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                               type: string
                           required:
                           - image
                           - monitors
                           type: object
                         scaleIO:
+                          description: scaleIO represents a ScaleIO persistent volume
+                            attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             gateway:
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
                               type: string
                             protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
+                              description: |-
+                                secretRef references to the secret for ScaleIO user and other
+                                sensitive information.
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication
+                                with Gateway, default false
                               type: boolean
                             storageMode:
+                              description: storageMode indicates whether the storage
+                                for a volume should be ThickProvisioned or ThinProvisioned.
                               type: string
                             storagePool:
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
                               type: string
                             system:
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
                               type: string
                             volumeName:
+                              description: |-
+                                volumeName is the name of a volume already created in the ScaleIO system
+                                that is associated with this volume source.
                               type: string
                           required:
                           - gateway
@@ -1886,19 +3150,35 @@ spec:
                           - system
                           type: object
                         secret:
+                          description: |-
+                            secret represents a secret that should populate this volume.
+                            More info: https://kubernetes.
                           properties:
                             defaultMode:
+                              description: 'defaultMode is Optional: mode bits used
+                                to set permissions on created files by default.'
                               format: int32
                               type: integer
                             items:
+                              description: |-
+                                items If unspecified, each key-value pair in the Data field of the referenced
+                                Secret will be projected into the volume a
                               items:
+                                description: Maps a string key to a path within a
+                                  volume.
                                 properties:
                                   key:
+                                    description: key is the key to project.
                                     type: string
                                   mode:
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file.'
                                     format: int32
                                     type: integer
                                   path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
                                     type: string
                                 required:
                                 - key
@@ -1907,37 +3187,75 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             optional:
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
                               type: boolean
                             secretName:
+                              description: |-
+                                secretName is the name of the secret in the pod's namespace to use.
+                                More info: https://kubernetes.
                               type: string
                           type: object
                         storageos:
+                          description: storageOS represents a StorageOS volume attached
+                            and mounted on Kubernetes nodes.
                           properties:
                             fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
+                              description: |-
+                                secretRef specifies the secret to use for obtaining the StorageOS API
+                                credentials.
                               properties:
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             volumeName:
+                              description: |-
+                                volumeName is the human-readable name of the StorageOS volume.  Volume
+                                names are only unique within a namespace.
                               type: string
                             volumeNamespace:
+                              description: volumeNamespace specifies the scope of
+                                the volume within StorageOS.
                               type: string
                           type: object
                         vsphereVolume:
+                          description: vsphereVolume represents a vSphere volume attached
+                            and mounted on kubelets host machine
                           properties:
                             fsType:
+                              description: |-
+                                fsType is filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex.
                               type: string
                             storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
                               type: string
                             storagePolicyName:
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
                               type: string
                             volumePath:
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
                               type: string
                           required:
                           - volumePath
@@ -1951,24 +3269,44 @@ spec:
             - feastProject
             type: object
           status:
+            description: FeatureStoreStatus defines the observed state of FeatureStore
             properties:
               applied:
+                description: Shows the currently applied feast configuration, including
+                  any pertinent defaults
                 properties:
                   authz:
+                    description: AuthzConfig defines the authorization settings for
+                      the deployed Feast services.
                     properties:
                       kubernetes:
+                        description: |-
+                          KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.
+                          https://kubernetes.
                         properties:
                           roles:
+                            description: The Kubernetes RBAC roles to be deployed
+                              in the same namespace of the FeatureStore.
                             items:
                               type: string
                             type: array
                         type: object
                       oidc:
+                        description: |-
+                          OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.
+                          https://auth0.
                         properties:
                           secretRef:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1981,45 +3319,75 @@ spec:
                       rule: '[has(self.kubernetes), has(self.oidc)].exists_one(c,
                         c)'
                   feastProject:
+                    description: FeastProject is the Feast project id.
                     pattern: ^[A-Za-z0-9][A-Za-z0-9_]*$
                     type: string
                   services:
+                    description: FeatureStoreServices defines the desired feast services.
+                      An ephemeral registry is deployed by default.
                     properties:
                       deploymentStrategy:
+                        description: DeploymentStrategy describes how to replace existing
+                          pods with new ones.
                         properties:
                           rollingUpdate:
+                            description: |-
+                              Rolling update config params. Present only if DeploymentStrategyType =
+                              RollingUpdate.
                             properties:
                               maxSurge:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                description: |-
+                                  The maximum number of pods that can be scheduled above the desired number of
+                                  pods.
                                 x-kubernetes-int-or-string: true
                               maxUnavailable:
                                 anyOf:
                                 - type: integer
                                 - type: string
+                                description: The maximum number of pods that can be
+                                  unavailable during the update.
                                 x-kubernetes-int-or-string: true
                             type: object
                           type:
+                            description: Type of deployment. Can be "Recreate" or
+                              "RollingUpdate". Default is RollingUpdate.
                             type: string
                         type: object
                       disableInitContainers:
+                        description: Disable the 'feast repo initialization' initContainer
                         type: boolean
                       offlineStore:
+                        description: OfflineStore configures the deployed offline
+                          store service
                         properties:
                           persistence:
+                            description: OfflineStorePersistence configures the persistence
+                              settings for the offline store service
                             properties:
                               file:
+                                description: OfflineStoreFilePersistence configures
+                                  the file-based persistence for the offline store
+                                  service
                                 properties:
                                   pvc:
+                                    description: PvcConfig defines the settings for
+                                      a persistent file store based on PVCs.
                                     properties:
                                       create:
+                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
+                                            description: AccessModes k8s persistent
+                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
+                                            description: Resources describes the storage
+                                              resource requirements for a volume.
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -2028,6 +3396,9 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -2036,20 +3407,34 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: Requests describes the
+                                                  minimum amount of compute resources
+                                                  required.
                                                 type: object
                                             type: object
                                           storageClassName:
+                                            description: StorageClassName is the name
+                                              of an existing StorageClass to which
+                                              this persistent volume belongs.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
+                                        description: |-
+                                          MountPath within the container at which the volume should be mounted.
+                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
+                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -2072,17 +3457,30 @@ spec:
                                     type: string
                                 type: object
                               store:
+                                description: OfflineStoreDBStorePersistence configures
+                                  the DB store persistence for the offline store service
                                 properties:
                                   secretKeyName:
+                                    description: By default, the selected store "type"
+                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
+                                    description: Data store parameters should be placed
+                                      as-is from the "feature_store.yaml" under the
+                                      secret key.
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   type:
+                                    description: Type of the persistence type you
+                                      want to use.
                                     enum:
                                     - snowflake.offline
                                     - bigquery
@@ -2103,63 +3501,111 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           server:
+                            description: Creates a remote offline server container
                             properties:
                               env:
                                 items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
                                   properties:
                                     name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
                                       type: string
                                     value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any
                                       type: string
                                     valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
                                       properties:
                                         configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
                                           properties:
                                             key:
+                                              description: The key to select.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
+                                          description: 'Selects a field of the pod:
+                                            supports metadata.name, metadata.namespace,
+                                            `metadata.labels[''<KEY>'']`, `metadata.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to
+                                                select'
                                               type: string
                                           required:
                                           - resource
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
                                           properties:
                                             key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
@@ -2172,24 +3618,42 @@ spec:
                                 type: array
                               envFrom:
                                 items:
+                                  description: EnvFromSource represents the source
+                                    of a set of ConfigMaps
                                   properties:
                                     configMapRef:
+                                      description: The ConfigMap to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
+                                      description: An optional identifier to prepend
+                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
+                                      description: The Secret to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -2198,8 +3662,13 @@ spec:
                               image:
                                 type: string
                               imagePullPolicy:
+                                description: PullPolicy describes a policy for if/when
+                                  to pull a container image
                                 type: string
                               logLevel:
+                                description: |-
+                                  LogLevel sets the logging level for the server
+                                  Allowed values: "debug", "info", "warning", "error", "critical".
                                 enum:
                                 - debug
                                 - info
@@ -2208,11 +3677,21 @@ spec:
                                 - critical
                                 type: string
                               resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
                                 properties:
                                   claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
                                     items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
                                       properties:
                                         name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used.
                                           type: string
                                       required:
                                       - name
@@ -2228,6 +3707,9 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -2236,23 +3718,40 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: Requests describes the minimum amount
+                                      of compute resources required.
                                     type: object
                                 type: object
                               tls:
+                                description: TlsConfigs configures server TLS for
+                                  a feast service.
                                 properties:
                                   disable:
+                                    description: will disable TLS for the feast service.
+                                      useful in an openshift cluster, for example,
+                                      where TLS is configured by default
                                     type: boolean
                                   secretKeyNames:
+                                    description: SecretKeyNames defines the secret
+                                      key names for the TLS key and cert.
                                     properties:
                                       tlsCrt:
+                                        description: defaults to "tls.crt"
                                         type: string
                                       tlsKey:
+                                        description: defaults to "tls.key"
                                         type: string
                                     type: object
                                   secretRef:
+                                    description: references the local k8s secret where
+                                      the TLS key and cert reside
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2262,21 +3761,44 @@ spec:
                                   rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                     : true'
                               volumeMounts:
+                                description: VolumeMounts defines the list of volumes
+                                  that should be mounted into the feast container.
                                 items:
+                                  description: VolumeMount describes a mounting of
+                                    a Volume within a container.
                                   properties:
                                     mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
                                       type: string
                                     mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
                                       type: string
                                     name:
+                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
                                       type: boolean
                                     recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
                                       type: string
                                     subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
                                       type: string
                                     subPathExpr:
+                                      description: Expanded path within the volume
+                                        from which the container's volume should be
+                                        mounted.
                                       type: string
                                   required:
                                   - mountPath
@@ -2286,22 +3808,36 @@ spec:
                             type: object
                         type: object
                       onlineStore:
+                        description: OnlineStore configures the deployed online store
+                          service
                         properties:
                           persistence:
+                            description: OnlineStorePersistence configures the persistence
+                              settings for the online store service
                             properties:
                               file:
+                                description: OnlineStoreFilePersistence configures
+                                  the file-based persistence for the online store
+                                  service
                                 properties:
                                   path:
                                     type: string
                                   pvc:
+                                    description: PvcConfig defines the settings for
+                                      a persistent file store based on PVCs.
                                     properties:
                                       create:
+                                        description: Settings for creating a new PVC
                                         properties:
                                           accessModes:
+                                            description: AccessModes k8s persistent
+                                              volume access modes. Defaults to ["ReadWriteOnce"].
                                             items:
                                               type: string
                                             type: array
                                           resources:
+                                            description: Resources describes the storage
+                                              resource requirements for a volume.
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -2310,6 +3846,9 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -2318,20 +3857,34 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
+                                                description: Requests describes the
+                                                  minimum amount of compute resources
+                                                  required.
                                                 type: object
                                             type: object
                                           storageClassName:
+                                            description: StorageClassName is the name
+                                              of an existing StorageClass to which
+                                              this persistent volume belongs.
                                             type: string
                                         type: object
                                         x-kubernetes-validations:
                                         - message: PvcCreate is immutable
                                           rule: self == oldSelf
                                       mountPath:
+                                        description: |-
+                                          MountPath within the container at which the volume should be mounted.
+                                          Must start by "/" and cannot contain ':'.
                                         type: string
                                       ref:
+                                        description: Reference to an existing field
                                         properties:
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -2360,17 +3913,30 @@ spec:
                                   rule: 'has(self.path) ? !(self.path.startsWith(''s3://'')
                                     || self.path.startsWith(''gs://'')) : true'
                               store:
+                                description: OnlineStoreDBStorePersistence configures
+                                  the DB store persistence for the online store service
                                 properties:
                                   secretKeyName:
+                                    description: By default, the selected store "type"
+                                      is used as the SecretKeyName
                                     type: string
                                   secretRef:
+                                    description: Data store parameters should be placed
+                                      as-is from the "feature_store.yaml" under the
+                                      secret key.
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   type:
+                                    description: Type of the persistence type you
+                                      want to use.
                                     enum:
                                     - snowflake.online
                                     - redis
@@ -2399,63 +3965,111 @@ spec:
                               rule: '[has(self.file), has(self.store)].exists_one(c,
                                 c)'
                           server:
+                            description: Creates a feature server container
                             properties:
                               env:
                                 items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
                                   properties:
                                     name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
                                       type: string
                                     value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any
                                       type: string
                                     valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
                                       properties:
                                         configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
                                           properties:
                                             key:
+                                              description: The key to select.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
+                                          description: 'Selects a field of the pod:
+                                            supports metadata.name, metadata.namespace,
+                                            `metadata.labels[''<KEY>'']`, `metadata.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to
+                                                select'
                                               type: string
                                           required:
                                           - resource
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
                                           properties:
                                             key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
                                               type: string
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                           - key
@@ -2468,24 +4082,42 @@ spec:
                                 type: array
                               envFrom:
                                 items:
+                                  description: EnvFromSource represents the source
+                                    of a set of ConfigMaps
                                   properties:
                                     configMapRef:
+                                      description: The ConfigMap to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
+                                      description: An optional identifier to prepend
+                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
+                                      description: The Secret to select from
                                       properties:
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            must be defined
                                           type: boolean
                                       type: object
                                       x-kubernetes-map-type: atomic
@@ -2494,8 +4126,13 @@ spec:
                               image:
                                 type: string
                               imagePullPolicy:
+                                description: PullPolicy describes a policy for if/when
+                                  to pull a container image
                                 type: string
                               logLevel:
+                                description: |-
+                                  LogLevel sets the logging level for the server
+                                  Allowed values: "debug", "info", "warning", "error", "critical".
                                 enum:
                                 - debug
                                 - info
@@ -2504,11 +4141,21 @@ spec:
                                 - critical
                                 type: string
                               resources:
+                                description: ResourceRequirements describes the compute
+                                  resource requirements.
                                 properties:
                                   claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
                                     items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
                                       properties:
                                         name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used.
                                           type: string
                                       required:
                                       - name
@@ -2524,6 +4171,9 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -2532,23 +4182,40 @@ spec:
                                       - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: Requests describes the minimum amount
+                                      of compute resources required.
                                     type: object
                                 type: object
                               tls:
+                                description: TlsConfigs configures server TLS for
+                                  a feast service.
                                 properties:
                                   disable:
+                                    description: will disable TLS for the feast service.
+                                      useful in an openshift cluster, for example,
+                                      where TLS is configured by default
                                     type: boolean
                                   secretKeyNames:
+                                    description: SecretKeyNames defines the secret
+                                      key names for the TLS key and cert.
                                     properties:
                                       tlsCrt:
+                                        description: defaults to "tls.crt"
                                         type: string
                                       tlsKey:
+                                        description: defaults to "tls.key"
                                         type: string
                                     type: object
                                   secretRef:
+                                    description: references the local k8s secret where
+                                      the TLS key and cert reside
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2558,21 +4225,44 @@ spec:
                                   rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                     : true'
                               volumeMounts:
+                                description: VolumeMounts defines the list of volumes
+                                  that should be mounted into the feast container.
                                 items:
+                                  description: VolumeMount describes a mounting of
+                                    a Volume within a container.
                                   properties:
                                     mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
                                       type: string
                                     mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
                                       type: string
                                     name:
+                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
                                       type: boolean
                                     recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
                                       type: string
                                     subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
                                       type: string
                                     subPathExpr:
+                                      description: Expanded path within the volume
+                                        from which the container's volume should be
+                                        mounted.
                                       type: string
                                   required:
                                   - mountPath
@@ -2582,24 +4272,43 @@ spec:
                             type: object
                         type: object
                       registry:
+                        description: Registry configures the registry service. One
+                          selection is required. Local is the default setting.
                         properties:
                           local:
+                            description: LocalRegistryConfig configures the deployed
+                              registry service
                             properties:
                               persistence:
+                                description: RegistryPersistence configures the persistence
+                                  settings for the registry service
                                 properties:
                                   file:
+                                    description: RegistryFilePersistence configures
+                                      the file-based persistence for the registry
+                                      service
                                     properties:
                                       path:
                                         type: string
                                       pvc:
+                                        description: PvcConfig defines the settings
+                                          for a persistent file store based on PVCs.
                                         properties:
                                           create:
+                                            description: Settings for creating a new
+                                              PVC
                                             properties:
                                               accessModes:
+                                                description: AccessModes k8s persistent
+                                                  volume access modes. Defaults to
+                                                  ["ReadWriteOnce"].
                                                 items:
                                                   type: string
                                                 type: array
                                               resources:
+                                                description: Resources describes the
+                                                  storage resource requirements for
+                                                  a volume.
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -2608,6 +4317,9 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
+                                                    description: |-
+                                                      Limits describes the maximum amount of compute resources allowed.
+                                                      More info: https://kubernetes.
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -2616,20 +4328,36 @@ spec:
                                                       - type: string
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
+                                                    description: Requests describes
+                                                      the minimum amount of compute
+                                                      resources required.
                                                     type: object
                                                 type: object
                                               storageClassName:
+                                                description: StorageClassName is the
+                                                  name of an existing StorageClass
+                                                  to which this persistent volume
+                                                  belongs.
                                                 type: string
                                             type: object
                                             x-kubernetes-validations:
                                             - message: PvcCreate is immutable
                                               rule: self == oldSelf
                                           mountPath:
+                                            description: |-
+                                              MountPath within the container at which the volume should be mounted.
+                                              Must start by "/" and cannot contain ':'.
                                             type: string
                                           ref:
+                                            description: Reference to an existing
+                                              field
                                             properties:
                                               name:
                                                 default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty.
                                                 type: string
                                             type: object
                                             x-kubernetes-map-type: atomic
@@ -2669,17 +4397,30 @@ spec:
                                       rule: '(has(self.s3_additional_kwargs) && has(self.path))
                                         ? self.path.startsWith(''s3://'') : true'
                                   store:
+                                    description: RegistryDBStorePersistence configures
+                                      the DB store persistence for the registry service
                                     properties:
                                       secretKeyName:
+                                        description: By default, the selected store
+                                          "type" is used as the SecretKeyName
                                         type: string
                                       secretRef:
+                                        description: Data store parameters should
+                                          be placed as-is from the "feature_store.yaml"
+                                          under the secret key.
                                         properties:
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       type:
+                                        description: Type of the persistence type
+                                          you want to use.
                                         enum:
                                         - sql
                                         - snowflake.registry
@@ -2695,63 +4436,113 @@ spec:
                                   rule: '[has(self.file), has(self.store)].exists_one(c,
                                     c)'
                               server:
+                                description: Creates a registry server container
                                 properties:
                                   env:
                                     items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
                                       properties:
                                         name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any
                                           type: string
                                         valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
                                           properties:
                                             configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
+                                                  description: The key to select.
                                                   type: string
                                                 name:
                                                   default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty.
                                                   type: string
                                                 optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                `metadata.labels[''<KEY>'']`, `metadata.'
                                               properties:
                                                 apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.
                                               properties:
                                                 containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
+                                                  description: 'Required: resource
+                                                    to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
                                               properties:
                                                 key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
                                                   type: string
                                                 name:
                                                   default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty.
                                                   type: string
                                                 optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -2764,24 +4555,43 @@ spec:
                                     type: array
                                   envFrom:
                                     items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
                                       properties:
                                         configMapRef:
+                                          description: The ConfigMap to select from
                                           properties:
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
                                               type: boolean
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
                                           type: string
                                         secretRef:
+                                          description: The Secret to select from
                                           properties:
                                             name:
                                               default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty.
                                               type: string
                                             optional:
+                                              description: Specify whether the Secret
+                                                must be defined
                                               type: boolean
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -2790,8 +4600,13 @@ spec:
                                   image:
                                     type: string
                                   imagePullPolicy:
+                                    description: PullPolicy describes a policy for
+                                      if/when to pull a container image
                                     type: string
                                   logLevel:
+                                    description: |-
+                                      LogLevel sets the logging level for the server
+                                      Allowed values: "debug", "info", "warning", "error", "critical".
                                     enum:
                                     - debug
                                     - info
@@ -2800,11 +4615,21 @@ spec:
                                     - critical
                                     type: string
                                   resources:
+                                    description: ResourceRequirements describes the
+                                      compute resource requirements.
                                     properties:
                                       claims:
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
                                         items:
+                                          description: ResourceClaim references one
+                                            entry in PodSpec.ResourceClaims.
                                           properties:
                                             name:
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used.
                                               type: string
                                           required:
                                           - name
@@ -2820,6 +4645,9 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2828,23 +4656,41 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: Requests describes the minimum
+                                          amount of compute resources required.
                                         type: object
                                     type: object
                                   tls:
+                                    description: TlsConfigs configures server TLS
+                                      for a feast service.
                                     properties:
                                       disable:
+                                        description: will disable TLS for the feast
+                                          service. useful in an openshift cluster,
+                                          for example, where TLS is configured by
+                                          default
                                         type: boolean
                                       secretKeyNames:
+                                        description: SecretKeyNames defines the secret
+                                          key names for the TLS key and cert.
                                         properties:
                                           tlsCrt:
+                                            description: defaults to "tls.crt"
                                             type: string
                                           tlsKey:
+                                            description: defaults to "tls.key"
                                             type: string
                                         type: object
                                       secretRef:
+                                        description: references the local k8s secret
+                                          where the TLS key and cert reside
                                         properties:
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -2855,21 +4701,46 @@ spec:
                                       rule: '(!has(self.disable) || !self.disable)
                                         ? has(self.secretRef) : true'
                                   volumeMounts:
+                                    description: VolumeMounts defines the list of
+                                      volumes that should be mounted into the feast
+                                      container.
                                     items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
                                       properties:
                                         mountPath:
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
+                                            not contain ':'.
                                           type: string
                                         mountPropagation:
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
+                                            to container and the other way around.
                                           type: string
                                         name:
+                                          description: This must match the Name of
+                                            a Volume.
                                           type: string
                                         readOnly:
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                                            Defaults to false.
                                           type: boolean
                                         recursiveReadOnly:
+                                          description: |-
+                                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                                            recursively.
                                           type: string
                                         subPath:
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted.
                                           type: string
                                       required:
                                       - mountPath
@@ -2879,26 +4750,44 @@ spec:
                                 type: object
                             type: object
                           remote:
+                            description: RemoteRegistryConfig points to a remote feast
+                              registry server.
                             properties:
                               feastRef:
+                                description: Reference to an existing `FeatureStore`
+                                  CR in the same k8s cluster.
                                 properties:
                                   name:
+                                    description: Name of the FeatureStore
                                     type: string
                                   namespace:
+                                    description: Namespace of the FeatureStore
                                     type: string
                                 required:
                                 - name
                                 type: object
                               hostname:
+                                description: Host address of the remote registry service
+                                  - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`
                                 type: string
                               tls:
+                                description: TlsRemoteRegistryConfigs configures client
+                                  TLS for a remote feast registry.
                                 properties:
                                   certName:
+                                    description: defines the configmap key name for
+                                      the client TLS cert.
                                     type: string
                                   configMapRef:
+                                    description: references the local k8s configmap
+                                      where the TLS cert resides
                                     properties:
                                       name:
                                         default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty.
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2917,63 +4806,108 @@ spec:
                           rule: '[has(self.local), has(self.remote)].exists_one(c,
                             c)'
                       ui:
+                        description: Creates a UI server container
                         properties:
                           env:
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
                                           type: string
                                       required:
                                       - fieldPath
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                           - type: integer
                                           - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                       - resource
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
                                           default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty.
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                       - key
@@ -2986,24 +4920,42 @@ spec:
                             type: array
                           envFrom:
                             items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must
+                                        be defined
                                       type: boolean
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3012,8 +4964,13 @@ spec:
                           image:
                             type: string
                           imagePullPolicy:
+                            description: PullPolicy describes a policy for if/when
+                              to pull a container image
                             type: string
                           logLevel:
+                            description: |-
+                              LogLevel sets the logging level for the server
+                              Allowed values: "debug", "info", "warning", "error", "critical".
                             enum:
                             - debug
                             - info
@@ -3022,11 +4979,21 @@ spec:
                             - critical
                             type: string
                           resources:
+                            description: ResourceRequirements describes the compute
+                              resource requirements.
                             properties:
                               claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
                                 items:
+                                  description: ResourceClaim references one entry
+                                    in PodSpec.ResourceClaims.
                                   properties:
                                     name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used.
                                       type: string
                                   required:
                                   - name
@@ -3042,6 +5009,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3050,23 +5020,40 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           tls:
+                            description: TlsConfigs configures server TLS for a feast
+                              service.
                             properties:
                               disable:
+                                description: will disable TLS for the feast service.
+                                  useful in an openshift cluster, for example, where
+                                  TLS is configured by default
                                 type: boolean
                               secretKeyNames:
+                                description: SecretKeyNames defines the secret key
+                                  names for the TLS key and cert.
                                 properties:
                                   tlsCrt:
+                                    description: defaults to "tls.crt"
                                     type: string
                                   tlsKey:
+                                    description: defaults to "tls.key"
                                     type: string
                                 type: object
                               secretRef:
+                                description: references the local k8s secret where
+                                  the TLS key and cert reside
                                 properties:
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
@@ -3076,21 +5063,43 @@ spec:
                               rule: '(!has(self.disable) || !self.disable) ? has(self.secretRef)
                                 : true'
                           volumeMounts:
+                            description: VolumeMounts defines the list of volumes
+                              that should be mounted into the feast container.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
                                   type: boolean
                                 recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
                                   type: string
                                 subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
                                   type: string
                               required:
                               - mountPath
@@ -3099,109 +5108,210 @@ spec:
                             type: array
                         type: object
                       volumes:
+                        description: Volumes specifies the volumes to mount in the
+                          FeatureStore deployment.
                         items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
+                              description: |-
+                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                kubelet's host machine and then exposed to th
                               properties:
                                 fsType:
+                                  description: fsType is the filesystem type of the
+                                    volume that you want to mount.
                                   type: string
                                 partition:
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
                                   format: int32
                                   type: integer
                                 readOnly:
+                                  description: |-
+                                    readOnly value true will force the readOnly setting in VolumeMounts.
+                                    More info: https://kubernetes.
                                   type: boolean
                                 volumeID:
+                                  description: |-
+                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                    More info: https://kubernetes.
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
+                              description: azureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
                                   type: string
                                 diskURI:
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
                                   type: string
                                 fsType:
+                                  description: |-
+                                    fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 kind:
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage accoun'
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
+                              description: azureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
+                              description: cephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
                               properties:
                                 monitors:
+                                  description: |-
+                                    monitors is Required: Monitors is a collection of Ceph monitors
+                                    More info: https://examples.k8s.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretFile:
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.'
                                   type: string
                                 secretRef:
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty.'
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
+                                  description: |-
+                                    user is optional: User is the rados user name, default is admin
+                                    More info: https://examples.k8s.
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
+                              description: |-
+                                cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                More info: https://examples.k8s.
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
+                                  description: |-
+                                    secretRef is optional: points to a secret object containing parameters used to connect
+                                    to OpenStack.
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeID:
+                                  description: |-
+                                    volumeID used to identify the volume in cinder.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
+                              description: configMap represents a configMap that should
+                                populate this volume
                               properties:
                                 defaultMode:
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.'
                                   format: int32
                                   type: integer
                                 items:
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volum
                                   items:
+                                    description: Maps a string key to a path within
+                                      a volume.
                                     properties:
                                       key:
+                                        description: key is the key to project.
                                         type: string
                                       mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file.'
                                         format: int32
                                         type: integer
                                       path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
                                         type: string
                                     required:
                                     - key
@@ -3211,67 +5321,125 @@ spec:
                                   x-kubernetes-list-type: atomic
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
                                   type: boolean
                               type: object
                               x-kubernetes-map-type: atomic
                             csi:
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers (Beta fea
                               properties:
                                 driver:
+                                  description: driver is the name of the CSI driver
+                                    that handles this volume.
                                   type: string
                                 fsType:
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs".
                                   type: string
                                 nodePublishSecretRef:
+                                  description: |-
+                                    nodePublishSecretRef is a reference to the secret object containing
+                                    sensitive information to pass to the CSI driver to c
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 readOnly:
+                                  description: |-
+                                    readOnly specifies a read-only configuration for the volume.
+                                    Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
+                                  description: |-
+                                    volumeAttributes stores driver-specific properties that are passed to the CSI
+                                    driver.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
                               properties:
                                 defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default.'
                                   format: int32
                                   type: integer
                                 items:
+                                  description: Items is a list of downward API volume
+                                    file
                                   items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
                                     properties:
                                       fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name,
+                                          namespace and uid are supported.'
                                         properties:
                                           apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
                                             type: string
                                           fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       mode:
+                                        description: |-
+                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                          between 0000 and 0777 or a decimal valu
                                         format: int32
                                         type: integer
                                       path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.'
                                         type: string
                                       resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, requests.
                                         properties:
                                           containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
+                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -3284,36 +5452,63 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             emptyDir:
+                              description: |-
+                                emptyDir represents a temporary directory that shares a pod's lifetime.
+                                More info: https://kubernetes.
                               properties:
                                 medium:
+                                  description: medium represents what type of storage
+                                    medium should back this directory.
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
+                              description: ephemeral represents a volume that is handled
+                                by a cluster storage driver.
                               properties:
                                 volumeClaimTemplate:
+                                  description: Will be used to create a stand-alone
+                                    PVC to provision the volume.
                                   properties:
                                     metadata:
+                                      description: |-
+                                        May contain labels and annotations that will be copied into the PVC
+                                        when creating it.
                                       type: object
                                     spec:
+                                      description: The specification for the PersistentVolumeClaim.
                                       properties:
                                         accessModes:
+                                          description: |-
+                                            accessModes contains the desired access modes the volume should have.
+                                            More info: https://kubernetes.
                                           items:
                                             type: string
                                           type: array
                                           x-kubernetes-list-type: atomic
                                         dataSource:
+                                          description: |-
+                                            dataSource field can be used to specify either:
+                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.
                                           properties:
                                             apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced.
                                               type: string
                                             kind:
+                                              description: Kind is the type of resource
+                                                being referenced
                                               type: string
                                             name:
+                                              description: Name is the name of resource
+                                                being referenced
                                               type: string
                                           required:
                                           - kind
@@ -3321,20 +5516,34 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         dataSourceRef:
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                            volume is desired.
                                           properties:
                                             apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced.
                                               type: string
                                             kind:
+                                              description: Kind is the type of resource
+                                                being referenced
                                               type: string
                                             name:
+                                              description: Name is the name of resource
+                                                being referenced
                                               type: string
                                             namespace:
+                                              description: |-
+                                                Namespace is the namespace of resource being referenced
+                                                Note that when a namespace is specified, a gateway.networking.
                                               type: string
                                           required:
                                           - kind
                                           - name
                                           type: object
                                         resources:
+                                          description: resources represents the minimum
+                                            resources the volume should have.
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -3343,6 +5552,9 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
+                                              description: |-
+                                                Limits describes the maximum amount of compute resources allowed.
+                                                More info: https://kubernetes.
                                               type: object
                                             requests:
                                               additionalProperties:
@@ -3351,18 +5563,38 @@ spec:
                                                 - type: string
                                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                 x-kubernetes-int-or-string: true
+                                              description: Requests describes the
+                                                minimum amount of compute resources
+                                                required.
                                               type: object
                                           type: object
                                         selector:
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
                                               items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
                                                 properties:
                                                   key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
                                                     type: string
                                                   operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3376,16 +5608,28 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs.
                                               type: object
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         storageClassName:
+                                          description: |-
+                                            storageClassName is the name of the StorageClass required by the claim.
+                                            More info: https://kubernetes.
                                           type: string
                                         volumeAttributesClassName:
+                                          description: volumeAttributesClassName may
+                                            be used to set the VolumeAttributesClass
+                                            used by this claim.
                                           type: string
                                         volumeMode:
+                                          description: volumeMode defines what type
+                                            of volume is required by the claim.
                                           type: string
                                         volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -3393,41 +5637,78 @@ spec:
                                   type: object
                               type: object
                             fc:
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 lun:
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 wwids:
+                                  description: "wwids Optional: FC volume world wide
+                                    identifiers (wwids)\nEither wwids or combination
+                                    of targetWWNs and lun must be set, "
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             flexVolume:
+                              description: |-
+                                flexVolume represents a generic volume resource that is
+                                provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
+                                  description: driver is the name of the driver to
+                                    use for this volume.
                                   type: string
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
                                   type: object
                                 readOnly:
+                                  description: |-
+                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
+                                  description: |-
+                                    secretRef is Optional: secretRef is reference to the secret object containing
+                                    sensitive information to pass to the plugi
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3435,90 +5716,171 @@ spec:
                               - driver
                               type: object
                             flocker:
+                              description: flocker represents a Flocker volume attached
+                                to a kubelet's host machine.
                               properties:
                                 datasetName:
+                                  description: |-
+                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                    should be considered as depreca
                                   type: string
                                 datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
+                              description: |-
+                                gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the po
                               properties:
                                 fsType:
+                                  description: fsType is filesystem type of the volume
+                                    that you want to mount.
                                   type: string
                                 partition:
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
                                   format: int32
                                   type: integer
                                 pdName:
+                                  description: |-
+                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                    More info: https://kubernetes.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://kubernetes.
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
+                              description: |-
+                                gitRepo represents a git repository at a particular revision.
+                                DEPRECATED: GitRepo is deprecated.
                               properties:
                                 directory:
+                                  description: |-
+                                    directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.
                                   type: string
                                 repository:
+                                  description: repository is the URL
                                   type: string
                                 revision:
+                                  description: revision is the commit hash for the
+                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
+                              description: |-
+                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.
                               properties:
                                 endpoints:
+                                  description: |-
+                                    endpoints is the endpoint name that details Glusterfs topology.
+                                    More info: https://examples.k8s.
                                   type: string
                                 path:
+                                  description: |-
+                                    path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                    Defaults to false.
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
+                              description: |-
+                                hostPath represents a pre-existing file or directory on the host
+                                machine that is directly exposed to the container.
                               properties:
                                 path:
+                                  description: |-
+                                    path of the directory on the host.
+                                    If the path is a symlink, it will follow the link to the real path.
                                   type: string
                                 type:
+                                  description: |-
+                                    type for HostPath Volume
+                                    Defaults to ""
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
+                              description: |-
+                                iscsi represents an ISCSI Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
                               properties:
                                 chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
+                                  description: fsType is the filesystem type of the
+                                    volume that you want to mount.
                                   type: string
                                 initiatorName:
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name.
                                   type: string
                                 iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
+                                  description: |-
+                                    iscsiInterface is the interface Name that uses an iSCSI transport.
+                                    Defaults to 'default' (tcp).
                                   type: string
                                 lun:
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
+                                  description: portals is the iSCSI Target Portal
+                                    List.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
                                   type: boolean
                                 secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 targetPortal:
+                                  description: targetPortal is iSCSI Target Portal.
                                   type: string
                               required:
                               - iqn
@@ -3526,68 +5888,139 @@ spec:
                               - targetPortal
                               type: object
                             name:
+                              description: |-
+                                name of the volume.
+                                Must be a DNS_LABEL and unique within the pod.
+                                More info: https://kubernetes.
                               type: string
                             nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.
                               properties:
                                 path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
                                   type: boolean
                                 server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
+                              description: |-
+                                persistentVolumeClaimVolumeSource represents a reference to a
+                                PersistentVolumeClaim in the same namespace.
                               properties:
                                 claimName:
+                                  description: claimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 pdID:
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
+                              description: portworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
+                                  description: |-
+                                    fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
                                   format: int32
                                   type: integer
                                 sources:
+                                  description: sources is the list of volume projections
                                   items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
                                     properties:
                                       clusterTrustBundle:
+                                        description: ClusterTrustBundle allows a pod
+                                          to access the `.spec.
                                         properties:
                                           labelSelector:
+                                            description: |-
+                                              Select all ClusterTrustBundles that match this label selector.  Only has
+                                              effect if signerName is set.
                                             properties:
                                               matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
                                                 items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
                                                       type: string
                                                     operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty.
                                                       items:
                                                         type: string
                                                       type: array
@@ -3601,31 +6034,58 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs.
                                                 type: object
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           name:
+                                            description: |-
+                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                              with signerName and labelSelector.
                                             type: string
                                           optional:
+                                            description: |-
+                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                              aren't available.
                                             type: boolean
                                           path:
+                                            description: Relative path from the volume
+                                              root to write the bundle.
                                             type: string
                                           signerName:
+                                            description: |-
+                                              Select all ClusterTrustBundles that match this signer name.
+                                              Mutually-exclusive with name.
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       configMap:
+                                        description: configMap information about the
+                                          configMap data to project
                                         properties:
                                           items:
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              ConfigMap will be projected into the volum
                                             items:
+                                              description: Maps a string key to a
+                                                path within a volume.
                                               properties:
                                                 key:
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
                                                   type: string
                                               required:
                                               - key
@@ -3635,42 +6095,83 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                           optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
                                         properties:
                                           items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
                                             items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
                                               properties:
                                                 fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name, namespace and uid
+                                                    are supported.'
                                                   properties:
                                                     apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                   x-kubernetes-map-type: atomic
                                                 mode:
+                                                  description: |-
+                                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                                    between 0000 and 0777 or a decimal valu
                                                   format: int32
                                                   type: integer
                                                 path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path.'
                                                   type: string
                                                 resourceFieldRef:
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, requests.
                                                   properties:
                                                     containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
+                                                      description: 'Required: resource
+                                                        to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -3683,16 +6184,30 @@ spec:
                                             x-kubernetes-list-type: atomic
                                         type: object
                                       secret:
+                                        description: secret information about the
+                                          secret data to project
                                         properties:
                                           items:
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              Secret will be projected into the volume a
                                             items:
+                                              description: Maps a string key to a
+                                                path within a volume.
                                               properties:
                                                 key:
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file.'
                                                   format: int32
                                                   type: integer
                                                 path:
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
                                                   type: string
                                               required:
                                               - key
@@ -3702,19 +6217,35 @@ spec:
                                             x-kubernetes-list-type: atomic
                                           name:
                                             default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty.
                                             type: string
                                           optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
+                                            description: audience is the intended
+                                              audience of the token.
                                             type: string
                                           expirationSeconds:
+                                            description: |-
+                                              expirationSeconds is the requested duration of validity of the service
+                                              account token.
                                             format: int64
                                             type: integer
                                           path:
+                                            description: |-
+                                              path is the path relative to the mount point of the file to project the
+                                              token into.
                                             type: string
                                         required:
                                         - path
@@ -3724,79 +6255,164 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             quobyte:
+                              description: quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
                               properties:
                                 group:
+                                  description: |-
+                                    group to map volume access to
+                                    Default is no group
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                    Defaults to false.
                                   type: boolean
                                 registry:
+                                  description: |-
+                                    registry represents a single or multiple Quobyte Registry services
+                                    specified as a string as host:port pair (multiple ent
                                   type: string
                                 tenant:
+                                  description: |-
+                                    tenant owning the given Quobyte volume in the Backend
+                                    Used with dynamically provisioned Quobyte volumes, value is set by
                                   type: string
                                 user:
+                                  description: |-
+                                    user to map volume access to
+                                    Defaults to serivceaccount user
                                   type: string
                                 volume:
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
+                              description: |-
+                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                More info: https://examples.k8s.
                               properties:
                                 fsType:
+                                  description: fsType is the filesystem type of the
+                                    volume that you want to mount.
                                   type: string
                                 image:
+                                  description: |-
+                                    image is the rados image name.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
+                                  description: |-
+                                    keyring is the path to key ring for RBDUser.
+                                    Default is /etc/ceph/keyring.
+                                    More info: https://examples.k8s.
                                   type: string
                                 monitors:
+                                  description: |-
+                                    monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 pool:
+                                  description: |-
+                                    pool is the rados pool name.
+                                    Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.
                                   type: boolean
                                 secretRef:
+                                  description: |-
+                                    secretRef is name of the authentication secret for RBDUser. If provided
+                                    overrides keyring.
+                                    Default is nil.
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
+                                  description: |-
+                                    user is the rados user name.
+                                    Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
+                              description: scaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 gateway:
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
+                                  description: |-
+                                    secretRef references to the secret for ScaleIO user and other
+                                    sensitive information.
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
                                   type: string
                                 storagePool:
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
                                   type: string
                                 system:
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
+                                  description: |-
+                                    volumeName is the name of a volume already created in the ScaleIO system
+                                    that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -3804,19 +6420,35 @@ spec:
                               - system
                               type: object
                             secret:
+                              description: |-
+                                secret represents a secret that should populate this volume.
+                                More info: https://kubernetes.
                               properties:
                                 defaultMode:
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.'
                                   format: int32
                                   type: integer
                                 items:
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume a
                                   items:
+                                    description: Maps a string key to a path within
+                                      a volume.
                                     properties:
                                       key:
+                                        description: key is the key to project.
                                         type: string
                                       mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file.'
                                         format: int32
                                         type: integer
                                       path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
                                         type: string
                                     required:
                                     - key
@@ -3825,37 +6457,76 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.
                                   type: string
                               type: object
                             storageos:
+                              description: storageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
+                                  description: |-
+                                    secretRef specifies the secret to use for obtaining the StorageOS API
+                                    credentials.
                                   properties:
                                     name:
                                       default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty.
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 volumeName:
+                                  description: |-
+                                    volumeName is the human-readable name of the StorageOS volume.  Volume
+                                    names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
+                                  description: volumeNamespace specifies the scope
+                                    of the volume within StorageOS.
                                   type: string
                               type: object
                             vsphereVolume:
+                              description: vsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
                               properties:
                                 fsType:
+                                  description: |-
+                                    fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex.
                                   type: string
                                 storagePolicyID:
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -3869,32 +6540,51 @@ spec:
                 - feastProject
                 type: object
               clientConfigMap:
+                description: ConfigMap in this namespace containing a client `feature_store.yaml`
+                  for this feast deployment
                 type: string
               conditions:
                 items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another.
                       format: date-time
                       type: string
                     message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
+                      description: status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - Unknown
                       type: string
                     type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -3911,6 +6601,8 @@ spec:
               phase:
                 type: string
               serviceHostnames:
+                description: ServiceHostnames defines the service hostnames in the
+                  format of <domain>:<port>, e.g. example.svc.cluster.local:80
                 properties:
                   offlineStore:
                     type: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
With the last release, we were experiencing k8s errors related to CRD bloat. Because of this we took the extreme measure of removing all descriptions from the CRD to reduce its size. However, keeping some level of field descrips is very important for a user's experience, both with the Operator and with Feast. In this PR, we'll continue to limit the line length of the descrips, but increase that length from `0` to `120`.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Relates to https://github.com/feast-dev/feast/pull/5001
