### PR TITLE
chore: Added make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,48 +40,61 @@ endef
 $(TOOL_DIR):
 	mkdir -p $@/bin
 
-format: format-python 
 
-lint: lint-python 
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-test: test-python-unit 
+format: format-python ## Format Python code
 
-protos: compile-protos-python compile-protos-docs
+lint: lint-python ## Lint Python code
 
-build: protos build-docker
+test: test-python-unit ## Run unit tests for Python
 
-# Python SDK - local
+protos: compile-protos-python compile-protos-docs ## Compile protobufs for Python SDK and generate docs
+
+build: protos build-docker ## Build protobufs, Java code, and Docker images
+
+format-python: ## Format Python code
+	cd ${ROOT_DIR}/sdk/python; python -m ruff check --fix feast/ tests/
+	cd ${ROOT_DIR}/sdk/python; python -m ruff format feast/ tests/
+
+lint-python: ## Lint Python code
+	cd ${ROOT_DIR}/sdk/python; python -m mypy feast
+	cd ${ROOT_DIR}/sdk/python; python -m ruff check feast/ tests/
+	cd ${ROOT_DIR}/sdk/python; python -m ruff format --check feast/ tests
+	
+##@ Python SDK - local
 # formerly install-python-ci-dependencies-uv-venv
 # editable install
-install-python-dependencies-dev:
+install-python-dependencies-dev: ## Install Python dev dependencies using uv (editable install)
 	uv pip sync --require-hashes sdk/python/requirements/py$(PYTHON_VERSION)-ci-requirements.txt
 	uv pip install --no-deps -e .
 
-install-python-dependencies-minimal:
+install-python-dependencies-minimal: ## Install minimal Python dependencies using uv (editable install)
 	uv pip sync --require-hashes sdk/python/requirements/py$(PYTHON_VERSION)-minimal-requirements.txt
 	uv pip install --no-deps -e .[minimal]
 
-# Python SDK - system
+##@ Python SDK - system
 # the --system flag installs dependencies in the global python context
 # instead of a venv which is useful when working in a docker container or ci.
 
 # Used in github actions/ci
 # formerly install-python-ci-dependencies-uv
-install-python-dependencies-ci:
+install-python-dependencies-ci: ## Install Python CI dependencies in system environment using uv
 	uv pip sync --system sdk/python/requirements/py$(PYTHON_VERSION)-ci-requirements.txt
 	uv pip install --system --no-deps -e .
 
 # Used by multicloud/Dockerfile.dev
-install-python-ci-dependencies:
+install-python-ci-dependencies: ## Install Python CI dependencies in system environment using piptools
 	python -m piptools sync sdk/python/requirements/py$(PYTHON_VERSION)-ci-requirements.txt
 	pip install --no-deps -e .
 
 # Currently used in test-end-to-end.sh
-install-python:
+install-python: ## Install Python requirements and develop package (setup.py develop)
 	python -m piptools sync sdk/python/requirements/py$(PYTHON_VERSION)-requirements.txt
 	python setup.py develop
 
