### PR TITLE
fix: Allow custom annotations on Operator installed objects

### DIFF
--- a/infra/feast-operator/internal/controller/services/client.go
+++ b/infra/feast-operator/internal/controller/services/client.go
@@ -70,12 +70,11 @@ func (feast *FeastServices) createCaConfigMap() error {
 }
 
 func (feast *FeastServices) setCaConfigMap(cm *corev1.ConfigMap) error {
-	cm.Labels = map[string]string{
-		NameLabelKey: feast.Handler.FeatureStore.Name,
+	cm.Labels = feast.getLabels()
+	if len(cm.Annotations) == 0 {
+		cm.Annotations = map[string]string{}
 	}
-	cm.Annotations = map[string]string{
-		"service.beta.openshift.io/inject-cabundle": "true",
-	}
+	cm.Annotations["service.beta.openshift.io/inject-cabundle"] = "true"
 	return controllerutil.SetControllerReference(feast.Handler.FeatureStore, cm, feast.Handler.Scheme)
 }
 

--- a/infra/feast-operator/internal/controller/services/services.go
+++ b/infra/feast-operator/internal/controller/services/services.go
@@ -586,9 +586,10 @@ func (feast *FeastServices) setInitContainer(podSpec *corev1.PodSpec, fsYamlB64 
 func (feast *FeastServices) setService(svc *corev1.Service, feastType FeastServiceType) error {
 	svc.Labels = feast.getFeastTypeLabels(feastType)
 	if feast.isOpenShiftTls(feastType) {
-		svc.Annotations = map[string]string{
-			"service.beta.openshift.io/serving-cert-secret-name": svc.Name + tlsNameSuffix,
+		if len(svc.Annotations) == 0 {
+			svc.Annotations = map[string]string{}
 		}
+		svc.Annotations["service.beta.openshift.io/serving-cert-secret-name"] = svc.Name + tlsNameSuffix
 	}
 
 	var port int32 = HttpPort


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
We need to allow a user to add their own annotations to any Operator created objects. While we already do so for the vast majority of said objects, 2 of them currently override any custom annotations. With this PR, we adjust the logic so that it we merely add to the annotations of these 2 object types, instead of overriding them completely.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/feast-dev/feast/issues/5302

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
