### PR TITLE
fix: Support pgvector under non-default schema

### DIFF
--- a/sdk/python/feast/infra/utils/postgres/connection_utils.py
+++ b/sdk/python/feast/infra/utils/postgres/connection_utils.py
@@ -68,12 +68,15 @@ def _get_conninfo(config: PostgreSQLConfig) -> str:
 
 def _get_conn_kwargs(config: PostgreSQLConfig) -> Dict[str, Any]:
     """Get the additional `kwargs` required for connection objects."""
+    search_path = (config.db_schema or config.user).strip()
+    if search_path != "public":
+        search_path += ",public"
     return {
         "sslmode": config.sslmode,
         "sslkey": config.sslkey_path,
         "sslcert": config.sslcert_path,
         "sslrootcert": config.sslrootcert_path,
-        "options": "-c search_path={}".format(config.db_schema or config.user),
+        "options": "-c search_path={}".format(search_path),
     }
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->

Vector extension for postgres is almost always installed under the public schema by default. When the table's schema is not public, add public to search_path.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/feast-dev/feast/issues/5814.

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->

Steps to reproduce the issue with the pgvector example under `examples/online_store/pgvector_tutorial`. This PR resolve the following error.
- Change db_schema in `feature_store.yaml` to a value other than 'public'.
- Execute `feast apply`.
- Execute `python3 pgvector_example.py`, and get the following error.
```
Performing similarity search for: 'wireless audio device with good sound'
Traceback (most recent call last):
  File "/Users/bytedance/Projects/feast/examples/online_store/pgvector_tutorial/pgvector_example.py", line 207, in <module>
    main()
  File "/Users/bytedance/Projects/feast/examples/online_store/pgvector_tutorial/pgvector_example.py", line 200, in main
    perform_similarity_search(store, "wireless audio device with good sound", top_k=3)
  File "/Users/bytedance/Projects/feast/examples/online_store/pgvector_tutorial/pgvector_example.py", line 136, in perform_similarity_search
    results = store.retrieve_online_documents(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bytedance/Projects/feast/sdk/python/feast/feature_store.py", line 2554, in retrieve_online_documents
    document_features = self._retrieve_from_online_store(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bytedance/Projects/feast/sdk/python/feast/feature_store.py", line 2785, in _retrieve_from_online_store
    documents = provider.retrieve_online_documents(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bytedance/Projects/feast/sdk/python/feast/infra/passthrough_provider.py", line 306, in retrieve_online_documents
    result = self.online_store.retrieve_online_documents(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bytedance/Projects/feast/sdk/python/feast/infra/online_stores/postgres_online_store/postgres.py", line 439, in retrieve_online_documents
    cur.execute(
  File "/Users/bytedance/Projects/feast/.venv/lib/python3.11/site-packages/psycopg/cursor.py", line 97, in execute
    raise ex.with_traceback(None)
psycopg.errors.UndefinedObject: type "vector" does not exist
LINE 7:                         vector_value <-> $1::vector as dista...
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/5970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