-lock-python-dependencies-all:
+lock-python-dependencies-all: ## Recompile and lock all Python dependency sets for all supported versions
 	# Remove all existing requirements because we noticed the lock file is not always updated correctly.
 	# Removing and running the command again ensures that the lock file is always up to date.
 	rm -rf sdk/python/requirements/* 2>/dev/null || true
@@ -111,26 +124,28 @@ lock-python-dependencies-all:
 		-o sdk/python/requirements/py3.11-minimal-sdist-requirements-build.txt \
 		sdk/python/requirements/py3.11-minimal-sdist-requirements.txt"
 
-compile-protos-python:
+compile-protos-python: ## Compile Python protobuf files
 	python infra/scripts/generate_protos.py
 
-benchmark-python:
+benchmark-python: ## Run integration + benchmark tests for Python
 	IS_TEST=True python -m pytest --integration --benchmark  --benchmark-autosave --benchmark-save-data sdk/python/tests
 
-benchmark-python-local:
+benchmark-python-local: ## Run integration + benchmark tests for Python (local dev mode)
 	IS_TEST=True FEAST_IS_LOCAL_TEST=True python -m pytest --integration --benchmark  --benchmark-autosave --benchmark-save-data sdk/python/tests
 
-test-python-unit:
+##@ Tests
+
+test-python-unit: ## Run Python unit tests
 	python -m pytest -n 8 --color=yes sdk/python/tests
 
-test-python-integration:
+test-python-integration: ## Run Python integration tests (CI)
 	python -m pytest --tb=short -v -n 8 --integration --color=yes --durations=10 --timeout=1200 --timeout_method=thread --dist loadgroup \
 		-k "(not snowflake or not test_historical_features_main)" \
 		-m "not rbac_remote_integration_test" \
 		--log-cli-level=INFO -s \
 		sdk/python/tests
 
-test-python-integration-local:
+test-python-integration-local: ## Run Python integration tests (local dev mode)
 	FEAST_IS_LOCAL_TEST=True \
 	FEAST_LOCAL_ONLINE_CONTAINER=True \
 	python -m pytest --tb=short -v -n 8 --color=yes --integration --durations=10 --timeout=1200 --timeout_method=thread --dist loadgroup \
@@ -139,7 +154,7 @@ test-python-integration-local:
 		--log-cli-level=INFO -s \
 		sdk/python/tests
 
-test-python-integration-rbac-remote:
+test-python-integration-rbac-remote: ## Run Python remote RBAC integration tests
 	FEAST_IS_LOCAL_TEST=True \
 	FEAST_LOCAL_ONLINE_CONTAINER=True \
 	python -m pytest --tb=short -v -n 8 --color=yes --integration --durations=10 --timeout=1200 --timeout_method=thread --dist loadgroup \
@@ -148,13 +163,13 @@ test-python-integration-rbac-remote:
 		--log-cli-level=INFO -s \
 		sdk/python/tests
 
-test-python-integration-container:
+test-python-integration-container: ## Run Python integration tests using Docker
 	@(docker info > /dev/null 2>&1 && \
 		FEAST_LOCAL_ONLINE_CONTAINER=True \
 		python -m pytest -n 8 --integration sdk/python/tests \
 	) || echo "This script uses Docker, and it isn't running - please start the Docker Daemon and try again!";
 
-test-python-universal-spark:
+test-python-universal-spark: ## Run Python Spark integration tests
 	PYTHONPATH='.' \
 	FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.spark_repo_configuration \
 	PYTEST_PLUGINS=feast.infra.offline_stores.contrib.spark_offline_store.tests \
@@ -177,7 +192,7 @@ test-python-universal-spark:
 			not test_snowflake" \
  	 sdk/python/tests
 
-test-python-universal-trino:
+test-python-universal-trino: ## Run Python Trino integration tests
 	PYTHONPATH='.' \
 	FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.trino_repo_configuration \
 	PYTEST_PLUGINS=feast.infra.offline_stores.contrib.trino_offline_store.tests \
@@ -203,7 +218,7 @@ test-python-universal-trino:
 
 # Note: to use this, you'll need to have Microsoft ODBC 17 installed.
 # See https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos?view=sql-server-ver15#17
-test-python-universal-mssql:
+test-python-universal-mssql: ## Run Python MSSQL integration tests
 	PYTHONPATH='.' \
 	FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.mssql_repo_configuration \
 	PYTEST_PLUGINS=feast.infra.offline_stores.contrib.mssql_offline_store.tests \
@@ -223,7 +238,7 @@ test-python-universal-mssql:
 # https://docs.aws.amazon.com/athena/latest/ug/getting-started.html
 # Modify environment variables ATHENA_REGION, ATHENA_DATA_SOURCE, ATHENA_DATABASE, ATHENA_WORKGROUP or
 # ATHENA_S3_BUCKET_NAME according to your needs. If tests fail with the pytest -n 8 option, change the number to 1.
-test-python-universal-athena:
+test-python-universal-athena: ## Run Python Athena integration tests
 	PYTHONPATH='.' \
 	FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.athena_repo_configuration \
 	PYTEST_PLUGINS=feast.infra.offline_stores.contrib.athena_offline_store.tests \
@@ -247,7 +262,7 @@ test-python-universal-athena:
 			not test_snowflake" \
 	sdk/python/tests
 
-test-python-universal-postgres-offline:
+test-python-universal-postgres-offline: ## Run Python Postgres integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.postgres_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.feast.infra.offline_stores.contrib.postgres_offline_store.tests \
@@ -268,7 +283,7 @@ test-python-universal-postgres-offline:
  				not test_spark" \
  			sdk/python/tests
 
- test-python-universal-clickhouse-offline:
+ test-python-universal-clickhouse-offline: ## Run Python Clickhouse integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.clickhouse_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.feast.infra.offline_stores.contrib.clickhouse_offline_store.tests \
@@ -289,7 +304,7 @@ test-python-universal-postgres-offline:
  				not test_spark" \
  			sdk/python/tests
 
-test-python-universal-postgres-online:
+test-python-universal-postgres-online: ## Run Python Postgres integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.postgres_online_store.postgres_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.postgres \
@@ -308,7 +323,7 @@ test-python-universal-postgres-online:
 				not test_snowflake" \
  			sdk/python/tests
 
- test-python-universal-pgvector-online:
+ test-python-universal-pgvector-online: ## Run Python Postgres integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.postgres_online_store.pgvector_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.postgres \
@@ -330,7 +345,7 @@ test-python-universal-postgres-online:
 				not test_snowflake" \
  			sdk/python/tests
 
-test-python-universal-mysql-online:
+test-python-universal-mysql-online: ## Run Python MySQL integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.mysql_online_store.mysql_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.mysql \
@@ -349,7 +364,7 @@ test-python-universal-mysql-online:
 				not test_snowflake" \
  			sdk/python/tests
 
-test-python-universal-cassandra:
+test-python-universal-cassandra: ## Run Python Cassandra integration tests
 	PYTHONPATH='.' \
 	FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.cassandra_online_store.cassandra_repo_configuration \
 	PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.cassandra \
@@ -360,7 +375,7 @@ test-python-universal-cassandra:
 			not test_spark_materialization_consistency and \
 			not test_universal_materialization"
 
-test-python-universal-hazelcast:
+test-python-universal-hazelcast: ## Run Python Hazelcast integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.hazelcast_online_store.hazelcast_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.hazelcast \
@@ -379,7 +394,7 @@ test-python-universal-hazelcast:
 				not test_snowflake" \
  			sdk/python/tests
 
-test-python-universal-cassandra-no-cloud-providers:
+test-python-universal-cassandra-no-cloud-providers: ## Run Python Cassandra integration tests
 	PYTHONPATH='.' \
 	FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.cassandra_online_store.cassandra_repo_configuration \
 	PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.cassandra \
@@ -396,7 +411,7 @@ test-python-universal-cassandra-no-cloud-providers:
 	  not test_snowflake" \
 	sdk/python/tests
 
-test-python-universal-elasticsearch-online:
+test-python-universal-elasticsearch-online: ## Run Python Elasticsearch online store integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.elasticsearch_online_store.elasticsearch_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.elasticsearch \
@@ -415,7 +430,7 @@ test-python-universal-elasticsearch-online:
 				not test_snowflake" \
  			sdk/python/tests
 
-test-python-universal-milvus-online:
+test-python-universal-milvus-online: ## Run Python Milvus online store integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.milvus_online_store.milvus_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.milvus \
@@ -423,7 +438,7 @@ test-python-universal-milvus-online:
 		-k "test_retrieve_online_milvus_documents" \
  			sdk/python/tests --ignore=sdk/python/tests/integration/offline_store/test_dqm_validation.py
 
-test-python-universal-singlestore-online:
+test-python-universal-singlestore-online: ## Run Python Singlestore online store integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.singlestore_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.singlestore \
@@ -434,7 +449,7 @@ test-python-universal-singlestore-online:
 				not test_snowflake" \
 			sdk/python/tests
 
-test-python-universal-qdrant-online:
+test-python-universal-qdrant-online: ## Run Python Qdrant online store integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.qdrant_online_store.qdrant_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.qdrant \
@@ -445,7 +460,7 @@ test-python-universal-qdrant-online:
 # To use Couchbase as an offline store, you need to create an Couchbase Capella Columnar cluster on cloud.couchbase.com.
 # Modify environment variables COUCHBASE_COLUMNAR_CONNECTION_STRING, COUCHBASE_COLUMNAR_USER, and COUCHBASE_COLUMNAR_PASSWORD
 # with the details from your Couchbase Columnar Cluster.
-test-python-universal-couchbase-offline:
+test-python-universal-couchbase-offline: ## Run Python Couchbase offline store integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.offline_stores.contrib.couchbase_columnar_repo_configuration \
 		PYTEST_PLUGINS=feast.infra.offline_stores.contrib.couchbase_offline_store.tests \
@@ -469,7 +484,7 @@ test-python-universal-couchbase-offline:
 				not test_universal_types" \
 			sdk/python/tests
 
-test-python-universal-couchbase-online:
+test-python-universal-couchbase-online:	## Run Python Couchbase online store integration tests
 	PYTHONPATH='.' \
 		FULL_REPO_CONFIGS_MODULE=sdk.python.feast.infra.online_stores.couchbase_online_store.couchbase_repo_configuration \
 		PYTEST_PLUGINS=sdk.python.tests.integration.feature_repos.universal.online_store.couchbase \
@@ -488,114 +503,106 @@ test-python-universal-couchbase-online:
 				not test_snowflake" \
 		sdk/python/tests
 
-test-python-universal:
+test-python-universal: ## Run all Python integration tests
 	python -m pytest -n 8 --integration sdk/python/tests
 
-format-python:
-	cd ${ROOT_DIR}/sdk/python; python -m ruff check --fix feast/ tests/
-	cd ${ROOT_DIR}/sdk/python; python -m ruff format feast/ tests/
+##@ Java
 
-lint-python:
-	cd ${ROOT_DIR}/sdk/python; python -m mypy feast
-	cd ${ROOT_DIR}/sdk/python; python -m ruff check feast/ tests/
-	cd ${ROOT_DIR}/sdk/python; python -m ruff format --check feast/ tests
-# Java
-
-install-java-ci-dependencies:
+install-java-ci-dependencies: ## Install Java CI dependencies
 	${MVN} verify clean --fail-never
 
-format-java:
+format-java: ## Format Java code
 	${MVN} spotless:apply
 
-lint-java:
+lint-java: ## Lint Java code
 	${MVN} --no-transfer-progress spotless:check
 
-test-java:
+test-java: ## Run Java unit tests
 	${MVN} --no-transfer-progress -DskipITs=true test
 
-test-java-integration:
+test-java-integration: ## Run Java integration tests
 	${MVN} --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true clean verify
 
-test-java-with-coverage:
+test-java-with-coverage: ## Run Java unit tests with coverage
 	${MVN} --no-transfer-progress -DskipITs=true test jacoco:report-aggregate
 
-build-java:
+build-java: ## Build Java code
 	${MVN} clean verify
 
-build-java-no-tests:
+build-java-no-tests: ## Build Java code without running tests
 	${MVN} --no-transfer-progress -Dmaven.javadoc.skip=true -Dgpg.skip -DskipUTs=true -DskipITs=true -Drevision=${REVISION} clean package
 
-# Trino plugin
-start-trino-locally:
+##@ Trino plugin
+start-trino-locally: ## Start Trino locally
 	cd ${ROOT_DIR}; docker run --detach --rm -p 8080:8080 --name trino -v ${ROOT_DIR}/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/test_config/properties/:/etc/catalog/:ro trinodb/trino:${TRINO_VERSION}
 	sleep 15
 
-test-trino-plugin-locally:
+test-trino-plugin-locally: ## Run Trino plugin tests locally
 	cd ${ROOT_DIR}/sdk/python; FULL_REPO_CONFIGS_MODULE=feast.infra.offline_stores.contrib.trino_offline_store.test_config.manual_tests IS_TEST=True python -m pytest --integration tests/
 
-kill-trino-locally:
+kill-trino-locally: ## Kill Trino locally
 	cd ${ROOT_DIR}; docker stop trino
 
-# Docker
+##@ Docker
 
-build-docker: build-feature-server-docker build-feature-transformation-server-docker build-feature-server-java-docker build-feast-operator-docker
+build-docker: build-feature-server-docker build-feature-transformation-server-docker build-feature-server-java-docker build-feast-operator-docker ## Build Docker images
 
-push-ci-docker:
+push-ci-docker: ## Push CI Docker images
 	docker push $(REGISTRY)/feast-ci:$(VERSION)
 
-push-feature-server-docker:
+push-feature-server-docker: ## Push Feature Server Docker image
 	docker push $(REGISTRY)/feature-server:$(VERSION)
 
-build-feature-server-docker:
+build-feature-server-docker: ## Build Feature Server Docker image
 	docker buildx build \
 		-t $(REGISTRY)/feature-server:$(VERSION) \
 		-f sdk/python/feast/infra/feature_servers/multicloud/Dockerfile \
 		--load sdk/python/feast/infra/feature_servers/multicloud
 
-push-feature-transformation-server-docker:
+push-feature-transformation-server-docker: ## Push Feature Transformation Server Docker image
 	docker push $(REGISTRY)/feature-transformation-server:$(VERSION)
 
-build-feature-transformation-server-docker:
+build-feature-transformation-server-docker: ## Build Feature Transformation Server Docker image
 	docker buildx build --build-arg VERSION=$(VERSION) \
 		-t $(REGISTRY)/feature-transformation-server:$(VERSION) \
 		-f sdk/python/feast/infra/transformation_servers/Dockerfile --load .
 
-push-feature-server-java-docker:
+push-feature-server-java-docker: ## Push Feature Server Java Docker image
 	docker push $(REGISTRY)/feature-server-java:$(VERSION)
 
-build-feature-server-java-docker:
+build-feature-server-java-docker: ## Build Feature Server Java Docker image	
 	docker buildx build --build-arg VERSION=$(VERSION) \
 		-t $(REGISTRY)/feature-server-java:$(VERSION) \
 		-f java/infra/docker/feature-server/Dockerfile --load .
 
-push-feast-operator-docker:
+push-feast-operator-docker: ## Push Feast Operator Docker image
 	cd infra/feast-operator && \
 	IMAGE_TAG_BASE=$(REGISTRY)/feast-operator \
 	VERSION=$(VERSION) \
 	$(MAKE) docker-push
 
-build-feast-operator-docker:
+build-feast-operator-docker: ## Build Feast Operator Docker image
 	cd infra/feast-operator && \
 	IMAGE_TAG_BASE=$(REGISTRY)/feast-operator \
 	VERSION=$(VERSION) \
 	$(MAKE) docker-build
 
-# Dev images
+##@ Dev images
 
-build-feature-server-dev:
+build-feature-server-dev: ## Build Feature Server Dev Docker image
 	docker buildx build \
 		-t feastdev/feature-server:dev \
 		-f sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev --load .
 
-build-feature-server-dev-docker:
+build-feature-server-dev-docker: ## Build Feature Server Dev Docker image
 	docker buildx build \
 		-t $(REGISTRY)/feature-server:$(VERSION) \
 		-f sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev --load .
 
-push-feature-server-dev-docker:
+push-feature-server-dev-docker: ## Push Feature Server Dev Docker image
 	docker push $(REGISTRY)/feature-server:$(VERSION)
 
-build-java-docker-dev:
+build-java-docker-dev: ## Build Java Dev Docker image
 	make build-java-no-tests REVISION=dev
 	docker buildx build --build-arg VERSION=dev \
 		-t feastdev/feature-transformation-server:dev \
@@ -604,9 +611,9 @@ build-java-docker-dev:
 		-t feastdev/feature-server-java:dev \
 		-f java/infra/docker/feature-server/Dockerfile.dev --load .
 
-# Documentation
+##@ Documentation
 
-install-dependencies-proto-docs:
+install-dependencies-proto-docs: ## Install dependencies for generating proto docs
 	cd ${ROOT_DIR}/protos;
 	mkdir -p $$HOME/bin
 	mkdir -p $$HOME/include
@@ -623,37 +630,37 @@ install-dependencies-proto-docs:
 	chmod +x $$HOME/bin/protoc && \
 	mv protoc3/include/* $$HOME/include
 
-compile-protos-docs:
+compile-protos-docs: ## Compile proto docs
 	rm -rf 	$(ROOT_DIR)/dist/grpc
 	mkdir -p dist/grpc;
 	cd ${ROOT_DIR}/protos && protoc --docs_out=../dist/grpc feast/*/*.proto
 
