### PR TITLE
chore: Consolidate wheels/source builds & artifacts for release

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build-python-wheel:
-    name: Build wheels
+    name: Build wheels and source
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
         with:
           custom_version: ${{ github.event.inputs.custom_version }}
           token: ${{ github.event.inputs.token }}
-      - name: Build wheels
+      - name: Checkout version and install dependencies
         env:
           VERSION: ${{ steps.get-version.outputs.release_version }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -58,58 +58,18 @@ jobs:
           git fetch --tags
           git checkout ${VERSION}
           python -m pip install build
-          python -m build --wheel --outdir wheelhouse/
+      - name: Build feast
+        run: python -m build
       - uses: actions/upload-artifact@v4
         with:
           name: python-wheels
-          path: ./wheelhouse/*.whl
-
-  build-source-distribution:
-    name: Build source distribution
-    runs-on: macos-13
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Python
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          architecture: x64
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: './ui/.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-      - id: get-version
-        uses: ./.github/actions/get-semantic-release-version
-        with:
-          custom_version: ${{ github.event.inputs.custom_version }}
-          token: ${{ github.event.inputs.token }}
-      - name: Build and install dependencies
-        env:
-          VERSION: ${{ steps.get-version.outputs.release_version }}
-        # There's a `git restore` in here because `make install-go-ci-dependencies` is actually messing up go.mod & go.sum.
-        run: |
-          git fetch --tags
-          git checkout ${VERSION}
-          pip install -U pip setuptools wheel twine
-          make build-ui
-          git status
-          git restore go.mod go.sum
-          git restore sdk/python/feast/ui/yarn.lock
-      - name: Build
-        run: |
-          python3 setup.py sdist
-      - uses: actions/upload-artifact@v4
-        with:
-          name: source-distribution
           path: dist/*
 
   # We add this step so the docker images can be built as part of the pre-release verification steps.
   build-docker-images:
     name: Build Docker images
     runs-on: ubuntu-latest
-    needs: [ build-python-wheel, build-source-distribution ]
+    needs: [ build-python-wheel ]
     strategy:
       matrix:
         component: [ feature-server-dev, feature-server-java, feature-transformation-server, feast-operator ]
@@ -137,7 +97,7 @@ jobs:
   verify-python-wheels:
     name: Verify Python wheels
     runs-on: ${{ matrix.os }}
-    needs: [ build-python-wheel, build-source-distribution ]
+    needs: [ build-python-wheel ]
     strategy:
       matrix:
         os: [ ubuntu-latest,  macos-13 ]
@@ -167,10 +127,6 @@ jobs:
       - uses: actions/download-artifact@v4.1.7
         with:
           name: python-wheels
-          path: dist
-      - uses: actions/download-artifact@v4.1.7
-        with:
-          name: source-distribution
           path: dist
       - name: Install OS X dependencies
         if: matrix.os == 'macos-13'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Since the `0.42.0` release, our workflow has no longer been uploading the sdist tarball to PyPi. This PR aims to fix this by consolidating the wheels and source builds to a single job and uploading said artifacts to the same temp storage which feeds the PyPi upload job.

It's worth noting that the separate source job appears to have previously been created to resolve some issues that the `make install-go-ci-dependencies` was causing. This make command is no longer in use as it has since been commented out.
https://github.com/feast-dev/feast/blob/75f5a90536f7caa566b38b9c368ec33a90d2bfa5/Makefile#L649-L651