### PR TITLE
fix: Operator - remove default replicas setting from Feast Deployment

### DIFF
--- a/infra/feast-operator/internal/controller/featurestore_controller_db_store_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_db_store_test.go
@@ -437,7 +437,7 @@ var _ = Describe("FeatureStore Controller - db storage services", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(deploy.Spec.Replicas).To(Equal(&services.DefaultReplicas))
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(1)))
 			Expect(controllerutil.HasControllerReference(deploy)).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(4))
 			svc := &corev1.Service{}

--- a/infra/feast-operator/internal/controller/featurestore_controller_ephemeral_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_ephemeral_test.go
@@ -206,7 +206,7 @@ var _ = Describe("FeatureStore Controller-Ephemeral services", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(deploy.Spec.Replicas).To(Equal(&services.DefaultReplicas))
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(1)))
 			Expect(controllerutil.HasControllerReference(deploy)).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(4))
 			svc := &corev1.Service{}

--- a/infra/feast-operator/internal/controller/featurestore_controller_kubernetes_auth_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_kubernetes_auth_test.go
@@ -200,7 +200,7 @@ var _ = Describe("FeatureStore Controller-Kubernetes authorization", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(deploy.Spec.Replicas).To(Equal(&services.DefaultReplicas))
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(1)))
 			Expect(controllerutil.HasControllerReference(deploy)).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(4))
 			Expect(deploy.Spec.Template.Spec.Volumes).To(HaveLen(1))

--- a/infra/feast-operator/internal/controller/featurestore_controller_loglevel_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_loglevel_test.go
@@ -171,7 +171,7 @@ var _ = Describe("FeatureStore Controller - Feast service LogLevel", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(deploy.Spec.Replicas).To(Equal(&services.DefaultReplicas))
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(1)))
 			Expect(controllerutil.HasControllerReference(deploy)).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(4))
 			command := services.GetRegistryContainer(*deploy).Command
@@ -244,7 +244,3 @@ var _ = Describe("FeatureStore Controller - Feast service LogLevel", func() {
 
 	})
 })
-
-func strPtr(str string) *string {
-	return &str
-}

--- a/infra/feast-operator/internal/controller/featurestore_controller_objectstore_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_objectstore_test.go
@@ -183,7 +183,7 @@ var _ = Describe("FeatureStore Controller-Ephemeral services", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(deploy.Spec.Replicas).To(Equal(&services.DefaultReplicas))
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(1)))
 			Expect(controllerutil.HasControllerReference(deploy)).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(2))
@@ -279,7 +279,7 @@ var _ = Describe("FeatureStore Controller-Ephemeral services", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(deploy.Spec.Replicas).To(Equal(&services.DefaultReplicas))
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(1)))
 			Expect(controllerutil.HasControllerReference(deploy)).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(2))
 			Expect(services.GetRegistryContainer(*deploy)).NotTo(BeNil())

--- a/infra/feast-operator/internal/controller/featurestore_controller_oidc_auth_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_oidc_auth_test.go
@@ -219,7 +219,7 @@ var _ = Describe("FeatureStore Controller-OIDC authorization", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(deploy.Spec.Replicas).To(Equal(&services.DefaultReplicas))
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(1)))
 			Expect(controllerutil.HasControllerReference(deploy)).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(4))

--- a/infra/feast-operator/internal/controller/featurestore_controller_pvc_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_pvc_test.go
@@ -281,7 +281,7 @@ var _ = Describe("FeatureStore Controller-Ephemeral services", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(deploy.Spec.Replicas).To(Equal(&services.DefaultReplicas))
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(1)))
 			Expect(controllerutil.HasControllerReference(deploy)).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(3))
 			Expect(deploy.Spec.Template.Spec.Volumes).To(HaveLen(3))

