### PR TITLE
chore: Updated feature server ubi image from 3.11 to python-312

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -1,6 +1,7 @@
-FROM registry.access.redhat.com/ubi9/python-311:1
+FROM registry.access.redhat.com/ubi9/python-312:1
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+ENV UV_CACHE_DIR=/tmp/uv-cache
 COPY requirements.txt requirements.txt
 RUN uv pip install -r requirements.txt
 

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311:1
+FROM registry.access.redhat.com/ubi9/python-312:1
 
 USER 0
 RUN npm install -g yarn yalc && rm -rf .npm
@@ -28,7 +28,7 @@ RUN yalc add @feast-dev/feast-ui && \
 WORKDIR ${APP_ROOT}/src
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 ENV UV_CACHE_DIR=/tmp/uv-cache
-RUN uv pip install --require-hashes --no-deps -r sdk/python/requirements/py3.11-minimal-requirements.txt
+RUN uv pip install --require-hashes --no-deps -r sdk/python/requirements/py3.12-minimal-requirements.txt
 RUN uv pip install --no-deps -e .[minimal]
 
 # modify permissions to support running with a random uid

--- a/sdk/python/feast/infra/feature_servers/multicloud/offline/Dockerfile.binary.release
+++ b/sdk/python/feast/infra/feature_servers/multicloud/offline/Dockerfile.binary.release
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311:1
+FROM registry.access.redhat.com/ubi9/python-312:1
 
 COPY requirements.txt requirements.txt
 RUN source /tmp/hermeto.env && \

--- a/sdk/python/feast/infra/feature_servers/multicloud/offline/Dockerfile.builder.yarn
+++ b/sdk/python/feast/infra/feature_servers/multicloud/offline/Dockerfile.builder.yarn
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311:1
+FROM registry.access.redhat.com/ubi9/python-312:1
 
 USER 0
 RUN npm install -g yarn yalc && rm -rf .npm

--- a/sdk/python/feast/infra/feature_servers/multicloud/offline/Dockerfile.builder.yum
+++ b/sdk/python/feast/infra/feature_servers/multicloud/offline/Dockerfile.builder.yum
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311:1
+FROM registry.access.redhat.com/ubi9/python-312:1
 ARG RELEASE
 
 ENV IBIS_VERSION="9.5.0"

--- a/sdk/python/feast/infra/feature_servers/multicloud/offline/Dockerfile.sdist.release
+++ b/sdk/python/feast/infra/feature_servers/multicloud/offline/Dockerfile.sdist.release
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311:1
+FROM registry.access.redhat.com/ubi9/python-312:1
 
 ENV APACHE_ARROW_VERSION="17.0.0"
 ENV MILVUS_LITE_VERSION="2.4.12"

--- a/sdk/python/feast/infra/feature_servers/multicloud/offline/offline-binary-build.sh
+++ b/sdk/python/feast/infra/feature_servers/multicloud/offline/offline-binary-build.sh
@@ -44,9 +44,9 @@ hermeto fetch-deps \
 "sdk/python/feast/infra/feature_servers/multicloud/requirements.txt"
 ],
   "requirements_build_files": [
-"sdk/python/requirements/py3.11-minimal-requirements.txt",
-"sdk/python/requirements/py3.11-minimal-sdist-requirements.txt",
-"sdk/python/requirements/py3.11-minimal-sdist-requirements-build.txt"
+"sdk/python/requirements/py3.12-minimal-requirements.txt",
+"sdk/python/requirements/py3.12-minimal-sdist-requirements.txt",
+"sdk/python/requirements/py3.12-minimal-sdist-requirements-build.txt"
 ],
   "allow_binary": "true"
 }'

--- a/sdk/python/feast/infra/feature_servers/multicloud/offline/offline-binary-release-build.sh
+++ b/sdk/python/feast/infra/feature_servers/multicloud/offline/offline-binary-release-build.sh
@@ -19,9 +19,9 @@ hermeto fetch-deps \
 "sdk/python/feast/infra/feature_servers/multicloud/requirements.txt"
 ],
   "requirements_build_files": [
-"sdk/python/requirements/py3.11-minimal-requirements.txt",
-"sdk/python/requirements/py3.11-minimal-sdist-requirements.txt",
-"sdk/python/requirements/py3.11-minimal-sdist-requirements-build.txt"
+"sdk/python/requirements/py3.12-minimal-requirements.txt",
+"sdk/python/requirements/py3.12-minimal-sdist-requirements.txt",
+"sdk/python/requirements/py3.12-minimal-sdist-requirements-build.txt"
 ],
   "allow_binary": "true"
 }'

--- a/sdk/python/feast/infra/feature_servers/multicloud/offline/offline-build.sh
+++ b/sdk/python/feast/infra/feature_servers/multicloud/offline/offline-build.sh
@@ -55,8 +55,8 @@ hermeto fetch-deps \
 "sdk/python/feast/infra/feature_servers/multicloud/requirements.txt"
 ],
   "requirements_build_files": [
-"sdk/python/requirements/py3.11-minimal-sdist-requirements.txt",
-"sdk/python/requirements/py3.11-minimal-sdist-requirements-build.txt"
+"sdk/python/requirements/py3.12-minimal-sdist-requirements.txt",
+"sdk/python/requirements/py3.12-minimal-sdist-requirements-build.txt"
 ],
   "allow_binary": "false"
 }'

--- a/sdk/python/feast/infra/feature_servers/multicloud/offline/offline-release-build.sh
+++ b/sdk/python/feast/infra/feature_servers/multicloud/offline/offline-release-build.sh
@@ -30,8 +30,8 @@ hermeto fetch-deps \
 "sdk/python/feast/infra/feature_servers/multicloud/requirements.txt"
 ],
   "requirements_build_files": [
-"sdk/python/requirements/py3.11-minimal-sdist-requirements.txt",
-"sdk/python/requirements/py3.11-minimal-sdist-requirements-build.txt"
+"sdk/python/requirements/py3.12-minimal-sdist-requirements.txt",
+"sdk/python/requirements/py3.12-minimal-sdist-requirements-build.txt"
 ],
   "allow_binary": "false"
 }'


### PR DESCRIPTION
# What this PR does / why we need it:

- Migrated all feast Dockerfiles from `ubi9/python-311:1` to `ubi9/python-312:1` for Python 3.12 support.
- Updated all `py3.11-minimal-*` requirements file references to `py3.12-minimal-*` across Dockerfiles and offline build scripts.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
