### PR TITLE
fix: Fix NumPy - PyArrow array type mapping in Trino offline store

### DIFF
--- a/docs/reference/data-sources/overview.md
+++ b/docs/reference/data-sources/overview.md
@@ -28,4 +28,4 @@ Below is a matrix indicating which data sources support which types.
 | `float64`   | yes | yes | yes       | yes | yes | yes | yes | yes |
 | `bool`      | yes | yes | yes       | yes | yes | yes | yes | yes |
 | `timestamp` | yes | yes | yes       | yes | yes | yes | yes | yes |
-| array types | yes | yes | yes       | no  | yes | yes | no  | no  |
+| array types | yes | yes | yes       | no  | yes | yes | yes | no  |

--- a/docs/reference/data-sources/trino.md
+++ b/docs/reference/data-sources/trino.md
@@ -8,7 +8,7 @@ These can be specified either by a table reference or a SQL query.
 ## Disclaimer
 
 The Trino data source does not achieve full test coverage.
-Please do not assume complete stability. 
+Please do not assume complete stability.
 
 ## Examples
 
@@ -30,5 +30,5 @@ The full set of configuration options is available [here](https://rtd.feast.dev/
 
 ## Supported Types
 
-Trino data sources support all eight primitive types, but currently do not support array types.
+Trino data sources support all eight primitive types and their corresponding array types.
 For a comparison against other batch data sources, please see [here](overview.md#functionality-matrix).

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
@@ -207,9 +207,7 @@ class TrinoRetrievalJob(RetrievalJob):
 
     def _to_arrow_internal(self, timeout: Optional[int] = None) -> pyarrow.Table:
         """Return payrrow dataset as synchronously including on demand transforms"""
-        return pyarrow.Table.from_pandas(
-            self._to_df_internal(timeout=timeout)
-        )
+        return pyarrow.Table.from_pandas(self._to_df_internal(timeout=timeout))
 
     def to_sql(self) -> str:
         """Returns the SQL query that will be executed in Trino to build the historical feature table"""

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
@@ -208,7 +208,7 @@ class TrinoRetrievalJob(RetrievalJob):
     def _to_arrow_internal(self, timeout: Optional[int] = None) -> pyarrow.Table:
         """Return payrrow dataset as synchronously including on demand transforms"""
         return pyarrow.Table.from_pandas(
-            self._to_df_internal(timeout=timeout), schema=self.pyarrow_schema
+            self._to_df_internal(timeout=timeout)
         )
 
     def to_sql(self) -> str:


### PR DESCRIPTION
# What this PR does / why we need it:
This PR fixes `ArrowNotImplementedError: ("NumPyConverter doesn't implement <list<item: int64>> conversion. ", 'Conversion failed for column with type float64')` error when calling `FeatureStore.get_historical_features().to_df()`.

Explanation: If I define some feature of type `array(bigint)` in Trino source after some joins a column with that feature may contain `None` values. Pandas (NumPy) will infer this column as float64, even though it still contains valid int64 arrays.

```diff
def _to_arrow_internal(self, timeout: Optional[int] = None) -> pyarrow.Table:
    """Return payrrow dataset as synchronously including on demand transforms"""
    return pyarrow.Table.from_pandas(
-       self._to_df_internal(timeout=timeout), schema=self.pyarrow_schema
+       self._to_df_internal(timeout=timeout)
    )
```

Since the schema is passed, PyArrow notices that I am trying to convert float64 value to an int64 array and throws an error. By simply removing forced schema, it solves this issue.

Obviously removing forced schema is questionable: however I checked the exact same function in Spark offline store `sdk\python\feast\infra\offline_stores\contrib\spark_offline_store\spark.py` and it does just that - does not pass schema. I guess it's up to maintainers to decide if this is a valid fix, but if it works well for Spark, I don't see why not do the same thing in Trino.

# Which issue(s) this PR fixes:
N/A — this issue was found independently and not yet tracked.

# Misc
[PyArrow `from_pandas()` method](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.from_pandas)

Note that I also added array support to documentation for Trino offline store. I can confirm that arrays are working no problem with this small fix.

Realese note: Fix Trino offline store to support array data types.