### PR TITLE
fix: Preserve remote URIs (e.g. s3://) in DaskOfflineStore path

### DIFF
--- a/sdk/python/feast/infra/offline_stores/dask.py
+++ b/sdk/python/feast/infra/offline_stores/dask.py
@@ -521,10 +521,9 @@ class DaskOfflineStore(OfflineStore):
 
         file_options = feature_view.batch_source.file_options
 
-        if config.repo_path is not None and not Path(file_options.uri).is_absolute():
-            absolute_path = config.repo_path / file_options.uri
-        else:
-            absolute_path = Path(file_options.uri)
+        absolute_path = FileSource.get_uri_for_file_path(
+            repo_path=config.repo_path, uri=file_options.uri
+        )
 
         filesystem, path = FileSource.create_filesystem_and_path(
             str(absolute_path), file_options.s3_endpoint_override
@@ -574,10 +573,11 @@ def _read_datasource(data_source, repo_path) -> dd.DataFrame:
         else None
     )
 
-    if not Path(data_source.path).is_absolute():
-        path = repo_path / data_source.path
-    else:
-        path = data_source.path
+    path = FileSource.get_uri_for_file_path(
+        repo_path=repo_path,
+        uri=data_source.file_options.uri,
+    )
+
     return dd.read_parquet(
         path,
         storage_options=storage_options,


### PR DESCRIPTION
… resolution

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
This PR fixes an issue where remote URIs such as `s3://...` in `FileSource` were mistakenly interpreted as local paths inside the `DaskOfflineStore`.

Previously, `Path("s3://bucket/file.parquet").is_absolute()` returned `False`, causing Feast to incorrectly join the remote URI with `repo_path`, leading to malformed paths like: /project/path/s3:/bucket/file.parquet
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Similar to logic in #5076 (but applied inside `DaskOfflineStore`)
-->
