### PR TITLE
fix: Spark Materialization Engine Cannot Infer Schema

### DIFF
--- a/sdk/python/feast/infra/compute_engines/spark/nodes.py
+++ b/sdk/python/feast/infra/compute_engines/spark/nodes.py
@@ -90,7 +90,6 @@ class SparkReadNode(DAGNode):
             else:
                 spark_df = self.spark_session.createDataFrame(arrow_table.to_pandas())
 
-
         return DAGValue(
             data=spark_df,
             format=DAGFormat.SPARK,
@@ -102,6 +101,7 @@ class SparkReadNode(DAGNode):
                 "end_date": self.end_time,
             },
         )
+
 
 class SparkAggregationNode(DAGNode):
     def __init__(


### PR DESCRIPTION
# What this PR does / why we need it:
Handle Arrow-to-Spark conversion without schema inference errors by deriving schema from Arrow and creating an empty Spark DataFrame when no rows are returned.

# Which issue(s) this PR fixes:
<!--5594