### PR TITLE
feat: Offline store update pull_all_from_table_or_query to make timestampfield optional

### DIFF
--- a/sdk/python/feast/infra/common/retrieval_task.py
+++ b/sdk/python/feast/infra/common/retrieval_task.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Union
+from typing import Optional, Union
 
 import pandas as pd
 
@@ -15,5 +15,5 @@ class HistoricalRetrievalTask:
     feature_view: Union[BatchFeatureView, StreamFeatureView]
     full_feature_name: bool
     registry: Registry
-    start_time: datetime
-    end_time: datetime
+    start_time: Optional[datetime] = None
+    end_time: Optional[datetime] = None

--- a/sdk/python/feast/infra/compute_engines/feature_builder.py
+++ b/sdk/python/feast/infra/compute_engines/feature_builder.py
@@ -72,10 +72,10 @@ class FeatureBuilder(ABC):
     def build(self) -> ExecutionPlan:
         last_node = self.build_source_node()
 
-        # PIT join entities to the feature data, and perform filtering
-        if isinstance(self.task, HistoricalRetrievalTask):
-            last_node = self.build_join_node(last_node)
+        # Join entity_df with source if needed
+        last_node = self.build_join_node(last_node)
 
+        # PIT filter, TTL, and user-defined filter
         last_node = self.build_filter_node(last_node)
 
         if self._should_aggregate():

--- a/sdk/python/feast/infra/compute_engines/local/feature_builder.py
+++ b/sdk/python/feast/infra/compute_engines/local/feature_builder.py
@@ -2,7 +2,6 @@ from typing import Union
 
 from feast.infra.common.materialization_job import MaterializationTask
 from feast.infra.common.retrieval_task import HistoricalRetrievalTask
-from feast.infra.compute_engines.dag.plan import ExecutionPlan
 from feast.infra.compute_engines.feature_builder import FeatureBuilder
 from feast.infra.compute_engines.local.backends.base import DataFrameBackend
 from feast.infra.compute_engines.local.nodes import (
@@ -95,25 +94,3 @@ class LocalFeatureBuilder(FeatureBuilder):
         node = LocalOutputNode("output")
         node.add_input(input_node)
         self.nodes.append(node)
-
-    def build(self) -> ExecutionPlan:
-        last_node = self.build_source_node()
-
-        if isinstance(self.task, HistoricalRetrievalTask):
-            last_node = self.build_join_node(last_node)
-
-        last_node = self.build_filter_node(last_node)
-
-        if self._should_aggregate():
-            last_node = self.build_aggregation_node(last_node)
-        elif isinstance(self.task, HistoricalRetrievalTask):
-            last_node = self.build_dedup_node(last_node)
-
-        if self._should_transform():
-            last_node = self.build_transformation_node(last_node)
-
-        if self._should_validate():
-            last_node = self.build_validation_node(last_node)
-
-        self.build_output_nodes(last_node)
-        return ExecutionPlan(self.nodes)

--- a/sdk/python/feast/infra/compute_engines/local/nodes.py
+++ b/sdk/python/feast/infra/compute_engines/local/nodes.py
@@ -2,8 +2,8 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 import pyarrow as pa
-from data_source import DataSource
 
+from feast.data_source import DataSource
 from feast.infra.compute_engines.dag.context import ExecutionContext
 from feast.infra.compute_engines.local.arrow_table_value import ArrowTableValue
 from feast.infra.compute_engines.local.backends.base import DataFrameBackend

--- a/sdk/python/feast/infra/compute_engines/local/nodes.py
+++ b/sdk/python/feast/infra/compute_engines/local/nodes.py
@@ -44,6 +44,7 @@ class LocalSourceReadNode(LocalNode):
             join_key_columns=join_key_columns,
             feature_name_columns=feature_name_columns,
             timestamp_field=timestamp_field,
+            created_timestamp_column=created_timestamp_column,
             start_date=self.start_time,
             end_date=self.end_time,
         )

--- a/sdk/python/feast/infra/compute_engines/spark/feature_builder.py
+++ b/sdk/python/feast/infra/compute_engines/spark/feature_builder.py
@@ -10,8 +10,9 @@ from feast.infra.compute_engines.spark.node import (
     SparkDedupNode,
     SparkFilterNode,
     SparkJoinNode,
+    SparkReadNode,
     SparkTransformationNode,
-    SparkWriteNode, SparkReadNode,
+    SparkWriteNode,
 )
 
 

--- a/sdk/python/feast/infra/compute_engines/spark/feature_builder.py
+++ b/sdk/python/feast/infra/compute_engines/spark/feature_builder.py
@@ -9,11 +9,9 @@ from feast.infra.compute_engines.spark.node import (
     SparkAggregationNode,
     SparkDedupNode,
     SparkFilterNode,
-    SparkHistoricalRetrievalReadNode,
     SparkJoinNode,
-    SparkMaterializationReadNode,
     SparkTransformationNode,
-    SparkWriteNode,
+    SparkWriteNode, SparkReadNode,
 )
 
 
@@ -27,12 +25,10 @@ class SparkFeatureBuilder(FeatureBuilder):
         self.spark_session = spark_session
 
     def build_source_node(self):
-        if isinstance(self.task, MaterializationTask):
-            node = SparkMaterializationReadNode("source", self.task)
-        else:
-            node = SparkHistoricalRetrievalReadNode(
-                "source", self.task, self.spark_session
-            )
+        source = self.feature_view.batch_source
+        start_time = self.task.start_time
+        end_time = self.task.end_time
+        node = SparkReadNode("source", source, start_time, end_time)
         self.nodes.append(node)
         return node
 

--- a/sdk/python/feast/infra/compute_engines/spark/node.py
+++ b/sdk/python/feast/infra/compute_engines/spark/node.py
@@ -1,14 +1,12 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import List, Optional, Union, cast
 
 from pyspark.sql import DataFrame, SparkSession, Window
 from pyspark.sql import functions as F
 
-from data_source import DataSource
 from feast import BatchFeatureView, StreamFeatureView
 from feast.aggregation import Aggregation
-from feast.infra.common.materialization_job import MaterializationTask
-from feast.infra.common.retrieval_task import HistoricalRetrievalTask
+from feast.data_source import DataSource
 from feast.infra.compute_engines.dag.context import ExecutionContext
 from feast.infra.compute_engines.dag.model import DAGFormat
 from feast.infra.compute_engines.dag.node import DAGNode
