### PR TITLE
fix: Fix the name typo in the local registry file example.

### DIFF
--- a/docs/reference/registries/local.md
+++ b/docs/reference/registries/local.md
@@ -14,7 +14,7 @@ An example of how to configure this would be:
 ```yaml
 project: feast_local
 registry:
-  path: registry.pb
+  path: registry.db
   cache_ttl_seconds: 60
 online_store: null
 offline_store:


### PR DESCRIPTION
# What this PR does / why we need it:
 the current document has a typo in the "local registry" example page.
A reasonable file named is "registry.db"
In the current doc, the file name is "registry.pb"

# Which issue(s) this PR fixes:
Fix the typo in the example page.


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
