### PR TITLE
fix: column quoting in query of `PostgreSQLOfflineStore.pull_all_from_table_or_query`

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
@@ -280,7 +280,10 @@ class PostgreSQLOfflineStore(OfflineStore):
         if created_timestamp_column:
             timestamp_fields.append(created_timestamp_column)
         field_string = ", ".join(
-            join_key_columns + feature_name_columns + timestamp_fields
+            _append_alias(
+                join_key_columns + feature_name_columns + timestamp_fields,
+                "paftoq_alias",
+            )
         )
 
         timestamp_filter = get_timestamp_filter_sql(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:

This fixes an issue with the `PostgreSQLOfflineStore` we had encountered. The implementation of materialization, using the local compute engine, changed after `feast>=0.50`. 
The invocation to `FeatureStore.materialize` now calls `PostgreSQLOfflineStore.pull_all_from_table_or_query` (instead of `PostgreSQLOfflineStore.pull_latest_from_table_or_query`).

In this method, the columns in the query are not quoted. This causes issues when columns contain e.g. capitalized characters, spaces etc. PostgreSQL by default lowercases everything when not quoted.

<details>

<summary>example error traceback</summary>

```python
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/.../lib/python3.12/site-packages/feast/feature_store.py:1604: in materialize
    provider.materialize_single_feature_view(
/.../lib/python3.12/site-packages/feast/infra/passthrough_provider.py:454: in materialize_single_feature_view
    raise e
/.../lib/python3.12/site-packages/feast/infra/compute_engines/local/compute.py:84: in _materialize_one
    plan.execute(context)
/.../lib/python3.12/site-packages/feast/infra/compute_engines/dag/plan.py:51: in execute
    output = node.execute(context)
/.../lib/python3.12/site-packages/feast/infra/compute_engines/local/nodes.py:48: in execute
    arrow_table = retrieval_job.to_arrow()
/.../lib/python3.12/site-packages/feast/infra/offline_stores/offline_store.py:111: in to_arrow
    features_table = self._to_arrow_internal(timeout=timeout)
/.../lib/python3.12/site-packages/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py:353: in _to_arrow_internal
    cur.execute(query)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <psycopg.Cursor [closed] [BAD] at 0x116ba0410>
query = '\n            SELECT CUSTOMER_ID, FEATURE_INT, FEATURE_FLOAT, FEATURE_STRING, FEATURE_BOOL, FEATURE_TIMESTAMP\n      ...TIMESTAMP" BETWEEN \'1900-01-01 00:00:00+00:00\'::timestamptz AND \'9999-12-31 00:00:00+00:00\'::timestamptz\n        '
params = None

    def execute(
        self,
        query: Query,
        params: Params | None = None,
        *,
        prepare: bool | None = None,
        binary: bool | None = None,
    ) -> Self:
        """
        Execute a query or command to the database.
        """
        try:
            with self._conn.lock:
                self._conn.wait(
                    self._execute_gen(query, params, prepare=prepare, binary=binary)
                )
        except e._NO_TRACEBACK as ex:
>           raise ex.with_traceback(None)
E           psycopg.errors.UndefinedColumn: column "customer_id" does not exist
E           LINE 2:             SELECT CUSTOMER_ID, FEATURE_INT, FEATURE_FLOAT, ...
E                                      ^

/.../lib/python3.12/site-packages/psycopg/cursor.py:97: UndefinedColumn
```

</details>

This PR adds a invocation to `_append_alias` to the columns, which also adds quotes to the column names. This is the same behaviour used in `PostgreSQLOfflineStore.pull_latest_from_table_or_query`.


# Misc
cc @TomSteenbergen 
