### PR TITLE
fix: Add missing conn.commit() in SnowflakeOnlineStore.online_write_batch

### DIFF
--- a/sdk/python/feast/infra/online_stores/snowflake.py
+++ b/sdk/python/feast/infra/online_stores/snowflake.py
@@ -149,7 +149,7 @@ class SnowflakeOnlineStore(OnlineStore):
                             "_feast_row" = 1;
                 """
                 execute_snowflake_statement(conn, query)
-
+                conn.commit()
             if progress:
                 progress(len(data))
 


### PR DESCRIPTION
What this PR does / why we need it:
This PR fixes a critical bug in SnowflakeOnlineStore.online_write_batch.

Currently, the method sets autocommit=False but does not explicitly call conn.commit() after writing data and running the INSERT OVERWRITE query. As a result, data is not persisted - the transaction is discarded when the connection closes - even though no error is raised.

This causes:
Data appears in first reads (same connection)
Data disappears after session ends - table is empty in Snowflake UI and subsequent reads return nothing.

Adding conn.commit() ensures that the transaction is persisted correctly.

# Which issue(s) this PR fixes:
Fixes #5431


# Misc
This is a minimal one-line fix, but solves a critical data loss bug.
I will look into tadding a test which would fail for current implementation. Since this is transactional behavior, testing may require an end-to-end integration test.