### PR TITLE
feat: Added support for filtering multi-projects

### DIFF
--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -61,16 +61,45 @@ def get_app(
     with importlib_resources.as_file(ui_dir_ref) as ui_dir:
         # Initialize with the projects-list.json file
         with ui_dir.joinpath("projects-list.json").open(mode="w") as f:
-            projects_dict = {
-                "projects": [
+            # Get all projects from the registry
+            discovered_projects = []
+            registry = store.registry.proto()
+
+            # Use the projects list from the registry
+            if registry and registry.projects and len(registry.projects) > 0:
+                for proj in registry.projects:
+                    if proj.spec and proj.spec.name:
+                        discovered_projects.append(
+                            {
+                                "name": proj.spec.name.replace("_", " ").title(),
+                                "description": proj.spec.description
+                                or f"Project: {proj.spec.name}",
+                                "id": proj.spec.name,
+                                "registryPath": f"{root_path}/registry",
+                            }
+                        )
+            else:
+                # If no projects in registry, use the current project from feature_store.yaml
+                discovered_projects.append(
                     {
                         "name": "Project",
                         "description": "Test project",
                         "id": project_id,
                         "registryPath": f"{root_path}/registry",
                     }
-                ]
-            }
+                )
+
+            # Add "All Projects" option at the beginning if there are multiple projects
+            if len(discovered_projects) > 1:
+                all_projects_entry = {
+                    "name": "All Projects",
+                    "description": "View data across all projects",
+                    "id": "all",
+                    "registryPath": f"{root_path}/registry",
+                }
+                discovered_projects.insert(0, all_projects_entry)
+
+            projects_dict = {"projects": discovered_projects}
             f.write(json.dumps(projects_dict))
 
     @app.get("/registry")

--- a/ui/src/components/CommandPalette.tsx
+++ b/ui/src/components/CommandPalette.tsx
@@ -149,6 +149,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
             ? String(item.spec.description || "")
             : "",
         type: getItemType(item, name),
+        projectId: "projectId" in item ? String(item.projectId) : undefined,
       };
     });
 
@@ -158,15 +159,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
     };
   });
 
-  console.log(
-    "CommandPalette isOpen:",
-    isOpen,
-    "categories:",
-    categories.length,
-  ); // Debug log
-
   if (!isOpen) {
-    console.log("CommandPalette not rendering due to isOpen=false");
     return null;
   }
 
@@ -227,16 +220,11 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
                                   href={item.link}
                                   onClick={(e) => {
                                     e.preventDefault();
-                                    console.log(
-                                      "Search result clicked:",
-                                      item.name,
-                                    );
 
                                     onClose();
 
                                     setSearchText("");
 
-                                    console.log("Navigating to:", item.link);
                                     navigate(item.link);
                                   }}
                                   style={{
@@ -251,6 +239,17 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
                                     style={commandPaletteStyles.itemDescription}
                                   >
                                     {item.description}
+                                  </div>
+                                )}
+                                {item.projectId && (
+                                  <div
+                                    style={{
+                                      fontSize: "0.85em",
+                                      color: "#69707D",
+                                      marginTop: "4px",
+                                    }}
+                                  >
+                                    Project: {item.projectId}
                                   </div>
                                 )}
                               </EuiFlexItem>

--- a/ui/src/components/GlobalSearchShortcut.tsx
+++ b/ui/src/components/GlobalSearchShortcut.tsx
@@ -9,23 +9,13 @@ const GlobalSearchShortcut: React.FC<GlobalSearchShortcutProps> = ({
 }) => {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      console.log(
-        "Key pressed:",
-        event.key,
-        "metaKey:",
-        event.metaKey,
-        "ctrlKey:",
-        event.ctrlKey,
-      );
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
-        console.log("Cmd+K detected, preventing default and calling onOpen");
         event.preventDefault();
         event.stopPropagation();
         onOpen();
       }
     };
 
