### PR TITLE
fix: Correct entity value type mapping for aliased feature views

### DIFF
--- a/sdk/python/feast/utils.py
+++ b/sdk/python/feast/utils.py
@@ -693,8 +693,13 @@ def _get_entity_maps(
                 entity.join_key, entity.join_key
             )
             entity_name_to_join_key_map[entity_name] = join_key
+
         for entity_column in feature_view.entity_columns:
-            entity_type_map[entity_column.name] = entity_column.dtype.to_value_type()
+            dtype = entity_column.dtype.to_value_type()
+            entity_join_key_column_name = feature_view.projection.join_key_map.get(
+                entity_column.name, entity_column.name
+            )
+            entity_type_map[entity_join_key_column_name] = dtype
 
     return (
         entity_name_to_join_key_map,


### PR DESCRIPTION
## Description

This fix addresses an issue where entity value types were incorrectly mapped when using feature views with join key aliases.

## Problem

Previously, when using feature views with join key aliases (like in the example below), the `entity_type_map` would use the original column name instead of the aliased join key:

```python
user_entity = Entity(
    name="user",
    join_keys=["user_id"],
    value_type=ValueType.INT32,
    description="User entity for the matching platform",
)

match_service = FeatureService(
    name="match_service",
    features=[
        user_profile_fv.with_name("user"),
        user_profile_fv.with_name("target_user").with_join_key_map(
            {"user_id": "target_user_id"}
        ),
    ],
)
```

This caused `target_user_id` to be interpreted as `ValueType.INT64` instead of the correct entity value type (`ValueType.INT32` in this case).

## Solution

The fix ensures that when a feature view has a join key map, the entity type mapping uses the correct aliased column name from the projection's `join_key_map`.

## Changes

- Modified `_get_entity_maps` function in `sdk/python/feast/utils.py`
- Added logic to check for join key aliases in the feature view projection
- Map entity types to the correct aliased column names

## Testing

This fix resolves the issue where aliased feature views would have incorrect entity value type mappings, ensuring that join keys maintain their correct data types even when aliased.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This fix has been tested with the scenario described above where feature views are aliased with join key mappings. The entity value types are now correctly preserved for aliased join keys.