### PR TITLE
test: Add RHOAI upgrate test to validate feast apply and materialize functionality

### DIFF
--- a/infra/feast-operator/test/e2e_rhoai/feast_postupgrade_test.go
+++ b/infra/feast-operator/test/e2e_rhoai/feast_postupgrade_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 Feast Community.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2erhoai
+
+import (
+	"fmt"
+
+	. "github.com/feast-dev/feast/infra/feast-operator/test/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Feast PostUpgrade scenario Testing", Ordered, func() {
+	const (
+		namespace           = "test-ns-feast-upgrade"
+		testDir             = "/test/e2e_rhoai"
+		feastDeploymentName = FeastPrefix + "credit-scoring"
+		feastCRName         = "credit-scoring"
+	)
+
+	AfterAll(func() {
+		By(fmt.Sprintf("Deleting test namespace: %s", namespace))
+		Expect(DeleteNamespace(namespace, testDir)).To(Succeed())
+		fmt.Printf("Namespace %s deleted successfully\n", namespace)
+	})
+	runPostUpgradeTest := func() {
+		By("Verify Feature Store CR is in Ready state")
+		ValidateFeatureStoreCRStatus(namespace, feastCRName)
+
+		By("Running `feast apply` and `feast materialize-incremental` to validate registry definitions")
+		VerifyApplyFeatureStoreDefinitions(namespace, feastCRName, feastDeploymentName)
+
+		By("Validating Feast entity, feature, and feature view presence")
+		VerifyFeastMethods(namespace, feastDeploymentName, testDir)
+	}
+
+	// This context verifies that a pre-created Feast FeatureStore CR continues to function as expected
+	// after an upgrade. It validates `feast apply`, registry sync, feature retrieval, and model execution.
+	Context("Feast post Upgrade Test", func() {
+		It("Should create and run a feastPostUpgrade test scenario feast apply and materialize functionality successfully", runPostUpgradeTest)
+	})
+})

--- a/infra/feast-operator/test/e2e_rhoai/feast_preupgrade_test.go
+++ b/infra/feast-operator/test/e2e_rhoai/feast_preupgrade_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 Feast Community.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2erhoai
+
+import (
+	"fmt"
+
+	. "github.com/feast-dev/feast/infra/feast-operator/test/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Feast PreUpgrade scenario Testing", Ordered, func() {
+	const (
+		namespace           = "test-ns-feast-upgrade"
+		replaceNamespace    = "test-ns-feast"
+		testDir             = "/test/e2e_rhoai"
+		feastDeploymentName = FeastPrefix + "credit-scoring"
+		feastCRName         = "credit-scoring"
+	)
+
+	filesToUpdateNamespace := []string{
+		"test/testdata/feast_integration_test_crs/postgres.yaml",
+		"test/testdata/feast_integration_test_crs/redis.yaml",
+		"test/testdata/feast_integration_test_crs/feast.yaml",
+	}
+
+	BeforeAll(func() {
+		By(fmt.Sprintf("Creating test namespace: %s", namespace))
+		Expect(CreateNamespace(namespace, testDir)).To(Succeed())
+		fmt.Printf("Namespace %s created successfully\n", namespace)
+
+		By("Replacing placeholder namespace in CR YAMLs for test setup")
+		Expect(ReplaceNamespaceInYamlFilesInPlace(filesToUpdateNamespace, replaceNamespace, namespace)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		By("Restoring original namespace in CR YAMLs")
+		Expect(ReplaceNamespaceInYamlFilesInPlace(filesToUpdateNamespace, namespace, replaceNamespace)).To(Succeed())
+
+		if CurrentSpecReport().Failed() {
+			By(fmt.Sprintf("Deleting test namespace: %s", namespace))
+			Expect(DeleteNamespace(namespace, testDir)).To(Succeed())
+			fmt.Printf("Namespace %s deleted successfully\n", namespace)
+		}
+	})
+
+	runPreUpgradeTest := func() {
+		By("Applying Feast infra manifests and verifying setup")
+		ApplyFeastInfraManifestsAndVerify(namespace, testDir)
+
+		By("Applying and validating the credit-scoring FeatureStore CR")
+		ApplyFeastYamlAndVerify(namespace, testDir, feastDeploymentName, feastCRName)
+	}
+
+	// This context ensures the Feast CR setup is functional prior to any upgrade
+	Context("Feast Pre Upgrade Test", func() {
+		It("Should create and run a feastPreUpgrade test scenario feast credit-scoring CR setup successfully", runPreUpgradeTest)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Added RHOAI upgrade test scenario of credit-scoring example to verify the functionality of a Feast FeatureStore
after upgrade. 
- Introduced `feast_preupgrade_test` to ensure the FeatureStore CR is correctly set up prior to upgrade
- Added `feast_post_upgrade_test` to validate feast apply and materialize functionality after upgrade
- Implemented `ReplaceNamespaceInYamlFilesInPlace` utility to dynamically update namespaces in YAMLs,
  preventing conflicts with existing namespaces used by other tests
- Removed model training functionality from Feast apply and materialize tests, as it is not relevant to validate



