### PR TITLE
fix: Standalone Web UI Publish Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,11 @@ on:
         required: true
         default: ""
         type: string
+      publish_ui:
+        description: 'Publish to NPM?'
+        required: true
+        default: true
+        type: boolean
   workflow_call: # Allows trigger the workflow from other workflow
     inputs:
       custom_version: # Optional input for a custom version
@@ -26,6 +31,11 @@ on:
         required: true
         default: ""
         type: string
+      publish_ui:
+        description: 'Publish to NPM?'
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   publish-python-sdk:
@@ -50,3 +60,12 @@ jobs:
     with:
       custom_version: ${{ github.event.inputs.custom_version }}
       token: ${{ github.event.inputs.token }}
+
+  publish-web-ui:
+    uses: ./.github/workflows/publish_web_ui.yml
+    needs: [ publish-python-sdk ]
+    secrets: inherit
+    with:
+      custom_version: ${{ github.event.inputs.custom_version }}
+      token: ${{ github.event.inputs.token || github.token }}
+      publish_ui: ${{ github.event.inputs.publish_ui != 'false' }}

--- a/.github/workflows/publish_web_ui.yml
+++ b/.github/workflows/publish_web_ui.yml
@@ -1,0 +1,72 @@
+name: publish web ui
+
+on:
+  workflow_dispatch: # Allows manual trigger of the workflow
+    inputs:
+      custom_version: # Optional input for a custom version
+        description: 'Custom version to publish (e.g., v1.2.3) -- only edit if you know what you are doing'
+        required: false
+        type: string
+      token:
+        description: 'Personal Access Token'
+        required: true
+        default: ""
+        type: string
+      publish_ui:
+        description: 'Publish to NPM?'
+        required: true
+        default: true
+        type: boolean
+  workflow_call: # Allows trigger of the workflow from another workflow
+    inputs:
+      custom_version: # Optional input for a custom version
+        description: 'Custom version to publish (e.g., v1.2.3) -- only edit if you know what you are doing'
+        required: false
+        type: string
+      token:
+        description: 'Personal Access Token'
+        required: true
+        default: ""
+        type: string
+      publish_ui:
+        description: 'Publish to NPM?'
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  publish-web-ui-npm:
+    if: github.repository == 'feast-dev/feast'
+    runs-on: ubuntu-latest
+    env:
+      # This publish is working using an NPM automation token to bypass 2FA
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: get-version
+        uses: ./.github/actions/get-semantic-release-version
+        with:
+          custom_version: ${{ github.event.inputs.custom_version }}
+          token: ${{ github.event.inputs.token || github.token }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: './ui/.nvmrc'
+      - name: Bump file versions (temporarily for Web UI publish)
+        env:
+          CURRENT_VERSION: ${{ steps.get-version.outputs.current_version }}
+          NEXT_VERSION: ${{ steps.get-version.outputs.version_without_prefix }}
+        run: python ./infra/scripts/release/bump_file_versions.py ${CURRENT_VERSION} ${NEXT_VERSION}
+      - name: Install yarn dependencies
+        working-directory: ./ui
+        run: yarn install
+      - name: Build yarn rollup
+        working-directory: ./ui
+        run: yarn build:lib
+      - name: Publish UI package
+        working-directory: ./ui
+        if: github.event.inputs.publish_ui != 'false'
+        run: npm publish
+        env:
+          # This publish is working using an NPM automation token to bypass 2FA
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,40 +112,10 @@ jobs:
       - name: Build & version operator-specific release files
         run: make -C infra/feast-operator build-installer bundle
 
-  publish-web-ui-npm:
-    needs: [ validate_version_bumps, get_dry_release_versions ]
-    runs-on: ubuntu-latest
-    env:
-      # This publish is working using an NPM automation token to bypass 2FA
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      CURRENT_VERSION: ${{ needs.get_dry_release_versions.outputs.current_version }}
-      NEXT_VERSION: ${{ needs.get_dry_release_versions.outputs.next_version }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: './ui/.nvmrc'
-      - name: Bump file versions (temporarily for Web UI publish)
-        run: python ./infra/scripts/release/bump_file_versions.py ${CURRENT_VERSION} ${NEXT_VERSION}
-      - name: Install yarn dependencies
-        working-directory: ./ui
-        run: yarn install
-      - name: Build yarn rollup
-        working-directory: ./ui
-        run: yarn build:lib
-      - name: Publish UI package
-        working-directory: ./ui
-        if: github.event.inputs.dry_run == 'false' && github.event.inputs.publish_ui == 'true'
-        run: npm publish
-        env:
-          # This publish is working using an NPM automation token to bypass 2FA
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   release:
     name: release
     runs-on: ubuntu-latest
-    needs: publish-web-ui-npm
+    needs: validate_version_bumps
     env:
       GITHUB_TOKEN: ${{ github.event.inputs.token }}
       GIT_AUTHOR_NAME: feast-ci-bot


### PR DESCRIPTION
# What this PR does / why we need it:

Earlier UI npm publish was part of release workflow, while all other publish workflows were part of publish.yml. 

All publish operations now follow the same modular pattern. UI npm publishing logic is isolated and reusable and can trigger UI publishing independently or as part of releases.

