### PR TITLE
feat: Add feature view lineage tab and filtering to home page lineage

### DIFF
--- a/ui/src/components/RegistryVisualization.tsx
+++ b/ui/src/components/RegistryVisualization.tsx
@@ -572,6 +572,7 @@ interface RegistryVisualizationProps {
   registryData: feast.core.Registry;
   relationships: EntityRelation[];
   indirectRelationships: EntityRelation[];
+  filterNode?: { type: FEAST_FCO_TYPES; name: string };
 }
 
 const RegistryVisualization: React.FC<RegistryVisualizationProps> = ({
@@ -592,9 +593,19 @@ const RegistryVisualization: React.FC<RegistryVisualizationProps> = ({
       setLoading(true);
 
       // Only include indirect relationships if the toggle is on
-      const relationshipsToShow = showIndirectRelationships
+      let relationshipsToShow = showIndirectRelationships
         ? [...relationships, ...indirectRelationships]
         : relationships;
+        
+      // Filter relationships based on filterNode if provided
+      if (filterNode) {
+        relationshipsToShow = relationshipsToShow.filter((rel) => {
+          return (
+            (rel.source.type === filterNode.type && rel.source.name === filterNode.name) ||
+            (rel.target.type === filterNode.type && rel.target.name === filterNode.name)
+          );
+        });
+      }
 
       // Filter out invalid relationships
       const validRelationships = relationshipsToShow.filter((rel) => {

--- a/ui/src/components/RegistryVisualization.tsx
+++ b/ui/src/components/RegistryVisualization.tsx
@@ -579,6 +579,7 @@ const RegistryVisualization: React.FC<RegistryVisualizationProps> = ({
   registryData,
   relationships,
   indirectRelationships,
+  filterNode,
 }) => {
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
@@ -596,13 +597,15 @@ const RegistryVisualization: React.FC<RegistryVisualizationProps> = ({
       let relationshipsToShow = showIndirectRelationships
         ? [...relationships, ...indirectRelationships]
         : relationships;
-        
+
       // Filter relationships based on filterNode if provided
       if (filterNode) {
         relationshipsToShow = relationshipsToShow.filter((rel) => {
           return (
-            (rel.source.type === filterNode.type && rel.source.name === filterNode.name) ||
-            (rel.target.type === filterNode.type && rel.target.name === filterNode.name)
+            (rel.source.type === filterNode.type &&
+              rel.source.name === filterNode.name) ||
+            (rel.target.type === filterNode.type &&
+              rel.target.name === filterNode.name)
           );
         });
       }
@@ -636,6 +639,7 @@ const RegistryVisualization: React.FC<RegistryVisualizationProps> = ({
     indirectRelationships,
     showIndirectRelationships,
     showIsolatedNodes,
+    filterNode,
     setNodes,
     setEdges,
   ]);

--- a/ui/src/components/RegistryVisualizationTab.tsx
+++ b/ui/src/components/RegistryVisualizationTab.tsx
@@ -1,5 +1,13 @@
 import React, { useContext, useState } from "react";
-import { EuiEmptyPrompt, EuiLoadingSpinner, EuiSpacer, EuiSelect, EuiFormRow, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
+import {
+  EuiEmptyPrompt,
+  EuiLoadingSpinner,
+  EuiSpacer,
+  EuiSelect,
+  EuiFormRow,
+  EuiFlexGroup,
+  EuiFlexItem,
+} from "@elastic/eui";
 import useLoadRegistry from "../queries/useLoadRegistry";
 import RegistryPathContext from "../contexts/RegistryPathContext";
 import RegistryVisualization from "./RegistryVisualization";
@@ -10,25 +18,33 @@ const RegistryVisualizationTab = () => {
   const { isLoading, isSuccess, isError, data } = useLoadRegistry(registryUrl);
   const [selectedObjectType, setSelectedObjectType] = useState("");
   const [selectedObjectName, setSelectedObjectName] = useState("");
-  
+
   const getObjectOptions = (objects: any, type: string) => {
     switch (type) {
       case "dataSource":
         const dataSources = new Set<string>();
         objects.featureViews?.forEach((fv: any) => {
-          if (fv.spec?.batchSource?.name) dataSources.add(fv.spec.batchSource.name);
+          if (fv.spec?.batchSource?.name)
+            dataSources.add(fv.spec.batchSource.name);
         });
         objects.streamFeatureViews?.forEach((sfv: any) => {
-          if (sfv.spec?.batchSource?.name) dataSources.add(sfv.spec.batchSource.name);
-          if (sfv.spec?.streamSource?.name) dataSources.add(sfv.spec.streamSource.name);
+          if (sfv.spec?.batchSource?.name)
+            dataSources.add(sfv.spec.batchSource.name);
+          if (sfv.spec?.streamSource?.name)
+            dataSources.add(sfv.spec.streamSource.name);
         });
         return Array.from(dataSources);
       case "entity":
         return objects.entities?.map((entity: any) => entity.spec?.name) || [];
       case "featureView":
-        return [...(objects.featureViews?.map((fv: any) => fv.spec?.name) || []),
-                ...(objects.onDemandFeatureViews?.map((odfv: any) => odfv.spec?.name) || []),
-                ...(objects.streamFeatureViews?.map((sfv: any) => sfv.spec?.name) || [])];
+        return [
+          ...(objects.featureViews?.map((fv: any) => fv.spec?.name) || []),
+          ...(objects.onDemandFeatureViews?.map(
+            (odfv: any) => odfv.spec?.name,
+          ) || []),
+          ...(objects.streamFeatureViews?.map((sfv: any) => sfv.spec?.name) ||
+            []),
+        ];
       case "featureService":
         return objects.featureServices?.map((fs: any) => fs.spec?.name) || [];
       default:
@@ -84,10 +100,12 @@ const RegistryVisualizationTab = () => {
                 <EuiSelect
                   options={[
                     { value: "", text: "All" },
-                    ...getObjectOptions(data.objects, selectedObjectType).map((name) => ({
-                      value: name,
-                      text: name,
-                    })),
+                    ...getObjectOptions(data.objects, selectedObjectType).map(
+                      (name: string) => ({
+                        value: name,
+                        text: name,
+                      }),
+                    ),
                   ]}
                   value={selectedObjectName}
                   onChange={(e) => setSelectedObjectName(e.target.value)}

--- a/ui/src/components/RegistryVisualizationTab.tsx
+++ b/ui/src/components/RegistryVisualizationTab.tsx
@@ -1,12 +1,40 @@
-import React, { useContext } from "react";
-import { EuiEmptyPrompt, EuiLoadingSpinner, EuiSpacer } from "@elastic/eui";
+import React, { useContext, useState } from "react";
+import { EuiEmptyPrompt, EuiLoadingSpinner, EuiSpacer, EuiSelect, EuiFormRow, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 import useLoadRegistry from "../queries/useLoadRegistry";
 import RegistryPathContext from "../contexts/RegistryPathContext";
 import RegistryVisualization from "./RegistryVisualization";
+import { FEAST_FCO_TYPES } from "../parsers/types";
 
 const RegistryVisualizationTab = () => {
   const registryUrl = useContext(RegistryPathContext);
   const { isLoading, isSuccess, isError, data } = useLoadRegistry(registryUrl);
+  const [selectedObjectType, setSelectedObjectType] = useState("");
+  const [selectedObjectName, setSelectedObjectName] = useState("");
+  
+  const getObjectOptions = (objects: any, type: string) => {
+    switch (type) {
+      case "dataSource":
+        const dataSources = new Set<string>();
+        objects.featureViews?.forEach((fv: any) => {
+          if (fv.spec?.batchSource?.name) dataSources.add(fv.spec.batchSource.name);
+        });
+        objects.streamFeatureViews?.forEach((sfv: any) => {
+          if (sfv.spec?.batchSource?.name) dataSources.add(sfv.spec.batchSource.name);
+          if (sfv.spec?.streamSource?.name) dataSources.add(sfv.spec.streamSource.name);
+        });
+        return Array.from(dataSources);
+      case "entity":
+        return objects.entities?.map((entity: any) => entity.spec?.name) || [];
+      case "featureView":
+        return [...(objects.featureViews?.map((fv: any) => fv.spec?.name) || []),
+                ...(objects.onDemandFeatureViews?.map((odfv: any) => odfv.spec?.name) || []),
+                ...(objects.streamFeatureViews?.map((sfv: any) => sfv.spec?.name) || [])];
+      case "featureService":
+        return objects.featureServices?.map((fs: any) => fs.spec?.name) || [];
+      default:
+        return [];
+    }
+  };
 
   return (
     <>
@@ -31,10 +59,56 @@ const RegistryVisualizationTab = () => {
       {isSuccess && data && (
         <>
           <EuiSpacer size="l" />
+          <EuiFlexGroup style={{ marginBottom: 16 }}>
+            <EuiFlexItem grow={false} style={{ width: 200 }}>
+              <EuiFormRow label="Filter by type">
+                <EuiSelect
+                  options={[
+                    { value: "", text: "All" },
+                    { value: "dataSource", text: "Data Source" },
+                    { value: "entity", text: "Entity" },
+                    { value: "featureView", text: "Feature View" },
+                    { value: "featureService", text: "Feature Service" },
+                  ]}
+                  value={selectedObjectType}
+                  onChange={(e) => {
+                    setSelectedObjectType(e.target.value);
+                    setSelectedObjectName(""); // Reset name when type changes
+                  }}
+                  aria-label="Select object type"
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false} style={{ width: 300 }}>
+              <EuiFormRow label="Select object">
+                <EuiSelect
+                  options={[
+                    { value: "", text: "All" },
+                    ...getObjectOptions(data.objects, selectedObjectType).map((name) => ({
+                      value: name,
+                      text: name,
+                    })),
+                  ]}
+                  value={selectedObjectName}
+                  onChange={(e) => setSelectedObjectName(e.target.value)}
+                  aria-label="Select object"
+                  disabled={selectedObjectType === ""}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
           <RegistryVisualization
             registryData={data.objects}
             relationships={data.relationships}
             indirectRelationships={data.indirectRelationships}
+            filterNode={
+              selectedObjectType && selectedObjectName
+                ? {
+                    type: selectedObjectType as FEAST_FCO_TYPES,
+                    name: selectedObjectName,
+                  }
+                : undefined
+            }
           />
         </>
       )}

--- a/ui/src/pages/feature-views/FeatureViewLineageTab.tsx
+++ b/ui/src/pages/feature-views/FeatureViewLineageTab.tsx
@@ -13,7 +13,12 @@ interface FeatureViewLineageTabProps {
 
 const FeatureViewLineageTab = ({ data }: FeatureViewLineageTabProps) => {
   const registryUrl = useContext(RegistryPathContext);
-  const { isLoading, isSuccess, isError, data: registryData } = useLoadRegistry(registryUrl);
+  const {
+    isLoading,
+    isSuccess,
+    isError,
+    data: registryData,
+  } = useLoadRegistry(registryUrl);
   const { featureViewName } = useParams();
 
   const filterNode = {

--- a/ui/src/pages/feature-views/FeatureViewLineageTab.tsx
+++ b/ui/src/pages/feature-views/FeatureViewLineageTab.tsx
@@ -1,0 +1,56 @@
+import React, { useContext } from "react";
+import { useParams } from "react-router-dom";
+import { EuiEmptyPrompt, EuiLoadingSpinner } from "@elastic/eui";
+import { feast } from "../../protos";
+import useLoadRegistry from "../../queries/useLoadRegistry";
+import RegistryPathContext from "../../contexts/RegistryPathContext";
+import RegistryVisualization from "../../components/RegistryVisualization";
+import { FEAST_FCO_TYPES } from "../../parsers/types";
+
+interface FeatureViewLineageTabProps {
+  data: feast.core.IFeatureView;
+}
+
+const FeatureViewLineageTab = ({ data }: FeatureViewLineageTabProps) => {
+  const registryUrl = useContext(RegistryPathContext);
+  const { isLoading, isSuccess, isError, data: registryData } = useLoadRegistry(registryUrl);
+  const { featureViewName } = useParams();
+
+  const filterNode = {
+    type: FEAST_FCO_TYPES.featureView,
+    name: featureViewName || data.spec?.name || "",
+  };
+
+  return (
+    <>
+      {isLoading && (
+        <div style={{ display: "flex", justifyContent: "center", padding: 25 }}>
+          <EuiLoadingSpinner size="xl" />
+        </div>
+      )}
+      {isError && (
+        <EuiEmptyPrompt
+          iconType="alert"
+          color="danger"
+          title={<h2>Error Loading Registry Data</h2>}
+          body={
+            <p>
+              There was an error loading the Registry Data. Please check that{" "}
+              <code>feature_store.yaml</code> file is available and well-formed.
+            </p>
+          }
+        />
+      )}
+      {isSuccess && registryData && (
+        <RegistryVisualization
+          registryData={registryData.objects}
+          relationships={registryData.relationships}
+          indirectRelationships={registryData.indirectRelationships}
+          filterNode={filterNode}
+        />
+      )}
+    </>
+  );
+};
+
+export default FeatureViewLineageTab;

--- a/ui/src/pages/feature-views/RegularFeatureViewInstance.tsx
+++ b/ui/src/pages/feature-views/RegularFeatureViewInstance.tsx
@@ -6,6 +6,7 @@ import { FeatureViewIcon } from "../../graphics/FeatureViewIcon";
 
 import { useMatchExact, useMatchSubpath } from "../../hooks/useMatchSubpath";
 import RegularFeatureViewOverviewTab from "./RegularFeatureViewOverviewTab";
+import FeatureViewLineageTab from "./FeatureViewLineageTab";
 
 import {
   useRegularFeatureViewCustomTabs,
@@ -32,6 +33,14 @@ const RegularFeatureInstance = ({ data }: RegularFeatureInstanceProps) => {
       },
     },
   ];
+
+  tabs.push({
+    label: "Lineage",
+    isSelected: useMatchSubpath("lineage"),
+    onClick: () => {
+      navigate("lineage");
+    },
+  });
 
   let statisticsIsSelected = useMatchSubpath("statistics");
   if (enabledFeatureStatistics) {
@@ -61,6 +70,10 @@ const RegularFeatureInstance = ({ data }: RegularFeatureInstanceProps) => {
           <Route
             path="/"
             element={<RegularFeatureViewOverviewTab data={data} />}
+          />
+          <Route
+            path="/lineage"
+            element={<FeatureViewLineageTab data={data} />}
           />
           {TabRoutes}
         </Routes>


### PR DESCRIPTION
# What this PR does / why we need it:

1. **Registry Visualization Enhancements**
   - **Filter by Type and Name:**
     - Added dropdown menus to filter objects in the registry visualization by type (`dataSource`, `entity`, `featureView`, `featureService`) and name.
     - Introduced a new `filterNode` prop in the `RegistryVisualization` component to apply these filters.
     - Updated logic in the `RegistryVisualization` component to filter relationships based on the selected type and name.
   - **UI/UX Improvements:**
     - Added new UI components such as `EuiSelect`, `EuiFormRow`, and `EuiFlexGroup` for a more user-friendly filter interface.

2. **Feature Lineage Tab**
   - Added a new `FeatureViewLineageTab` component to visualize the lineage of a feature view.
   - Integrated the tab into the `RegularFeatureViewInstance` component:
     - Added a "Lineage" tab to the UI.
     - Created a route for the lineage view (`/lineage`) in the `RegularFeatureInstance` component.

3. **Code Refactoring**
   - Updated `RegistryVisualizationProps` to include a new optional `filterNode`.
   - Introduced helper functions (`getObjectOptions`) to dynamically generate dropdown options for filtering.

#### **New Functionality:**
- Users can now filter registry visualizations to focus on specific object types and names.
- Added a dedicated "Lineage" tab for feature views, allowing users to explore the relationships and dependencies of a feature view.

#### **Files Modified:**
1. **`RegistryVisualization.tsx`**
   - Added `filterNode` prop and filtering logic for relationships.
   - Updated state management for nodes and edges.

2. **`RegistryVisualizationTab.tsx`**
   - Introduced dropdown menus for filtering registry visualizations.
   - Added helper functions to dynamically retrieve filter options.

3. **`FeatureViewLineageTab.tsx`**
   - New component for displaying feature view lineage.

4. **`RegularFeatureViewInstance.tsx`**
   - Added "Lineage" tab and routing for the new `FeatureViewLineageTab`.


![image](https://github.com/user-attachments/assets/79957868-6991-468f-b415-0b78be8fdb53)

![image](https://github.com/user-attachments/assets/f29d687c-35af-4c7b-b409-fe2c7efca9aa)

![image](https://github.com/user-attachments/assets/dcd59ae2-5d6a-4c6d-93cf-ec4fa75ff129)

# Which issue(s) this PR fixes:


# Misc
#### **Testing Notes:**
- Verified that filtering by type and name correctly updates the registry visualization.
- Confirmed that the new "Lineage" tab displays relevant lineage information for feature views.
- Ensured backward compatibility for existing registry visualization functionality.