-build-sphinx: compile-protos-python
+build-sphinx: compile-protos-python ## Build Sphinx documentation
 	cd 	$(ROOT_DIR)/sdk/python/docs && $(MAKE) build-api-source
 
-build-templates:
+build-templates: ## Build templates
 	python infra/scripts/compile-templates.py
 
-build-helm-docs:
+build-helm-docs: ## Build helm docs
 	cd ${ROOT_DIR}/infra/charts/feast; helm-docs
 	cd ${ROOT_DIR}/infra/charts/feast-feature-server; helm-docs
 
-# Web UI
+##@ Web UI
 # Note: these require node and yarn to be installed
 
-build-ui:
+build-ui: ## Build Feast UI
 	cd $(ROOT_DIR)/sdk/python/feast/ui && yarn upgrade @feast-dev/feast-ui --latest && yarn install && npm run build --omit=dev
 
-build-ui-local:
+build-ui-local: ## Build Feast UI locally
 	cd $(ROOT_DIR)/ui && yarn install && npm run build --omit=dev
 	rm -rf $(ROOT_DIR)/sdk/python/feast/ui/build
 	cp -r $(ROOT_DIR)/ui/build $(ROOT_DIR)/sdk/python/feast/ui/
 	
-format-ui:
+format-ui: ## Format Feast UI
 	cd $(ROOT_DIR)/ui && NPM_TOKEN= yarn install && NPM_TOKEN= yarn format
 
 
