### PR TITLE
fix: Fix current version in publish workflow

### DIFF
--- a/.github/workflows/publish_web_ui.yml
+++ b/.github/workflows/publish_web_ui.yml
@@ -54,7 +54,7 @@ jobs:
           node-version-file: './ui/.nvmrc'
       - name: Bump file versions (temporarily for Web UI publish)
         env:
-          CURRENT_VERSION: ${{ steps.get-version.outputs.current_version }}
+          CURRENT_VERSION: ${{ steps.get-version.outputs.highest_semver_tag }}
           NEXT_VERSION: ${{ steps.get-version.outputs.version_without_prefix }}
         run: python ./infra/scripts/release/bump_file_versions.py ${CURRENT_VERSION} ${NEXT_VERSION}
       - name: Install yarn dependencies


### PR DESCRIPTION
# What this PR does / why we need it:
Fix  current version on web-ui publish workflow. 

- Workflow picks up latest tag (from get_tag_release -m) if run against tagged branches.
- Always provide a custom version when running on non-tagged branches (like master).