### PR TITLE
fix: Added support to handle empty dataframe

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1746,8 +1746,6 @@ class FeatureStore:
             allow_registry_cache (optional): Whether to allow retrieving feature views from a cached registry.
             transform_on_write (optional): Whether to transform the data before pushing.
 
-        Raises:
-            ValueError: If the dataframe is empty (has no rows) or if feature columns are empty.
         """
 
         feature_view, df = self._get_feature_view_and_df_for_online_write(
@@ -1793,8 +1791,6 @@ class FeatureStore:
             inputs: Optional the dictionary object to be written
             allow_registry_cache (optional): Whether to allow retrieving feature views from a cached registry.
 
-        Raises:
-            ValueError: If the dataframe is empty (has no rows) or if feature columns are empty.
         """
 
         feature_view, df = self._get_feature_view_and_df_for_online_write(

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1761,14 +1761,14 @@ class FeatureStore:
         # Validate that the dataframe has meaningful feature data
         if df is not None:
             if df.empty:
-                raise ValueError("Cannot write empty dataframe to online store")
+                warnings.warn("Cannot write empty dataframe to online store")
 
             # Check if feature columns are empty (entity columns may have data but feature columns are empty)
             feature_column_names = [f.name for f in feature_view.features]
             if feature_column_names:
                 feature_df = df[feature_column_names]
                 if feature_df.empty or feature_df.isnull().all().all():
-                    raise ValueError(
+                    warnings.warn(
                         "Cannot write dataframe with empty feature columns to online store"
                     )
 
@@ -1805,14 +1805,14 @@ class FeatureStore:
         # Validate that the dataframe has meaningful feature data
         if df is not None:
             if df.empty:
-                raise ValueError("Cannot write empty dataframe to online store")
+                warnings.warn("Cannot write empty dataframe to online store")
 
             # Check if feature columns are empty (entity columns may have data but feature columns are empty)
             feature_column_names = [f.name for f in feature_view.features]
             if feature_column_names:
                 feature_df = df[feature_column_names]
                 if feature_df.empty or feature_df.isnull().all().all():
-                    raise ValueError(
+                    warnings.warn(
                         "Cannot write dataframe with empty feature columns to online store"
                     )
 

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1745,7 +1745,6 @@ class FeatureStore:
             inputs: Optional the dictionary object to be written
             allow_registry_cache (optional): Whether to allow retrieving feature views from a cached registry.
             transform_on_write (optional): Whether to transform the data before pushing.
-
         """
 
         feature_view, df = self._get_feature_view_and_df_for_online_write(
@@ -1790,7 +1789,6 @@ class FeatureStore:
             df: The dataframe to be persisted.
             inputs: Optional the dictionary object to be written
             allow_registry_cache (optional): Whether to allow retrieving feature views from a cached registry.
-
         """
 
         feature_view, df = self._get_feature_view_and_df_for_online_write(

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1757,19 +1757,21 @@ class FeatureStore:
             allow_registry_cache=allow_registry_cache,
             transform_on_write=transform_on_write,
         )
-        
+
         # Validate that the dataframe has meaningful feature data
         if df is not None:
             if df.empty:
                 raise ValueError("Cannot write empty dataframe to online store")
-            
+
             # Check if feature columns are empty (entity columns may have data but feature columns are empty)
             feature_column_names = [f.name for f in feature_view.features]
             if feature_column_names:
                 feature_df = df[feature_column_names]
                 if feature_df.empty or feature_df.isnull().all().all():
-                    raise ValueError("Cannot write dataframe with empty feature columns to online store")
-        
+                    raise ValueError(
+                        "Cannot write dataframe with empty feature columns to online store"
+                    )
+
         provider = self._get_provider()
         provider.ingest_df(feature_view, df)
 
@@ -1799,19 +1801,21 @@ class FeatureStore:
             inputs=inputs,
             allow_registry_cache=allow_registry_cache,
         )
-        
+
         # Validate that the dataframe has meaningful feature data
         if df is not None:
             if df.empty:
                 raise ValueError("Cannot write empty dataframe to online store")
-            
+
             # Check if feature columns are empty (entity columns may have data but feature columns are empty)
             feature_column_names = [f.name for f in feature_view.features]
             if feature_column_names:
                 feature_df = df[feature_column_names]
                 if feature_df.empty or feature_df.isnull().all().all():
-                    raise ValueError("Cannot write dataframe with empty feature columns to online store")
-        
+                    raise ValueError(
+                        "Cannot write dataframe with empty feature columns to online store"
+                    )
+
         provider = self._get_provider()
         await provider.ingest_df_async(feature_view, df)
 

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1745,6 +1745,9 @@ class FeatureStore:
             inputs: Optional the dictionary object to be written
             allow_registry_cache (optional): Whether to allow retrieving feature views from a cached registry.
             transform_on_write (optional): Whether to transform the data before pushing.
+
+        Raises:
+            ValueError: If the dataframe is empty (has no rows) or if feature columns are empty.
         """
 
         feature_view, df = self._get_feature_view_and_df_for_online_write(
@@ -1754,6 +1757,19 @@ class FeatureStore:
             allow_registry_cache=allow_registry_cache,
             transform_on_write=transform_on_write,
         )
+        
+        # Validate that the dataframe has meaningful feature data
+        if df is not None:
+            if df.empty:
+                raise ValueError("Cannot write empty dataframe to online store")
+            
+            # Check if feature columns are empty (entity columns may have data but feature columns are empty)
+            feature_column_names = [f.name for f in feature_view.features]
+            if feature_column_names:
+                feature_df = df[feature_column_names]
+                if feature_df.empty or feature_df.isnull().all().all():
+                    raise ValueError("Cannot write dataframe with empty feature columns to online store")
+        
         provider = self._get_provider()
         provider.ingest_df(feature_view, df)
 
@@ -1772,6 +1788,9 @@ class FeatureStore:
             df: The dataframe to be persisted.
             inputs: Optional the dictionary object to be written
             allow_registry_cache (optional): Whether to allow retrieving feature views from a cached registry.
+
+        Raises:
+            ValueError: If the dataframe is empty (has no rows) or if feature columns are empty.
         """
 
         feature_view, df = self._get_feature_view_and_df_for_online_write(
@@ -1780,6 +1799,19 @@ class FeatureStore:
             inputs=inputs,
             allow_registry_cache=allow_registry_cache,
         )
+        
+        # Validate that the dataframe has meaningful feature data
+        if df is not None:
+            if df.empty:
+                raise ValueError("Cannot write empty dataframe to online store")
+            
+            # Check if feature columns are empty (entity columns may have data but feature columns are empty)
+            feature_column_names = [f.name for f in feature_view.features]
+            if feature_column_names:
+                feature_df = df[feature_column_names]
+                if feature_df.empty or feature_df.isnull().all().all():
+                    raise ValueError("Cannot write dataframe with empty feature columns to online store")
+        
         provider = self._get_provider()
         await provider.ingest_df_async(feature_view, df)
 

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1762,6 +1762,7 @@ class FeatureStore:
         if df is not None:
             if df.empty:
                 warnings.warn("Cannot write empty dataframe to online store")
+                return  # Early return for empty dataframe
 
             # Check if feature columns are empty (entity columns may have data but feature columns are empty)
             feature_column_names = [f.name for f in feature_view.features]
@@ -1771,6 +1772,7 @@ class FeatureStore:
                     warnings.warn(
                         "Cannot write dataframe with empty feature columns to online store"
                     )
+                    return  # Early return for empty feature columns
 
         provider = self._get_provider()
         provider.ingest_df(feature_view, df)
@@ -1806,6 +1808,7 @@ class FeatureStore:
         if df is not None:
             if df.empty:
                 warnings.warn("Cannot write empty dataframe to online store")
+                return  # Early return for empty dataframe
 
             # Check if feature columns are empty (entity columns may have data but feature columns are empty)
             feature_column_names = [f.name for f in feature_view.features]
@@ -1815,6 +1818,7 @@ class FeatureStore:
                     warnings.warn(
                         "Cannot write dataframe with empty feature columns to online store"
                     )
+                    return  # Early return for empty feature columns
 
         provider = self._get_provider()
         await provider.ingest_df_async(feature_view, df)

--- a/sdk/python/tests/unit/online_store/test_online_writes.py
+++ b/sdk/python/tests/unit/online_store/test_online_writes.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import os
+import shutil
 import tempfile
 import unittest
 import warnings
@@ -20,6 +22,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import pandas as pd
+import pytest
 
 from feast import (
     Entity,
@@ -205,8 +208,6 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
         self.store.apply([driver, driver_stats_source, driver_stats_fv])
 
     def tearDown(self):
-        import shutil
-
         shutil.rmtree(self.data_dir)
 
     def test_empty_dataframe_warns(self):
@@ -231,7 +232,6 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
 
     def test_empty_dataframe_async_warns(self):
         """Test that completely empty dataframe warns instead of raising error in async version"""
-        import asyncio
 
         async def test_async_empty():
             empty_df = pd.DataFrame()
@@ -287,7 +287,6 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
 
     def test_dataframe_with_empty_feature_columns_async_warns(self):
         """Test that dataframe with entity data but empty feature columns warns instead of raising error in async version"""
-        import asyncio
 
         async def test_async_empty_features():
             current_time = pd.Timestamp.now()
@@ -342,10 +341,6 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
 
     def test_valid_dataframe_async(self):
         """Test that valid dataframe with feature data succeeds in async version"""
-        import asyncio
-
-        import pytest
-
         pytest.skip("Feature not implemented yet")
 
         async def test_async_valid():
@@ -443,8 +438,6 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
 
     def test_multiple_feature_views_materialization_with_empty_data(self):
         """Test materializing multiple feature views where one has empty data - should not break materialization"""
-        import tempfile
-        from datetime import timedelta
 
         with tempfile.TemporaryDirectory() as data_dir:
             # Create a new store for this test
@@ -525,10 +518,10 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
                             entity_key: pd.Series([], dtype="int64"),
                             "event_timestamp": pd.Series(
                                 [], dtype="datetime64[ns, UTC]"
-                            ),  # ✅ Timezone-aware
+                            ),  # Timezone-aware
                             "created": pd.Series(
                                 [], dtype="datetime64[ns, UTC]"
-                            ),  # ✅ Timezone-aware
+                            ),  # Timezone-aware
                             f"feature_{i + 1}_rate": pd.Series([], dtype="float32"),
                             f"feature_{i + 1}_count": pd.Series([], dtype="int64"),
                         }

