### PR TITLE
chore: Adding pattern command to makefile to easily test single files…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,8 +150,8 @@ benchmark-python-local: ## Run integration + benchmark tests for Python (local d
 
 ##@ Tests
 
-test-python-unit: ## Run Python unit tests
-	python -m pytest -n 8 --color=yes sdk/python/tests
+test-python-unit: ## Run Python unit tests (use pattern=<pattern> to filter tests, e.g., pattern=milvus, pattern=test_online_retrieval.py, pattern=test_online_retrieval.py::test_get_online_features_milvus)
+	python -m pytest -n 8 --color=yes $(if $(pattern),-k "$(pattern)") sdk/python/tests
 
 test-python-integration: ## Run Python integration tests (CI)
 	python -m pytest --tb=short -v -n 8 --integration --color=yes --durations=10 --timeout=1200 --timeout_method=thread --dist loadgroup \


### PR DESCRIPTION
# What this PR does / why we need it:
Makes
`make test-python-unit pattern="file.py and test"` work.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