-    console.log("Adding keydown event listener to window");
     window.addEventListener("keydown", handleKeyDown, true);
     return () => {
       window.removeEventListener("keydown", handleKeyDown, true);

--- a/ui/src/components/ProjectSelector.tsx
+++ b/ui/src/components/ProjectSelector.tsx
@@ -1,11 +1,12 @@
 import { EuiSelect, useGeneratedHtmlId } from "@elastic/eui";
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
 import { useLoadProjectsList } from "../contexts/ProjectListContext";
 
 const ProjectSelector = () => {
   const { projectName } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const { isLoading, data } = useLoadProjectsList();
 
@@ -22,7 +23,20 @@ const ProjectSelector = () => {
 
   const basicSelectId = useGeneratedHtmlId({ prefix: "basicSelect" });
   const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    navigate(`/p/${e.target.value}`);
+    const newProjectId = e.target.value;
+
+    // If we're on a project page, maintain the current path context
+    if (projectName && location.pathname.startsWith(`/p/${projectName}`)) {
+      // Replace the old project name with the new one in the current path
+      const newPath = location.pathname.replace(
+        `/p/${projectName}`,
+        `/p/${newProjectId}`,
+      );
+      navigate(newPath);
+    } else {
+      // Otherwise, just navigate to the project home
+      navigate(`/p/${newProjectId}`);
+    }
   };
 
   return (

--- a/ui/src/components/RegistrySearch.tsx
+++ b/ui/src/components/RegistrySearch.tsx
@@ -112,6 +112,7 @@ const RegistrySearch = forwardRef<RegistrySearchRef, RegistrySearchProps>(
               ? String(item.spec.description || "")
               : "",
           type: getItemType(item, name),
+          projectId: "projectId" in item ? String(item.projectId) : undefined,
         };
       });
 
@@ -185,6 +186,17 @@ const RegistrySearch = forwardRef<RegistrySearchRef, RegistrySearchProps>(
                                   style={searchResultsStyles.itemDescription}
                                 >
                                   {item.description}
+                                </div>
+                              )}
+                              {item.projectId && (
+                                <div
+                                  style={{
+                                    fontSize: "0.85em",
+                                    color: "#69707D",
+                                    marginTop: "4px",
+                                  }}
+                                >
+                                  Project: {item.projectId}
                                 </div>
                               )}
                             </EuiFlexItem>

