### PR TITLE
feat: Override the udf name when provided as input to an on demand transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The list below contains the functionality that contributors are planning to deve
   * [x] Python Client
   * [x] [Python feature server](https://docs.feast.dev/reference/feature-servers/python-feature-server)
   * [x] [Java feature server (alpha)](https://github.com/feast-dev/feast/blob/master/infra/charts/feast/README.md)
-  * [x] [Go feature server (alpha)](https://github.com/feast-dev/feast/blob/master/go/README.md)
+  * [x] [Go feature server (alpha)](https://docs.feast.dev/reference/feature-servers/go-feature-server)
 * **Data Quality Management (See [RFC](https://docs.google.com/document/d/110F72d4NTv80p35wDSONxhhPBqWRwbZXG4f9mNEMd98/edit))**
   * [x] Data profiling and validation (Great Expectations)
 * **Feature Discovery and Governance**

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -722,6 +722,7 @@ class OnDemandFeatureView(BaseFeatureView):
 
 def on_demand_feature_view(
     *,
+    name: Optional[str] = None,
     entities: Optional[List[Entity]] = None,
     schema: list[Field],
     sources: list[
@@ -742,6 +743,7 @@ def on_demand_feature_view(
     Creates an OnDemandFeatureView object with the given user function as udf.
 
     Args:
+        name (optional): The name of the on demand feature view. If not provided, the name will be the name of the user function.
         entities (Optional): The list of names of entities that this feature view is associated with.
         schema: The list of features in the output of the on demand feature view, after
             the transformation has been applied.
@@ -791,7 +793,7 @@ def on_demand_feature_view(
             transformation = SubstraitTransformation.from_ibis(user_function, sources)
 
         on_demand_feature_view_obj = OnDemandFeatureView(
-            name=user_function.__name__,
+            name=name if name is not None else user_function.__name__,
             sources=sources,
             schema=schema,
             feature_transformation=transformation,

--- a/sdk/python/tests/unit/test_on_demand_feature_view.py
+++ b/sdk/python/tests/unit/test_on_demand_feature_view.py
@@ -374,7 +374,6 @@ def test_function_call_syntax():
     )
     sources = [feature_view]
 
-    # Test with default name (function name)
     def transform_features(features_df: pd.DataFrame) -> pd.DataFrame:
         df = pd.DataFrame()
         df["output1"] = features_df["feature1"]
@@ -389,7 +388,6 @@ def test_function_call_syntax():
         ],
     )(transform_features)
 
-    # Verify default name behavior
     assert odfv.name == transform_features.__name__
     assert isinstance(odfv, OnDemandFeatureView)
 
@@ -399,7 +397,6 @@ def test_function_call_syntax():
     deserialized = OnDemandFeatureView.from_proto(proto)
     assert deserialized.name == transform_features.__name__
 
-    # Test with custom name
     def another_transform(features_df: pd.DataFrame) -> pd.DataFrame:
         df = pd.DataFrame()
         df["output1"] = features_df["feature1"]
@@ -415,7 +412,6 @@ def test_function_call_syntax():
         ],
     )(another_transform)
 
-    # Verify custom name behavior
     assert odfv_custom.name == CUSTOM_FUNCTION_NAME
     assert isinstance(odfv_custom, OnDemandFeatureView)
 

--- a/sdk/python/tests/unit/test_on_demand_feature_view.py
+++ b/sdk/python/tests/unit/test_on_demand_feature_view.py
@@ -28,6 +28,8 @@ from feast.on_demand_feature_view import (
 )
 from feast.types import Float32
 
+CUSTOM_FUNCTION_NAME = "custom-function-name"
+
 
 def udf1(features_df: pd.DataFrame) -> pd.DataFrame:
     df = pd.DataFrame()
@@ -388,14 +390,14 @@ def test_function_call_syntax():
     )(transform_features)
 
     # Verify default name behavior
-    assert odfv.name == "transform_features"
+    assert odfv.name == transform_features.__name__
     assert isinstance(odfv, OnDemandFeatureView)
 
     proto = odfv.to_proto()
-    assert proto.spec.name == "transform_features"
+    assert proto.spec.name == transform_features.__name__
 
     deserialized = OnDemandFeatureView.from_proto(proto)
-    assert deserialized.name == "transform_features"
+    assert deserialized.name == transform_features.__name__
 
     # Test with custom name
     def another_transform(features_df: pd.DataFrame) -> pd.DataFrame:
@@ -405,7 +407,7 @@ def test_function_call_syntax():
         return df
 
     odfv_custom = on_demand_feature_view(
-        name="custom-function-name",
+        name=CUSTOM_FUNCTION_NAME,
         sources=sources,
         schema=[
             Field(name="output1", dtype=Float32),
@@ -414,11 +416,11 @@ def test_function_call_syntax():
     )(another_transform)
 
     # Verify custom name behavior
-    assert odfv_custom.name == "custom-function-name"
+    assert odfv_custom.name == CUSTOM_FUNCTION_NAME
     assert isinstance(odfv_custom, OnDemandFeatureView)
 
     proto = odfv_custom.to_proto()
-    assert proto.spec.name == "custom-function-name"
+    assert proto.spec.name == CUSTOM_FUNCTION_NAME
 
     deserialized = OnDemandFeatureView.from_proto(proto)
-    assert deserialized.name == "custom-function-name"
+    assert deserialized.name == CUSTOM_FUNCTION_NAME

--- a/sdk/python/tests/unit/test_on_demand_feature_view.py
+++ b/sdk/python/tests/unit/test_on_demand_feature_view.py
@@ -28,8 +28,6 @@ from feast.on_demand_feature_view import (
 )
 from feast.types import Float32
 
-CUSTOM_FUNCTION_NAME = "custom-function-name"
-
 
 def udf1(features_df: pd.DataFrame) -> pd.DataFrame:
     df = pd.DataFrame()
@@ -362,6 +360,7 @@ def test_on_demand_feature_view_stored_writes():
 
 
 def test_function_call_syntax():
+    CUSTOM_FUNCTION_NAME = "custom-function-name"
     file_source = FileSource(name="my-file-source", path="test.parquet")
     feature_view = FeatureView(
         name="my-feature-view",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
This PR allows the user to define an ODFV function with a name override so we don't have to use the function name if we don't want to. This is also meant to provide feature parody with other ways of defining an ODFV.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
N/A
