### PR TITLE
feat: Add async DynamoDB timeout and retry configuration

### DIFF
--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -96,9 +96,7 @@ class DynamoDBOnlineStoreConfig(FeastConfigBaseModel):
     total_max_retry_attempts: Union[int, None] = None
     """Maximum number of total attempts that will be made on a single request.
 
-    Maps to `retries.total_max_attempts` in botocore.config.Config. Cf.
-    https://github.com/boto/botocore/blob/dd8406d5fa1df18037d1dd2977aec47334f7e3ce/botocore/args.py#L558
-    as for why `retries.max_attempts` is not exposed here.
+    Maps to `retries.total_max_attempts` in botocore.config.Config.
     """
 
     retry_mode: Union[Literal["legacy", "standard", "adaptive"], None] = None
@@ -607,7 +605,7 @@ async def _get_aiodynamodb_client(
                 max_pool_connections=max_pool_connections,
                 connect_timeout=connect_timeout,
                 read_timeout=read_timeout,
-                retries=retries,
+                retries=retries if retries else None,
                 connector_args={"keepalive_timeout": keepalive_timeout},
             ),
         )

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -96,13 +96,16 @@ class DynamoDBOnlineStoreConfig(FeastConfigBaseModel):
     total_max_retry_attempts: Union[int, None] = None
     """Maximum number of total attempts that will be made on a single request.
 
-    Cf.
+    Maps to `retries.total_max_attempts in botocore.config.Config. Cf.
     https://github.com/boto/botocore/blob/dd8406d5fa1df18037d1dd2977aec47334f7e3ce/botocore/args.py#L558
-    as for why `max_attempts` is not exposed here.
+    as for why `retries.max_attempts` is not exposed here.
     """
 
     retry_mode: Union[Literal["legacy", "standard", "adaptive"], None] = None
-    """The type of retry mode (aio)botocore should use."""
+    """The type of retry mode (aio)botocore should use.
+
+    Maps to `retries.mode in botocore.config.Config.
+    """
 
 
 class DynamoDBOnlineStore(OnlineStore):

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -96,7 +96,7 @@ class DynamoDBOnlineStoreConfig(FeastConfigBaseModel):
     total_max_retry_attempts: Union[int, None] = None
     """Maximum number of total attempts that will be made on a single request.
 
-    Maps to `retries.total_max_attempts in botocore.config.Config. Cf.
+    Maps to `retries.total_max_attempts` in botocore.config.Config. Cf.
     https://github.com/boto/botocore/blob/dd8406d5fa1df18037d1dd2977aec47334f7e3ce/botocore/args.py#L558
     as for why `retries.max_attempts` is not exposed here.
     """
@@ -104,7 +104,7 @@ class DynamoDBOnlineStoreConfig(FeastConfigBaseModel):
     retry_mode: Union[Literal["legacy", "standard", "adaptive"], None] = None
     """The type of retry mode (aio)botocore should use.
 
-    Maps to `retries.mode in botocore.config.Config.
+    Maps to `retries.mode` in botocore.config.Config.
     """
 
 

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -59,13 +59,13 @@ class DynamoDBOnlineStoreRetryConfig(FeastConfigBaseModel):
     for details.
     """
 
-    total_max_attempts: int | None = None
+    total_max_attempts: Union[int, None] = None
     """Maximum number of total attempts that will be made on a single request."""
 
-    max_attempts: int | None = None
+    max_attempts: Union[int, None] = None
     """Maximum number of retry attempts that will be made on a single request."""
 
-    mode: Literal["legacy", "standard", "adaptive"] | None = None
+    mode: Union[Literal["legacy", "standard", "adaptive"], None] = None
     """The type of retry mode (aio)botocore should use."""
 
 
@@ -102,11 +102,11 @@ class DynamoDBOnlineStoreConfig(FeastConfigBaseModel):
     keepalive_timeout: float = 12.0
     """Keep-alive timeout in seconds for async Dynamodb connections."""
 
-    connect_timeout: int | float = 60
+    connect_timeout: Union[int, float] = 60
     """The time in seconds until a timeout exception is thrown when attempting to make
     an async connection."""
 
-    read_timeout: int | float = 60
+    read_timeout: Union[int, float] = 60
     """The time in seconds until a timeout exception is thrown when attempting to read
     from an async connection."""
 
@@ -588,8 +588,8 @@ async def _get_aiodynamodb_client(
     region: str,
     max_pool_connections: int,
     keepalive_timeout: float,
-    connect_timeout: int | float,
-    read_timeout: int | float,
+    connect_timeout: Union[int, float],
+    read_timeout: Union[int, float],
     retries: DynamoDBOnlineStoreRetryConfig,
 ):
     global _aioboto_client

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -591,7 +591,7 @@ async def _get_aiodynamodb_client(
     if _aioboto_client is None:
         logger.debug("initializing the aiobotocore dynamodb client")
 
-        retries = {}
+        retries: Dict[str, Any] = {}
         if total_max_retry_attempts is not None:
             retries["total_max_attempts"] = total_max_retry_attempts
         if retry_mode is not None:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:

In some cases it can be useful to be able to control the timeout and retry behavior of (async) DynamoDB connections. This PR exposes the respective functionality of (aio)botocore in the current project. By default, `connect_timeout` and `read_timeout` are set to 60 seconds, which is the default in (aio)botocore (https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html). Therefore this value is currently also implicitly used.

The `DynamoDBOnlineStoreRetryConfig` model was introduced to stay close to what the configuration would look like in botocore. If preferred, the respective fields could also be moved into the top level config model, i.e., DynamoDBOnlineStoreConfig.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