@@ -24,7 +22,6 @@ from feast.infra.offline_stores.contrib.spark_offline_store.spark import (
 from feast.infra.offline_stores.offline_utils import (
     infer_event_timestamp_from_entity_df,
 )
-from feast.utils import _get_fields_with_aliases
 
 ENTITY_TS_ALIAS = "__entity_event_timestamp"
 
@@ -53,10 +50,10 @@ def rename_entity_ts_column(
 class SparkReadNode(DAGNode):
     def __init__(
         self,
-            name: str,
-            source: DataSource,
-            start_time: Optional[timedelta] = None,
-            end_time: Optional[timedelta] = None,
+        name: str,
+        source: DataSource,
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
     ):
         super().__init__(name)
         self.source = source

--- a/sdk/python/feast/infra/compute_engines/spark/node.py
+++ b/sdk/python/feast/infra/compute_engines/spark/node.py
@@ -161,7 +161,12 @@ class SparkJoinNode(DAGNode):
         feature_df: DataFrame = feature_value.data
 
         entity_df = context.entity_df
-        assert entity_df is not None, "entity_df must be set in ExecutionContext"
+        if not entity_df:
+            return DAGValue(
+                data=feature_df,
+                format=DAGFormat.SPARK,
+                metadata={"joined_on": None},
+            )
 
         # Get timestamp fields from feature view
         join_keys, feature_cols, ts_col, created_ts_col = context.column_info

--- a/sdk/python/feast/infra/compute_engines/spark/node.py
+++ b/sdk/python/feast/infra/compute_engines/spark/node.py
@@ -211,13 +211,13 @@ class SparkFilterNode(DAGNode):
         if ENTITY_TS_ALIAS in input_df.columns:
             filtered_df = filtered_df.filter(F.col(ts_col) <= F.col(ENTITY_TS_ALIAS))
 
-        # Optional TTL filter: feature.ts >= entity.event_timestamp - ttl
-        if self.ttl:
-            ttl_seconds = int(self.ttl.total_seconds())
-            lower_bound = F.col(ENTITY_TS_ALIAS) - F.expr(
-                f"INTERVAL {ttl_seconds} seconds"
-            )
-            filtered_df = filtered_df.filter(F.col(ts_col) >= lower_bound)
+            # Optional TTL filter: feature.ts >= entity.event_timestamp - ttl
+            if self.ttl:
+                ttl_seconds = int(self.ttl.total_seconds())
+                lower_bound = F.col(ENTITY_TS_ALIAS) - F.expr(
+                    f"INTERVAL {ttl_seconds} seconds"
+                )
+                filtered_df = filtered_df.filter(F.col(ts_col) >= lower_bound)
 
         # Optional custom filter condition
         if self.filter_condition:

--- a/sdk/python/feast/infra/compute_engines/spark/node.py
+++ b/sdk/python/feast/infra/compute_engines/spark/node.py
@@ -76,6 +76,7 @@ class SparkReadNode(DAGNode):
             join_key_columns=join_key_columns,
             feature_name_columns=feature_name_columns,
             timestamp_field=timestamp_field,
+            created_timestamp_column=created_timestamp_column,
             start_date=self.start_time,
             end_date=self.end_time,
         )

--- a/sdk/python/feast/infra/compute_engines/spark/node.py
+++ b/sdk/python/feast/infra/compute_engines/spark/node.py
@@ -161,7 +161,7 @@ class SparkJoinNode(DAGNode):
         feature_df: DataFrame = feature_value.data
 
         entity_df = context.entity_df
-        if not entity_df:
+        if entity_df is None:
             return DAGValue(
                 data=feature_df,
                 format=DAGFormat.SPARK,

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -208,7 +208,7 @@ class BigQueryOfflineStore(OfflineStore):
             + [timestamp_field]
         )
         timestamp_filter = get_timestamp_filter_sql(
-            start_date, end_date, timestamp_field, quote_fields=False
+            start_date, end_date, timestamp_field, quote_fields=False, cast_style="timestamp_func"
         )
         query = f"""
             SELECT {field_string}

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -213,7 +213,7 @@ class BigQueryOfflineStore(OfflineStore):
         query = f"""
             SELECT {field_string}
             FROM {from_expression}
-            {timestamp_filter}
+            WHERE {timestamp_filter}
         """
         return BigQueryRetrievalJob(
             query=query,

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -207,7 +207,9 @@ class BigQueryOfflineStore(OfflineStore):
             + BigQueryOfflineStore._escape_query_columns(feature_name_columns)
             + [timestamp_field]
         )
-        timestamp_filter = get_timestamp_filter_sql(start_date, end_date, timestamp_field)
+        timestamp_filter = get_timestamp_filter_sql(
+            start_date, end_date, timestamp_field
+        )
         query = f"""
             SELECT {field_string}
             FROM {from_expression}

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -208,7 +208,7 @@ class BigQueryOfflineStore(OfflineStore):
             + [timestamp_field]
         )
         timestamp_filter = get_timestamp_filter_sql(
-            start_date, end_date, timestamp_field
+            start_date, end_date, timestamp_field, quote_fields=False
         )
         query = f"""
             SELECT {field_string}

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -189,6 +189,7 @@ class BigQueryOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -202,10 +203,14 @@ class BigQueryOfflineStore(OfflineStore):
             project=project_id,
             location=config.offline_store.location,
         )
+
+        timestamp_fields = [timestamp_field]
+        if created_timestamp_column:
+            timestamp_fields.append(created_timestamp_column)
         field_string = ", ".join(
             BigQueryOfflineStore._escape_query_columns(join_key_columns)
             + BigQueryOfflineStore._escape_query_columns(feature_name_columns)
-            + [timestamp_field]
+            + timestamp_fields
         )
         timestamp_filter = get_timestamp_filter_sql(
             start_date,

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -208,7 +208,11 @@ class BigQueryOfflineStore(OfflineStore):
             + [timestamp_field]
         )
         timestamp_filter = get_timestamp_filter_sql(
-            start_date, end_date, timestamp_field, quote_fields=False, cast_style="timestamp_func"
+            start_date,
+            end_date,
+            timestamp_field,
+            quote_fields=False,
+            cast_style="timestamp_func",
         )
         query = f"""
             SELECT {field_string}

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -52,6 +52,7 @@ from .bigquery_source import (
     BigQuerySource,
     SavedDatasetBigQueryStorage,
 )
