### PR TITLE
feat: Added recent visit logging api for registry server

### DIFF
--- a/sdk/python/feast/api/registry/rest/__init__.py
+++ b/sdk/python/feast/api/registry/rest/__init__.py
@@ -6,12 +6,13 @@ from feast.api.registry.rest.feature_services import get_feature_service_router
 from feast.api.registry.rest.feature_views import get_feature_view_router
 from feast.api.registry.rest.features import get_feature_router
 from feast.api.registry.rest.lineage import get_lineage_router
+from feast.api.registry.rest.metrics import get_metrics_router
 from feast.api.registry.rest.permissions import get_permission_router
 from feast.api.registry.rest.projects import get_project_router
 from feast.api.registry.rest.saved_datasets import get_saved_dataset_router
 
 
-def register_all_routes(app: FastAPI, grpc_handler):
+def register_all_routes(app: FastAPI, grpc_handler, server=None):
     app.include_router(get_entity_router(grpc_handler))
     app.include_router(get_data_source_router(grpc_handler))
     app.include_router(get_feature_service_router(grpc_handler))
@@ -21,3 +22,4 @@ def register_all_routes(app: FastAPI, grpc_handler):
     app.include_router(get_permission_router(grpc_handler))
     app.include_router(get_project_router(grpc_handler))
     app.include_router(get_saved_dataset_router(grpc_handler))
+    app.include_router(get_metrics_router(grpc_handler, server))

