### PR TITLE
feat: Add max_file_size to Snowflake config

### DIFF
--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -130,6 +130,9 @@ class SnowflakeOfflineStoreConfig(FeastConfigBaseModel):
 
     convert_timestamp_columns: Optional[bool] = None
     """ Convert timestamp columns on export to a Parquet-supported format """
+
+    max_file_size: Optional[int] = None
+    """ Upper size limit (in bytes) of each file that is offloaded. Default: 16777216"""
     model_config = ConfigDict(populate_by_name=True)
 
 
@@ -616,6 +619,9 @@ class SnowflakeRetrievalJob(RetrievalJob):
               DETAILED_OUTPUT = TRUE
               HEADER = TRUE
         """
+        if (max_file_size := self.config.offline_store.max_file_size) is not None:
+            query += f"\nMAX_FILE_SIZE = {max_file_size}"
+
         cursor = execute_snowflake_statement(self.snowflake_conn, query)
         # s3gov schema is used by Snowflake in AWS govcloud regions
         # remove gov portion from schema and pass it to online store upload


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:

When using the Snowflake storage integration to export features as parquet files on S3 it can be useful to set a maximum file size. When working with the Lambda materialization engine we faced the issue that the number of rows per file and thus per invoked Lambda function was so large that the Lambda functions timed out. 
With the new `max_file_size` parameter the file size can be reduced so that each Lambda function needs to write less rows to the online store.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
Snowflake docs https://docs.snowflake.com/en/sql-reference/sql/copy-into-location#copy-options-copyoptions