### PR TITLE
fix: Make timestamp field handling  compatible with Athena V3

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena.py
@@ -168,7 +168,7 @@ class AthenaOfflineStore(OfflineStore):
             end_date_str,
             timestamp_field,
             date_partition_column,
-            cast_style="raw",
+            cast_style="timestamp",
             quote_fields=False,
         )
 


### PR DESCRIPTION
# What this PR does / why we need it:
This PR fixes incompatibility with Athena V3, which has stricter type checking, introduced by https://github.com/feast-dev/feast/pull/5281 (specifically https://github.com/feast-dev/feast/commit/4b94608f400a3c379b37ce7ea0bdb969eee1527d)

# Which issue(s) this PR fixes:

https://github.com/feast-dev/feast/issues/5935

# Misc

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/5936">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