--- a/sdk/python/feast/api/registry/rest/metrics.py
+++ b/sdk/python/feast/api/registry/rest/metrics.py
@@ -1,0 +1,164 @@
+import json
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from feast.api.registry.rest.rest_utils import (
+    get_pagination_params,
+    get_sorting_params,
+    grpc_call,
+    paginate_and_sort,
+)
+from feast.protos.feast.registry import RegistryServer_pb2
+
+
+def get_metrics_router(grpc_handler, server=None) -> APIRouter:
+    logger = logging.getLogger(__name__)
+    router = APIRouter()
+
+    @router.get("/metrics/resource_counts", tags=["Metrics"])
+    async def resource_counts(
+        project: Optional[str] = Query(
+            None, description="Project name to filter resource counts"
+        ),
+    ):
+        def count_resources_for_project(project_name: str):
+            entities = grpc_call(
+                grpc_handler.ListEntities,
+                RegistryServer_pb2.ListEntitiesRequest(project=project_name),
+            )
+            data_sources = grpc_call(
+                grpc_handler.ListDataSources,
+                RegistryServer_pb2.ListDataSourcesRequest(project=project_name),
+            )
+            try:
+                saved_datasets = grpc_call(
+                    grpc_handler.ListSavedDatasets,
+                    RegistryServer_pb2.ListSavedDatasetsRequest(project=project_name),
+                )
+            except Exception:
+                saved_datasets = {"savedDatasets": []}
+            try:
+                features = grpc_call(
+                    grpc_handler.ListFeatures,
+                    RegistryServer_pb2.ListFeaturesRequest(project=project_name),
+                )
+            except Exception:
+                features = {"features": []}
+            try:
+                feature_views = grpc_call(
+                    grpc_handler.ListFeatureViews,
+                    RegistryServer_pb2.ListFeatureViewsRequest(project=project_name),
+                )
+            except Exception:
+                feature_views = {"featureViews": []}
+            try:
+                feature_services = grpc_call(
+                    grpc_handler.ListFeatureServices,
+                    RegistryServer_pb2.ListFeatureServicesRequest(project=project_name),
+                )
+            except Exception:
+                feature_services = {"featureServices": []}
+            return {
+                "entities": len(entities.get("entities", [])),
+                "dataSources": len(data_sources.get("dataSources", [])),
+                "savedDatasets": len(saved_datasets.get("savedDatasets", [])),
+                "features": len(features.get("features", [])),
+                "featureViews": len(feature_views.get("featureViews", [])),
+                "featureServices": len(feature_services.get("featureServices", [])),
+            }
+
+        if project:
+            counts = count_resources_for_project(project)
+            return {"project": project, "counts": counts}
+        else:
+            # List all projects via gRPC
+            projects_resp = grpc_call(
+                grpc_handler.ListProjects, RegistryServer_pb2.ListProjectsRequest()
+            )
+            all_projects = [
+                p["spec"]["name"] for p in projects_resp.get("projects", [])
+            ]
+            all_counts = {}
+            total_counts = {
+                "entities": 0,
+                "dataSources": 0,
+                "savedDatasets": 0,
+                "features": 0,
+                "featureViews": 0,
+                "featureServices": 0,
+            }
+            for project_name in all_projects:
+                counts = count_resources_for_project(project_name)
+                all_counts[project_name] = counts
+                for k in total_counts:
+                    total_counts[k] += counts[k]
+            return {"total": total_counts, "perProject": all_counts}
+
+    @router.get("/metrics/recently_visited", tags=["Metrics"])
+    async def recently_visited(
+        request: Request,
+        project: Optional[str] = Query(
+            None, description="Project name to filter recent visits"
+        ),
+        object_type: Optional[str] = Query(
+            None,
+            alias="object",
+            description="Object type to filter recent visits (e.g., entities, features)",
+        ),
+        pagination_params: dict = Depends(get_pagination_params),
+        sorting_params: dict = Depends(get_sorting_params),
+    ):
+        user = None
+        if hasattr(request.state, "user"):
+            user = getattr(request.state, "user", None)
+        if not user:
+            user = "anonymous"
+        project_val = project or (server.store.project if server else None)
+        key = f"recently_visited_{user}"
+        logger.info(
+            f"[/metrics/recently_visited] Project: {project_val}, Key: {key}, Object: {object_type}"
+        )
+        try:
+            visits_json = (
+                server.registry.get_project_metadata(project_val, key)
+                if server
+                else None
+            )
+            visits = json.loads(visits_json) if visits_json else []
+        except Exception:
+            visits = []
+        if object_type:
+            visits = [v for v in visits if v.get("object") == object_type]
+
+        server_limit = getattr(server, "recent_visits_limit", 100) if server else 100
+        visits = visits[-server_limit:]
+
+        page = pagination_params.get("page", 0)
+        limit = pagination_params.get("limit", 0)
+        sort_by = sorting_params.get("sort_by")
+        sort_order = sorting_params.get("sort_order", "asc")
+
+        if page == 0 and limit == 0:
+            if sort_by:
+                visits = sorted(
+                    visits,
+                    key=lambda x: x.get(sort_by, ""),
+                    reverse=(sort_order == "desc"),
+                )
+            return {"visits": visits, "pagination": {"totalCount": len(visits)}}
+        else:
+            if page == 0:
+                page = 1
+            if limit == 0:
+                limit = 50
+            paged_visits, pagination = paginate_and_sort(
+                visits, page, limit, sort_by, sort_order
+            )
+            return {
+                "visits": paged_visits,
+                "pagination": pagination,
+            }
+
+    return router

--- a/sdk/python/feast/api/registry/rest/rest_registry_server.py
+++ b/sdk/python/feast/api/registry/rest/rest_registry_server.py
@@ -1,4 +1,6 @@
+import json
 import logging
+import re
 
 from fastapi import Depends, FastAPI, status
 
@@ -13,6 +15,7 @@ from feast.permissions.server.utils import (
     str_to_auth_manager_type,
 )
 from feast.registry_server import RegistryServer
+from feast.utils import _utc_now
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -23,6 +26,26 @@ class RestRegistryServer:
         self.store = store
         self.registry = store.registry
         self.grpc_handler = RegistryServer(self.registry)
