### PR TITLE
feat: Set value_type of entity directly in from_proto

### DIFF
--- a/sdk/python/feast/entity.py
+++ b/sdk/python/feast/entity.py
@@ -173,12 +173,11 @@ class Entity:
         entity = cls(
             name=entity_proto.spec.name,
             join_keys=[entity_proto.spec.join_key],
+            value_type=ValueType(entity_proto.spec.value_type),
             description=entity_proto.spec.description,
             tags=dict(entity_proto.spec.tags),
             owner=entity_proto.spec.owner,
         )
-
-        entity.value_type = ValueType(entity_proto.spec.value_type)
 
         if entity_proto.meta.HasField("created_timestamp"):
             entity.created_timestamp = entity_proto.meta.created_timestamp.ToDatetime()


### PR DESCRIPTION
# What this PR does / why we need it:
<!--
Outline what you're doing
-->

In the last release a deprecation warning was added to `Entity` if the `value_type` is `None`. Currently, the `from_proto` method creates an `Entity` object first without `value_type` and sets it afterwards. Therefore, for each creation a Warning log is issued.

This change moves the `value_type` into the creator of `Entity` in the `from_proto` method.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
