### PR TITLE
feat: Feast-festure-server helm support more deployment config

### DIFF
--- a/infra/charts/feast-feature-server/README.md
+++ b/infra/charts/feast-feature-server/README.md
@@ -35,6 +35,7 @@ See [here](https://github.com/feast-dev/feast/tree/master/examples/python-helm-d
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| extraEnvs | list | `[]` | Additional environment variables to be set in the container |
 | feast_mode | string | `"online"` | Feast supported deployment modes - online (default), offline, ui and registry |
 | feature_store_yaml_base64 | string | `""` | [required] a base64 encoded version of feature_store.yaml |
 | fullnameOverride | string | `""` |  |
@@ -62,3 +63,5 @@ See [here](https://github.com/feast-dev/feast/tree/master/examples/python-helm-d
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.name | string | `""` |  |
 | tolerations | list | `[]` |  |
+| volumeMounts | list | `[]` |  |
+| volumes | list | `[]` |  |

--- a/infra/charts/feast-feature-server/templates/deployment.yaml
+++ b/infra/charts/feast-feature-server/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -39,6 +43,9 @@ spec:
               value: {{ .Values.feature_store_yaml_base64 }}
             - name: INTRA_COMMUNICATION_BASE64
               value: {{ "intra-server-communication" | b64enc }}
+            {{- with .Values.extraEnvs}}
+              {{- toYaml . | nindent 12 }}
+            {{- end}}
           command:
             {{- if eq .Values.feast_mode "offline" }}
             - "feast"
@@ -99,6 +106,10 @@ spec:
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts}}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/infra/charts/feast-feature-server/values.yaml
+++ b/infra/charts/feast-feature-server/values.yaml
@@ -75,6 +75,13 @@ readinessProbe:
   initialDelaySeconds: 20
   periodSeconds: 10
 
+volumeMounts: []
+
+# extraEnvs -- Additional environment variables to be set in the container
+extraEnvs: []
+
+volumes: []
+
 # to create OpenShift Route object for UI
 route:
   enabled: false


### PR DESCRIPTION
# What this PR does / why we need it:

This PR let the feast-festure-server helm chart support the env, volume and volumemount config in values.yaml. And if not provide any values, it will keep the same render result as before.

Why I raise this juse because I am deploy the server in GKE, but in out case we need access the AWS dynamoDB as the online store for test now. After my expriment, I need add the env, volume and volumemount in the deployment manifest, but the config can not support those fields, I have to patch them after helm upgrade. So just made this change to support them.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
N/A