+        recent_visit_logging_cfg = {}
+        feature_server_cfg = getattr(
+            getattr(store, "config", None), "feature_server", None
+        )
+        if isinstance(feature_server_cfg, dict):
+            recent_visit_logging_cfg = feature_server_cfg.get(
+                "recent_visit_logging", {}
+            )
+        self.recent_visits_limit = recent_visit_logging_cfg.get("limit", 100)
+        self.log_patterns = recent_visit_logging_cfg.get(
+            "log_patterns",
+            [
+                r".*/entities/(?!all$)[^/]+$",
+                r".*/data_sources/(?!all$)[^/]+$",
+                r".*/feature_views/(?!all$)[^/]+$",
+                r".*/features/(?!all$)[^/]+$",
+                r".*/feature_services/(?!all$)[^/]+$",
+                r".*/saved_datasets/(?!all$)[^/]+$",
+            ],
+        )
         self.app = FastAPI(
             title="Feast REST Registry Server",
             description="Feast REST Registry Server",
@@ -39,9 +62,90 @@ class RestRegistryServer:
                 "X-Frame-Options": "DENY",
             },
         )
+        self._add_logging_middleware()
         self._add_openapi_security()
         self._init_auth()
         self._register_routes()
+
+    def _add_logging_middleware(self):
+        from fastapi import Request
+        from starlette.middleware.base import BaseHTTPMiddleware
+
+        class LoggingMiddleware(BaseHTTPMiddleware):
+            def __init__(
+                self, app, registry, project, recent_visits_limit, log_patterns
+            ):
+                super().__init__(app)
+                self.registry = registry
+                self.project = project
+                self.recent_visits_limit = recent_visits_limit
+                self.log_patterns = [re.compile(p) for p in log_patterns]
+
+            async def dispatch(self, request: Request, call_next):
+                LOG_PATTERNS = self.log_patterns
+                if request.method == "GET":
+                    user = None
+                    if hasattr(request.state, "user"):
+                        user = getattr(request.state, "user", None)
+                    if not user:
+                        user = "anonymous"
+                    project = request.query_params.get("project") or self.project
+                    key = f"recently_visited_{user}"
+                    logger.info(f"[LoggingMiddleware] Project: {project}, Key: {key}")
+                    path = str(request.url.path)
+                    method = request.method
+
+                    if path.startswith("/api/v1/metrics/"):
+                        response = await call_next(request)
+                        return response
+
+                    object_type = None
+                    object_name = None
+                    if not any(p.match(path) for p in LOG_PATTERNS):
+                        response = await call_next(request)
+                        return response
+                    m = re.match(r"/api/v1/([^/]+)(?:/([^/]+))?", path)
+                    if m:
+                        object_type = m.group(1)
+                        object_name = m.group(2)
+                    else:
+                        object_type = None
+                        object_name = None
+                    visit = {
+                        "path": path,
+                        "timestamp": _utc_now().isoformat(),
+                        "project": project,
+                        "user": user,
+                        "object": object_type,
+                        "object_name": object_name,
+                        "method": method,
+                    }
+                    try:
+                        visits_json = self.registry.get_project_metadata(project, key)
+                        visits = json.loads(visits_json) if visits_json else []
+                    except Exception:
+                        visits = []
+                    visits.append(visit)
+                    visits = visits[-self.recent_visits_limit :]
+                    try:
+                        self.registry.set_project_metadata(
+                            project, key, json.dumps(visits)
+                        )
+                    except Exception as e:
+                        logger.warning(f"Failed to persist recent visits: {e}")
+                response = await call_next(request)
+                return response
+
+        self.app.add_middleware(
+            LoggingMiddleware,
+            registry=self.registry,
+            project=self.store.project,
+            recent_visits_limit=self.recent_visits_limit,
+            log_patterns=self.log_patterns,
+        )
+
+    def _register_routes(self):
+        register_all_routes(self.app, self.grpc_handler, self)
 
     def _add_openapi_security(self):
         if self.app.openapi_schema:
@@ -74,9 +178,6 @@ class RestRegistryServer:
             auth_config=self.store.config.auth_config,
         )
         self.auth_manager = get_auth_manager()
