### PR TITLE
feat: Add registry metadata summary metrics endpoint (#5921)

### DIFF
--- a/sdk/python/feast/api/registry/rest/metrics.py
+++ b/sdk/python/feast/api/registry/rest/metrics.py
@@ -154,7 +154,7 @@ def get_metrics_router(grpc_handler, server=None) -> APIRouter:
                 for k in total_counts:
                     total_counts[k] += counts[k]
 
-                try: 
+                try:
                     feature_views = grpc_call(
                         grpc_handler.ListAllFeatureViews,
                         RegistryServer_pb2.ListAllFeatureViewsRequest(
@@ -178,7 +178,7 @@ def get_metrics_router(grpc_handler, server=None) -> APIRouter:
             return {
                 "totalProjects": len(all_projects),
                 "lastUpdatedTimestamp": last_updated_ts,
-                "total": total_counts, 
+                "total": total_counts,
                 "perProject": all_counts,
                 }
 


### PR DESCRIPTION
# What this PR does / why we need it:

This PR extends the existing Metrics API to provide registry-level metadata summary statistics.  
It adds a new `/api/v1/metrics/summary` endpoint that aggregates resource counts across all projects and exposes high-level registry insights.

This helps users quickly understand the overall state of their registry without querying multiple endpoints.

# Which issue(s) this PR fixes:

Fixes #5921

# Misc

- The implementation reuses existing gRPC-based metrics logic.
- Includes best-effort tracking of the latest update timestamp.
- Not tested locally yet due to dependency setup constraints; happy to add tests or make adjustments based on feedback.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/5939">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
