### PR TITLE
feat: Add missing pull_all_from_table_or_query to Clickhouse offline store

### DIFF
--- a/sdk/python/tests/integration/registration/test_universal_types.py
+++ b/sdk/python/tests/integration/registration/test_universal_types.py
@@ -343,7 +343,6 @@ def offline_types_test_fixtures(request, environment):
     if (
         environment.data_source_creator.__class__.__name__
         == "ClickhouseDataSourceCreator"
-        and config.feature_dtype in {"float", "datetime", "bool"}
         and config.feature_is_list
         and not config.has_empty_list
     ):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

As discussed in https://github.com/feast-dev/feast/issues/5493, from 0.50.0 materialize does not work against Clickhouse offline store, with the reason being `pull_all_from_table_or_query` missing in the CH store implementation.

The PR adjusts this by adding the method. Also, makes sure some typing tests are not excluded anymore, apparently they pass just fine now.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

https://github.com/feast-dev/feast/issues/5493,


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
