### PR TITLE
feat: Add an OOTB Chat uI to the Feature Server to support RAG demo

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ prune examples
 
 graft sdk/python/feast/ui/build
 graft sdk/python/feast/embedded_go/lib
+recursive-include sdk/python/feast/static *

--- a/sdk/python/feast/static/chat/index.html
+++ b/sdk/python/feast/static/chat/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Feast Chat</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+        }
+        .chat-container {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            padding: 20px;
+            overflow-y: auto;
+        }
+        .message {
+            margin-bottom: 10px;
+            padding: 10px;
+            border-radius: 5px;
+            max-width: 70%;
+        }
+        .user-message {
+            background-color: #e6f7ff;
+            align-self: flex-end;
+        }
+        .bot-message {
+            background-color: #f0f0f0;
+            align-self: flex-start;
+        }
+        .input-container {
+            display: flex;
+            padding: 10px;
+            border-top: 1px solid #ccc;
+        }
+        #message-input {
+            flex: 1;
+            padding: 10px;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            margin-right: 10px;
+        }
+        #send-button {
+            padding: 10px 20px;
+            background-color: #1890ff;
+            color: white;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+    <div class="chat-container" id="chat-container">
+        <div class="message bot-message">Hello! How can I help you today?</div>
+    </div>
+    <div class="input-container">
+        <input type="text" id="message-input" placeholder="Type your message...">
+        <button id="send-button">Send</button>
+    </div>
+    <script>
+        const chatContainer = document.getElementById('chat-container');
+        const messageInput = document.getElementById('message-input');
+        const sendButton = document.getElementById('send-button');
+        
+        // WebSocket connection
+        const ws = new WebSocket(`ws://${window.location.host}/ws/chat`);
+        
+        ws.onmessage = function(event) {
+            // Check if there's an existing bot message being built
+            const lastMessage = chatContainer.lastElementChild;
+            if (lastMessage && lastMessage.classList.contains('bot-message') && lastMessage.dataset.streaming === 'true') {
+                // Append to the existing message
+                lastMessage.textContent += event.data;
+            } else {
+                // Create a new bot message
+                const botMessage = document.createElement('div');
+                botMessage.classList.add('message', 'bot-message');
+                botMessage.dataset.streaming = 'true';
+                botMessage.textContent = event.data;
+                chatContainer.appendChild(botMessage);
+                chatContainer.scrollTop = chatContainer.scrollHeight;
+            }
+        };
+        
+        ws.onclose = function(event) {
+            console.log('Connection closed');
+            // Mark the last message as complete if it was streaming
+            const lastMessage = chatContainer.lastElementChild;
+            if (lastMessage && lastMessage.classList.contains('bot-message') && lastMessage.dataset.streaming === 'true') {
+                lastMessage.dataset.streaming = 'false';
+            }
+        };
+        
+        function sendMessage() {
+            const message = messageInput.value.trim();
+            if (message) {
+                // Add user message to chat
+                const userMessage = document.createElement('div');
+                userMessage.classList.add('message', 'user-message');
+                userMessage.textContent = message;
+                chatContainer.appendChild(userMessage);
+                
+                // Send message to server
+                ws.send(message);
+                
+                // Clear input
+                messageInput.value = '';
+                
+                // Scroll to bottom
+                chatContainer.scrollTop = chatContainer.scrollHeight;
+            }
+        }
+        
+        sendButton.addEventListener('click', sendMessage);
+        messageInput.addEventListener('keypress', function(event) {
+            if (event.key === 'Enter') {
+                sendMessage();
+            }
+        });
+    </script>
+</body>
+</html>

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -69,6 +69,8 @@ def get_app(
 
     @app.get("/registry")
     def read_registry():
+        if registry_proto is None:
+            return Response(status_code=503)  # Service Unavailable
         return Response(
             content=registry_proto.SerializeToString(),
             media_type="application/octet-stream",


### PR DESCRIPTION
# What this PR does / why we need it:
This pull request introduces several enhancements to the Feast feature server, including the addition of a chat UI, WebSocket support, and improvements to the server's API documentation.

1.  `MANIFEST.in`:
    - Added a new line to include static files in the package.
2. `sdk/python/feast/feature_server.py`:
    - Imported new modules and libraries (asyncio, os, importlib_resources, WebSocket, WebSocketDisconnect, StaticFiles).
    - Added new classes for chat functionality (ChatMessage, ChatRequest).
    - Extended get_app function to document its purpose and endpoints in detail.
    - Introduced new endpoints:
          - /chat: POST endpoint to process chat requests.
          - /chat: GET endpoint to serve the chat UI.
          - /ws/chat: WebSocket endpoint for real-time chat communication.
    - Created a ConnectionManager class to manage WebSocket connections and handle incoming messages.
3. `sdk/python/feast/ui_server.py`:
    - Added a check to return a 503 status code if the registry is unavailable.
4.`sdk/python/feast/static/chat/index.html`:
    - Added a new HTML file to provide a basic chat UI for the Feast feature server.
          - The UI includes an input box for user messages and a container for displaying chat messages.
          - Integrated WebSocket for real-time chat functionality.

# Which issue(s) this PR fixes:
N/A

# Misc
The chat looks like this and supports streaming output:

![Screenshot 2025-02-27 at 9 09 18 PM](https://github.com/user-attachments/assets/728171c9-c4e2-4e68-9140-292d85bbddac)

