### PR TITLE
fix: resolve Python logger warnings

### DIFF
--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -237,7 +237,7 @@ def get_app(
     async def retrieve_online_documents(
         request: GetOnlineFeaturesRequest,
     ) -> Dict[str, Any]:
-        logger.warn(
+        logger.warning(
             "This endpoint is in alpha and will be moved to /get-online-features when stable."
         )
         # Initialize parameters for FeatureStore.retrieve_online_documents_v2(...) call


### PR DESCRIPTION
# What this PR does / why we need it:
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

# Which issue(s) this PR fixes:

# Misc
