### PR TITLE
docs: Small formatting improvements in UI documentation

### DIFF
--- a/docs/reference/alpha-web-ui.md
+++ b/docs/reference/alpha-web-ui.md
@@ -100,7 +100,7 @@ yarn start
 
 The advantage of importing Feast UI as a module is in the ease of customization. The `<FeastUI>` component exposes a `feastUIConfigs` prop thorough which you can customize the UI. Currently it supports a few parameters.
 
-**Fetching the Project List**
+##### Fetching the Project List
 
 You can use `projectListPromise` to provide a promise that overrides where the Feast UI fetches the project list from.
 
@@ -118,11 +118,11 @@ You can use `projectListPromise` to provide a promise that overrides where the F
 />
 ```
 
-**Custom Tabs**
+##### Custom Tabs
 
 You can add custom tabs for any of the core Feast objects through the `tabsRegistry`.
 
-```
+```jsx
 const tabsRegistry = {
   RegularFeatureViewCustomTabs: [
     {

--- a/ui/README.md
+++ b/ui/README.md
@@ -97,7 +97,7 @@ You can use `projectListPromise` to provide a promise that overrides where the F
 
 You can add custom tabs for any of the core Feast objects through the `tabsRegistry`.
 
-```
+```jsx
 const tabsRegistry = {
   RegularFeatureViewCustomTabs: [
     {


### PR DESCRIPTION
# What this PR does / why we need it:

- Use subheadings in Customization section in alpha-web-ui.md too (they are already used in ui/README.md)
- Mark code examples as jsx for colors

# Which issue(s) this PR fixes:

None.

# Misc

See the documents rendered with these changes in [alpha-web-ui.md](https://github.com/peruukki/feast/blob/ui-docs-formatting-improvements/docs/reference/alpha-web-ui.md#custom-basename) and [ui/README.md](https://github.com/peruukki/feast/tree/ui-docs-formatting-improvements/ui#custom-basename)