### PR TITLE
Fix broken link to registry documentation

### DIFF
--- a/docs/reference/registries/README.md
+++ b/docs/reference/registries/README.md
@@ -1,6 +1,6 @@
 # Registies
 
-Please see [Registry](../../getting-started/architecture-and-components/registry.md) for a conceptual explanation of registries.
+Please see [Registry](../../getting-started/components/registry.md) for a conceptual explanation of registries.
 
 {% content-ref url="local.md" %}
 [local.md](local.md)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
The link to more information about registries on [this page](https://docs.feast.dev/reference/registries) is broken. This change fixes that.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
