### PR TITLE
chore: Added make command to build locally built Feast UI package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -644,6 +644,11 @@ build-helm-docs:
 build-ui:
 	cd $(ROOT_DIR)/sdk/python/feast/ui && yarn upgrade @feast-dev/feast-ui --latest && yarn install && npm run build --omit=dev
 
+build-ui-local:
+	cd $(ROOT_DIR)/ui && yarn install && npm run build --omit=dev
+	rm -rf $(ROOT_DIR)/sdk/python/feast/ui/build
+	cp -r $(ROOT_DIR)/ui/build $(ROOT_DIR)/sdk/python/feast/ui/
+	
 format-ui:
 	cd $(ROOT_DIR)/ui && NPM_TOKEN= yarn install && NPM_TOKEN= yarn format
 

--- a/docs/project/development-guide.md
+++ b/docs/project/development-guide.md
@@ -135,10 +135,19 @@ Note that this means if you are midway through working through a PR and rebase, 
 - activate the venv: `source venv/bin/activate`
 - Install dependencies `make install-python-dependencies-dev`
 
-### building the UI
+### Building the UI
+To build the UI from the latest released NPM package (hosted under @feast-dev/feast-ui):
+
 ```sh
 make build-ui
 ```
+
+If you want to test backend and frontend together using 'feast ui' command and with a locally built Feast UI package, you can build using:
+
+```sh
+make build-ui-local
+```
+Use this when you are making changes to the React UI code and want to see them live via the backend.
 
 ### Recompiling python lock files
 Recompile python lock files. This only needs to be run when you make changes to requirements or simply want to update python lock files to reflect latest versions.

--- a/sdk/python/feast/ui/README.md
+++ b/sdk/python/feast/ui/README.md
@@ -26,6 +26,15 @@ The `feast ui` command will generate the necessary `projects-list.json` file and
 
 ## Dev
 To test with a locally built Feast UI package, do:
+
+```bash
+   make build-ui-local
+   feast ui
+   ```
+
+OR
+
+You can also do: 
 1. `yarn link` in ui/ 
 2. `yarn install` in ui/
 3. `yarn link` in ui/node_modules/react


### PR DESCRIPTION

# What this PR does / why we need it:
This PR adds `make build-ui-local` command which can be used while doing development and it is useful when you are making changes to the React UI code and want to see them live via the backend.

This command also helps you to deploy unreleased version of frontend locally for testing.