-
-    def _register_routes(self):
-        register_all_routes(self.app, self.grpc_handler)
 
     def start_server(
         self,

--- a/sdk/python/feast/api/registry/rest/rest_utils.py
+++ b/sdk/python/feast/api/registry/rest/rest_utils.py
@@ -220,12 +220,18 @@ def paginate_and_sort(
     start = (page - 1) * limit
     end = start + limit
     paged_items = items[start:end]
-    pagination = {
-        "page": page,
-        "limit": limit,
-        "total_count": total,
-        "total_pages": (total + limit - 1) // limit,
-        "has_next": end < total,
-        "has_previous": start > 0,
-    }
+    pagination = {}
+    if page:
+        pagination["page"] = page
+    if limit:
+        pagination["limit"] = limit
+    if total:
+        pagination["totalCount"] = total
+    total_pages = (total + limit - 1) // limit
+    if total_pages:
+        pagination["totalPages"] = total_pages
+    if end < total:
+        pagination["hasNext"] = True
+    if start > 0:
+        pagination["hasPrevious"] = True
     return paged_items, pagination

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -603,6 +603,20 @@ class BaseRegistry(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def get_project_metadata(self, project: str, key: str) -> Optional[str]:
+        """
+        Retrieves a custom project metadata value by key.
+
+        Args:
+            project: Feast project name
+            key: Metadata key
+
+        Returns:
+            The metadata value as a string, or None if not found.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def update_infra(self, infra: Infra, project: str, commit: bool = True):
         """
         Updates the stored Infra object.

--- a/sdk/python/feast/infra/registry/contrib/azure/azure_registry_store.py
+++ b/sdk/python/feast/infra/registry/contrib/azure/azure_registry_store.py
@@ -1,10 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+import json
 import os
 import uuid
 from pathlib import Path
 from tempfile import TemporaryFile
+from typing import Optional
 from urllib.parse import urlparse
 
 from feast.infra.registry.registry import RegistryConfig
@@ -96,3 +98,39 @@ class AzBlobRegistryStore(RegistryStore):
         file_obj.seek(0)
         self.blob.upload_blob(file_obj, overwrite=True)  # type: ignore
         return
+
+    def set_project_metadata(self, project: str, key: str, value: str):
+        registry_proto = self.get_registry_proto()
+        found = False
+        for pm in registry_proto.project_metadata:
+            if pm.project == project:
+                try:
+                    meta = json.loads(pm.project_uuid) if pm.project_uuid else {}
+                except Exception:
+                    meta = {}
+                if not isinstance(meta, dict):
+                    meta = {}
+                meta[key] = value
+                pm.project_uuid = json.dumps(meta)
+                found = True
+                break
+        if not found:
+            from feast.project_metadata import ProjectMetadata
+
+            pm = ProjectMetadata(project_name=project)
+            pm.project_uuid = json.dumps({key: value})
+            registry_proto.project_metadata.append(pm.to_proto())
+        self.update_registry_proto(registry_proto)
+
+    def get_project_metadata(self, project: str, key: str) -> Optional[str]:
+        registry_proto = self.get_registry_proto()
+        for pm in registry_proto.project_metadata:
+            if pm.project == project:
+                try:
+                    meta = json.loads(pm.project_uuid) if pm.project_uuid else {}
+                except Exception:
+                    meta = {}
+                if not isinstance(meta, dict):
+                    return None
+                return meta.get(key, None)
+        return None

--- a/sdk/python/feast/infra/registry/gcs.py
+++ b/sdk/python/feast/infra/registry/gcs.py
@@ -1,6 +1,8 @@
+import json
 import uuid
 from pathlib import Path
 from tempfile import TemporaryFile
+from typing import Optional
 from urllib.parse import urlparse
 
 from feast.infra.registry.registry_store import RegistryStore
@@ -70,3 +72,39 @@ class GCSRegistryStore(RegistryStore):
         file_obj.write(registry_proto.SerializeToString())
         file_obj.seek(0)
         blob.upload_from_file(file_obj)
+
+    def set_project_metadata(self, project: str, key: str, value: str):
+        registry_proto = self.get_registry_proto()
+        found = False
+        for pm in registry_proto.project_metadata:
+            if pm.project == project:
+                try:
+                    meta = json.loads(pm.project_uuid) if pm.project_uuid else {}
+                except Exception:
+                    meta = {}
+                if not isinstance(meta, dict):
+                    meta = {}
+                meta[key] = value
+                pm.project_uuid = json.dumps(meta)
+                found = True
+                break
+        if not found:
+            from feast.project_metadata import ProjectMetadata
+
+            pm = ProjectMetadata(project_name=project)
+            pm.project_uuid = json.dumps({key: value})
+            registry_proto.project_metadata.append(pm.to_proto())
+        self.update_registry_proto(registry_proto)
+
+    def get_project_metadata(self, project: str, key: str) -> Optional[str]:
+        registry_proto = self.get_registry_proto()
+        for pm in registry_proto.project_metadata:
+            if pm.project == project:
+                try:
+                    meta = json.loads(pm.project_uuid) if pm.project_uuid else {}
+                except Exception:
+                    meta = {}
+                if not isinstance(meta, dict):
+                    return None
+                return meta.get(key, None)
+        return None

--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -164,6 +164,24 @@ class Registry(BaseRegistry):
     ) -> Optional[bytes]:
         pass
 
+    def set_project_metadata(self, project: str, key: str, value: str):
+        """Set a custom project metadata key-value pair in the registry backend."""
+        if hasattr(self._registry_store, "set_project_metadata"):
+            self._registry_store.set_project_metadata(project, key, value)
+        else:
+            raise NotImplementedError(
+                "set_project_metadata not implemented for this registry backend"
+            )
+
+    def get_project_metadata(self, project: str, key: str) -> Optional[str]:
+        """Get a custom project metadata value by key from the registry backend."""
+        if hasattr(self._registry_store, "get_project_metadata"):
+            return self._registry_store.get_project_metadata(project, key)
+        else:
+            raise NotImplementedError(
+                "get_project_metadata not implemented for this registry backend"
+            )
+
     # The cached_registry_proto object is used for both reads and writes. In particular,
     # all write operations refresh the cache and modify it in memory; the write must
     # then be persisted to the underlying RegistryStore with a call to commit().

--- a/sdk/python/tests/unit/api/test_api_rest_registry_server.py
+++ b/sdk/python/tests/unit/api/test_api_rest_registry_server.py
@@ -40,7 +40,9 @@ def test_rest_registry_server_initializes_correctly(
     assert server.grpc_handler == mock_grpc_handler
 
     # Validate route registration and auth init
-    mock_register_all_routes.assert_called_once_with(server.app, mock_grpc_handler)
+    mock_register_all_routes.assert_called_once_with(
+        server.app, mock_grpc_handler, server
+    )
     mock_init_security_manager.assert_called_once()
     mock_init_auth_manager.assert_called_once()
     mock_get_auth_manager.assert_called_once()
@@ -80,3 +82,5 @@ def test_routes_registered_in_app(mock_store_and_registry):
     assert "/features" in route_paths
     assert "/features/all" in route_paths
     assert "/features/{feature_view}/{name}" in route_paths
+    assert "/metrics/resource_counts" in route_paths
+    assert "/metrics/recently_visited" in route_paths

--- a/sdk/python/tests/unit/infra/registry/test_registry.py
+++ b/sdk/python/tests/unit/infra/registry/test_registry.py
@@ -9,6 +9,16 @@ from feast.infra.registry.caching_registry import CachingRegistry
 class TestCachingRegistry(CachingRegistry):
     """Test subclass that implements abstract methods as no-ops"""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._test_metadata = {}
+
+    def get_project_metadata(self, project: str, key: str) -> str:
+        return self._test_metadata.get((project, key))
+
+    def set_project_metadata(self, project: str, key: str, value: str):
+        self._test_metadata[(project, key)] = value
+
     def _get_any_feature_view(self, *args, **kwargs):
         pass
 


### PR DESCRIPTION

# What this PR does / why we need it:

This PR enhances the Feast Registry Server API with visit logging and metrics capabilities, providing better observability and user activity tracking.

- Recent Visit Logging
     - Tracks user interactions with registry objects (entities, features, feature views, etc.)
     - Stores visit history per user and per project in registry metadata.
     - Configurable and stores 100 last visits records per user by default.

- Metrics APIs
`/metrics/resource_counts` - Get resource counts per project or globally.
`/metrics/recently_visited` - Retrieve recent visit history.