--- a/infra/feast-operator/internal/controller/featurestore_controller_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_test.go
@@ -201,12 +201,16 @@ var _ = Describe("FeatureStore Controller", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(deploy.Spec.Replicas).To(Equal(&services.DefaultReplicas))
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(1)))
 			Expect(controllerutil.HasControllerReference(deploy)).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.ServiceAccountName).To(Equal(deploy.Name))
 			Expect(deploy.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 			Expect(deploy.Spec.Template.Spec.InitContainers[0].Args[0]).To(ContainSubstring("feast init"))
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
+
+			deploy.Spec.Replicas = int32Ptr(3)
+			err = k8sClient.Update(ctx, deploy)
+			Expect(err).NotTo(HaveOccurred())
 
 			svc := &corev1.Service{}
 			err = k8sClient.Get(ctx, types.NamespacedName{
@@ -253,6 +257,7 @@ var _ = Describe("FeatureStore Controller", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(3)))
 			Expect(deploy.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 			Expect(deploy.Spec.Template.Spec.InitContainers[0].Args[0]).To(ContainSubstring("git -c http.sslVerify=false clone"))
 			Expect(deploy.Spec.Template.Spec.InitContainers[0].Args[0]).To(ContainSubstring("git checkout " + ref))
@@ -650,7 +655,7 @@ var _ = Describe("FeatureStore Controller", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(deploy.Spec.Replicas).To(Equal(&services.DefaultReplicas))
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(1)))
 			Expect(controllerutil.HasControllerReference(deploy)).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.ServiceAccountName).To(Equal(deploy.Name))
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(4))
@@ -1393,4 +1398,12 @@ func areEnvVarArraysEqual(arr1 []corev1.EnvVar, arr2 []corev1.EnvVar) bool {
 	}
 
 	return true
+}
+
+func strPtr(str string) *string {
+	return &str
+}
+
+func int32Ptr(value int32) *int32 {
+	return &value
 }

--- a/infra/feast-operator/internal/controller/featurestore_controller_tls_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_tls_test.go
@@ -188,7 +188,7 @@ var _ = Describe("FeatureStore Controller - Feast service TLS", func() {
 				Namespace: objMeta.Namespace,
 			}, deploy)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(deploy.Spec.Replicas).To(Equal(&services.DefaultReplicas))
+			Expect(deploy.Spec.Replicas).To(Equal(int32Ptr(1)))
 			Expect(controllerutil.HasControllerReference(deploy)).To(BeTrue())
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(4))
 			svc := &corev1.Service{}

--- a/infra/feast-operator/internal/controller/services/services.go
+++ b/infra/feast-operator/internal/controller/services/services.go
@@ -331,9 +331,11 @@ func (feast *FeastServices) createPVC(pvcCreate *feastdevv1alpha1.PvcCreate, fea
 }
 
 func (feast *FeastServices) setDeployment(deploy *appsv1.Deployment) error {
+	replicas := deploy.Spec.Replicas
+
 	deploy.Labels = feast.getLabels()
 	deploy.Spec = appsv1.DeploymentSpec{
-		Replicas: &DefaultReplicas,
+		Replicas: replicas,
 		Selector: metav1.SetAsLabelSelector(deploy.GetLabels()),
 		Strategy: feast.getDeploymentStrategy(),
 		Template: corev1.PodTemplateSpec{

--- a/infra/feast-operator/internal/controller/services/services_types.go
+++ b/infra/feast-operator/internal/controller/services/services_types.go
@@ -92,7 +92,6 @@ const (
 var (
 	DefaultImage          = "quay.io/feastdev/feature-server:" + feastversion.FeastVersion
 	DefaultCronJobImage   = "quay.io/openshift/origin-cli:4.17"
-	DefaultReplicas       = int32(1)
 	DefaultPVCAccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 	NameLabelKey          = feastdevv1alpha1.GroupVersion.Group + "/name"
 	ServiceTypeLabelKey   = feastdevv1alpha1.GroupVersion.Group + "/service-type"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
With this PR, the Operator will honor whatever number of replicas the Feast Deployment is scaled to (by the user, HPA, etc.).

Currently, the Operator enforces only 1 replica per Feature Store Deployment. We should leave this up to the user. While Feast does not support any kind of HA implementation, certain data store types may support horizontal scaling of feast.

Doing this also gets the Operator out of the business of making any future HA or scaling decisions.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
