### PR TITLE
chore: Improve version detection for UI publish

### DIFF
--- a/.github/workflows/publish_web_ui.yml
+++ b/.github/workflows/publish_web_ui.yml
@@ -3,6 +3,10 @@ name: publish web ui
 on:
   workflow_dispatch: # Allows manual trigger of the workflow
     inputs:
+      current_version:
+        description: 'Current version to bump from (e.g., v1.2.3). If not provided, will auto-detect from git tags'
+        required: false
+        type: string
       custom_version: # Optional input for a custom version
         description: 'Custom version to publish (e.g., v1.2.3) -- only edit if you know what you are doing'
         required: false
@@ -19,6 +23,10 @@ on:
         type: boolean
   workflow_call: # Allows trigger of the workflow from another workflow
     inputs:
+      current_version:
+        description: 'Current version to bump from (e.g., v1.2.3). If not provided, will auto-detect from git tags'
+        required: false
+        type: string
       custom_version: # Optional input for a custom version
         description: 'Custom version to publish (e.g., v1.2.3) -- only edit if you know what you are doing'
         required: false
@@ -43,11 +51,60 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - id: get-current-version
+      - name: Determine current version
+        id: get-current-version
         if: github.event.inputs.custom_version != ''
-        uses: ./.github/actions/get-semantic-release-version
-        with:
-          token: ${{ github.event.inputs.token || github.token }}
+        shell: bash
+        run: |
+          if [[ -n "${{ github.event.inputs.current_version }}" ]]; then
+            # Use provided current version
+            CURRENT_VERSION_RAW="${{ github.event.inputs.current_version }}"
+            echo "Using provided current version: $CURRENT_VERSION_RAW"
+            
+          else
+            # Auto-detect current version from git tags
+            echo "No current version provided, auto-detecting from git tags..."
+            source infra/scripts/setup-common-functions.sh
+            
+            if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+              # If running from a tag, get the previous tag
+              CURRENT_TAG="${GITHUB_REF#refs/tags/}"
+              echo "Running from tag: $CURRENT_TAG"
+              
+              # Get all tags, sort them, find the one before current tag
+              PREVIOUS_TAG=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | grep -B1 "^${CURRENT_TAG}$" | head -1)
+              
+              if [[ -z "$PREVIOUS_TAG" ]]; then
+                echo "Error: Could not find previous version before $CURRENT_TAG"
+                exit 1
+              fi
+              
+              echo "Found previous version: $PREVIOUS_TAG"
+              CURRENT_VERSION_RAW="$PREVIOUS_TAG"
+              
+            else
+              # If running from branch, get the latest released version
+              LATEST_TAG=$(get_tag_release -s)
+              
+              if [[ -z "$LATEST_TAG" ]]; then
+                echo "Error: No semantic version tags found in repository"
+                exit 1
+              fi
+              
+              echo "Latest released version: $LATEST_TAG"
+              CURRENT_VERSION_RAW="$LATEST_TAG"
+            fi
+          fi
+          
+          # Remove 'v' prefix once at the end if present
+          if [[ "$CURRENT_VERSION_RAW" =~ ^v ]]; then
+            CURRENT_VERSION="${CURRENT_VERSION_RAW:1}"
+          else
+            CURRENT_VERSION="$CURRENT_VERSION_RAW"
+          fi
+          
+          echo "version_without_prefix=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "Final current version (without prefix): $CURRENT_VERSION"
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -57,7 +114,7 @@ jobs:
         env:
           CUSTOM_VERSION: ${{ github.event.inputs.custom_version }}
         run: |
-          # Get current version from action output (already normalized without 'v' prefix)
+          # Get current version from previous step
           CURRENT_VERSION="${{ steps.get-current-version.outputs.version_without_prefix }}"
           
           # Normalize custom version (next version) by removing 'v' prefix if present
@@ -66,7 +123,7 @@ jobs:
             NEXT_VERSION="${NEXT_VERSION:1}"
           fi
           
-          echo "Using current version from action: $CURRENT_VERSION"
+          echo "Using current version: $CURRENT_VERSION"
           echo "Using next version (custom): $NEXT_VERSION"
           python ./infra/scripts/release/bump_file_versions.py ${CURRENT_VERSION} ${NEXT_VERSION}
       - name: Install yarn dependencies


### PR DESCRIPTION
# What this PR does / why we need it:

The problem with current code is workflow is not able to identify current version if run from master or any other branch.
 
This PR will allow us to do standalone and hotfix releases of UI and identify the tags smartly. 


## **How It Works Now:**

| Source | Version Detection | Effective Version Used |
|--------|-------------------|------------------------|
| From master + `current_version="v1.2.3"` | Provided | Uses "1.2.3" |
| From master + no `current_version` | Auto-detect | Uses latest released tag (e.g., "1.2.3") |
| From tag `v1.2.4` + `current_version="v1.2.3"` | Provided | Uses "1.2.3" |
| From tag `v1.2.4` + no `current_version` | Auto-detect | Finds previous tag before `v1.2.4` |



