### PR TITLE
fix: Add mode field to Transformation proto for proper serialization

### DIFF
--- a/protos/feast/core/FeatureView.proto
+++ b/protos/feast/core/FeatureView.proto
@@ -36,7 +36,7 @@ message FeatureView {
     FeatureViewMeta meta = 2;
 }
 
-// Next available id: 16
+// Next available id: 17
 // TODO(adchia): refactor common fields from this and ODFV into separate metadata proto
 message FeatureViewSpec {
     // Name of the feature view. Must be unique. Not updated.
@@ -51,17 +51,8 @@ message FeatureViewSpec {
     // List of specifications for each feature defined as part of this feature view.
     repeated FeatureSpecV2 features = 4;
 
-    // List of specifications for each entity defined as part of this feature view.
-    repeated FeatureSpecV2 entity_columns = 12;
-
-    // Description of the feature view.
-    string description = 10;
-
     // User defined metadata
     map<string,string> tags = 5;
-
-    // Owner of the feature view.
-    string owner = 11;
 
     // Features in this feature view can only be retrieved from online serving
     // younger than ttl. Ttl is measured as the duration of time between
@@ -71,12 +62,22 @@ message FeatureViewSpec {
 
     // Batch/Offline DataSource where this view can retrieve offline feature data.
     DataSource batch_source = 7;
-    // Streaming DataSource from where this view can consume "online" feature data.
-    DataSource stream_source = 9;
 
     // Whether these features should be served online or not
     // This is also used to determine whether the features should be written to the online store
     bool online = 8;
+
+    // Streaming DataSource from where this view can consume "online" feature data.
+    DataSource stream_source = 9;
+
+    // Description of the feature view.
+    string description = 10;
+
+    // Owner of the feature view.
+    string owner = 11;
+
+    // List of specifications for each entity defined as part of this feature view.
+    repeated FeatureSpecV2 entity_columns = 12;
 
     // Whether these features should be written to the offline store
     bool offline = 13;
@@ -85,6 +86,9 @@ message FeatureViewSpec {
 
     // Feature transformation for batch feature views
     FeatureTransformationV2 feature_transformation = 15;
+
+    // The transformation mode (e.g., "python", "pandas", "spark", "sql", "ray")
+    string mode = 16;
 }
 
 message FeatureViewMeta {

--- a/protos/feast/core/Transformation.proto
+++ b/protos/feast/core/Transformation.proto
@@ -15,6 +15,9 @@ message UserDefinedFunctionV2 {
 
     // The string representation of the udf
     string body_text = 3;
+
+    // The transformation mode (e.g., "python", "pandas", "spark", "sql")
+    string mode = 4;
 }
 
 // A feature transformation executed as a user-defined function

--- a/sdk/python/feast/batch_feature_view.py
+++ b/sdk/python/feast/batch_feature_view.py
@@ -136,6 +136,7 @@ class BatchFeatureView(FeatureView):
             schema=schema,
             source=source,  # type: ignore[arg-type]
             sink_source=sink_source,
+            mode=mode,
         )
 
     def get_feature_transformation(self) -> Optional[Transformation]:

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -39,6 +39,7 @@ from feast.protos.feast.core.FeatureView_pb2 import (
 from feast.protos.feast.core.Transformation_pb2 import (
     FeatureTransformationV2 as FeatureTransformationProto,
 )
+from feast.transformation.mode import TransformationMode
 from feast.types import from_value_type
 from feast.value_type import ValueType
 
@@ -102,6 +103,7 @@ class FeatureView(BaseFeatureView):
     tags: Dict[str, str]
     owner: str
     materialization_intervals: List[Tuple[datetime, datetime]]
+    mode: Optional[Union["TransformationMode", str]]
 
     def __init__(
         self,
@@ -117,6 +119,7 @@ class FeatureView(BaseFeatureView):
         description: str = "",
         tags: Optional[Dict[str, str]] = None,
         owner: str = "",
+        mode: Optional[Union["TransformationMode", str]] = None,
     ):
         """
         Creates a FeatureView object.
@@ -140,6 +143,7 @@ class FeatureView(BaseFeatureView):
             tags (optional): A dictionary of key-value pairs to store arbitrary metadata.
             owner (optional): The owner of the feature view, typically the email of the
                 primary maintainer.
+            mode (optional): The transformation mode to use (e.g., python, pandas, spark, sql).
 
         Raises:
             ValueError: A field mapping conflicts with an Entity or a Feature.
@@ -252,6 +256,7 @@ class FeatureView(BaseFeatureView):
         )
         self.online = online
         self.offline = offline
+        self.mode = mode
         self.materialization_intervals = []
 
     def __hash__(self):
@@ -439,6 +444,14 @@ class FeatureView(BaseFeatureView):
                     substrait_transformation=transformation_proto,
                 )
 
+        mode_str = ""
+        if self.mode:
+            mode_str = (
+                self.mode.value
+                if isinstance(self.mode, TransformationMode)
+                else self.mode
+            )
+
         return FeatureViewSpecProto(
             name=self.name,
             entities=self.entities,
@@ -454,6 +467,7 @@ class FeatureView(BaseFeatureView):
             stream_source=stream_source_proto,
             source_views=source_view_protos,
             feature_transformation=feature_transformation_proto,
+            mode=mode_str,
         )
 
     def to_proto_meta(self):
@@ -527,6 +541,7 @@ class FeatureView(BaseFeatureView):
 
         if has_transformation and cls == FeatureView:
             from feast.batch_feature_view import BatchFeatureView
+            from feast.transformation.factory import get_transformation_class_from_type
             from feast.transformation.python_transformation import PythonTransformation
             from feast.transformation.substrait_transformation import (
                 SubstraitTransformation,
@@ -538,13 +553,29 @@ class FeatureView(BaseFeatureView):
             transformation = None
 
             if feature_transformation_proto.HasField("user_defined_function"):
-                transformation = PythonTransformation.from_proto(
-                    feature_transformation_proto.user_defined_function
-                )
+                udf_proto = feature_transformation_proto.user_defined_function
+                if udf_proto.mode:
+                    try:
+                        transformation_class = get_transformation_class_from_type(
+                            udf_proto.mode
+                        )
+                        transformation = transformation_class.from_proto(udf_proto)
+                    except (ValueError, KeyError):
+                        transformation = PythonTransformation.from_proto(udf_proto)
+                else:
+                    transformation = PythonTransformation.from_proto(udf_proto)
             elif feature_transformation_proto.HasField("substrait_transformation"):
                 transformation = SubstraitTransformation.from_proto(
                     feature_transformation_proto.substrait_transformation
                 )
+
+            mode: Union[TransformationMode, str]
+            if feature_view_proto.spec.mode:
+                mode = feature_view_proto.spec.mode
+            elif transformation and hasattr(transformation, "mode"):
+                mode = transformation.mode
+            else:
+                mode = TransformationMode.PYTHON
 
             feature_view: FeatureView = BatchFeatureView(  # type: ignore[assignment]
                 name=feature_view_proto.spec.name,
@@ -560,9 +591,14 @@ class FeatureView(BaseFeatureView):
                 ),
                 source=source_views if source_views else batch_source,  # type: ignore[arg-type]
                 sink_source=batch_source if source_views else None,
+                mode=mode,
                 feature_transformation=transformation,
             )
         else:
+            mode_from_spec = (
+                feature_view_proto.spec.mode if feature_view_proto.spec.mode else None
+            )
+
             feature_view = cls(  # type: ignore[assignment]
                 name=feature_view_proto.spec.name,
                 description=feature_view_proto.spec.description,
@@ -577,6 +613,7 @@ class FeatureView(BaseFeatureView):
                 ),
                 source=source_views if source_views else batch_source,
                 sink_source=batch_source if source_views else None,
+                mode=mode_from_spec,
             )
         if stream_source:
             feature_view.stream_source = stream_source

--- a/sdk/python/feast/protos/feast/core/FeatureView_pb2.py
+++ b/sdk/python/feast/protos/feast/core/FeatureView_pb2.py
@@ -19,7 +19,7 @@ from feast.protos.feast.core import Feature_pb2 as feast_dot_core_dot_Feature__p
 from feast.protos.feast.core import Transformation_pb2 as feast_dot_core_dot_Transformation__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1c\x66\x65\x61st/core/FeatureView.proto\x12\nfeast.core\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1b\x66\x65\x61st/core/DataSource.proto\x1a\x18\x66\x65\x61st/core/Feature.proto\x1a\x1f\x66\x65\x61st/core/Transformation.proto\"c\n\x0b\x46\x65\x61tureView\x12)\n\x04spec\x18\x01 \x01(\x0b\x32\x1b.feast.core.FeatureViewSpec\x12)\n\x04meta\x18\x02 \x01(\x0b\x32\x1b.feast.core.FeatureViewMeta\"\xc6\x04\n\x0f\x46\x65\x61tureViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07project\x18\x02 \x01(\t\x12\x10\n\x08\x65ntities\x18\x03 \x03(\t\x12+\n\x08\x66\x65\x61tures\x18\x04 \x03(\x0b\x32\x19.feast.core.FeatureSpecV2\x12\x31\n\x0e\x65ntity_columns\x18\x0c \x03(\x0b\x32\x19.feast.core.FeatureSpecV2\x12\x13\n\x0b\x64\x65scription\x18\n \x01(\t\x12\x33\n\x04tags\x18\x05 \x03(\x0b\x32%.feast.core.FeatureViewSpec.TagsEntry\x12\r\n\x05owner\x18\x0b \x01(\t\x12&\n\x03ttl\x18\x06 \x01(\x0b\x32\x19.google.protobuf.Duration\x12,\n\x0c\x62\x61tch_source\x18\x07 \x01(\x0b\x32\x16.feast.core.DataSource\x12-\n\rstream_source\x18\t \x01(\x0b\x32\x16.feast.core.DataSource\x12\x0e\n\x06online\x18\x08 \x01(\x08\x12\x0f\n\x07offline\x18\r \x01(\x08\x12\x31\n\x0csource_views\x18\x0e \x03(\x0b\x32\x1b.feast.core.FeatureViewSpec\x12\x43\n\x16\x66\x65\x61ture_transformation\x18\x0f \x01(\x0b\x32#.feast.core.FeatureTransformationV2\x1a+\n\tTagsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xcc\x01\n\x0f\x46\x65\x61tureViewMeta\x12\x35\n\x11\x63reated_timestamp\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12:\n\x16last_updated_timestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x46\n\x19materialization_intervals\x18\x03 \x03(\x0b\x32#.feast.core.MaterializationInterval\"w\n\x17MaterializationInterval\x12.\n\nstart_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"@\n\x0f\x46\x65\x61tureViewList\x12-\n\x0c\x66\x65\x61tureviews\x18\x01 \x03(\x0b\x32\x17.feast.core.FeatureViewBU\n\x10\x66\x65\x61st.proto.coreB\x10\x46\x65\x61tureViewProtoZ/github.com/feast-dev/feast/go/protos/feast/coreb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1c\x66\x65\x61st/core/FeatureView.proto\x12\nfeast.core\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1b\x66\x65\x61st/core/DataSource.proto\x1a\x18\x66\x65\x61st/core/Feature.proto\x1a\x1f\x66\x65\x61st/core/Transformation.proto\"c\n\x0b\x46\x65\x61tureView\x12)\n\x04spec\x18\x01 \x01(\x0b\x32\x1b.feast.core.FeatureViewSpec\x12)\n\x04meta\x18\x02 \x01(\x0b\x32\x1b.feast.core.FeatureViewMeta\"\xd4\x04\n\x0f\x46\x65\x61tureViewSpec\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07project\x18\x02 \x01(\t\x12\x10\n\x08\x65ntities\x18\x03 \x03(\t\x12+\n\x08\x66\x65\x61tures\x18\x04 \x03(\x0b\x32\x19.feast.core.FeatureSpecV2\x12\x33\n\x04tags\x18\x05 \x03(\x0b\x32%.feast.core.FeatureViewSpec.TagsEntry\x12&\n\x03ttl\x18\x06 \x01(\x0b\x32\x19.google.protobuf.Duration\x12,\n\x0c\x62\x61tch_source\x18\x07 \x01(\x0b\x32\x16.feast.core.DataSource\x12\x0e\n\x06online\x18\x08 \x01(\x08\x12-\n\rstream_source\x18\t \x01(\x0b\x32\x16.feast.core.DataSource\x12\x13\n\x0b\x64\x65scription\x18\n \x01(\t\x12\r\n\x05owner\x18\x0b \x01(\t\x12\x31\n\x0e\x65ntity_columns\x18\x0c \x03(\x0b\x32\x19.feast.core.FeatureSpecV2\x12\x0f\n\x07offline\x18\r \x01(\x08\x12\x31\n\x0csource_views\x18\x0e \x03(\x0b\x32\x1b.feast.core.FeatureViewSpec\x12\x43\n\x16\x66\x65\x61ture_transformation\x18\x0f \x01(\x0b\x32#.feast.core.FeatureTransformationV2\x12\x0c\n\x04mode\x18\x10 \x01(\t\x1a+\n\tTagsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xcc\x01\n\x0f\x46\x65\x61tureViewMeta\x12\x35\n\x11\x63reated_timestamp\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12:\n\x16last_updated_timestamp\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x46\n\x19materialization_intervals\x18\x03 \x03(\x0b\x32#.feast.core.MaterializationInterval\"w\n\x17MaterializationInterval\x12.\n\nstart_time\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08\x65nd_time\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"@\n\x0f\x46\x65\x61tureViewList\x12-\n\x0c\x66\x65\x61tureviews\x18\x01 \x03(\x0b\x32\x17.feast.core.FeatureViewBU\n\x10\x66\x65\x61st.proto.coreB\x10\x46\x65\x61tureViewProtoZ/github.com/feast-dev/feast/go/protos/feast/coreb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,13 +32,13 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_FEATUREVIEW']._serialized_start=197
   _globals['_FEATUREVIEW']._serialized_end=296
   _globals['_FEATUREVIEWSPEC']._serialized_start=299
-  _globals['_FEATUREVIEWSPEC']._serialized_end=881
-  _globals['_FEATUREVIEWSPEC_TAGSENTRY']._serialized_start=838
-  _globals['_FEATUREVIEWSPEC_TAGSENTRY']._serialized_end=881
-  _globals['_FEATUREVIEWMETA']._serialized_start=884
-  _globals['_FEATUREVIEWMETA']._serialized_end=1088
-  _globals['_MATERIALIZATIONINTERVAL']._serialized_start=1090
-  _globals['_MATERIALIZATIONINTERVAL']._serialized_end=1209
-  _globals['_FEATUREVIEWLIST']._serialized_start=1211
-  _globals['_FEATUREVIEWLIST']._serialized_end=1275
+  _globals['_FEATUREVIEWSPEC']._serialized_end=895
+  _globals['_FEATUREVIEWSPEC_TAGSENTRY']._serialized_start=852
+  _globals['_FEATUREVIEWSPEC_TAGSENTRY']._serialized_end=895
+  _globals['_FEATUREVIEWMETA']._serialized_start=898
+  _globals['_FEATUREVIEWMETA']._serialized_end=1102
+  _globals['_MATERIALIZATIONINTERVAL']._serialized_start=1104
+  _globals['_MATERIALIZATIONINTERVAL']._serialized_end=1223
+  _globals['_FEATUREVIEWLIST']._serialized_start=1225
+  _globals['_FEATUREVIEWLIST']._serialized_end=1289
 # @@protoc_insertion_point(module_scope)

--- a/sdk/python/feast/protos/feast/core/FeatureView_pb2.pyi
+++ b/sdk/python/feast/protos/feast/core/FeatureView_pb2.pyi
@@ -58,7 +58,7 @@ class FeatureView(google.protobuf.message.Message):
 global___FeatureView = FeatureView
 
 class FeatureViewSpec(google.protobuf.message.Message):
-    """Next available id: 16
+    """Next available id: 17
     TODO(adchia): refactor common fields from this and ODFV into separate metadata proto
     """
 
@@ -83,17 +83,18 @@ class FeatureViewSpec(google.protobuf.message.Message):
     PROJECT_FIELD_NUMBER: builtins.int
     ENTITIES_FIELD_NUMBER: builtins.int
     FEATURES_FIELD_NUMBER: builtins.int
-    ENTITY_COLUMNS_FIELD_NUMBER: builtins.int
-    DESCRIPTION_FIELD_NUMBER: builtins.int
     TAGS_FIELD_NUMBER: builtins.int
-    OWNER_FIELD_NUMBER: builtins.int
     TTL_FIELD_NUMBER: builtins.int
     BATCH_SOURCE_FIELD_NUMBER: builtins.int
-    STREAM_SOURCE_FIELD_NUMBER: builtins.int
     ONLINE_FIELD_NUMBER: builtins.int
+    STREAM_SOURCE_FIELD_NUMBER: builtins.int
+    DESCRIPTION_FIELD_NUMBER: builtins.int
+    OWNER_FIELD_NUMBER: builtins.int
+    ENTITY_COLUMNS_FIELD_NUMBER: builtins.int
     OFFLINE_FIELD_NUMBER: builtins.int
     SOURCE_VIEWS_FIELD_NUMBER: builtins.int
     FEATURE_TRANSFORMATION_FIELD_NUMBER: builtins.int
+    MODE_FIELD_NUMBER: builtins.int
     name: builtins.str
     """Name of the feature view. Must be unique. Not updated."""
     project: builtins.str
@@ -105,15 +106,8 @@ class FeatureViewSpec(google.protobuf.message.Message):
     def features(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[feast.core.Feature_pb2.FeatureSpecV2]:
         """List of specifications for each feature defined as part of this feature view."""
     @property
-    def entity_columns(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[feast.core.Feature_pb2.FeatureSpecV2]:
-        """List of specifications for each entity defined as part of this feature view."""
-    description: builtins.str
-    """Description of the feature view."""
-    @property
     def tags(self) -> google.protobuf.internal.containers.ScalarMap[builtins.str, builtins.str]:
         """User defined metadata"""
-    owner: builtins.str
-    """Owner of the feature view."""
     @property
     def ttl(self) -> google.protobuf.duration_pb2.Duration:
         """Features in this feature view can only be retrieved from online serving
@@ -124,20 +118,29 @@ class FeatureViewSpec(google.protobuf.message.Message):
     @property
     def batch_source(self) -> feast.core.DataSource_pb2.DataSource:
         """Batch/Offline DataSource where this view can retrieve offline feature data."""
-    @property
-    def stream_source(self) -> feast.core.DataSource_pb2.DataSource:
-        """Streaming DataSource from where this view can consume "online" feature data."""
     online: builtins.bool
     """Whether these features should be served online or not
     This is also used to determine whether the features should be written to the online store
     """
+    @property
+    def stream_source(self) -> feast.core.DataSource_pb2.DataSource:
+        """Streaming DataSource from where this view can consume "online" feature data."""
+    description: builtins.str
+    """Description of the feature view."""
+    owner: builtins.str
+    """Owner of the feature view."""
+    @property
+    def entity_columns(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[feast.core.Feature_pb2.FeatureSpecV2]:
+        """List of specifications for each entity defined as part of this feature view."""
     offline: builtins.bool
     """Whether these features should be written to the offline store"""
     @property
     def source_views(self) -> google.protobuf.internal.containers.RepeatedCompositeFieldContainer[global___FeatureViewSpec]: ...
     @property
     def feature_transformation(self) -> feast.core.Transformation_pb2.FeatureTransformationV2:
-        """Feature transformation (UDF or Substrait) for batch feature views"""
+        """Feature transformation for batch feature views"""
+    mode: builtins.str
+    """The transformation mode (e.g., "python", "pandas", "spark", "sql", "ray")"""
     def __init__(
         self,
         *,
@@ -145,20 +148,21 @@ class FeatureViewSpec(google.protobuf.message.Message):
         project: builtins.str = ...,
         entities: collections.abc.Iterable[builtins.str] | None = ...,
         features: collections.abc.Iterable[feast.core.Feature_pb2.FeatureSpecV2] | None = ...,
-        entity_columns: collections.abc.Iterable[feast.core.Feature_pb2.FeatureSpecV2] | None = ...,
-        description: builtins.str = ...,
         tags: collections.abc.Mapping[builtins.str, builtins.str] | None = ...,
-        owner: builtins.str = ...,
         ttl: google.protobuf.duration_pb2.Duration | None = ...,
         batch_source: feast.core.DataSource_pb2.DataSource | None = ...,
-        stream_source: feast.core.DataSource_pb2.DataSource | None = ...,
         online: builtins.bool = ...,
+        stream_source: feast.core.DataSource_pb2.DataSource | None = ...,
+        description: builtins.str = ...,
+        owner: builtins.str = ...,
+        entity_columns: collections.abc.Iterable[feast.core.Feature_pb2.FeatureSpecV2] | None = ...,
         offline: builtins.bool = ...,
         source_views: collections.abc.Iterable[global___FeatureViewSpec] | None = ...,
         feature_transformation: feast.core.Transformation_pb2.FeatureTransformationV2 | None = ...,
+        mode: builtins.str = ...,
     ) -> None: ...
     def HasField(self, field_name: typing_extensions.Literal["batch_source", b"batch_source", "feature_transformation", b"feature_transformation", "stream_source", b"stream_source", "ttl", b"ttl"]) -> builtins.bool: ...
-    def ClearField(self, field_name: typing_extensions.Literal["batch_source", b"batch_source", "description", b"description", "entities", b"entities", "entity_columns", b"entity_columns", "feature_transformation", b"feature_transformation", "features", b"features", "name", b"name", "offline", b"offline", "online", b"online", "owner", b"owner", "project", b"project", "source_views", b"source_views", "stream_source", b"stream_source", "tags", b"tags", "ttl", b"ttl"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["batch_source", b"batch_source", "description", b"description", "entities", b"entities", "entity_columns", b"entity_columns", "feature_transformation", b"feature_transformation", "features", b"features", "mode", b"mode", "name", b"name", "offline", b"offline", "online", b"online", "owner", b"owner", "project", b"project", "source_views", b"source_views", "stream_source", b"stream_source", "tags", b"tags", "ttl", b"ttl"]) -> None: ...
 
 global___FeatureViewSpec = FeatureViewSpec
 

--- a/sdk/python/feast/protos/feast/core/Transformation_pb2.py
+++ b/sdk/python/feast/protos/feast/core/Transformation_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1f\x66\x65\x61st/core/Transformation.proto\x12\nfeast.core\"F\n\x15UserDefinedFunctionV2\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x62ody\x18\x02 \x01(\x0c\x12\x11\n\tbody_text\x18\x03 \x01(\t\"\xba\x01\n\x17\x46\x65\x61tureTransformationV2\x12\x42\n\x15user_defined_function\x18\x01 \x01(\x0b\x32!.feast.core.UserDefinedFunctionV2H\x00\x12I\n\x18substrait_transformation\x18\x02 \x01(\x0b\x32%.feast.core.SubstraitTransformationV2H\x00\x42\x10\n\x0etransformation\"J\n\x19SubstraitTransformationV2\x12\x16\n\x0esubstrait_plan\x18\x01 \x01(\x0c\x12\x15\n\ribis_function\x18\x02 \x01(\x0c\x42_\n\x10\x66\x65\x61st.proto.coreB\x1a\x46\x65\x61tureTransformationProtoZ/github.com/feast-dev/feast/go/protos/feast/coreb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1f\x66\x65\x61st/core/Transformation.proto\x12\nfeast.core\"T\n\x15UserDefinedFunctionV2\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0c\n\x04\x62ody\x18\x02 \x01(\x0c\x12\x11\n\tbody_text\x18\x03 \x01(\t\x12\x0c\n\x04mode\x18\x04 \x01(\t\"\xba\x01\n\x17\x46\x65\x61tureTransformationV2\x12\x42\n\x15user_defined_function\x18\x01 \x01(\x0b\x32!.feast.core.UserDefinedFunctionV2H\x00\x12I\n\x18substrait_transformation\x18\x02 \x01(\x0b\x32%.feast.core.SubstraitTransformationV2H\x00\x42\x10\n\x0etransformation\"J\n\x19SubstraitTransformationV2\x12\x16\n\x0esubstrait_plan\x18\x01 \x01(\x0c\x12\x15\n\ribis_function\x18\x02 \x01(\x0c\x42_\n\x10\x66\x65\x61st.proto.coreB\x1a\x46\x65\x61tureTransformationProtoZ/github.com/feast-dev/feast/go/protos/feast/coreb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -23,9 +23,9 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['DESCRIPTOR']._options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\020feast.proto.coreB\032FeatureTransformationProtoZ/github.com/feast-dev/feast/go/protos/feast/core'
   _globals['_USERDEFINEDFUNCTIONV2']._serialized_start=47
-  _globals['_USERDEFINEDFUNCTIONV2']._serialized_end=117
-  _globals['_FEATURETRANSFORMATIONV2']._serialized_start=120
-  _globals['_FEATURETRANSFORMATIONV2']._serialized_end=306
-  _globals['_SUBSTRAITTRANSFORMATIONV2']._serialized_start=308
-  _globals['_SUBSTRAITTRANSFORMATIONV2']._serialized_end=382
+  _globals['_USERDEFINEDFUNCTIONV2']._serialized_end=131
+  _globals['_FEATURETRANSFORMATIONV2']._serialized_start=134
+  _globals['_FEATURETRANSFORMATIONV2']._serialized_end=320
+  _globals['_SUBSTRAITTRANSFORMATIONV2']._serialized_start=322
+  _globals['_SUBSTRAITTRANSFORMATIONV2']._serialized_end=396
 # @@protoc_insertion_point(module_scope)

--- a/sdk/python/feast/protos/feast/core/Transformation_pb2.pyi
+++ b/sdk/python/feast/protos/feast/core/Transformation_pb2.pyi
@@ -22,20 +22,24 @@ class UserDefinedFunctionV2(google.protobuf.message.Message):
     NAME_FIELD_NUMBER: builtins.int
     BODY_FIELD_NUMBER: builtins.int
     BODY_TEXT_FIELD_NUMBER: builtins.int
+    MODE_FIELD_NUMBER: builtins.int
     name: builtins.str
     """The function name"""
     body: builtins.bytes
     """The python-syntax function body (serialized by dill)"""
     body_text: builtins.str
     """The string representation of the udf"""
+    mode: builtins.str
+    """The transformation mode (e.g., "python", "pandas", "spark", "sql")"""
     def __init__(
         self,
         *,
         name: builtins.str = ...,
         body: builtins.bytes = ...,
         body_text: builtins.str = ...,
+        mode: builtins.str = ...,
     ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["body", b"body", "body_text", b"body_text", "name", b"name"]) -> None: ...
+    def ClearField(self, field_name: typing_extensions.Literal["body", b"body", "body_text", b"body_text", "mode", b"mode", "name", b"name"]) -> None: ...
 
 global___UserDefinedFunctionV2 = UserDefinedFunctionV2
 

--- a/sdk/python/feast/stream_feature_view.py
+++ b/sdk/python/feast/stream_feature_view.py
@@ -157,6 +157,7 @@ class StreamFeatureView(FeatureView):
             owner=owner,
             schema=schema,
             source=source,  # type: ignore[arg-type]
+            mode=mode,
             sink_source=sink_source,
         )
 

--- a/sdk/python/feast/transformation/base.py
+++ b/sdk/python/feast/transformation/base.py
@@ -90,10 +90,14 @@ class Transformation(ABC):
         self.owner = owner
 
     def to_proto(self) -> Union[UserDefinedFunctionProto, SubstraitTransformationProto]:
+        mode_str = (
+            self.mode.value if isinstance(self.mode, TransformationMode) else self.mode
+        )
         return UserDefinedFunctionProto(
             name=self.udf.__name__,
             body=dill.dumps(self.udf, recurse=True),
             body_text=self.udf_string,
+            mode=mode_str,
         )
 
     def __deepcopy__(self, memo: Optional[Dict[int, Any]] = None) -> "Transformation":


### PR DESCRIPTION
# What this PR does / why we need it:

This fixes a bug where transformation mode (pandas, python, spark, sql)
was stored in Python objects but not serialized to proto, causing
mode information to be lost during save/load cycles.

- Mode is stored in UserDefinedFunctionV2.mode (inside the Transformation proto)
- FeatureViewSpec has feature_transformation field which contains the transformation with mode
- Add mode at the FeatureView level for easy access (unification of Feature View) 

