### PR TITLE
fix: SQLite online store deletes tables from other projects in shared registry scenarios

### DIFF
--- a/sdk/python/feast/diff/infra_diff.py
+++ b/sdk/python/feast/diff/infra_diff.py
@@ -98,7 +98,9 @@ def tag_infra_proto_objects_for_keep_delete_add(
 
 
 def diff_infra_protos(
-    current_infra_proto: InfraProto, new_infra_proto: InfraProto, project: Optional[str] = None
+    current_infra_proto: InfraProto,
+    new_infra_proto: InfraProto,
+    project: Optional[str] = None,
 ) -> InfraDiff:
     infra_diff = InfraDiff()
 
@@ -114,18 +116,18 @@ def diff_infra_protos(
         new_infra_objects = get_infra_object_protos_by_type(
             new_infra_proto, infra_object_class_type
         )
-        
+
         # Filter infra objects by project prefix when using shared online stores
         # Table names include project prefix: {project}_{table_name}
         if project:
             project_prefix = f"{project}_"
             current_infra_objects = [
-                obj for obj in current_infra_objects
+                obj
+                for obj in current_infra_objects
                 if obj.name.startswith(project_prefix)
             ]
             new_infra_objects = [
-                obj for obj in new_infra_objects
-                if obj.name.startswith(project_prefix)
+                obj for obj in new_infra_objects if obj.name.startswith(project_prefix)
             ]
         (
             infra_objects_to_keep,

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -78,7 +78,6 @@ from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.online_response import OnlineResponse
 from feast.permissions.permission import Permission
 from feast.project import Project
-from feast.protos.feast.core.InfraObject_pb2 import Infra as InfraProto
 from feast.protos.feast.serving.ServingService_pb2 import (
     FieldStatus,
     GetOnlineFeaturesResponse,
@@ -796,7 +795,9 @@ class FeatureStore:
         desired_registry_proto = desired_repo_contents.to_registry_proto()
         new_infra = self._provider.plan_infra(self.config, desired_registry_proto)
         new_infra_proto = new_infra.to_proto()
-        infra_diff = diff_infra_protos(current_infra_proto, new_infra_proto, project=self.project)
+        infra_diff = diff_infra_protos(
+            current_infra_proto, new_infra_proto, project=self.project
+        )
 
         return registry_diff, infra_diff, new_infra
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
When multiple projects share a SQL registry and the same online store database, applying changes to one project incorrectly deletes tables from other projects.

### Root cause analysis

- Wrong infra retrieval in plan(): The code used self._registry.proto().infra, which returns infra from the last project processed in the registry (see comment at sql.py:871-873). With multiple projects, this can return another project's infra, causing incorrect diffs.
- Missing project filtering in infra diff: The diff_infra_protos() function compared all infra objects without filtering by project. Even if retrieval was correct, if the stored infra contained objects from multiple projects (e.g., from historical data or a bug), the diff would mark other projects' tables for deletion.

### Fix

- Changed plan() to use self._registry.get_infra(self.project) instead of self._registry.proto().infra to retrieve infra for the current project.
- Added project prefix filtering in diff_infra_protos() to only compare infra objects whose names start with {project}_ (table names follow this pattern: {project}_{table_name}).

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
#5616 
[RHOAIENG-34863](https://issues.redhat.com/browse/RHOAIENG-34863)

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
