### PR TITLE
docs: Removed ref to unused kind

### DIFF
--- a/examples/operator-quickstart/01-Install.ipynb
+++ b/examples/operator-quickstart/01-Install.ipynb
@@ -7,7 +7,7 @@
     "# Install Feast on Kubernetes with the Feast Operator\n",
     "## Objective\n",
     "\n",
-    "Provide a reference implementation of a runbook to deploy a Feast environment on a Kubernetes cluster using [Kind](https://kind.sigs.k8s.io/docs/user/quick-start) and the [Feast Operator](../../infra/feast-operator/)."
+    "Provide a reference implementation of a runbook to deploy a Feast environment on a Kubernetes cluster using the [Feast Operator](../../infra/feast-operator/)."
    ]
   },
   {
@@ -87,7 +87,7 @@
    "metadata": {},
    "source": [
     "## Deployment Architecture\n",
-    "The primary objective of this runbook is to guide the deployment of Feast services on a Kubernetes Kind cluster, using the `postgres` template to set up a basic feature store.\n",
+    "The primary objective of this runbook is to guide the deployment of Feast services on a Kubernetes cluster, using the `postgres` template to set up a basic feature store.\n",
     "\n",
     "In this notebook, we will deploy a distributed topology of Feast services, which includes:\n",
     "\n",
@@ -95,7 +95,7 @@
     "* `Online Store Server`: Uses the `Registry Server` to query metadata and is responsible for low-latency serving of features.\n",
     "* `Offline Store Server`: Uses the `Registry Server` to query metadata and provides access to batch data for historical feature retrieval.\n",
     "\n",
-    "Each service is backed by a `PostgreSQL` database, which is also deployed within the same Kind cluster."
+    "Each service is backed by a `PostgreSQL` database, which is also deployed within the same cluster."
    ]
   },
   {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
The notebook suggests that it will use a Kind cluster for implementation, but then ends up using Colima. I removed the references to Kind, so that users won't be confused.

