### PR TITLE
fix: Serialize_entity_key to handle empty entities (#5628)

### DIFF
--- a/sdk/python/feast/infra/key_encoding_utils.py
+++ b/sdk/python/feast/infra/key_encoding_utils.py
@@ -142,9 +142,16 @@ def serialize_entity_key(
             "Serialization of entity key with version < 3 is removed. Please use version 3 by setting entity_key_serialization_version=3."
             "To reserializa your online store featrues refer -  https://github.com/feast-dev/feast/blob/master/docs/how-to-guides/entity-reserialization-of-from-v2-to-v3.md"
         )
-    sorted_keys, sorted_values = zip(
-        *sorted(zip(entity_key.join_keys, entity_key.entity_values))
-    )
+
+    sorted_keys: List[str]
+    sorted_values: List[ValueProto]
+    if not entity_key.join_keys:
+        sorted_keys = []
+        sorted_values = []
+    else:
+        pairs = sorted(zip(entity_key.join_keys, entity_key.entity_values))
+        sorted_keys = [k for k, _ in pairs]
+        sorted_values = [v for _, v in pairs]
 
     output: List[bytes] = []
     if entity_key_serialization_version > 2:


### PR DESCRIPTION
# What this PR does / why we need it:
Fixes the 

# Which issue(s) this PR fixes:
#5628


# Misc
I used these tests locally but did want to add them to the codebase to avoid code bloat

`sdk/python/tests/unit/infra/online_store/test_redis.py
def test_generate_entity_redis_keys_empty_entities(
    redis_online_store: RedisOnlineStore, repo_config
):
    """Test that empty entity keys can be generated (for feature views with no entities)."""
    entity_keys = [
        EntityKeyProto(join_keys=[], entity_values=[]),
    ]

    actual = redis_online_store._generate_redis_keys_for_entities(
        repo_config, entity_keys
    )
    # Empty entity key should serialize to 4 bytes (count of 0) + project name
    expected = [b"\x00\x00\x00\x00test"]
    assert actual == expected`


`
sdk/python/tests/unit/infra/test_key_encoding_utils.py
def test_serialize_empty_entity_key():
    """Test serialization and deserialization of empty entity keys (feature views with no entities)."""
    # Create an empty entity key (no entities)
    entity_key_proto = EntityKeyProto(join_keys=[], entity_values=[])

    # Should not raise an error
    serialized_key = serialize_entity_key(
        entity_key_proto,
        entity_key_serialization_version=3,
    )

    # Verify the serialized key has the expected format (just the count of 0 keys)
    # For version 3, this should be 4 bytes with value 0
    assert len(serialized_key) == 4
    assert serialized_key == b"\x00\x00\x00\x00"

    # Deserialize and verify round-trip
    deserialized_key = deserialize_entity_key(
        serialized_key,
        entity_key_serialization_version=3,
    )

    assert deserialized_key == entity_key_proto
    assert len(deserialized_key.join_keys) == 0
    assert len(deserialized_key.entity_values) == 0
`

