### PR TITLE
fix: Push Source inherits the timestamp fields from Data Source

### DIFF
--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -922,6 +922,19 @@ class PushSource(DataSource):
             owner=self.owner,
         )
 
+        # Only set timestamp fields if we have a batch source and this PushSource doesn't have its own fields
+        if self.batch_source and not (
+            self.timestamp_field or self.created_timestamp_column or self.field_mapping
+        ):
+            data_source_proto.timestamp_field = self.batch_source.timestamp_field
+            data_source_proto.created_timestamp_column = (
+                self.batch_source.created_timestamp_column
+            )
+            data_source_proto.field_mapping.update(self.batch_source.field_mapping)
+            data_source_proto.date_partition_column = (
+                self.batch_source.date_partition_column
+            )
+
         if self.batch_source:
             data_source_proto.batch_source.MergeFrom(self.batch_source.to_proto())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Inherits the timestamp fields from batch source / data source to push source.
# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes: https://github.com/feast-dev/feast/issues/5549

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
