### PR TITLE
fix: Correct inverted default_value in _construct_random_input

### DIFF
--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -1011,7 +1011,7 @@ class OnDemandFeatureView(BaseFeatureView):
             sample_values = {k: v[0] for k, v in sample_values.items()}
 
         # Default value for missing types
-        default_value = None if not singleton else [None]
+        default_value = [None] if not singleton else None
 
         feature_dict = {}
 


### PR DESCRIPTION
# What this PR does / why we need it:

In `OnDemandFeatureView._construct_random_input`, the `default_value` assignment for missing source columns was inverted. When `singleton=True` (single row), the fallback should be a scalar `None`; when `singleton=False` (batch), it should be `[None]`. The existing code had these swapped, causing downstream errors when the random input was consumed.

# Which issue(s) this PR fixes:

Fixes #6008

# Misc

One-line fix in `sdk/python/feast/on_demand_feature_view.py`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
