### PR TITLE
perf: Remove redundant entity key serialization in online_read

### DIFF
--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -263,11 +263,7 @@ class SqliteOnlineStore(OnlineStore):
         rows = {
             k: list(group) for k, group in itertools.groupby(rows, key=lambda r: r[0])
         }
-        for entity_key in entity_keys:
-            entity_key_bin = serialize_entity_key(
-                entity_key,
-                entity_key_serialization_version=config.entity_key_serialization_version,
-            )
+        for entity_key_bin in serialized_entity_keys:
             res = {}
             res_ts = None
             for _, feature_name, val_bin, ts in rows.get(entity_key_bin, []):


### PR DESCRIPTION
## Summary

Removes redundant entity key serialization in `online_read()` for SQLite and Snowflake online stores.

**Before:** Entity keys were serialized twice - once for the query and again when iterating results
**After:** Pre-computed `serialized_entity_keys` list is reused

## Changes

- **SQLite**: Reuse `serialized_entity_keys` instead of re-calling `serialize_entity_key()` in result loop
- **Snowflake**: Pre-compute serialized keys and reuse in both query building and result processing

## Benchmark Results (SQLite)

| Config | Before | After | Improvement |
|--------|--------|-------|-------------|
| 50f × 100e | 18.21ms | 17.51ms | 3.8% faster |
| 50f × 500e | 92.63ms | 89.60ms | 3.3% faster |

## Test Plan

- [x] Existing unit tests pass
- [x] Benchmarked before/after on SQLite
- [ ] Snowflake changes follow same pattern (no Snowflake test env available)

Fixes #6005
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
