### PR TITLE
chore: Update Trino (contrib) docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/feast)](https://pypi.org/project/feast/)
 [![GitHub contributors](https://img.shields.io/github/contributors/feast-dev/feast)](https://github.com/feast-dev/feast/graphs/contributors)
-[![unit-tests](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml/badge.svg?branch=master&event=pull_request)](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml)
+[![unit-tests](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml/badge.svg?branch=master)](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml)
 [![integration-tests-and-build](https://github.com/feast-dev/feast/actions/workflows/master_only.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/master_only.yml)
 [![java-integration-tests](https://github.com/feast-dev/feast/actions/workflows/java_master_only.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/java_master_only.yml)
 [![linter](https://github.com/feast-dev/feast/actions/workflows/linter.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/linter.yml)
@@ -20,8 +20,6 @@
 
 ## Join us on Slack!
 👋👋👋 [Come say hi on Slack!](https://communityinviter.com/apps/feastopensource/feast-the-open-source-feature-store)
-
-[Check out our DeepWiki!](https://deepwiki.com/feast-dev/feast)
 
 ## Overview
 

--- a/docs/reference/offline-stores/trino.md
+++ b/docs/reference/offline-stores/trino.md
@@ -34,11 +34,40 @@ offline_store:
 		type: hive
 		file_format: parquet
 	user: trino
-	auth:
-		type: basic
-		config:
-			username: ${TRINO_USER}
-			password: ${TRINO_PWD}
+		# Enables authentication in Trino connections, pick the one you need
+    auth:
+        # Basic Auth
+        type: basic
+        config:
+            username: ${TRINO_USER}
+            password: ${TRINO_PWD}
+
+        # Certificate
+        type: certificate
+        config:
+            cert-file: /path/to/cert/file
+            key-file: /path/to/key/file
+
+        # JWT
+        type: jwt
+        config:
+            token: ${JWT_TOKEN}
+
+        # OAuth2 (no config required)
+        type: oauth2
+
+        # Kerberos
+        type: kerberos
+        config:
+            config-file: /path/to/kerberos/config/file
+            service-name: foo
+            mutual-authentication: true
+            force-preemptive: true
+            hostname-override: custom-hostname
+            sanitize-mutual-error-response: true
+            principal: principal-name
+            delegate: true
+            ca_bundle: /path/to/ca/bundle/file
 online_store:
 	path: data/online_store.db
 # Prevents "Unsupported Hive type: timestamp(3) with time zone" TrinoUserError

--- a/docs/reference/offline-stores/trino.md
+++ b/docs/reference/offline-stores/trino.md
@@ -18,58 +18,34 @@ In order to use this offline store, you'll need to run `pip install 'feast[trino
 {% code title="feature_store.yaml" %}
 ```yaml
 project: feature_repo
-registry: data/registry.db
+project_description: This Feast project is a Trino Offline Store demo.
 provider: local
+registry: data/registry.db
 offline_store:
-    type: feast_trino.trino.TrinoOfflineStore
-    host: localhost
-    port: 8080
-    catalog: memory
-    connector:
-        type: memory
-    user: trino
-    source: feast-trino-offline-store
-    http-scheme: https
-    ssl-verify: false
-    x-trino-extra-credential-header: foo=bar, baz=qux
-
-    # enables authentication in Trino connections, pick the one you need
-    # if you don't need authentication, you can safely remove the whole auth block
-    auth:
-        # Basic Auth
-        type: basic
-        config:
-            username: foo
-            password: $FOO
-
-        # Certificate
-        type: certificate
-        config:
-            cert-file: /path/to/cert/file
-            key-file: /path/to/key/file
-
-        # JWT
-        type: jwt
-        config:
-            token: $JWT_TOKEN
-
-        # OAuth2 (no config required)
-        type: oauth2
-
-        # Kerberos
-        type: kerberos
-        config:
-            config-file: /path/to/kerberos/config/file
-            service-name: foo
-            mutual-authentication: true
-            force-preemptive: true
-            hostname-override: custom-hostname
-            sanitize-mutual-error-response: true
-            principal: principal-name
-            delegate: true
-            ca_bundle: /path/to/ca/bundle/file
+	type: trino
+	host: ${TRINO_HOST}
+	port: ${TRINO_PORT}
+	http-scheme: http
+	ssl-verify: false
+	catalog: hive
+	dataset: ${DATASET_NAME}
+    # Hive connection as example
+	connector:
+		type: hive
+		file_format: parquet
+	user: trino
+	auth:
+		type: basic
+		config:
+			username: ${TRINO_USER}
+			password: ${TRINO_PWD}
 online_store:
-    path: data/online_store.db
+	path: data/online_store.db
+# Prevents "Unsupported Hive type: timestamp(3) with time zone" TrinoUserError
+coerce_tz_aware: false
+entity_key_serialization_version: 3
+auth:
+	type: no_auth
 ```
 {% endcode %}
 


### PR DESCRIPTION
# What this PR does / why we need it:
[Trino (contrib)](https://docs.feast.dev/reference/offline-stores/trino) documentation page still gave code example with `type: feast_trino.trino.TrinoOfflineStore`, which is a class from an archived project [Shopify/feast-trino](https://github.com/Shopify/feast-trino).

# Which issue(s) this PR fixes:
[Trino offline store example in documentation is outdated #4837](https://github.com/feast-dev/feast/issues/4837)

# Misc
Also this PR adds a comment about `coerce_tz_aware: false`, which prevents (possibly a bug) Feast Trino connector from adding time zones to pandas dataframes when using Hive Metastore, This resulted in an error during execution of `feast.get_historical_features()`: `TrinoUserError: TrinoUserError(type=USER_ERROR, name=NOT_SUPPORTED, message="Unsupported Hive type: timestamp(3) with time zone")`