### PR TITLE
fix: Fix non-specific label selector on metrics service

### DIFF
--- a/docs/how-to-guides/feast-on-kubernetes.md
+++ b/docs/how-to-guides/feast-on-kubernetes.md
@@ -64,6 +64,46 @@ spec:
 
 > _More advanced FeatureStore CR examples can be found in the feast-operator [samples directory](../../infra/feast-operator/config/samples)._
 
+## Upgrading the Operator
+
+### OLM-managed installations
+
+If the operator was installed via OLM, upgrades are handled
+automatically. No manual steps are required — OLM recreates the operator Deployment
+during the upgrade process.
+
+### kubectl-managed installations
+
+For most upgrades, re-running the install command is sufficient:
+
+```sh
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/feast-dev/feast/refs/heads/stable/infra/feast-operator/dist/install.yaml
+```
+
+#### One-time step: upgrading from versions before 0.61.0
+
+Version 0.61.0 updated the operator Deployment's `spec.selector` to include the
+`app.kubernetes.io/name: feast-operator` label, fixing a bug where the metrics service
+could accidentally target pods from other operators in shared namespaces.
+
+Because Kubernetes treats `spec.selector` as an immutable field, upgrading directly from
+a pre-0.61.0 version with `kubectl apply` will fail with:
+
+```
+The Deployment "feast-operator-controller-manager" is invalid: spec.selector: Invalid value: ... field is immutable
+```
+
+To resolve this, delete the existing operator Deployment before applying the new manifest:
+
+```sh
+kubectl delete deployment feast-operator-controller-manager -n feast-operator-system --ignore-not-found=true
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/feast-dev/feast/refs/heads/stable/infra/feast-operator/dist/install.yaml
+```
+
+This is only required once. Existing FeatureStore CRs and their managed workloads (feature
+servers, registry, etc.) are not affected — the new operator pod will reconcile them
+automatically on startup. Future upgrades from 0.61.0 onward will not require this step.
+
 {% hint style="success" %}
 **Scaling & High Availability:** The Feast Operator supports horizontal scaling via static replicas, HPA autoscaling, or external autoscalers like [KEDA](https://keda.sh). Scaling requires DB-backed persistence for all enabled services.
 

--- a/infra/feast-operator/README.md
+++ b/infra/feast-operator/README.md
@@ -24,6 +24,7 @@ kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.c
 ```
 
 > **NOTE**: Server-Side Apply (`--server-side`) is required because the CRD includes both v1alpha1 and v1 API versions, making it too large for the standard `kubectl apply` annotation limit. If you encounter annotation size errors, use `--server-side --force-conflicts` flags.
+
 ##### Feast Operator Demo Videos
 [![](https://img.youtube.com/vi/48cb4AHxPR4/0.jpg)](https://www.youtube.com/playlist?list=PLPzVNzik7rsAN-amQLZckd0so3cIr7blX)
 

--- a/infra/feast-operator/bundle/manifests/feast-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/infra/feast-operator/bundle/manifests/feast-operator-controller-manager-metrics-service_v1_service.yaml
@@ -14,6 +14,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
+    app.kubernetes.io/name: feast-operator
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
+++ b/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
@@ -212,6 +212,7 @@ spec:
           replicas: 1
           selector:
             matchLabels:
+              app.kubernetes.io/name: feast-operator
               control-plane: controller-manager
           strategy: {}
           template:
@@ -219,6 +220,7 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
+                app.kubernetes.io/name: feast-operator
                 control-plane: controller-manager
             spec:
               containers:

--- a/infra/feast-operator/config/default/metrics_service.yaml
+++ b/infra/feast-operator/config/default/metrics_service.yaml
@@ -14,4 +14,5 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
+    app.kubernetes.io/name: feast-operator
     control-plane: controller-manager

--- a/infra/feast-operator/config/manager/manager.yaml
+++ b/infra/feast-operator/config/manager/manager.yaml
@@ -19,6 +19,7 @@ metadata:
 spec:
   selector:
     matchLabels:
+      app.kubernetes.io/name: feast-operator
       control-plane: controller-manager
   replicas: 1
   template:
@@ -26,6 +27,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        app.kubernetes.io/name: feast-operator
         control-plane: controller-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression

--- a/infra/feast-operator/config/prometheus/monitor.yaml
+++ b/infra/feast-operator/config/prometheus/monitor.yaml
@@ -27,4 +27,5 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
+      app.kubernetes.io/name: feast-operator
       control-plane: controller-manager

--- a/infra/feast-operator/dist/install.yaml
+++ b/infra/feast-operator/dist/install.yaml
@@ -20512,6 +20512,7 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
+    app.kubernetes.io/name: feast-operator
     control-plane: controller-manager
 ---
 apiVersion: apps/v1
@@ -20527,12 +20528,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/name: feast-operator
       control-plane: controller-manager
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        app.kubernetes.io/name: feast-operator
         control-plane: controller-manager
     spec:
       containers:

--- a/infra/feast-operator/test/utils/test_util.go
+++ b/infra/feast-operator/test/utils/test_util.go
@@ -409,6 +409,10 @@ func DeployOperatorFromCode(testDir string, skipBuilds bool) {
 		_, err = Run(cmd, testDir)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
+		By("deleting existing controller-manager deployment to allow selector changes on upgrade")
+		cmd = exec.Command("kubectl", "delete", "deployment", ControllerDeploymentName, "-n", FeastControllerNamespace, "--ignore-not-found=true")
+		_, _ = Run(cmd, testDir)
+
 		By("deploying the controller-manager")
 		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage), fmt.Sprintf("FS_IMG=%s", feastLocalImage))
 		_, err = Run(cmd, testDir)


### PR DESCRIPTION
# What this PR does / why we need it:

The `feast-operator-controller-manager-metrics-service` uses a non-specific label selector (`control-plane: controller-manager`) that matches pods from any operator using the standard kubebuilder scaffolding label. In shared-namespace environments, where multiple operators are deployed in the same namespace, this causes the Service to incorrectly select pods belonging to other operators.

Added `app.kubernetes.io/name: feast-operator` to all selectors and pod template labels so that the metrics Service, Deployment, and ServiceMonitor uniquely identify Feast operator pods.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
