### PR TITLE
fix: Typo in metrics.enabled in feast-feature-server chart

### DIFF
--- a/infra/charts/feast-feature-server/templates/deployment.yaml
+++ b/infra/charts/feast-feature-server/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - "{{ .Values.logLevel }}"
             - "serve_registry"
             {{- else }}
-            {{- if .Values.metrics.enlabled }}
+            {{- if .Values.metrics.enabled }}
             - "feast"
             - "--log-level"
             - "{{ .Values.logLevel }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
There's a typo in deployment.yaml of the chart. The actual value is metrics.enabled while in the deployment.yaml its metrics.enlabled. 

# Which issue(s) this PR fixes:

The issue fixes the metrics.enabled in the chart.


# Misc
N/A