--- a/sdk/python/tests/unit/online_store/test_online_writes.py
+++ b/sdk/python/tests/unit/online_store/test_online_writes.py
@@ -17,7 +17,6 @@ import os
 import shutil
 import tempfile
 import unittest
-import warnings
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -37,109 +36,7 @@ from feast.field import Field
 from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
 from feast.on_demand_feature_view import on_demand_feature_view
 from feast.types import Array, Float32, Float64, Int64, PdfBytes, String, ValueType
-
-
-def check_warnings(
-    expected_warnings=None,  # List of warnings that MUST be present
-    forbidden_warnings=None,  # List of warnings that MUST NOT be present
-    match_type="contains",  # "exact", "contains", "regex"
-    capture_all=True,  # Capture all warnings or just specific types
-    fail_on_unexpected=False,  # Fail if unexpected warnings appear
-    min_count=None,  # Minimum number of expected warnings
-    max_count=None,  # Maximum number of expected warnings
-):
-    """
-    Decorator to automatically capture and validate warnings in test methods.
-
-    Args:
-        expected_warnings: List of warning messages that MUST be present
-        forbidden_warnings: List of warning messages that MUST NOT be present
-        match_type: How to match warnings ("exact", "contains", "regex")
-        capture_all: Whether to capture all warnings
-        fail_on_unexpected: Whether to fail if unexpected warnings appear
-        min_count: Minimum number of warnings expected
-        max_count: Maximum number of warnings expected
-    """
-
-    def decorator(test_func):
-        def wrapper(*args, **kwargs):
-            # Setup warning capture
-            with warnings.catch_warnings(record=True) as warning_list:
-                warnings.simplefilter("always")
-
-                # Execute the test function
-                result = test_func(*args, **kwargs)
-
-                # Convert warnings to string messages
-                captured_messages = [str(w.message) for w in warning_list]
-
-                # Validate expected warnings are present
-                if expected_warnings:
-                    for expected_warning in expected_warnings:
-                        if not _warning_matches(
-                            expected_warning, captured_messages, match_type
-                        ):
-                            raise AssertionError(
-                                f"Expected warning '{expected_warning}' not found. "
-                                f"Captured warnings: {captured_messages}"
-                            )
-
-                # Validate forbidden warnings are NOT present
-                if forbidden_warnings:
-                    for forbidden_warning in forbidden_warnings:
-                        if _warning_matches(
-                            forbidden_warning, captured_messages, match_type
-                        ):
-                            raise AssertionError(
-                                f"Forbidden warning '{forbidden_warning}' was found. "
-                                f"Captured warnings: {captured_messages}"
-                            )
-
-                # Validate warning count constraints
-                if min_count is not None and len(warning_list) < min_count:
-                    raise AssertionError(
-                        f"Expected at least {min_count} warnings, got {len(warning_list)}"
-                    )
-
-                if max_count is not None and len(warning_list) > max_count:
-                    raise AssertionError(
-                        f"Expected at most {max_count} warnings, got {len(warning_list)}"
-                    )
-
-                # Validate no unexpected warnings (if enabled)
-                if fail_on_unexpected and expected_warnings:
-                    all_expected = expected_warnings + (forbidden_warnings or [])
-                    for message in captured_messages:
-                        if not any(
-                            _warning_matches(exp, [message], match_type)
-                            for exp in all_expected
-                        ):
-                            raise AssertionError(
-                                f"Unexpected warning found: '{message}'"
-                            )
-
-                return result
-
-        return wrapper
-
-    return decorator
-
-
-def _warning_matches(pattern, messages, match_type):
-    """Helper function to check if pattern matches any message"""
-    for message in messages:
-        if match_type == "exact":
-            if pattern == message:
-                return True
-        elif match_type == "contains":
-            if pattern in message:
-                return True
-        elif match_type == "regex":
-            import re
-
-            if re.search(pattern, message):
-                return True
-    return False
+from tests.utils.test_wrappers import check_warnings
 
 
 class TestOnlineWrites(unittest.TestCase):

