### PR TITLE
fix: Increase the Operator Manager memory limits and requests

### DIFF
--- a/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
+++ b/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
@@ -233,11 +233,11 @@ spec:
                   periodSeconds: 10
                 resources:
                   limits:
-                    cpu: 500m
-                    memory: 128Mi
+                    cpu: 1000m
+                    memory: 256Mi
                   requests:
-                    cpu: 10m
-                    memory: 64Mi
+                    cpu: 50m
+                    memory: 128Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/infra/feast-operator/config/manager/manager.yaml
+++ b/infra/feast-operator/config/manager/manager.yaml
@@ -91,8 +91,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
-            cpu: 500m
-            memory: 128Mi
+            cpu: 1000m
+            memory: 256Mi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/infra/feast-operator/dist/install.yaml
+++ b/infra/feast-operator/dist/install.yaml
@@ -8425,8 +8425,8 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 500m
-            memory: 128Mi
+            cpu: 1000m
+            memory: 256Mi
           requests:
             cpu: 10m
             memory: 64Mi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
The operator manager pod is failing with CrashBackLoop due to OOM. 
```
Terminated at Jun 10, 2025, 1:12 PM with exit code 137 (OOMKilled)
```

This indicates that the operator manager pod and manifest needs to have an increased resources.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
RHOAIENG-27341


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
