### PR TITLE
fix: Fix NPM authentication

### DIFF
--- a/.github/workflows/publish_web_ui.yml
+++ b/.github/workflows/publish_web_ui.yml
@@ -109,6 +109,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: './ui/.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
       - name: Bump file versions (temporarily for Web UI publish)
         if: github.event.inputs.custom_version != ''
         env:
@@ -138,4 +139,4 @@ jobs:
         run: npm publish
         env:
           # This publish is working using an NPM automation token to bypass 2FA
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} 
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 


### PR DESCRIPTION


# What this PR does / why we need it:

Fixes npm auth issue. Newer `setup-node@v3` +` Node 16+` version requires : 

1. Setup Node with registry-url: registry-url: 'https://registry.npmjs.org'
2. Use NODE_AUTH_TOKEN: `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`