### PR TITLE
fix: Increase available action VM storage and reduce dev feature-server image size

### DIFF
--- a/.github/workflows/operator-e2e-integration-tests.yml
+++ b/.github/workflows/operator-e2e-integration-tests.yml
@@ -36,6 +36,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+          tool-cache: false
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -49,7 +60,7 @@ jobs:
           nodes:
             - role: control-plane
               extraMounts:
-                - hostPath: /tmp/kind
+                - hostPath: /mnt/kind
                   containerPath: /var/lib/containerd
           EOF
 
@@ -63,12 +74,6 @@ jobs:
           # Run the e2e tests
           cd infra/feast-operator/
           make test-e2e
-
-      - name: Clean up docker images
-        if: always()
-        run: |
-          docker images --format '{{.Repository}}:{{.Tag}}' | grep 'feast' | xargs -r docker rmi -f
-          docker system prune -a -f
 
       - name: Run Previous version tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -554,12 +554,6 @@ build-feast-operator-docker:
 
 # Dev images
 
-build-feature-server-dev-minimal:
-	docker buildx build \
-		-t feastdev/feature-server:dev \
-		-f sdk/python/feast/infra/feature_servers/multicloud/Dockerfile \
-		--load sdk/python/feast/infra/feature_servers/multicloud
-
 build-feature-server-dev:
 	docker buildx build \
 		-t feastdev/feature-server:dev \

--- a/infra/feast-operator/Makefile
+++ b/infra/feast-operator/Makefile
@@ -162,8 +162,7 @@ docker-build: ## Build docker image with the manager.
 ## Build feast docker image.
 .PHONY: feast-ci-dev-docker-img
 feast-ci-dev-docker-img:
-	cd ./../.. && make build-feature-server-dev-minimal
-
+	cd ./../.. && make build-feature-server-dev
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/infra/feast-operator/test/e2e/e2e_test.go
+++ b/infra/feast-operator/test/e2e/e2e_test.go
@@ -40,7 +40,7 @@ var _ = Describe("controller", Ordered, func() {
 		featureStoreName, feastResourceName, feastK8sResourceNames)
 
 	BeforeAll(func() {
-		utils.DeployOperatorFromCode("/test/e2e")
+		utils.DeployOperatorFromCode("/test/e2e", false)
 	})
 
 	AfterAll(func() {

--- a/infra/feast-operator/test/upgrade/upgrade_test.go
+++ b/infra/feast-operator/test/upgrade/upgrade_test.go
@@ -24,7 +24,7 @@ import (
 var _ = Describe("operator upgrade", Ordered, func() {
 	BeforeAll(func() {
 		utils.DeployPreviousVersionOperator()
-		utils.DeployOperatorFromCode("/test/e2e")
+		utils.DeployOperatorFromCode("/test/e2e", true)
 	})
 
 	AfterAll(func() {

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -4,7 +4,11 @@ USER 0
 RUN npm install -g yarn yalc && rm -rf .npm
 USER default
 
-COPY --chown=default . ${APP_ROOT}/src
+COPY --chown=default .git ${APP_ROOT}/src/.git
+COPY --chown=default setup.py pyproject.toml README.md Makefile ${APP_ROOT}/src/
+COPY --chown=default protos ${APP_ROOT}/src/protos
+COPY --chown=default ui ${APP_ROOT}/src/ui
+COPY --chown=default sdk/python ${APP_ROOT}/src/sdk/python
 
 WORKDIR ${APP_ROOT}/src/ui
 RUN npm install && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Cleans up unused ubuntu installations, switches kind container dir to use /mnt, and only copies specific folders during feature-server image build. This PR also skips additional image builds for later tests. Only one image build is necessary for the operator and feature-server, respectively.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/feast-dev/feast/issues/5108

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
reverts some of the changes made in https://github.com/feast-dev/feast/pull/5089

recent addition of pytorch appears problematic ...  adding at least 755mb
```shell
Downloading torch-2.2.2-cp311-cp311-manylinux1_x86_64.whl (755.6 MB)
```