### PR TITLE
fix: Fixed torch install issue in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,13 @@ install-python-dependencies-minimal: ## Install minimal Python dependencies usin
 install-python-dependencies-ci: ## Install Python CI dependencies in system environment using uv
 	# Install CPU-only torch first to prevent CUDA dependency issues
 	pip uninstall torch torchvision -y || true
-	pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu --force-reinstall
-	uv pip sync --system sdk/python/requirements/py$(PYTHON_VERSION)-ci-requirements.txt
+	@if [ "$$(uname -s)" = "Linux" ]; then \
+		echo "Installing dependencies with torch CPU index for Linux..."; \
+		uv pip sync --system --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match sdk/python/requirements/py$(PYTHON_VERSION)-ci-requirements.txt; \
+	else \
+		echo "Installing dependencies from PyPI for macOS..."; \
+		uv pip sync --system sdk/python/requirements/py$(PYTHON_VERSION)-ci-requirements.txt; \
+	fi
 	uv pip install --system --no-deps -e .
 
 # Used in github actions/ci


### PR DESCRIPTION
# What this PR does / why we need it:

The torch release pipeline occasionally releases wheel builds to their index (https://download.pytorch.org/whl/cpu) before the PyPI release is available. This causes issues in our CI pipeline where:

1. `pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu --force-reinstall` installs the latest version (e.g., 2.9.0) from the torch wheel index
2. `uv pip sync` then tries to sync with our pinned requirements, but the new version isn't on PyPI yet.
3. This creates a version mismatch, causing installation failures or test failures

This PR implements the two-step process with a single `uv pip sync` command that uses `--extra-index-url`.
