### PR TITLE
fix: Update the deprecated functions in Go feature server.

### DIFF
--- a/go/infra/docker/feature-server/Dockerfile
+++ b/go/infra/docker/feature-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.5
+FROM golang:1.23.12
 
 # Update the package list and install the ca-certificates package
 RUN apt-get update && apt-get install -y ca-certificates

--- a/go/internal/feast/model/featureview.go
+++ b/go/internal/feast/model/featureview.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"slices"
+
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/feast-dev/feast/go/protos/feast/core"
@@ -66,10 +68,5 @@ func (fv *FeatureView) NewFeatureViewFromBase(base *BaseFeatureView) *FeatureVie
 }
 
 func (fv *FeatureView) HasEntity(name string) bool {
-	for _, entityName := range fv.EntityNames {
-		if entityName == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(fv.EntityNames, name)
 }

--- a/go/internal/feast/registry/local.go
+++ b/go/internal/feast/registry/local.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"github.com/google/uuid"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -33,7 +32,7 @@ func NewFileRegistryStore(config *RegistryConfig, repoPath string) *FileRegistry
 // GetRegistryProto reads and parses the registry proto from the file path.
 func (r *FileRegistryStore) GetRegistryProto() (*core.Registry, error) {
 	registry := &core.Registry{}
-	in, err := ioutil.ReadFile(r.filePath)
+	in, err := os.ReadFile(r.filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +57,7 @@ func (r *FileRegistryStore) writeRegistry(rp *core.Registry) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(r.filePath, bytes, 0644)
+	err = os.WriteFile(r.filePath, bytes, 0644)
 	if err != nil {
 		return err
 	}

--- a/go/internal/feast/registry/registry_test.go
+++ b/go/internal/feast/registry/registry_test.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"strings"
 	"testing"
@@ -16,7 +16,7 @@ func TestGetOnlineFeaturesS3Registry(t *testing.T) {
 	mockS3Client := &MockS3Client{
 		GetObjectFn: func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
 			return &s3.GetObjectOutput{
-				Body: ioutil.NopCloser(strings.NewReader("mock data")),
+				Body: io.NopCloser(strings.NewReader("mock data")),
 			}, nil
 		},
 		DeleteObjectFn: func(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {

--- a/go/internal/feast/registry/s3.go
+++ b/go/internal/feast/registry/s3.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
@@ -65,7 +65,7 @@ func (r *S3RegistryStore) GetRegistryProto() (*core.Registry, error) {
 	}
 	defer output.Body.Close()
 
-	data, err := ioutil.ReadAll(output.Body)
+	data, err := io.ReadAll(output.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/go/internal/feast/server/logging/logger_test.go
+++ b/go/internal/feast/server/logging/logger_test.go
@@ -2,7 +2,7 @@ package logging
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -114,11 +114,11 @@ func TestLogAndFlushToFile(t *testing.T) {
 	))
 
 	require.Eventually(t, func() bool {
-		files, _ := ioutil.ReadDir(sink.path)
+		files, _ := os.ReadDir(sink.path)
 		return len(files) > 0
 	}, 60*time.Second, 100*time.Millisecond)
 
-	files, _ := ioutil.ReadDir(sink.path)
+	files, _ := os.ReadDir(sink.path)
 
 	pf, err := file.OpenParquetFile(filepath.Join(sink.path, files[0].Name()), false)
 	assert.Nil(t, err)

--- a/go/internal/feast/server/logging/offlinestoresink.go
+++ b/go/internal/feast/server/logging/offlinestoresink.go
@@ -3,7 +3,6 @@ package logging
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -33,7 +32,7 @@ func (s *OfflineStoreSink) getOrCreateDatasetDir() (string, error) {
 	if s.datasetDir != "" {
 		return s.datasetDir, nil
 	}
-	dir, err := ioutil.TempDir("", "*")
+	dir, err := os.MkdirTemp("", "*")
 	if err != nil {
 		return "", err
 	}

--- a/sdk/python/feast/api/registry/rest/search.py
+++ b/sdk/python/feast/api/registry/rest/search.py
@@ -167,6 +167,7 @@ def get_search_router(grpc_handler) -> APIRouter:
                             "name": feature.get("name", ""),
                             "description": feature.get("description", ""),
                             "project": current_project,
+                            "featureView": feature.get("featureView", ""),
                             "tags": feature.get("tags", {}),
                         }
                     )

--- a/sdk/python/tests/unit/api/test_search_api.py
+++ b/sdk/python/tests/unit/api/test_search_api.py
@@ -802,6 +802,15 @@ class TestSearchAPI:
             "Expected individual features to appear in search results, but found none"
         )
 
+        for feature_result in feature_results:
+            assert "featureView" in feature_result
+            assert feature_result["featureView"] in [
+                "user_features",
+                "product_features",
+                "transaction_features",
+                "user_on_demand_features",
+            ]
+
         # Verify we have features that likely come from different feature views
         feature_names = {f["name"] for f in feature_results}
 


### PR DESCRIPTION

# What this PR does / why we need it:
There are few function calls are deprecated.

# Which issue(s) this PR fixes:
Fix #5623 


# Misc

```

(feast) shuchu@shuchu-win:~/feast$ make test-go
python infra/scripts/generate_protos.py
Writing mypy to feast/core/Aggregation_pb2.pyi
Writing mypy to feast/core/Permission_pb2.pyi
Writing mypy to feast/core/DataFormat_pb2.pyi
Writing mypy to feast/core/Transformation_pb2.pyi
Writing mypy to feast/core/StreamFeatureView_pb2.pyi
Writing mypy to feast/core/FeatureView_pb2.pyi
Writing mypy to feast/core/InfraObject_pb2.pyi
Writing mypy to feast/core/Project_pb2.pyi
Writing mypy to feast/core/FeatureTable_pb2.pyi
Writing mypy to feast/core/Policy_pb2.pyi
Writing mypy to feast/core/DatastoreTable_pb2.pyi
Writing mypy to feast/core/OnDemandFeatureView_pb2.pyi
Writing mypy to feast/core/SqliteTable_pb2.pyi
Writing mypy to feast/core/SavedDataset_pb2.pyi
Writing mypy to feast/core/Entity_pb2.pyi
Writing mypy to feast/core/FeatureService_pb2.pyi
Writing mypy to feast/core/Feature_pb2.pyi
Writing mypy to feast/core/ValidationProfile_pb2.pyi
Writing mypy to feast/core/DataSource_pb2.pyi
Writing mypy to feast/core/Registry_pb2.pyi
Writing mypy to feast/core/FeatureViewProjection_pb2.pyi
Writing mypy to feast/core/Store_pb2.pyi
Writing mypy to feast/registry/RegistryServer_pb2.pyi
Writing mypy to feast/serving/ServingService_pb2.pyi
Writing mypy to feast/serving/GrpcServer_pb2.pyi
Writing mypy to feast/serving/Connector_pb2.pyi
Writing mypy to feast/serving/TransformationService_pb2.pyi
Writing mypy to feast/types/Field_pb2.pyi
Writing mypy to feast/types/Value_pb2.pyi
Writing mypy to feast/types/EntityKey_pb2.pyi
Writing mypy to feast/storage/Redis_pb2.pyi
unzip -u /home/shuchu/feast/tools/protoc-30.2-linux-x86_64.zip -d /home/shuchu/feast/tools
Archive:  /home/shuchu/feast/tools/protoc-30.2-linux-x86_64.zip
go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
mkdir -p /home/shuchu/feast/go/protos
protoc --proto_path=/home/shuchu/feast/protos --go_out=/home/shuchu/feast/go/protos --go_opt=module=github.com/feast-dev/feast/go/protos --go-grpc_out=/home/shuchu/feast/go/protos --go-grpc_opt=module=github.com/feast-dev/feast/go/protos /home/shuchu/feast/protos/feast/core/*.proto;   protoc --proto_path=/home/shuchu/feast/protos --go_out=/home/shuchu/feast/go/protos --go_opt=module=github.com/feast-dev/feast/go/protos --go-grpc_out=/home/shuchu/feast/go/protos --go-grpc_opt=module=github.com/feast-dev/feast/go/protos /home/shuchu/feast/protos/feast/registry/*.proto;   protoc --proto_path=/home/shuchu/feast/protos --go_out=/home/shuchu/feast/go/protos --go_opt=module=github.com/feast-dev/feast/go/protos --go-grpc_out=/home/shuchu/feast/go/protos --go-grpc_opt=module=github.com/feast-dev/feast/go/protos /home/shuchu/feast/protos/feast/serving/*.proto;   protoc --proto_path=/home/shuchu/feast/protos --go_out=/home/shuchu/feast/go/protos --go_opt=module=github.com/feast-dev/feast/go/protos --go-grpc_out=/home/shuchu/feast/go/protos --go-grpc_opt=module=github.com/feast-dev/feast/go/protos /home/shuchu/feast/protos/feast/types/*.proto;   protoc --proto_path=/home/shuchu/feast/protos --go_out=/home/shuchu/feast/go/protos --go_opt=module=github.com/feast-dev/feast/go/protos --go-grpc_out=/home/shuchu/feast/go/protos --go-grpc_opt=module=github.com/feast-dev/feast/go/protos /home/shuchu/feast/protos/feast/storage/*.proto;  true
go install golang.org/x/tools/cmd/goimports
uv pip install "pybindgen==0.22.1" "grpcio-tools>=1.56.2,<2" "mypy-protobuf>=3.1"
Audited 3 packages in 2ms
uv pip install -e "."
Resolved 65 packages in 2.02s
      Built feast @ file:///home/shuchu/feast
Prepared 1 package in 1.96s
Uninstalled 1 package in 0.64ms
Installed 1 package in 2ms
 ~ feast==0.53.1.dev15+g5ab18a6a2.d20250923 (from file:///home/shuchu/feast)
/home/shuchu/feast/tools/bin:/home/shuchu/feast/.venv/bin:/home/shuchu/.vscodium-server/bin/b18126fb99b60533fc069575d08d72758cd90fed/bin/remote-cli:/home/shuchu/.local/bin:/home/shuchu/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/mnt/c/WINDOWS/system32:/mnt/c/WINDOWS:/mnt/c/WINDOWS/System32/Wbem:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:/mnt/c/WINDOWS/System32/OpenSSH/:/mnt/c/Program Files/NVIDIA Corporation/NVIDIA App/NvDLISR:/mnt/c/Program Files (x86)/NVIDIA Corporation/PhysX/Common:/mnt/c/Program Files/RedHat/Podman/:/mnt/c/Users/shuch/AppData/Local/Microsoft/WindowsApps:/mnt/c/Users/shuch/AppData/Local/Programs/VSCodium/bin
CGO_ENABLED=1 go test -coverprofile=coverage.out ./... && go tool cover -html=coverage.out -o coverage.html
ok      github.com/feast-dev/feast/go   0.023s  coverage: 3.8% of statements
        github.com/feast-dev/feast/go/embedded          coverage: 0.0% of statements
ok      github.com/feast-dev/feast/go/internal/feast    5.725s  coverage: 53.9% of statements
        github.com/feast-dev/feast/go/internal/feast/model              coverage: 0.0% of statements
ok      github.com/feast-dev/feast/go/internal/feast/onlineserving      0.030s  coverage: 49.1% of statements
ok      github.com/feast-dev/feast/go/internal/feast/onlinestore        16.426s coverage: 44.0% of statements
ok      github.com/feast-dev/feast/go/internal/feast/registry   0.030s  coverage: 28.7% of statements
ok      github.com/feast-dev/feast/go/internal/feast/server     17.069s coverage: 29.6% of statements
ok      github.com/feast-dev/feast/go/internal/feast/server/logging     0.141s  coverage: 62.3% of statements
        github.com/feast-dev/feast/go/internal/feast/transformation             coverage: 0.0% of statements
        github.com/feast-dev/feast/go/internal/test             coverage: 0.0% of statements
        github.com/feast-dev/feast/go/protos/feast/core         coverage: 0.0% of statements
        github.com/feast-dev/feast/go/protos/feast/registry             coverage: 0.0% of statements
        github.com/feast-dev/feast/go/protos/feast/serving              coverage: 0.0% of statements
        github.com/feast-dev/feast/go/protos/feast/storage              coverage: 0.0% of statements
        github.com/feast-dev/feast/go/protos/feast/types                coverage: 0.0% of statements
ok      github.com/feast-dev/feast/go/types     0.010s  coverage: 86.1% of statements
```
