### PR TITLE
fix: Allow get_historical_features with only On Demand Feature View

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ ci = [
     "pytest-mock==1.10.4",
     "pytest-env",
     "Sphinx>4.0.0,<7",
+    "sqlglot[rs]>=26.12.1",
     "testcontainers==4.9.0",
     "python-keycloak==4.2.2",
     "pre-commit<3.3.2",

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
@@ -484,8 +484,10 @@ entity_dataframe AS (
         {% else %}
             {{ left_table_query_string }}
         {% endif %}
-),
-
+)
+{% if featureviews | length > 0 %}
+,
+{% endif %}
 {% for featureview in featureviews %}
 
 "{{ featureview.name }}__entity_dataframe" AS (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
Currently, when trying to `get_historical_features` from a postgres offline store without specifying a FeatureView, the call fails due to bad SQL generated. This PR fixes the SQL generated and also introduces a way(via `sqlglot`) to validate the SQL as part of unit tests to hopefully keep this from happening in the future.

# Which issue(s) this PR fixes:
https://github.com/feast-dev/feast/issues/5239


# Misc
The RedShift implementation is most likely suffering from this same issue as the template code is basically the same.