--- a/sdk/python/tests/unit/online_store/test_online_writes.py
+++ b/sdk/python/tests/unit/online_store/test_online_writes.py
@@ -155,6 +155,220 @@ class TestOnlineWrites(unittest.TestCase):
         )
 
 
+class TestEmptyDataFrameValidation(unittest.TestCase):
+    def setUp(self):
+        with tempfile.TemporaryDirectory() as data_dir:
+            self.store = FeatureStore(
+                config=RepoConfig(
+                    project="test_empty_df_validation",
+                    registry=os.path.join(data_dir, "registry.db"),
+                    provider="local",
+                    entity_key_serialization_version=2,
+                    online_store=SqliteOnlineStoreConfig(
+                        path=os.path.join(data_dir, "online.db")
+                    ),
+                )
+            )
+
+            # Generate test data for schema creation
+            end_date = datetime.now().replace(microsecond=0, second=0, minute=0)
+            start_date = end_date - timedelta(days=1)
+
+            driver_entities = [1001]
+            driver_df = create_driver_hourly_stats_df(
+                driver_entities, start_date, end_date
+            )
+            driver_stats_path = os.path.join(data_dir, "driver_stats.parquet")
+            driver_df.to_parquet(
+                path=driver_stats_path, allow_truncated_timestamps=True
+            )
+
+            driver = Entity(name="driver", join_keys=["driver_id"])
+
+            driver_stats_source = FileSource(
+                name="driver_hourly_stats_source",
+                path=driver_stats_path,
+                timestamp_field="event_timestamp",
+                created_timestamp_column="created",
+            )
+
+            driver_stats_fv = FeatureView(
+                name="driver_hourly_stats",
+                entities=[driver],
+                ttl=timedelta(days=0),
+                schema=[
+                    Field(name="conv_rate", dtype=Float32),
+                    Field(name="acc_rate", dtype=Float32),
+                    Field(name="avg_daily_trips", dtype=Int64),
+                ],
+                online=True,
+                source=driver_stats_source,
+            )
+
+            self.store.apply([driver, driver_stats_source, driver_stats_fv])
+
+    def test_empty_dataframe_raises_error(self):
+        """Test that completely empty dataframe raises ValueError"""
+        empty_df = pd.DataFrame()
+        
+        with self.assertRaises(ValueError) as context:
+            self.store.write_to_online_store(
+                feature_view_name="driver_hourly_stats", df=empty_df
+            )
+        
+        self.assertIn("Cannot write empty dataframe to online store", str(context.exception))
+
+    def test_empty_dataframe_async_raises_error(self):
+        """Test that completely empty dataframe raises ValueError in async version"""
+        import asyncio
+        
+        async def test_async_empty():
+            empty_df = pd.DataFrame()
+            
+            with self.assertRaises(ValueError) as context:
+                await self.store.write_to_online_store_async(
+                    feature_view_name="driver_hourly_stats", df=empty_df
+                )
+            
+            self.assertIn("Cannot write empty dataframe to online store", str(context.exception))
+        
+        asyncio.run(test_async_empty())
+
+    def test_dataframe_with_empty_feature_columns_raises_error(self):
+        """Test that dataframe with entity data but empty feature columns raises ValueError"""
+        current_time = pd.Timestamp.now()
+        df_with_entity_only = pd.DataFrame({
+            "driver_id": [1001, 1002, 1003],
+            "event_timestamp": [current_time] * 3,
+            "created": [current_time] * 3,
+            "conv_rate": [None, None, None],  # All nulls
+            "acc_rate": [None, None, None],   # All nulls
+            "avg_daily_trips": [None, None, None]  # All nulls
+        })
+        
+        with self.assertRaises(ValueError) as context:
+            self.store.write_to_online_store(
+                feature_view_name="driver_hourly_stats", df=df_with_entity_only
+            )
+        
+        self.assertIn("Cannot write dataframe with empty feature columns to online store", str(context.exception))
+
+    def test_dataframe_with_empty_feature_columns_async_raises_error(self):
+        """Test that dataframe with entity data but empty feature columns raises ValueError in async version"""
+        import asyncio
+        
+        async def test_async_empty_features():
+            current_time = pd.Timestamp.now()
+            df_with_entity_only = pd.DataFrame({
+                "driver_id": [1001, 1002, 1003],
+                "event_timestamp": [current_time] * 3,
+                "created": [current_time] * 3,
+                "conv_rate": [None, None, None],
+                "acc_rate": [None, None, None],
+                "avg_daily_trips": [None, None, None]
+            })
+            
+            with self.assertRaises(ValueError) as context:
+                await self.store.write_to_online_store_async(
+                    feature_view_name="driver_hourly_stats", df=df_with_entity_only
+                )
+            
+            self.assertIn("Cannot write dataframe with empty feature columns to online store", str(context.exception))
+        
+        asyncio.run(test_async_empty_features())
+
+    def test_valid_dataframe_succeeds(self):
+        """Test that valid dataframe with feature data succeeds"""
+        current_time = pd.Timestamp.now()
+        valid_df = pd.DataFrame({
+            "driver_id": [1001, 1002],
+            "event_timestamp": [current_time] * 2,
+            "created": [current_time] * 2,
+            "conv_rate": [0.5, 0.7],
+            "acc_rate": [0.8, 0.9],
+            "avg_daily_trips": [10, 12]
+        })
+        
+        # This should not raise an exception
+        self.store.write_to_online_store(
+            feature_view_name="driver_hourly_stats", df=valid_df
+        )
+
+    def test_valid_dataframe_async_succeeds(self):
+        """Test that valid dataframe with feature data succeeds in async version"""
+        import asyncio
+        
+        async def test_async_valid():
+            current_time = pd.Timestamp.now()
+            valid_df = pd.DataFrame({
+                "driver_id": [1001, 1002],
+                "event_timestamp": [current_time] * 2,
+                "created": [current_time] * 2,
+                "conv_rate": [0.5, 0.7],
+                "acc_rate": [0.8, 0.9],
+                "avg_daily_trips": [10, 12]
+            })
+            
+            # This should not raise an exception
+            await self.store.write_to_online_store_async(
+                feature_view_name="driver_hourly_stats", df=valid_df
+            )
+        
+        asyncio.run(test_async_valid())
+
+    def test_mixed_dataframe_with_some_valid_features_succeeds(self):
+        """Test that dataframe with some valid feature values succeeds"""
+        current_time = pd.Timestamp.now()
+        mixed_df = pd.DataFrame({
+            "driver_id": [1001, 1002, 1003],
+            "event_timestamp": [current_time] * 3,
+            "created": [current_time] * 3,
+            "conv_rate": [0.5, None, 0.7],  # Mixed values
+            "acc_rate": [0.8, 0.9, None],   # Mixed values
+            "avg_daily_trips": [10, 12, 15]  # All valid
+        })
+        
+        # This should not raise an exception because not all feature values are null
+        self.store.write_to_online_store(
+            feature_view_name="driver_hourly_stats", df=mixed_df
+        )
+
+    def test_empty_inputs_dict_raises_error(self):
+        """Test that empty inputs dict raises ValueError"""
+        empty_inputs = {
+            "driver_id": [],
+            "conv_rate": [],
+            "acc_rate": [],
+            "avg_daily_trips": []
+        }
+        
+        with self.assertRaises(ValueError) as context:
+            self.store.write_to_online_store(
+                feature_view_name="driver_hourly_stats", inputs=empty_inputs
+            )
+        
+        self.assertIn("Cannot write empty dataframe to online store", str(context.exception))
+
+    def test_inputs_dict_with_empty_features_raises_error(self):
+        """Test that inputs dict with empty feature values raises ValueError"""
+        current_time = pd.Timestamp.now()
+        empty_feature_inputs = {
+            "driver_id": [1001, 1002, 1003],
+            "event_timestamp": [current_time] * 3,
+            "created": [current_time] * 3,
+            "conv_rate": [None, None, None],
+            "acc_rate": [None, None, None],
+            "avg_daily_trips": [None, None, None]
+        }
+        
+        with self.assertRaises(ValueError) as context:
+            self.store.write_to_online_store(
+                feature_view_name="driver_hourly_stats", inputs=empty_feature_inputs
+            )
+        
+        self.assertIn("Cannot write dataframe with empty feature columns to online store", str(context.exception))
+
+
 class TestOnlineWritesWithTransform(unittest.TestCase):
     def test_transform_on_write_pdf(self):
         with tempfile.TemporaryDirectory() as data_dir:

