### PR TITLE
docs: Fix minor grammar issues in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Feast allows ML platform teams to:
 
 * **Make features consistently available for training and serving** by managing an _offline store_ (to process historical data for scale-out batch scoring or model training), a low-latency _online store_ (to power real-time prediction)_,_ and a battle-tested _feature server_ (to serve pre-computed features online).
 * **Avoid data leakage** by generating point-in-time correct feature sets so data scientists can focus on feature engineering rather than debugging error-prone dataset joining logic. This ensure that future feature values do not leak to models during training.
-* **Decouple ML from data infrastructure** by providing a single data access layer that abstracts feature storage from feature retrieval, ensuring models remain portable as you move from training models to serving models, from batch models to realtime models, and from one data infra system to another.
+* **Decouple ML from data infrastructure** by providing a single data access layer that abstracts feature storage from feature retrieval, ensuring models remain portable as you move from training models to serving models, from batch models to real-time models, and from one data infra system to another.
 
 Please see our [documentation](https://docs.feast.dev/) for more information about the project.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,11 +7,11 @@ operate production ML systems at scale by allowing them to define, manage, valid
 AI/ML. 
 
 Feast's feature store is composed of two foundational components: (1) an [offline store](getting-started/components/offline-store.md) 
-for historical feature extraction used in model training and an (2) [online store](getting-started/components/online-store.md) 
+for historical feature extraction used in model training and (2) an [online store](getting-started/components/online-store.md) 
 for serving features at low-latency in production systems and applications.
 
 Feast is a configurable operational data system that re-uses existing infrastructure to manage and serve machine learning 
-features to realtime models. For more details, please review our [architecture](getting-started/architecture/overview.md).
+features to real-time models. For more details, please review our [architecture](getting-started/architecture/overview.md).
 
 Concretely, Feast provides:
 
@@ -93,7 +93,7 @@ Explore the following resources to get started with Feast:
 * [Quickstart](getting-started/quickstart.md) is the fastest way to get started with Feast
 * [Concepts](getting-started/concepts/) describes all important Feast API concepts
 * [Architecture](getting-started/architecture/) describes Feast's overall architecture.
-* [Tutorials](tutorials/tutorials-overview/) shows full examples of using Feast in machine learning applications.
+* [Tutorials](tutorials/tutorials-overview/) show full examples of using Feast in machine learning applications.
 * [Running Feast with Snowflake/GCP/AWS](how-to-guides/feast-snowflake-gcp-aws/) provides a more in-depth guide to using Feast.
 * [Reference](reference/feast-cli-commands.md) contains detailed API and design documents.
 * [Contributing](project/contributing.md) contains resources for anyone who wants to contribute to Feast.


### PR DESCRIPTION
# What this PR does / why we need it:

Fixes minor grammar issues in README.md and docs/README.md.

### Changes made

1. Hyphenation fix:
   - Before: `realtime models`
   - After: `real-time models`

2. Subject–verb agreement fix:
   - Before: `Tutorials shows full examples of using Feast in machine learning applications.`
   - After: `Tutorials show full examples of using Feast in machine learning applications.`

3. Article placement fix:
   - Before: `... model training and an (2) online store ...`
   - After: `... model training and (2) an online store ...`

These are documentation-only changes and do not affect functionality.


# Which issue(s) this PR fixes:

N/A


# Misc

No user-facing changes.

Release note: NONE

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/5969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
