### PR TITLE
chore: Added language-specific patterns in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,28 @@ infra/website/dist/
 
 # offline builds
 offline_build/
+
+# Java compiled
+*.class
+*.jar
+*.war
+*.ear
+
+# Go binaries
+*.exe
+*.exe~
+*.out
+
+# Editor swap/backup files
+*.swp
+*.swo
+*~
+\#*\#
+
+# OS files
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# AgentReady reports
+.agentready/


### PR DESCRIPTION

# What this PR does / why we need it:

Added the missing language-specific patterns in `.gitignore`.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/5982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
