### PR TITLE
feat: Added global registry search support in Feast UI

### DIFF
--- a/ui/src/components/RegistrySearch.tsx
+++ b/ui/src/components/RegistrySearch.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+import { EuiText, EuiFieldSearch, EuiSpacer } from "@elastic/eui";
+import EuiCustomLink from "./EuiCustomLink";
+
+interface RegistrySearchProps {
+  categories: {
+    name: string;
+    data: any[];
+    getLink: (item: any) => string;
+  }[];
+}
+
+const RegistrySearch: React.FC<RegistrySearchProps> = ({ categories }) => {
+  const [searchText, setSearchText] = useState("");
+
+  const searchResults = categories.map(({ name, data, getLink }) => {
+    const filteredItems = searchText
+      ? data.filter((item) => {
+          const itemName =
+            "name" in item
+              ? String(item.name)
+              : "spec" in item && item.spec && "name" in item.spec
+                ? String(item.spec.name ?? "Unknown")
+                : "Unknown";
+
+          return itemName.toLowerCase().includes(searchText.toLowerCase());
+        })
+      : [];
+
+    return { name, items: filteredItems, getLink };
+  });
+
+  return (
+    <>
+      <EuiSpacer size="l" />
+      <EuiText>
+        <h3>Search in registry</h3>
+      </EuiText>
+      <EuiFieldSearch
+        placeholder="Search across Feature Views, Features, Entities, etc."
+        value={searchText}
+        onChange={(e) => setSearchText(e.target.value)}
+        isClearable
+        fullWidth
+      />
+      <EuiSpacer size="m" />
+
+      {searchText && (
+        <EuiText>
+          <h3>Search Results</h3>
+          {searchResults.some(({ items }) => items.length > 0) ? (
+            searchResults.map(({ name, items, getLink }, index) =>
+              items.length > 0 ? (
+                <div key={index}>
+                  <h4>{name}</h4>
+                  <ul>
+                    {items.map((item, idx) => {
+                      const itemName =
+                        "name" in item
+                          ? item.name
+                          : "spec" in item
+                            ? item.spec?.name
+                            : "Unknown";
+
+                      const itemLink = getLink(item);
+
+                      return (
+                        <li key={idx}>
+                          <EuiCustomLink to={itemLink}>
+                            {itemName}
+                          </EuiCustomLink>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ) : null,
+            )
+          ) : (
+            <p>No matches found.</p>
+          )}
+        </EuiText>
+      )}
+    </>
+  );
+};
+
+export default RegistrySearch;

--- a/ui/src/components/RegistrySearch.tsx
+++ b/ui/src/components/RegistrySearch.tsx
@@ -36,6 +36,7 @@ const RegistrySearch: React.FC<RegistrySearchProps> = ({ categories }) => {
       <EuiText>
         <h3>Search in registry</h3>
       </EuiText>
+      <EuiSpacer size="s" />
       <EuiFieldSearch
         placeholder="Search across Feature Views, Features, Entities, etc."
         value={searchText}
@@ -73,6 +74,7 @@ const RegistrySearch: React.FC<RegistrySearchProps> = ({ categories }) => {
                       );
                     })}
                   </ul>
+                  <EuiSpacer size="m" />
                 </div>
               ) : null,
             )

--- a/ui/src/pages/ProjectOverviewPage.tsx
+++ b/ui/src/pages/ProjectOverviewPage.tsx
@@ -130,7 +130,7 @@ const ProjectOverviewPage = () => {
         </EuiFlexGroup>
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section>
-        <RegistrySearch categories={categories} />
+        {isSuccess && <RegistrySearch categories={categories} />}
       </EuiPageTemplate.Section>
     </EuiPageTemplate>
   );

--- a/ui/src/pages/ProjectOverviewPage.tsx
+++ b/ui/src/pages/ProjectOverviewPage.tsx
@@ -16,7 +16,7 @@ import ObjectsCountStats from "../components/ObjectsCountStats";
 import ExplorePanel from "../components/ExplorePanel";
 import useLoadRegistry from "../queries/useLoadRegistry";
 import RegistryPathContext from "../contexts/RegistryPathContext";
-import EuiCustomLink from "../components/EuiCustomLink";
+import RegistrySearch from "../components/RegistrySearch";
 import { useParams } from "react-router-dom";
 
 const ProjectOverviewPage = () => {
@@ -65,22 +65,6 @@ const ProjectOverviewPage = () => {
       },
     },
   ];
