### PR TITLE
refactor: Rework `get_online_features` helper functions

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -2018,7 +2018,7 @@ class FeatureStore:
                         entity_key_dict[key] = []
                     entity_key_dict[key].append(python_value)
 
-        table_entity_values, idxs = utils._get_unique_entities_from_values(
+        table_entity_values, idxs, output_len = utils._get_unique_entities_from_values(
             entity_key_dict,
         )
 
@@ -2040,6 +2040,7 @@ class FeatureStore:
             full_feature_names=False,
             requested_features=features_to_request,
             table=table,
+            output_len=output_len,
         )
 
         return OnlineResponse(online_features_response)

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -187,7 +187,7 @@ class OnlineStore(ABC):
 
         for table, requested_features in grouped_refs:
             # Get the correct set of entity values with the correct join keys.
-            table_entity_values, idxs = utils._get_unique_entities(
+            table_entity_values, idxs, output_len = utils._get_unique_entities(
                 table,
                 join_key_values,
                 entity_name_to_join_key_map,
@@ -215,6 +215,7 @@ class OnlineStore(ABC):
                 full_feature_names,
                 requested_features,
                 table,
+                output_len,
             )
 
         if requested_on_demand_feature_views:
@@ -274,7 +275,7 @@ class OnlineStore(ABC):
 
         async def query_table(table, requested_features):
             # Get the correct set of entity values with the correct join keys.
-            table_entity_values, idxs = utils._get_unique_entities(
+            table_entity_values, idxs, output_len = utils._get_unique_entities(
                 table,
                 join_key_values,
                 entity_name_to_join_key_map,
@@ -290,7 +291,7 @@ class OnlineStore(ABC):
                 requested_features=requested_features,
             )
 
-            return idxs, read_rows
+            return idxs, read_rows, output_len
 
         all_responses = await asyncio.gather(
             *[
@@ -299,7 +300,7 @@ class OnlineStore(ABC):
             ]
         )
 
-        for (idxs, read_rows), (table, requested_features) in zip(
+        for (idxs, read_rows, output_len), (table, requested_features) in zip(
             all_responses, grouped_refs
         ):
             feature_data = utils._convert_rows_to_protobuf(
@@ -314,6 +315,7 @@ class OnlineStore(ABC):
                 full_feature_names,
                 requested_features,
                 table,
+                output_len,
             )
 
         if requested_on_demand_feature_views:

--- a/sdk/python/feast/utils.py
+++ b/sdk/python/feast/utils.py
@@ -1242,7 +1242,7 @@ def _get_entity_key_protos(
 
 def _convert_rows_to_protobuf(
     requested_features: List[str],
-    read_rows: List[Tuple[datetime | None, dict[str, ValueProto] | None]],
+    read_rows: List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]],
 ) -> List[Tuple[List[Timestamp], List["FieldStatus.ValueType"], List[ValueProto]]]:
     # Pre-calculate the length to avoid repeated calculations
     n_rows = len(read_rows)

--- a/sdk/python/feast/utils.py
+++ b/sdk/python/feast/utils.py
@@ -494,18 +494,18 @@ def construct_response_feature_vector(
     values_vector: Iterable[Any],
     statuses_vector: Iterable[Any],
     timestamp_vector: Iterable[Any],
-    mapping_indexes: Iterable[list[int]],
+    mapping_indexes: Iterable[List[int]],
     output_len: int,
 ) -> GetOnlineFeaturesResponse.FeatureVector:
-    values_output = [None] * output_len
-    statuses_output = [None] * output_len
-    timestamp_output = [None] * output_len
+    values_output: Iterable[Any] = [None] * output_len
+    statuses_output: Iterable[Any] = [None] * output_len
+    timestamp_output: Iterable[Any] = [None] * output_len
 
     for i, destinations in enumerate(mapping_indexes):
         for idx in destinations:
-            values_output[idx] = values_vector[i]
-            statuses_output[idx] = statuses_vector[i]
-            timestamp_output[idx] = timestamp_vector[i]
+            values_output[idx] = values_vector[i]  # type: ignore[index]
+            statuses_output[idx] = statuses_vector[i]  # type: ignore[index]
+            timestamp_output[idx] = timestamp_vector[i]  # type: ignore[index]
 
     return GetOnlineFeaturesResponse.FeatureVector(
         values=values_output,
@@ -876,22 +876,12 @@ def _populate_response_from_feature_data(
     ]
     online_features_response.metadata.feature_names.val.extend(requested_feature_refs)
 
-    timestamps, statuses, values = zip(*feature_data)
-
-    # Populate the result with data fetched from the OnlineStore
-    # which is guaranteed to be aligned with `requested_features`.
-    for (
-        feature_idx,
-        (timestamp_vector, statuses_vector, values_vector),
-    ) in enumerate(zip(zip(*timestamps), zip(*statuses), zip(*values))):
-        response_feature_vector = construct_response_feature_vector(
-            values_vector=values_vector,
-            statuses_vector=statuses_vector,
-            timestamp_vector=timestamp_vector,
-            mapping_indexes=indexes,
-            output_len=output_len,
+    # Process each feature vector in a single pass
+    for timestamp_vector, statuses_vector, values_vector in feature_data:
+        response_vector = construct_response_feature_vector(
+            values_vector, statuses_vector, timestamp_vector, indexes, output_len
         )
-        online_features_response.results.append(response_feature_vector)
+        online_features_response.results.append(response_vector)
 
 
 def _populate_response_from_feature_data_v2(
@@ -903,6 +893,7 @@ def _populate_response_from_feature_data_v2(
     indexes: Iterable[List[int]],
     online_features_response: GetOnlineFeaturesResponse,
     requested_features: Iterable[str],
+    output_len: int,
 ):
     """Populate the GetOnlineFeaturesResponse with feature data.
 
@@ -920,6 +911,7 @@ def _populate_response_from_feature_data_v2(
             "customer_fv__daily_transactions").
         requested_features: The names of the features in `feature_data`. This should be ordered in the same way as the
             data in `feature_data`.
+        output_len: The number of result rows in `online_features_response`.
     """
     # Add the feature names to the response.
     requested_feature_refs = [(feature_name) for feature_name in requested_features]
@@ -929,17 +921,11 @@ def _populate_response_from_feature_data_v2(
 
     # Populate the result with data fetched from the OnlineStore
     # which is guaranteed to be aligned with `requested_features`.
-    for (
-        feature_idx,
-        (timestamp_vector, statuses_vector, values_vector),
-    ) in enumerate(zip(zip(*timestamps), zip(*statuses), zip(*values))):
-        online_features_response.results.append(
-            GetOnlineFeaturesResponse.FeatureVector(
-                values=apply_list_mapping(values_vector, indexes),
-                statuses=apply_list_mapping(statuses_vector, indexes),
-                event_timestamps=apply_list_mapping(timestamp_vector, indexes),
-            )
+    for timestamp_vector, statuses_vector, values_vector in feature_data:
+        response_vector = construct_response_feature_vector(
+            values_vector, statuses_vector, timestamp_vector, indexes, output_len
         )
+        online_features_response.results.append(response_vector)
 
 
 def _convert_entity_key_to_proto_to_dict(
@@ -1256,35 +1242,34 @@ def _get_entity_key_protos(
 
 def _convert_rows_to_protobuf(
     requested_features: List[str],
-    read_rows: List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]],
+    read_rows: List[Tuple[datetime | None, dict[str, ValueProto] | None]],
 ) -> List[Tuple[List[Timestamp], List["FieldStatus.ValueType"], List[ValueProto]]]:
-    # Each row is a set of features for a given entity key.
-    # We only need to convert the data to Protobuf once.
+    # Pre-calculate the length to avoid repeated calculations
+    n_rows = len(read_rows)
+
+    # Create single instances of commonly used values
     null_value = ValueProto()
-    read_row_protos = []
-    for read_row in read_rows:
-        row_ts_proto = Timestamp()
-        row_ts, feature_data = read_row
-        # TODO (Ly): reuse whatever timestamp if row_ts is None?
-        if row_ts is not None:
-            row_ts_proto.FromDatetime(row_ts)
-        event_timestamps = [row_ts_proto] * len(requested_features)
-        if feature_data is None:
-            statuses = [FieldStatus.NOT_FOUND] * len(requested_features)
-            values = [null_value] * len(requested_features)
-        else:
-            statuses = []
-            values = []
-            for feature_name in requested_features:
-                # Make sure order of data is the same as requested_features.
-                if feature_name not in feature_data:
-                    statuses.append(FieldStatus.NOT_FOUND)
-                    values.append(null_value)
-                else:
-                    statuses.append(FieldStatus.PRESENT)
-                    values.append(feature_data[feature_name])
-        read_row_protos.append((event_timestamps, statuses, values))
-    return read_row_protos
+    null_status = FieldStatus.NOT_FOUND
+    null_timestamp = Timestamp()
+    present_status = FieldStatus.PRESENT
+
+    requested_features_vectors = []
+    for feature_name in requested_features:
+        ts_vector = [null_timestamp] * n_rows
+        status_vector = [null_status] * n_rows
+        value_vector = [null_value] * n_rows
+        for idx, read_row in enumerate(read_rows):
+            row_ts_proto = Timestamp()
+            row_ts, feature_data = read_row
+            # TODO (Ly): reuse whatever timestamp if row_ts is None?
+            if row_ts is not None:
+                row_ts_proto.FromDatetime(row_ts)
+            ts_vector[idx] = row_ts_proto
+            if (feature_data is not None) and (feature_name in feature_data):
+                status_vector[idx] = present_status
+                value_vector[idx] = feature_data[feature_name]
+        requested_features_vectors.append((ts_vector, status_vector, value_vector))
+    return requested_features_vectors
 
 
 def has_all_tags(

--- a/sdk/python/tests/unit/test_unit_feature_store.py
+++ b/sdk/python/tests/unit/test_unit_feature_store.py
@@ -38,7 +38,7 @@ def test_get_unique_entities_success():
         projection=MockFeatureViewProjection(join_key_map={}),
     )
 
-    unique_entities, indexes = utils._get_unique_entities(
+    unique_entities, indexes, output_len = utils._get_unique_entities(
         table=fv,
         join_key_values=entity_values,
         entity_name_to_join_key_map=entity_name_to_join_key_map,
@@ -51,6 +51,7 @@ def test_get_unique_entities_success():
 
     assert unique_entities == expected_entities
     assert indexes == expected_indexes
+    assert output_len == 3
 
 
 def test_get_unique_entities_missing_join_key_success():
@@ -74,7 +75,7 @@ def test_get_unique_entities_missing_join_key_success():
         projection=MockFeatureViewProjection(join_key_map={}),
     )
 
-    unique_entities, indexes = utils._get_unique_entities(
+    unique_entities, indexes, output_len = utils._get_unique_entities(
         table=fv,
         join_key_values=entity_values,
         entity_name_to_join_key_map=entity_name_to_join_key_map,
@@ -87,6 +88,7 @@ def test_get_unique_entities_missing_join_key_success():
 
     assert unique_entities == expected_entities
     assert indexes == expected_indexes
+    assert output_len == 3
     # We're not say anything about the entity_1 missing from the unique_entities list
     assert "entity_1" not in [entity.keys() for entity in unique_entities]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Is some use cases, for example in recommender systems, we need to retrieve features for hundreds and thousands of entities. As stated in the issue https://github.com/feast-dev/feast/issues/3596, current implementation has a significant overhead.

I ran a benchmark test for 1000 entities with profiling and noticed, that `_populate_response_from_feature_data` and `_convert_rows_to_protobuf` functions are quite heavy.

A have several proposals for improvement:
- `_populate_response_from_feature_data` has 3 calls of `apply_list_mapping` where we calculate `output_len = sum(len(item) for item in mapping_indexes)` which is time consuming. We could calculate `output_len` only once, when we deduplicate entities. And we could combine all 3 vectors into response in one loop
- We get feature_data from `_convert_rows_to_protobuf` and start re-formatting it with zip(zip)s. We could construct `feature_data` exactly in the desired format and get rid of this unpacking.


[This test](https://github.com/feast-dev/feast/blob/master/sdk/python/tests/unit/online_store/test_online_retrieval.py) should cover all the above changes.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
For experimentation I used current benchmark tooling with some adjustments. What I changed:

- tested different amount of entities from 10 to 2000
- increased number of iterations to 3 and number of rounds to 50
- tested against `redis` and `sqlite`

Here's results for the latest release (time in ms):
<google-sheets-html-origin style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">
Number of entities | OnlineStore | Min | Max | Mean | StdDev | Median
-- | -- | -- | -- | -- | -- | --
10 | sqlite | 4.4021 (1.0) | 5.0044 (1.0) | 4.6377 (1.0) | 0.1576 (1.0) | 4.6037 (1.0)
10 | redis | 5.9276 (1.35) | 7.7548 (1.55) | 6.4771 (1.40) | 0.3828 (2.43) | 6.4391 (1.40)
100 | sqlite | 8.3776 (1.0) | 10.5403 (1.0) | 8.9139 (1.0) | 0.4123 (1.0) | 8.8378 (1.0)
100 | redis | 10.6544 (1.27) | 13.3852 (1.27) | 11.6403 (1.31) | 0.4281 (1.04) | 11.6137 (1.31)
1000 | sqlite | 49.6249 (1.0) | 104.2753 (1.0) | 84.5442 (1.0) | 24.7145 (1.00) | 101.4559 (1.0)
1000 | redis | 59.1902 (1.19) | 115.1285 (1.10) | 92.3902 (1.09) | 24.6651 (1.0) | 110.0397 (1.08)
2000 | sqlite | 142.5302 (1.0) | 208.4495 (1.0) | 178.5956 (1.0) | 26.7520 (1.04) | 176.8854 (1.01)
2000 | redis | 168.0299 (1.18) | 241.9603 (1.16) | 195.3997 (1.09) | 25.6117 (1.0) | 174.3306 (1.0)

</google-sheets-html-origin>

And here's results for proposed changes. Performance for 1000 and more entities is better:
<google-sheets-html-origin style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">
Number of entities | OnlineStore | Min | Max | Mean | StdDev | Median
-- | -- | -- | -- | -- | -- | --
10 | sqlite | 4.4178 (1.0) | 5.1714 (1.0) | 4.6655 (1.0) | 0.1594 (1.0) | 4.6369 (1.0)
10 | redis | 6.1177 (1.38) | 8.8817 (1.72) | 6.6482 (1.42) | 0.4161 (2.61) | 6.5609 (1.41)
100 | sqlite | 8.3808 (1.0) | 9.7838 (1.0) | 8.8807 (1.0) | 0.2814 (1.0) | 8.9061 (1.0)
100 | redis | 11.3189 (1.35) | 61.7919 (6.32) | 12.8694 (1.45) | 7.0757 (25.15) | 11.8019 (1.33)
1000 | sqlite | 51.3373 (1.0) | 105.2218 (1.0) | 75.3780 (1.0) | 25.4122 (1.03) | 53.5322 (1.0)
1000 | redis | 62.3018 (1.21) | 116.3195 (1.11) | 88.0296 (1.17) | 24.7718 (1.0) | 67.4150 (1.26)
2000 | sqlite | 139.8804 (1.0) | 201.7754 (1.0) | 155.1063 (1.0) | 18.3177 (1.0) | 148.7958 (1.0)
2000 | redis | 163.8357 (1.17) | 222.4737 (1.10) | 179.5300 (1.16) | 21.5222 (1.17) | 168.8162 (1.13)

</google-sheets-html-origin>

