### PR TITLE
chore: Add kustomize overlay to Operator for RHOAI install support

### DIFF
--- a/infra/feast-operator/config/overlays/rhoai/delete-namespace.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/delete-namespace.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system

--- a/infra/feast-operator/config/overlays/rhoai/kustomization.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/kustomization.yaml
@@ -1,0 +1,54 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: redhat-ods-applications
+
+
+resources:
+  - ../../default
+
+
+patches:
+  # patch to remove default `system` namespace in ../../manager/manager.yaml
+  - path: delete-namespace.yaml
+
+configMapGenerator:
+  - name:  feast-operator-parameters
+    envs:
+      - params.env
+
+configurations:
+  - params.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: feast-operator-parameters
+      version: v1
+      fieldPath: data.RELATED_IMAGE_FEAST_OPERATOR
+    targets:
+      - select:
+          kind: Deployment
+          name: controller-manager
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].image
+  - source:
+      kind: ConfigMap
+      name: feast-operator-parameters
+      fieldPath: data.RELATED_IMAGE_FEATURE_SERVER
+    targets:
+      - select:
+          kind: Deployment
+          name: controller-manager
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=RELATED_IMAGE_FEATURE_SERVER].value
+  - source:
+      kind: ConfigMap
+      name: feast-operator-parameters
+      fieldPath: data.RELATED_IMAGE_CRON_JOB
+    targets:
+      - select:
+          kind: Deployment
+          name: controller-manager
+        fieldPaths:
+          - spec.template.spec.containers.[name=manager].env.[name=RELATED_IMAGE_CRON_JOB].value

--- a/infra/feast-operator/config/overlays/rhoai/params.env
+++ b/infra/feast-operator/config/overlays/rhoai/params.env
@@ -1,0 +1,3 @@
+RELATED_IMAGE_FEAST_OPERATOR=quay.io/feastdev/feast-operator:0.47.0
+RELATED_IMAGE_FEATURE_SERVER=quay.io/feastdev/feature-server:0.47.0
+RELATED_IMAGE_CRON_JOB=registry.redhat.io/openshift4/ose-cli:v4.15

--- a/infra/feast-operator/config/overlays/rhoai/params.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment

--- a/infra/scripts/release/files_to_bump.txt
+++ b/infra/scripts/release/files_to_bump.txt
@@ -14,6 +14,7 @@ infra/feast-operator/Makefile 6
 infra/feast-operator/config/manager/kustomization.yaml 8
 infra/feast-operator/config/component_metadata.yaml 4
 infra/feast-operator/config/overlays/odh/params.env 1 2
+infra/feast-operator/config/overlays/rhoai/params.env 1 2
 infra/feast-operator/api/feastversion/version.go 20
 java/pom.xml 38
 sdk/python/feast/infra/feature_servers/multicloud/requirements.txt 2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
This adds a new kustomize overlay for RHOAI Operator installations. Currently, the only real difference in this overlay is the use of a RH product image - `registry.redhat.io/openshift4/ose-cli:v4.15`