-
-  const searchResults = categories.map(({ name, data }) => {
-    const filteredItems = searchText
-      ? data.filter((item) => {
-          const itemName =
-            "name" in item
-              ? String(item.name)
-              : "spec" in item && item.spec && "name" in item.spec
-                ? String(item.spec.name ?? "Unknown")
-                : "Unknown";
-
-          return itemName.toLowerCase().includes(searchText.toLowerCase());
-        })
-      : [];
-    return { name, items: filteredItems };
-  });
 
   return (
     <EuiPageTemplate panelled>
@@ -145,57 +129,8 @@ const ProjectOverviewPage = () => {
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPageTemplate.Section>
-
       <EuiPageTemplate.Section>
-        <EuiSpacer size="l" />
-        <EuiTitle size="xs">
-          <h3>Search in Registry</h3>
-        </EuiTitle>
-        <EuiFieldSearch
-          placeholder="Search across Feature Views, Features, Entities, etc."
-          value={searchText}
-          onChange={(e) => setSearchText(e.target.value)}
-          isClearable
-          fullWidth
-        />
-        <EuiSpacer size="m" />
-
-        {searchText && (
-          <EuiText>
-            <h3>Search Results</h3>
-            {searchResults.some(({ items }) => items.length > 0) ? (
-              searchResults.map(({ name, items }, index) =>
-                items.length > 0 ? (
-                  <div key={index}>
-                    <h4>{name}</h4>
-                    <ul>
-                      {items.map((item, idx) => {
-                        const itemName =
-                          "name" in item
-                            ? item.name
-                            : "spec" in item
-                              ? item.spec?.name
-                              : "Unknown";
-
-                        const itemLink = categories[index].getLink(item);
-
-                        return (
-                          <li key={idx}>
-                            <EuiCustomLink to={itemLink}>
-                              {itemName}
-                            </EuiCustomLink>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  </div>
-                ) : null,
-              )
-            ) : (
-              <p>No matches found.</p>
-            )}
-          </EuiText>
-        )}
+        <RegistrySearch categories={categories} />
       </EuiPageTemplate.Section>
     </EuiPageTemplate>
   );

--- a/ui/src/pages/features/FeatureListPage.tsx
+++ b/ui/src/pages/features/FeatureListPage.tsx
@@ -12,6 +12,7 @@ import EuiCustomLink from "../../components/EuiCustomLink";
 import { useParams } from "react-router-dom";
 import useLoadRegistry from "../../queries/useLoadRegistry";
 import RegistryPathContext from "../../contexts/RegistryPathContext";
+import { FeatureIcon } from "../../graphics/FeatureIcon";
 
 interface Feature {
   name: string;
@@ -34,9 +35,6 @@ const FeatureListPage = () => {
 
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(100);
-
-  if (isLoading) return <p>Loading...</p>;
-  if (isError) return <p>Error loading features.</p>;
 
   const features: Feature[] = data?.allFeatures || [];
 
@@ -107,24 +105,36 @@ const FeatureListPage = () => {
 
   return (
     <EuiPageTemplate panelled>
-      <EuiPageTemplate.Header pageTitle="Feature List" />
+      <EuiPageTemplate.Header
+        restrictWidth
+        iconType={FeatureIcon}
+        pageTitle="Feature List"
+      />
       <EuiPageTemplate.Section>
-        <EuiFieldSearch
-          placeholder="Search features"
-          value={searchText}
-          onChange={(e) => setSearchText(e.target.value)}
-          fullWidth
-        />
-        <EuiBasicTable
-          columns={columns}
-          items={paginatedFeatures}
-          rowProps={getRowProps}
-          sorting={{
-            sort: { field: sortField, direction: sortDirection },
-          }}
-          onChange={onTableChange}
-          pagination={pagination}
-        />
+        {isLoading ? (
+          <p>Loading...</p>
+        ) : isError ? (
+          <p>We encountered an error while loading.</p>
+        ) : (
+          <>
+            <EuiFieldSearch
+              placeholder="Search features"
+              value={searchText}
+              onChange={(e) => setSearchText(e.target.value)}
+              fullWidth
+            />
+            <EuiBasicTable
+              columns={columns}
+              items={paginatedFeatures}
+              rowProps={getRowProps}
+              sorting={{
+                sort: { field: sortField, direction: sortDirection },
+              }}
+              onChange={onTableChange}
+              pagination={pagination}
+            />
+          </>
+        )}
       </EuiPageTemplate.Section>
     </EuiPageTemplate>
   );


### PR DESCRIPTION
# What this PR does / why we need it:
This adds registry search support at feast homepage. As a user, I should be able to use search in the Feast UI and return FVs, Entities, Data Sources, and anything else in the registry.

# Which issue(s) this PR fixes:

Fixes #5146 


# Misc
Screenshot:

<img width="1490" alt="Screenshot 2025-03-27 at 11 10 41 PM" src="https://github.com/user-attachments/assets/7d4040d4-cba0-4443-9048-e46404b19c7d" />




