### PR TITLE
fix: Remove misleading HTTP prefix from gRPC endpoints in logs and doc

### DIFF
--- a/docs/reference/registries/remote.md
+++ b/docs/reference/registries/remote.md
@@ -13,7 +13,7 @@ The `path` parameter is a URL with a port (default is 6570) used by the client t
 ```yaml
 registry:
   registry_type: remote
-  path: http://localhost:6570
+  path: localhost:6570
 ```
 {% endcode %}
 

--- a/sdk/python/feast/registry_server.py
+++ b/sdk/python/feast/registry_server.py
@@ -808,9 +808,7 @@ def start_server(
         server.add_insecure_port(f"[::]:{port}")
     server.start()
     if wait_for_termination:
-        logger.info(
-            f"Grpc server started at {'https' if tls_cert_path and tls_key_path else 'http'}://localhost:{port}"
-        )
+        logger.info(f"Grpc server started at localhost:{port}")
         server.wait_for_termination()
     else:
         return server


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Remove misleading HTTP prefix from gRPC endpoints in logs and documentation since gRPC servers don’t serve standard HTTP requests that the http:// prefix implies


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
