### PR TITLE
feat: Provide ready-to-use Python definitions in api

### DIFF
--- a/sdk/python/feast/api/registry/rest/codegen_utils.py
+++ b/sdk/python/feast/api/registry/rest/codegen_utils.py
@@ -1,0 +1,51 @@
+import logging
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+
+def render_template(template_name, context):
+    template_dir = Path(__file__).parent / "templates"
+    env = Environment(
+        loader=FileSystemLoader(str(template_dir)), trim_blocks=True, lstrip_blocks=True
+    )
+    template = env.get_template(template_name)
+    try:
+        return template.render(**context)
+    except Exception as e:
+        logging.warning(
+            f"Failed to render template {template_name} for {context.get('name', 'unknown')}: {e}"
+        )
+        return ""
+
+
+def render_feature_view_code(context):
+    return render_template("feature_view_template.jinja2", context)
+
+
+def render_entity_code(context):
+    return render_template("entity_template.jinja2", context)
+
+
+def render_data_source_code(context):
+    return render_template("data_source_template.jinja2", context)
+
+
+def render_feature_service_code(context):
+    return render_template("feature_service_template.jinja2", context)
+
+
+def render_feature_code(context):
+    return render_template("feature_template.jinja2", context)
+
+
+def render_saved_dataset_code(context):
+    return render_template("saved_dataset_template.jinja2", context)
+
+
+def render_request_source_code(context):
+    return render_template("request_source_template.jinja2", context)
+
+
+def render_push_source_code(context):
+    return render_template("push_source_template.jinja2", context)

--- a/sdk/python/feast/api/registry/rest/entities.py
+++ b/sdk/python/feast/api/registry/rest/entities.py
@@ -2,6 +2,7 @@ import logging
 
 from fastapi import APIRouter, Depends, Query
 
+from feast.api.registry.rest.codegen_utils import render_entity_code
 from feast.api.registry.rest.rest_utils import (
     aggregate_across_projects,
     create_grpc_pagination_params,
@@ -101,6 +102,20 @@ def get_entity_router(grpc_handler) -> APIRouter:
             )
             result["relationships"] = relationships
 
+        if result:
+            spec = result.get("spec", result)
+            name = spec.get("name") or result.get("name") or "default_entity"
+            join_keys = spec.get("joinKeys") or (
+                [spec["joinKey"]] if "joinKey" in spec else []
+            )
+
+            context = {
+                "name": name,
+                "join_keys": join_keys,
+                "description": spec.get("description", ""),
+                "tags": spec.get("tags", {}),
+            }
+            result["featureDefinition"] = render_entity_code(context)
         return result
 
     return router

--- a/sdk/python/feast/api/registry/rest/features.py
+++ b/sdk/python/feast/api/registry/rest/features.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, Query
 
