### PR TITLE
fix: Fix Trino offline store SQL in Jinja template

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/feast)](https://pypi.org/project/feast/)
 [![GitHub contributors](https://img.shields.io/github/contributors/feast-dev/feast)](https://github.com/feast-dev/feast/graphs/contributors)
-[![unit-tests](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml/badge.svg?branch=master&event=pull_request)](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml)
+[![unit-tests](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml/badge.svg?branch=master)](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml)
 [![integration-tests-and-build](https://github.com/feast-dev/feast/actions/workflows/master_only.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/master_only.yml)
 [![java-integration-tests](https://github.com/feast-dev/feast/actions/workflows/java_master_only.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/java_master_only.yml)
 [![linter](https://github.com/feast-dev/feast/actions/workflows/linter.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/linter.yml)
@@ -20,8 +20,6 @@
 
 ## Join us on Slack!
 👋👋👋 [Come say hi on Slack!](https://communityinviter.com/apps/feastopensource/feast-the-open-source-feature-store)
-
-[Check out our DeepWiki!](https://deepwiki.com/feast-dev/feast)
 
 ## Overview
 

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
@@ -590,7 +590,9 @@ WITH entity_dataframe AS (
         {% for feature in featureview.features %}
             {{ feature }} as {% if full_feature_names %}{{ featureview.name }}__{{featureview.field_mapping.get(feature, feature)}}{% else %}{{ featureview.field_mapping.get(feature, feature) }}{% endif %}{% if loop.last %}{% else %}, {% endif %}
         {% endfor %}
-    FROM {{ featureview.table_subquery }}
+    FROM (
+        {{ featureview.table_subquery }}
+    ) AS {{ featureview.name }}__subquery
     WHERE {{ featureview.timestamp_field }} <= from_iso8601_timestamp('{{ featureview.max_event_timestamp }}')
     {% if featureview.ttl == 0 %}{% else %}
     AND {{ featureview.timestamp_field }} >= from_iso8601_timestamp('{{ featureview.min_event_timestamp }}')


### PR DESCRIPTION
# What this PR does / why we need it:
Feast’s Trino connector generated SQL like:
```sql
SELECT ...
FROM
SELECT ...
FROM my_table
```
which Trino rejects with:
`TrinoUserError: TrinoUserError(type=USER_ERROR, name=SYNTAX_ERROR, message="line 60:9: mismatched input 'SELECT'. Expecting: '(', 'JSON_TABLE', 'LATERAL', 'TABLE', 'UNNEST', <identifier>")`

By wrapping the subquery in `(...) AS alias`, we produce valid Trino SQL in accordance with its grammar rules for subqueries.

This PR updates the Trino offline store connector’s Jinja SQL template so that the `FROM` clause always wraps the `featureview.table_subquery` in parentheses and assigns it an explicit alias.

Previously:
```jinja
FROM {{ featureview.table_subquery }}
```

Now:
```jinja
FROM (
    {{ featureview.table_subquery }}
) AS {{ featureview.name }}__subquery
```

# Which issue(s) this PR fixes:
N/A — this issue was found independently and not yet tracked.

# Misc
Realese note: Fix Trino offline store SQL in Jinja template by wrapping `table_subquery` in parentheses and aliasing it `(AS {{ featureview.name }}__subquery)` to satisfy Trino’s subquery grammar.