### PR TITLE
fix: Identify s3/remote uri path correctly

### DIFF
--- a/sdk/python/feast/infra/offline_stores/dask.py
+++ b/sdk/python/feast/infra/offline_stores/dask.py
@@ -100,11 +100,9 @@ class DaskRetrievalJob(RetrievalJob):
         # Check if the specified location already exists.
         if not allow_overwrite and os.path.exists(storage.file_options.uri):
             raise SavedDatasetLocationAlreadyExists(location=storage.file_options.uri)
-
-        if not Path(storage.file_options.uri).is_absolute():
-            absolute_path = Path(self.repo_path) / storage.file_options.uri
-        else:
-            absolute_path = Path(storage.file_options.uri)
+        absolute_path = FileSource.get_uri_for_file_path(
+            repo_path=self.repo_path, uri=storage.file_options.uri
+        )
 
         filesystem, path = FileSource.create_filesystem_and_path(
             str(absolute_path),

--- a/sdk/python/feast/infra/offline_stores/duckdb.py
+++ b/sdk/python/feast/infra/offline_stores/duckdb.py
@@ -51,10 +51,9 @@ def _write_data_source(
 
     file_options = data_source.file_options
 
-    if not Path(file_options.uri).is_absolute():
-        absolute_path = Path(repo_path) / file_options.uri
-    else:
-        absolute_path = Path(file_options.uri)
+    absolute_path = FileSource.get_uri_for_file_path(
+        repo_path=repo_path, uri=file_options.uri
+    )
 
     if (
         mode == "overwrite"

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
+from urllib.parse import urlparse
 
 import pyarrow
 from packaging import version
@@ -154,17 +155,21 @@ class FileSource(DataSource):
     def source_datatype_to_feast_value_type() -> Callable[[str], ValueType]:
         return type_map.pa_to_feast_value_type
 
+    @staticmethod
+    def get_uri_for_file_path(repo_path: Union[Path, str, None], uri: str) -> str:
+        parsed_uri = urlparse(uri)
+        if parsed_uri.scheme and parsed_uri.netloc:
+            return uri  # Keep remote URIs as they are
+        if repo_path is not None and not Path(uri).is_absolute():
+            return str(Path(repo_path) / uri)
+        return str(Path(uri))
+
     def get_table_column_names_and_types(
         self, config: RepoConfig
     ) -> Iterable[Tuple[str, str]]:
-        if (
-            config.repo_path is not None
-            and not Path(self.file_options.uri).is_absolute()
-        ):
-            absolute_path = config.repo_path / self.file_options.uri
-        else:
-            absolute_path = Path(self.file_options.uri)
-
+        absolute_path = self.get_uri_for_file_path(
+            repo_path=config.repo_path, uri=self.file_options.uri
+        )
         filesystem, path = FileSource.create_filesystem_and_path(
             str(absolute_path), self.file_options.s3_endpoint_override
         )


### PR DESCRIPTION
# What this PR does / why we need it:

This is the fix to correctly identify the file path as relative or absolute or remote path using urllib urlparse, which checks both scheme and netloc, ensuring it's a remote URI. 

This seems the regression introduced in https://github.com/feast-dev/feast/pull/4624

Input cases :

Input URI ->  Recognized As -> Behavior
- s3://bucket/data.parquet -> Remote -> Uses as-is
- /absolute/path/file.parquet -> Local -> Resolves normally
- relative/path/file.parquet -> Local -> Resolves against `config.repo_path`
- C:/path/to/file.parquet (Windows) -> Local -> Resolves correctly



# Which issue(s) this PR fixes:

Fixes #4873 #4753 #4993 