+from feast.api.registry.rest.codegen_utils import render_feature_code
 from feast.api.registry.rest.rest_utils import (
     aggregate_across_projects,
     create_grpc_pagination_params,
@@ -11,6 +12,8 @@ from feast.api.registry.rest.rest_utils import (
     grpc_call,
 )
 from feast.registry_server import RegistryServer_pb2
+from feast.type_map import _convert_value_type_str_to_value_type
+from feast.types import from_value_type
 
 
 def get_feature_router(grpc_handler) -> APIRouter:
@@ -65,6 +68,26 @@ def get_feature_router(grpc_handler) -> APIRouter:
             response["relationships"] = get_object_relationships(
                 grpc_handler, "feature", name, project
             )
+        if response:
+            dtype_str = response.get("type") or response.get("dtype")
+            value_type_enum = (
+                _convert_value_type_str_to_value_type(dtype_str.upper())
+                if dtype_str
+                else None
+            )
+            feast_type = from_value_type(value_type_enum) if value_type_enum else None
+            dtype = (
+                feast_type.__name__
+                if feast_type and hasattr(feast_type, "__name__")
+                else "String"
+            )
+            context = dict(
+                name=response.get("name", name),
+                dtype=dtype,
+                description=response.get("description", ""),
+                tags=response.get("tags", response.get("labels", {})) or {},
+            )
+            response["featureDefinition"] = render_feature_code(context)
         return response
 
     @router.get("/features/all")

--- a/sdk/python/feast/api/registry/rest/templates/data_source_template.jinja2
+++ b/sdk/python/feast/api/registry/rest/templates/data_source_template.jinja2
@@ -1,0 +1,8 @@
+from feast import FileSource
+
+{{ name }} = FileSource(
+    name="{{ name }}",
+    path="{{ path }}",
+    timestamp_field="{{ timestamp_field }}",
+    {% if created_timestamp_column %}created_timestamp_column="{{ created_timestamp_column }}",{% endif %}
+) 

--- a/sdk/python/feast/api/registry/rest/templates/entity_template.jinja2
+++ b/sdk/python/feast/api/registry/rest/templates/entity_template.jinja2
@@ -1,0 +1,8 @@
+from feast import Entity
+
+{{ name }} = Entity(
+    name="{{ name }}",
+    join_keys={{ join_keys }}{% if description %},
+    description="{{ description }}"{% endif %}{% if tags %},
+    tags={{ tags }}{% endif %}
+) 

--- a/sdk/python/feast/api/registry/rest/templates/feature_service_template.jinja2
+++ b/sdk/python/feast/api/registry/rest/templates/feature_service_template.jinja2
@@ -1,0 +1,9 @@
+from feast import FeatureService
+
+{{ name }} = FeatureService(
+    name="{{ name }}",
+    features=[{{ features }}],
+    {% if tags %}tags={{ tags }},{% endif %}
+    {% if description %}description="{{ description }}",{% endif %}
+    {% if logging_config %}logging_config={{ logging_config }},{% endif %}
+) 

--- a/sdk/python/feast/api/registry/rest/templates/feature_template.jinja2
+++ b/sdk/python/feast/api/registry/rest/templates/feature_template.jinja2
@@ -1,0 +1,8 @@
+from feast import Feature
+
+{{ name }} = Feature(
+    name="{{ name }}",
+    dtype={{ dtype }},
+    {% if description %}description="{{ description }}",{% endif %}
+    {% if tags %}labels={{ tags }},{% endif %}
+) 

--- a/sdk/python/feast/api/registry/rest/templates/feature_view_template.jinja2
+++ b/sdk/python/feast/api/registry/rest/templates/feature_view_template.jinja2
@@ -1,0 +1,39 @@
+{# --- Imports Section --- #}
+{% set unique_types = feast_types | unique | list %}
+{% set class_imports = [class_name] %}
+{% if class_name == "OnDemandFeatureView" %}
+from feast import Field
+from feast.on_demand_feature_view import on_demand_feature_view
+import pandas as pd
+{% else %}
+from feast import Field, {{ class_name }}
+{% endif %}
+from feast.types import {{ feast_types | join(', ') }}
+
+{% if class_name == "OnDemandFeatureView" %}
+# Assumes {{ entities_str }} and {{ source_name }} are defined elsewhere in your repo
+@on_demand_feature_view(
+    sources={{ source_name }},
+    schema=[
+{% for field in schema_lines %}{{ field }}
+{% endfor %}    ],
+)
+def {{ name }}(inputs: pd.DataFrame) -> pd.DataFrame:
+    df = pd.DataFrame()
+    # Your transformation logic here
+    # Example: df["feature_name"] = inputs["source_column"]
+    return df
+{% else %}
+# Assumes {{ entities_str }} and {{ source_name }} are defined elsewhere in your repo
+{{ name }}_feature_view = {{ class_name }}(
+    name="{{ name }}",
+    entities=[{{ entities_str }}],
+    ttl={{ ttl_str }},
+    schema=[
+{% for field in schema_lines %}{{ field }}
+{% endfor %}    ],
+    online={{ online }},
+    source={{ source_name }},
+    {{ tags_str }}
+)
+{% endif %} 

--- a/sdk/python/feast/api/registry/rest/templates/push_source_template.jinja2
+++ b/sdk/python/feast/api/registry/rest/templates/push_source_template.jinja2
@@ -1,0 +1,6 @@
+from feast import PushSource
+
+{{ name }} = PushSource(
+    name="{{ name }}",
+    batch_source={{ batch_source_name }},
+) 

--- a/sdk/python/feast/api/registry/rest/templates/request_source_template.jinja2
+++ b/sdk/python/feast/api/registry/rest/templates/request_source_template.jinja2
@@ -1,0 +1,9 @@
+from feast import RequestSource, Field
+from feast.types import {{ feast_types | join(', ') }}
+
+{{ name }} = RequestSource(
+    name="{{ name }}",
+    schema=[
+{% for field in schema_lines %}{{ field }}
+{% endfor %}    ],
+) 

--- a/sdk/python/feast/api/registry/rest/templates/saved_dataset_template.jinja2
+++ b/sdk/python/feast/api/registry/rest/templates/saved_dataset_template.jinja2
@@ -1,0 +1,7 @@
+from feast import SavedDataset
+
+{{ name }} = SavedDataset(
+    name="{{ name }}",
+    features=[{{ features }}],
+    {% if tags %}tags={{ tags }},{% endif %}
+) 

--- a/sdk/python/tests/unit/api/test_api_rest_registry.py
+++ b/sdk/python/tests/unit/api/test_api_rest_registry.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import tempfile
 
@@ -97,7 +98,18 @@ def test_entities_via_rest(fastapi_test_app):
     assert "entities" in response.json()
     response = fastapi_test_app.get("/entities/user_id?project=demo_project")
     assert response.status_code == 200
-    assert response.json()["spec"]["name"] == "user_id"
+    data = response.json()
+    assert data["spec"]["name"] == "user_id"
+    # Check featureDefinition
+    assert "featureDefinition" in data
+    code = data["featureDefinition"]
+    assert code
+    assert "Entity" in code
+    assert "user_id" in code
+    try:
+        ast.parse(code)
+    except SyntaxError as e:
+        pytest.fail(f"featureDefinition is not valid Python: {e}")
 
 
 def test_feature_views_via_rest(fastapi_test_app):
@@ -106,7 +118,18 @@ def test_feature_views_via_rest(fastapi_test_app):
     assert "featureViews" in response.json()
     response = fastapi_test_app.get("/feature_views/user_profile?project=demo_project")
     assert response.status_code == 200
-    assert response.json()["spec"]["name"] == "user_profile"
+    data = response.json()
+    assert data["spec"]["name"] == "user_profile"
+    # Check featureDefinition
+    assert "featureDefinition" in data
+    code = data["featureDefinition"]
+    assert code
+    assert "FeatureView" in code
+    assert "user_profile" in code
+    try:
+        ast.parse(code)
+    except SyntaxError as e:
+        pytest.fail(f"featureDefinition is not valid Python: {e}")
 
 
 def test_feature_views_type_field_via_rest(fastapi_test_app):
@@ -140,7 +163,18 @@ def test_feature_services_via_rest(fastapi_test_app):
         "/feature_services/user_service?project=demo_project"
     )
     assert response.status_code == 200
-    assert response.json()["spec"]["name"] == "user_service"
+    data = response.json()
+    assert data["spec"]["name"] == "user_service"
+    # Check featureDefinition
+    assert "featureDefinition" in data
+    code = data["featureDefinition"]
+    assert code
+    assert "FeatureService" in code
+    assert "user_service" in code
+    try:
+        ast.parse(code)
+    except SyntaxError as e:
+        pytest.fail(f"featureDefinition is not valid Python: {e}")
 
 
 def test_data_sources_via_rest(fastapi_test_app):
@@ -151,7 +185,18 @@ def test_data_sources_via_rest(fastapi_test_app):
         "/data_sources/user_profile_source?project=demo_project"
     )
     assert response.status_code == 200
