### PR TITLE
fix: Embed Query configuration breaks when switching between DataFrame and SQL

### DIFF
--- a/sdk/python/tests/unit/infra/offline_stores/contrib/postgres_offline_store/test_postgres.py
+++ b/sdk/python/tests/unit/infra/offline_stores/contrib/postgres_offline_store/test_postgres.py
@@ -362,7 +362,7 @@ def test_get_historical_features_entity_select_modes_embed_query(
 @patch(
     "feast.infra.offline_stores.contrib.postgres_offline_store.postgres.get_query_schema"
 )
-def test_get_historical_features_entity_select_modes_embed_query(
+def test_get_historical_features_entity_select_modes_embed_query_with_dataframe(
     mock_get_query_schema, mock_df_to_postgres_table, mock_get_conn
 ):
     mock_conn = MagicMock()


### PR DESCRIPTION
# What this PR does / why we need it:
This PR fixes a bug introduced w/ the `entity_select_mode`. Currently, if a user sets `entity_select_mode="embed_query` and then passed a DataFrame, we fail. This should not happen as we can no longer be in a mixed state of both SQL queries w/ `entity_select_mode="embed_query` and DataFrames.

# Which issue(s) this PR fixes:
N/A


# Misc
N/A
