### PR TITLE
fix: Move Feast to pyproject.toml instead of setup.py

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,6 +37,7 @@ The list below contains the functionality that contributors are planning to deve
   * [x] [Azure Cache for Redis (community plugin)](https://github.com/Azure/feast-azure)
   * [x] [Postgres (contrib plugin)](https://docs.feast.dev/reference/online-stores/postgres)
   * [x] [Cassandra / AstraDB (contrib plugin)](https://docs.feast.dev/reference/online-stores/cassandra)
+  * [x] [ScyllaDB (contrib plugin)](https://docs.feast.dev/reference/online-stores/scylladb)
   * [x] [Custom online store support](https://docs.feast.dev/how-to-guides/customizing-feast/adding-support-for-a-new-online-store)
 * **Feature Engineering**
   * [x] On-demand Transformations (Beta release. See [RFC](https://docs.google.com/document/d/1lgfIw0Drc65LpaxbUu49RCeJgMew547meSJttnUqz7c/edit#))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,167 @@
+[project]
+name = "feast"
+description = "Python SDK for Feast"
+readme = "README.md"
+requires-python = ">=3.9.0"
+license = {file = "LICENSE"}
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9"
+]
+dynamic = [
+    "version",
+]
+dependencies = [
+    "click>=7.0.0,<9.0.0",
+    "colorama>=0.3.9,<1",
+    "dill~=0.3.0",
+    "protobuf>=4.24.0",
+    "Jinja2>=2,<4",
+    "jsonschema",
+    "mmh3",
+    "numpy>=1.22,<2",
+    "pandas>=1.4.3,<3",
+    "pyarrow<18.1.0",
+    "pydantic>=2.0.0",
+    "pygments>=2.12.0,<3",
+    "PyYAML>=5.4.0,<7",
+    "requests",
+    "SQLAlchemy[mypy]>1",
+    "tabulate>=0.8.0,<1",
+    "tenacity>=7,<9",
+    "toml>=0.10.0,<1",
+    "tqdm>=4,<5",
+    "typeguard>=4.0.0",
+    "fastapi>=0.68.0",
+    "uvicorn[standard]>=0.14.0,<1",
+    "uvicorn-worker",
+    "gunicorn; platform_system != 'Windows'",
+    "dask[dataframe]>=2024.2.1",
+    "prometheus_client",
+    "psutil",
+    "bigtree>=0.19.2",
+    "pyjwt",
+]
+
+[project.optional-dependencies]
+aws = ["boto3>=1.17.0,<2", "fsspec<=2024.9.0", "aiobotocore>2,<3"]
+azure = [
+    "azure-storage-blob>=0.37.0",
+    "azure-identity>=1.6.1",
+    "SQLAlchemy>=1.4.19",
+    "pyodbc>=4.0.30",
+    "pymssql"
+]
+cassandra = ["cassandra-driver>=3.24.0,<4"]
+couchbase = ["couchbase==4.3.2"]
+delta = ["deltalake"]
+duckdb = ["ibis-framework[duckdb]>=9.0.0,<10"]
+elasticsearch = ["elasticsearch>=8.13.0"]
+faiss = ["faiss-cpu>=1.7.0,<2"]
+gcp = [
+    "google-api-core>=1.23.0,<3",
+    "googleapis-common-protos>=1.52.0,<2",
+    "google-cloud-bigquery[pandas]>=2,<4",
+    "google-cloud-bigquery-storage >= 2.0.0,<3",
+    "google-cloud-datastore>=2.16.0,<3",
+    "google-cloud-storage>=1.34.0,<3",
+    "google-cloud-bigtable>=2.11.0,<3",
+    "fsspec<=2024.9.0",
+]
+ge = ["great_expectations>=0.15.41"]
+go = ["cffi~=1.15.0"]
+grpcio = [
+    "grpcio>=1.56.2,<2",
+    "grpcio-reflection>=1.56.2,<2",
+    "grpcio-health-checking>=1.56.2,<2",
+]
+hazelcast = ["hazelcast-python-client>=5.1"]
+hbase = ["happybase>=1.2.0,<3"]
+ibis = [
+    "ibis-framework>=9.0.0,<10",
+    "ibis-substrait>=4.0.0",
+]
+ikv = [
+    "ikvpy>=0.0.36",
+]
+k8s = ["kubernetes<=20.13.0"]
+milvus = ["pymilvus"]
+mssql = ["ibis-framework[mssql]>=9.0.0,<10"]
+mysql = ["pymysql", "types-PyMySQL"]
+opentelemetry = ["prometheus_client", "psutil"]
+spark = ["pyspark>=3.0.0,<4"]
+trino = ["trino>=0.305.0,<0.400.0", "regex"]
+postgres = ["psycopg[binary,pool]>=3.0.0,<4"]
+qdrant = ["qdrant-client>=1.12.0"]
+redis = [
+    "redis>=4.2.2,<5",
+    "hiredis>=2.0.0,<3",
+]
+singlestore = ["singlestoredb<1.8.0"]
+snowflake = [
+    "snowflake-connector-python[pandas]>=3.7,<4",
+]
+sqlite_vec = ["sqlite-vec==v0.1.6"]
+
+ci = [
+    "build",
+    "virtualenv==20.23.0",
+    "cryptography>=43.0,<44",
+    "ruff>=0.8.0",
+    "mypy-protobuf>=3.1",
+    "grpcio-tools>=1.56.2,<2",
+    "grpcio-testing>=1.56.2,<2",
+    # FastAPI does not correctly pull starlette dependency on httpx see thread(https://github.com/tiangolo/fastapi/issues/5656).
+    "httpx==0.27.2",
+    "minio==7.2.11",
+    "mock==2.0.0",
+    "moto<5",
+    "mypy>=1.4.1,<1.11.3",
+    "urllib3>=1.25.4,<3",
+    "psutil==5.9.0",
+    "py>=1.11.0",  # https://github.com/pytest-dev/pytest/issues/10420
+    "pytest>=6.0.0,<8",
+    "pytest-asyncio<=0.24.0",
+    "pytest-cov",
+    "pytest-xdist",
+    "pytest-benchmark>=3.4.1,<4",
+    "pytest-lazy-fixture==0.6.3",
+    "pytest-timeout==1.4.2",
+    "pytest-ordering~=0.6.0",
+    "pytest-mock==1.10.4",
+    "pytest-env",
+    "Sphinx>4.0.0,<7",
+    "testcontainers==4.8.2",
+    "python-keycloak==4.2.2",
+    "pre-commit<3.3.2",
+    "assertpy==1.1",
+    "pip-tools",
+    "pybindgen",
+    "types-protobuf~=3.19.22",
+    "types-python-dateutil",
+    "types-pytz",
+    "types-PyYAML",
+    "types-redis",
+    "types-requests<2.31.0",
+    "types-setuptools",
+    "types-tabulate",
+    "virtualenv<20.24.2",
+    "feast[aws, azure, cassandra, couchbase, delta, duckdb, elasticsearch, faiss, gcp, ge, go, grpcio, hazelcast, hbase, ibis, ikv, k8s, milvus, mssql, mysql, opentelemetry, spark, trino, postgres, qdrant, redis, singlestore, snowflake, sqlite_vec]"
+]
+dev = ["feast[ci]"]
+docs = ["feast[ci]"]
+
+[project.urls]
+Homepage = "https://github.com/feast-dev/feast"
+
+[[project.authors]]
+name = "Feast"
+
+[project.scripts]
+feast = "feast.cli:cli"
+
 [build-system]
 requires = [
   "pybindgen==0.22.0",
@@ -7,8 +171,15 @@ requires = [
   "wheel",
 ]
 
+[tool.setuptools]
+packages = {find = {where = ["sdk/python"], exclude = ["java", "infra", "sdk/python/tests", "ui"]}}
+
 [tool.setuptools_scm]
-# Including this section is comparable to supplying use_scm_version=True in setup.py.
+# Add Support for parsing tags that have a prefix containing '/' (ie 'sdk/go') to setuptools_scm.
+# Regex modified from default tag regex in:
+# https://github.com/pypa/setuptools_scm/blob/2a1b46d38fb2b8aeac09853e660bcd0d7c1bc7be/src/setuptools_scm/config.py#L9
+tag_regex = "^(?:[\\/\\w-]+)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"
+
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
# What this PR does / why we need it:
Move setup.py configs to pyproject.toml

# Which issue(s) this PR fixes:
Fixes #5066 