+from .offline_utils import get_timestamp_filter_sql
 
 try:
     from google.api_core import client_info as http_client_info
@@ -188,8 +189,8 @@ class BigQueryOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
-        start_date: datetime,
-        end_date: datetime,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
         assert isinstance(config.offline_store, BigQueryOfflineStoreConfig)
         assert isinstance(data_source, BigQuerySource)
@@ -206,10 +207,11 @@ class BigQueryOfflineStore(OfflineStore):
             + BigQueryOfflineStore._escape_query_columns(feature_name_columns)
             + [timestamp_field]
         )
+        timestamp_filter = get_timestamp_filter_sql(start_date, end_date, timestamp_field)
         query = f"""
             SELECT {field_string}
             FROM {from_expression}
-            WHERE {timestamp_field} BETWEEN TIMESTAMP('{start_date}') AND TIMESTAMP('{end_date}')
+            {timestamp_filter}
         """
         return BigQueryRetrievalJob(
             query=query,

--- a/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena.py
@@ -132,6 +132,7 @@ class AthenaOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -139,8 +140,11 @@ class AthenaOfflineStore(OfflineStore):
         assert isinstance(data_source, AthenaSource)
         from_expression = data_source.get_table_query_string(config)
 
+        timestamp_fields = [timestamp_field]
+        if created_timestamp_column:
+            timestamp_fields.append(created_timestamp_column)
         field_string = ", ".join(
-            join_key_columns + feature_name_columns + [timestamp_field]
+            join_key_columns + feature_name_columns + timestamp_fields
         )
 
         athena_client = aws_utils.get_athena_data_client(config.offline_store.region)

--- a/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena.py
@@ -160,7 +160,12 @@ class AthenaOfflineStore(OfflineStore):
             )[:-3]
 
         timestamp_filter = get_timestamp_filter_sql(
-            start_date_str, end_date_str, timestamp_field, date_partition_column
+            start_date_str,
+            end_date_str,
+            timestamp_field,
+            date_partition_column,
+            cast_style="raw",
+            quote_fields=False,
         )
 
         query = f"""

--- a/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena.py
@@ -18,7 +18,6 @@ import numpy as np
 import pandas as pd
 import pyarrow
 import pyarrow as pa
-from infra.offline_stores.offline_utils import get_timestamp_filter_sql
 from pydantic import StrictStr
 
 from feast import OnDemandFeatureView
@@ -37,6 +36,7 @@ from feast.infra.offline_stores.offline_store import (
     RetrievalJob,
     RetrievalMetadata,
 )
+from feast.infra.offline_stores.offline_utils import get_timestamp_filter_sql
 from feast.infra.registry.base_registry import BaseRegistry
 from feast.infra.utils import aws_utils
 from feast.repo_config import FeastConfigBaseModel, RepoConfig

--- a/sdk/python/feast/infra/offline_stores/contrib/couchbase_offline_store/couchbase.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/couchbase_offline_store/couchbase.py
@@ -42,11 +42,11 @@ from feast.repo_config import FeastConfigBaseModel, RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
 
 from ... import offline_utils
+from ...offline_utils import get_timestamp_filter_sql
 from .couchbase_source import (
     CouchbaseColumnarSource,
     SavedDatasetCouchbaseColumnarStorage,
 )
-from ...offline_utils import get_timestamp_filter_sql
 
 # Only prints out runtime warnings once.
 warnings.simplefilter("once", RuntimeWarning)
@@ -229,8 +229,8 @@ class CouchbaseColumnarOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
-        start_date: datetime,
-        end_date: datetime,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
         """
         Fetch all rows from the specified table or query within the time range.
@@ -251,9 +251,7 @@ class CouchbaseColumnarOfflineStore(OfflineStore):
         start_date_normalized = normalize_timestamp(start_date) if start_date else None
         end_date_normalized = normalize_timestamp(end_date) if end_date else None
         timestamp_filter = get_timestamp_filter_sql(
-            start_date_normalized,
-            end_date_normalized,
-            timestamp_field
+            start_date_normalized, end_date_normalized, timestamp_field
         )
 
         query = f"""

--- a/sdk/python/feast/infra/offline_stores/contrib/couchbase_offline_store/couchbase.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/couchbase_offline_store/couchbase.py
@@ -247,11 +247,16 @@ class CouchbaseColumnarOfflineStore(OfflineStore):
         field_string = ", ".join(
             join_key_columns + feature_name_columns + [timestamp_field]
         )
-
-        start_date_normalized = normalize_timestamp(start_date) if start_date else None
-        end_date_normalized = normalize_timestamp(end_date) if end_date else None
+        start_date_normalized = (
+            f"`{normalize_timestamp(start_date)}`" if start_date else None
+        )
+        end_date_normalized = f"`{normalize_timestamp(end_date)}`" if end_date else None
         timestamp_filter = get_timestamp_filter_sql(
-            start_date_normalized, end_date_normalized, timestamp_field
+            start_date_normalized,
+            end_date_normalized,
+            timestamp_field,
+            cast_style="raw",
+            quote_fields=False,
         )
 
         query = f"""

--- a/sdk/python/feast/infra/offline_stores/contrib/couchbase_offline_store/couchbase.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/couchbase_offline_store/couchbase.py
@@ -229,6 +229,7 @@ class CouchbaseColumnarOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -244,8 +245,11 @@ class CouchbaseColumnarOfflineStore(OfflineStore):
         assert isinstance(data_source, CouchbaseColumnarSource)
         from_expression = data_source.get_table_query_string()
 
