### PR TITLE
fix: ODFV not getting counted in resource count

### DIFF
--- a/sdk/python/feast/api/registry/rest/metrics.py
+++ b/sdk/python/feast/api/registry/rest/metrics.py
@@ -98,8 +98,8 @@ def get_metrics_router(grpc_handler, server=None) -> APIRouter:
                 features = {"features": []}
             try:
                 feature_views = grpc_call(
-                    grpc_handler.ListFeatureViews,
-                    RegistryServer_pb2.ListFeatureViewsRequest(
+                    grpc_handler.ListAllFeatureViews,
+                    RegistryServer_pb2.ListAllFeatureViewsRequest(
                         project=project_name, allow_cache=allow_cache
                     ),
                 )


### PR DESCRIPTION

# What this PR does / why we need it:

This PR address the issue where on-demand and stream feature views were not being counted in the `/api/v1/metrics/resource_counts` endpoint.

Before: Used `ListFeatureViews` which only returned regular feature views
After: Now uses `ListAllFeatureViews` which returns all types of feature views (regular, on-demand, and stream)

Added test coverage - test_feature_views_all_types_and_resource_counts_match ensures that resource counts accurately reflect all feature views.