-    assert response.json()["name"] == "user_profile_source"
+    data = response.json()
+    assert data["name"] == "user_profile_source"
+    # Check featureDefinition
+    assert "featureDefinition" in data
+    code = data["featureDefinition"]
+    assert code
+    assert "FileSource" in code
+    assert "user_profile_source" in code
+    try:
+        ast.parse(code)
+    except SyntaxError as e:
+        pytest.fail(f"featureDefinition is not valid Python: {e}")
 
 
 def test_projects_via_rest(fastapi_test_app):
@@ -882,6 +927,16 @@ def test_features_get_via_rest(fastapi_test_app):
     assert data["name"] == "age"
     assert data["featureView"] == "user_profile"
     assert data["type"] == "Int64"
+    # Check featureDefinition
+    assert "featureDefinition" in data
+    code = data["featureDefinition"]
+    assert code
+    assert "Feature" in code
+    assert "age" in code
+    try:
+        ast.parse(code)
+    except SyntaxError as e:
+        pytest.fail(f"featureDefinition is not valid Python: {e}")
 
     response = fastapi_test_app.get(
         "/features/user_profile/age?project=demo_project&include_relationships=true"


### PR DESCRIPTION
# What this PR does / why we need it:

This PR adds `featureDefinition` field to all resource GET API responses containing dynamically generated, copy-pasteable Python code examples for all resource types (feature views, entities, data sources, feature services, features, saved datasets). These examples should help developers understand how these resources are defined programmatically.

Also, added tests to verify code generated is correct python code. 
Ex:

```
{
  "spec": {
    "name": "driver",
    "joinKey": "driver_id"
  },
  "meta": {
    "createdTimestamp": "2025-07-18T11:52:59.070198Z",
    "lastUpdatedTimestamp": "2025-07-18T11:52:59.070198Z"
  },
  "featureDefinition": "from feast import Entity\n\ndriver = Entity(\n    name=\"driver\",\n    join_keys=['driver_id'],\n) "
}
```