### PR TITLE
fix: Add grpcio dependency group to transformation server Dockerfile

### DIFF
--- a/sdk/python/feast/infra/transformation_servers/Dockerfile
+++ b/sdk/python/feast/infra/transformation_servers/Dockerfile
@@ -15,7 +15,7 @@ COPY pyproject.toml pyproject.toml
 COPY README.md README.md
 
 # Install dependencies
-RUN --mount=source=.git,target=.git,type=bind uv pip install --system --no-cache-dir '.[gcp,aws]'
+RUN --mount=source=.git,target=.git,type=bind uv pip install --system --no-cache-dir '.[gcp,aws,grpcio]'
 
 # Start feature transformation server
 CMD [ "python", "app.py" ]


### PR DESCRIPTION
# What this PR does / why we need it:

The `feature-transformation-server` Docker image fails at runtime with `ModuleNotFoundError: No module named 'grpc_reflection'` because `transformation_server.py` imports `grpc_reflection.v1alpha.reflection`, but the `grpcio` optional dependency group (which includes `grpcio-reflection`) is not installed in the image.

This adds `grpcio` to the pip install extras in the transformation server Dockerfile alongside the existing `gcp` and `aws` groups.

# Which issue(s) this PR fixes:

Fixes #5564

# Misc

One-line change in the Dockerfile: `.[gcp,aws]` → `.[gcp,aws,grpcio]`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
