### PR TITLE
fix: Skip macOS 14 with Python 3.10 due to gettext library

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -115,6 +115,10 @@ jobs:
         os: [ ubuntu-latest,  macos-14 ]
         python-version: [ "3.10", "3.11", "3.12"]
         from-source: [ True, False ]
+        exclude:
+          # Skip macOS 14 with Python 3.10 due to gettext library issues
+          - os: macos-14
+            python-version: "3.10"
     env:
       # this script is for testing servers
       # it starts server with timeout and checks whether process killed by timeout (started healthy) or died by itself


### PR DESCRIPTION
# What this PR does / why we need it:

Skip running macos-14 with Python 3.10 due to gettext library

https://github.com/actions/setup-python/issues/825 

Fix applied on v0.50-branch
