### PR TITLE
fix: Fixing the release workflow to refresh the stable branch when the release is not running in the dry run mode.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,7 @@ jobs:
 
   update_stable_branch:
     name: Update Stable Branch after release
+    if: github.event.inputs.dry_run == 'false'
     runs-on: ubuntu-latest
     needs: release
     env:


### PR DESCRIPTION
Fixing the release workflow to refresh the stable branch when the release is not running in the dry run mode.

Fixes: [5058](https://github.com/feast-dev/feast/issues/5058)