### PR TITLE
fix: Date wise remote offline store historical data retrieval 

### DIFF
--- a/sdk/python/feast/infra/offline_stores/remote.py
+++ b/sdk/python/feast/infra/offline_stores/remote.py
@@ -219,7 +219,7 @@ class RemoteOfflineStore(OfflineStore):
             "full_feature_names": full_feature_names,
             "name_aliases": name_aliases,
         }
-        
+
         # Extract and serialize start_date/end_date for remote transmission
         start_date = kwargs.get("start_date", None)
         end_date = kwargs.get("end_date", None)

--- a/sdk/python/feast/offline_server.py
+++ b/sdk/python/feast/offline_server.py
@@ -449,7 +449,7 @@ class OfflineServer(fl.FlightServerBase):
                 resource=feature_view, actions=[AuthzedAction.READ_OFFLINE]
             )
 
-    # Extract and deserialize start_date/end_date if present
+        # Extract and deserialize start_date/end_date if present
         kwargs = {}
         if "start_date" in command and command["start_date"] is not None:
             kwargs["start_date"] = utils.make_tzaware(
@@ -459,7 +459,7 @@ class OfflineServer(fl.FlightServerBase):
             kwargs["end_date"] = utils.make_tzaware(
                 datetime.fromisoformat(command["end_date"])
             )
-        
+
         retJob = self.offline_store.get_historical_features(
             config=self.store.config,
             feature_views=feature_views,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
When using a remote offline store with PostgreSQL backend, calling get_historical_features() with start_date and end_date parameters fails with:

> TypeError: Got an unexpected keyword argument 'start_date' / 'end_date' for RemoteOfflineStore

The implementation follows the same pattern used by local PostgreSQL based offline stores ensuring consistency across the codebase:

- Client-side changes (remote.py):
  -   Add **kwargs parameter to RemoteOfflineStore.get_historical_features() method signature
  -   Extract start_date and end_date from kwargs and serialize them to ISO format strings
  -   Include serialized dates in api_parameters for transmission over Arrow Flight


- Server-side changes (offline_server.py):
  - Extract start_date and end_date from the command dict (if present)
  - Deserialize ISO format strings back to timezone-aware datetime objects
  - Pass extracted dates as **kwargs to the underlying offline store

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