--- a/sdk/python/tests/unit/online_store/test_online_writes.py
+++ b/sdk/python/tests/unit/online_store/test_online_writes.py
@@ -15,6 +15,7 @@
 import os
 import tempfile
 import unittest
+import warnings
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -208,39 +209,47 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
 
         shutil.rmtree(self.data_dir)
 
-    def test_empty_dataframe_raises_error(self):
-        """Test that completely empty dataframe raises ValueError"""
+    def test_empty_dataframe_warns(self):
+        """Test that completely empty dataframe warns"""
         empty_df = pd.DataFrame()
 
-        with self.assertRaises(ValueError) as context:
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
             self.store.write_to_online_store(
                 feature_view_name="driver_hourly_stats", df=empty_df
             )
 
-        self.assertIn(
-            "Cannot write empty dataframe to online store", str(context.exception)
+        # Check that our specific warning message is present
+        warning_messages = [str(w.message) for w in warning_list]
+        self.assertTrue(
+            any("Cannot write empty dataframe to online store" in msg for msg in warning_messages),
+            f"Expected warning not found. Actual warnings: {warning_messages}"
         )
 
-    def test_empty_dataframe_async_raises_error(self):
-        """Test that completely empty dataframe raises ValueError in async version"""
+    def test_empty_dataframe_async_warns(self):
+        """Test that completely empty dataframe warns instead of raising error in async version"""
         import asyncio
 
         async def test_async_empty():
             empty_df = pd.DataFrame()
 
-            with self.assertRaises(ValueError) as context:
+            with warnings.catch_warnings(record=True) as warning_list:
+                warnings.simplefilter("always")
                 await self.store.write_to_online_store_async(
                     feature_view_name="driver_hourly_stats", df=empty_df
                 )
 
-            self.assertIn(
-                "Cannot write empty dataframe to online store", str(context.exception)
+            # Check that our specific warning message is present
+            warning_messages = [str(w.message) for w in warning_list]
+            self.assertTrue(
+                any("Cannot write empty dataframe to online store" in msg for msg in warning_messages),
+                f"Expected warning not found. Actual warnings: {warning_messages}"
             )
 
         asyncio.run(test_async_empty())
 
-    def test_dataframe_with_empty_feature_columns_raises_error(self):
-        """Test that dataframe with entity data but empty feature columns raises ValueError"""
+    def test_dataframe_with_empty_feature_columns_warns(self):
+        """Test that dataframe with entity data but empty feature columns warns instead of raising error"""
         current_time = pd.Timestamp.now()
         df_with_entity_only = pd.DataFrame(
             {
@@ -253,18 +262,21 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
             }
         )
 
-        with self.assertRaises(ValueError) as context:
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
             self.store.write_to_online_store(
                 feature_view_name="driver_hourly_stats", df=df_with_entity_only
             )
 
-        self.assertIn(
-            "Cannot write dataframe with empty feature columns to online store",
-            str(context.exception),
+        # Check that our specific warning message is present
+        warning_messages = [str(w.message) for w in warning_list]
+        self.assertTrue(
+            any("Cannot write dataframe with empty feature columns to online store" in msg for msg in warning_messages),
+            f"Expected warning not found. Actual warnings: {warning_messages}"
         )
 
-    def test_dataframe_with_empty_feature_columns_async_raises_error(self):
-        """Test that dataframe with entity data but empty feature columns raises ValueError in async version"""
+    def test_dataframe_with_empty_feature_columns_async_warns(self):
+        """Test that dataframe with entity data but empty feature columns warns instead of raising error in async version"""
         import asyncio
 
         async def test_async_empty_features():
@@ -280,14 +292,17 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
                 }
             )
 
-            with self.assertRaises(ValueError) as context:
+            with warnings.catch_warnings(record=True) as warning_list:
+                warnings.simplefilter("always")
                 await self.store.write_to_online_store_async(
                     feature_view_name="driver_hourly_stats", df=df_with_entity_only
                 )
 
-            self.assertIn(
-                "Cannot write dataframe with empty feature columns to online store",
-                str(context.exception),
+            # Check that our specific warning message is present
+            warning_messages = [str(w.message) for w in warning_list]
+            self.assertTrue(
+                any("Cannot write dataframe with empty feature columns to online store" in msg for msg in warning_messages),
+                f"Expected warning not found. Actual warnings: {warning_messages}"
             )
 
         asyncio.run(test_async_empty_features())
@@ -358,8 +373,8 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
             feature_view_name="driver_hourly_stats", df=mixed_df
         )
 
-    def test_empty_inputs_dict_raises_error(self):
-        """Test that empty inputs dict raises ValueError"""
+    def test_empty_inputs_dict_warns(self):
+        """Test that empty inputs dict warns instead of raising error"""
         empty_inputs = {
             "driver_id": [],
             "conv_rate": [],
@@ -367,17 +382,21 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
             "avg_daily_trips": [],
         }
 
-        with self.assertRaises(ValueError) as context:
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
             self.store.write_to_online_store(
                 feature_view_name="driver_hourly_stats", inputs=empty_inputs
             )
 
-        self.assertIn(
-            "Cannot write empty dataframe to online store", str(context.exception)
-        )
+            # Check that our specific warning message is present
+            warning_messages = [str(w.message) for w in warning_list]
+            self.assertTrue(
+                any("Cannot write empty dataframe to online store" in msg for msg in warning_messages),
+                f"Expected warning not found. Actual warnings: {warning_messages}"
+            )
 
-    def test_inputs_dict_with_empty_features_raises_error(self):
-        """Test that inputs dict with empty feature values raises ValueError"""
+    def test_inputs_dict_with_empty_features_warns(self):
+        """Test that inputs dict with empty feature values warns instead of raising error"""
         current_time = pd.Timestamp.now()
         empty_feature_inputs = {
             "driver_id": [1001, 1002, 1003],
@@ -388,14 +407,16 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
             "avg_daily_trips": [None, None, None],
         }
 
-        with self.assertRaises(ValueError) as context:
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
             self.store.write_to_online_store(
                 feature_view_name="driver_hourly_stats", inputs=empty_feature_inputs
             )
 
+        self.assertEqual(len(warning_list), 1)
         self.assertIn(
             "Cannot write dataframe with empty feature columns to online store",
-            str(context.exception),
+            str(warning_list[0].message),
         )
 
 

--- a/sdk/python/tests/unit/online_store/test_online_writes.py
+++ b/sdk/python/tests/unit/online_store/test_online_writes.py
@@ -127,10 +127,6 @@ class TestOnlineWrites(unittest.TestCase):
                 inputs=driver_dict,
             )
 
