### PR TITLE
feat: Snowflake source. fetch MAX in a single query

### DIFF
--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -245,6 +245,38 @@ class SnowflakeSource(DataSource):
                     "The following source:\n" + query + "\n ... is empty"
                 )
 
+        high_precision_number_columns = [
+            col["column_name"]
+            for col in metadata
+            if col["type_code"] == 0 and col["scale"] == 0 and col["precision"] > 19
+        ]
+
+        if high_precision_number_columns:
+            max_selects = [
+                f'MAX("{col}") AS "{col}"' for col in high_precision_number_columns
+            ]
+            query = (
+                f"SELECT {', '.join(max_selects)} FROM {self.get_table_query_string()}"
+            )
+
+            with GetSnowflakeConnection(config.offline_store) as conn:
+                result = execute_snowflake_statement(conn, query).fetch_pandas_all()
+
+            for col in high_precision_number_columns:
+                max_value = result[col].iloc[0]
+                if max_value is not None:
+                    str_length = len(str(int(max_value)))
+                    for row in metadata:
+                        if row["column_name"] == col:
+                            if str_length <= 9:
+                                row["snowflake_type"] = "NUMBER32"
+                            elif str_length <= 19:
+                                row["snowflake_type"] = "NUMBER64"
+                            else:
+                                raise NotImplementedError(
+                                    f"Number in column {col} larger than INT64 is not supported"
+                                )
+
         for row in metadata:
             if row["type_code"] == 0:
                 if row["scale"] == 0:
@@ -253,34 +285,7 @@ class SnowflakeSource(DataSource):
                     elif row["precision"] <= 18:  # max precision size to ensure INT64
                         row["snowflake_type"] = "NUMBER64"
                     else:
-                        column = row["column_name"]
-
-                        with GetSnowflakeConnection(config.offline_store) as conn:
-                            query = f'SELECT MAX("{column}") AS "{column}" FROM {self.get_table_query_string()}'
-                            result = execute_snowflake_statement(
-                                conn, query
-                            ).fetch_pandas_all()
-                        if (
-                            result.dtypes[column].name
-                            in python_int_to_snowflake_type_map
-                        ):
-                            row["snowflake_type"] = python_int_to_snowflake_type_map[
-                                result.dtypes[column].name
-                            ]
-                        else:
-                            if len(result) > 0:
-                                max_value = result.iloc[0][0]
-                                if max_value is not None and len(str(max_value)) <= 9:
-                                    row["snowflake_type"] = "NUMBER32"
-                                    continue
-                                elif (
-                                    max_value is not None and len(str(max_value)) <= 18
-                                ):
-                                    row["snowflake_type"] = "NUMBER64"
-                                    continue
-                            raise NotImplementedError(
-                                "NaNs or Numbers larger than INT64 are not supported"
-                            )
+                        continue
                 else:
                     row["snowflake_type"] = "NUMBERwSCALE"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Default precision in Snowflake is 38 ([Docs](https://docs.snowflake.com/en/sql-reference/data-types-numeric#number)).
Current realisation executes a bunch of `MAX(column)` queries to check the exact precision.

This PR introduces a small optimisation to execute a single query for all columns.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
N/A