### PR TITLE
fix: Fix milvus online_read

### DIFF
--- a/sdk/python/feast/infra/online_stores/milvus_online_store/milvus.py
+++ b/sdk/python/feast/infra/online_stores/milvus_online_store/milvus.py
@@ -412,16 +412,7 @@ class MilvusOnlineStore(OnlineStore):
                                 "float_list_val",
                                 "double_list_val",
                             ]:
-                                setattr(
-                                    val,
-                                    proto_attr,
-                                    list(
-                                        map(
-                                            type(getattr(val, proto_attr)).__args__[0],
-                                            field_value,
-                                        )
-                                    ),
-                                )
+                                getattr(val, proto_attr).val.extend(field_value)
                             else:
                                 setattr(val, proto_attr, field_value)
                         else:


### PR DESCRIPTION
# What this PR does / why we need it:

Fixes get_online_features for milvus:

```
"/Users/farceo/dev/feast/sdk/python/feast/infra/online_stores/online_store.py", line 199, in get_online_features
    read_rows = self.online_read(
  File "/Users/farceo/dev/feast/sdk/python/feast/infra/online_stores/milvus_online_store/milvus.py", line 421, in online_read
    type(getattr(val, proto_attr)).__args__[0],
AttributeError: __args__
```

After fix:

```
def run_entity_retrieval_demo():
    entity_retrieved_features = store.get_online_features(
        features=[
            "docling_transform_docs:vector",
            "docling_transform_docs:chunk_id",
            "docling_transform_docs:chunk_text",
            "docling_transform_docs:document_id",
        ],
        entity_rows=[{"document_id": "doc-1", "chunk_id": "chunk-1"}],
    )
    print("docling transformed features retrieved via entity =")
    print(entity_retrieved_features.to_df())
```

```
Connecting to Milvus in local mode using data/online_store.db
docling transformed features retrieved via entity =
  document_id chunk_id                                         chunk_text                                             vector
0       doc-1  chunk-1  a. Picture of a table:\nTables organize valuab...  [0.05077127367258072, -0.005573314614593983, -...

```
