### PR TITLE
fix: Support arro3 table schema with newer deltalake packages

### DIFF
--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -202,10 +202,9 @@ class FileSource(DataSource):
                 "AWS_ENDPOINT_URL": str(self.s3_endpoint_override),
             }
 
-            delta_schema = (
-                DeltaTable(self.path, storage_options=storage_options)
-                .schema()
-            )
+            delta_schema = DeltaTable(
+                self.path, storage_options=storage_options
+            ).schema()
             if hasattr(delta_schema, "to_arrow"):
                 # deltalake >= 0.10.0
                 arro3_schema = delta_schema.to_arrow()
@@ -214,7 +213,7 @@ class FileSource(DataSource):
                 # deltalake < 0.10.0
                 schema = delta_schema.to_pyarrow()
             else:
-                raise Exception(f"Unknown DeltaTable package version")
+                raise Exception("Unknown DeltaTable package version")
         else:
             raise Exception(f"Unknown FileFormat -> {self.file_format}")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
delta-rs package switched to arro3 package for schema, so they removed `to_pyarrow` method from table - this breaks deltatable file source support in feast.
I've added compatibility for newer version of delta-rs package, while keeping support for older versions too

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
