### PR TITLE
fix: Fixed IntegrityError on SqlRegistry

### DIFF
--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -23,6 +23,7 @@ from sqlalchemy import (  # type: ignore
     update,
 )
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
 
 from feast import utils
 from feast.base_feature_view import BaseFeatureView
@@ -1028,8 +1029,15 @@ class SqlRegistry(CachingRegistry):
                     "last_updated_timestamp": update_time,
                     "project_id": project,
                 }
-                insert_stmt = insert(feast_metadata).values(values)
-                conn.execute(insert_stmt)
+                try:
+                    with conn.begin_nested():
+                        conn.execute(insert(feast_metadata).values(values))
+                except IntegrityError:
+                    logger.info(
+                        "Project metadata for %s already initialized by "
+                        "another process.",
+                        project,
+                    )
 
     def _delete_object(
         self,


### PR DESCRIPTION

# What this PR does / why we need it:

This PR fixes rest api tests intermittent failures.  Sometimes gRPC registry server is crashing on startup with a UniqueViolation:

```
sqlalchemy.exc.IntegrityError: (psycopg.errors.UniqueViolation) 
duplicate key value violates unique constraint "projects_pkey"
DETAIL:  Key (project_id)=(driver_ranking) already exists.
```

The Feast pod has two containers (online server + registry server) and these create their own SqlRegistry instance against the same shared Postgres. During initialization, multiple processes race on `_maybe_init_project_metadata()` -- INSERT into feast_metadata


Fixes https://github.com/feast-dev/feast/issues/5977 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
