### PR TITLE
docs: Updated documentation for delete_feature_view

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -543,7 +543,7 @@ class FeatureStore:
 
     def delete_feature_view(self, name: str):
         """
-        Deletes a feature view.
+        Deletes a feature view of any kind (FeatureView, OnDemandFeatureView, StreamFeatureView).
 
         Args:
             name: Name of feature view.

--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -266,7 +266,9 @@ class BaseRegistry(ABC):
     @abstractmethod
     def delete_feature_view(self, name: str, project: str, commit: bool = True):
         """
-        Deletes a feature view or raises an exception if not found.
+        Deletes a feature view  of any kind (FeatureView, OnDemandFeatureView, StreamFeatureView).
+        Or raises an exception if not found.
+
 
         Args:
             name: Name of feature view


### PR DESCRIPTION
# What this PR does / why we need it:
Add documentation for method delete_feature_view to also handle OnDemandFeatureView and StreamFeatureView.

# Which issue(s) this PR fixes:
Fixes the issue reported in the Feast Slack workspace where users couldn't find a way to delete on-demand feature views.

# Misc
Replaces the PR https://github.com/franciscojavierarceo/feast/pull/36