### PR TITLE
chore: Complete removal of py3.9

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,10 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.9-buster
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.12
 
 USER vscode
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 RUN curl -fsSL https://pixi.sh/install.sh | bash
 ENV PATH=$PATH:/home/vscode/.cargo/bin
-ENV PYTHON=3.9
+ENV PYTHON=3.12
 RUN uv venv ~/.local
 ENV VIRTUAL_ENV=~/.local
 ENV PATH=$VIRTUAL_ENV/bin:$PATH

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -16,7 +16,7 @@ Feast (Feature Store) is an open-source feature store designed to facilitate the
 For more info refer to [Introduction to feast](../README.md)
 
 ## Prerequisites
-* Ensure that you have Python (3.9 or above) installed.
+* Ensure that you have Python (3.10 or above) installed.
 * It is recommended to create and work in a virtual environment:
   ```sh
   # create & activate a virtual environment

--- a/docs/how-to-guides/customizing-feast/adding-support-for-a-new-online-store.md
+++ b/docs/how-to-guides/customizing-feast/adding-support-for-a-new-online-store.md
@@ -386,7 +386,7 @@ test-python-universal-cassandra:
 
 Add any dependencies for your online store to our `sdk/python/setup.py` under a new `<ONLINE_STORE>_REQUIRED` list with the packages and add it to the setup script so that if your online store is needed, users can install the necessary python packages. These packages should be defined as extras so that they are not installed by users by default.
 
-* You will need to regenerate our requirements files. To do this, create separate pyenv environments for python 3.8, 3.9, and 3.10. In each environment, run the following commands:
+* You will need to regenerate our requirements files. To do this, create separate pyenv environments for python 3.10, 3.11, and 3.12. In each environment, run the following commands:
 
 ```
 export PYTHON=<version>

--- a/environment-setup.md
+++ b/environment-setup.md
@@ -1,7 +1,7 @@
 1. install anaconda, install docker
-2. create an environment for feast, selecting python 3.9. Activate the environment:
+2. create an environment for feast, selecting python 3.12. Activate the environment:
 ```bash
-conda create --name feast python=3.9
+conda create --name feast python=3.12
 conda activate feast
 ```
 3. install dependencies:
@@ -13,7 +13,7 @@ pip install cryptography -U
 conda install protobuf
 conda install pymssql
 pip install -e ".[dev]"
