### PR TITLE
feat: Provide callback function for threaded cache refresh failures

### DIFF
--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -230,6 +230,9 @@ class SqlRegistryConfig(RegistryConfig):
     """ str: Read Path to metadata store if different from path.
     If registry_type is 'sql', then this is a Read Endpoint for database URL. If not set, path will be used for read and write. """
 
+    on_cache_refresh_failure: Optional[Callable[[Exception], None]] = None
+    """ Optional[Callable[[Exception], None]]: Callback function for if CachingRegistry cache refresh fails. """
+
     sqlalchemy_config_kwargs: Dict[str, Any] = {"echo": False}
     """ Dict[str, Any]: Extra arguments to pass to SQLAlchemy.create_engine. """
 
@@ -246,6 +249,7 @@ class SqlRegistry(CachingRegistry):
         registry_config,
         project: str,
         repo_path: Optional[Path],
+        on_cache_refresh_failure: Optional[Callable[[Exception], None]] = None,
     ):
         assert registry_config is not None and isinstance(
             registry_config, SqlRegistryConfig
@@ -278,6 +282,7 @@ class SqlRegistry(CachingRegistry):
             project=project,
             cache_ttl_seconds=registry_config.cache_ttl_seconds,
             cache_mode=registry_config.cache_mode,
+            on_cache_refresh_failure=on_cache_refresh_failure,
         )
 
     def _sync_feast_metadata_to_projects_table(self):

--- a/sdk/python/tests/unit/infra/registry/test_registry.py
+++ b/sdk/python/tests/unit/infra/registry/test_registry.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
@@ -195,3 +196,21 @@ def test_skip_refresh_if_lock_held(registry):
         # Since the lock was already held, refresh should NOT be called
         mock_refresh.assert_not_called()
     registry._refresh_lock.release()
+
+
+def test_refresh_failure_triggers_alert_in_thread_mode(registry):
+    """Test that refresh failures in thread mode trigger the failure handler"""
+
+    registry._on_cache_refresh_failure = lambda e: None
+
+    with (
+        patch.object(registry, "_on_cache_refresh_failure") as mock_handler,
+        patch.object(
+            registry, "refresh", side_effect=Exception("Mock refresh failure")
+        ),
+    ):
+        registry._start_thread_async_refresh(cache_ttl_seconds=1)
+
+        time.sleep(2)
+
+        mock_handler.assert_called_once()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
The previous implementation of `_start_thread_async_refresh` was constantly creating new background threads to handle refreshing the cache. This exposed the possibility of running into a `Runtime Error: Can't start new thread` when attempting to start one, leading to no refresh thread running a causing a stale cache.

We are switching to keeping the same thread running, but using time.sleep() to control when a refresh occurs.

We are also introducing a callback function that is passed through `SqlRegistry` to `CachingRegistry`, which allows users to be notified whenever cache refreshes fail, and handle them in whatever way they want.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
@EXPEbdodla 
