### PR TITLE
refactor: Centralize feature view object lookup

### DIFF
--- a/sdk/python/feast/feature_logging.py
+++ b/sdk/python/feast/feature_logging.py
@@ -10,7 +10,7 @@ from feast.errors import (
     FeastObjectNotFoundException,
 )
 from feast.feature_view import DUMMY_ENTITY_ID
-from feast.feature_view_utils import get_feast_object_from_registry
+from feast.feature_view_utils import get_feature_view_from_registry
 from feast.protos.feast.core.FeatureService_pb2 import (
     LoggingConfig as LoggingConfigProto,
 )
@@ -57,7 +57,7 @@ class FeatureServiceLoggingSource(LoggingSource):
             # Go code can be found here:
             # https://github.com/feast-dev/feast/blob/master/go/internal/feast/server/logging/memorybuffer.go#L51
             try:
-                feast_object = get_feast_object_from_registry(
+                feast_object = get_feature_view_from_registry(
                     registry,
                     projection.name,
                     self._project,

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -53,7 +53,7 @@ from feast.errors import (
     FeastError,
 )
 from feast.feast_object import FeastObject
-from feast.feature_view_utils import get_feast_object_from_feature_store
+from feast.feature_view_utils import get_feature_view_from_feature_store
 from feast.permissions.action import WRITE, AuthzedAction
 from feast.permissions.security_manager import assert_permissions
 from feast.permissions.server.rest import inject_user_details
@@ -482,10 +482,8 @@ def get_app(
     async def _get_feast_object(
         feature_view_name: str, allow_registry_cache: bool
     ) -> FeastObject:
-        # FIXME: this logic repeated at least 3 times in the codebase - should be centralized
-        # in logging, in server and in feature_store (Python SDK)
         return await run_in_threadpool(
-            get_feast_object_from_feature_store,
+            get_feature_view_from_feature_store,
             store,
             feature_view_name,
             allow_registry_cache,

--- a/sdk/python/feast/feature_view_utils.py
+++ b/sdk/python/feast/feature_view_utils.py
@@ -5,7 +5,7 @@ Utility functions for feature view operations including source resolution.
 import logging
 import typing
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 from feast.errors import (
     FeastObjectNotFoundException,
@@ -17,11 +17,15 @@ if typing.TYPE_CHECKING:
     from feast.data_source import DataSource
     from feast.feature_store import FeatureStore
     from feast.feature_view import FeatureView
-    from feast.feast_object import FeastObject
     from feast.infra.registry.base_registry import BaseRegistry
+    from feast.on_demand_feature_view import OnDemandFeatureView
     from feast.repo_config import RepoConfig
+    from feast.stream_feature_view import StreamFeatureView
 
 logger = logging.getLogger(__name__)
+
+
+FeatureViewLike = Union["FeatureView", "OnDemandFeatureView", "StreamFeatureView"]
 
 
 @dataclass
@@ -238,11 +242,11 @@ def resolve_feature_view_source_with_fallback(
             )
 
 
-def get_feast_object_from_feature_store(
+def get_feature_view_from_feature_store(
     store: "FeatureStore",
     name: str,
     allow_registry_cache: bool = False,
- ) -> "FeastObject":
+) -> FeatureViewLike:
     try:
         return store.get_feature_view(name, allow_registry_cache=allow_registry_cache)
     except FeatureViewNotFoundException:
@@ -261,12 +265,12 @@ def get_feast_object_from_feature_store(
                 ) from e
 
 
-def get_feast_object_from_registry(
+def get_feature_view_from_registry(
     registry: "BaseRegistry",
     name: str,
     project: str,
     allow_cache: bool = False,
- ) -> "FeastObject":
+) -> FeatureViewLike:
     try:
         return registry.get_feature_view(name, project, allow_cache=allow_cache)
     except FeatureViewNotFoundException:


### PR DESCRIPTION
##Summary
This PR centralizes the repeated logic used to resolve a “feature view-like” name into the correct Feast object type:
- FeatureView
- OnDemandFeatureView
- StreamFeatureView

Previously, this lookup pattern was duplicated across multiple Python SDK/server components.
## What changed
- Added shared helpers in sdk/python/feast/feature_view_utils.py:
   - get_feast_object_from_feature_store(...) (FeatureStore-style APIs)
   - get_feast_object_from_registry(...) (Registry-style APIs)
- Updated call sites to use the centralized helpers:
   - sdk/python/feast/feature_server.py (_get_feast_object)
   - sdk/python/feast/feature_logging.py (FeatureServiceLoggingSource.get_schema)
## Motivation
- Reduce copy/pasted try/except blocks across the codebase.
- Make behavior consistent and easier to maintain (single place to adjust lookup semantics).
## Notes / Testing
Local sanity check: python -m compileall on the modified files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/5898">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