-make install-python-ci-dependencies PYTHON=3.9
+make install-python-ci-dependencies
 ```
 4. start the docker daemon
 5. run unit tests:

--- a/examples/kind-quickstart/01-Install.ipynb
+++ b/examples/kind-quickstart/01-Install.ipynb
@@ -77,9 +77,7 @@
     }
    ],
    "source": [
-    "# WE MUST ENSURE PYTHON CONSISTENCY BETWEEN NOTEBOOK AND FEAST SERVERS\n",
-    "# LAUNCH THIS NOTEBOOK FROM A CLEAN PYTHON ENVIRONMENT >3.9\n",
-    "%pip install feast==0.40.1"
+    "%pip install feast"
    ]
   },
   {

--- a/examples/kind-quickstart/02-Client.ipynb
+++ b/examples/kind-quickstart/02-Client.ipynb
@@ -93,9 +93,7 @@
     }
    ],
    "source": [
-    "# WE MUST ENSURE PYTHON CONSISTENCY BETWEEN NOTEBOOK AND FEAST SERVERS\n",
-    "# LAUNCH THIS NOTEBOOK FROM A CLEAN PYTHON ENVIRONMENT >3.9\n",
-    "%pip install feast==0.40.1"
+    "%pip install feast"
    ]
   },
   {

--- a/examples/podman_local/README.md
+++ b/examples/podman_local/README.md
@@ -7,7 +7,7 @@ This guide explains how to deploy Feast remote server components using Podman Co
 
 1. **Podman**: [Podman installation guide](https://podman.io/).
 2. **Podman Compose**: [Podman Compose Installation guide](https://github.com/containers/podman-compose/tree/main?tab=readme-ov-file#installation]).
-3. **Python 3.9+ environment**
+3. **Correct Python version environment**
 4. **Feast CLI** 
 
 ## Setup

--- a/examples/rhoai-quickstart/feast-demo-quickstart.ipynb
+++ b/examples/rhoai-quickstart/feast-demo-quickstart.ipynb
@@ -30,9 +30,7 @@
     }
    ],
    "source": [
-    "# WE MUST ENSURE PYTHON CONSISTENCY BETWEEN NOTEBOOK AND FEAST SERVERS\n",
-    "# LAUNCH THIS NOTEBOOK FROM A CLEAN PYTHON ENVIRONMENT >3.9\n",
-    "%pip install -q feast==0.40.1\n",
+    "%pip install -q feast\n",
     "# grpcio is needed as a dependency in the later section of the example to run the feast registry server.\n",
     "%pip install -q grpcio\n"
    ]

--- a/infra/scripts/pixi/pixi.toml
+++ b/infra/scripts/pixi/pixi.toml
@@ -7,9 +7,7 @@ platforms = ["linux-64", "osx-arm64", "osx-64"]
 
 [dependencies]
 uv = ">=0.6.3"
-
-[feature.py39.dependencies]
-python = "~=3.9.0"
+python = "~=3.12.0"
 
 [feature.py310.dependencies]
 python = "~=3.10.0"
@@ -21,7 +19,6 @@ python = "~=3.11.0"
 python = "~=3.12.0"
 
 [environments]
-py39 = ["py39"]
 py310 = ["py310"]
 py311 = ["py311"]
 py312 = ["py312"]

--- a/sdk/python/feast/infra/compute_engines/aws_lambda/Dockerfile
+++ b/sdk/python/feast/infra/compute_engines/aws_lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.9
+FROM public.ecr.aws/lambda/python:3.12
 
 RUN yum install -y git
 

--- a/sdk/python/feast/infra/utils/snowflake/snowpark/snowflake_python_udfs_creation.sql
+++ b/sdk/python/feast/infra/utils/snowflake/snowpark/snowflake_python_udfs_creation.sql
@@ -1,7 +1,7 @@
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_binary_to_bytes_proto(df BINARY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_binary_to_bytes_proto'
   IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -9,7 +9,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_binary_to_bytes_proto
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_varchar_to_string_proto(df VARCHAR)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_varchar_to_string_proto'
   IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -17,7 +17,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_varchar_to_string_pro
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_bytes_to_list_bytes_proto(df ARRAY)
     RETURNS BINARY
     LANGUAGE PYTHON
-    RUNTIME_VERSION = '3.9'
+    RUNTIME_VERSION = '3.12'
     PACKAGES = ('protobuf', 'pandas')
     HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_bytes_to_list_bytes_proto'
     IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -25,7 +25,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_bytes_to_list_b
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_varchar_to_list_string_proto(df ARRAY)
     RETURNS BINARY
     LANGUAGE PYTHON
-    RUNTIME_VERSION = '3.9'
+    RUNTIME_VERSION = '3.12'
     PACKAGES = ('protobuf', 'pandas')
     HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_varchar_to_list_string_proto'
     IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -33,7 +33,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_varchar_to_list
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_number_to_list_int32_proto(df ARRAY)
     RETURNS BINARY
     LANGUAGE PYTHON
-    RUNTIME_VERSION = '3.9'
+    RUNTIME_VERSION = '3.12'
     PACKAGES = ('protobuf', 'pandas')
     HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_number_to_list_int32_proto'
     IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -41,7 +41,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_number_to_list_
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_number_to_list_int64_proto(df ARRAY)
     RETURNS BINARY
     LANGUAGE PYTHON
-    RUNTIME_VERSION = '3.9'
+    RUNTIME_VERSION = '3.12'
     PACKAGES = ('protobuf', 'pandas')
     HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_number_to_list_int64_proto'
     IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -49,7 +49,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_number_to_list_
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_float_to_list_double_proto(df ARRAY)
     RETURNS BINARY
     LANGUAGE PYTHON
-    RUNTIME_VERSION = '3.9'
+    RUNTIME_VERSION = '3.12'
     PACKAGES = ('protobuf', 'pandas')
     HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_float_to_list_double_proto'
     IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -57,7 +57,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_float_to_list_d
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_boolean_to_list_bool_proto(df ARRAY)
     RETURNS BINARY
     LANGUAGE PYTHON
-    RUNTIME_VERSION = '3.9'
+    RUNTIME_VERSION = '3.12'
     PACKAGES = ('protobuf', 'pandas')
     HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_boolean_to_list_bool_proto'
     IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -65,7 +65,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_boolean_to_list
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_timestamp_to_list_unix_timestamp_proto(df ARRAY)
     RETURNS BINARY
     LANGUAGE PYTHON
-    RUNTIME_VERSION = '3.9'
+    RUNTIME_VERSION = '3.12'
     PACKAGES = ('protobuf', 'pandas')
     HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_timestamp_to_list_unix_timestamp_proto'
     IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -73,7 +73,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_array_timestamp_to_li
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_number_to_int32_proto(df NUMBER)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_number_to_int32_proto'
   IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -81,7 +81,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_number_to_int32_proto
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_number_to_int64_proto(df NUMBER)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_number_to_int64_proto'
   IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -89,7 +89,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_number_to_int64_proto
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_float_to_double_proto(df DOUBLE)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_float_to_double_proto'
   IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -97,7 +97,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_float_to_double_proto
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_boolean_to_bool_proto(df BOOLEAN)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_boolean_to_bool_boolean_proto'
   IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -105,7 +105,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_boolean_to_bool_proto
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_timestamp_to_unix_timestamp_proto(df NUMBER)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_timestamp_to_unix_timestamp_proto'
   IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -113,7 +113,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_snowflake_timestamp_to_unix_tim
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_serialize_entity_keys(names ARRAY, data ARRAY, types ARRAY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_serialize_entity_keys'
   IMPORTS = ('@STAGE_HOLDER/feast.zip');
@@ -121,7 +121,7 @@ CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_serialize_entity_keys(names ARR
 CREATE FUNCTION IF NOT EXISTS feast_PROJECT_NAME_entity_key_proto_to_string(names ARRAY, data ARRAY, types ARRAY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_entity_key_proto_to_string'
   IMPORTS = ('@STAGE_HOLDER/feast.zip')

--- a/sdk/python/feast/infra/utils/snowflake/snowpark/snowflake_udfs.py
+++ b/sdk/python/feast/infra/utils/snowflake/snowpark/snowflake_udfs.py
@@ -18,7 +18,7 @@ from feast.value_type import ValueType
 CREATE OR REPLACE FUNCTION feast_snowflake_binary_to_bytes_proto(df BINARY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_binary_to_bytes_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -41,7 +41,7 @@ def feast_snowflake_binary_to_bytes_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_varchar_to_string_proto(df VARCHAR)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_varchar_to_string_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -64,7 +64,7 @@ def feast_snowflake_varchar_to_string_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_array_bytes_to_list_bytes_proto(df ARRAY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_bytes_to_list_bytes_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -90,7 +90,7 @@ def feast_snowflake_array_bytes_to_list_bytes_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_array_varchar_to_list_string_proto(df ARRAY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_varchar_to_list_string_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -114,7 +114,7 @@ def feast_snowflake_array_varchar_to_list_string_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_array_number_to_list_int32_proto(df ARRAY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_number_to_list_int32_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -138,7 +138,7 @@ def feast_snowflake_array_number_to_list_int32_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_array_number_to_list_int64_proto(df ARRAY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_number_to_list_int64_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -162,7 +162,7 @@ def feast_snowflake_array_number_to_list_int64_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_array_float_to_list_double_proto(df ARRAY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_float_to_list_double_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -188,7 +188,7 @@ def feast_snowflake_array_float_to_list_double_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_array_boolean_to_list_bool_proto(df ARRAY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_boolean_to_list_bool_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -212,7 +212,7 @@ def feast_snowflake_array_boolean_to_list_bool_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_array_timestamp_to_list_unix_timestamp_proto(df ARRAY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_array_timestamp_to_list_unix_timestamp_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -238,7 +238,7 @@ def feast_snowflake_array_timestamp_to_list_unix_timestamp_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_number_to_int32_proto(df NUMBER)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_number_to_int32_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -261,7 +261,7 @@ def feast_snowflake_number_to_int32_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_number_to_int64_proto(df NUMBER)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_number_to_int64_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -286,7 +286,7 @@ def feast_snowflake_number_to_int64_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_float_to_double_proto(df DOUBLE)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_float_to_double_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -309,7 +309,7 @@ def feast_snowflake_float_to_double_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_boolean_to_bool_proto(df BOOLEAN)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_boolean_to_bool_boolean_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -332,7 +332,7 @@ def feast_snowflake_boolean_to_bool_boolean_proto(df):
 CREATE OR REPLACE FUNCTION feast_snowflake_timestamp_to_unix_timestamp_proto(df NUMBER)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_snowflake_timestamp_to_unix_timestamp_proto'
   IMPORTS = ('@feast_stage/feast.zip');
@@ -358,7 +358,7 @@ def feast_snowflake_timestamp_to_unix_timestamp_proto(df):
 CREATE OR REPLACE FUNCTION feast_serialize_entity_keys(names ARRAY, data ARRAY, types ARRAY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_serialize_entity_keys'
   IMPORTS = ('@feast_stage/feast.zip')
@@ -405,7 +405,7 @@ def feast_serialize_entity_keys(df):
 CREATE OR REPLACE FUNCTION feast_entity_key_proto_to_string(names ARRAY, data ARRAY, types ARRAY)
   RETURNS BINARY
   LANGUAGE PYTHON
-  RUNTIME_VERSION = '3.9'
+  RUNTIME_VERSION = '3.12'
   PACKAGES = ('protobuf', 'pandas')
   HANDLER = 'feast.infra.utils.snowflake.snowpark.snowflake_udfs.feast_entity_key_proto_to_string'
   IMPORTS = ('@feast_stage/feast.zip')


### PR DESCRIPTION

# What this PR does / why we need it:
macOS-14 runners has a dependency on the GNU gettext library (libintl.8.dylib), but this library wasn't available on the runner. 

Fixing https://github.com/feast-dev/feast/actions/runs/15988854964/job/45099219895 