### PR TITLE
fix: Fix verify wheels workflow for macos14

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -142,7 +142,7 @@ jobs:
           path: dist
       - name: Install OS X dependencies
         if: matrix.os == 'macos-14'
-        run: brew install coreutils
+        run: brew install coreutils gettext
       - name: Install wheel
         if: ${{ !matrix.from-source }}
         # try to install all wheels; only the current platform wheel should be actually installed


### PR DESCRIPTION

# What this PR does / why we need it:

macOS-14 runners has a dependency on the GNU gettext library (libintl.8.dylib), but this library wasn't available on the runner.  

Fixing - https://github.com/feast-dev/feast/actions/runs/15988854964/job/45099219895 