### PR TITLE
feat: Operator mounts the odh-trusted-ca-bundle configmap when deployed on RHOAI or ODH

### DIFF
--- a/infra/feast-operator/go.mod
+++ b/infra/feast-operator/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/infra/feast-operator/internal/controller/services/services_types.go
+++ b/infra/feast-operator/internal/controller/services/services_types.go
@@ -34,12 +34,16 @@ const (
 	DefaultOnlineStorePath    = "online_store.db"
 	svcDomain                 = ".svc.cluster.local"
 
-	HttpPort      = 80
-	HttpsPort     = 443
-	HttpScheme    = "http"
-	HttpsScheme   = "https"
-	tlsPath       = "/tls/"
-	tlsNameSuffix = "-tls"
+	HttpPort              = 80
+	HttpsPort             = 443
+	HttpScheme            = "http"
+	HttpsScheme           = "https"
+	tlsPath               = "/tls/"
+	tlsPathCustomCABundle = "/etc/pki/tls/custom-certs/ca-bundle.crt"
+	tlsNameSuffix         = "-tls"
+
+	caBundleAnnotation = "config.openshift.io/inject-trusted-cabundle"
+	caBundleName       = "odh-trusted-ca-bundle"
 
 	DefaultOfflineStorageRequest  = "20Gi"
 	DefaultOnlineStorageRequest   = "5Gi"
@@ -267,4 +271,11 @@ type deploymentSettings struct {
 	Args            []string
 	TargetHttpPort  int32
 	TargetHttpsPort int32
+}
+
+// CustomCertificatesBundle represents a custom CA bundle configuration
+type CustomCertificatesBundle struct {
+	IsDefined     bool
+	VolumeName    string
+	ConfigMapName string
 }

--- a/infra/feast-operator/internal/controller/services/tls_test.go
+++ b/infra/feast-operator/internal/controller/services/tls_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package services
 
 import (
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"context"
 
 	feastdevv1alpha1 "github.com/feast-dev/feast/infra/feast-operator/api/v1alpha1"
 	"github.com/feast-dev/feast/infra/feast-operator/internal/controller/handler"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -46,8 +47,10 @@ var _ = Describe("TLS Config", func() {
 			// registry server w/o tls
 			feast := FeastServices{
 				Handler: handler.FeastHandler{
-					FeatureStore: minimalFeatureStore(),
+					Client:       k8sClient,
 					Scheme:       scheme,
+					Context:      context.TODO(),
+					FeatureStore: minimalFeatureStore(),
 				},
 			}
 			feast.Handler.FeatureStore.Spec.Services = &feastdevv1alpha1.FeatureStoreServices{


### PR DESCRIPTION
The operator searches for the `odh-trusted-ca-bundle` ConfigMap and mounts it into the Feast containers. In case the standalone feast operator is deployed and the ConfigMap is not present, the operator will not mount it.

This change is required when the Feast operator is deployed with ODH or RHOAI.

example of volume mount. 
![Screenshot 2025-03-20 at 2 34 59 PM](https://github.com/user-attachments/assets/0f4b59b4-520a-4b96-aeff-58fddd1ee5b7)


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