-# Go SDK & embedded
+##@ Go SDK 
 PB_REL = https://github.com/protocolbuffers/protobuf/releases
 PB_VERSION = 30.2
 PB_ARCH := $(shell uname -m)
@@ -670,13 +677,13 @@ $(TOOL_DIR)/protoc-$(PB_VERSION)-$(OS)-$(PB_ARCH).zip: $(TOOL_DIR)
 	curl -LO $(PB_REL)/download/v$(PB_VERSION)/protoc-$(PB_VERSION)-$(OS)-$(PB_ARCH).zip
 
 .PHONY: install-go-proto-dependencies
-install-go-proto-dependencies: $(TOOL_DIR)/protoc-$(PB_VERSION)-$(OS)-$(PB_ARCH).zip
+install-go-proto-dependencies: $(TOOL_DIR)/protoc-$(PB_VERSION)-$(OS)-$(PB_ARCH).zip ## Install Go proto dependencies
 	unzip -u $(TOOL_DIR)/protoc-$(PB_VERSION)-$(OS)-$(PB_ARCH).zip -d $(TOOL_DIR)
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
 	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
 
 .PHONY: compile-protos-go
-compile-protos-go: install-go-proto-dependencies
+compile-protos-go: install-go-proto-dependencies ## Compile Go protobuf files
 	mkdir -p $(ROOT_DIR)/go/protos
 	$(foreach folder,$(PB_PROTO_FOLDERS), \
 		protoc --proto_path=$(ROOT_DIR)/protos \
@@ -690,27 +697,27 @@ compile-protos-go: install-go-proto-dependencies
 	# python -m pip install "pybindgen==0.22.1" "grpcio-tools>=1.56.2,<2" "mypy-protobuf>=3.1"
 
 .PHONY: build-go
-build-go: compile-protos-go 
+build-go: compile-protos-go ## Build Go code
 	go build -o feast ./go/main.go
 
 .PHONY: install-feast-ci-locally
-install-feast-ci-locally:
+install-feast-ci-locally: ## Install Feast CI dependencies locally
 	uv pip install -e ".[ci]"
 
 .PHONY: test-go
-test-go: compile-protos-go install-feast-ci-locally compile-protos-python  
+test-go: compile-protos-go install-feast-ci-locally compile-protos-python ## Run Go tests
 	CGO_ENABLED=1 go test -coverprofile=coverage.out ./... && go tool cover -html=coverage.out -o coverage.html
 
 .PHONY: format-go
-format-go:
+format-go: ## Format Go code
 	gofmt -s -w go/
 
 .PHONY: lint-go
-lint-go: compile-protos-go
+lint-go: compile-protos-go ## Lint Go code
 	go vet ./go/internal/feast
 
 .PHONY: build-go-docker-dev
-build-go-docker-dev:
+build-go-docker-dev: ## Build Go Docker image for development
 	docker buildx build --build-arg VERSION=dev \
 		-t feastdev/feature-server-go:dev \
 		-f go/infra/docker/feature-server/Dockerfile --load .

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test: test-python-unit ## Run unit tests for Python
 
 protos: compile-protos-python compile-protos-docs ## Compile protobufs for Python SDK and generate docs
 
-build: protos build-docker ## Build protobufs, Java code, and Docker images
+build: protos build-docker ## Build protobufs and Docker images
 
 format-python: ## Format Python code
 	cd ${ROOT_DIR}/sdk/python; python -m ruff check --fix feast/ tests/


### PR DESCRIPTION
# What this PR does / why we need it:
Reading Makefile is difficult, adding help to get better understanding. 

<img width="1482" alt="Screenshot 2025-05-17 at 8 49 01 PM" src="https://github.com/user-attachments/assets/549ad33b-95f8-4bd5-9562-403a02a8e0fd" />

```

# make help

Usage:
  make <target>
  help             Display this help.
  test             Run unit tests for Python and Java
  protos           Compile protobufs for Python SDK and generate docs
  build            Build protobufs, Java code, and Docker images
  format           Format Python and Java code
  format-python    Format Python code
  lint             Run linters for Python and Java
  lint-python      Lint Python code

Python SDK - local
  install-python-dependencies-dev  Install Python dev dependencies using uv (editable install)
  install-python-dependencies-minimal  Install minimal Python dependencies using uv (editable install)

Python SDK - system
  install-python-dependencies-ci  Install Python CI dependencies in system environment using uv
  install-python-ci-dependencies  Install Python CI dependencies in system environment using piptools
  install-python   Install Python requirements and develop package (setup.py develop)
  lock-python-dependencies-all  Recompile and lock all Python dependency sets for all supported versions
  compile-protos-python  Compile Python protobuf files
  benchmark-python  Run integration + benchmark tests for Python
  benchmark-python-local  Run integration + benchmark tests for Python (local dev mode)

Tests
  test-python-unit  Run Python unit tests
  test-python-integration  Run Python integration tests (CI)
  test-python-integration-local  Run Python integration tests (local dev mode)
  test-python-integration-rbac-remote  Run Python remote RBAC integration tests
  test-python-integration-container  Run Python integration tests using Docker
  test-python-universal-spark  Run Python Spark integration tests
  test-python-universal-trino  Run Python Trino integration tests
  test-python-universal-mssql  Run Python MSSQL integration tests
  test-python-universal-athena  Run Python Athena integration tests
  test-python-universal-postgres-offline  Run Python Postgres integration tests
  test-python-universal-postgres-online  Run Python Postgres integration tests
  test-python-universal-mysql-online  Run Python MySQL integration tests
  test-python-universal-cassandra  Run Python Cassandra integration tests
  test-python-universal-hazelcast  Run Python Hazelcast integration tests
  test-python-universal-cassandra-no-cloud-providers  Run Python Cassandra integration tests
  test-python-universal-elasticsearch-online  Run Python Elasticsearch online store integration tests
  test-python-universal-milvus-online  Run Python Milvus online store integration tests
  test-python-universal-singlestore-online  Run Python Singlestore online store integration tests
  test-python-universal-qdrant-online  Run Python Qdrant online store integration tests
  test-python-universal-couchbase-offline  Run Python Couchbase offline store integration tests
  test-python-universal-couchbase-online  Run Python Couchbase online store integration tests
  test-python-universal  Run all Python integration tests

Java
  install-java-ci-dependencies  Install Java CI dependencies
  format-java      Format Java code
  lint-java        Lint Java code
  test-java        Run Java unit tests
  test-java-integration  Run Java integration tests
  test-java-with-coverage  Run Java unit tests with coverage
  build-java       Build Java code
  build-java-no-tests  Build Java code without running tests

Trino plugin
  start-trino-locally  Start Trino locally
  test-trino-plugin-locally  Run Trino plugin tests locally
  kill-trino-locally  Kill Trino locally

Docker
  build-docker     Build Docker images
  push-ci-docker   Push CI Docker images
  push-feature-server-docker  Push Feature Server Docker image
  build-feature-server-docker  Build Feature Server Docker image
  push-feature-transformation-server-docker  Push Feature Transformation Server Docker image
  build-feature-transformation-server-docker  Build Feature Transformation Server Docker image
  push-feature-server-java-docker  Push Feature Server Java Docker image
  build-feature-server-java-docker  Build Feature Server Java Docker image
  push-feast-operator-docker  Push Feast Operator Docker image
  build-feast-operator-docker  Build Feast Operator Docker image

Dev images
  build-feature-server-dev  Build Feature Server Dev Docker image
  build-feature-server-dev-docker  Build Feature Server Dev Docker image
  push-feature-server-dev-docker  Push Feature Server Dev Docker image
  build-java-docker-dev  Build Java Dev Docker image

Documentation
  install-dependencies-proto-docs  Install dependencies for generating proto docs
  compile-protos-docs  Compile proto docs
  build-sphinx     Build Sphinx documentation
  build-templates  Build templates
  build-helm-docs  Build helm docs

Web UI
  build-ui         Build Feast UI
  build-ui-local   Build Feast UI locally
  format-ui        Format Feast UI

Go SDK
  install-go-proto-dependencies  Install Go proto dependencies
  compile-protos-go  Compile Go protobuf files
  build-go         Build Go code
  install-feast-ci-locally  Install Feast CI dependencies locally
  test-go          Run Go tests
  format-go        Format Go code
  lint-go          Lint Go code
  build-go-docker-dev  Build Go Docker image for development
```