+        timestamp_fields = [timestamp_field]
+        if created_timestamp_column:
+            timestamp_fields.append(created_timestamp_column)
         field_string = ", ".join(
-            join_key_columns + feature_name_columns + [timestamp_field]
+            join_key_columns + feature_name_columns + timestamp_fields
         )
         start_date_normalized = (
             f"`{normalize_timestamp(start_date)}`" if start_date else None

--- a/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssql.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssql.py
@@ -177,6 +177,7 @@ class MsSqlServerOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -186,6 +187,7 @@ class MsSqlServerOfflineStore(OfflineStore):
             join_key_columns=join_key_columns,
             feature_name_columns=feature_name_columns,
             timestamp_field=timestamp_field,
+            created_timestamp_column=created_timestamp_column,
             start_date=start_date,
             end_date=end_date,
             data_source_reader=_build_data_source_reader(config),

--- a/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssql.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssql.py
@@ -177,8 +177,8 @@ class MsSqlServerOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
-        start_date: datetime,
-        end_date: datetime,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
         return pull_all_from_table_or_query_ibis(
             config=config,

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
@@ -238,14 +238,12 @@ class PostgreSQLOfflineStore(OfflineStore):
             join_key_columns + feature_name_columns + [timestamp_field]
         )
 
-        start_date_str = None
-        if start_date:
-            start_date_str = f"'{start_date}'::timestamptz"
-        end_date_str = None
-        if end_date:
-            end_date_str = f"'{end_date}'::timestamptz"
         timestamp_filter = get_timestamp_filter_sql(
-            start_date_str, end_date_str, timestamp_field, tz=timezone.utc
+            start_date,
+            end_date,
+            timestamp_field,
+            tz=timezone.utc,
+            cast_style="timestamptz",
         )
 
         query = f"""

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
@@ -244,6 +244,7 @@ class PostgreSQLOfflineStore(OfflineStore):
             timestamp_field,
             tz=timezone.utc,
             cast_style="timestamptz",
+            date_time_separator=" ",  # backwards compatibility but inconsistent with other offline stores
         )
 
         query = f"""

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
@@ -227,6 +227,7 @@ class PostgreSQLOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -234,8 +235,11 @@ class PostgreSQLOfflineStore(OfflineStore):
         assert isinstance(data_source, PostgreSQLSource)
         from_expression = data_source.get_table_query_string()
 
+        timestamp_fields = [timestamp_field]
+        if created_timestamp_column:
+            timestamp_fields.append(created_timestamp_column)
         field_string = ", ".join(
-            join_key_columns + feature_name_columns + [timestamp_field]
+            join_key_columns + feature_name_columns + timestamp_fields
         )
 
         timestamp_filter = get_timestamp_filter_sql(

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
@@ -34,6 +34,7 @@ from feast.infra.offline_stores.offline_store import (
     RetrievalJob,
     RetrievalMetadata,
 )
+from feast.infra.offline_stores.offline_utils import get_timestamp_filter_sql
 from feast.infra.registry.base_registry import BaseRegistry
 from feast.infra.utils.postgres.connection_utils import (
     _get_conn,
@@ -46,7 +47,6 @@ from feast.repo_config import RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
 from feast.type_map import pg_type_code_to_arrow
 
-from feast.infra.offline_stores.offline_utils import get_timestamp_filter_sql
 from .postgres_source import PostgreSQLSource
 
 

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
@@ -46,7 +46,7 @@ from feast.repo_config import RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
 from feast.type_map import pg_type_code_to_arrow
 
-from ...offline_utils import get_timestamp_filter_sql
+from feast.infra.offline_stores.offline_utils import get_timestamp_filter_sql
 from .postgres_source import PostgreSQLSource
 
 

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -29,12 +29,12 @@ from feast.infra.offline_stores.offline_store import (
     RetrievalJob,
     RetrievalMetadata,
 )
+from feast.infra.offline_stores.offline_utils import get_timestamp_filter_sql
 from feast.infra.registry.base_registry import BaseRegistry
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
 from feast.type_map import spark_schema_to_np_dtypes
 from feast.utils import _get_fields_with_aliases
-from feast.infra.offline_stores.offline_utils import get_timestamp_filter_sql
 
 # Make sure spark warning doesn't raise more than once.
 warnings.simplefilter("once", RuntimeWarning)
@@ -297,7 +297,9 @@ class SparkOfflineStore(OfflineStore):
         fields_with_alias_string = ", ".join(fields_with_aliases)
 
         from_expression = data_source.get_table_query_string()
-        timestamp_filter = get_timestamp_filter_sql(start_date, end_date, timestamp_field, timezone.utc)
+        timestamp_filter = get_timestamp_filter_sql(
+            start_date, end_date, timestamp_field, tz=timezone.utc
+        )
 
         query = f"""
             SELECT {fields_with_alias_string}

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -270,6 +270,7 @@ class SparkOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -289,8 +290,12 @@ class SparkOfflineStore(OfflineStore):
         spark_session = get_spark_session_or_start_new_with_repoconfig(
             store_config=config.offline_store
         )
+
+        timestamp_fields = [timestamp_field]
+        if created_timestamp_column:
+            timestamp_fields.append(created_timestamp_column)
         (fields_with_aliases, aliases) = _get_fields_with_aliases(
-            fields=join_key_columns + feature_name_columns + [timestamp_field],
+            fields=join_key_columns + feature_name_columns + timestamp_fields,
             field_mappings=data_source.field_mapping,
         )
 

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -304,7 +304,7 @@ class SparkOfflineStore(OfflineStore):
         query = f"""
             SELECT {fields_with_alias_string}
             FROM {from_expression}
-            {timestamp_filter}
+            WHERE {timestamp_filter}
         """
 
         return SparkRetrievalJob(

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -298,7 +298,7 @@ class SparkOfflineStore(OfflineStore):
 
         from_expression = data_source.get_table_query_string()
         timestamp_filter = get_timestamp_filter_sql(
-            start_date, end_date, timestamp_field, tz=timezone.utc
+            start_date, end_date, timestamp_field, tz=timezone.utc, quote_fields=False
         )
 
         query = f"""

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
@@ -419,7 +419,7 @@ class TrinoOfflineStore(OfflineStore):
         )
 
         timestamp_filter = get_timestamp_filter_sql(
-            start_date, end_date, timestamp_field
+            start_date, end_date, timestamp_field, quote_fields=False
         )
         query = f"""
             SELECT {field_string}

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
@@ -406,6 +406,7 @@ class TrinoOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -414,8 +415,12 @@ class TrinoOfflineStore(OfflineStore):
         from_expression = data_source.get_table_query_string()
 
         client = _get_trino_client(config=config)
+
+        timestamp_fields = [timestamp_field]
+        if created_timestamp_column:
+            timestamp_fields.append(created_timestamp_column)
         field_string = ", ".join(
-            join_key_columns + feature_name_columns + [timestamp_field]
+            join_key_columns + feature_name_columns + timestamp_fields
         )
 
         timestamp_filter = get_timestamp_filter_sql(

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
@@ -31,11 +31,11 @@ from feast.infra.offline_stores.offline_store import (
     RetrievalJob,
     RetrievalMetadata,
 )
+from feast.infra.offline_stores.offline_utils import get_timestamp_filter_sql
 from feast.infra.registry.base_registry import BaseRegistry
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
-from feast.infra.offline_stores.offline_utils import get_timestamp_filter_sql
 
 
 class BasicAuthModel(FeastConfigBaseModel):
@@ -418,7 +418,9 @@ class TrinoOfflineStore(OfflineStore):
             join_key_columns + feature_name_columns + [timestamp_field]
         )
 
-        timestamp_filter = get_timestamp_filter_sql(start_date, end_date, timestamp_field)
+        timestamp_filter = get_timestamp_filter_sql(
+            start_date, end_date, timestamp_field
+        )
         query = f"""
             SELECT {field_string}
             FROM {from_expression}

--- a/sdk/python/feast/infra/offline_stores/dask.py
+++ b/sdk/python/feast/infra/offline_stores/dask.py
@@ -364,7 +364,7 @@ class DaskOfflineStore(OfflineStore):
             if start_date or end_date:
                 if start_date and end_date:
                     source_df = source_df[
-                        source_df[timestamp_field].between(start_date, end_date)
+                        source_df[timestamp_field].between(start_date, end_date, inclusive="left")
                     ]
                 elif start_date:
                     source_df = source_df[source_df[timestamp_field] >= start_date]

--- a/sdk/python/feast/infra/offline_stores/dask.py
+++ b/sdk/python/feast/infra/offline_stores/dask.py
@@ -363,7 +363,9 @@ class DaskOfflineStore(OfflineStore):
             # Which is inconsistent with other offline stores.
             if start_date or end_date:
                 if start_date and end_date:
-                    source_df = source_df[source_df[timestamp_field].between(start_date, end_date)]
+                    source_df = source_df[
+                        source_df[timestamp_field].between(start_date, end_date)
+                    ]
                 elif start_date:
                     source_df = source_df[source_df[timestamp_field] >= start_date]
                 elif end_date:

--- a/sdk/python/feast/infra/offline_stores/dask.py
+++ b/sdk/python/feast/infra/offline_stores/dask.py
@@ -364,7 +364,9 @@ class DaskOfflineStore(OfflineStore):
             if start_date or end_date:
                 if start_date and end_date:
                     source_df = source_df[
-                        source_df[timestamp_field].between(start_date, end_date, inclusive="left")
+                        source_df[timestamp_field].between(
+                            start_date, end_date, inclusive="left"
+                        )
                     ]
                 elif start_date:
                     source_df = source_df[source_df[timestamp_field] >= start_date]

--- a/sdk/python/feast/infra/offline_stores/dask.py
+++ b/sdk/python/feast/infra/offline_stores/dask.py
@@ -402,6 +402,7 @@ class DaskOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -415,7 +416,7 @@ class DaskOfflineStore(OfflineStore):
             + [timestamp_field],  # avoid deduplication
             feature_name_columns=feature_name_columns,
             timestamp_field=timestamp_field,
-            created_timestamp_column=None,
+            created_timestamp_column=created_timestamp_column,
             start_date=start_date,
             end_date=end_date,
         )

--- a/sdk/python/feast/infra/offline_stores/duckdb.py
+++ b/sdk/python/feast/infra/offline_stores/duckdb.py
@@ -179,8 +179,8 @@ class DuckDBOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
-        start_date: datetime,
-        end_date: datetime,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
         return pull_all_from_table_or_query_ibis(
             config=config,

--- a/sdk/python/feast/infra/offline_stores/duckdb.py
+++ b/sdk/python/feast/infra/offline_stores/duckdb.py
@@ -179,6 +179,7 @@ class DuckDBOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -188,6 +189,7 @@ class DuckDBOfflineStore(OfflineStore):
             join_key_columns=join_key_columns,
             feature_name_columns=feature_name_columns,
             timestamp_field=timestamp_field,
+            created_timestamp_column=created_timestamp_column,
             start_date=start_date,
             end_date=end_date,
             data_source_reader=_read_data_source,

--- a/sdk/python/feast/infra/offline_stores/ibis.py
+++ b/sdk/python/feast/infra/offline_stores/ibis.py
@@ -268,8 +268,10 @@ def pull_all_from_table_or_query_ibis(
     staging_location_endpoint_override: Optional[str] = None,
 ) -> RetrievalJob:
     fields = join_key_columns + feature_name_columns + [timestamp_field]
-    start_date = start_date.astimezone(tz=timezone.utc)
-    end_date = end_date.astimezone(tz=timezone.utc)
+    if start_date:
+        start_date = start_date.astimezone(tz=timezone.utc)
+    if end_date:
+        end_date = end_date.astimezone(tz=timezone.utc)
 
     table = data_source_reader(data_source, str(config.repo_path))
 

--- a/sdk/python/feast/infra/offline_stores/ibis.py
+++ b/sdk/python/feast/infra/offline_stores/ibis.py
@@ -262,12 +262,16 @@ def pull_all_from_table_or_query_ibis(
     timestamp_field: str,
     data_source_reader: Callable[[DataSource, str], Table],
     data_source_writer: Callable[[pyarrow.Table, DataSource, str], None],
+    created_timestamp_column: Optional[str] = None,
     start_date: Optional[datetime] = None,
     end_date: Optional[datetime] = None,
     staging_location: Optional[str] = None,
     staging_location_endpoint_override: Optional[str] = None,
 ) -> RetrievalJob:
-    fields = join_key_columns + feature_name_columns + [timestamp_field]
+    timestamp_fields = [timestamp_field]
+    if created_timestamp_column:
+        timestamp_fields.append(created_timestamp_column)
+    fields = join_key_columns + feature_name_columns + timestamp_fields
     if start_date:
         start_date = start_date.astimezone(tz=timezone.utc)
     if end_date:

--- a/sdk/python/feast/infra/offline_stores/ibis.py
+++ b/sdk/python/feast/infra/offline_stores/ibis.py
@@ -260,10 +260,10 @@ def pull_all_from_table_or_query_ibis(
     join_key_columns: List[str],
     feature_name_columns: List[str],
     timestamp_field: str,
-    start_date: datetime,
-    end_date: datetime,
     data_source_reader: Callable[[DataSource, str], Table],
     data_source_writer: Callable[[pyarrow.Table, DataSource, str], None],
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
     staging_location: Optional[str] = None,
     staging_location_endpoint_override: Optional[str] = None,
 ) -> RetrievalJob:
@@ -281,8 +281,12 @@ def pull_all_from_table_or_query_ibis(
 
     table = table.filter(
         ibis.and_(
-            table[timestamp_field] >= ibis.literal(start_date),
-            table[timestamp_field] <= ibis.literal(end_date),
+            table[timestamp_field] >= ibis.literal(start_date)
+            if start_date
+            else ibis.literal(True),
+            table[timestamp_field] <= ibis.literal(end_date)
+            if end_date
+            else ibis.literal(True),
         )
     )
 

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -294,8 +294,8 @@ class OfflineStore(ABC):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
-        start_date: Optional[datetime],
-        end_date: Optional[datetime],
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
         """
         Extracts all the entity rows (i.e. the combination of join key columns, feature columns, and

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -294,6 +294,7 @@ class OfflineStore(ABC):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -309,7 +310,8 @@ class OfflineStore(ABC):
             data_source: The data source from which the entity rows will be extracted.
             join_key_columns: The columns of the join keys.
             feature_name_columns: The columns of the features.
-            timestamp_field: The timestamp column.
+            timestamp_field: The timestamp column, used to determine which rows are the most recent.
+            created_timestamp_column (Optional): The column indicating when the row was created, used to break ties.
             start_date (Optional): The start of the time range.
             end_date (Optional): The end of the time range.
 

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -294,8 +294,8 @@ class OfflineStore(ABC):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
-        start_date: datetime,
-        end_date: datetime,
+        start_date: Optional[datetime],
+        end_date: Optional[datetime],
     ) -> RetrievalJob:
         """
         Extracts all the entity rows (i.e. the combination of join key columns, feature columns, and
@@ -310,8 +310,8 @@ class OfflineStore(ABC):
             join_key_columns: The columns of the join keys.
             feature_name_columns: The columns of the features.
             timestamp_field: The timestamp column.
-            start_date: The start of the time range.
-            end_date: The end of the time range.
+            start_date (Optional): The start of the time range.
+            end_date (Optional): The end of the time range.
 
         Returns:
             A RetrievalJob that can be executed to get the entity rows.

--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -274,7 +274,9 @@ def get_timestamp_filter_sql(
     timestamp_field: Optional[str] = DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,
     date_partition_column: Optional[str] = None,
     tz: Optional[timezone] = None,
-    cast_style: Literal["timestamp_func", "timestamp", "timestamptz", "raw"] = "timestamp_func",
+    cast_style: Literal[
+        "timestamp", "timestamp_func", "timestamptz", "raw"
+    ] = "timestamp",
     date_time_separator: str = "T",
     quote_fields: bool = True,
 ) -> str:
@@ -312,9 +314,11 @@ def get_timestamp_filter_sql(
         else:
             val_str = val
 
-        if cast_style == "timestamp_func":
+        if cast_style == "timestamp":
+            return f"TIMESTAMP '{val_str}'"
+        elif cast_style == "timestamp_func":
             return f"TIMESTAMP('{val_str}')"
-        elif cast_style in ("timestamptz", "timestamp"):
+        elif cast_style == "timestamptz":
             return f"'{val_str}'::{cast_style}"
         else:
             return f"'{val_str}'"

--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -275,6 +275,8 @@ def get_timestamp_filter_sql(
     date_partition_column: Optional[str] = None,
     tz: Optional[timezone] = None,
     cast_style: Literal["timestamp_func", "timestamptz", "raw"] = "timestamp_func",
+    date_time_separator: str = "T",
+    quote_fields: bool = True,
 ) -> str:
     """
     Returns SQL filter condition (no WHERE) with flexible timestamp casting.
@@ -289,21 +291,33 @@ def get_timestamp_filter_sql(
             - "timestamp_func": TIMESTAMP('...')         → Snowflake, BigQuery, Athena
             - "timestamptz": '...'::timestamptz          → PostgreSQL
             - "raw": '...'                               → no cast, string only
+        date_time_separator: separator for datetime strings (default is "T")
+            (e.g. "2023-10-01T00:00:00" or "2023-10-01 00:00:00")
+        quote_fields: whether to quote the timestamp and partition column names
 
     Returns:
         SQL filter string without WHERE
     """
 
+    def quote_column_if_needed(column: Optional[str]) -> Optional[str]:
+        if not column or not quote_fields:
+            return column
+        return f'"{column}"'
+
     def format_casted_ts(val: Union[str, datetime]) -> str:
         if isinstance(val, datetime):
             if tz:
                 val = val.astimezone(tz)
-        if cast_style == "timestamp_func":
-            return f"TIMESTAMP('{val}')"
-        elif cast_style == "timestamptz":
-            return f"'{val}'::timestamptz"
+            val_str = val.isoformat(sep=date_time_separator)
         else:
-            return f"'{val}'"
+            val_str = val
+
+        if cast_style == "timestamp_func":
+            return f"TIMESTAMP('{val_str}')"
+        elif cast_style == "timestamptz":
+            return f"'{val_str}'::timestamptz"
+        else:
+            return f"'{val_str}'"
 
     def format_date(val: Union[str, datetime]) -> str:
         if isinstance(val, datetime):
@@ -312,23 +326,26 @@ def get_timestamp_filter_sql(
             return val.strftime("%Y-%m-%d")
         return val
 
+    ts_field = quote_column_if_needed(timestamp_field)
+    dp_field = quote_column_if_needed(date_partition_column)
+
     filters = []
 
     # Timestamp filters
     if start_date and end_date:
         filters.append(
-            f'"{timestamp_field}" BETWEEN {format_casted_ts(start_date)} AND {format_casted_ts(end_date)}'
+            f"{ts_field} BETWEEN {format_casted_ts(start_date)} AND {format_casted_ts(end_date)}"
         )
     elif start_date:
-        filters.append(f"{timestamp_field} >= {format_casted_ts(start_date)}")
+        filters.append(f"{ts_field} >= {format_casted_ts(start_date)}")
     elif end_date:
-        filters.append(f"{timestamp_field} <= {format_casted_ts(end_date)}")
+        filters.append(f"{ts_field} <= {format_casted_ts(end_date)}")
 
     # Partition pruning
     if date_partition_column:
         if start_date:
-            filters.append(f"{date_partition_column} >= '{format_date(start_date)}'")
+            filters.append(f"{dp_field} >= '{format_date(start_date)}'")
         if end_date:
-            filters.append(f"{date_partition_column} <= '{format_date(end_date)}'")
+            filters.append(f"{dp_field} <= '{format_date(end_date)}'")
 
     return " AND ".join(filters) if filters else ""

--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -274,7 +274,7 @@ def get_timestamp_filter_sql(
     timestamp_field: Optional[str] = DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL,
     date_partition_column: Optional[str] = None,
     tz: Optional[timezone] = None,
-    cast_style: Literal["timestamp_func", "timestamptz", "raw"] = "timestamp_func",
+    cast_style: Literal["timestamp_func", "timestamp", "timestamptz", "raw"] = "timestamp_func",
     date_time_separator: str = "T",
     quote_fields: bool = True,
 ) -> str:
@@ -314,8 +314,8 @@ def get_timestamp_filter_sql(
 
         if cast_style == "timestamp_func":
             return f"TIMESTAMP('{val_str}')"
-        elif cast_style == "timestamptz":
-            return f"'{val_str}'::timestamptz"
+        elif cast_style in ("timestamptz", "timestamp"):
+            return f"'{val_str}'::{cast_style}"
         else:
             return f"'{val_str}'"
 

--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -298,16 +298,12 @@ def get_timestamp_filter_sql(
         if isinstance(val, datetime):
             if tz:
                 val = val.astimezone(tz)
-            val_str = val.isoformat()
-        else:
-            val_str = val
-
         if cast_style == "timestamp_func":
-            return f"TIMESTAMP('{val_str}')"
+            return f"TIMESTAMP('{val}')"
         elif cast_style == "timestamptz":
-            return f"'{val_str}'::timestamptz"
-        else:  # raw
-            return f"'{val_str}'"
+            return f"'{val}'::timestamptz"
+        else:
+            return f"'{val}'"
 
     def format_date(val: Union[str, datetime]) -> str:
         if isinstance(val, datetime):
@@ -321,7 +317,7 @@ def get_timestamp_filter_sql(
     # Timestamp filters
     if start_date and end_date:
         filters.append(
-            f"{timestamp_field} BETWEEN {format_casted_ts(start_date)} AND {format_casted_ts(end_date)}"
+            f'"{timestamp_field}" BETWEEN {format_casted_ts(start_date)} AND {format_casted_ts(end_date)}'
         )
     elif start_date:
         filters.append(f"{timestamp_field} >= {format_casted_ts(start_date)}")

--- a/sdk/python/feast/infra/offline_stores/offline_utils.py
+++ b/sdk/python/feast/infra/offline_stores/offline_utils.py
@@ -290,7 +290,8 @@ def get_timestamp_filter_sql(
         date_partition_column: optional partition column (for pruning)
         tz: optional timezone for datetime inputs
         cast_style: one of:
-            - "timestamp_func": TIMESTAMP('...')         → Snowflake, BigQuery, Athena
+            - "timestamp": TIMESTAMP '...'                  → Common Sql engine Snowflake, Redshift etc.
+            - "timestamp_func": TIMESTAMP('...')         → BigQuery, Couchbase etc.
             - "timestamptz": '...'::timestamptz          → PostgreSQL
             - "raw": '...'                               → no cast, string only
         date_time_separator: separator for datetime strings (default is "T")

--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -175,7 +175,10 @@ class RedshiftOfflineStore(OfflineStore):
         s3_resource = aws_utils.get_s3_resource(config.offline_store.region)
 
         timestamp_filter = get_timestamp_filter_sql(
-            start_date, end_date, timestamp_field, tz=timezone.utc, cast_style="timestamp"
+            start_date,
+            end_date,
+            timestamp_field,
+            tz=timezone.utc,
         )
 
         query = f"""

--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -158,6 +158,7 @@ class RedshiftOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -165,8 +166,11 @@ class RedshiftOfflineStore(OfflineStore):
         assert isinstance(data_source, RedshiftSource)
         from_expression = data_source.get_table_query_string()
 
+        timestamp_fields = [timestamp_field]
+        if created_timestamp_column:
+            timestamp_fields.append(created_timestamp_column)
         field_string = ", ".join(
-            join_key_columns + feature_name_columns + [timestamp_field]
+            join_key_columns + feature_name_columns + timestamp_fields
         )
 
         redshift_client = aws_utils.get_redshift_data_client(

--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -175,7 +175,7 @@ class RedshiftOfflineStore(OfflineStore):
         s3_resource = aws_utils.get_s3_resource(config.offline_store.region)
 
         timestamp_filter = get_timestamp_filter_sql(
-            start_date, end_date, timestamp_field, tz=timezone.utc
+            start_date, end_date, timestamp_field, tz=timezone.utc, cast_style="timestamp"
         )
 
         query = f"""

--- a/sdk/python/feast/infra/offline_stores/remote.py
+++ b/sdk/python/feast/infra/offline_stores/remote.py
@@ -234,6 +234,7 @@ class RemoteOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -253,6 +254,7 @@ class RemoteOfflineStore(OfflineStore):
             "join_key_columns": join_key_columns,
             "feature_name_columns": feature_name_columns,
             "timestamp_field": timestamp_field,
+            "created_timestamp_column": created_timestamp_column,
             "start_date": start_date.isoformat() if start_date else None,
             "end_date": end_date.isoformat() if end_date else None,
         }

--- a/sdk/python/feast/infra/offline_stores/remote.py
+++ b/sdk/python/feast/infra/offline_stores/remote.py
@@ -234,8 +234,8 @@ class RemoteOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
-        start_date: datetime,
-        end_date: datetime,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
         assert isinstance(config.offline_store, RemoteOfflineStoreConfig)
 
@@ -253,8 +253,8 @@ class RemoteOfflineStore(OfflineStore):
             "join_key_columns": join_key_columns,
             "feature_name_columns": feature_name_columns,
             "timestamp_field": timestamp_field,
-            "start_date": start_date.isoformat(),
-            "end_date": end_date.isoformat(),
+            "start_date": start_date.isoformat() if start_date else None,
+            "end_date": end_date.isoformat() if end_date else None,
         }
 
         return RemoteRetrievalJob(

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -230,6 +230,7 @@ class SnowflakeOfflineStore(OfflineStore):
         join_key_columns: List[str],
         feature_name_columns: List[str],
         timestamp_field: str,
+        created_timestamp_column: Optional[str] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ) -> RetrievalJob:
@@ -242,9 +243,12 @@ class SnowflakeOfflineStore(OfflineStore):
         if not data_source.database and data_source.schema and data_source.table:
             from_expression = f'"{config.offline_store.database}".{from_expression}'
 
+        timestamp_fields = [timestamp_field]
+        if created_timestamp_column:
+            timestamp_fields.append(created_timestamp_column)
         field_string = (
             '"'
-            + '", "'.join(join_key_columns + feature_name_columns + [timestamp_field])
+            + '", "'.join(join_key_columns + feature_name_columns + timestamp_fields)
             + '"'
         )
 

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -24,7 +24,6 @@ from typing import (
 import numpy as np
 import pandas as pd
 import pyarrow
-from infra.offline_stores.offline_utils import get_timestamp_filter_sql
 from pydantic import ConfigDict, Field, StrictStr
 
 from feast import OnDemandFeatureView
@@ -38,6 +37,7 @@ from feast.infra.offline_stores.offline_store import (
     RetrievalJob,
     RetrievalMetadata,
 )
+from feast.infra.offline_stores.offline_utils import get_timestamp_filter_sql
 from feast.infra.offline_stores.snowflake_source import (
     SavedDatasetSnowflakeStorage,
     SnowflakeLoggingDestination,

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -258,7 +258,7 @@ class SnowflakeOfflineStore(OfflineStore):
         query = f"""
             SELECT {field_string}
             FROM {from_expression}
-            {timestamp_filter}
+            WHERE {timestamp_filter}
         """
 
         return SnowflakeRetrievalJob(

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -24,6 +24,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 import pyarrow
+from infra.offline_stores.offline_utils import get_timestamp_filter_sql
 from pydantic import ConfigDict, Field, StrictStr
 
 from feast import OnDemandFeatureView
@@ -62,7 +63,6 @@ from feast.types import (
     String,
     UnixTimestamp,
 )
-from infra.offline_stores.offline_utils import get_timestamp_filter_sql
 
 try:
     from snowflake.connector import SnowflakeConnection
@@ -251,7 +251,9 @@ class SnowflakeOfflineStore(OfflineStore):
         with GetSnowflakeConnection(config.offline_store) as conn:
             snowflake_conn = conn
 
-        timestamp_filter = get_timestamp_filter_sql(start_date, end_date, timestamp_field, timezone.utc)
+        timestamp_filter = get_timestamp_filter_sql(
+            start_date, end_date, timestamp_field, tz=timezone.utc
+        )
 
         query = f"""
             SELECT {field_string}

--- a/sdk/python/feast/offline_server.py
+++ b/sdk/python/feast/offline_server.py
@@ -354,13 +354,15 @@ class OfflineServer(fl.FlightServerBase):
         assert_permissions(data_source, actions=[AuthzedAction.READ_OFFLINE])
 
         return self.offline_store.pull_all_from_table_or_query(
-            self.store.config,
-            data_source,
-            command["join_key_columns"],
-            command["feature_name_columns"],
-            command["timestamp_field"],
-            utils.make_tzaware(datetime.fromisoformat(command["start_date"])),
-            utils.make_tzaware(datetime.fromisoformat(command["end_date"])),
+            config=self.store.config,
+            data_source=data_source,
+            join_key_columns=command["join_key_columns"],
+            feature_name_columns=command["feature_name_columns"],
+            timestamp_field=command["timestamp_field"],
+            start_date=utils.make_tzaware(
+                datetime.fromisoformat(command["start_date"])
+            ),
+            end_date=utils.make_tzaware(datetime.fromisoformat(command["end_date"])),
         )
 
     def _validate_pull_latest_from_table_or_query_parameters(self, command: dict):

--- a/sdk/python/tests/integration/compute_engines/spark/test_compute.py
+++ b/sdk/python/tests/integration/compute_engines/spark/test_compute.py
@@ -226,7 +226,7 @@ def test_spark_compute_engine_materialize():
         task = MaterializationTask(
             project=spark_environment.project,
             feature_view=driver_stats_fv,
-            start_time=now - timedelta(days=1),
+            start_time=now - timedelta(days=2),
             end_time=now,
             tqdm_builder=tqdm_builder,
         )

--- a/sdk/python/tests/integration/compute_engines/spark/test_compute.py
+++ b/sdk/python/tests/integration/compute_engines/spark/test_compute.py
@@ -161,8 +161,6 @@ def test_spark_compute_engine_get_historical_features():
             feature_view=driver_stats_fv,
             full_feature_name=False,
             registry=registry,
-            start_time=now - timedelta(days=1),
-            end_time=now,
         )
 
         # 🧪 Run SparkComputeEngine


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

The major change in this PR is making the start_date and end_date in pull_all_from_table_or_query optional:
```
    def pull_all_from_table_or_query(
        config: RepoConfig,
        data_source: DataSource,
        join_key_columns: List[str],
        feature_name_columns: List[str],
        timestamp_field: str,
        created_timestamp_field: Optional[str] = None,
        start_date: Optional[datetime] = None,
        end_date: Optional[datetime] = None,
    ) -> RetrievalJob:
```
The reason is the API should be able to let the user skip the time range selection, and return all entities with features.
This will also make the current `materialization` and `get_historical_features` in Compute Engine to be able to use this API.
The change is non-breaking, and the API currently is only used in `retrieve_feature_service_logs`, and `retrieve_saved_dataset`.


# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
