### PR TITLE
fix: Fix pandas 2.x compatibility issue of Trino offline store caused by removed Series.iteritems() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/feast)](https://pypi.org/project/feast/)
 [![GitHub contributors](https://img.shields.io/github/contributors/feast-dev/feast)](https://github.com/feast-dev/feast/graphs/contributors)
-[![unit-tests](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml/badge.svg?branch=master&event=pull_request)](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml)
+[![unit-tests](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml/badge.svg?branch=master)](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml)
 [![integration-tests-and-build](https://github.com/feast-dev/feast/actions/workflows/master_only.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/master_only.yml)
 [![java-integration-tests](https://github.com/feast-dev/feast/actions/workflows/java_master_only.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/java_master_only.yml)
 [![linter](https://github.com/feast-dev/feast/actions/workflows/linter.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/linter.yml)
@@ -20,8 +20,6 @@
 
 ## Join us on Slack!
 👋👋👋 [Come say hi on Slack!](https://communityinviter.com/apps/feastopensource/feast-the-open-source-feature-store)
-
-[Check out our DeepWiki!](https://deepwiki.com/feast-dev/feast)
 
 ## Overview
 

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/connectors/upload.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/connectors/upload.py
@@ -115,7 +115,7 @@ def format_pandas_row(df: pd.DataFrame) -> str:
 
     def _format_value(row: pd.Series, schema: Dict[str, Any]) -> str:
         formated_values = []
-        for row_name, row_value in row.iteritems():
+        for row_name, row_value in row.items():
             if schema[row_name].startswith("timestamp"):
                 if isinstance(row_value, datetime):
                     row_value = format_datetime(row_value)


### PR DESCRIPTION
# Description
This PR fixes an `AttributeError` encountered when using `feast.get_historical_features()` with Trino as offline store and `pandas>=2.0.0`, where `Series.iteritems()` has been removed. The code now uses `row.items()`, which is compatible with both older and newer pandas versions.

# What this PR does / why we need it:
Feast with Trino as offline store currently breaks when used with pandas 2.x due to the removal of `Series.iteritems()`. This simple change ensures compatibility with modern pandas versions while retaining backwards compatibility with <2.0.0.
So users don't have to add `pandas>=1.5.3,<2.0.0` to `requirements.txt`, this PR will replace iteritems() method with items() for pandas 2.x compatibility in Trino offline store connector.

# Which issue(s) this PR fixes:
N/A — this issue was found independently and not yet tracked.

# Misc
This PR ensures compatibility with [`pandas >= 0.23.0`](https://pandas.pydata.org/docs/reference/api/pandas.Series.items.html) when calling historical feature retrieval function with Trino offline store.