### PR TITLE
fix: Fixed integration tests for qdrant and milvus

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -2020,10 +2020,6 @@ class FeatureStore:
         """
         Search and return document features from the online document store.
         """
-        vector_field_metadata = _get_feature_view_vector_field_metadata(table)
-        if vector_field_metadata:
-            distance_metric = vector_field_metadata.vector_search_metric
-
         documents = provider.retrieve_online_documents(
             config=self.config,
             table=table,

--- a/sdk/python/feast/infra/online_stores/qdrant_online_store/qdrant.py
+++ b/sdk/python/feast/infra/online_stores/qdrant_online_store/qdrant.py
@@ -115,7 +115,11 @@ class QdrantOnlineStore(OnlineStore):
                 encoded_value = base64.b64encode(value.SerializeToString()).decode(
                     "utf-8"
                 )
-                vector_val = json.loads(get_list_val_str(value))
+                vector_val = get_list_val_str(value)
+                if vector_val:
+                    vector = {config.online_store.vector_name: json.loads(vector_val)}
+                else:
+                    vector = {}
                 points.append(
                     models.PointStruct(
                         id=uuid.uuid4().hex,
@@ -126,7 +130,7 @@ class QdrantOnlineStore(OnlineStore):
                             "timestamp": timestamp,
                             "created_ts": created_ts,
                         },
-                        vector={config.online_store.vector_name: vector_val},
+                        vector=vector,
                     )
                 )
 

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -565,9 +565,13 @@ def construct_test_environment(
             cache_ttl_seconds=1,
         )
 
-    if isinstance(
-        test_repo_config.online_store, dict
-    ) and test_repo_config.online_store.get("type") in ["milvus", "pgvector", "qdrant"]:
+    online_store = (
+        test_repo_config.online_store.get("type")
+        if isinstance(test_repo_config.online_store, dict)
+        else test_repo_config.online_store
+    )
+
+    if online_store in ["milvus", "pgvector", "qdrant"]:
         entity_key_serialization_version = 3
 
     environment_params = {

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -870,7 +870,7 @@ def test_retrieve_online_documents(environment, fake_document_data):
     fs.write_to_online_store("item_embeddings", df)
 
     documents = fs.retrieve_online_documents(
-        features=["item_embeddings:embedding_float"],
+        features=["item_embeddings:embedding_float", "item_embeddings:item_id"],
         query=[1.0, 2.0],
         top_k=2,
         distance_metric="L2",


### PR DESCRIPTION
# What this PR does / why we need it:
Fixed integration tests for milvus and qdrant.

```
make test-python-universal-milvus-online

make test-python-universal-qdrant-online
```

- sdk/python/feast/feature_store.py
       - Removed override of distance_metric in _retrieve_from_online_store. This was always overriding distance_metric with default value of vector_search_metric even wrong value is passed. It's required only in v2 method. It was added in https://github.com/feast-dev/feast/pull/4971 . 
     
- sdk/python/feast/infra/online_stores/qdrant_online_store/qdrant.py 
     - Fixed `json.loads() `when `get_list_val_str` returns `None`. In `online_write_batch()`, we are assuming that every value will be a a vector/embedding. But some of the features (like `string_feature: "a"`) are not embeddings. 

- sdk/python/tests/integration/feature_repos/repo_configuration.py
    - Fixed entity_key_serialization_version set logic.
