### PR TITLE
test: Fixed path for milvus tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/feast)](https://pypi.org/project/feast/)
 [![GitHub contributors](https://img.shields.io/github/contributors/feast-dev/feast)](https://github.com/feast-dev/feast/graphs/contributors)
-[![unit-tests](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml/badge.svg?branch=master)](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml)
+[![unit-tests](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml/badge.svg?branch=master&event=pull_request)](https://github.com/feast-dev/feast/actions/workflows/unit_tests.yml)
 [![integration-tests-and-build](https://github.com/feast-dev/feast/actions/workflows/master_only.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/master_only.yml)
 [![linter](https://github.com/feast-dev/feast/actions/workflows/linter.yml/badge.svg?branch=master&event=push)](https://github.com/feast-dev/feast/actions/workflows/linter.yml)
 [![Docs Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://docs.feast.dev/)
@@ -19,6 +19,8 @@
 
 ## Join us on Slack!
 👋👋👋 [Come say hi on Slack!](https://communityinviter.com/apps/feastopensource/feast-the-open-source-feature-store)
+
+[Check out our DeepWiki!](https://deepwiki.com/feast-dev/feast)
 
 ## Overview
 

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/milvus.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/milvus.py
@@ -32,6 +32,7 @@ class MilvusOnlineStoreCreator(OnlineStoreCreator):
             "type": "milvus",
             "host": host,
             "port": int(port),
+            "path": "online_store.db",
             "index_type": "IVF_FLAT",
             "metric_type": "L2",
             "embedding_dim": 2,


### PR DESCRIPTION
# What this PR does / why we need it:

PR https://github.com/feast-dev/feast/pull/5382 removed default path for milvus causing failures in integration tests. This PR fixes integration tests by setting path in MilvusOnlineStoreCreator. 

```
ERROR sdk/python/tests/integration/online_store/test_universal_online.py::test_online_retrieval_success[ParameterSet(values=(LOCAL:File:milvus:python_fs:False,), marks=[], id=None)] - pymilvus.exceptions.ConnectionConfigException: <ConnectionConfigException: (code=1, message=uri: localhost:19530 is illegal, needs start with [unix, http, https, tcp] or a local file endswith [.db])>
ERROR sdk/python/tests/integration/online_store/test_universal_online.py::test_retrieve_online_milvus_documents[ParameterSet(values=(LOCAL:File:milvus:python_fs:False,), marks=[], id=None)] - pymilvus.exceptions.ConnectionConfigException: <ConnectionConfigException: (code=1, message=uri: localhost:19530 is illegal, needs start with [unix, http, https, tcp] or a local file endswith [.db])>
ERROR sdk/python/tests/integration/online_store/test_universal_online.py::test_online_retrieval_with_event_timestamps[ParameterSet(values=(LOCAL:File:milvus:python_fs:False,), marks=[], id=None)] - pymilvus.exceptions.ConnectionConfigException: <ConnectionConfigException: (code=1, message=uri: localhost:19530 is illegal, needs start with [unix, http, https, tcp] or a local file endswith [.db])>
```

