### PR TITLE
chore: Add compiled go test binary in github release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.22.9
+      - name: Compile Go Test Binaries
+        run: |
+          cd infra/feast-operator
+          mkdir -p dist
+          go test -c -o dist/operator-e2e-tests ./test/e2e/
       - name: Release (Dry Run)
         if: github.event.inputs.dry_run == 'true'
         run: |
@@ -178,7 +183,7 @@ jobs:
       - name: Release
         if: github.event.inputs.dry_run == 'false'
         run: |
-          npx -p @semantic-release/changelog -p @semantic-release/git -p @semantic-release/exec -p semantic-release semantic-release
+          npx -p @semantic-release/changelog -p @semantic-release/git -p @semantic-release/exec -p semantic-release semantic-release --github-assets "infra/feast-operator/dist/operator-e2e-tests"
           
 
   update_stable_branch:


### PR DESCRIPTION
# What this PR does / why we need it:

This PR adds compiling and attaching feast-operator e2e test binaries to the GitHub release,  so that it can be used anywhere by simply downloading.
(This is required for running upstream tests in RHOAI downstream builds)