### PR TITLE
fix: update minimum protobuf version to >=6.30.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "click>=7.0.0,<9.0.0",
     "colorama>=0.3.9,<1",
     "dill~=0.3.0",
-    "protobuf>=4.24.0",
+    "protobuf>=6.30.2,<7",
     "Jinja2>=2,<4",
     "jsonschema",
     "mmh3",


### PR DESCRIPTION
# What this PR does / why we need it:

This PR updates the minimum required `protobuf` version in `pyproject.toml` to `>=6.30.2`.

The current version range (`>=3.20.3,<7`) allows older versions like `4.25.6` or `5.26.0` that do not include `google.protobuf.runtime_version`, which is used by Feast internally. This causes an `ImportError` when importing modules like `FeatureStore`.

Updating the minimum ensures that users install a compatible version of `protobuf` and avoids runtime failures.

# Which issue(s) this PR fixes:

Fixes #5457  