### PR TITLE
fix: The ignore_paths not taking effect duration feast apply

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -69,7 +69,7 @@ def read_feastignore(repo_root: Path) -> List[str]:
 def get_ignore_files(repo_root: Path, ignore_paths: List[str]) -> Set[Path]:
     """Get all ignore files that match any of the user-defined ignore paths"""
     ignore_files = set()
-    for ignore_path in ignore_paths:
+    for ignore_path in set(ignore_paths):
         # ignore_path may contains matchers (* or **). Use glob() to match user-defined path to actual paths
         for matched_path in repo_root.glob(ignore_path):
             if matched_path.is_file():
@@ -88,9 +88,7 @@ def get_ignore_files(repo_root: Path, ignore_paths: List[str]) -> Set[Path]:
 def get_repo_files(repo_root: Path) -> List[Path]:
     """Get the list of all repo files, ignoring undesired files & directories specified in .feastignore"""
     # Read ignore paths from .feastignore and create a set of all files that match any of these paths
-    ignore_paths = read_feastignore(repo_root)
-    ignore_files = get_ignore_files(repo_root, ignore_paths)
-    ignore_paths += [
+    ignore_paths = read_feastignore(repo_root) + [
         ".git",
         ".feastignore",
         ".venv",
@@ -98,6 +96,7 @@ def get_repo_files(repo_root: Path) -> List[Path]:
         "__pycache__",
         ".ipynb_checkpoints",
     ]
+    ignore_files = get_ignore_files(repo_root, ignore_paths)
 
     # List all Python files in the root directory (recursively)
     repo_files = {

--- a/sdk/python/tests/unit/infra/scaffolding/test_repo_operations.py
+++ b/sdk/python/tests/unit/infra/scaffolding/test_repo_operations.py
@@ -30,7 +30,7 @@ def feature_repo(feastignore_contents: Optional[str]):
         (repo_root / "bar/subdir1/subdir2").mkdir()
 
         (repo_root / "a.py").touch()
-        (repo_root / ".ipynb_checkpoints/test-checkpoint.ipynb").touch()
+        (repo_root / ".ipynb_checkpoints/test-checkpoint.py").touch()
         (repo_root / "foo/b.py").touch()
         (repo_root / "foo1/c.py").touch()
         (repo_root / "foo1/bar/d.py").touch()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
It seems that `ignore_paths` added in [#4276](https://github.com/feast-dev/feast/pull/4276) does not take effect

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