-    def tearDown(self):
-        import shutil
-        shutil.rmtree(self.data_dir)
-
     def test_online_retrieval(self):
         entity_rows = [
             {

--- a/sdk/python/tests/unit/online_store/test_online_writes.py
+++ b/sdk/python/tests/unit/online_store/test_online_writes.py
@@ -175,13 +175,9 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
         start_date = end_date - timedelta(days=1)
 
         driver_entities = [1001]
-        driver_df = create_driver_hourly_stats_df(
-            driver_entities, start_date, end_date
-        )
+        driver_df = create_driver_hourly_stats_df(driver_entities, start_date, end_date)
         driver_stats_path = os.path.join(self.data_dir, "driver_stats.parquet")
-        driver_df.to_parquet(
-            path=driver_stats_path, allow_truncated_timestamps=True
-        )
+        driver_df.to_parquet(path=driver_stats_path, allow_truncated_timestamps=True)
 
         driver = Entity(name="driver", join_keys=["driver_id"])
 
@@ -209,90 +205,107 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self.data_dir)
 
     def test_empty_dataframe_raises_error(self):
         """Test that completely empty dataframe raises ValueError"""
         empty_df = pd.DataFrame()
-        
+
         with self.assertRaises(ValueError) as context:
             self.store.write_to_online_store(
                 feature_view_name="driver_hourly_stats", df=empty_df
             )
-        
-        self.assertIn("Cannot write empty dataframe to online store", str(context.exception))
+
+        self.assertIn(
+            "Cannot write empty dataframe to online store", str(context.exception)
+        )
 
     def test_empty_dataframe_async_raises_error(self):
         """Test that completely empty dataframe raises ValueError in async version"""
         import asyncio
-        
+
         async def test_async_empty():
             empty_df = pd.DataFrame()
-            
+
             with self.assertRaises(ValueError) as context:
                 await self.store.write_to_online_store_async(
                     feature_view_name="driver_hourly_stats", df=empty_df
                 )
-            
-            self.assertIn("Cannot write empty dataframe to online store", str(context.exception))
-        
+
+            self.assertIn(
+                "Cannot write empty dataframe to online store", str(context.exception)
+            )
+
         asyncio.run(test_async_empty())
 
     def test_dataframe_with_empty_feature_columns_raises_error(self):
         """Test that dataframe with entity data but empty feature columns raises ValueError"""
         current_time = pd.Timestamp.now()
-        df_with_entity_only = pd.DataFrame({
-            "driver_id": [1001, 1002, 1003],
-            "event_timestamp": [current_time] * 3,
-            "created": [current_time] * 3,
-            "conv_rate": [None, None, None],  # All nulls
-            "acc_rate": [None, None, None],   # All nulls
-            "avg_daily_trips": [None, None, None]  # All nulls
-        })
-        
+        df_with_entity_only = pd.DataFrame(
+            {
+                "driver_id": [1001, 1002, 1003],
+                "event_timestamp": [current_time] * 3,
+                "created": [current_time] * 3,
+                "conv_rate": [None, None, None],  # All nulls
+                "acc_rate": [None, None, None],  # All nulls
+                "avg_daily_trips": [None, None, None],  # All nulls
+            }
+        )
+
         with self.assertRaises(ValueError) as context:
             self.store.write_to_online_store(
                 feature_view_name="driver_hourly_stats", df=df_with_entity_only
             )
-        
-        self.assertIn("Cannot write dataframe with empty feature columns to online store", str(context.exception))
+
+        self.assertIn(
+            "Cannot write dataframe with empty feature columns to online store",
+            str(context.exception),
+        )
 
     def test_dataframe_with_empty_feature_columns_async_raises_error(self):
         """Test that dataframe with entity data but empty feature columns raises ValueError in async version"""
         import asyncio
-        
+
         async def test_async_empty_features():
             current_time = pd.Timestamp.now()
-            df_with_entity_only = pd.DataFrame({
-                "driver_id": [1001, 1002, 1003],
-                "event_timestamp": [current_time] * 3,
-                "created": [current_time] * 3,
-                "conv_rate": [None, None, None],
-                "acc_rate": [None, None, None],
-                "avg_daily_trips": [None, None, None]
-            })
-            
+            df_with_entity_only = pd.DataFrame(
+                {
+                    "driver_id": [1001, 1002, 1003],
+                    "event_timestamp": [current_time] * 3,
+                    "created": [current_time] * 3,
+                    "conv_rate": [None, None, None],
+                    "acc_rate": [None, None, None],
+                    "avg_daily_trips": [None, None, None],
+                }
+            )
+
             with self.assertRaises(ValueError) as context:
                 await self.store.write_to_online_store_async(
                     feature_view_name="driver_hourly_stats", df=df_with_entity_only
                 )
-            
-            self.assertIn("Cannot write dataframe with empty feature columns to online store", str(context.exception))
-        
+
+            self.assertIn(
+                "Cannot write dataframe with empty feature columns to online store",
+                str(context.exception),
+            )
+
         asyncio.run(test_async_empty_features())
 
     def test_valid_dataframe(self):
         """Test that valid dataframe with feature data succeeds"""
         current_time = pd.Timestamp.now()
-        valid_df = pd.DataFrame({
-            "driver_id": [1001, 1002],
-            "event_timestamp": [current_time] * 2,
-            "created": [current_time] * 2,
-            "conv_rate": [0.5, 0.7],
-            "acc_rate": [0.8, 0.9],
-            "avg_daily_trips": [10, 12]
-        })
-        
+        valid_df = pd.DataFrame(
+            {
+                "driver_id": [1001, 1002],
+                "event_timestamp": [current_time] * 2,
+                "created": [current_time] * 2,
+                "conv_rate": [0.5, 0.7],
+                "acc_rate": [0.8, 0.9],
+                "avg_daily_trips": [10, 12],
+            }
+        )
+
         # This should not raise an exception
         self.store.write_to_online_store(
             feature_view_name="driver_hourly_stats", df=valid_df
@@ -301,40 +314,45 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
     def test_valid_dataframe_async(self):
         """Test that valid dataframe with feature data succeeds in async version"""
         import asyncio
+
         import pytest
-        
+
         pytest.skip("Feature not implemented yet")
-        
+
         async def test_async_valid():
             current_time = pd.Timestamp.now()
-            valid_df = pd.DataFrame({
-                "driver_id": [1001, 1002],
-                "event_timestamp": [current_time] * 2,
-                "created": [current_time] * 2,
-                "conv_rate": [0.5, 0.7],
-                "acc_rate": [0.8, 0.9],
-                "avg_daily_trips": [10, 12]
-            })
-            
+            valid_df = pd.DataFrame(
+                {
+                    "driver_id": [1001, 1002],
+                    "event_timestamp": [current_time] * 2,
+                    "created": [current_time] * 2,
+                    "conv_rate": [0.5, 0.7],
+                    "acc_rate": [0.8, 0.9],
+                    "avg_daily_trips": [10, 12],
+                }
+            )
+
             # This should not raise an exception
             await self.store.write_to_online_store_async(
                 feature_view_name="driver_hourly_stats", df=valid_df
             )
-        
+
         asyncio.run(test_async_valid())
 
     def test_mixed_dataframe_with_some_valid_features(self):
         """Test that dataframe with some valid feature values succeeds"""
         current_time = pd.Timestamp.now()
-        mixed_df = pd.DataFrame({
-            "driver_id": [1001, 1002, 1003],
-            "event_timestamp": [current_time] * 3,
-            "created": [current_time] * 3,
-            "conv_rate": [0.5, None, 0.7],  # Mixed values
-            "acc_rate": [0.8, 0.9, None],   # Mixed values
-            "avg_daily_trips": [10, 12, 15]  # All valid
-        })
-        
+        mixed_df = pd.DataFrame(
+            {
+                "driver_id": [1001, 1002, 1003],
+                "event_timestamp": [current_time] * 3,
+                "created": [current_time] * 3,
+                "conv_rate": [0.5, None, 0.7],  # Mixed values
+                "acc_rate": [0.8, 0.9, None],  # Mixed values
+                "avg_daily_trips": [10, 12, 15],  # All valid
+            }
+        )
+
         # This should not raise an exception because not all feature values are null
         self.store.write_to_online_store(
             feature_view_name="driver_hourly_stats", df=mixed_df
@@ -346,15 +364,17 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
             "driver_id": [],
             "conv_rate": [],
             "acc_rate": [],
-            "avg_daily_trips": []
+            "avg_daily_trips": [],
         }
-        
+
         with self.assertRaises(ValueError) as context:
             self.store.write_to_online_store(
                 feature_view_name="driver_hourly_stats", inputs=empty_inputs
             )
-        
-        self.assertIn("Cannot write empty dataframe to online store", str(context.exception))
+
+        self.assertIn(
+            "Cannot write empty dataframe to online store", str(context.exception)
+        )
 
     def test_inputs_dict_with_empty_features_raises_error(self):
         """Test that inputs dict with empty feature values raises ValueError"""
@@ -365,15 +385,18 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
             "created": [current_time] * 3,
             "conv_rate": [None, None, None],
             "acc_rate": [None, None, None],
-            "avg_daily_trips": [None, None, None]
+            "avg_daily_trips": [None, None, None],
         }
-        
+
         with self.assertRaises(ValueError) as context:
             self.store.write_to_online_store(
                 feature_view_name="driver_hourly_stats", inputs=empty_feature_inputs
             )
-        
-        self.assertIn("Cannot write dataframe with empty feature columns to online store", str(context.exception))
+
+        self.assertIn(
+            "Cannot write dataframe with empty feature columns to online store",
+            str(context.exception),
+        )
 
 
 class TestOnlineWritesWithTransform(unittest.TestCase):

--- a/sdk/python/tests/unit/online_store/test_online_writes.py
+++ b/sdk/python/tests/unit/online_store/test_online_writes.py
@@ -222,8 +222,11 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
         # Check that our specific warning message is present
         warning_messages = [str(w.message) for w in warning_list]
         self.assertTrue(
-            any("Cannot write empty dataframe to online store" in msg for msg in warning_messages),
-            f"Expected warning not found. Actual warnings: {warning_messages}"
+            any(
+                "Cannot write empty dataframe to online store" in msg
+                for msg in warning_messages
+            ),
+            f"Expected warning not found. Actual warnings: {warning_messages}",
         )
 
     def test_empty_dataframe_async_warns(self):
@@ -242,8 +245,11 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
             # Check that our specific warning message is present
             warning_messages = [str(w.message) for w in warning_list]
             self.assertTrue(
-                any("Cannot write empty dataframe to online store" in msg for msg in warning_messages),
-                f"Expected warning not found. Actual warnings: {warning_messages}"
+                any(
+                    "Cannot write empty dataframe to online store" in msg
+                    for msg in warning_messages
+                ),
+                f"Expected warning not found. Actual warnings: {warning_messages}",
             )
 
         asyncio.run(test_async_empty())
@@ -271,8 +277,12 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
         # Check that our specific warning message is present
         warning_messages = [str(w.message) for w in warning_list]
         self.assertTrue(
-            any("Cannot write dataframe with empty feature columns to online store" in msg for msg in warning_messages),
-            f"Expected warning not found. Actual warnings: {warning_messages}"
+            any(
+                "Cannot write dataframe with empty feature columns to online store"
+                in msg
+                for msg in warning_messages
+            ),
+            f"Expected warning not found. Actual warnings: {warning_messages}",
         )
 
     def test_dataframe_with_empty_feature_columns_async_warns(self):
@@ -301,8 +311,12 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
             # Check that our specific warning message is present
             warning_messages = [str(w.message) for w in warning_list]
             self.assertTrue(
-                any("Cannot write dataframe with empty feature columns to online store" in msg for msg in warning_messages),
-                f"Expected warning not found. Actual warnings: {warning_messages}"
+                any(
+                    "Cannot write dataframe with empty feature columns to online store"
+                    in msg
+                    for msg in warning_messages
+                ),
+                f"Expected warning not found. Actual warnings: {warning_messages}",
             )
 
         asyncio.run(test_async_empty_features())
@@ -391,8 +405,11 @@ class TestEmptyDataFrameValidation(unittest.TestCase):
             # Check that our specific warning message is present
             warning_messages = [str(w.message) for w in warning_list]
             self.assertTrue(
-                any("Cannot write empty dataframe to online store" in msg for msg in warning_messages),
-                f"Expected warning not found. Actual warnings: {warning_messages}"
+                any(
+                    "Cannot write empty dataframe to online store" in msg
+                    for msg in warning_messages
+                ),
+                f"Expected warning not found. Actual warnings: {warning_messages}",
             )
 
     def test_inputs_dict_with_empty_features_warns(self):

--- a/sdk/python/tests/utils/test_wrappers.py
+++ b/sdk/python/tests/utils/test_wrappers.py
@@ -12,3 +12,106 @@ def no_warnings(func):
             )
 
     return wrapper_no_warnings
