### PR TITLE
fix: Fixed Permissions object parameter in example

### DIFF
--- a/examples/rbac-local/01.3-setup-feast.ipynb
+++ b/examples/rbac-local/01.3-setup-feast.ipynb
@@ -488,7 +488,7 @@
     "write_fresh_permission = Permission(\n",
     "    name=\"write_fresh_permission\",\n",
     "    types=FeatureView,\n",
-    "    name_pattern=\".*_fresh\",\n",
+    "    name_patterns=\".*_fresh\",\n",
     "    policy=RoleBasedPolicy(roles=[\"fresh_writer\"]),\n",
     "    actions=AuthzedAction.WRITE_ONLINE\n",
     ")\n",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

This is a small PR to fix the parameter in the RBAC local example, specifically for the `Permissions` class instantiation. The current class instantiation has a `name_patterns` parameter (plural) instead of the singular as used in the example. 

Without this fix, the example instantiation fails with an error. 

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->

You can verify the parameters needed with:
```
from feast.permissions.permission import Permission

help(Permission)
```
which returns the following (note the plural `name_patterns` parameter):
```
Init signature:
Permission(
    name: str,
    types: Union[list['FeastObject'], ForwardRef('FeastObject'), NoneType] = [],
    name_patterns: Union[str, list[str], NoneType] = [],
    actions: Union[list[feast.permissions.action.AuthzedAction], feast.permissions.action.AuthzedAction] = [<AuthzedAction.CREATE: 'create'>, <AuthzedAction.DESCRIBE: 'describe'>, <AuthzedAction.UPDATE: 'update'>, <AuthzedAction.DELETE: 'delete'>, <AuthzedAction.READ_ONLINE: 'read_online'>, <AuthzedAction.READ_OFFLINE: 'read_offline'>, <AuthzedAction.WRITE_ONLINE: 'write_online'>, <AuthzedAction.WRITE_OFFLINE: 'write_offline'>],
    policy: feast.permissions.policy.Policy = <abc.AllowAll object at 0x145017010>,
    tags: Optional[dict[str, str]] = None,
    required_tags: Optional[dict[str, str]] = None,
)
Docstring:     
The Permission class defines the authorization policy to be validated whenever the identified actions are
requested on the matching resources.

Attributes:
    name: The permission name (can be duplicated, used for logging troubleshooting).
    types: The list of protected resource types as defined by the `FeastObject` type. The match includes all the sub-classes of the given types.
    Defaults to all managed types (e.g. the `ALL_RESOURCE_TYPES` constant)
    name_patterns: A possibly empty list of regex patterns to match the resource name. Defaults to empty list, e.g. no name filtering is applied
    be present in a resource tags with the given value. Defaults to None, meaning that no tags filtering is applied.
    actions: The actions authorized by this permission. Defaults to `ALL_ACTIONS`.
    policy: The policy to be applied to validate a client request.
    tags: A dictionary of key-value pairs to store arbitrary metadata.
    required_tags: Dictionary of key-value pairs that must match the resource tags. All these tags must
File:           ~/Code/Feast/feast/.venv/lib/python3.11/site-packages/feast/permissions/permission.py
Type:           ABCMeta
Subclasses:     
~
```
