### PR TITLE
feat: Added torch.Tensor as option for online and offline retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/feast)](https://pypi.org/project/feast/)
 [![GitHub contributors](https://img.shields.io/github/contributors/feast-dev/feast)](https://github.com/feast-dev/feast/graphs/contributors)
-[![unit-tests](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml/badge.svg?branch=master)](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml)
+[![unit-tests](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml/badge.svg?branch=master&event=pull_request)](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml)
 [![integration-tests-and-build](https://github.com/feast-dev/feast/actions/workflows/master_only.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/master_only.yml)
 [![java-integration-tests](https://github.com/feast-dev/feast/actions/workflows/java_master_only.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/java_master_only.yml)
 [![linter](https://github.com/feast-dev/feast/actions/workflows/linter.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/linter.yml)
@@ -20,6 +20,8 @@
 
 ## Join us on Slack!
 👋👋👋 [Come say hi on Slack!](https://communityinviter.com/apps/feastopensource/feast-the-open-source-feature-store)
+
+[Check out our DeepWiki!](https://deepwiki.com/feast-dev/feast)
 
 ## Overview
 

--- a/sdk/python/feast/infra/offline_stores/offline_store.py
+++ b/sdk/python/feast/infra/offline_stores/offline_store.py
@@ -19,6 +19,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
     Iterable,
     List,
     Optional,
@@ -28,6 +29,7 @@ from typing import (
 
 import pandas as pd
 import pyarrow
+import torch
 
 from feast import flags_helper
 from feast.data_source import DataSource
@@ -136,6 +138,38 @@ class RetrievalJob(ABC):
                 raise ValidationFailed(validation_result)
 
         return features_table
+
+    def to_tensor(
+        self,
+        kind: str = "torch",
+        default_value: Any = float("nan"),
+        timeout: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """
+        Converts historical features into a dictionary of 1D torch tensors or lists (for non-numeric types).
+
+        Args:
+            kind: "torch" (default and only supported kind).
+            default_value: Value to replace missing (None or NaN) entries.
+            timeout: Optional timeout for query execution.
+
+        Returns:
+            Dict[str, Union[torch.Tensor, List]]: Feature column name -> tensor or list.
+        """
+        if kind != "torch":
+            raise ValueError(
+                f"Unsupported tensor kind: {kind}. Only 'torch' is supported."
+            )
+        df = self.to_df(timeout=timeout)
+        tensor_dict = {}
+        for column in df.columns:
+            values = df[column].fillna(default_value).tolist()
+            first_non_null = next((v for v in values if v is not None), None)
+            if isinstance(first_non_null, (int, float, bool)):
+                tensor_dict[column] = torch.tensor(values)
+            else:
+                tensor_dict[column] = values
+        return tensor_dict
 
     def to_sql(self) -> str:
         """

--- a/sdk/python/feast/online_response.py
+++ b/sdk/python/feast/online_response.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 import pandas as pd
 import pyarrow as pa
+import torch
 
 from feast.feature_view import DUMMY_ENTITY_ID
 from feast.protos.feast.serving.ServingService_pb2 import GetOnlineFeaturesResponse
@@ -88,3 +89,46 @@ class OnlineResponse:
         """
 
         return pa.Table.from_pydict(self.to_dict(include_event_timestamps))
+
+    def to_tensor(
+        self,
+        kind: str = "torch",
+        default_value: Any = float("nan"),
+    ) -> Dict[str, Union[torch.Tensor, List[Any]]]:
+        """
+        Converts GetOnlineFeaturesResponse features into a dictionary of tensors or lists.
+
+        - Numeric features (int, float, bool) -> torch.Tensor
+        - Non-numeric features (e.g., strings) -> list[Any]
+
+        Args:
+            kind: Backend tensor type. Currently only "torch" is supported.
+            default_value: Value to substitute for missing (None) entries.
+
+        Returns:
+            Dict[str, Union[torch.Tensor, List[Any]]]: Mapping of feature names to tensors or lists.
+        """
+        if kind != "torch":
+            raise ValueError(
+                f"Unsupported tensor kind: {kind}. Only 'torch' is supported currently."
+            )
+
+        feature_dict = self.to_dict(include_event_timestamps=False)
+        feature_keys = set(self.proto.metadata.feature_names.val)
+        tensor_dict: Dict[str, Union[torch.Tensor, List[Any]]] = {}
+        for key in feature_keys:
+            raw_values = feature_dict[key]
+            values = [v if v is not None else default_value for v in raw_values]
+            first_valid = next((v for v in values if v is not None), None)
+            if isinstance(first_valid, (int, float, bool)):
+                try:
+                    tensor_dict[key] = torch.tensor(values)
+                except Exception as e:
+                    raise ValueError(
+                        f"Failed to convert values for '{key}' to tensor: {e}"
+                    )
+            else:
+                tensor_dict[key] = (
+                    values  # Return as-is for strings or unsupported types
+                )
+        return tensor_dict

--- a/sdk/python/tests/unit/online_store/test_online_retrieval.py
+++ b/sdk/python/tests/unit/online_store/test_online_retrieval.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import sqlite_vec
+import torch
 from pandas.testing import assert_frame_equal
 
 from feast import FeatureStore, RepoConfig
@@ -129,6 +130,35 @@ def test_get_online_features() -> None:
         assert result["name"] == ["John", "John"]
         assert result["trips"] == [7, 7]
 
+        tensor_result = store.get_online_features(
+            features=[
+                "driver_locations:lon",
+                "customer_profile:avg_orders_day",
+                "customer_profile:name",
+                "customer_driver_combined:trips",
+            ],
+            entity_rows=[
+                {"driver_id": 1, "customer_id": "5"},
+                {"driver_id": 1, "customer_id": 5},
+            ],
+            full_feature_names=False,
+        ).to_tensor()
+
+        assert "lon" in tensor_result
+        assert "avg_orders_day" in tensor_result
+        assert "name" in tensor_result
+        assert "trips" in tensor_result
+
+        # Entity values
+        assert torch.equal(tensor_result["driver_id"], torch.tensor([1, 1]))
+        assert tensor_result["customer_id"] == ["5", "5"]
+
+        # Feature values
+        assert tensor_result["lon"] == ["1.0", "1.0"]  # String -> not tensor
+        assert torch.equal(tensor_result["avg_orders_day"], torch.tensor([1.0, 1.0]))
+        assert tensor_result["name"] == ["John", "John"]
+        assert torch.equal(tensor_result["trips"], torch.tensor([7, 7]))
+
         # Ensure features are still in result when keys not found
         result = store.get_online_features(
             features=["customer_driver_combined:trips"],
@@ -137,6 +167,15 @@ def test_get_online_features() -> None:
         ).to_dict()
 
         assert "trips" in result
+
+        result = store.get_online_features(
+            features=["customer_driver_combined:trips"],
+            entity_rows=[{"driver_id": 0, "customer_id": 0}],
+            full_feature_names=False,
+        ).to_tensor()
+
+        assert "trips" in result
+        assert isinstance(result["trips"], torch.Tensor)
 
         with pytest.raises(KeyError) as excinfo:
             _ = store.get_online_features(


### PR DESCRIPTION

# What this PR does / why we need it:
Added torch.Tensor as option for online and offline retrieval.

**Offline retrieval** : 
```
In [1]: training_df = store.get_historical_features(entity_df=entity_df, features = [
  'driver_hourly_stats:conv_rate',
  'driver_hourly_stats:acc_rate',
  'driver_hourly_stats:avg_daily_trips'
 ]).to_tensor()

In [2]: training_df
Out[2]:
{'driver_id': tensor([1001, 1002, 1003, 1004]),
 'event_timestamp': [Timestamp('2021-04-12 10:59:42+0000', tz='UTC'),
  Timestamp('2021-04-12 08:12:10+0000', tz='UTC'),
  Timestamp('2021-04-12 16:40:26+0000', tz='UTC'),
  Timestamp('2021-04-12 15:01:12+0000', tz='UTC')],
 'conv_rate': tensor([0.2038, 0.1892, 0.5150, 0.7388]),
 'acc_rate': tensor([0.2656, 0.6340, 0.4973, 0.3355]),
 'avg_daily_trips': tensor([939, 671, 133, 138])}
```

**Online retrieval** : 
```
In [1]: store.get_online_features(
    features=[
    'driver_hourly_stats:conv_rate',
    driver_hourly_stats:acc_rate',
    'driver_hourly_stats:avg_daily_trips'
    ],
    entity_rows=[{"driver_id": 1001}, {"driver_id": 1002}]).to_tensor()
Out[1]:
{'conv_rate': tensor([0.2038, 0.1892]),
 'avg_daily_trips': tensor([939, 671]),
 'acc_rate': tensor([0.2656, 0.6340]),
 'driver_id': tensor([1001, 1002])}
```

# Which issue(s) this PR fixes:

Fixed #4890 
