### PR TITLE
fix: Fixed file-based registry cache sync

### DIFF
--- a/sdk/python/feast/infra/registry/file.py
+++ b/sdk/python/feast/infra/registry/file.py
@@ -1,4 +1,5 @@
 import json
+import os
 import uuid
 from pathlib import Path
 from typing import Optional
@@ -44,6 +45,8 @@ class FileRegistryStore(RegistryStore):
         file_dir.mkdir(exist_ok=True)
         with open(self._filepath, mode="wb", buffering=0) as f:
             f.write(registry_proto.SerializeToString())
+            f.flush()
+            os.fsync(f.fileno())
 
     def set_project_metadata(self, project: str, key: str, value: str):
         """Set a custom project metadata key-value pair in the registry proto (file backend)."""

--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -221,6 +221,13 @@ class Registry(BaseRegistry):
             else False
         )
 
+        self.cache_mode = (
+            registry_config.cache_mode if registry_config is not None else "sync"
+        )
+
+        self._file_mtime = None
+        self._file_path = None
+
         if registry_config:
             registry_store_type = registry_config.registry_store_type
             registry_path = registry_config.path
@@ -237,6 +244,13 @@ class Registry(BaseRegistry):
                     else 0
                 )
             )
+
+            from feast.infra.registry.file import FileRegistryStore
+
+            if isinstance(self._registry_store, FileRegistryStore):
+                self._file_path = self._registry_store._filepath
+                if self._file_path.exists():
+                    self._file_mtime = self._file_path.stat().st_mtime
 
             try:
                 registry_proto = self._registry_store.get_registry_proto()
@@ -883,6 +897,11 @@ class Registry(BaseRegistry):
         """Commits the state of the registry cache to the remote registry store."""
         if self.cached_registry_proto:
             self._registry_store.update_registry_proto(self.cached_registry_proto)
+            if self._file_path is not None and self._file_path.exists():
+                try:
+                    self._file_mtime = self._file_path.stat().st_mtime
+                except (OSError, FileNotFoundError):
+                    pass
 
     def refresh(self, project: Optional[str] = None):
         """Refreshes the state of the registry cache by fetching the registry state from the remote registry store."""
@@ -939,6 +958,23 @@ class Registry(BaseRegistry):
         Returns: Returns a RegistryProto object which represents the state of the registry
         """
         with self._refresh_lock:
+            # For file-based registries in sync mode, check file modification time
+            # to detect changes immediately, not just based on TTL
+            file_modified = False
+            if (
+                allow_cache
+                and self.cache_mode == "sync"
+                and self._file_path is not None
+                and self._file_path.exists()
+            ):
+                try:
+                    current_mtime = self._file_path.stat().st_mtime
+                    if self._file_mtime is None or current_mtime > self._file_mtime:
+                        file_modified = True
+                        self._file_mtime = current_mtime
+                except (OSError, FileNotFoundError):
+                    file_modified = True
+
             expired = (self.cached_registry_proto_created is None) or (
                 self.cached_registry_proto_ttl.total_seconds()
                 > 0  # 0 ttl means infinity
@@ -951,12 +987,25 @@ class Registry(BaseRegistry):
                 )
             )
 
-            if allow_cache and not expired:
+            # Refresh if expired or file was modified (for sync mode with file registry)
+            if allow_cache and not expired and not file_modified:
                 return self.cached_registry_proto
-            logger.info("Registry cache expired, so refreshing")
+
+            if file_modified:
+                logger.info("Registry file modified, so refreshing")
+            else:
+                logger.info("Registry cache expired, so refreshing")
+
             registry_proto = self._registry_store.get_registry_proto()
             self.cached_registry_proto = registry_proto
             self.cached_registry_proto_created = _utc_now()
+
+            if self._file_path is not None and self._file_path.exists():
+                try:
+                    self._file_mtime = self._file_path.stat().st_mtime
+                except (OSError, FileNotFoundError):
+                    pass
+
             return registry_proto
 
     def _check_conflicting_feature_view_names(self, feature_view: BaseFeatureView):


### PR DESCRIPTION
# What this PR does / why we need it:

This PR fixes an issue where file-based registries, where registry servers in operator deployments, were not refreshing immediately after `feast apply` even when `cache_mode: sync` was set. The changes ensure that registry servers detect file modifications immediately, providing immediate consistency as expected with sync mode.

## Problem

1. **Python File Registry**: File writes were not being synced to disk, causing `refresh_registry()` to potentially read stale data immediately after `commit()`.

2. **Python Registry Sync Mode**: The `Registry` class only checked TTL expiration, not file modification time. This meant that even with `cache_mode: sync`, separate registry server processes would only see changes after the TTL expired (default 600 seconds), not immediately.

## Solution

### 1. File Registry Disk Sync (Python)
- Added `f.flush()` and `os.fsync(f.fileno())` to `FileRegistryStore._write_registry()` to ensure writes are synced to disk before returning.

### 2. Python Registry File Modification Time Checking
- Enhanced `Registry` class to:
  - Store `cache_mode` from registry config
  - Track file path and modification time for file-based registries
  - Check file modification time in `_get_registry_proto()` when `cache_mode == "sync"` and `allow_cache=True`
  - Refresh immediately if file modification time changed, regardless of TTL expiration
