### PR TITLE
chore: Removing java commands from top of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,15 +40,15 @@ endef
 $(TOOL_DIR):
 	mkdir -p $@/bin
 
-format: format-python format-java
+format: format-python 
 
-lint: lint-python lint-java
+lint: lint-python 
 
-test: test-python-unit test-java
+test: test-python-unit 
 
 protos: compile-protos-python compile-protos-docs
 
-build: protos build-java build-docker
+build: protos build-docker
 
 # Python SDK - local
 # formerly install-python-ci-dependencies-uv-venv


### PR DESCRIPTION
# What this PR does / why we need it:
Removing java commands from top of Makefile

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