--- a/ui/src/components/RegistryVisualizationTab.tsx
+++ b/ui/src/components/RegistryVisualizationTab.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState } from "react";
+import { useParams } from "react-router-dom";
 import {
   EuiEmptyPrompt,
   EuiLoadingSpinner,
@@ -16,7 +17,11 @@ import { filterPermissionsByAction } from "../utils/permissionUtils";
 
 const RegistryVisualizationTab = () => {
   const registryUrl = useContext(RegistryPathContext);
-  const { isLoading, isSuccess, isError, data } = useLoadRegistry(registryUrl);
+  const { projectName } = useParams();
+  const { isLoading, isSuccess, isError, data } = useLoadRegistry(
+    registryUrl,
+    projectName,
+  );
   const [selectedObjectType, setSelectedObjectType] = useState("");
   const [selectedObjectName, setSelectedObjectName] = useState("");
   const [selectedPermissionAction, setSelectedPermissionAction] = useState("");

--- a/ui/src/mocks/handlers.ts
+++ b/ui/src/mocks/handlers.ts
@@ -8,12 +8,12 @@ const registry = readFileSync(
 
 const projectsListWithDefaultProject = http.get("/projects-list.json", () =>
   HttpResponse.json({
-    default: "credit_score_project",
+    default: "credit_scoring_aws",
     projects: [
       {
         name: "Credit Score Project",
         description: "Project for credit scoring team and associated models.",
-        id: "credit_score_project",
+        id: "credit_scoring_aws",
         registryPath: "/registry.db", // Changed to match what the test expects
       },
     ],

--- a/ui/src/pages/ProjectOverviewPage.tsx
+++ b/ui/src/pages/ProjectOverviewPage.tsx
@@ -9,6 +9,9 @@ import {
   EuiSkeletonText,
   EuiEmptyPrompt,
   EuiFieldSearch,
+  EuiPanel,
+  EuiStat,
+  EuiCard,
 } from "@elastic/eui";
 
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
@@ -18,14 +21,191 @@ import useLoadRegistry from "../queries/useLoadRegistry";
 import RegistryPathContext from "../contexts/RegistryPathContext";
 import RegistryVisualizationTab from "../components/RegistryVisualizationTab";
 import RegistrySearch from "../components/RegistrySearch";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
+import { useLoadProjectsList } from "../contexts/ProjectListContext";
+
+// Component for "All Projects" view
+const AllProjectsDashboard = () => {
+  const registryUrl = useContext(RegistryPathContext);
+  const navigate = useNavigate();
+  const { data: projectsData } = useLoadProjectsList();
+  const { data: registryData } = useLoadRegistry(registryUrl);
+
+  if (!registryData) {
+    return <EuiSkeletonText lines={10} />;
+  }
+
+  // Calculate total counts across all projects
+  const totalCounts = {
+    featureViews: registryData.objects.featureViews?.length || 0,
+    entities: registryData.objects.entities?.length || 0,
+    dataSources: registryData.objects.dataSources?.length || 0,
+    featureServices: registryData.objects.featureServices?.length || 0,
+    features: registryData.allFeatures?.length || 0,
+  };
+
+  // Get projects from registry and count their objects
+  const projects = projectsData?.projects.filter((p) => p.id !== "all") || [];
+  const projectStats = projects.map((project) => {
+    const projectFVs =
+      registryData.objects.featureViews?.filter(
+        (fv: any) => fv?.spec?.project === project.id,
+      ) || [];
+    const projectEntities =
+      registryData.objects.entities?.filter(
+        (e: any) => e?.spec?.project === project.id,
+      ) || [];
+    const projectFeatures =
+      registryData.allFeatures?.filter((f: any) => f?.project === project.id) ||
+      [];
+
+    return {
+      ...project,
+      counts: {
+        featureViews: projectFVs.length,
+        entities: projectEntities.length,
+        features: projectFeatures.length,
+      },
+    };
+  });
+
+  return (
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Section>
+        <EuiTitle size="l">
+          <h1>All Projects Overview</h1>
+        </EuiTitle>
+        <EuiSpacer />
+
+        <EuiText>
+          <p>
+            View aggregated statistics and explore data across all your Feast
+            projects.
+          </p>
+        </EuiText>
+        <EuiSpacer size="l" />
+
+        {/* Total Stats */}
+        <EuiPanel hasBorder>
+          <EuiTitle size="s">
+            <h3>Total Across All Projects</h3>
+          </EuiTitle>
+          <EuiSpacer size="m" />
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiStat
+                title={totalCounts.featureViews.toString()}
+                description="Feature Views"
+                titleSize="m"
+                textAlign="center"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiStat
+                title={totalCounts.entities.toString()}
+                description="Entities"
+                titleSize="m"
+                textAlign="center"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiStat
+                title={totalCounts.features.toString()}
+                description="Features"
+                titleSize="m"
+                textAlign="center"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiStat
+                title={totalCounts.featureServices.toString()}
+                description="Feature Services"
+                titleSize="m"
+                textAlign="center"
+              />
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiStat
+                title={totalCounts.dataSources.toString()}
+                description="Data Sources"
+                titleSize="m"
+                textAlign="center"
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiPanel>
+
+        <EuiSpacer size="l" />
+
+        {/* Individual Projects */}
+        <EuiTitle size="s">
+          <h3>Projects ({projects.length})</h3>
+        </EuiTitle>
+        <EuiSpacer size="m" />
+        <EuiFlexGroup gutterSize="l" wrap>
+          {projectStats.map((project) => (
+            <EuiFlexItem
+              key={project.id}
+              style={{ minWidth: "300px", maxWidth: "400px" }}
+            >
+              <EuiCard
+                title={project.name}
+                description={project.description}
+                onClick={() => navigate(`/p/${project.id}`)}
+                style={{ cursor: "pointer" }}
+              >
+                <EuiSpacer size="s" />
+                <EuiFlexGroup justifyContent="spaceAround" gutterSize="s">
+                  <EuiFlexItem grow={false}>
+                    <EuiText size="s" textAlign="center">
+                      <strong>{project.counts.featureViews}</strong>
+                      <br />
+                      <span style={{ fontSize: "0.85em", color: "#69707D" }}>
+                        Feature Views
+                      </span>
+                    </EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiText size="s" textAlign="center">
+                      <strong>{project.counts.entities}</strong>
+                      <br />
+                      <span style={{ fontSize: "0.85em", color: "#69707D" }}>
+                        Entities
+                      </span>
+                    </EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false}>
+                    <EuiText size="s" textAlign="center">
+                      <strong>{project.counts.features}</strong>
+                      <br />
+                      <span style={{ fontSize: "0.85em", color: "#69707D" }}>
+                        Features
+                      </span>
+                    </EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiCard>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGroup>
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
+  );
+};
 
 const ProjectOverviewPage = () => {
   useDocumentTitle("Feast Home");
   const registryUrl = useContext(RegistryPathContext);
-  const { isLoading, isSuccess, isError, data } = useLoadRegistry(registryUrl);
-
   const { projectName } = useParams<{ projectName: string }>();
+  const { isLoading, isSuccess, isError, data } = useLoadRegistry(
+    registryUrl,
+    projectName,
+  );
+
+  // Show aggregated dashboard for "All Projects" view
+  if (projectName === "all") {
+    return <AllProjectsDashboard />;
+  }
 
   const categories = [
     {

--- a/ui/src/pages/Sidebar.tsx
+++ b/ui/src/pages/Sidebar.tsx
@@ -17,8 +17,8 @@ import { PermissionsIcon } from "../graphics/PermissionsIcon";
 
 const SideNav = () => {
   const registryUrl = useContext(RegistryPathContext);
-  const { isSuccess, data } = useLoadRegistry(registryUrl);
   const { projectName } = useParams();
+  const { isSuccess, data } = useLoadRegistry(registryUrl, projectName);
 
   const [isSideNavOpenOnMobile, setisSideNavOpenOnMobile] = useState(false);
 

--- a/ui/src/pages/data-sources/DataSourceOverviewTab.tsx
+++ b/ui/src/pages/data-sources/DataSourceOverviewTab.tsx
@@ -27,9 +27,9 @@ import RequestDataSourceSchemaTable from "./RequestDataSourceSchemaTable";
 import useLoadDataSource from "./useLoadDataSource";
 
 const DataSourceOverviewTab = () => {
-  let { dataSourceName } = useParams();
+  let { dataSourceName, projectName } = useParams();
   const registryUrl = useContext(RegistryPathContext);
-  const registryQuery = useLoadRegistry(registryUrl);
+  const registryQuery = useLoadRegistry(registryUrl, projectName);
 
   const dsName = dataSourceName === undefined ? "" : dataSourceName;
   const { isLoading, isSuccess, isError, data, consumingFeatureViews } =

--- a/ui/src/pages/data-sources/DataSourcesListingTable.tsx
+++ b/ui/src/pages/data-sources/DataSourcesListingTable.tsx
@@ -18,9 +18,11 @@ const DatasourcesListingTable = ({
       name: "Name",
       field: "name",
       sortable: true,
-      render: (name: string) => {
+      render: (name: string, item: feast.core.IDataSource) => {
+        // For "All Projects" view, link to the specific project
+        const itemProject = item?.project || projectName;
         return (
-          <EuiCustomLink to={`/p/${projectName}/data-source/${name}`}>
+          <EuiCustomLink to={`/p/${itemProject}/data-source/${name}`}>
             {name}
           </EuiCustomLink>
         );
@@ -35,6 +37,18 @@ const DatasourcesListingTable = ({
       },
     },
   ];
+
+  // Add Project column when viewing all projects
+  if (projectName === "all") {
+    columns.splice(1, 0, {
+      name: "Project",
+      field: "project",
+      sortable: true,
+      render: (project: string) => {
+        return <span>{project || "Unknown"}</span>;
+      },
+    });
+  }
 
   const getRowProps = (item: feast.core.IDataSource) => {
     return {

--- a/ui/src/pages/data-sources/Index.tsx
+++ b/ui/src/pages/data-sources/Index.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import { useParams } from "react-router-dom";
 
 import {
   EuiPageTemplate,
@@ -22,7 +23,8 @@ import ExportButton from "../../components/ExportButton";
 
 const useLoadDatasources = () => {
   const registryUrl = useContext(RegistryPathContext);
-  const registryQuery = useLoadRegistry(registryUrl);
+  const { projectName } = useParams();
+  const registryQuery = useLoadRegistry(registryUrl, projectName);
 
   const data =
     registryQuery.data === undefined

--- a/ui/src/pages/data-sources/useLoadDataSource.ts
+++ b/ui/src/pages/data-sources/useLoadDataSource.ts
@@ -1,11 +1,13 @@
 import { useContext } from "react";
+import { useParams } from "react-router-dom";
 import RegistryPathContext from "../../contexts/RegistryPathContext";
 import { FEAST_FCO_TYPES } from "../../parsers/types";
 import useLoadRegistry from "../../queries/useLoadRegistry";
 
 const useLoadDataSource = (dataSourceName: string) => {
   const registryUrl = useContext(RegistryPathContext);
-  const registryQuery = useLoadRegistry(registryUrl);
+  const { projectName } = useParams();
+  const registryQuery = useLoadRegistry(registryUrl, projectName);
 
   const data =
     registryQuery.data === undefined

--- a/ui/src/pages/entities/EntitiesListingTable.tsx
+++ b/ui/src/pages/entities/EntitiesListingTable.tsx
@@ -18,9 +18,11 @@ const EntitiesListingTable = ({ entities }: EntitiesListingTableProps) => {
       name: "Name",
       field: "spec.name",
       sortable: true,
-      render: (name: string) => {
+      render: (name: string, item: feast.core.IEntity) => {
+        // For "All Projects" view, link to the specific project
+        const itemProject = item?.spec?.project || projectName;
         return (
-          <EuiCustomLink to={`/p/${projectName}/entity/${name}`}>
+          <EuiCustomLink to={`/p/${itemProject}/entity/${name}`}>
             {name}
           </EuiCustomLink>
         );
@@ -45,6 +47,18 @@ const EntitiesListingTable = ({ entities }: EntitiesListingTableProps) => {
       },
     },
   ];
+
+  // Add Project column when viewing all projects
+  if (projectName === "all") {
+    columns.splice(1, 0, {
+      name: "Project",
+      field: "spec.project",
+      sortable: true,
+      render: (project: string) => {
+        return <span>{project || "Unknown"}</span>;
+      },
+    });
+  }
 
   const getRowProps = (item: feast.core.IEntity) => {
     return {

--- a/ui/src/pages/entities/EntityOverviewTab.tsx
+++ b/ui/src/pages/entities/EntityOverviewTab.tsx
@@ -28,9 +28,9 @@ import useFeatureViewEdgesByEntity from "./useFeatureViewEdgesByEntity";
 import useLoadEntity from "./useLoadEntity";
 
 const EntityOverviewTab = () => {
-  let { entityName } = useParams();
+  let { entityName, projectName } = useParams();
   const registryUrl = useContext(RegistryPathContext);
-  const registryQuery = useLoadRegistry(registryUrl);
+  const registryQuery = useLoadRegistry(registryUrl, projectName);
 
   const eName = entityName === undefined ? "" : entityName;
   const { isLoading, isSuccess, isError, data } = useLoadEntity(eName);

--- a/ui/src/pages/entities/Index.tsx
+++ b/ui/src/pages/entities/Index.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import { useParams } from "react-router-dom";
 
 import { EuiPageTemplate, EuiLoadingSpinner } from "@elastic/eui";
 
@@ -13,7 +14,8 @@ import ExportButton from "../../components/ExportButton";
 
 const useLoadEntities = () => {
   const registryUrl = useContext(RegistryPathContext);
-  const registryQuery = useLoadRegistry(registryUrl);
+  const { projectName } = useParams();
+  const registryQuery = useLoadRegistry(registryUrl, projectName);
 
   const data =
     registryQuery.data === undefined

--- a/ui/src/pages/entities/useLoadEntity.ts
+++ b/ui/src/pages/entities/useLoadEntity.ts
@@ -1,10 +1,12 @@
 import { useContext } from "react";
+import { useParams } from "react-router-dom";
 import RegistryPathContext from "../../contexts/RegistryPathContext";
 import useLoadRegistry from "../../queries/useLoadRegistry";
 
 const useLoadEntity = (entityName: string) => {
   const registryUrl = useContext(RegistryPathContext);
-  const registryQuery = useLoadRegistry(registryUrl);
+  const { projectName } = useParams();
+  const registryQuery = useLoadRegistry(registryUrl, projectName);
 
   const data =
     registryQuery.data === undefined

--- a/ui/src/pages/feature-services/FeatureServiceListingTable.tsx
+++ b/ui/src/pages/feature-services/FeatureServiceListingTable.tsx
@@ -28,9 +28,11 @@ const FeatureServiceListingTable = ({
     {
       name: "Name",
       field: "spec.name",
-      render: (name: string) => {
+      render: (name: string, item: feast.core.IFeatureService) => {
+        // For "All Projects" view, link to the specific project
+        const itemProject = item?.spec?.project || projectName;
         return (
-          <EuiCustomLink to={`/p/${projectName}/feature-service/${name}`}>
+          <EuiCustomLink to={`/p/${itemProject}/feature-service/${name}`}>
             {name}
           </EuiCustomLink>
         );
@@ -55,6 +57,18 @@ const FeatureServiceListingTable = ({
       },
     },
   ];
+
+  // Add Project column when viewing all projects
+  if (projectName === "all") {
+    columns.splice(1, 0, {
+      name: "Project",
+      field: "spec.project",
+      sortable: true,
+      render: (project: string) => {
+        return project || "Unknown";
+      },
+    });
+  }
 
   tagKeysSet.forEach((key) => {
     columns.push({

--- a/ui/src/pages/feature-services/Index.tsx
+++ b/ui/src/pages/feature-services/Index.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import { useParams } from "react-router-dom";
 
 import {
   EuiPageTemplate,
@@ -30,7 +31,8 @@ import { feast } from "../../protos";
 
 const useLoadFeatureServices = () => {
   const registryUrl = useContext(RegistryPathContext);
-  const registryQuery = useLoadRegistry(registryUrl);
+  const { projectName } = useParams();
+  const registryQuery = useLoadRegistry(registryUrl, projectName);
 
   const data =
     registryQuery.data === undefined

--- a/ui/src/pages/feature-services/useLoadFeatureService.ts
+++ b/ui/src/pages/feature-services/useLoadFeatureService.ts
@@ -1,5 +1,6 @@
 import { FEAST_FCO_TYPES } from "../../parsers/types";
 import { useContext } from "react";
+import { useParams } from "react-router-dom";
 import RegistryPathContext from "../../contexts/RegistryPathContext";
 
 import useLoadRegistry from "../../queries/useLoadRegistry";
@@ -7,7 +8,8 @@ import { EntityReference } from "../../parsers/parseEntityRelationships";
 
 const useLoadFeatureService = (featureServiceName: string) => {
   const registryUrl = useContext(RegistryPathContext);
-  const registryQuery = useLoadRegistry(registryUrl);
+  const { projectName } = useParams();
+  const registryQuery = useLoadRegistry(registryUrl, projectName);
 
   const data =
     registryQuery.data === undefined

--- a/ui/src/pages/feature-views/FeatureViewInstance.tsx
+++ b/ui/src/pages/feature-views/FeatureViewInstance.tsx
@@ -14,9 +14,9 @@ import useLoadRegistry from "../../queries/useLoadRegistry";
 import RegistryPathContext from "../../contexts/RegistryPathContext";
 
 const FeatureViewInstance = () => {
-  const { featureViewName } = useParams();
+  const { featureViewName, projectName } = useParams();
   const registryUrl = React.useContext(RegistryPathContext);
-  const registryQuery = useLoadRegistry(registryUrl);
+  const registryQuery = useLoadRegistry(registryUrl, projectName);
 
   const fvName = featureViewName === undefined ? "" : featureViewName;
 

--- a/ui/src/pages/feature-views/FeatureViewLineageTab.tsx
+++ b/ui/src/pages/feature-views/FeatureViewLineageTab.tsx
@@ -22,13 +22,13 @@ interface FeatureViewLineageTabProps {
 
 const FeatureViewLineageTab = ({ data }: FeatureViewLineageTabProps) => {
   const registryUrl = useContext(RegistryPathContext);
+  const { featureViewName, projectName } = useParams();
   const {
     isLoading,
     isSuccess,
     isError,
     data: registryData,
-  } = useLoadRegistry(registryUrl);
-  const { featureViewName } = useParams();
+  } = useLoadRegistry(registryUrl, projectName);
   const [selectedPermissionAction, setSelectedPermissionAction] = useState("");
 
   const filterNode = {

--- a/ui/src/pages/feature-views/FeatureViewListingTable.tsx
+++ b/ui/src/pages/feature-views/FeatureViewListingTable.tsx
@@ -30,8 +30,10 @@ const FeatureViewListingTable = ({
       field: "name",
       sortable: true,
       render: (name: string, item: genericFVType) => {
+        // For "All Projects" view, link to the specific project
+        const itemProject = item.object?.spec?.project || projectName;
         return (
-          <EuiCustomLink to={`/p/${projectName}/feature-view/${name}`}>
+          <EuiCustomLink to={`/p/${itemProject}/feature-view/${name}`}>
             {name}{" "}
             {(item.type === "ondemand" && <EuiBadge>ondemand</EuiBadge>) ||
               (item.type === "stream" && <EuiBadge>stream</EuiBadge>)}
@@ -48,6 +50,16 @@ const FeatureViewListingTable = ({
       },
     },
   ];
+
+  // Add Project column when viewing all projects
+  if (projectName === "all") {
+    columns.splice(1, 0, {
+      name: "Project",
+      render: (item: genericFVType) => {
+        return <span>{item.object?.spec?.project || "Unknown"}</span>;
+      },
+    });
+  }
 
   // Add columns if they come up in search
   tagKeysSet.forEach((key) => {

--- a/ui/src/pages/feature-views/Index.tsx
+++ b/ui/src/pages/feature-views/Index.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import { useParams } from "react-router-dom";
 
 import {
   EuiPageTemplate,
@@ -29,7 +30,8 @@ import ExportButton from "../../components/ExportButton";
 
 const useLoadFeatureViews = () => {
   const registryUrl = useContext(RegistryPathContext);
-  const registryQuery = useLoadRegistry(registryUrl);
+  const { projectName } = useParams();
+  const registryQuery = useLoadRegistry(registryUrl, projectName);
 
   const data =
     registryQuery.data === undefined

--- a/ui/src/pages/features/FeatureListPage.tsx
+++ b/ui/src/pages/features/FeatureListPage.tsx
@@ -33,6 +33,7 @@ interface Feature {
   name: string;
   featureView: string;
   type: string;
+  project?: string;
   permissions?: any[];
 }
 
@@ -43,7 +44,10 @@ type FeatureColumn =
 const FeatureListPage = () => {
   const { projectName } = useParams();
   const registryUrl = useContext(RegistryPathContext);
-  const { data, isLoading, isError } = useLoadRegistry(registryUrl);
+  const { data, isLoading, isError } = useLoadRegistry(
+    registryUrl,
+    projectName,
+  );
   const [searchText, setSearchText] = useState("");
   const [selectedPermissionAction, setSelectedPermissionAction] = useState("");
 
@@ -95,23 +99,31 @@ const FeatureListPage = () => {
       name: "Feature Name",
       field: "name",
       sortable: true,
-      render: (name: string, feature: Feature) => (
-        <EuiCustomLink
-          to={`/p/${projectName}/feature-view/${feature.featureView}/feature/${name}`}
-        >
-          {name}
-        </EuiCustomLink>
-      ),
+      render: (name: string, feature: Feature) => {
+        // For "All Projects" view, link to the specific project
+        const itemProject = feature.project || projectName;
+        return (
+          <EuiCustomLink
+            to={`/p/${itemProject}/feature-view/${feature.featureView}/feature/${name}`}
+          >
+            {name}
+          </EuiCustomLink>
+        );
+      },
     },
     {
       name: "Feature View",
       field: "featureView",
       sortable: true,
-      render: (featureView: string) => (
-        <EuiCustomLink to={`/p/${projectName}/feature-view/${featureView}`}>
-          {featureView}
-        </EuiCustomLink>
-      ),
+      render: (featureView: string, feature: Feature) => {
+        // For "All Projects" view, link to the specific project
+        const itemProject = feature.project || projectName;
+        return (
+          <EuiCustomLink to={`/p/${itemProject}/feature-view/${featureView}`}>
+            {featureView}
+          </EuiCustomLink>
+        );
+      },
     },
     { name: "Type", field: "type", sortable: true },
     {
@@ -143,6 +155,18 @@ const FeatureListPage = () => {
       },
     },
   ];
+
+  // Add Project column when viewing all projects
+  if (projectName === "all") {
+    columns.splice(1, 0, {
+      name: "Project",
+      field: "project",
+      sortable: true,
+      render: (project: string) => {
+        return <span>{project || "Unknown"}</span>;
+      },
+    });
+  }
 
   const onTableChange = ({ page, sort }: CriteriaWithPagination<Feature>) => {
     if (sort) {

--- a/ui/src/pages/lineage/Index.tsx
+++ b/ui/src/pages/lineage/Index.tsx
@@ -16,8 +16,44 @@ import { useParams } from "react-router-dom";
 const LineagePage = () => {
   useDocumentTitle("Feast Lineage");
   const registryUrl = useContext(RegistryPathContext);
-  const { isLoading, isSuccess, isError, data } = useLoadRegistry(registryUrl);
   const { projectName } = useParams<{ projectName: string }>();
+  const { isLoading, isSuccess, isError, data } = useLoadRegistry(
+    registryUrl,
+    projectName,
+  );
+
+  // Show message for "All Projects" view
+  if (projectName === "all") {
+    return (
+      <EuiPageTemplate panelled>
+        <EuiPageTemplate.Section>
+          <EuiTitle size="l">
+            <h1>Lineage Visualization</h1>
+          </EuiTitle>
+          <EuiSpacer />
+          <EuiEmptyPrompt
+            iconType="branch"
+            title={<h2>Project Selection Required</h2>}
+            body={
+              <>
+                <p>
+                  Lineage visualization requires a specific project context to
+                  show the relationships between Feature Views, Entities, and
+                  Data Sources.
+                </p>
+                <p>
+                  <strong>
+                    Please select a specific project from the dropdown above
+                  </strong>{" "}
+                  to view its lineage graph.
+                </p>
+              </>
+            }
+          />
+        </EuiPageTemplate.Section>
+      </EuiPageTemplate>
+    );
+  }
 
   return (
     <EuiPageTemplate panelled>

--- a/ui/src/pages/permissions/Index.tsx
+++ b/ui/src/pages/permissions/Index.tsx
@@ -13,6 +13,7 @@ import {
   EuiFormRow,
 } from "@elastic/eui";
 import { useContext, useState } from "react";
+import { useParams } from "react-router-dom";
 import RegistryPathContext from "../../contexts/RegistryPathContext";
 import useLoadRegistry from "../../queries/useLoadRegistry";
 import PermissionsDisplay from "../../components/PermissionsDisplay";
@@ -20,7 +21,11 @@ import { filterPermissionsByAction } from "../../utils/permissionUtils";
 
 const PermissionsIndex = () => {
   const registryUrl = useContext(RegistryPathContext);
-  const { isLoading, isSuccess, isError, data } = useLoadRegistry(registryUrl);
+  const { projectName } = useParams();
+  const { isLoading, isSuccess, isError, data } = useLoadRegistry(
+    registryUrl,
+    projectName,
+  );
   const [selectedPermissionAction, setSelectedPermissionAction] = useState("");
 
   return (

--- a/ui/src/queries/useLoadRelationshipsData.ts
+++ b/ui/src/queries/useLoadRelationshipsData.ts
@@ -1,10 +1,12 @@
 import { useContext } from "react";
+import { useParams } from "react-router-dom";
 import RegistryPathContext from "../contexts/RegistryPathContext";
 import useLoadRegistry from "./useLoadRegistry";
 
 const useLoadRelationshipData = () => {
   const registryUrl = useContext(RegistryPathContext);
-  const registryQuery = useLoadRegistry(registryUrl);
+  const { projectName } = useParams();
+  const registryQuery = useLoadRegistry(registryUrl, projectName);
 
   const data =
     registryQuery.data === undefined


### PR DESCRIPTION
# What this PR does / why we need it:

This PR adds comprehensive multi-project support to the Feast UI, enabling users to view and filter data across multiple projects when using a shared registry. Previously, the UI would display all objects from all projects without distinction, making it difficult to work with multi-project setups.

**Features**:

- Project-Based Filtering
- Data on all list pages is now filtered based on the selected project
- Cross-Project Global Search
- Search results display the project name for each item
- "All Projects" View
- Appears automatically when multiple projects exist in the registry
- Maintains current page context when switching projects
- Projects are automatically detected from registry

https://github.com/user-attachments/assets/a9061600-44f6-48d8-86bc-efda8da31b71