+
+
+def check_warnings(
+    expected_warnings=None,  # List of warnings that MUST be present
+    forbidden_warnings=None,  # List of warnings that MUST NOT be present
+    match_type="contains",  # "exact", "contains", "regex"
+    capture_all=True,  # Capture all warnings or just specific types
+    fail_on_unexpected=False,  # Fail if unexpected warnings appear
+    min_count=None,  # Minimum number of expected warnings
+    max_count=None,  # Maximum number of expected warnings
+):
+    """
+    Decorator to automatically capture and validate warnings in test methods.
+
+    Args:
+        expected_warnings: List of warning messages that MUST be present
+        forbidden_warnings: List of warning messages that MUST NOT be present
+        match_type: How to match warnings ("exact", "contains", "regex")
+        capture_all: Whether to capture all warnings
+        fail_on_unexpected: Whether to fail if unexpected warnings appear
+        min_count: Minimum number of warnings expected
+        max_count: Maximum number of warnings expected
+    """
+
+    def decorator(test_func):
+        def wrapper(*args, **kwargs):
+            # Setup warning capture
+            with warnings.catch_warnings(record=True) as warning_list:
+                warnings.simplefilter("always")
+
+                # Execute the test function
+                result = test_func(*args, **kwargs)
+
+                # Convert warnings to string messages
+                captured_messages = [str(w.message) for w in warning_list]
+
+                # Validate expected warnings are present
+                if expected_warnings:
+                    for expected_warning in expected_warnings:
+                        if not _warning_matches(
+                            expected_warning, captured_messages, match_type
+                        ):
+                            raise AssertionError(
+                                f"Expected warning '{expected_warning}' not found. "
+                                f"Captured warnings: {captured_messages}"
+                            )
+
+                # Validate forbidden warnings are NOT present
+                if forbidden_warnings:
+                    for forbidden_warning in forbidden_warnings:
+                        if _warning_matches(
+                            forbidden_warning, captured_messages, match_type
+                        ):
+                            raise AssertionError(
+                                f"Forbidden warning '{forbidden_warning}' was found. "
+                                f"Captured warnings: {captured_messages}"
+                            )
+
+                # Validate warning count constraints
+                if min_count is not None and len(warning_list) < min_count:
+                    raise AssertionError(
+                        f"Expected at least {min_count} warnings, got {len(warning_list)}"
+                    )
+
+                if max_count is not None and len(warning_list) > max_count:
+                    raise AssertionError(
+                        f"Expected at most {max_count} warnings, got {len(warning_list)}"
+                    )
+
+                # Validate no unexpected warnings (if enabled)
+                if fail_on_unexpected and expected_warnings:
+                    all_expected = expected_warnings + (forbidden_warnings or [])
+                    for message in captured_messages:
+                        if not any(
+                            _warning_matches(exp, [message], match_type)
+                            for exp in all_expected
+                        ):
+                            raise AssertionError(
+                                f"Unexpected warning found: '{message}'"
+                            )
+
+                return result
+
+        return wrapper
+
+    return decorator
+
+
+def _warning_matches(pattern, messages, match_type):
+    """Helper function to check if pattern matches any message"""
+    for message in messages:
+        if match_type == "exact":
+            if pattern == message:
+                return True
+        elif match_type == "contains":
+            if pattern in message:
+                return True
+        elif match_type == "regex":
+            import re
+
+            if re.search(pattern, message):
+                return True
+    return False


### PR DESCRIPTION
# What this PR does / why we need it:

Adds validation to `write_to_online_store` and `write_to_online_store_async` to prevent empty dataframes from being written to the online store.

**Changes:**
- Validates completely empty dataframes 
- Validates dataframes with entity data but empty feature columns
- Works with both `df` and `inputs` parameters
- Throws descriptive `ValueError` messages

# Which issue(s) this PR fixes:
[RHOAIENG-27681](https://issues.redhat.com/browse/RHOAIENG-27681)

# Misc

Added comprehensive unit tests in `TestEmptyDataFrameValidation` class. 