### PR TITLE
fix: Updating milvus connect function to work with remote instance

### DIFF
--- a/sdk/python/feast/infra/online_stores/milvus_online_store/milvus.py
+++ b/sdk/python/feast/infra/online_stores/milvus_online_store/milvus.py
@@ -88,8 +88,8 @@ class MilvusOnlineStoreConfig(FeastConfigBaseModel, VectorStoreConfig):
     """
 
     type: Literal["milvus"] = "milvus"
-    path: Optional[StrictStr] = "online_store.db"
-    host: Optional[StrictStr] = "localhost"
+    path: Optional[StrictStr] = ""
+    host: Optional[StrictStr] = "http://localhost"
     port: Optional[int] = 19530
     index_type: Optional[str] = "FLAT"
     metric_type: Optional[str] = "COSINE"
@@ -126,13 +126,16 @@ class MilvusOnlineStore(OnlineStore):
 
     def _connect(self, config: RepoConfig) -> MilvusClient:
         if not self.client:
-            if config.provider == "local":
+            if config.provider == "local" and config.online_store.path:
                 db_path = self._get_db_path(config)
                 print(f"Connecting to Milvus in local mode using {db_path}")
                 self.client = MilvusClient(db_path)
             else:
+                print(
+                    f"Connecting to Milvus remotely at {config.online_store.host}:{config.online_store.port}"
+                )
                 self.client = MilvusClient(
-                    url=f"{config.online_store.host}:{config.online_store.port}",
+                    uri=f"{config.online_store.host}:{config.online_store.port}",
                     token=f"{config.online_store.username}:{config.online_store.password}"
                     if config.online_store.username and config.online_store.password
                     else "",

--- a/sdk/python/tests/integration/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/integration/feature_repos/repo_configuration.py
@@ -89,7 +89,7 @@ from tests.integration.feature_repos.universal.online_store_creator import (
 )
 
 DYNAMO_CONFIG = {"type": "dynamodb", "region": "us-west-2"}
-MILVUS_CONFIG = {"type": "milvus", "embedding_dim": "2"}
+MILVUS_CONFIG = {"type": "milvus", "embedding_dim": 2, "path": "online_store.db"}
 REDIS_CONFIG = {"type": "redis", "connection_string": "localhost:6379,db=0"}
 REDIS_CLUSTER_CONFIG = {
     "type": "redis",

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/milvus.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/milvus.py
@@ -1,9 +1,5 @@
 from typing import Any, Dict
 
-import docker
-from testcontainers.core.container import DockerContainer
-from testcontainers.core.waiting_utils import wait_for_logs
-
 from tests.integration.feature_repos.universal.online_store_creator import (
     OnlineStoreCreator,
 )
@@ -12,26 +8,10 @@ from tests.integration.feature_repos.universal.online_store_creator import (
 class MilvusOnlineStoreCreator(OnlineStoreCreator):
     def __init__(self, project_name: str, **kwargs):
         super().__init__(project_name)
-        self.fixed_port = 19530
-        self.container = DockerContainer("milvusdb/milvus:v2.4.9").with_exposed_ports(
-            self.fixed_port
-        )
-        self.client = docker.from_env()
 
     def create_online_store(self) -> Dict[str, Any]:
-        self.container.start()
-        # Wait for Milvus server to be ready
-        # log_string_to_wait_for = "Ready to accept connections"
-        log_string_to_wait_for = ""
-        wait_for_logs(
-            container=self.container, predicate=log_string_to_wait_for, timeout=30
-        )
-        host = "http://localhost"
-        port = self.container.get_exposed_port(self.fixed_port)
         return {
             "type": "milvus",
-            "host": host,
-            "port": int(port),
             "path": "online_store.db",
             "index_type": "IVF_FLAT",
             "metric_type": "L2",
@@ -39,6 +19,3 @@ class MilvusOnlineStoreCreator(OnlineStoreCreator):
             "vector_enabled": True,
             "nlist": 1,
         }
-
-    def teardown(self):
-        self.container.stop()

--- a/sdk/python/tests/integration/feature_repos/universal/online_store/milvus.py
+++ b/sdk/python/tests/integration/feature_repos/universal/online_store/milvus.py
@@ -26,7 +26,7 @@ class MilvusOnlineStoreCreator(OnlineStoreCreator):
         wait_for_logs(
             container=self.container, predicate=log_string_to_wait_for, timeout=30
         )
-        host = "localhost"
+        host = "http://localhost"
         port = self.container.get_exposed_port(self.fixed_port)
         return {
             "type": "milvus",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
This PR allows for a local remote instance of Milvus to connect, as previously it was bypassed by provider: local which remains and is correct but not the only consideration when using local milvus. The PR also updates the variable from url to uri as expected by the MilvusClient.
Milvus expects that host starts with `[unix, http, https, tcp] or a local file endswith [.db]`, so updated `localhost` default to `http://localhost`.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
