### PR TITLE
fix: Denial by default to all resources when no permissions set 

### DIFF
--- a/sdk/python/feast/permissions/enforcer.py
+++ b/sdk/python/feast/permissions/enforcer.py
@@ -72,19 +72,14 @@ def enforce_policy(
                 if evaluator.is_decided():
                     grant, explanations = evaluator.grant()
                     if not grant:
-                        if not filter_only:
-                            logger.error(f"Permission denied: {','.join(explanations)}")
-                            raise FeastPermissionError(",".join(explanations))
-                        elif filter_only and not p.name_patterns:
-                            logger.error(f"Permission denied: {','.join(explanations)}")
-                            raise FeastPermissionError(",".join(explanations))
-                        else:
+                        if filter_only and p.name_patterns:
                             continue
-                    if grant:
-                        logger.debug(
-                            f"Permission granted for {type(resource).__name__}:{resource.name}"
-                        )
-                        _permitted_resources.append(resource)
+                        logger.error(f"Permission denied: {','.join(explanations)}")
+                        raise FeastPermissionError(",".join(explanations))
+                    logger.debug(
+                        f"Permission granted for {type(resource).__name__}:{resource.name}"
+                    )
+                    _permitted_resources.append(resource)
                     break
         else:
             if not filter_only:

--- a/sdk/python/tests/unit/permissions/auth/server/test_auth_registry_server.py
+++ b/sdk/python/tests/unit/permissions/auth/server/test_auth_registry_server.py
@@ -142,6 +142,11 @@ def _test_get_historical_features(client_fs: FeatureStore):
 
 
 def _test_get_entity(client_fs: FeatureStore, permissions: list[Permission]):
+    if _is_auth_enabled(client_fs) and len(permissions) == 0:
+        with pytest.raises(FeastPermissionError):
+            client_fs.get_entity("driver")
+        return
+
     if not _is_auth_enabled(client_fs) or _is_permission_enabled(
         client_fs, permissions, read_entities_perm
     ):
@@ -156,6 +161,18 @@ def _test_get_entity(client_fs: FeatureStore, permissions: list[Permission]):
 
 
 def _test_list_entities(client_fs: FeatureStore, permissions: list[Permission]):
+    if _is_auth_enabled(client_fs) and len(permissions) == 0:
+        with pytest.raises(FeastPermissionError):
+            client_fs.list_entities()
+        return
+
+    if _is_auth_enabled(client_fs) and _permissions_exist_in_permission_list(
+        [invalid_list_entities_perm], permissions
+    ):
+        with pytest.raises(FeastPermissionError):
+            client_fs.list_entities()
+        return
+
     entities = client_fs.list_entities()
 
     if not _is_auth_enabled(client_fs) or _is_permission_enabled(
@@ -181,6 +198,10 @@ def _test_list_permissions(
         [invalid_list_entities_perm], applied_permissions
     ):
         with pytest.raises(Exception):
+            client_fs.list_permissions()
+        return []
+    elif _is_auth_enabled(client_fs) and len(applied_permissions) == 0:
+        with pytest.raises(FeastPermissionError):
             client_fs.list_permissions()
         return []
     else:
@@ -229,6 +250,11 @@ def _is_auth_enabled(client_fs: FeatureStore) -> bool:
 
 
 def _test_get_fv(client_fs: FeatureStore, permissions: list[Permission]):
+    if _is_auth_enabled(client_fs) and len(permissions) == 0:
+        with pytest.raises(FeastPermissionError):
+            client_fs.get_feature_view("driver_hourly_stats")
+        return
+
     if not _is_auth_enabled(client_fs) or _is_permission_enabled(
         client_fs, permissions, read_fv_perm
     ):
@@ -247,6 +273,10 @@ def _test_list_fvs(client_fs: FeatureStore, permissions: list[Permission]):
         [invalid_list_entities_perm], permissions
     ):
         with pytest.raises(Exception):
+            client_fs.list_feature_views()
+        return []
+    elif _is_auth_enabled(client_fs) and len(permissions) == 0:
+        with pytest.raises(FeastPermissionError):
             client_fs.list_feature_views()
         return []
     else:

--- a/sdk/python/tests/unit/permissions/test_security_manager.py
+++ b/sdk/python/tests/unit/permissions/test_security_manager.py
@@ -15,7 +15,7 @@ from feast.permissions.user import User
 @pytest.mark.parametrize(
     "username, requested_actions, allowed, allowed_single, raise_error_in_assert, raise_error_in_permit, intra_communication_flag",
     [
-        (None, [], False, [False, False], [True, True], False, False),
+        (None, [], False, [False, False], [True, True], True, False),
         (None, [], True, [True, True], [False, False], False, True),
         (
             "r",
@@ -42,7 +42,7 @@ from feast.permissions.user import User
             False,
             [False, False],
             [True, True],
-            False,
+            True,
             False,
         ),
         ("r", [AuthzedAction.UPDATE], True, [True, True], [False, False], False, True),
@@ -52,7 +52,7 @@ from feast.permissions.user import User
             False,
             [False, False],
             [True, True],
-            False,
+            True,
             False,
         ),
         (
@@ -116,7 +116,7 @@ from feast.permissions.user import User
             False,
             [False, False],
             [True, True],
-            True,
+            False,
             False,
         ),
         (
@@ -134,7 +134,7 @@ from feast.permissions.user import User
             False,
             [False, True],
             [True, False],
-            True,
+            False,
             False,
         ),
         (
@@ -152,7 +152,7 @@ from feast.permissions.user import User
             False,
             [False, False],
             [True, True],
-            True,
+            False,
             False,
         ),
         (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
We observed Inconsistent permission response behavior across Feature Store API routes. 
- Fixing the  behaviour by changes in filter_only and named_patterns 

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Inconsistent permission response behavior across Feature Store API routes. [RHOAIENG-35929](https://issues.redhat.com/browse/RHOAIENG-35929) 

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
