### PR TITLE
feat: Add dark mode toggle to Feast UI

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -2,3 +2,8 @@ html {
   background: url("assets/feast-icon-white.svg") no-repeat bottom left;
   background-size: 20vh;
 }
+
+body.euiTheme--dark html {
+  background: url("assets/feast-icon-white.svg") no-repeat bottom left;
+  background-size: 20vh;
+}

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -72,10 +72,10 @@ const FeastUISansProviders = ({
 
   return (
     <ThemeProvider>
-      <FeastUISansProvidersInner 
-        basename={basename} 
-        projectListContext={projectListContext} 
-        feastUIConfigs={feastUIConfigs} 
+      <FeastUISansProvidersInner
+        basename={basename}
+        projectListContext={projectListContext}
+        feastUIConfigs={feastUIConfigs}
       />
     </ThemeProvider>
   );
@@ -91,7 +91,6 @@ const FeastUISansProvidersInner = ({
   feastUIConfigs?: FeastUIConfigs;
 }) => {
   const { colorMode } = useTheme();
-  
 
   return (
     <EuiProvider colorMode={colorMode}>

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 
-import "@elastic/eui/dist/eui_theme_light.css";
 import "./index.css";
 
 import { Routes, Route } from "react-router-dom";
 import { EuiProvider, EuiErrorBoundary } from "@elastic/eui";
+import { ThemeProvider, useTheme } from "./contexts/ThemeContext";
 
 import ProjectOverviewPage from "./pages/ProjectOverviewPage";
 import Layout from "./pages/Layout";
@@ -70,7 +70,37 @@ const FeastUISansProviders = ({
         };
 
   return (
-    <EuiProvider colorMode="light">
+    <ThemeProvider>
+      <FeastUISansProvidersInner 
+        basename={basename} 
+        projectListContext={projectListContext} 
+        feastUIConfigs={feastUIConfigs} 
+      />
+    </ThemeProvider>
+  );
+};
+
+const FeastUISansProvidersInner = ({
+  basename,
+  projectListContext,
+  feastUIConfigs,
+}: {
+  basename: string;
+  projectListContext: ProjectsListContextInterface;
+  feastUIConfigs?: FeastUIConfigs;
+}) => {
+  const { colorMode } = useTheme();
+  
+  React.useEffect(() => {
+    if (colorMode === "dark") {
+      import("@elastic/eui/dist/eui_theme_dark.css");
+    } else {
+      import("@elastic/eui/dist/eui_theme_light.css");
+    }
+  }, [colorMode]);
+
+  return (
+    <EuiProvider colorMode={colorMode}>
       <EuiErrorBoundary>
         <TabsRegistryContext.Provider
           value={feastUIConfigs?.tabsRegistry || {}}

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import "@elastic/eui/dist/eui_theme_light.css";
 import "./index.css";
 
 import { Routes, Route } from "react-router-dom";
@@ -91,13 +92,6 @@ const FeastUISansProvidersInner = ({
 }) => {
   const { colorMode } = useTheme();
   
-  React.useEffect(() => {
-    if (colorMode === "dark") {
-      import("@elastic/eui/dist/eui_theme_dark.css");
-    } else {
-      import("@elastic/eui/dist/eui_theme_light.css");
-    }
-  }, [colorMode]);
 
   return (
     <EuiProvider colorMode={colorMode}>

--- a/ui/src/components/RegistryVisualization.tsx
+++ b/ui/src/components/RegistryVisualization.tsx
@@ -382,8 +382,8 @@ const Legend = () => {
   const backgroundColor = isDarkMode ? "#1D1E24" : "white";
   const borderColor = isDarkMode ? "#343741" : "#ddd";
   const textColor = isDarkMode ? "#DFE5EF" : "#333";
-  const boxShadow = isDarkMode 
-    ? "0 2px 5px rgba(0,0,0,0.3)" 
+  const boxShadow = isDarkMode
+    ? "0 2px 5px rgba(0,0,0,0.3)"
     : "0 2px 5px rgba(0,0,0,0.1)";
 
   return (
@@ -400,12 +400,14 @@ const Legend = () => {
         boxShadow: boxShadow,
       }}
     >
-      <div style={{ 
-        fontSize: 14, 
-        fontWeight: 600, 
-        marginBottom: 5,
-        color: textColor 
-      }}>
+      <div
+        style={{
+          fontSize: 14,
+          fontWeight: 600,
+          marginBottom: 5,
+          color: textColor,
+        }}
+      >
         Legend
       </div>
       {types.map((item) => (
@@ -616,32 +618,40 @@ const RegistryVisualization: React.FC<RegistryVisualizationProps> = ({
       // Filter relationships based on filterNode if provided
       if (filterNode) {
         const connectedNodes = new Set<string>();
-        
+
         const filterNodeId = `${getNodePrefix(filterNode.type)}-${filterNode.name}`;
         connectedNodes.add(filterNodeId);
-        
+
         // Function to recursively find all connected nodes
         const findConnectedNodes = (nodeId: string, isDownstream: boolean) => {
           relationshipsToShow.forEach((rel) => {
             const sourceId = `${getNodePrefix(rel.source.type)}-${rel.source.name}`;
             const targetId = `${getNodePrefix(rel.target.type)}-${rel.target.name}`;
-            
-            if (isDownstream && sourceId === nodeId && !connectedNodes.has(targetId)) {
+
+            if (
+              isDownstream &&
+              sourceId === nodeId &&
+              !connectedNodes.has(targetId)
+            ) {
               connectedNodes.add(targetId);
               findConnectedNodes(targetId, isDownstream);
             }
-            
-            if (!isDownstream && targetId === nodeId && !connectedNodes.has(sourceId)) {
+
+            if (
+              !isDownstream &&
+              targetId === nodeId &&
+              !connectedNodes.has(sourceId)
+            ) {
               connectedNodes.add(sourceId);
               findConnectedNodes(sourceId, isDownstream);
             }
           });
         };
-        
+
         findConnectedNodes(filterNodeId, true);
-        
+
         findConnectedNodes(filterNodeId, false);
-        
+
         relationshipsToShow = relationshipsToShow.filter((rel) => {
           const sourceId = `${getNodePrefix(rel.source.type)}-${rel.source.name}`;
           const targetId = `${getNodePrefix(rel.target.type)}-${rel.target.name}`;

--- a/ui/src/components/RegistryVisualization.tsx
+++ b/ui/src/components/RegistryVisualization.tsx
@@ -19,6 +19,7 @@ import { EuiPanel, EuiTitle, EuiSpacer, EuiLoadingSpinner } from "@elastic/eui";
 import { FEAST_FCO_TYPES } from "../parsers/types";
 import { EntityRelation } from "../parsers/parseEntityRelationships";
 import { feast } from "../protos";
+import { useTheme } from "../contexts/ThemeContext";
 
 const edgeAnimationStyle = `
   @keyframes dashdraw {
@@ -369,6 +370,7 @@ const getLayoutedElements = (
   };
 };
 const Legend = () => {
+  const { colorMode } = useTheme();
   const types = [
     { type: FEAST_FCO_TYPES.featureService, label: "Feature Service" },
     { type: FEAST_FCO_TYPES.featureView, label: "Feature View" },
@@ -376,21 +378,34 @@ const Legend = () => {
     { type: FEAST_FCO_TYPES.dataSource, label: "Data Source" },
   ];
 
+  const isDarkMode = colorMode === "dark";
+  const backgroundColor = isDarkMode ? "#1D1E24" : "white";
+  const borderColor = isDarkMode ? "#343741" : "#ddd";
+  const textColor = isDarkMode ? "#DFE5EF" : "#333";
+  const boxShadow = isDarkMode 
+    ? "0 2px 5px rgba(0,0,0,0.3)" 
+    : "0 2px 5px rgba(0,0,0,0.1)";
+
   return (
     <div
       style={{
         position: "absolute",
         left: 10,
         top: 10,
-        background: "white",
-        border: "1px solid #ddd",
+        background: backgroundColor,
+        border: `1px solid ${borderColor}`,
         borderRadius: 5,
         padding: 10,
         zIndex: 10,
-        boxShadow: "0 2px 5px rgba(0,0,0,0.1)",
+        boxShadow: boxShadow,
       }}
     >
-      <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 5 }}>
+      <div style={{ 
+        fontSize: 14, 
+        fontWeight: 600, 
+        marginBottom: 5,
+        color: textColor 
+      }}>
         Legend
       </div>
       {types.map((item) => (
@@ -414,7 +429,7 @@ const Legend = () => {
           >
             {getNodeIcon(item.type)}
           </div>
-          <div style={{ fontSize: 12 }}>{item.label}</div>
+          <div style={{ fontSize: 12, color: textColor }}>{item.label}</div>
         </div>
       ))}
     </div>

--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { 
+  EuiButtonIcon, 
+  EuiToolTip,
+  useGeneratedHtmlId
+} from "@elastic/eui";
+import { useTheme } from "../contexts/ThemeContext";
+
+const ThemeToggle: React.FC = () => {
+  const { colorMode, toggleColorMode } = useTheme();
+  const buttonId = useGeneratedHtmlId({ prefix: "themeToggle" });
+  
+  return (
+    <EuiToolTip
+      position="right"
+      content={`Switch to ${colorMode === "light" ? "dark" : "light"} theme`}
+    >
+      <EuiButtonIcon
+        id={buttonId}
+        onClick={toggleColorMode}
+        iconType={colorMode === "light" ? "moon" : "sun"}
+        aria-label={`Switch to ${colorMode === "light" ? "dark" : "light"} theme`}
+        color="text"
+      />
+    </EuiToolTip>
+  );
+};
+
+export default ThemeToggle;

--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -1,15 +1,11 @@
 import React from "react";
-import { 
-  EuiButtonIcon, 
-  EuiToolTip,
-  useGeneratedHtmlId
-} from "@elastic/eui";
+import { EuiButtonIcon, EuiToolTip, useGeneratedHtmlId } from "@elastic/eui";
 import { useTheme } from "../contexts/ThemeContext";
 
 const ThemeToggle: React.FC = () => {
   const { colorMode, toggleColorMode } = useTheme();
   const buttonId = useGeneratedHtmlId({ prefix: "themeToggle" });
-  
+
   return (
     <EuiToolTip
       position="right"

--- a/ui/src/contexts/ThemeContext.tsx
+++ b/ui/src/contexts/ThemeContext.tsx
@@ -14,8 +14,8 @@ const ThemeContext = createContext<ThemeContextType>({
   toggleColorMode: () => {},
 });
 
-export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ 
-  children 
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
 }) => {
   const [colorMode, setColorMode] = useState<ThemeMode>(() => {
     const savedTheme = localStorage.getItem("feast-theme");
@@ -24,7 +24,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
 
   useEffect(() => {
     localStorage.setItem("feast-theme", colorMode);
-    
+
     if (colorMode === "dark") {
       document.body.classList.add("euiTheme--dark");
     } else {
@@ -33,13 +33,11 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [colorMode]);
 
   const toggleColorMode = () => {
-    setColorMode(prevMode => (prevMode === "light" ? "dark" : "light"));
+    setColorMode((prevMode) => (prevMode === "light" ? "dark" : "light"));
   };
 
   return (
-    <ThemeContext.Provider 
-      value={{ colorMode, setColorMode, toggleColorMode }}
-    >
+    <ThemeContext.Provider value={{ colorMode, setColorMode, toggleColorMode }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/ui/src/contexts/ThemeContext.tsx
+++ b/ui/src/contexts/ThemeContext.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useState, useContext, useEffect } from "react";
+
+type ThemeMode = "light" | "dark";
+
+interface ThemeContextType {
+  colorMode: ThemeMode;
+  setColorMode: (mode: ThemeMode) => void;
+  toggleColorMode: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  colorMode: "light",
+  setColorMode: () => {},
+  toggleColorMode: () => {},
+});
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ 
+  children 
+}) => {
+  const [colorMode, setColorMode] = useState<ThemeMode>(() => {
+    const savedTheme = localStorage.getItem("feast-theme");
+    return (savedTheme === "dark" ? "dark" : "light") as ThemeMode;
+  });
+
+  useEffect(() => {
+    localStorage.setItem("feast-theme", colorMode);
+    
+    if (colorMode === "dark") {
+      document.body.classList.add("euiTheme--dark");
+    } else {
+      document.body.classList.remove("euiTheme--dark");
+    }
+  }, [colorMode]);
+
+  const toggleColorMode = () => {
+    setColorMode(prevMode => (prevMode === "light" ? "dark" : "light"));
+  };
+
+  return (
+    <ThemeContext.Provider 
+      value={{ colorMode, setColorMode, toggleColorMode }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);
+
+export default ThemeContext;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -10,6 +10,13 @@ html {
   background-attachment: fixed;
 }
 
+/* Add dark mode specific styles */
+body.euiTheme--dark html {
+  background: url("assets/feast-icon-grey.svg") no-repeat -6vh 56vh;
+  background-size: 50vh;
+  filter: brightness(0.7); /* Darken the background image for dark mode */
+}
+
 body {
   margin: 0;
   font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",

--- a/ui/src/pages/Layout.tsx
+++ b/ui/src/pages/Layout.tsx
@@ -17,6 +17,7 @@ import { useLoadProjectsList } from "../contexts/ProjectListContext";
 import ProjectSelector from "../components/ProjectSelector";
 import Sidebar from "./Sidebar";
 import FeastWordMark from "../graphics/FeastWordMark";
+import ThemeToggle from "../components/ThemeToggle";
 
 const Layout = () => {
   // Registry Path Context has to be inside Layout
@@ -48,6 +49,9 @@ const Layout = () => {
             <React.Fragment>
               <EuiHorizontalRule margin="s" />
               <Sidebar />
+              <EuiSpacer size="l" />
+              <EuiHorizontalRule margin="s" />
+              <ThemeToggle />
             </React.Fragment>
           )}
         </EuiPageSidebar>


### PR DESCRIPTION
# What this PR does / why we need it:
Add Dark mode.
Also fix a bug where child object of the DAG weren't included in graph.

![Screenshot 2025-04-30 at 11 03 39 PM](https://github.com/user-attachments/assets/bdfad64f-e309-487b-a589-21fc1230ca61)

![Screenshot 2025-04-30 at 11 04 04 PM](https://github.com/user-attachments/assets/e1f21df3-85c0-4305-865c-248e9df1dc15)


# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
