### PR TITLE
chore: Drop 3.9 from master CI and add 3.12

### DIFF
--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         os: [ ubuntu-latest ]
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
# What this PR does / why we need it:
Drop 3.9 from master CI and add 3.12

# Which issue(s) this PR fixes:

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
