### PR TITLE
chore: Add format-ui Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -620,11 +620,13 @@ build-helm-docs:
 	cd ${ROOT_DIR}/infra/charts/feast-feature-server; helm-docs
 
 # Web UI
+# Note: these require node and yarn to be installed
 
-# Note: requires node and yarn to be installed
 build-ui:
 	cd $(ROOT_DIR)/sdk/python/feast/ui && yarn upgrade @feast-dev/feast-ui --latest && yarn install && npm run build --omit=dev
 
+format-ui:
+	cd $(ROOT_DIR)/ui && NPM_TOKEN= yarn install && NPM_TOKEN= yarn format
 
 
 # Go SDK & embedded


### PR DESCRIPTION
# What this PR does / why we need it:

Adds a Makefile target for formatting the UI code.

# Which issue(s) this PR fixes:

This was requested in #5149 (if I understood the request correctly).

# Misc

The `ui` directory requires the `NPM_TOKEN` environment variable to exist to run any package manager command via [.npmrc](https://github.com/feast-dev/feast/blob/master/ui/.npmrc). I just always define it to an empty value like in these changes, don't know if there is a more convenient way, or if we can assume that the developer already has it defined in their environment.