### PR TITLE
feat: Added CodeQL SAST scanning and detect-secrets pre-commit hook

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,67 @@
+name: "Security"
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  codeql:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python", "javascript-typescript"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  safety:
+    name: Dependency Security Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install project dependencies and safety
+        run: |
+          pip install safety
+          pip install -e ".[ci]" || pip install -e .
+
+      - name: Run safety scan
+        continue-on-error: true
+        run: safety scan --output json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,15 @@ repos:
         files: ^infra/templates/|\.jinja2$|^docs/roadmap\.md$
         entry: make build-templates
         pass_filenames: false
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        exclude: |
+          (?x)^(
+            .*\.lock|
+            .*requirements.*\.txt|
+            .*\.svg|
+            .*\.html
+          )$


### PR DESCRIPTION
# What this PR does / why we need it:

This PR adds CodeQL SAST scanning and detect-secrets hook that runs on every commit to catch accidentally committed secrets.

CodeQL SAST scanning that runs on:
 - PRs targeting master
 - Pushes to master
 - Weekly schedule (Mondays 6am UTC)
 - Scoped to python and javascript-typescript
 
.pre-commit-config.yaml (modified) - added detect-secrets hook that runs on every commit to catch accidentally committed secrets. Excludes lock files, requirements, SVGs, and HTML to avoid false positives.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/5983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
