### PR TITLE
fix: Fixes a `PydanticDeprecatedSince20` warning for trino_offline_store

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino.py
@@ -116,7 +116,7 @@ class AuthConfig(FeastConfigBaseModel):
 
         model_cls = CLASSES_BY_AUTH_TYPE[auth_type]["auth_model"]
         model = model_cls(**self.config)
-        return trino_auth_cls(**model.dict())
+        return trino_auth_cls(**model.model_dump())
 
 
 class TrinoOfflineStoreConfig(FeastConfigBaseModel):


### PR DESCRIPTION
Small fix for a boring warning:

```
feast/infra/offline_stores/contrib/trino_offline_store/trino.py:119: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
  return trino_auth_cls(**model.dict())
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/5991" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
