### PR TITLE
fix: Use context.Background() in client constructors

### DIFF
--- a/go/internal/feast/onlinestore/dynamodbonlinestore.go
+++ b/go/internal/feast/onlinestore/dynamodbonlinestore.go
@@ -50,8 +50,7 @@ func NewDynamodbOnlineStore(project string, config *registry.RepoConfig, onlineS
 	}
 
 	// aws configuration
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	ctx := context.Background()
 	cfg, err := awsConfig.LoadDefaultConfig(ctx)
 	if err != nil {
 		panic(err)

--- a/go/internal/feast/registry/gcs.go
+++ b/go/internal/feast/registry/gcs.go
@@ -42,8 +42,7 @@ type GCSRegistryStore struct {
 // NewGCSRegistryStore creates a GCSRegistryStore with the given configuration.
 func NewGCSRegistryStore(config *RegistryConfig, repoPath string) *GCSRegistryStore {
 	var rs GCSRegistryStore
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	ctx := context.Background()
 
 	client, err := storage.NewClient(ctx)
 	if err != nil {

--- a/go/internal/feast/registry/s3.go
+++ b/go/internal/feast/registry/s3.go
@@ -29,22 +29,21 @@ type S3RegistryStore struct {
 
 // NewS3RegistryStore creates a S3RegistryStore with the given configuration
 func NewS3RegistryStore(config *RegistryConfig, repoPath string) *S3RegistryStore {
-	var lr S3RegistryStore
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	var rs S3RegistryStore
+	ctx := context.Background()
 
 	cfg, err := awsConfig.LoadDefaultConfig(ctx)
 	if err != nil {
-		lr = S3RegistryStore{
+		rs = S3RegistryStore{
 			filePath: config.Path,
 		}
 	} else {
-		lr = S3RegistryStore{
+		rs = S3RegistryStore{
 			filePath: config.Path,
 			s3Client: s3.NewFromConfig(cfg),
 		}
 	}
-	return &lr
+	return &rs
 }
 
 func (r *S3RegistryStore) GetRegistryProto() (*core.Registry, error) {


### PR DESCRIPTION
# What this PR does / why we need it:
<!--
Outline what you're doing
-->
This PR fixes a critical `context canceled` bug in the GCS/S3 RegistryStore and DynamoDB OnlineStore constructors.

### The Bug: Immediate Context Cancellation
During testing with the Go feature server (running in a local Docker container) connected to live cloud infrastructure (GCS, Redis), the following error occurred immediately upon startup:
```bash
{"level":"error","error":"Get \"https://storage.googleapis.com/.../feature_registry.db\": Post \"https://oauth2.googleapis.com/token\": context canceled", "message":"Registry refresh Failed"}
```
### Root Cause
In the previous implementation, the constructor (NewGCSRegistryStore) initialized cloud clients using `context.WithTimeout()` and `defer cancel()`. Because `cancel()` is called immediately when the constructor returns, the base context for the GCS client becomes invalidated. This leads to an immediate failure when the client attempts to perform its first operation (like fetching an OAuth token or reading the registry), even if the 5-second timeout hasn't elapsed.

### The Fix: Lifecycle Alignment
A storage client's lifecycle should be tied to the server's uptime.
1. Constructor (Long-lived): Changed to use `context.Background()`. This ensures the client's underlying connection and token-refresh routines remain valid as long as the server is running.
2. Methods (Request-scoped): Kept the 5-second `context.WithTimeout()` inside individual methods (GetRegistryProto, Teardown). This correctly applies a deadline to specific I/O operations without killing the persistent client.

This follows Go's recommended practice of not storing or canceling request-scoped contexts in long-lived objects.

### Consistency
To ensure architectural consistency across the project and prevent similar latent bugs, this fix has been applied to:
- GCS Registry Store (NewGCSRegistryStore)
- S3 Registry Store (NewS3RegistryStore)
- DynamoDB Online Store (NewDynamodbOnlineStore)

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes the `context canceled` error that prevents the Go feature server from properly connecting to live cloud registries and online stores.

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
Refactored internal variable names (changing `lr` to `rs` in NewS3RegistryStore) to align with the naming conventions used in gcs.go and to accurately reflect their purpose as RegistryStore.