### PR TITLE
fix: Fix STRING type handling in on-demand feature views

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -172,6 +172,16 @@ def python_type_to_feast_value_type(
     if type_name in type_map:
         return type_map[type_name]
 
+    # Handle pandas "object" dtype by inspecting the actual value
+    if type_name == "object" and value is not None:
+        # Check the actual type of the value
+        actual_type = type(value).__name__.lower()
+        if actual_type == "str":
+            return ValueType.STRING
+        # If it's a different type wrapped in object, try to infer from the value
+        elif actual_type in type_map:
+            return type_map[actual_type]
+
     if isinstance(value, np.ndarray) and str(value.dtype) in type_map:
         item_type = type_map[str(value.dtype)]
         return ValueType[item_type.name + "_LIST"]

--- a/sdk/python/tests/unit/infra/test_inference_unit_tests.py
+++ b/sdk/python/tests/unit/infra/test_inference_unit_tests.py
@@ -96,14 +96,6 @@ def test_on_demand_features_valid_type_inference():
 
     python_native_test_view.infer_features()
 
-
-def test_on_demand_features_invalid_type_inference():
-    # Create Feature Views
-    date_request = RequestSource(
-        name="date_request",
-        schema=[Field(name="some_date", dtype=UnixTimestamp)],
-    )
-
     @on_demand_feature_view(
         sources=[date_request],
         schema=[
@@ -111,14 +103,20 @@ def test_on_demand_features_invalid_type_inference():
             Field(name="object_output", dtype=String),
         ],
     )
-    def invalid_test_view(features_df: pd.DataFrame) -> pd.DataFrame:
+    def object_string_test_view(features_df: pd.DataFrame) -> pd.DataFrame:
         data = pd.DataFrame()
         data["output"] = features_df["some_date"]
         data["object_output"] = features_df["some_date"].astype(str)
         return data
 
-    with pytest.raises(ValueError, match="Value with native type object"):
-        invalid_test_view.infer_features()
+    object_string_test_view.infer_features()
+
+
+def test_on_demand_features_invalid_type_inference():
+    date_request = RequestSource(
+        name="date_request",
+        schema=[Field(name="some_date", dtype=UnixTimestamp)],
+    )
 
     @on_demand_feature_view(
         schema=[
@@ -184,14 +182,13 @@ def test_datasource_inference():
             Field(name="object_output", dtype=String),
         ],
     )
-    def invalid_test_view(features_df: pd.DataFrame) -> pd.DataFrame:
+    def object_string_view(features_df: pd.DataFrame) -> pd.DataFrame:
         data = pd.DataFrame()
         data["output"] = features_df["some_date"]
         data["object_output"] = features_df["some_date"].astype(str)
         return data
 
-    with pytest.raises(ValueError, match="Value with native type object"):
-        invalid_test_view.infer_features()
+    object_string_view.infer_features()
 
     @on_demand_feature_view(
         sources=[date_request],


### PR DESCRIPTION
# What this PR does / why we need it:

Pandas DataFrames use dtype=object for strings by default (not dtype=string), but Feast's type inference system didn't handle "object" dtype, causing it to fail when trying to convert string columns.

# Which issue(s) this PR fixes:
Fixes https://github.com/feast-dev/feast/issues/5641 
