### PR TITLE
fix: Add scylladb to online stores list in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The list below contains the functionality that contributors are planning to deve
   * [x] [Azure Cache for Redis (community plugin)](https://github.com/Azure/feast-azure)
   * [x] [Postgres (contrib plugin)](https://docs.feast.dev/reference/online-stores/postgres)
   * [x] [Cassandra / AstraDB (contrib plugin)](https://docs.feast.dev/reference/online-stores/cassandra)
+  * [x] [ScyllaDB (contrib plugin)](https://docs.feast.dev/reference/online-stores/scylladb)
   * [x] [Custom online store support](https://docs.feast.dev/how-to-guides/customizing-feast/adding-support-for-a-new-online-store)
 * **Feature Engineering**
   * [x] On-demand Transformations (Beta release. See [RFC](https://docs.google.com/document/d/1lgfIw0Drc65LpaxbUu49RCeJgMew547meSJttnUqz7c/edit#))


### PR DESCRIPTION

# What this PR does / why we need it:
ScyllaDB is already supported as online stores and even have separate [docs](https://docs.feast.dev/reference/online-stores/scylladb)
# Which issue(s) this PR fixes:
List Scylladb in online stores lists in repos README.md