### PR TITLE
feat: ignore ipynb files during apply

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -104,6 +104,7 @@ def get_repo_files(repo_root: Path) -> List[Path]:
         p.resolve()
         for p in repo_root.glob("**/*.py")
         if p.is_file() and "__init__.py" != p.name
+        and not p.name.endswith(".ipynb") # Ignore Jupyter Notebook files during feast apply
     }
     # Ignore all files that match any of the ignore paths in .feastignore
     repo_files -= ignore_files


### PR DESCRIPTION
# What this PR does / why we need it:
Ignore Jupyter Notebook Files extensions when using feast apply

# Which issue(s) this PR fixes:
Fixes #5145 