### PR TITLE
feat: Add Decimal to allowed python scalar types

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import decimal
 import json
 import logging
 from collections import defaultdict
@@ -310,7 +311,11 @@ PYTHON_SCALAR_VALUE_TYPE_TO_PROTO_VALUE: Dict[
         None,
     ),
     ValueType.FLOAT: ("float_val", lambda x: float(x), None),
-    ValueType.DOUBLE: ("double_val", lambda x: x, {float, np.float64, int, np.int_}),
+    ValueType.DOUBLE: (
+        "double_val",
+        lambda x: x,
+        {float, np.float64, int, np.int_, decimal.Decimal},
+    ),
     ValueType.STRING: ("string_val", lambda x: str(x), None),
     ValueType.BYTES: ("bytes_val", lambda x: x, {bytes}),
     ValueType.BOOL: ("bool_val", lambda x: x, {bool, np.bool_, int, np.int_}),
@@ -457,7 +462,7 @@ def _python_value_to_proto_value(
             if (sample == 0 or sample == 0.0) and feast_value_type != ValueType.BOOL:
                 # Numpy convert 0 to int. However, in the feature view definition, the type of column may be a float.
                 # So, if value is 0, type validation must pass if scalar_types are either int or float.
-                allowed_types = {np.int64, int, np.float64, float}
+                allowed_types = {np.int64, int, np.float64, float, decimal.Decimal}
                 assert type(sample) in allowed_types, (
                     f"Type `{type(sample)}` not in {allowed_types}"
                 )


### PR DESCRIPTION
# What this PR does / why we need it:

When exporting features to parquet files (via `to_remote_storage()`) columns of type `NUMBER` are converted to the pyarrow `decimal128` type. This type is translated into `decimal.Decimal` in python when trying to convert it into proto values (https://github.com/feast-dev/feast/blob/648c53dc64ad88077e49e56f0cfc70756d6a5824/sdk/python/feast/utils.py#L282).

Eventually, it fails when the conversion into a proto value is done because `decimal.Decimal` is not supported as a valid type in https://github.com/feast-dev/feast/blob/648c53dc64ad88077e49e56f0cfc70756d6a5824/sdk/python/feast/type_map.py#L313. As far as I could see there was nothing immediately against adding `Decimal` to the supported list as it can be converted into Double. I might be overlooking something however.

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
I stumbled upon this issue when using the Lambda materialization engine.

Slightly related to https://github.com/feast-dev/feast/issues/3146