### PR TITLE
fix: Fixed transaction handling with SQLite registry

### DIFF
--- a/infra/templates/README.md.jinja2
+++ b/infra/templates/README.md.jinja2
@@ -1,6 +1,6 @@
 <p align="center">
     <a href="https://feast.dev/">
-      <img src="docs/assets/feast_logo.png" width="550">
+      <img src="https://raw.githubusercontent.com/feast-dev/feast/master/docs/assets/feast_logo.png" width="550">
     </a>
 </p>
 <br />
@@ -36,7 +36,7 @@ Feast allows ML platform teams to:
 Please see our [documentation](https://docs.feast.dev/) for more information about the project.
 
 ## 📐 Architecture
-![](docs/assets/feast_marchitecture.png)
+![](https://raw.githubusercontent.com/feast-dev/feast/master/docs/assets/feast_marchitecture.png)
 
 The above architecture is the minimal Feast deployment. Want to run the full Feast on Snowflake/GCP/AWS? Click [here](https://docs.feast.dev/how-to-guides/feast-snowflake-gcp-aws).
 
@@ -60,7 +60,7 @@ feast apply
 
 ### 4. Explore your data in the web UI (experimental)
 
-![Web UI](ui/sample.png)
+![Web UI](https://raw.githubusercontent.com/feast-dev/feast/master/ui/sample.png)
 ```commandline
 feast ui
 ```

--- a/sdk/python/tests/unit/infra/registry/test_sql_registry.py
+++ b/sdk/python/tests/unit/infra/registry/test_sql_registry.py
@@ -1,0 +1,58 @@
+# Copyright 2021 The Feast Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+
+import pytest
+
+from feast.entity import Entity
+from feast.infra.registry.sql import SqlRegistry, SqlRegistryConfig
+
+
+@pytest.fixture
+def sqlite_registry():
+    """Create a temporary SQLite registry for testing."""
+    fd, registry_path = tempfile.mkstemp()
+    registry_config = SqlRegistryConfig(
+        registry_type="sql",
+        path=f"sqlite:///{registry_path}",
+        purge_feast_metadata=False,
+    )
+
+    registry = SqlRegistry(registry_config, "test_project", None)
+    yield registry
+    registry.teardown()
+
+
+def test_sql_registry(sqlite_registry):
+    """
+    Test the SQL registry
+    """
+    entity = Entity(
+        name="test_entity",
+        description="Test entity for testing",
+        tags={"test": "transaction"},
+    )
+    sqlite_registry.apply_entity(entity, "test_project")
+    retrieved_entity = sqlite_registry.get_entity("test_entity", "test_project")
+    assert retrieved_entity.name == "test_entity"
+    assert retrieved_entity.description == "Test entity for testing"
+
+    sqlite_registry.set_project_metadata("test_project", "test_key", "test_value")
+    value = sqlite_registry.get_project_metadata("test_project", "test_key")
+    assert value == "test_value"
+
+    sqlite_registry.delete_entity("test_entity", "test_project")
+    with pytest.raises(Exception):
+        sqlite_registry.get_entity("test_entity", "test_project")


### PR DESCRIPTION
# What this PR does / why we need it:

This PR fixed the SQLite database lock issue in the Feast SQL Registry.  The error `sqlite3.OperationalError: database is locked` was occurring because the `_set_last_updated_metadata` method was being called from within the `_apply_object` method's transaction context, but `_set_last_updated_metadata` was trying to start its own transaction with `self.write_engine.begin()`. This created a nested transaction scenario that SQLite doesn't handle well.

Modified the methods now to accept an optional connection parameter to use the existing transaction (for calls from within other transactions).

# Which issue(s) this PR fixes:
Fixes #5565 
