### PR TITLE
feat!: Include PUBLIC_URL in defaultProjectListPromise URL in /ui

### DIFF
--- a/docs/reference/alpha-web-ui.md
+++ b/docs/reference/alpha-web-ui.md
@@ -102,7 +102,7 @@ The advantage of importing Feast UI as a module is in the ease of customization.
 
 ##### Fetching the Project List
 
-You can use `projectListPromise` to provide a promise that overrides where the Feast UI fetches the project list from.
+By default, the Feast UI fetches the project list from the app root path. You can use `projectListPromise` to provide a promise that overrides where it's fetched from.
 
 ```jsx
 <FeastUI

--- a/ui/README.md
+++ b/ui/README.md
@@ -77,7 +77,7 @@ The advantage of importing Feast UI as a module is in the ease of customization.
 
 ##### Fetching the Project List
 
-You can use `projectListPromise` to provide a promise that overrides where the Feast UI fetches the project list from.
+By default, the Feast UI fetches the project list from the app root path. You can use `projectListPromise` to provide a promise that overrides where it's fetched from.
 
 ```jsx
 <FeastUI

--- a/ui/src/FeastUI.tsx
+++ b/ui/src/FeastUI.tsx
@@ -25,7 +25,7 @@ const FeastUI = ({ reactQueryClient, feastUIConfigs }: FeastUIProps) => {
     >
       <QueryClientProvider client={queryClient}>
         <QueryParamProvider adapter={ReactRouter6Adapter}>
-          <FeastUISansProviders feastUIConfigs={feastUIConfigs} />
+          <FeastUISansProviders basename={basename} feastUIConfigs={feastUIConfigs} />
         </QueryParamProvider>
       </QueryClientProvider>
     </BrowserRouter>

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -40,8 +40,8 @@ interface FeastUIConfigs {
   projectListPromise?: Promise<any>;
 }
 
-const defaultProjectListPromise = () => {
-  return fetch("/projects-list.json", {
+const defaultProjectListPromise = (basename: string) => {
+  return fetch(`${basename}/projects-list.json`, {
     headers: {
       "Content-Type": "application/json",
     },
@@ -51,8 +51,10 @@ const defaultProjectListPromise = () => {
 };
 
 const FeastUISansProviders = ({
+  basename = "",
   feastUIConfigs,
 }: {
+  basename?: string;
   feastUIConfigs?: FeastUIConfigs;
 }) => {
   const projectListContext: ProjectsListContextInterface =
@@ -61,7 +63,7 @@ const FeastUISansProviders = ({
           projectsListPromise: feastUIConfigs?.projectListPromise,
           isCustom: true,
         }
-      : { projectsListPromise: defaultProjectListPromise(), isCustom: false };
+      : { projectsListPromise: defaultProjectListPromise(basename), isCustom: false };
 
   return (
     <EuiProvider colorMode="light">

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -96,16 +96,7 @@ root.render(
   <React.StrictMode>
     <FeastUI
       reactQueryClient={queryClient}
-      feastUIConfigs={{
-        tabsRegistry: tabsRegistry,
-        projectListPromise: fetch((process.env.PUBLIC_URL || "") + "/projects-list.json", {
-            headers: {
-              "Content-Type": "application/json",
-            },
-          }).then((res) => {
-            return res.json();
-          })
-      }}
+      feastUIConfigs={{ tabsRegistry }}
     />
   </React.StrictMode>
 );


### PR DESCRIPTION
# What this PR does / why we need it:

We currently always fetch the project list from the root path by default, even if the UI is served from a non-root path via PUBLIC_URL.

It seems reasonable to assume that the project list would be served from the same path as the UI by default, so change the default project list URL to include the [basename from PUBLIC_URL](https://github.com/feast-dev/feast/blob/2ac4906da2e87aa1f7457430dce75dcf8d3075a4/ui/src/FeastUI.tsx#L18). This way you don't need to specify a custom `projectListPromise` for this base case, as shown by the changes in ui/src/index.tsx.

## Breaking change

The PUBLIC_URL environment variable is now taken into account by default when fetching the project list. This is a breaking change only if all these points apply:

1. You're using Feast UI [as a module](https://github.com/feast-dev/feast/tree/master/ui#importing-the-ui-as-a-module)
2. You're serving the UI files from a non-root path via the PUBLIC_URL environment variable
3. You're serving the project list from the root path
4. You're not passing the `feastUIConfigs.projectListPromise` prop to the FeastUI component

In this case, you need to explicitly fetch the project list from the root path via the `feastUIConfigs.projectListPromise` prop:

```diff
 const root = createRoot(document.getElementById("root")!);
 root.render(
   <React.StrictMode>
-    <FeastUI />
+    <FeastUI
+      feastUIConfigs={{
+        projectListPromise: fetch("/projects-list.json", {
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }).then((res) => res.json())
+      }}
+    />
   </React.StrictMode>
 );
```

# Which issue(s) this PR fixes:

No existing issue, this came up in https://github.com/feast-dev/feast/pull/5004#issuecomment-2641149515:

> (And now looking at that, we could use basename in [defaultProjectListPromise](https://github.com/feast-dev/feast/blob/f4afcd2e9bb831e412dd31327b8596961422be5a/ui/src/FeastUISansProviders.tsx#L44) too, so you wouldn't always need to provide a custom projectListPromise just for this, but maybe that's for another pull request. 😄)

# Misc

I made this pull request because this new behavior would better match my expectations as a developer than the previous one, and would require less code if e.g. the PUBLIC_URL changes in different environments for a project. But I may well have missed something because I don't know the situations in which people use PUBLIC_URL. So feel free to dismiss this if it's not worth the hassle. 🙂