### PR TITLE
Fix: Integrate kube-api-linter (KAL) for Kubernetes API type validation

### DIFF
--- a/.github/workflows/operator_pr.yml
+++ b/.github/workflows/operator_pr.yml
@@ -15,7 +15,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.22.9
+      - name: Operator lint
+        run: make -C infra/feast-operator lint
       - name: Operator tests
-        run: make -C infra/feast-operator test
+        run: make -C infra/feast-operator test SKIP_LINT=1
       - name: After code formatting, check for uncommitted differences
         run: git diff --exit-code infra/feast-operator

--- a/infra/feast-operator/.custom-gcl.yml
+++ b/infra/feast-operator/.custom-gcl.yml
@@ -1,0 +1,6 @@
+version: v2.8.0
+name: golangci-lint-kube-api-linter
+destination: ./bin
+plugins:
+  - module: sigs.k8s.io/kube-api-linter
+    version: v0.0.0-20260206102632-39e3d06a2850

--- a/infra/feast-operator/.golangci.yml
+++ b/infra/feast-operator/.golangci.yml
@@ -1,40 +1,16 @@
+version: "2"
+
 run:
   timeout: 5m
   allow-parallel-runners: true
 
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
-    - path: "test/*"
-      linters:
-        - lll
-    - path: "upgrade/*"
-      linters:
-        - lll
-    - path: "previous-version/*"
-      linters:
-        - lll
 linters:
-  disable-all: true
+  default: none
   enable:
     - dupl
     - errcheck
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -44,12 +20,52 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-
-linters-settings:
-  revive:
+    - kubeapilinter
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+    custom:
+      kubeapilinter:
+        type: module
+        description: Kube API Linter lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters:
+            disable:
+              - "*"
+            enable:
+              - commentstart
+              - optionalorrequired
+              - defaults
+              - nonpointerstructs
+              - conditions
+          lintersConfig: {}
+  exclusions:
     rules:
-      - name: comment-spacings
+      - path: "api/.*"
+        linters:
+          - lll
+      - path: "internal/.*"
+        linters:
+          - dupl
+          - lll
+      - path: "test/.*"
+        linters:
+          - lll
+      - path: "upgrade/.*"
+        linters:
+          - lll
+      - path: "previous-version/.*"
+        linters:
+          - lll
+      - path-except: "api/.*"
+        linters:
+          - kubeapilinter
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/infra/feast-operator/Makefile
+++ b/infra/feast-operator/Makefile
@@ -114,8 +114,13 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+TEST_DEPS = build-installer vet envtest
+ifndef SKIP_LINT
+TEST_DEPS += lint
+endif
+
 .PHONY: test
-test: build-installer vet lint envtest ## Run tests.
+test: $(TEST_DEPS) ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path --use-deprecated-gcs=false)" go test $$(go list ./... | grep -v test/e2e | grep -v test/data-source-types | grep -v test/upgrade | grep -v test/previous-version) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
@@ -138,12 +143,12 @@ test-datasources:
 	go test ./test/data-source-types/
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
-	$(GOLANGCI_LINT) run
+lint: golangci-lint-custom ## Run golangci-lint linter & yamllint
+	$(GOLANGCI_LINT_CUSTOM) run
 
 .PHONY: lint-fix
-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
-	$(GOLANGCI_LINT) run --fix
+lint-fix: golangci-lint-custom ## Run golangci-lint linter and perform fixes
+	$(GOLANGCI_LINT_CUSTOM) run --fix
 
 ##@ Build
 
@@ -236,6 +241,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+GOLANGCI_LINT_CUSTOM = $(LOCALBIN)/golangci-lint-kube-api-linter
 ENVSUBST = $(LOCALBIN)/envsubst
 
 ## Tool Versions
@@ -243,7 +249,7 @@ KUSTOMIZE_VERSION ?= v5.4.2
 CONTROLLER_TOOLS_VERSION ?= v0.15.0
 CRD_REF_DOCS_VERSION ?= v0.1.0
 ENVTEST_VERSION ?= release-0.18
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v2.8.0
 ENVSUBST_VERSION ?= v1.4.2
 
 .PHONY: kustomize
@@ -264,7 +270,12 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+.PHONY: golangci-lint-custom
+golangci-lint-custom: $(GOLANGCI_LINT_CUSTOM) ## Build custom golangci-lint with kube-api-linter.
+$(GOLANGCI_LINT_CUSTOM): $(GOLANGCI_LINT) .custom-gcl.yml
+	$(GOLANGCI_LINT) custom
 
 .PHONY: envsubst
 envsubst: $(ENVSUBST) ## Download envsubst locally if necessary.

--- a/infra/feast-operator/api/v1/featurestore_types.go
+++ b/infra/feast-operator/api/v1/featurestore_types.go
@@ -74,66 +74,98 @@ const (
 // +kubebuilder:validation:XValidation:rule="self.replicas <= 1 && (!has(self.services) || !has(self.services.scaling) || !has(self.services.scaling.autoscaling)) || (!has(self.services) || !has(self.services.offlineStore) || (has(self.services.offlineStore.persistence) && has(self.services.offlineStore.persistence.store)))",message="Scaling requires DB-backed persistence for the offline store. Configure services.offlineStore.persistence.store when using replicas > 1 or autoscaling."
 // +kubebuilder:validation:XValidation:rule="self.replicas <= 1 && (!has(self.services) || !has(self.services.scaling) || !has(self.services.scaling.autoscaling)) || (has(self.services) && has(self.services.registry) && (has(self.services.registry.remote) || (has(self.services.registry.local) && has(self.services.registry.local.persistence) && (has(self.services.registry.local.persistence.store) || (has(self.services.registry.local.persistence.file) && has(self.services.registry.local.persistence.file.path) && (self.services.registry.local.persistence.file.path.startsWith('s3://') || self.services.registry.local.persistence.file.path.startsWith('gs://')))))))",message="Scaling requires DB-backed or remote registry. Configure registry.local.persistence.store or use a remote registry when using replicas > 1 or autoscaling. S3/GCS-backed registry is also allowed."
 type FeatureStoreSpec struct {
+	// feastProject is the Feast project id. This can be any alphanumeric string with underscores and hyphens, but it cannot start with an underscore or hyphen. Required.
 	// +kubebuilder:validation:Pattern="^[A-Za-z0-9][A-Za-z0-9_-]*$"
-	// FeastProject is the Feast project id. This can be any alphanumeric string with underscores and hyphens, but it cannot start with an underscore or hyphen. Required.
-	FeastProject    string                `json:"feastProject"`
-	FeastProjectDir *FeastProjectDir      `json:"feastProjectDir,omitempty"`
-	Services        *FeatureStoreServices `json:"services,omitempty"`
-	AuthzConfig     *AuthzConfig          `json:"authz,omitempty"`
-	CronJob         *FeastCronJob         `json:"cronJob,omitempty"`
-	BatchEngine     *BatchEngineConfig    `json:"batchEngine,omitempty"`
-	// Replicas is the desired number of pod replicas. Used by the scale sub-resource.
+	// +required
+	FeastProject string `json:"feastProject"`
+	// feastProjectDir defines how to create the feast project directory.
+	// +optional
+	FeastProjectDir *FeastProjectDir `json:"feastProjectDir,omitempty"`
+	// services configures the Feast services for this FeatureStore.
+	// +optional
+	Services *FeatureStoreServices `json:"services,omitempty"`
+	// authz configures authorization for Feast services.
+	// +optional
+	AuthzConfig *AuthzConfig `json:"authz,omitempty"`
+	// cronJob configures CronJobs to run against this FeatureStore deployment.
+	// +optional
+	CronJob *FeastCronJob `json:"cronJob,omitempty"`
+	// batchEngine configures the batch compute engine settings.
+	// +optional
+	BatchEngine *BatchEngineConfig `json:"batchEngine,omitempty"`
+	// replicas is the desired number of pod replicas. Used by the scale sub-resource.
 	// Mutually exclusive with services.scaling.autoscaling.
-	// +kubebuilder:default=1
+	// +default=1
+	// +optional
 	// +kubebuilder:validation:Minimum=1
-	Replicas *int32 `json:"replicas"`
+	Replicas *int32 `json:"replicas,omitempty"`
 }
 
 // FeastProjectDir defines how to create the feast project directory.
 // +kubebuilder:validation:XValidation:rule="[has(self.git), has(self.init)].exists_one(c, c)",message="One selection required between init or git."
 type FeastProjectDir struct {
-	Git  *GitCloneOptions  `json:"git,omitempty"`
+	// git configures cloning the feature repository.
+	// +optional
+	Git *GitCloneOptions `json:"git,omitempty"`
+	// init configures `feast init` project creation.
+	// +optional
 	Init *FeastInitOptions `json:"init,omitempty"`
 }
 
 // GitCloneOptions describes how a clone should be performed.
 // +kubebuilder:validation:XValidation:rule="has(self.featureRepoPath) ? !self.featureRepoPath.startsWith('/') : true",message="RepoPath must be a file name only, with no slashes."
 type GitCloneOptions struct {
-	// The repository URL to clone from.
+	// url is the repository URL to clone from.
+	// +required
 	URL string `json:"url"`
-	// Reference to a branch / tag / commit
+	// ref is a reference to a branch / tag / commit.
+	// +optional
 	Ref string `json:"ref,omitempty"`
-	// Configs passed to git via `-c`
+	// configs are passed to git via `-c`.
 	// e.g. http.sslVerify: 'false'
 	// OR 'url."https://api:\${TOKEN}@github.com/".insteadOf': 'https://github.com/'
+	// +optional
 	Configs map[string]string `json:"configs,omitempty"`
-	// FeatureRepoPath is the relative path to the feature repo subdirectory. Default is 'feature_repo'.
-	FeatureRepoPath string                  `json:"featureRepoPath,omitempty"`
-	Env             *[]corev1.EnvVar        `json:"env,omitempty"`
-	EnvFrom         *[]corev1.EnvFromSource `json:"envFrom,omitempty"`
+	// featureRepoPath is the relative path to the feature repo subdirectory. Default is 'feature_repo'.
+	// +optional
+	FeatureRepoPath string `json:"featureRepoPath,omitempty"`
+	// env adds environment variables for cloning the repository.
+	// +optional
+	Env *[]corev1.EnvVar `json:"env,omitempty"`
+	// envFrom adds environment sources for cloning the repository.
+	// +optional
+	EnvFrom *[]corev1.EnvFromSource `json:"envFrom,omitempty"`
 }
 
 // FeastInitOptions defines how to run a `feast init`.
 type FeastInitOptions struct {
+	// minimal configures whether to use the minimal project template.
+	// +optional
 	Minimal bool `json:"minimal,omitempty"`
-	// Template for the created project
+	// template selects the created project template.
 	// +kubebuilder:validation:Enum=local;gcp;aws;snowflake;spark;postgres;hbase;cassandra;hazelcast;couchbase;clickhouse
+	// +optional
 	Template string `json:"template,omitempty"`
 }
 
 // FeastCronJob defines a CronJob to execute against a Feature Store deployment.
 type FeastCronJob struct {
-	// Annotations to be added to the CronJob metadata.
+	// annotations are added to the CronJob metadata.
+	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	// Specification of the desired behavior of a job.
-	JobSpec          *JobSpec                 `json:"jobSpec,omitempty"`
+	// jobSpec specifies the desired behavior of a job.
+	// +optional
+	JobSpec *JobSpec `json:"jobSpec,omitempty"`
+	// containerConfigs configures the CronJob container settings.
+	// +optional
 	ContainerConfigs *CronJobContainerConfigs `json:"containerConfigs,omitempty"`
 
-	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+	// schedule is in Cron format, see https://en.wikipedia.org/wiki/Cron.
+	// +optional
 	Schedule string `json:"schedule,omitempty"`
 
-	// The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+	// timeZone is the time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
 	// If not specified, this will default to the time zone of the kube-controller-manager process.
 	// The set of valid time zone names and the time zone offset is loaded from the system-wide time zone
 	// database by the API server during CronJob validation and the controller manager during execution.
@@ -142,70 +174,82 @@ type FeastCronJob struct {
 	// configuration, the controller will stop creating new new Jobs and will create a system event with the
 	// reason UnknownTimeZone.
 	// More information can be found in https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+	// +optional
 	TimeZone *string `json:"timeZone,omitempty"`
 
-	// Optional deadline in seconds for starting the job if it misses scheduled
+	// startingDeadlineSeconds is an optional deadline in seconds for starting the job if it misses scheduled
 	// time for any reason.  Missed jobs executions will be counted as failed ones.
+	// +optional
 	StartingDeadlineSeconds *int64 `json:"startingDeadlineSeconds,omitempty"`
 
-	// Specifies how to treat concurrent executions of a Job.
+	// concurrencyPolicy specifies how to treat concurrent executions of a Job.
 	// Valid values are:
 	//
 	// - "Allow" (default): allows CronJobs to run concurrently;
 	// - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
 	// - "Replace": cancels currently running job and replaces it with a new one
+	// +optional
 	ConcurrencyPolicy batchv1.ConcurrencyPolicy `json:"concurrencyPolicy,omitempty"`
 
-	// This flag tells the controller to suspend subsequent executions, it does
+	// suspend tells the controller to suspend subsequent executions, it does
 	// not apply to already started executions.
+	// +optional
 	Suspend *bool `json:"suspend,omitempty"`
 
-	// The number of successful finished jobs to retain. Value must be non-negative integer.
+	// successfulJobsHistoryLimit is the number of successful finished jobs to retain. Value must be non-negative integer.
+	// +optional
 	SuccessfulJobsHistoryLimit *int32 `json:"successfulJobsHistoryLimit,omitempty"`
 
-	// The number of failed finished jobs to retain. Value must be non-negative integer.
+	// failedJobsHistoryLimit is the number of failed finished jobs to retain. Value must be non-negative integer.
+	// +optional
 	FailedJobsHistoryLimit *int32 `json:"failedJobsHistoryLimit,omitempty"`
 }
 
 // BatchEngineConfig defines the batch compute engine configuration.
 type BatchEngineConfig struct {
-	// Reference to a ConfigMap containing the batch engine configuration.
+	// configMapRef references a ConfigMap containing the batch engine configuration.
 	// The ConfigMap should contain YAML-formatted config with 'type' and engine-specific fields.
+	// +optional
 	ConfigMapRef *corev1.LocalObjectReference `json:"configMapRef,omitempty"`
-	// Key name in the ConfigMap. Defaults to "config" if not specified.
+	// configMapKey is the key name in the ConfigMap. Defaults to "config" if not specified.
+	// +optional
 	ConfigMapKey string `json:"configMapKey,omitempty"`
 }
 
 // JobSpec describes how the job execution will look like.
 type JobSpec struct {
-	// PodTemplateAnnotations are annotations to be applied to the CronJob's PodTemplate
+	// podTemplateAnnotations are annotations to be applied to the CronJob's PodTemplate
 	// metadata. This is separate from the CronJob-level annotations and must be
 	// set explicitly by users if they want annotations on the PodTemplate.
+	// +optional
 	PodTemplateAnnotations map[string]string `json:"podTemplateAnnotations,omitempty"`
 
-	// Specifies the maximum desired number of pods the job should
+	// parallelism specifies the maximum desired number of pods the job should
 	// run at any given time. The actual number of pods running in steady state will
 	// be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
 	// i.e. when the work left to do is less than max parallelism.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+	// +optional
 	Parallelism *int32 `json:"parallelism,omitempty"`
 
-	// Specifies the desired number of successfully finished pods the
+	// completions specifies the desired number of successfully finished pods the
 	// job should be run with.  Setting to null means that the success of any
 	// pod signals the success of all pods, and allows parallelism to have any positive
 	// value.  Setting to 1 means that parallelism is limited to 1 and the success of that
 	// pod signals the success of the job.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+	// +optional
 	Completions *int32 `json:"completions,omitempty"`
 
-	// Specifies the duration in seconds relative to the startTime that the job
+	// activeDeadlineSeconds specifies the duration in seconds relative to the startTime that the job
 	// may be continuously active before the system tries to terminate it; value
 	// must be positive integer. If a Job is suspended (at creation or through an
 	// update), this timer will effectively be stopped and reset when the Job is
 	// resumed again.
+	// +optional
 	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
 
-	// Specifies the policy of handling failed pods. In particular, it allows to
+	// podFailurePolicy specifies the policy of handling failed pods. In particular, it allows to
 	// specify the set of actions and conditions which need to be
 	// satisfied to take the associated action.
 	// If empty, the default behaviour applies - the counter of failed pods,
@@ -215,12 +259,14 @@ type JobSpec struct {
 	//
 	// This field is beta-level. It can be used when the `JobPodFailurePolicy`
 	// feature gate is enabled (enabled by default).
+	// +optional
 	PodFailurePolicy *batchv1.PodFailurePolicy `json:"podFailurePolicy,omitempty"`
 
-	// Specifies the number of retries before marking this job failed.
+	// backoffLimit specifies the number of retries before marking this job failed.
+	// +optional
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
 
-	// Specifies the limit for the number of retries within an
+	// backoffLimitPerIndex specifies the limit for the number of retries within an
 	// index before marking this index as failed. When enabled the number of
 	// failures per index is kept in the pod's
 	// batch.kubernetes.io/job-index-failure-count annotation. It can only
@@ -228,9 +274,10 @@ type JobSpec struct {
 	// policy is Never. The field is immutable.
 	// This field is beta-level. It can be used when the `JobBackoffLimitPerIndex`
 	// feature gate is enabled (enabled by default).
+	// +optional
 	BackoffLimitPerIndex *int32 `json:"backoffLimitPerIndex,omitempty"`
 
-	// Specifies the maximal number of failed indexes before marking the Job as
+	// maxFailedIndexes specifies the maximal number of failed indexes before marking the Job as
 	// failed, when backoffLimitPerIndex is set. Once the number of failed
 	// indexes exceeds this number the entire Job is marked as Failed and its
 	// execution is terminated. When left as null the job continues execution of
@@ -240,6 +287,7 @@ type JobSpec struct {
 	// less than or equal to 10^4 when is completions greater than 10^5.
 	// This field is beta-level. It can be used when the `JobBackoffLimitPerIndex`
 	// feature gate is enabled (enabled by default).
+	// +optional
 	MaxFailedIndexes *int32 `json:"maxFailedIndexes,omitempty"`
 
 	// ttlSecondsAfterFinished limits the lifetime of a Job that has finished
@@ -249,6 +297,7 @@ type JobSpec struct {
 	// guarantees (e.g. finalizers) will be honored. If this field is unset,
 	// the Job won't be automatically deleted. If this field is set to zero,
 	// the Job becomes eligible to be deleted immediately after it finishes.
+	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 
 	// completionMode specifies how Pod completions are tracked. It can be
@@ -273,6 +322,7 @@ type JobSpec struct {
 	// If the Job controller observes a mode that it doesn't recognize, which
 	// is possible during upgrades due to version skew, the controller
 	// skips updates for the Job.
+	// +optional
 	CompletionMode *batchv1.CompletionMode `json:"completionMode,omitempty"`
 
 	// suspend specifies whether the Job controller should create Pods or not. If
@@ -283,6 +333,7 @@ type JobSpec struct {
 	// Suspending a Job will reset the StartTime field of the Job, effectively
 	// resetting the ActiveDeadlineSeconds timer too.
 	//
+	// +optional
 	Suspend *bool `json:"suspend,omitempty"`
 
 	// podReplacementPolicy specifies when to create replacement Pods.
@@ -296,36 +347,51 @@ type JobSpec struct {
 	// TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use.
 	// This is an beta field. To use this, enable the JobPodReplacementPolicy feature toggle.
 	// This is on by default.
+	// +optional
 	PodReplacementPolicy *batchv1.PodReplacementPolicy `json:"podReplacementPolicy,omitempty"`
 }
 
 // FeatureStoreServices defines the desired feast services. An ephemeral onlineStore feature server is deployed by default.
 type FeatureStoreServices struct {
+	// offlineStore configures the offline store service.
+	// +optional
 	OfflineStore *OfflineStore `json:"offlineStore,omitempty"`
-	OnlineStore  *OnlineStore  `json:"onlineStore,omitempty"`
-	Registry     *Registry     `json:"registry,omitempty"`
-	// Creates a UI server container
-	UI                 *ServerConfigs             `json:"ui,omitempty"`
+	// onlineStore configures the online store service.
+	// +optional
+	OnlineStore *OnlineStore `json:"onlineStore,omitempty"`
+	// registry configures the registry service.
+	// +optional
+	Registry *Registry `json:"registry,omitempty"`
+	// ui creates a UI server container.
+	// +optional
+	UI *ServerConfigs `json:"ui,omitempty"`
+	// deploymentStrategy configures the deployment strategy for Feast services.
+	// +optional
 	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
-	SecurityContext    *corev1.PodSecurityContext `json:"securityContext,omitempty"`
-	// Disable the 'feast repo initialization' initContainer
+	// securityContext configures the pod security context for Feast services.
+	// +optional
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+	// disableInitContainers disables the 'feast repo initialization' initContainer.
+	// +optional
 	DisableInitContainers bool `json:"disableInitContainers,omitempty"`
-	// Volumes specifies the volumes to mount in the FeatureStore deployment. A corresponding `VolumeMount` should be added to whichever feast service(s) require access to said volume(s).
+	// volumes specifies the volumes to mount in the FeatureStore deployment. A corresponding `VolumeMount` should be added to whichever feast service(s) require access to said volume(s).
+	// +optional
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
-	// Scaling configures horizontal scaling for the FeatureStore deployment (e.g. HPA autoscaling).
+	// scaling configures horizontal scaling for the FeatureStore deployment (e.g. HPA autoscaling).
 	// For static replicas, use spec.replicas instead.
+	// +optional
 	Scaling *ScalingConfig `json:"scaling,omitempty"`
-	// PodDisruptionBudgets configures a PodDisruptionBudget for the FeatureStore deployment.
+	// podDisruptionBudgets configures a PodDisruptionBudget for the FeatureStore deployment.
 	// Only created when scaling is enabled (replicas > 1 or autoscaling).
 	// +optional
 	PodDisruptionBudgets *PDBConfig `json:"podDisruptionBudgets,omitempty"`
-	// TopologySpreadConstraints defines how pods are spread across topology domains.
+	// topologySpreadConstraints defines how pods are spread across topology domains.
 	// When scaling is enabled and this is not set, the operator auto-injects a soft
 	// zone-spread constraint (whenUnsatisfiable: ScheduleAnyway).
 	// Set to an empty array to disable auto-injection.
 	// +optional
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
-	// Affinity defines the pod scheduling constraints for the FeatureStore deployment.
+	// affinity defines the pod scheduling constraints for the FeatureStore deployment.
 	// When scaling is enabled and this is not set, the operator auto-injects a soft
 	// pod anti-affinity rule to prefer spreading pods across nodes.
 	// +optional
@@ -334,7 +400,7 @@ type FeatureStoreServices struct {
 
 // ScalingConfig configures horizontal scaling for the FeatureStore deployment.
 type ScalingConfig struct {
-	// Autoscaling configures a HorizontalPodAutoscaler for the FeatureStore deployment.
+	// autoscaling configures a HorizontalPodAutoscaler for the FeatureStore deployment.
 	// Mutually exclusive with spec.replicas.
 	// +optional
 	Autoscaling *AutoscalingConfig `json:"autoscaling,omitempty"`
@@ -342,18 +408,19 @@ type ScalingConfig struct {
 
 // AutoscalingConfig defines HPA settings for the FeatureStore deployment.
 type AutoscalingConfig struct {
-	// MinReplicas is the lower limit for the number of replicas. Defaults to 1.
+	// minReplicas is the lower limit for the number of replicas. Defaults to 1.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	MinReplicas *int32 `json:"minReplicas,omitempty"`
-	// MaxReplicas is the upper limit for the number of replicas. Required.
+	// maxReplicas is the upper limit for the number of replicas. Required.
 	// +kubebuilder:validation:Minimum=1
+	// +required
 	MaxReplicas int32 `json:"maxReplicas"`
-	// Metrics contains the specifications for which to use to calculate the desired replica count.
+	// metrics contains the specifications for which to use to calculate the desired replica count.
 	// If not set, defaults to 80% CPU utilization.
 	// +optional
 	Metrics []autoscalingv2.MetricSpec `json:"metrics,omitempty"`
-	// Behavior configures the scaling behavior of the target.
+	// behavior configures the scaling behavior of the target.
 	// +optional
 	Behavior *autoscalingv2.HorizontalPodAutoscalerBehavior `json:"behavior,omitempty"`
 }
@@ -362,11 +429,11 @@ type AutoscalingConfig struct {
 // Exactly one of minAvailable or maxUnavailable must be set.
 // +kubebuilder:validation:XValidation:rule="[has(self.minAvailable), has(self.maxUnavailable)].exists_one(c, c)",message="Exactly one of minAvailable or maxUnavailable must be set."
 type PDBConfig struct {
-	// MinAvailable specifies the minimum number/percentage of pods that must remain available.
+	// minAvailable specifies the minimum number/percentage of pods that must remain available.
 	// Mutually exclusive with maxUnavailable.
 	// +optional
 	MinAvailable *intstr.IntOrString `json:"minAvailable,omitempty"`
-	// MaxUnavailable specifies the maximum number/percentage of pods that can be unavailable.
+	// maxUnavailable specifies the maximum number/percentage of pods that can be unavailable.
 	// Mutually exclusive with minAvailable.
 	// +optional
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
@@ -374,22 +441,33 @@ type PDBConfig struct {
 
 // OfflineStore configures the offline store service
 type OfflineStore struct {
-	// Creates a remote offline server container
-	Server      *ServerConfigs           `json:"server,omitempty"`
+	// server creates a remote offline server container.
+	// +optional
+	Server *ServerConfigs `json:"server,omitempty"`
+	// persistence configures offline store persistence.
+	// +optional
 	Persistence *OfflineStorePersistence `json:"persistence,omitempty"`
 }
 
 // OfflineStorePersistence configures the persistence settings for the offline store service
 // +kubebuilder:validation:XValidation:rule="[has(self.file), has(self.store)].exists_one(c, c)",message="One selection required between file or store."
 type OfflineStorePersistence struct {
-	FilePersistence *OfflineStoreFilePersistence    `json:"file,omitempty"`
-	DBPersistence   *OfflineStoreDBStorePersistence `json:"store,omitempty"`
+	// file configures file-based persistence.
+	// +optional
+	FilePersistence *OfflineStoreFilePersistence `json:"file,omitempty"`
+	// store configures store-based persistence.
+	// +optional
+	DBPersistence *OfflineStoreDBStorePersistence `json:"store,omitempty"`
 }
 
 // OfflineStoreFilePersistence configures the file-based persistence for the offline store service
 type OfflineStoreFilePersistence struct {
+	// type is the file-based persistence type.
 	// +kubebuilder:validation:Enum=file;dask;duckdb
-	Type      string     `json:"type,omitempty"`
+	// +optional
+	Type string `json:"type,omitempty"`
+	// pvc configures persistent volume claims for file-based persistence.
+	// +optional
 	PvcConfig *PvcConfig `json:"pvc,omitempty"`
 }
 
@@ -401,12 +479,15 @@ var ValidOfflineStoreFilePersistenceTypes = []string{
 
 // OfflineStoreDBStorePersistence configures the DB store persistence for the offline store service
 type OfflineStoreDBStorePersistence struct {
-	// Type of the persistence type you want to use.
+	// type is the persistence type you want to use.
 	// +kubebuilder:validation:Enum=snowflake.offline;bigquery;redshift;spark;postgres;trino;athena;mssql;couchbase.offline;clickhouse;ray
+	// +required
 	Type string `json:"type"`
-	// Data store parameters should be placed as-is from the "feature_store.yaml" under the secret key. "registry_type" & "type" fields should be removed.
+	// secretRef holds data store parameters from "feature_store.yaml". "registry_type" & "type" fields should be removed.
+	// +required
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
-	// By default, the selected store "type" is used as the SecretKeyName
+	// secretKeyName defaults to the selected store "type".
+	// +optional
 	SecretKeyName string `json:"secretKeyName,omitempty"`
 }
 
@@ -426,16 +507,23 @@ var ValidOfflineStoreDBStorePersistenceTypes = []string{
 
 // OnlineStore configures the online store service
 type OnlineStore struct {
-	// Creates a feature server container
-	Server      *ServerConfigs          `json:"server,omitempty"`
+	// server creates a feature server container.
+	// +optional
+	Server *ServerConfigs `json:"server,omitempty"`
+	// persistence configures online store persistence.
+	// +optional
 	Persistence *OnlineStorePersistence `json:"persistence,omitempty"`
 }
 
 // OnlineStorePersistence configures the persistence settings for the online store service
 // +kubebuilder:validation:XValidation:rule="[has(self.file), has(self.store)].exists_one(c, c)",message="One selection required between file or store."
 type OnlineStorePersistence struct {
-	FilePersistence *OnlineStoreFilePersistence    `json:"file,omitempty"`
-	DBPersistence   *OnlineStoreDBStorePersistence `json:"store,omitempty"`
+	// file configures file-based persistence.
+	// +optional
+	FilePersistence *OnlineStoreFilePersistence `json:"file,omitempty"`
+	// store configures store-based persistence.
+	// +optional
+	DBPersistence *OnlineStoreDBStorePersistence `json:"store,omitempty"`
 }
 
 // OnlineStoreFilePersistence configures the file-based persistence for the online store service
@@ -443,18 +531,25 @@ type OnlineStorePersistence struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.pvc) && has(self.path)) ? !self.path.startsWith('/') : true",message="PVC path must be a file name only, with no slashes."
 // +kubebuilder:validation:XValidation:rule="has(self.path) ? !(self.path.startsWith('s3://') || self.path.startsWith('gs://')) : true",message="Online store does not support S3 or GS buckets."
 type OnlineStoreFilePersistence struct {
-	Path      string     `json:"path,omitempty"`
+	// path is the filesystem path for file-based persistence.
+	// +optional
+	Path string `json:"path,omitempty"`
+	// pvc configures persistent volume claims for file-based persistence.
+	// +optional
 	PvcConfig *PvcConfig `json:"pvc,omitempty"`
 }
 
 // OnlineStoreDBStorePersistence configures the DB store persistence for the online store service
 type OnlineStoreDBStorePersistence struct {
-	// Type of the persistence type you want to use.
+	// type is the persistence type you want to use.
 	// +kubebuilder:validation:Enum=snowflake.online;redis;datastore;dynamodb;bigtable;postgres;cassandra;mysql;hazelcast;singlestore;hbase;elasticsearch;qdrant;couchbase.online;milvus;hybrid
+	// +required
 	Type string `json:"type"`
-	// Data store parameters should be placed as-is from the "feature_store.yaml" under the secret key. "registry_type" & "type" fields should be removed.
+	// secretRef holds data store parameters from "feature_store.yaml". "registry_type" & "type" fields should be removed.
+	// +required
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
-	// By default, the selected store "type" is used as the SecretKeyName
+	// secretKeyName defaults to the selected store "type".
+	// +optional
 	SecretKeyName string `json:"secretKeyName,omitempty"`
 }
 
@@ -479,16 +574,23 @@ var ValidOnlineStoreDBStorePersistenceTypes = []string{
 
 // LocalRegistryConfig configures the registry service
 type LocalRegistryConfig struct {
-	// Creates a registry server container
-	Server      *RegistryServerConfigs `json:"server,omitempty"`
-	Persistence *RegistryPersistence   `json:"persistence,omitempty"`
+	// server creates a registry server container.
+	// +optional
+	Server *RegistryServerConfigs `json:"server,omitempty"`
+	// persistence configures registry persistence.
+	// +optional
+	Persistence *RegistryPersistence `json:"persistence,omitempty"`
 }
 
 // RegistryPersistence configures the persistence settings for the registry service
 // +kubebuilder:validation:XValidation:rule="[has(self.file), has(self.store)].exists_one(c, c)",message="One selection required between file or store."
 type RegistryPersistence struct {
-	FilePersistence *RegistryFilePersistence    `json:"file,omitempty"`
-	DBPersistence   *RegistryDBStorePersistence `json:"store,omitempty"`
+	// file configures file-based persistence.
+	// +optional
+	FilePersistence *RegistryFilePersistence `json:"file,omitempty"`
+	// store configures store-based persistence.
+	// +optional
+	DBPersistence *RegistryDBStorePersistence `json:"store,omitempty"`
 }
 
 // RegistryFilePersistence configures the file-based persistence for the registry service
@@ -497,16 +599,22 @@ type RegistryPersistence struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.pvc) && has(self.path)) ? !(self.path.startsWith('s3://') || self.path.startsWith('gs://')) : true",message="PVC persistence does not support S3 or GS object store URIs."
 // +kubebuilder:validation:XValidation:rule="(has(self.s3_additional_kwargs) && has(self.path)) ? self.path.startsWith('s3://') : true",message="Additional S3 settings are available only for S3 object store URIs."
 type RegistryFilePersistence struct {
-	Path               string             `json:"path,omitempty"`
-	PvcConfig          *PvcConfig         `json:"pvc,omitempty"`
+	// path is the filesystem path or object store URI for registry persistence.
+	// +optional
+	Path string `json:"path,omitempty"`
+	// pvc configures persistent volume claims for registry persistence.
+	// +optional
+	PvcConfig *PvcConfig `json:"pvc,omitempty"`
+	// s3_additional_kwargs configures additional S3 settings for registry persistence.
+	// +optional
 	S3AdditionalKwargs *map[string]string `json:"s3_additional_kwargs,omitempty"`
 
-	// CacheTTLSeconds defines the TTL (in seconds) for the registry cache.
+	// cache_ttl_seconds defines the TTL (in seconds) for the registry cache.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	CacheTTLSeconds *int32 `json:"cache_ttl_seconds,omitempty"`
 
-	// CacheMode defines the registry cache update strategy.
+	// cache_mode defines the registry cache update strategy.
 	// Allowed values are "sync" and "thread".
 	// +kubebuilder:validation:Enum=none;sync;thread
 	// +optional
@@ -515,12 +623,15 @@ type RegistryFilePersistence struct {
 
 // RegistryDBStorePersistence configures the DB store persistence for the registry service
 type RegistryDBStorePersistence struct {
-	// Type of the persistence type you want to use.
+	// type is the persistence type you want to use.
 	// +kubebuilder:validation:Enum=sql;snowflake.registry
+	// +required
 	Type string `json:"type"`
-	// Data store parameters should be placed as-is from the "feature_store.yaml" under the secret key. "registry_type" & "type" fields should be removed.
+	// secretRef holds data store parameters from "feature_store.yaml". "registry_type" & "type" fields should be removed.
+	// +required
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
-	// By default, the selected store "type" is used as the SecretKeyName
+	// secretKeyName defaults to the selected store "type".
+	// +optional
 	SecretKeyName string `json:"secretKeyName,omitempty"`
 }
 
@@ -534,12 +645,15 @@ var ValidRegistryDBStorePersistenceTypes = []string{
 // +kubebuilder:validation:XValidation:rule="[has(self.ref), has(self.create)].exists_one(c, c)",message="One selection is required between ref and create."
 // +kubebuilder:validation:XValidation:rule="self.mountPath.matches('^/[^:]*$')",message="Mount path must start with '/' and must not contain ':'"
 type PvcConfig struct {
-	// Reference to an existing field
+	// ref references an existing PVC.
+	// +optional
 	Ref *corev1.LocalObjectReference `json:"ref,omitempty"`
-	// Settings for creating a new PVC
+	// create specifies settings for creating a new PVC.
+	// +optional
 	Create *PvcCreate `json:"create,omitempty"`
-	// MountPath within the container at which the volume should be mounted.
+	// mountPath is the path within the container at which the volume should be mounted.
 	// Must start by "/" and cannot contain ':'.
+	// +required
 	MountPath string `json:"mountPath"`
 }
 
@@ -547,23 +661,30 @@ type PvcConfig struct {
 // The PVC name is the same as the associated deployment & feast service name.
 // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="PvcCreate is immutable"
 type PvcCreate struct {
-	// AccessModes k8s persistent volume access modes. Defaults to ["ReadWriteOnce"].
+	// accessModes are the k8s persistent volume access modes. Defaults to ["ReadWriteOnce"].
+	// +optional
 	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
-	// StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
+	// storageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
 	// means that this volume does not belong to any StorageClass and the cluster default will be used.
+	// +optional
 	StorageClassName *string `json:"storageClassName,omitempty"`
-	// Resources describes the storage resource requirements for a volume.
+	// resources describes the storage resource requirements for a volume.
 	// Default requested storage size depends on the associated service:
 	// - 10Gi for offline store
 	// - 5Gi for online store
 	// - 5Gi for registry
+	// +optional
 	Resources corev1.VolumeResourceRequirements `json:"resources,omitempty"`
 }
 
 // Registry configures the registry service. One selection is required. Local is the default setting.
 // +kubebuilder:validation:XValidation:rule="[has(self.local), has(self.remote)].exists_one(c, c)",message="One selection required."
 type Registry struct {
-	Local  *LocalRegistryConfig  `json:"local,omitempty"`
+	// local configures a local registry deployment.
+	// +optional
+	Local *LocalRegistryConfig `json:"local,omitempty"`
+	// remote configures a remote registry endpoint.
+	// +optional
 	Remote *RemoteRegistryConfig `json:"remote,omitempty"`
 }
 
@@ -571,70 +692,82 @@ type Registry struct {
 // Instead, this FeatureStore CR's online/offline services will use a remote registry. One selection is required.
 // +kubebuilder:validation:XValidation:rule="[has(self.hostname), has(self.feastRef)].exists_one(c, c)",message="One selection required."
 type RemoteRegistryConfig struct {
-	// Host address of the remote registry service - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`
+	// hostname is the host address of the remote registry service - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`.
+	// +optional
 	Hostname *string `json:"hostname,omitempty"`
-	// Reference to an existing `FeatureStore` CR in the same k8s cluster.
-	FeastRef *FeatureStoreRef          `json:"feastRef,omitempty"`
-	TLS      *TlsRemoteRegistryConfigs `json:"tls,omitempty"`
+	// feastRef references an existing `FeatureStore` CR in the same k8s cluster.
+	// +optional
+	FeastRef *FeatureStoreRef `json:"feastRef,omitempty"`
+	// tls configures TLS settings for the remote registry.
+	// +optional
+	TLS *TlsRemoteRegistryConfigs `json:"tls,omitempty"`
 }
 
 // FeatureStoreRef defines which existing FeatureStore's registry should be used
 type FeatureStoreRef struct {
-	// Name of the FeatureStore
+	// name is the name of the FeatureStore.
+	// +required
 	Name string `json:"name"`
-	// Namespace of the FeatureStore
+	// namespace is the namespace of the FeatureStore.
+	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }
 
 // ServerConfigs creates a server for the feast service, with specified container configurations.
 type ServerConfigs struct {
 	ContainerConfigs `json:",inline"`
-	TLS              *TlsConfigs `json:"tls,omitempty"`
-	// LogLevel sets the logging level for the server
+	// tls configures TLS settings for the server.
+	// +optional
+	TLS *TlsConfigs `json:"tls,omitempty"`
+	// logLevel sets the logging level for the server.
 	// Allowed values: "debug", "info", "warning", "error", "critical".
 	// +kubebuilder:validation:Enum=debug;info;warning;error;critical
+	// +optional
 	LogLevel *string `json:"logLevel,omitempty"`
-	// Metrics exposes Prometheus-compatible metrics for the Feast server when enabled.
+	// metrics exposes Prometheus-compatible metrics for the Feast server when enabled.
+	// +optional
 	Metrics *bool `json:"metrics,omitempty"`
-	// VolumeMounts defines the list of volumes that should be mounted into the feast container.
+	// volumeMounts defines the list of volumes that should be mounted into the feast container.
 	// This allows attaching persistent storage, config files, secrets, or other resources
 	// required by the Feast components. Ensure that each volume mount has a corresponding
 	// volume definition in the Volumes field.
+	// +optional
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
-	// WorkerConfigs defines the worker configuration for the Feast server.
+	// workerConfigs defines the worker configuration for the Feast server.
 	// These options are primarily used for production deployments to optimize performance.
+	// +optional
 	WorkerConfigs *WorkerConfigs `json:"workerConfigs,omitempty"`
 }
 
 // WorkerConfigs defines the worker configuration for Feast servers.
 // These settings control gunicorn worker processes for production deployments.
 type WorkerConfigs struct {
-	// Workers is the number of worker processes. Use -1 to auto-calculate based on CPU cores (2 * CPU + 1).
+	// workers is the number of worker processes. Use -1 to auto-calculate based on CPU cores (2 * CPU + 1).
 	// Defaults to 1 if not specified.
 	// +kubebuilder:validation:Minimum=-1
 	// +optional
 	Workers *int32 `json:"workers,omitempty"`
-	// WorkerConnections is the maximum number of simultaneous clients per worker process.
+	// workerConnections is the maximum number of simultaneous clients per worker process.
 	// Defaults to 1000.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	WorkerConnections *int32 `json:"workerConnections,omitempty"`
-	// MaxRequests is the maximum number of requests a worker will process before restarting.
+	// maxRequests is the maximum number of requests a worker will process before restarting.
 	// This helps prevent memory leaks. Defaults to 1000.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	MaxRequests *int32 `json:"maxRequests,omitempty"`
-	// MaxRequestsJitter is the maximum jitter to add to max-requests to prevent
+	// maxRequestsJitter is the maximum jitter to add to max-requests to prevent
 	// thundering herd effect on worker restart. Defaults to 50.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	MaxRequestsJitter *int32 `json:"maxRequestsJitter,omitempty"`
-	// KeepAliveTimeout is the timeout for keep-alive connections in seconds.
+	// keepAliveTimeout is the timeout for keep-alive connections in seconds.
 	// Defaults to 30.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	KeepAliveTimeout *int32 `json:"keepAliveTimeout,omitempty"`
-	// RegistryTTLSeconds is the number of seconds after which the registry is refreshed.
+	// registryTTLSeconds is the number of seconds after which the registry is refreshed.
 	// Higher values reduce refresh overhead but increase staleness. Defaults to 60.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
@@ -646,10 +779,12 @@ type WorkerConfigs struct {
 type RegistryServerConfigs struct {
 	ServerConfigs `json:",inline"`
 
-	// Enable REST API registry server.
+	// restAPI enables the REST API registry server.
+	// +optional
 	RestAPI *bool `json:"restAPI,omitempty"`
 
-	// Enable gRPC registry server. Defaults to true if unset.
+	// grpc enables the gRPC registry server. Defaults to true if unset.
+	// +optional
 	GRPC *bool `json:"grpc,omitempty"`
 }
 
@@ -657,8 +792,9 @@ type RegistryServerConfigs struct {
 type CronJobContainerConfigs struct {
 	ContainerConfigs `json:",inline"`
 
-	// Array of commands to be executed (in order) against a Feature Store deployment.
+	// commands are executed (in order) against a Feature Store deployment.
 	// Defaults to "feast apply" & "feast materialize-incremental $(date -u +'%Y-%m-%dT%H:%M:%S')"
+	// +optional
 	Commands []string `json:"commands,omitempty"`
 }
 
@@ -670,50 +806,73 @@ type ContainerConfigs struct {
 
 // DefaultCtrConfigs k8s container settings that are applied by default
 type DefaultCtrConfigs struct {
+	// image overrides the default container image.
+	// +optional
 	Image *string `json:"image,omitempty"`
 }
 
 // OptionalCtrConfigs k8s container settings that are optional
 type OptionalCtrConfigs struct {
-	Env             *[]corev1.EnvVar             `json:"env,omitempty"`
-	EnvFrom         *[]corev1.EnvFromSource      `json:"envFrom,omitempty"`
-	ImagePullPolicy *corev1.PullPolicy           `json:"imagePullPolicy,omitempty"`
-	Resources       *corev1.ResourceRequirements `json:"resources,omitempty"`
-	NodeSelector    *map[string]string           `json:"nodeSelector,omitempty"`
+	// env overrides container environment variables.
+	// +optional
+	Env *[]corev1.EnvVar `json:"env,omitempty"`
+	// envFrom overrides container environment sources.
+	// +optional
+	EnvFrom *[]corev1.EnvFromSource `json:"envFrom,omitempty"`
+	// imagePullPolicy overrides the container image pull policy.
+	// +optional
+	ImagePullPolicy *corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	// resources overrides the container resource requirements.
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+	// nodeSelector overrides the container node selector.
+	// +optional
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // AuthzConfig defines the authorization settings for the deployed Feast services.
 // +kubebuilder:validation:XValidation:rule="[has(self.kubernetes), has(self.oidc)].exists_one(c, c)",message="One selection required between kubernetes or oidc."
 type AuthzConfig struct {
+	// kubernetes configures Kubernetes RBAC authorization.
+	// +optional
 	KubernetesAuthz *KubernetesAuthz `json:"kubernetes,omitempty"`
-	OidcAuthz       *OidcAuthz       `json:"oidc,omitempty"`
+	// oidc configures OpenID Connect authorization.
+	// +optional
+	OidcAuthz *OidcAuthz `json:"oidc,omitempty"`
 }
 
 // KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.
 // https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 type KubernetesAuthz struct {
-	// The Kubernetes RBAC roles to be deployed in the same namespace of the FeatureStore.
+	// roles are the Kubernetes RBAC roles to be deployed in the same namespace of the FeatureStore.
 	// Roles are managed by the operator and created with an empty list of rules.
 	// See the Feast permission model at https://docs.feast.dev/getting-started/concepts/permission
 	// The feature store admin is not obligated to manage roles using the Feast operator, roles can be managed independently.
 	// This configuration option is only providing a way to automate this procedure.
 	// Important note: the operator cannot ensure that these roles will match the ones used in the configured Feast permissions.
+	// +optional
 	Roles []string `json:"roles,omitempty"`
 }
 
 // OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.
 // https://auth0.com/docs/authenticate/protocols/openid-connect-protocol
 type OidcAuthz struct {
+	// secretRef references the secret containing OIDC configuration.
+	// +required
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
 }
 
 // TlsConfigs configures server TLS for a feast service. in an openshift cluster, this is configured by default using service serving certificates.
 // +kubebuilder:validation:XValidation:rule="(!has(self.disable) || !self.disable) ? has(self.secretRef) : true",message="`secretRef` required if `disable` is false."
 type TlsConfigs struct {
-	// references the local k8s secret where the TLS key and cert reside
-	SecretRef      *corev1.LocalObjectReference `json:"secretRef,omitempty"`
-	SecretKeyNames SecretKeyNames               `json:"secretKeyNames,omitempty"`
-	// will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default
+	// secretRef references the local k8s secret where the TLS key and cert reside.
+	// +optional
+	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty"`
+	// secretKeyNames defines the secret key names for TLS.
+	// +optional
+	SecretKeyNames SecretKeyNames `json:"secretKeyNames,omitempty"`
+	// disable will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default.
+	// +optional
 	Disable *bool `json:"disable,omitempty"`
 }
 
@@ -732,55 +891,89 @@ func (tls *TlsConfigs) IsTLS() bool {
 
 // TlsRemoteRegistryConfigs configures client TLS for a remote feast registry. in an openshift cluster, this is configured by default when the remote feast registry is using service serving certificates.
 type TlsRemoteRegistryConfigs struct {
-	// references the local k8s configmap where the TLS cert resides
+	// configMapRef references the local k8s configmap where the TLS cert resides.
+	// +required
 	ConfigMapRef corev1.LocalObjectReference `json:"configMapRef"`
-	// defines the configmap key name for the client TLS cert.
+	// certName defines the configmap key name for the client TLS cert.
+	// +required
 	CertName string `json:"certName"`
 }
 
 // SecretKeyNames defines the secret key names for the TLS key and cert.
 type SecretKeyNames struct {
-	// defaults to "tls.crt"
+	// tlsCrt defaults to "tls.crt".
+	// +optional
 	TlsCrt string `json:"tlsCrt,omitempty"`
-	// defaults to "tls.key"
+	// tlsKey defaults to "tls.key".
+	// +optional
 	TlsKey string `json:"tlsKey,omitempty"`
 }
 
 // FeatureStoreStatus defines the observed state of FeatureStore
 type FeatureStoreStatus struct {
-	// Shows the currently applied feast configuration, including any pertinent defaults
+	// conditions report the current status conditions.
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	// applied shows the currently applied feast configuration, including any pertinent defaults.
+	// +required
 	Applied FeatureStoreSpec `json:"applied,omitempty"`
-	// ConfigMap in this namespace containing a client `feature_store.yaml` for this feast deployment
+	// clientConfigMap is the ConfigMap containing a client `feature_store.yaml` for this feast deployment.
+	// +optional
 	ClientConfigMap string `json:"clientConfigMap,omitempty"`
-	// CronJob in this namespace for this feast deployment
-	CronJob          string             `json:"cronJob,omitempty"`
-	Conditions       []metav1.Condition `json:"conditions,omitempty"`
-	FeastVersion     string             `json:"feastVersion,omitempty"`
-	Phase            string             `json:"phase,omitempty"`
-	ServiceHostnames ServiceHostnames   `json:"serviceHostnames,omitempty"`
-	// Replicas is the current number of ready pod replicas (used by the scale sub-resource).
+	// cronJob is the CronJob in this namespace for this feast deployment.
+	// +optional
+	CronJob string `json:"cronJob,omitempty"`
+	// feastVersion is the resolved Feast version for this deployment.
+	// +optional
+	FeastVersion string `json:"feastVersion,omitempty"`
+	// phase is the current lifecycle phase.
+	// +optional
+	Phase string `json:"phase,omitempty"`
+	// serviceHostnames contains resolved service hostnames.
+	// +optional
+	ServiceHostnames ServiceHostnames `json:"serviceHostnames,omitempty"`
+	// replicas is the current number of ready pod replicas (used by the scale sub-resource).
+	// +optional
 	Replicas int32 `json:"replicas,omitempty"`
-	// Selector is the label selector for pods managed by the FeatureStore deployment (used by the scale sub-resource).
+	// selector is the label selector for pods managed by the FeatureStore deployment (used by the scale sub-resource).
+	// +optional
 	Selector string `json:"selector,omitempty"`
-	// ScalingStatus reports the current scaling state of the FeatureStore deployment.
+	// scalingStatus reports the current scaling state of the FeatureStore deployment.
+	// +optional
 	ScalingStatus *ScalingStatus `json:"scalingStatus,omitempty"`
 }
 
 // ScalingStatus reports the observed scaling state.
 type ScalingStatus struct {
-	// CurrentReplicas is the current number of pod replicas.
+	// currentReplicas is the current number of pod replicas.
+	// +optional
 	CurrentReplicas int32 `json:"currentReplicas,omitempty"`
-	// DesiredReplicas is the desired number of pod replicas.
+	// desiredReplicas is the desired number of pod replicas.
+	// +optional
 	DesiredReplicas int32 `json:"desiredReplicas,omitempty"`
 }
 
 // ServiceHostnames defines the service hostnames in the format of <domain>:<port>, e.g. example.svc.cluster.local:80
 type ServiceHostnames struct {
+	// offlineStore is the offline store service hostname.
+	// +optional
 	OfflineStore string `json:"offlineStore,omitempty"`
-	OnlineStore  string `json:"onlineStore,omitempty"`
-	Registry     string `json:"registry,omitempty"`
+	// onlineStore is the online store service hostname.
+	// +optional
+	OnlineStore string `json:"onlineStore,omitempty"`
+	// registry is the registry service hostname.
+	// +optional
+	Registry string `json:"registry,omitempty"`
+	// registryRest is the registry REST service hostname.
+	// +optional
 	RegistryRest string `json:"registryRest,omitempty"`
-	UI           string `json:"ui,omitempty"`
+	// ui is the UI service hostname.
+	// +optional
+	UI string `json:"ui,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -793,10 +986,16 @@ type ServiceHostnames struct {
 
 // FeatureStore is the Schema for the featurestores API
 type FeatureStore struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata contains the object's metadata.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   FeatureStoreSpec   `json:"spec,omitempty"`
+	// spec defines the desired state of FeatureStore.
+	// +required
+	Spec FeatureStoreSpec `json:"spec,omitempty"`
+	// status defines the observed state of FeatureStore.
+	// +required
 	Status FeatureStoreStatus `json:"status,omitempty"`
 }
 

--- a/infra/feast-operator/api/v1alpha1/featurestore_types.go
+++ b/infra/feast-operator/api/v1alpha1/featurestore_types.go
@@ -68,60 +68,89 @@ const (
 
 // FeatureStoreSpec defines the desired state of FeatureStore
 type FeatureStoreSpec struct {
+	// feastProject is the Feast project id. This can be any alphanumeric string with underscores and hyphens, but it cannot start with an underscore or hyphen. Required.
 	// +kubebuilder:validation:Pattern="^[A-Za-z0-9][A-Za-z0-9_-]*$"
-	// FeastProject is the Feast project id. This can be any alphanumeric string with underscores and hyphens, but it cannot start with an underscore or hyphen. Required.
-	FeastProject    string                `json:"feastProject"`
-	FeastProjectDir *FeastProjectDir      `json:"feastProjectDir,omitempty"`
-	Services        *FeatureStoreServices `json:"services,omitempty"`
-	AuthzConfig     *AuthzConfig          `json:"authz,omitempty"`
-	CronJob         *FeastCronJob         `json:"cronJob,omitempty"`
+	// +required
+	FeastProject string `json:"feastProject"`
+	// feastProjectDir defines how to create the feast project directory.
+	// +optional
+	FeastProjectDir *FeastProjectDir `json:"feastProjectDir,omitempty"`
+	// services configures the Feast services for this FeatureStore.
+	// +optional
+	Services *FeatureStoreServices `json:"services,omitempty"`
+	// authz configures authorization for Feast services.
+	// +optional
+	AuthzConfig *AuthzConfig `json:"authz,omitempty"`
+	// cronJob configures CronJobs to run against this FeatureStore deployment.
+	// +optional
+	CronJob *FeastCronJob `json:"cronJob,omitempty"`
 }
 
 // FeastProjectDir defines how to create the feast project directory.
 // +kubebuilder:validation:XValidation:rule="[has(self.git), has(self.init)].exists_one(c, c)",message="One selection required between init or git."
 type FeastProjectDir struct {
-	Git  *GitCloneOptions  `json:"git,omitempty"`
+	// git configures cloning the feature repository.
+	// +optional
+	Git *GitCloneOptions `json:"git,omitempty"`
+	// init configures `feast init` project creation.
+	// +optional
 	Init *FeastInitOptions `json:"init,omitempty"`
 }
 
 // GitCloneOptions describes how a clone should be performed.
 // +kubebuilder:validation:XValidation:rule="has(self.featureRepoPath) ? !self.featureRepoPath.startsWith('/') : true",message="RepoPath must be a file name only, with no slashes."
 type GitCloneOptions struct {
-	// The repository URL to clone from.
+	// url is the repository URL to clone from.
+	// +required
 	URL string `json:"url"`
-	// Reference to a branch / tag / commit
+	// ref is a reference to a branch / tag / commit.
+	// +optional
 	Ref string `json:"ref,omitempty"`
-	// Configs passed to git via `-c`
+	// configs are passed to git via `-c`.
 	// e.g. http.sslVerify: 'false'
 	// OR 'url."https://api:\${TOKEN}@github.com/".insteadOf': 'https://github.com/'
+	// +optional
 	Configs map[string]string `json:"configs,omitempty"`
-	// FeatureRepoPath is the relative path to the feature repo subdirectory. Default is 'feature_repo'.
-	FeatureRepoPath string                  `json:"featureRepoPath,omitempty"`
-	Env             *[]corev1.EnvVar        `json:"env,omitempty"`
-	EnvFrom         *[]corev1.EnvFromSource `json:"envFrom,omitempty"`
+	// featureRepoPath is the relative path to the feature repo subdirectory. Default is 'feature_repo'.
+	// +optional
+	FeatureRepoPath string `json:"featureRepoPath,omitempty"`
+	// env adds environment variables for cloning the repository.
+	// +optional
+	Env *[]corev1.EnvVar `json:"env,omitempty"`
+	// envFrom adds environment sources for cloning the repository.
+	// +optional
+	EnvFrom *[]corev1.EnvFromSource `json:"envFrom,omitempty"`
 }
 
 // FeastInitOptions defines how to run a `feast init`.
 type FeastInitOptions struct {
+	// minimal configures whether to use the minimal project template.
+	// +optional
 	Minimal bool `json:"minimal,omitempty"`
-	// Template for the created project
+	// template selects the created project template.
 	// +kubebuilder:validation:Enum=local;gcp;aws;snowflake;spark;postgres;hbase;cassandra;hazelcast;couchbase;clickhouse
+	// +optional
 	Template string `json:"template,omitempty"`
 }
 
 // FeastCronJob defines a CronJob to execute against a Feature Store deployment.
 type FeastCronJob struct {
-	// Annotations to be added to the CronJob metadata.
+	// annotations are added to the CronJob metadata.
+	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	// Specification of the desired behavior of a job.
-	JobSpec          *JobSpec                 `json:"jobSpec,omitempty"`
+	// jobSpec specifies the desired behavior of a job.
+	// +optional
+	JobSpec *JobSpec `json:"jobSpec,omitempty"`
+	// containerConfigs configures the CronJob container settings.
+	// +optional
 	ContainerConfigs *CronJobContainerConfigs `json:"containerConfigs,omitempty"`
 
-	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+	// schedule is in Cron format, see https://en.wikipedia.org/wiki/Cron.
+	// +optional
 	Schedule string `json:"schedule,omitempty"`
 
-	// The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
+	// timeZone is the time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.
 	// If not specified, this will default to the time zone of the kube-controller-manager process.
 	// The set of valid time zone names and the time zone offset is loaded from the system-wide time zone
 	// database by the API server during CronJob validation and the controller manager during execution.
@@ -130,61 +159,71 @@ type FeastCronJob struct {
 	// configuration, the controller will stop creating new new Jobs and will create a system event with the
 	// reason UnknownTimeZone.
 	// More information can be found in https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+	// +optional
 	TimeZone *string `json:"timeZone,omitempty"`
 
-	// Optional deadline in seconds for starting the job if it misses scheduled
+	// startingDeadlineSeconds is an optional deadline in seconds for starting the job if it misses scheduled
 	// time for any reason.  Missed jobs executions will be counted as failed ones.
+	// +optional
 	StartingDeadlineSeconds *int64 `json:"startingDeadlineSeconds,omitempty"`
 
-	// Specifies how to treat concurrent executions of a Job.
+	// concurrencyPolicy specifies how to treat concurrent executions of a Job.
 	// Valid values are:
 	//
 	// - "Allow" (default): allows CronJobs to run concurrently;
 	// - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet;
 	// - "Replace": cancels currently running job and replaces it with a new one
+	// +optional
 	ConcurrencyPolicy batchv1.ConcurrencyPolicy `json:"concurrencyPolicy,omitempty"`
 
-	// This flag tells the controller to suspend subsequent executions, it does
+	// suspend tells the controller to suspend subsequent executions, it does
 	// not apply to already started executions.
+	// +optional
 	Suspend *bool `json:"suspend,omitempty"`
 
-	// The number of successful finished jobs to retain. Value must be non-negative integer.
+	// successfulJobsHistoryLimit is the number of successful finished jobs to retain. Value must be non-negative integer.
+	// +optional
 	SuccessfulJobsHistoryLimit *int32 `json:"successfulJobsHistoryLimit,omitempty"`
 
-	// The number of failed finished jobs to retain. Value must be non-negative integer.
+	// failedJobsHistoryLimit is the number of failed finished jobs to retain. Value must be non-negative integer.
+	// +optional
 	FailedJobsHistoryLimit *int32 `json:"failedJobsHistoryLimit,omitempty"`
 }
 
 // JobSpec describes how the job execution will look like.
 type JobSpec struct {
-	// PodTemplateAnnotations are annotations to be applied to the CronJob's PodTemplate
+	// podTemplateAnnotations are annotations to be applied to the CronJob's PodTemplate
 	// metadata. This is separate from the CronJob-level annotations and must be
 	// set explicitly by users if they want annotations on the PodTemplate.
+	// +optional
 	PodTemplateAnnotations map[string]string `json:"podTemplateAnnotations,omitempty"`
 
-	// Specifies the maximum desired number of pods the job should
+	// parallelism specifies the maximum desired number of pods the job should
 	// run at any given time. The actual number of pods running in steady state will
 	// be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
 	// i.e. when the work left to do is less than max parallelism.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+	// +optional
 	Parallelism *int32 `json:"parallelism,omitempty"`
 
-	// Specifies the desired number of successfully finished pods the
+	// completions specifies the desired number of successfully finished pods the
 	// job should be run with.  Setting to null means that the success of any
 	// pod signals the success of all pods, and allows parallelism to have any positive
 	// value.  Setting to 1 means that parallelism is limited to 1 and the success of that
 	// pod signals the success of the job.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+	// +optional
 	Completions *int32 `json:"completions,omitempty"`
 
-	// Specifies the duration in seconds relative to the startTime that the job
+	// activeDeadlineSeconds specifies the duration in seconds relative to the startTime that the job
 	// may be continuously active before the system tries to terminate it; value
 	// must be positive integer. If a Job is suspended (at creation or through an
 	// update), this timer will effectively be stopped and reset when the Job is
 	// resumed again.
+	// +optional
 	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
 
-	// Specifies the policy of handling failed pods. In particular, it allows to
+	// podFailurePolicy specifies the policy of handling failed pods. In particular, it allows to
 	// specify the set of actions and conditions which need to be
 	// satisfied to take the associated action.
 	// If empty, the default behaviour applies - the counter of failed pods,
@@ -194,12 +233,14 @@ type JobSpec struct {
 	//
 	// This field is beta-level. It can be used when the `JobPodFailurePolicy`
 	// feature gate is enabled (enabled by default).
+	// +optional
 	PodFailurePolicy *batchv1.PodFailurePolicy `json:"podFailurePolicy,omitempty"`
 
-	// Specifies the number of retries before marking this job failed.
+	// backoffLimit specifies the number of retries before marking this job failed.
+	// +optional
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
 
-	// Specifies the limit for the number of retries within an
+	// backoffLimitPerIndex specifies the limit for the number of retries within an
 	// index before marking this index as failed. When enabled the number of
 	// failures per index is kept in the pod's
 	// batch.kubernetes.io/job-index-failure-count annotation. It can only
@@ -207,9 +248,10 @@ type JobSpec struct {
 	// policy is Never. The field is immutable.
 	// This field is beta-level. It can be used when the `JobBackoffLimitPerIndex`
 	// feature gate is enabled (enabled by default).
+	// +optional
 	BackoffLimitPerIndex *int32 `json:"backoffLimitPerIndex,omitempty"`
 
-	// Specifies the maximal number of failed indexes before marking the Job as
+	// maxFailedIndexes specifies the maximal number of failed indexes before marking the Job as
 	// failed, when backoffLimitPerIndex is set. Once the number of failed
 	// indexes exceeds this number the entire Job is marked as Failed and its
 	// execution is terminated. When left as null the job continues execution of
@@ -219,6 +261,7 @@ type JobSpec struct {
 	// less than or equal to 10^4 when is completions greater than 10^5.
 	// This field is beta-level. It can be used when the `JobBackoffLimitPerIndex`
 	// feature gate is enabled (enabled by default).
+	// +optional
 	MaxFailedIndexes *int32 `json:"maxFailedIndexes,omitempty"`
 
 	// ttlSecondsAfterFinished limits the lifetime of a Job that has finished
@@ -228,6 +271,7 @@ type JobSpec struct {
 	// guarantees (e.g. finalizers) will be honored. If this field is unset,
 	// the Job won't be automatically deleted. If this field is set to zero,
 	// the Job becomes eligible to be deleted immediately after it finishes.
+	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 
 	// completionMode specifies how Pod completions are tracked. It can be
@@ -252,6 +296,7 @@ type JobSpec struct {
 	// If the Job controller observes a mode that it doesn't recognize, which
 	// is possible during upgrades due to version skew, the controller
 	// skips updates for the Job.
+	// +optional
 	CompletionMode *batchv1.CompletionMode `json:"completionMode,omitempty"`
 
 	// suspend specifies whether the Job controller should create Pods or not. If
@@ -262,6 +307,7 @@ type JobSpec struct {
 	// Suspending a Job will reset the StartTime field of the Job, effectively
 	// resetting the ActiveDeadlineSeconds timer too.
 	//
+	// +optional
 	Suspend *bool `json:"suspend,omitempty"`
 
 	// podReplacementPolicy specifies when to create replacement Pods.
@@ -275,42 +321,67 @@ type JobSpec struct {
 	// TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use.
 	// This is an beta field. To use this, enable the JobPodReplacementPolicy feature toggle.
 	// This is on by default.
+	// +optional
 	PodReplacementPolicy *batchv1.PodReplacementPolicy `json:"podReplacementPolicy,omitempty"`
 }
 
 // FeatureStoreServices defines the desired feast services. An ephemeral onlineStore feature server is deployed by default.
 type FeatureStoreServices struct {
+	// offlineStore configures the offline store service.
+	// +optional
 	OfflineStore *OfflineStore `json:"offlineStore,omitempty"`
-	OnlineStore  *OnlineStore  `json:"onlineStore,omitempty"`
-	Registry     *Registry     `json:"registry,omitempty"`
-	// Creates a UI server container
-	UI                 *ServerConfigs             `json:"ui,omitempty"`
+	// onlineStore configures the online store service.
+	// +optional
+	OnlineStore *OnlineStore `json:"onlineStore,omitempty"`
+	// registry configures the registry service.
+	// +optional
+	Registry *Registry `json:"registry,omitempty"`
+	// ui creates a UI server container.
+	// +optional
+	UI *ServerConfigs `json:"ui,omitempty"`
+	// deploymentStrategy configures the deployment strategy for Feast services.
+	// +optional
 	DeploymentStrategy *appsv1.DeploymentStrategy `json:"deploymentStrategy,omitempty"`
-	SecurityContext    *corev1.PodSecurityContext `json:"securityContext,omitempty"`
-	// Disable the 'feast repo initialization' initContainer
+	// securityContext configures the pod security context for Feast services.
+	// +optional
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+	// disableInitContainers disables the 'feast repo initialization' initContainer.
+	// +optional
 	DisableInitContainers bool `json:"disableInitContainers,omitempty"`
-	// Volumes specifies the volumes to mount in the FeatureStore deployment. A corresponding `VolumeMount` should be added to whichever feast service(s) require access to said volume(s).
+	// volumes specifies the volumes to mount in the FeatureStore deployment. A corresponding `VolumeMount` should be added to whichever feast service(s) require access to said volume(s).
+	// +optional
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 }
 
 // OfflineStore configures the offline store service
 type OfflineStore struct {
-	// Creates a remote offline server container
-	Server      *ServerConfigs           `json:"server,omitempty"`
+	// server creates a remote offline server container.
+	// +optional
+	Server *ServerConfigs `json:"server,omitempty"`
+	// persistence configures offline store persistence.
+	// +optional
 	Persistence *OfflineStorePersistence `json:"persistence,omitempty"`
 }
 
 // OfflineStorePersistence configures the persistence settings for the offline store service
 // +kubebuilder:validation:XValidation:rule="[has(self.file), has(self.store)].exists_one(c, c)",message="One selection required between file or store."
 type OfflineStorePersistence struct {
-	FilePersistence *OfflineStoreFilePersistence    `json:"file,omitempty"`
-	DBPersistence   *OfflineStoreDBStorePersistence `json:"store,omitempty"`
+	// file configures file-based persistence.
+	// +optional
+	FilePersistence *OfflineStoreFilePersistence `json:"file,omitempty"`
+	// store configures store-based persistence.
+	// +optional
+	DBPersistence *OfflineStoreDBStorePersistence `json:"store,omitempty"`
 }
 
 // OfflineStoreFilePersistence configures the file-based persistence for the offline store service
 type OfflineStoreFilePersistence struct {
+	// type is the file-based persistence type.
 	// +kubebuilder:validation:Enum=file;dask;duckdb
-	Type      string     `json:"type,omitempty"`
+	// +optional
+	Type string `json:"type,omitempty"`
+	// pvc configures persistent volume claims for file-based persistence.
+	// +optional
 	PvcConfig *PvcConfig `json:"pvc,omitempty"`
 }
 
@@ -322,12 +393,15 @@ var ValidOfflineStoreFilePersistenceTypes = []string{
 
 // OfflineStoreDBStorePersistence configures the DB store persistence for the offline store service
 type OfflineStoreDBStorePersistence struct {
-	// Type of the persistence type you want to use.
+	// type is the persistence type you want to use.
 	// +kubebuilder:validation:Enum=snowflake.offline;bigquery;redshift;spark;postgres;trino;athena;mssql;couchbase.offline;clickhouse;ray
+	// +required
 	Type string `json:"type"`
-	// Data store parameters should be placed as-is from the "feature_store.yaml" under the secret key. "registry_type" & "type" fields should be removed.
+	// secretRef holds data store parameters from "feature_store.yaml". "registry_type" & "type" fields should be removed.
+	// +required
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
-	// By default, the selected store "type" is used as the SecretKeyName
+	// secretKeyName defaults to the selected store "type".
+	// +optional
 	SecretKeyName string `json:"secretKeyName,omitempty"`
 }
 
@@ -347,16 +421,23 @@ var ValidOfflineStoreDBStorePersistenceTypes = []string{
 
 // OnlineStore configures the online store service
 type OnlineStore struct {
-	// Creates a feature server container
-	Server      *ServerConfigs          `json:"server,omitempty"`
+	// server creates a feature server container.
+	// +optional
+	Server *ServerConfigs `json:"server,omitempty"`
+	// persistence configures online store persistence.
+	// +optional
 	Persistence *OnlineStorePersistence `json:"persistence,omitempty"`
 }
 
 // OnlineStorePersistence configures the persistence settings for the online store service
 // +kubebuilder:validation:XValidation:rule="[has(self.file), has(self.store)].exists_one(c, c)",message="One selection required between file or store."
 type OnlineStorePersistence struct {
-	FilePersistence *OnlineStoreFilePersistence    `json:"file,omitempty"`
-	DBPersistence   *OnlineStoreDBStorePersistence `json:"store,omitempty"`
+	// file configures file-based persistence.
+	// +optional
+	FilePersistence *OnlineStoreFilePersistence `json:"file,omitempty"`
+	// store configures store-based persistence.
+	// +optional
+	DBPersistence *OnlineStoreDBStorePersistence `json:"store,omitempty"`
 }
 
 // OnlineStoreFilePersistence configures the file-based persistence for the online store service
@@ -364,18 +445,25 @@ type OnlineStorePersistence struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.pvc) && has(self.path)) ? !self.path.startsWith('/') : true",message="PVC path must be a file name only, with no slashes."
 // +kubebuilder:validation:XValidation:rule="has(self.path) ? !(self.path.startsWith('s3://') || self.path.startsWith('gs://')) : true",message="Online store does not support S3 or GS buckets."
 type OnlineStoreFilePersistence struct {
-	Path      string     `json:"path,omitempty"`
+	// path is the filesystem path for file-based persistence.
+	// +optional
+	Path string `json:"path,omitempty"`
+	// pvc configures persistent volume claims for file-based persistence.
+	// +optional
 	PvcConfig *PvcConfig `json:"pvc,omitempty"`
 }
 
 // OnlineStoreDBStorePersistence configures the DB store persistence for the online store service
 type OnlineStoreDBStorePersistence struct {
-	// Type of the persistence type you want to use.
+	// type is the persistence type you want to use.
 	// +kubebuilder:validation:Enum=snowflake.online;redis;datastore;dynamodb;bigtable;postgres;cassandra;mysql;hazelcast;singlestore;hbase;elasticsearch;qdrant;couchbase.online;milvus;hybrid
+	// +required
 	Type string `json:"type"`
-	// Data store parameters should be placed as-is from the "feature_store.yaml" under the secret key. "registry_type" & "type" fields should be removed.
+	// secretRef holds data store parameters from "feature_store.yaml". "registry_type" & "type" fields should be removed.
+	// +required
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
-	// By default, the selected store "type" is used as the SecretKeyName
+	// secretKeyName defaults to the selected store "type".
+	// +optional
 	SecretKeyName string `json:"secretKeyName,omitempty"`
 }
 
@@ -400,16 +488,23 @@ var ValidOnlineStoreDBStorePersistenceTypes = []string{
 
 // LocalRegistryConfig configures the registry service
 type LocalRegistryConfig struct {
-	// Creates a registry server container
-	Server      *RegistryServerConfigs `json:"server,omitempty"`
-	Persistence *RegistryPersistence   `json:"persistence,omitempty"`
+	// server creates a registry server container.
+	// +optional
+	Server *RegistryServerConfigs `json:"server,omitempty"`
+	// persistence configures registry persistence.
+	// +optional
+	Persistence *RegistryPersistence `json:"persistence,omitempty"`
 }
 
 // RegistryPersistence configures the persistence settings for the registry service
 // +kubebuilder:validation:XValidation:rule="[has(self.file), has(self.store)].exists_one(c, c)",message="One selection required between file or store."
 type RegistryPersistence struct {
-	FilePersistence *RegistryFilePersistence    `json:"file,omitempty"`
-	DBPersistence   *RegistryDBStorePersistence `json:"store,omitempty"`
+	// file configures file-based persistence.
+	// +optional
+	FilePersistence *RegistryFilePersistence `json:"file,omitempty"`
+	// store configures store-based persistence.
+	// +optional
+	DBPersistence *RegistryDBStorePersistence `json:"store,omitempty"`
 }
 
 // RegistryFilePersistence configures the file-based persistence for the registry service
@@ -418,16 +513,22 @@ type RegistryPersistence struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.pvc) && has(self.path)) ? !(self.path.startsWith('s3://') || self.path.startsWith('gs://')) : true",message="PVC persistence does not support S3 or GS object store URIs."
 // +kubebuilder:validation:XValidation:rule="(has(self.s3_additional_kwargs) && has(self.path)) ? self.path.startsWith('s3://') : true",message="Additional S3 settings are available only for S3 object store URIs."
 type RegistryFilePersistence struct {
-	Path               string             `json:"path,omitempty"`
-	PvcConfig          *PvcConfig         `json:"pvc,omitempty"`
+	// path is the filesystem path or object store URI for registry persistence.
+	// +optional
+	Path string `json:"path,omitempty"`
+	// pvc configures persistent volume claims for registry persistence.
+	// +optional
+	PvcConfig *PvcConfig `json:"pvc,omitempty"`
+	// s3_additional_kwargs configures additional S3 settings for registry persistence.
+	// +optional
 	S3AdditionalKwargs *map[string]string `json:"s3_additional_kwargs,omitempty"`
 
-	// CacheTTLSeconds defines the TTL (in seconds) for the registry cache.
+	// cache_ttl_seconds defines the TTL (in seconds) for the registry cache.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	CacheTTLSeconds *int32 `json:"cache_ttl_seconds,omitempty"`
 
-	// CacheMode defines the registry cache update strategy.
+	// cache_mode defines the registry cache update strategy.
 	// Allowed values are "sync" and "thread".
 	// +kubebuilder:validation:Enum=none;sync;thread
 	// +optional
@@ -436,12 +537,15 @@ type RegistryFilePersistence struct {
 
 // RegistryDBStorePersistence configures the DB store persistence for the registry service
 type RegistryDBStorePersistence struct {
-	// Type of the persistence type you want to use.
+	// type is the persistence type you want to use.
 	// +kubebuilder:validation:Enum=sql;snowflake.registry
+	// +required
 	Type string `json:"type"`
-	// Data store parameters should be placed as-is from the "feature_store.yaml" under the secret key. "registry_type" & "type" fields should be removed.
+	// secretRef holds data store parameters from "feature_store.yaml". "registry_type" & "type" fields should be removed.
+	// +required
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
-	// By default, the selected store "type" is used as the SecretKeyName
+	// secretKeyName defaults to the selected store "type".
+	// +optional
 	SecretKeyName string `json:"secretKeyName,omitempty"`
 }
 
@@ -455,12 +559,15 @@ var ValidRegistryDBStorePersistenceTypes = []string{
 // +kubebuilder:validation:XValidation:rule="[has(self.ref), has(self.create)].exists_one(c, c)",message="One selection is required between ref and create."
 // +kubebuilder:validation:XValidation:rule="self.mountPath.matches('^/[^:]*$')",message="Mount path must start with '/' and must not contain ':'"
 type PvcConfig struct {
-	// Reference to an existing field
+	// ref references an existing PVC.
+	// +optional
 	Ref *corev1.LocalObjectReference `json:"ref,omitempty"`
-	// Settings for creating a new PVC
+	// create specifies settings for creating a new PVC.
+	// +optional
 	Create *PvcCreate `json:"create,omitempty"`
-	// MountPath within the container at which the volume should be mounted.
+	// mountPath is the path within the container at which the volume should be mounted.
 	// Must start by "/" and cannot contain ':'.
+	// +required
 	MountPath string `json:"mountPath"`
 }
 
@@ -468,23 +575,30 @@ type PvcConfig struct {
 // The PVC name is the same as the associated deployment & feast service name.
 // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="PvcCreate is immutable"
 type PvcCreate struct {
-	// AccessModes k8s persistent volume access modes. Defaults to ["ReadWriteOnce"].
+	// accessModes are the k8s persistent volume access modes. Defaults to ["ReadWriteOnce"].
+	// +optional
 	AccessModes []corev1.PersistentVolumeAccessMode `json:"accessModes,omitempty"`
-	// StorageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
+	// storageClassName is the name of an existing StorageClass to which this persistent volume belongs. Empty value
 	// means that this volume does not belong to any StorageClass and the cluster default will be used.
+	// +optional
 	StorageClassName *string `json:"storageClassName,omitempty"`
-	// Resources describes the storage resource requirements for a volume.
+	// resources describes the storage resource requirements for a volume.
 	// Default requested storage size depends on the associated service:
 	// - 10Gi for offline store
 	// - 5Gi for online store
 	// - 5Gi for registry
+	// +optional
 	Resources corev1.VolumeResourceRequirements `json:"resources,omitempty"`
 }
 
 // Registry configures the registry service. One selection is required. Local is the default setting.
 // +kubebuilder:validation:XValidation:rule="[has(self.local), has(self.remote)].exists_one(c, c)",message="One selection required."
 type Registry struct {
-	Local  *LocalRegistryConfig  `json:"local,omitempty"`
+	// local configures a local registry deployment.
+	// +optional
+	Local *LocalRegistryConfig `json:"local,omitempty"`
+	// remote configures a remote registry endpoint.
+	// +optional
 	Remote *RemoteRegistryConfig `json:"remote,omitempty"`
 }
 
@@ -492,70 +606,82 @@ type Registry struct {
 // Instead, this FeatureStore CR's online/offline services will use a remote registry. One selection is required.
 // +kubebuilder:validation:XValidation:rule="[has(self.hostname), has(self.feastRef)].exists_one(c, c)",message="One selection required."
 type RemoteRegistryConfig struct {
-	// Host address of the remote registry service - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`
+	// hostname is the host address of the remote registry service - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`.
+	// +optional
 	Hostname *string `json:"hostname,omitempty"`
-	// Reference to an existing `FeatureStore` CR in the same k8s cluster.
-	FeastRef *FeatureStoreRef          `json:"feastRef,omitempty"`
-	TLS      *TlsRemoteRegistryConfigs `json:"tls,omitempty"`
+	// feastRef references an existing `FeatureStore` CR in the same k8s cluster.
+	// +optional
+	FeastRef *FeatureStoreRef `json:"feastRef,omitempty"`
+	// tls configures TLS settings for the remote registry.
+	// +optional
+	TLS *TlsRemoteRegistryConfigs `json:"tls,omitempty"`
 }
 
 // FeatureStoreRef defines which existing FeatureStore's registry should be used
 type FeatureStoreRef struct {
-	// Name of the FeatureStore
+	// name is the name of the FeatureStore.
+	// +required
 	Name string `json:"name"`
-	// Namespace of the FeatureStore
+	// namespace is the namespace of the FeatureStore.
+	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }
 
 // ServerConfigs creates a server for the feast service, with specified container configurations.
 type ServerConfigs struct {
 	ContainerConfigs `json:",inline"`
-	TLS              *TlsConfigs `json:"tls,omitempty"`
-	// LogLevel sets the logging level for the server
+	// tls configures TLS settings for the server.
+	// +optional
+	TLS *TlsConfigs `json:"tls,omitempty"`
+	// logLevel sets the logging level for the server.
 	// Allowed values: "debug", "info", "warning", "error", "critical".
 	// +kubebuilder:validation:Enum=debug;info;warning;error;critical
+	// +optional
 	LogLevel *string `json:"logLevel,omitempty"`
-	// Metrics exposes Prometheus-compatible metrics for the Feast server when enabled.
+	// metrics exposes Prometheus-compatible metrics for the Feast server when enabled.
+	// +optional
 	Metrics *bool `json:"metrics,omitempty"`
-	// VolumeMounts defines the list of volumes that should be mounted into the feast container.
+	// volumeMounts defines the list of volumes that should be mounted into the feast container.
 	// This allows attaching persistent storage, config files, secrets, or other resources
 	// required by the Feast components. Ensure that each volume mount has a corresponding
 	// volume definition in the Volumes field.
+	// +optional
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
-	// WorkerConfigs defines the worker configuration for the Feast server.
+	// workerConfigs defines the worker configuration for the Feast server.
 	// These options are primarily used for production deployments to optimize performance.
+	// +optional
 	WorkerConfigs *WorkerConfigs `json:"workerConfigs,omitempty"`
 }
 
 // WorkerConfigs defines the worker configuration for Feast servers.
 // These settings control gunicorn worker processes for production deployments.
 type WorkerConfigs struct {
-	// Workers is the number of worker processes. Use -1 to auto-calculate based on CPU cores (2 * CPU + 1).
+	// workers is the number of worker processes. Use -1 to auto-calculate based on CPU cores (2 * CPU + 1).
 	// Defaults to 1 if not specified.
 	// +kubebuilder:validation:Minimum=-1
 	// +optional
 	Workers *int32 `json:"workers,omitempty"`
-	// WorkerConnections is the maximum number of simultaneous clients per worker process.
+	// workerConnections is the maximum number of simultaneous clients per worker process.
 	// Defaults to 1000.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	WorkerConnections *int32 `json:"workerConnections,omitempty"`
-	// MaxRequests is the maximum number of requests a worker will process before restarting.
+	// maxRequests is the maximum number of requests a worker will process before restarting.
 	// This helps prevent memory leaks. Defaults to 1000.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	MaxRequests *int32 `json:"maxRequests,omitempty"`
-	// MaxRequestsJitter is the maximum jitter to add to max-requests to prevent
+	// maxRequestsJitter is the maximum jitter to add to max-requests to prevent
 	// thundering herd effect on worker restart. Defaults to 50.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	MaxRequestsJitter *int32 `json:"maxRequestsJitter,omitempty"`
-	// KeepAliveTimeout is the timeout for keep-alive connections in seconds.
+	// keepAliveTimeout is the timeout for keep-alive connections in seconds.
 	// Defaults to 30.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	KeepAliveTimeout *int32 `json:"keepAliveTimeout,omitempty"`
-	// RegistryTTLSeconds is the number of seconds after which the registry is refreshed.
+	// registryTTLSeconds is the number of seconds after which the registry is refreshed.
 	// Higher values reduce refresh overhead but increase staleness. Defaults to 60.
 	// +kubebuilder:validation:Minimum=0
 	// +optional
@@ -567,10 +693,12 @@ type WorkerConfigs struct {
 type RegistryServerConfigs struct {
 	ServerConfigs `json:",inline"`
 
-	// Enable REST API registry server.
+	// restAPI enables the REST API registry server.
+	// +optional
 	RestAPI *bool `json:"restAPI,omitempty"`
 
-	// Enable gRPC registry server. Defaults to true if unset.
+	// grpc enables the gRPC registry server. Defaults to true if unset.
+	// +optional
 	GRPC *bool `json:"grpc,omitempty"`
 }
 
@@ -578,8 +706,9 @@ type RegistryServerConfigs struct {
 type CronJobContainerConfigs struct {
 	ContainerConfigs `json:",inline"`
 
-	// Array of commands to be executed (in order) against a Feature Store deployment.
+	// commands are executed (in order) against a Feature Store deployment.
 	// Defaults to "feast apply" & "feast materialize-incremental $(date -u +'%Y-%m-%dT%H:%M:%S')"
+	// +optional
 	Commands []string `json:"commands,omitempty"`
 }
 
@@ -591,50 +720,73 @@ type ContainerConfigs struct {
 
 // DefaultCtrConfigs k8s container settings that are applied by default
 type DefaultCtrConfigs struct {
+	// image overrides the default container image.
+	// +optional
 	Image *string `json:"image,omitempty"`
 }
 
 // OptionalCtrConfigs k8s container settings that are optional
 type OptionalCtrConfigs struct {
-	Env             *[]corev1.EnvVar             `json:"env,omitempty"`
-	EnvFrom         *[]corev1.EnvFromSource      `json:"envFrom,omitempty"`
-	ImagePullPolicy *corev1.PullPolicy           `json:"imagePullPolicy,omitempty"`
-	Resources       *corev1.ResourceRequirements `json:"resources,omitempty"`
-	NodeSelector    *map[string]string           `json:"nodeSelector,omitempty"`
+	// env overrides container environment variables.
+	// +optional
+	Env *[]corev1.EnvVar `json:"env,omitempty"`
+	// envFrom overrides container environment sources.
+	// +optional
+	EnvFrom *[]corev1.EnvFromSource `json:"envFrom,omitempty"`
+	// imagePullPolicy overrides the container image pull policy.
+	// +optional
+	ImagePullPolicy *corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
+	// resources overrides the container resource requirements.
+	// +optional
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+	// nodeSelector overrides the container node selector.
+	// +optional
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // AuthzConfig defines the authorization settings for the deployed Feast services.
 // +kubebuilder:validation:XValidation:rule="[has(self.kubernetes), has(self.oidc)].exists_one(c, c)",message="One selection required between kubernetes or oidc."
 type AuthzConfig struct {
+	// kubernetes configures Kubernetes RBAC authorization.
+	// +optional
 	KubernetesAuthz *KubernetesAuthz `json:"kubernetes,omitempty"`
-	OidcAuthz       *OidcAuthz       `json:"oidc,omitempty"`
+	// oidc configures OpenID Connect authorization.
+	// +optional
+	OidcAuthz *OidcAuthz `json:"oidc,omitempty"`
 }
 
 // KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.
 // https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 type KubernetesAuthz struct {
-	// The Kubernetes RBAC roles to be deployed in the same namespace of the FeatureStore.
+	// roles are the Kubernetes RBAC roles to be deployed in the same namespace of the FeatureStore.
 	// Roles are managed by the operator and created with an empty list of rules.
 	// See the Feast permission model at https://docs.feast.dev/getting-started/concepts/permission
 	// The feature store admin is not obligated to manage roles using the Feast operator, roles can be managed independently.
 	// This configuration option is only providing a way to automate this procedure.
 	// Important note: the operator cannot ensure that these roles will match the ones used in the configured Feast permissions.
+	// +optional
 	Roles []string `json:"roles,omitempty"`
 }
 
 // OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.
 // https://auth0.com/docs/authenticate/protocols/openid-connect-protocol
 type OidcAuthz struct {
+	// secretRef references the secret containing OIDC configuration.
+	// +required
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
 }
 
 // TlsConfigs configures server TLS for a feast service. in an openshift cluster, this is configured by default using service serving certificates.
 // +kubebuilder:validation:XValidation:rule="(!has(self.disable) || !self.disable) ? has(self.secretRef) : true",message="`secretRef` required if `disable` is false."
 type TlsConfigs struct {
-	// references the local k8s secret where the TLS key and cert reside
-	SecretRef      *corev1.LocalObjectReference `json:"secretRef,omitempty"`
-	SecretKeyNames SecretKeyNames               `json:"secretKeyNames,omitempty"`
-	// will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default
+	// secretRef references the local k8s secret where the TLS key and cert reside.
+	// +optional
+	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty"`
+	// secretKeyNames defines the secret key names for TLS.
+	// +optional
+	SecretKeyNames SecretKeyNames `json:"secretKeyNames,omitempty"`
+	// disable will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default.
+	// +optional
 	Disable *bool `json:"disable,omitempty"`
 }
 
@@ -653,41 +805,70 @@ func (tls *TlsConfigs) IsTLS() bool {
 
 // TlsRemoteRegistryConfigs configures client TLS for a remote feast registry. in an openshift cluster, this is configured by default when the remote feast registry is using service serving certificates.
 type TlsRemoteRegistryConfigs struct {
-	// references the local k8s configmap where the TLS cert resides
+	// configMapRef references the local k8s configmap where the TLS cert resides.
+	// +required
 	ConfigMapRef corev1.LocalObjectReference `json:"configMapRef"`
-	// defines the configmap key name for the client TLS cert.
+	// certName defines the configmap key name for the client TLS cert.
+	// +required
 	CertName string `json:"certName"`
 }
 
 // SecretKeyNames defines the secret key names for the TLS key and cert.
 type SecretKeyNames struct {
-	// defaults to "tls.crt"
+	// tlsCrt defaults to "tls.crt".
+	// +optional
 	TlsCrt string `json:"tlsCrt,omitempty"`
-	// defaults to "tls.key"
+	// tlsKey defaults to "tls.key".
+	// +optional
 	TlsKey string `json:"tlsKey,omitempty"`
 }
 
 // FeatureStoreStatus defines the observed state of FeatureStore
 type FeatureStoreStatus struct {
-	// Shows the currently applied feast configuration, including any pertinent defaults
+	// conditions report the current status conditions.
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	// +patchStrategy=merge
+	// +patchMergeKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	// applied shows the currently applied feast configuration, including any pertinent defaults.
+	// +required
 	Applied FeatureStoreSpec `json:"applied,omitempty"`
-	// ConfigMap in this namespace containing a client `feature_store.yaml` for this feast deployment
+	// clientConfigMap is the ConfigMap containing a client `feature_store.yaml` for this feast deployment.
+	// +optional
 	ClientConfigMap string `json:"clientConfigMap,omitempty"`
-	// CronJob in this namespace for this feast deployment
-	CronJob          string             `json:"cronJob,omitempty"`
-	Conditions       []metav1.Condition `json:"conditions,omitempty"`
-	FeastVersion     string             `json:"feastVersion,omitempty"`
-	Phase            string             `json:"phase,omitempty"`
-	ServiceHostnames ServiceHostnames   `json:"serviceHostnames,omitempty"`
+	// cronJob is the CronJob in this namespace for this feast deployment.
+	// +optional
+	CronJob string `json:"cronJob,omitempty"`
+	// feastVersion is the resolved Feast version for this deployment.
+	// +optional
+	FeastVersion string `json:"feastVersion,omitempty"`
+	// phase is the current lifecycle phase.
+	// +optional
+	Phase string `json:"phase,omitempty"`
+	// serviceHostnames contains resolved service hostnames.
+	// +optional
+	ServiceHostnames ServiceHostnames `json:"serviceHostnames,omitempty"`
 }
 
 // ServiceHostnames defines the service hostnames in the format of <domain>:<port>, e.g. example.svc.cluster.local:80
 type ServiceHostnames struct {
+	// offlineStore is the offline store service hostname.
+	// +optional
 	OfflineStore string `json:"offlineStore,omitempty"`
-	OnlineStore  string `json:"onlineStore,omitempty"`
-	Registry     string `json:"registry,omitempty"`
+	// onlineStore is the online store service hostname.
+	// +optional
+	OnlineStore string `json:"onlineStore,omitempty"`
+	// registry is the registry service hostname.
+	// +optional
+	Registry string `json:"registry,omitempty"`
+	// registryRest is the registry REST service hostname.
+	// +optional
 	RegistryRest string `json:"registryRest,omitempty"`
-	UI           string `json:"ui,omitempty"`
+	// ui is the UI service hostname.
+	// +optional
+	UI string `json:"ui,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -699,10 +880,16 @@ type ServiceHostnames struct {
 
 // FeatureStore is the Schema for the featurestores API
 type FeatureStore struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+	// metadata contains the object's metadata.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   FeatureStoreSpec   `json:"spec,omitempty"`
+	// spec defines the desired state of FeatureStore.
+	// +required
+	Spec FeatureStoreSpec `json:"spec,omitempty"`
+	// status defines the observed state of FeatureStore.
+	// +required
 	Status FeatureStoreStatus `json:"status,omitempty"`
 }
 

--- a/infra/feast-operator/internal/controller/authz/authz.go
+++ b/infra/feast-operator/internal/controller/authz/authz.go
@@ -65,7 +65,7 @@ func (authz *FeastAuthorization) deployKubernetesAuth() error {
 
 func (authz *FeastAuthorization) removeOrphanedRoles() {
 	roleList := &rbacv1.RoleList{}
-	err := authz.Handler.Client.List(context.TODO(), roleList, &client.ListOptions{
+	err := authz.Handler.List(context.TODO(), roleList, &client.ListOptions{
 		Namespace:     authz.Handler.FeatureStore.Namespace,
 		LabelSelector: labels.SelectorFromSet(authz.getLabels()),
 	})

--- a/infra/feast-operator/internal/controller/featurestore_controller.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller.go
@@ -87,8 +87,8 @@ func (r *FeatureStoreReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			// Clean up namespace registry entry even if the CR is not found
 			if err := r.cleanupNamespaceRegistry(ctx, &feastdevv1.FeatureStore{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      req.NamespacedName.Name,
-					Namespace: req.NamespacedName.Namespace,
+					Name:      req.Name,
+					Namespace: req.Namespace,
 				},
 			}); err != nil {
 				logger.Error(err, "Failed to clean up namespace registry entry for deleted FeatureStore")

--- a/infra/feast-operator/internal/controller/handler/handler.go
+++ b/infra/feast-operator/internal/controller/handler/handler.go
@@ -10,7 +10,7 @@ import (
 func (handler *FeastHandler) DeleteOwnedFeastObj(obj client.Object) error {
 	name := obj.GetName()
 	kind := obj.GetObjectKind().GroupVersionKind().Kind
-	if err := handler.Client.Get(handler.Context, client.ObjectKeyFromObject(obj), obj); err != nil {
+	if err := handler.Get(handler.Context, client.ObjectKeyFromObject(obj), obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
@@ -18,7 +18,7 @@ func (handler *FeastHandler) DeleteOwnedFeastObj(obj client.Object) error {
 	}
 	for _, ref := range obj.GetOwnerReferences() {
 		if *ref.Controller && ref.UID == handler.FeatureStore.UID {
-			if err := handler.Client.Delete(handler.Context, obj); err != nil {
+			if err := handler.Delete(handler.Context, obj); err != nil {
 				return err
 			}
 			log.FromContext(handler.Context).Info("Successfully deleted", kind, name)

--- a/infra/feast-operator/internal/controller/services/namespace_registry.go
+++ b/infra/feast-operator/internal/controller/services/namespace_registry.go
@@ -243,7 +243,7 @@ func (feast *FeastServices) AddToNamespaceRegistry() error {
 
 	// Get the existing ConfigMap
 	cm := &corev1.ConfigMap{}
-	err = feast.Handler.Client.Get(feast.Handler.Context, types.NamespacedName{
+	err = feast.Handler.Get(feast.Handler.Context, types.NamespacedName{
 		Name:      NamespaceRegistryConfigMapName,
 		Namespace: targetNamespace,
 	}, cm)
@@ -306,7 +306,7 @@ func (feast *FeastServices) AddToNamespaceRegistry() error {
 	cm.Data[NamespaceRegistryDataKey] = string(dataBytes)
 
 	// Update the ConfigMap
-	if err := feast.Handler.Client.Update(feast.Handler.Context, cm); err != nil {
+	if err := feast.Handler.Update(feast.Handler.Context, cm); err != nil {
 		return fmt.Errorf("failed to update namespace registry ConfigMap: %w", err)
 	}
 
@@ -331,7 +331,7 @@ func (feast *FeastServices) RemoveFromNamespaceRegistry() error {
 
 	// Get the existing ConfigMap
 	cm := &corev1.ConfigMap{}
-	err = feast.Handler.Client.Get(feast.Handler.Context, client.ObjectKey{
+	err = feast.Handler.Get(feast.Handler.Context, client.ObjectKey{
 		Name:      NamespaceRegistryConfigMapName,
 		Namespace: targetNamespace,
 	}, cm)
@@ -414,7 +414,7 @@ func (feast *FeastServices) RemoveFromNamespaceRegistry() error {
 	cm.Data[NamespaceRegistryDataKey] = string(dataBytes)
 
 	// Update the ConfigMap
-	if err := feast.Handler.Client.Update(feast.Handler.Context, cm); err != nil {
+	if err := feast.Handler.Update(feast.Handler.Context, cm); err != nil {
 		return fmt.Errorf("failed to update namespace registry ConfigMap: %w", err)
 	}
 

--- a/infra/feast-operator/internal/controller/services/scaling.go
+++ b/infra/feast-operator/internal/controller/services/scaling.go
@@ -79,7 +79,7 @@ func (feast *FeastServices) createOrDeleteHPA() error {
 
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{ObjectMeta: feast.GetObjectMeta()}
 	logger := log.FromContext(feast.Handler.Context)
-	if err := feast.Handler.Client.Patch(feast.Handler.Context, hpa,
+	if err := feast.Handler.Patch(feast.Handler.Context, hpa,
 		client.RawPatch(types.ApplyPatchType, data),
 		client.FieldOwner(fieldManager), client.ForceOwnership); err != nil {
 		return err
@@ -202,7 +202,7 @@ func (feast *FeastServices) applyOrDeletePDB() error {
 
 	pdb := &policyv1.PodDisruptionBudget{ObjectMeta: feast.GetObjectMeta()}
 	logger := log.FromContext(feast.Handler.Context)
-	if err := feast.Handler.Client.Patch(feast.Handler.Context, pdb,
+	if err := feast.Handler.Patch(feast.Handler.Context, pdb,
 		client.RawPatch(types.ApplyPatchType, data),
 		client.FieldOwner(fieldManager), client.ForceOwnership); err != nil {
 		return err

--- a/infra/feast-operator/internal/controller/services/services.go
+++ b/infra/feast-operator/internal/controller/services/services.go
@@ -381,9 +381,9 @@ func (feast *FeastServices) createPVC(pvcCreate *feastdevv1.PvcCreate, feastType
 	}
 
 	// PVCs are immutable, so we only create... we don't update an existing one.
-	err = feast.Handler.Client.Get(feast.Handler.Context, client.ObjectKeyFromObject(pvc), pvc)
+	err = feast.Handler.Get(feast.Handler.Context, client.ObjectKeyFromObject(pvc), pvc)
 	if err != nil && apierrors.IsNotFound(err) {
-		err = feast.Handler.Client.Create(feast.Handler.Context, pvc)
+		err = feast.Handler.Create(feast.Handler.Context, pvc)
 		if err != nil {
 			return err
 		}
@@ -895,7 +895,7 @@ func (feast *FeastServices) isMetricsEnabled(feastType FeastServiceType) bool {
 
 func (feast *FeastServices) getNodeSelectorForType(feastType FeastServiceType) *map[string]string {
 	if serviceConfigs := feast.getServerConfigs(feastType); serviceConfigs != nil {
-		return serviceConfigs.ContainerConfigs.OptionalCtrConfigs.NodeSelector
+		return serviceConfigs.NodeSelector
 	}
 	return nil
 }
@@ -1116,7 +1116,7 @@ func (feast *FeastServices) getRemoteRegistryFeastHandler() (*FeastServices, err
 			return nil, errors.New("FeatureStore '" + crNsName.Name + "' can't reference itself in `spec.services.registry.remote.feastRef`")
 		}
 		remoteFeastObj := &feastdevv1.FeatureStore{}
-		if err := feast.Handler.Client.Get(feast.Handler.Context, nsName, remoteFeastObj); err != nil {
+		if err := feast.Handler.Get(feast.Handler.Context, nsName, remoteFeastObj); err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil, errors.New("Referenced FeatureStore '" + feastRemoteRef.Name + "' was not found")
 			}
@@ -1180,7 +1180,7 @@ func (feast *FeastServices) isOnlineStore() bool {
 }
 
 func (feast *FeastServices) noLocalCoreServerConfigured() bool {
-	return !(feast.isRegistryServer() || feast.isOnlineServer() || feast.isOfflineServer())
+	return !feast.isRegistryServer() && !feast.isOnlineServer() && !feast.isOfflineServer()
 }
 
 func (feast *FeastServices) isUiServer() bool {
@@ -1241,21 +1241,21 @@ func (feast *FeastServices) initRoute(feastType FeastServiceType) *routev1.Route
 }
 
 func applyCtrConfigs(container *corev1.Container, containerConfigs feastdevv1.ContainerConfigs) {
-	if containerConfigs.DefaultCtrConfigs.Image != nil {
-		container.Image = *containerConfigs.DefaultCtrConfigs.Image
+	if containerConfigs.Image != nil {
+		container.Image = *containerConfigs.Image
 	}
 	// apply optional container configs
-	if containerConfigs.OptionalCtrConfigs.Env != nil {
-		container.Env = envOverride(container.Env, *containerConfigs.OptionalCtrConfigs.Env)
+	if containerConfigs.Env != nil {
+		container.Env = envOverride(container.Env, *containerConfigs.Env)
 	}
-	if containerConfigs.OptionalCtrConfigs.EnvFrom != nil {
-		container.EnvFrom = *containerConfigs.OptionalCtrConfigs.EnvFrom
+	if containerConfigs.EnvFrom != nil {
+		container.EnvFrom = *containerConfigs.EnvFrom
 	}
-	if containerConfigs.OptionalCtrConfigs.ImagePullPolicy != nil {
-		container.ImagePullPolicy = *containerConfigs.OptionalCtrConfigs.ImagePullPolicy
+	if containerConfigs.ImagePullPolicy != nil {
+		container.ImagePullPolicy = *containerConfigs.ImagePullPolicy
 	}
-	if containerConfigs.OptionalCtrConfigs.Resources != nil {
-		container.Resources = *containerConfigs.OptionalCtrConfigs.Resources
+	if containerConfigs.Resources != nil {
+		container.Resources = *containerConfigs.Resources
 	}
 }
 

--- a/infra/feast-operator/internal/controller/services/services_test.go
+++ b/infra/feast-operator/internal/controller/services/services_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Registry Service", func() {
 				"kubernetes.io/os": "linux",
 				"node-type":        "compute",
 			}
-			featureStore.Spec.Services.Registry.Local.Server.ContainerConfigs.OptionalCtrConfigs.NodeSelector = &nodeSelector
+			featureStore.Spec.Services.Registry.Local.Server.NodeSelector = &nodeSelector
 			Expect(k8sClient.Update(ctx, featureStore)).To(Succeed())
 			Expect(feast.ApplyDefaults()).To(Succeed())
 			applySpecToStatus(featureStore)
@@ -234,7 +234,7 @@ var _ = Describe("Registry Service", func() {
 				"kubernetes.io/os": "linux",
 				"node-type":        "compute",
 			}
-			featureStore.Spec.Services.Registry.Local.Server.ContainerConfigs.OptionalCtrConfigs.NodeSelector = &registryNodeSelector
+			featureStore.Spec.Services.Registry.Local.Server.NodeSelector = &registryNodeSelector
 
 			// Set NodeSelector for online store service
 			onlineNodeSelector := map[string]string{
@@ -418,7 +418,7 @@ var _ = Describe("Registry Service", func() {
 		It("should handle empty NodeSelector gracefully", func() {
 			// Set empty NodeSelector
 			emptyNodeSelector := map[string]string{}
-			featureStore.Spec.Services.Registry.Local.Server.ContainerConfigs.OptionalCtrConfigs.NodeSelector = &emptyNodeSelector
+			featureStore.Spec.Services.Registry.Local.Server.NodeSelector = &emptyNodeSelector
 			Expect(k8sClient.Update(ctx, featureStore)).To(Succeed())
 			Expect(feast.ApplyDefaults()).To(Succeed())
 			applySpecToStatus(featureStore)

--- a/infra/feast-operator/internal/controller/services/tls.go
+++ b/infra/feast-operator/internal/controller/services/tls.go
@@ -286,7 +286,7 @@ func (feast *FeastServices) GetCustomCertificatesBundle() CustomCertificatesBund
 	configMapList := &corev1.ConfigMapList{}
 	labelSelector := client.MatchingLabels{caBundleAnnotation: "true"}
 
-	err := feast.Handler.Client.List(
+	err := feast.Handler.List(
 		feast.Handler.Context,
 		configMapList,
 		client.InNamespace(feast.Handler.FeatureStore.Namespace),

--- a/infra/feast-operator/internal/controller/services/util.go
+++ b/infra/feast-operator/internal/controller/services/util.go
@@ -124,7 +124,7 @@ func ApplyDefaultsToStatus(cr *feastdevv1.FeatureStore) {
 			}
 
 			if services.Registry.Local.Server != nil {
-				setDefaultCtrConfigs(&services.Registry.Local.Server.ContainerConfigs.DefaultCtrConfigs)
+				setDefaultCtrConfigs(&services.Registry.Local.Server.DefaultCtrConfigs)
 				// Set default for GRPC: true if nil
 				if services.Registry.Local.Server.GRPC == nil {
 					defaultGRPC := true
@@ -155,7 +155,7 @@ func ApplyDefaultsToStatus(cr *feastdevv1.FeatureStore) {
 		}
 
 		if services.OfflineStore.Server != nil {
-			setDefaultCtrConfigs(&services.OfflineStore.Server.ContainerConfigs.DefaultCtrConfigs)
+			setDefaultCtrConfigs(&services.OfflineStore.Server.DefaultCtrConfigs)
 		}
 	}
 
@@ -182,10 +182,10 @@ func ApplyDefaultsToStatus(cr *feastdevv1.FeatureStore) {
 	if services.OnlineStore.Server == nil {
 		services.OnlineStore.Server = &feastdevv1.ServerConfigs{}
 	}
-	setDefaultCtrConfigs(&services.OnlineStore.Server.ContainerConfigs.DefaultCtrConfigs)
+	setDefaultCtrConfigs(&services.OnlineStore.Server.DefaultCtrConfigs)
 
 	if services.UI != nil {
-		setDefaultCtrConfigs(&services.UI.ContainerConfigs.DefaultCtrConfigs)
+		setDefaultCtrConfigs(&services.UI.DefaultCtrConfigs)
 	}
 
 	if applied.CronJob == nil {
@@ -285,7 +285,7 @@ func (feast *FeastServices) getSecret(secretRef string) (*corev1.Secret, error) 
 	logger := log.FromContext(feast.Handler.Context)
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretRef, Namespace: feast.Handler.FeatureStore.Namespace}}
 	objectKey := client.ObjectKeyFromObject(secret)
-	if err := feast.Handler.Client.Get(feast.Handler.Context, objectKey, secret); err != nil {
+	if err := feast.Handler.Get(feast.Handler.Context, objectKey, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Error(err, "invalid secret "+secretRef+" for offline store")
 		}
@@ -299,7 +299,7 @@ func (feast *FeastServices) getConfigMap(configMapRef string) (*corev1.ConfigMap
 	logger := log.FromContext(feast.Handler.Context)
 	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: configMapRef, Namespace: feast.Handler.FeatureStore.Namespace}}
 	objectKey := client.ObjectKeyFromObject(configMap)
-	if err := feast.Handler.Client.Get(feast.Handler.Context, objectKey, configMap); err != nil {
+	if err := feast.Handler.Get(feast.Handler.Context, objectKey, configMap); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Error(err, "invalid configmap "+configMapRef+" for batch engine")
 		}

--- a/infra/feast-operator/test/utils/test_util.go
+++ b/infra/feast-operator/test/utils/test_util.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/feast-dev/feast/infra/feast-operator/api/feastversion"
@@ -237,7 +237,7 @@ func isFeatureStoreHavingRemoteRegistry(namespace, featureStoreName string) (boo
 
 func validateTheFeatureStoreCustomResource(namespace string, featureStoreName string, feastResourceName string, feastK8sResourceNames []string, timeout time.Duration) {
 	hasRemoteRegistry, err := isFeatureStoreHavingRemoteRegistry(namespace, featureStoreName)
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), fmt.Sprintf(
 		"Error occurred while checking FeatureStore %s is having remote registry or not. \nError: %v\n",
 		featureStoreName, err))
 
@@ -248,28 +248,28 @@ func validateTheFeatureStoreCustomResource(namespace string, featureStoreName st
 	}
 
 	for _, deploymentName := range k8sResourceNames {
-		By(fmt.Sprintf("validate the feast deployment: %s is up and in availability state.", deploymentName))
+		ginkgo.By(fmt.Sprintf("validate the feast deployment: %s is up and in availability state.", deploymentName))
 		err = CheckIfDeploymentExistsAndAvailable(namespace, deploymentName, timeout)
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), fmt.Sprintf(
 			"Deployment %s is not available but expected to be available. \nError: %v\n",
 			deploymentName, err,
 		))
 		fmt.Printf("Feast Deployment %s is available\n", deploymentName)
 	}
 
-	By("Check if the feast client - kubernetes config map exists.")
+	ginkgo.By("Check if the feast client - kubernetes config map exists.")
 	configMapName := feastResourceName + "-client"
 	err = checkIfConfigMapExists(namespace, configMapName)
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), fmt.Sprintf(
 		"config map %s is not available but expected to be available. \nError: %v\n",
 		configMapName, err,
 	))
 	fmt.Printf("Feast Deployment client config map %s is available\n", configMapName)
 
 	for _, serviceAccountName := range k8sResourceNames {
-		By(fmt.Sprintf("validate the feast service account: %s is available.", serviceAccountName))
+		ginkgo.By(fmt.Sprintf("validate the feast service account: %s is available.", serviceAccountName))
 		err = checkIfServiceAccountExists(namespace, serviceAccountName)
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), fmt.Sprintf(
 			"Service account %s does not exist in namespace %s. Error: %v",
 			serviceAccountName, namespace, err,
 		))
@@ -277,18 +277,18 @@ func validateTheFeatureStoreCustomResource(namespace string, featureStoreName st
 	}
 
 	for _, serviceName := range feastK8sResourceNames {
-		By(fmt.Sprintf("validate the kubernetes service name: %s is available.", serviceName))
+		ginkgo.By(fmt.Sprintf("validate the kubernetes service name: %s is available.", serviceName))
 		err = checkIfKubernetesServiceExists(namespace, serviceName)
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), fmt.Sprintf(
 			"kubernetes service %s is not available but expected to be available. \nError: %v\n",
 			serviceName, err,
 		))
 		fmt.Printf("kubernetes service %s is available\n", serviceName)
 	}
 
-	By(fmt.Sprintf("Checking FeatureStore customer resource: %s is in Ready Status.", featureStoreName))
+	ginkgo.By(fmt.Sprintf("Checking FeatureStore customer resource: %s is in Ready Status.", featureStoreName))
 	err = checkIfFeatureStoreCustomResourceConditionsInReady(featureStoreName, namespace)
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), fmt.Sprintf(
 		"FeatureStore custom resource %s all conditions are not in ready state. \nError: %v\n",
 		featureStoreName, err,
 	))
@@ -298,60 +298,60 @@ func validateTheFeatureStoreCustomResource(namespace string, featureStoreName st
 // GetTestDeploySimpleCRFunc - returns a simple CR deployment function
 func GetTestDeploySimpleCRFunc(testDir string, crYaml string, featureStoreName string, feastResourceName string, feastK8sResourceNames []string, namespace string) func() {
 	return func() {
-		By("deploying the Simple Feast Custom Resource to Kubernetes")
+		ginkgo.By("deploying the Simple Feast Custom Resource to Kubernetes")
 
 		cmd := exec.Command("kubectl", "apply", "-f", crYaml, "-n", namespace)
 		_, cmdOutputerr := Run(cmd, testDir)
-		ExpectWithOffset(1, cmdOutputerr).NotTo(HaveOccurred())
+		gomega.ExpectWithOffset(1, cmdOutputerr).NotTo(gomega.HaveOccurred())
 
 		validateTheFeatureStoreCustomResource(namespace, featureStoreName, feastResourceName, feastK8sResourceNames, Timeout)
 
-		By("deleting the feast deployment")
+		ginkgo.By("deleting the feast deployment")
 		cmd = exec.Command("kubectl", "delete", "-f", crYaml, "-n", namespace)
 		_, cmdOutputerr = Run(cmd, testDir)
-		ExpectWithOffset(1, cmdOutputerr).NotTo(HaveOccurred())
+		gomega.ExpectWithOffset(1, cmdOutputerr).NotTo(gomega.HaveOccurred())
 	}
 }
 
 // GetTestWithRemoteRegistryFunc - returns a CR deployment with a remote registry function
 func GetTestWithRemoteRegistryFunc(testDir string, crYaml string, remoteRegistryCRYaml string, featureStoreName string, feastResourceName string, feastK8sResourceNames []string, namespace string) func() {
 	return func() {
-		By("deploying the Simple Feast Custom Resource to Kubernetes")
+		ginkgo.By("deploying the Simple Feast Custom Resource to Kubernetes")
 		cmd := exec.Command("kubectl", "apply", "-f", crYaml, "-n", namespace)
 		_, cmdOutputErr := Run(cmd, testDir)
-		ExpectWithOffset(1, cmdOutputErr).NotTo(HaveOccurred())
+		gomega.ExpectWithOffset(1, cmdOutputErr).NotTo(gomega.HaveOccurred())
 
 		validateTheFeatureStoreCustomResource(namespace, featureStoreName, feastResourceName, feastK8sResourceNames, Timeout)
 
 		var remoteRegistryNs = "test-ns-remote-registry"
 		err := CreateNamespace(remoteRegistryNs, "/test/e2e")
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to create namespace %s", remoteRegistryNs))
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), fmt.Sprintf("failed to create namespace %s", remoteRegistryNs))
 
-		DeferCleanup(func() {
-			By(fmt.Sprintf("Deleting remote registry namespace: %s", remoteRegistryNs))
+		ginkgo.DeferCleanup(func() {
+			ginkgo.By(fmt.Sprintf("Deleting remote registry namespace: %s", remoteRegistryNs))
 			err := DeleteNamespace(remoteRegistryNs, testDir)
-			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to delete namespace %s", remoteRegistryNs))
+			gomega.Expect(err).ToNot(gomega.HaveOccurred(), fmt.Sprintf("failed to delete namespace %s", remoteRegistryNs))
 		})
 
-		By("deploying the Simple Feast remote registry Custom Resource on Kubernetes")
+		ginkgo.By("deploying the Simple Feast remote registry Custom Resource on Kubernetes")
 		cmd = exec.Command("kubectl", "apply", "-f", remoteRegistryCRYaml, "-n", remoteRegistryNs)
 		_, cmdOutputErr = Run(cmd, testDir)
-		ExpectWithOffset(1, cmdOutputErr).NotTo(HaveOccurred())
+		gomega.ExpectWithOffset(1, cmdOutputErr).NotTo(gomega.HaveOccurred())
 
 		remoteFeatureStoreName := "simple-feast-remote-setup"
 		remoteFeastResourceName := FeastPrefix + remoteFeatureStoreName
 		fixRemoteFeastK8sResourceNames(feastK8sResourceNames, remoteFeastResourceName)
 		validateTheFeatureStoreCustomResource(remoteRegistryNs, remoteFeatureStoreName, remoteFeastResourceName, feastK8sResourceNames, Timeout)
 
-		By("deleting the feast remote registry deployment")
+		ginkgo.By("deleting the feast remote registry deployment")
 		cmd = exec.Command("kubectl", "delete", "-f", remoteRegistryCRYaml, "-n", remoteRegistryNs)
 		_, cmdOutputErr = Run(cmd, testDir)
-		ExpectWithOffset(1, cmdOutputErr).NotTo(HaveOccurred())
+		gomega.ExpectWithOffset(1, cmdOutputErr).NotTo(gomega.HaveOccurred())
 
-		By("deleting the feast deployment")
+		ginkgo.By("deleting the feast deployment")
 		cmd = exec.Command("kubectl", "delete", "-f", crYaml, "-n", namespace)
 		_, cmdOutputErr = Run(cmd, testDir)
-		ExpectWithOffset(1, cmdOutputErr).NotTo(HaveOccurred())
+		gomega.ExpectWithOffset(1, cmdOutputErr).NotTo(gomega.HaveOccurred())
 	}
 }
 
@@ -367,7 +367,7 @@ func fixRemoteFeastK8sResourceNames(feastK8sResourceNames []string, remoteFeastR
 func DeployOperatorFromCode(testDir string, skipBuilds bool) {
 	_, isRunOnOpenShiftCI := os.LookupEnv("RUN_ON_OPENSHIFT_CI")
 	if !isRunOnOpenShiftCI {
-		By("creating manager namespace")
+		ginkgo.By("creating manager namespace")
 		cmd := exec.Command("kubectl", "create", "ns", FeastControllerNamespace)
 		_, _ = Run(cmd, testDir)
 
@@ -380,44 +380,44 @@ func DeployOperatorFromCode(testDir string, skipBuilds bool) {
 		var feastLocalImage = "localhost/feastdev/feature-server:dev"
 
 		if !skipBuilds {
-			By("building the manager(Operator) image")
+			ginkgo.By("building the manager(Operator) image")
 			cmd = exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", projectimage))
 			_, err = Run(cmd, testDir)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
-			By("loading the the manager(Operator) image on Kind")
+			ginkgo.By("loading the the manager(Operator) image on Kind")
 			err = LoadImageToKindClusterWithName(projectimage, testDir)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
-			By("building the feast image")
+			ginkgo.By("building the feast image")
 			cmd = exec.Command("make", "feast-ci-dev-docker-img")
 			_, err = Run(cmd, testDir)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
-			By("Tag the local feast image for the integration tests")
+			ginkgo.By("Tag the local feast image for the integration tests")
 			cmd = exec.Command("docker", "image", "tag", feastImage, feastLocalImage)
 			_, err = Run(cmd, testDir)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
-			By("loading the the feast image on Kind cluster")
+			ginkgo.By("loading the the feast image on Kind cluster")
 			err = LoadImageToKindClusterWithName(feastLocalImage, testDir)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 		}
 
-		By("installing CRDs")
+		ginkgo.By("installing CRDs")
 		cmd = exec.Command("make", "install")
 		_, err = Run(cmd, testDir)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
-		By("deploying the controller-manager")
+		ginkgo.By("deploying the controller-manager")
 		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectimage), fmt.Sprintf("FS_IMG=%s", feastLocalImage))
 		_, err = Run(cmd, testDir)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	}
 
-	By("Validating that the controller-manager deployment is in available state")
+	ginkgo.By("Validating that the controller-manager deployment is in available state")
 	err := CheckIfDeploymentExistsAndAvailable(FeastControllerNamespace, ControllerDeploymentName, Timeout)
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), fmt.Sprintf(
 		"Deployment %s is not available but expected to be available. \nError: %v\n",
 		ControllerDeploymentName, err,
 	))
@@ -428,10 +428,10 @@ func DeployOperatorFromCode(testDir string, skipBuilds bool) {
 func DeleteOperatorDeployment(testDir string) {
 	_, isRunOnOpenShiftCI := os.LookupEnv("RUN_ON_OPENSHIFT_CI")
 	if !isRunOnOpenShiftCI {
-		By("Uninstalling the feast CRD")
+		ginkgo.By("Uninstalling the feast CRD")
 		cmd := exec.Command("kubectl", "delete", "deployment", ControllerDeploymentName, "-n", FeastControllerNamespace)
 		_, err := Run(cmd, testDir)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	}
 }
 
@@ -441,20 +441,20 @@ func DeployPreviousVersionOperator() {
 
 	// Delete existing CRD first to avoid version conflicts when downgrading
 	// The old operator version may not have v1, but the cluster might have v1 in status.storedVersions
-	By("Deleting existing CRD to allow downgrade to previous version")
+	ginkgo.By("Deleting existing CRD to allow downgrade to previous version")
 	cmd := exec.Command("kubectl", "delete", "crd", "featurestores.feast.dev", "--ignore-not-found=true")
 	_, err = Run(cmd, "/test/upgrade")
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
 	// Wait a bit for CRD deletion to complete
 	time.Sleep(2 * time.Second)
 
 	cmd = exec.Command("kubectl", "apply", "--server-side", "--force-conflicts", "-f", fmt.Sprintf("https://raw.githubusercontent.com/feast-dev/feast/refs/tags/v%s/infra/feast-operator/dist/install.yaml", feastversion.FeastVersion))
 	_, err = Run(cmd, "/test/upgrade")
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
 	err = CheckIfDeploymentExistsAndAvailable(FeastControllerNamespace, ControllerDeploymentName, Timeout)
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), fmt.Sprintf(
 		"Deployment %s is not available but expected to be available. \nError: %v\n",
 		ControllerDeploymentName, err,
 	))
@@ -503,24 +503,24 @@ func RunTestApplyAndMaterializeFunc(testDir string, namespace string, feastCRNam
 
 // applies the manifests for Redis and Postgres and checks whether the deployments become available
 func ApplyFeastInfraManifestsAndVerify(namespace string, testDir string) {
-	By("Applying postgres.yaml and redis.yaml manifests")
+	ginkgo.By("Applying postgres.yaml and redis.yaml manifests")
 	cmd := exec.Command("kubectl", "apply", "-n", namespace, "-f", "test/testdata/feast_integration_test_crs/postgres.yaml", "-f", "test/testdata/feast_integration_test_crs/redis.yaml")
 	_, cmdOutputerr := Run(cmd, testDir)
-	ExpectWithOffset(1, cmdOutputerr).NotTo(HaveOccurred())
+	gomega.ExpectWithOffset(1, cmdOutputerr).NotTo(gomega.HaveOccurred())
 	checkDeployment(namespace, "postgres")
 	checkDeployment(namespace, "redis")
 }
 
 // validates the `feast apply` and `feast materialize-incremental commands were configured in the FeatureStore CR's CronJob config.
 func VerifyApplyFeatureStoreDefinitions(namespace string, feastCRName string, feastDeploymentName string) {
-	By("Verify CronJob commands in FeatureStore CR")
+	ginkgo.By("Verify CronJob commands in FeatureStore CR")
 	cmd := exec.Command("kubectl", "get", "-n", namespace, "feast/"+feastCRName, "-o", "jsonpath={.status.applied.cronJob.containerConfigs.commands}")
 	output, err := cmd.CombinedOutput()
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to fetch CronJob commands:\n%s", output))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to fetch CronJob commands:\n%s", output))
 	commands := string(output)
 	fmt.Println("CronJob commands:", commands)
-	Expect(commands).To(ContainSubstring(`feast apply`))
-	Expect(commands).To(ContainSubstring(`feast materialize-incremental $(date -u +'%Y-%m-%dT%H:%M:%S')`))
+	gomega.Expect(commands).To(gomega.ContainSubstring(`feast apply`))
+	gomega.Expect(commands).To(gomega.ContainSubstring(`feast materialize-incremental $(date -u +'%Y-%m-%dT%H:%M:%S')`))
 
 	CreateAndVerifyJobFromCron(namespace, feastDeploymentName, "feast-test-apply", "", []string{
 		"No project found in the repository",
@@ -579,7 +579,7 @@ func VerifyFeastMethods(namespace string, feastDeploymentName string, testDir st
 		cmd := exec.Command("kubectl", "exec", "deploy/"+feastDeploymentName, "-n", namespace, "-c", "online", "--")
 		cmd.Args = append(cmd.Args, check.command...)
 		output, err := Run(cmd, testDir)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
 		fmt.Printf("%s:\n%s\n", check.logPrefix, string(output))
 		VerifyOutputContains(output, check.expected)
@@ -590,41 +590,41 @@ func VerifyFeastMethods(namespace string, feastDeploymentName string, testDir st
 func VerifyOutputContains(output []byte, expectedSubstrings []string) {
 	outputStr := string(output)
 	for _, expected := range expectedSubstrings {
-		Expect(outputStr).To(ContainSubstring(expected), fmt.Sprintf("Expected output to contain: %s", expected))
+		gomega.Expect(outputStr).To(gomega.ContainSubstring(expected), fmt.Sprintf("Expected output to contain: %s", expected))
 	}
 }
 
 // Create a Job and verifies its logs contain expected substrings
 func CreateAndVerifyJobFromCron(namespace, cronName, jobName, testDir string, expectedLogSubstrings []string) {
-	By(fmt.Sprintf("Creating Job %s from CronJob %s", jobName, cronName))
+	ginkgo.By(fmt.Sprintf("Creating Job %s from CronJob %s", jobName, cronName))
 	cmd := exec.Command("kubectl", "create", "job", "--from=cronjob/"+cronName, jobName, "-n", namespace)
 	_, err := Run(cmd, testDir)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
-	By("Waiting for Job completion")
+	ginkgo.By("Waiting for Job completion")
 	cmd = exec.Command("kubectl", "wait", "--for=condition=complete", "--timeout=5m", "job/"+jobName, "-n", namespace)
 	_, err = Run(cmd, testDir)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
-	By("Checking logs of completed job")
+	ginkgo.By("Checking logs of completed job")
 	cmd = exec.Command("kubectl", "logs", "job/"+jobName, "-n", namespace, "--all-containers=true")
 	output, err := Run(cmd, testDir)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
 	outputStr := string(output)
 	ansi := regexp.MustCompile(`\x1b\[[0-9;]*m`)
 	outputStr = ansi.ReplaceAllString(outputStr, "")
 	for _, expected := range expectedLogSubstrings {
-		Expect(outputStr).To(ContainSubstring(expected))
+		gomega.Expect(outputStr).To(gomega.ContainSubstring(expected))
 	}
 	fmt.Printf("created Job %s and Verified expected Logs ", jobName)
 }
 
 // verifies the specified deployment exists and is in the "Available" state.
 func checkDeployment(namespace, name string) {
-	By(fmt.Sprintf("Waiting for %s deployment to become available", name))
+	ginkgo.By(fmt.Sprintf("Waiting for %s deployment to become available", name))
 	err := CheckIfDeploymentExistsAndAvailable(namespace, name, 2*Timeout)
-	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), fmt.Sprintf(
 		"Deployment %s is not available but expected to be.\nError: %v", name, err,
 	))
 	fmt.Printf("Deployment %s is available\n", name)
@@ -632,14 +632,14 @@ func checkDeployment(namespace, name string) {
 
 // validate that the status of the FeatureStore CR is "Ready".
 func ValidateFeatureStoreCRStatus(namespace, crName string) {
-	Eventually(func() string {
+	gomega.Eventually(func() string {
 		cmd := exec.Command("kubectl", "get", "feast", crName, "-n", namespace, "-o", "jsonpath={.status.phase}")
 		output, err := cmd.Output()
 		if err != nil {
 			return ""
 		}
 		return string(output)
-	}, "2m", "5s").Should(Equal("Ready"), "Feature Store CR did not reach 'Ready' state in time")
+	}, "2m", "5s").Should(gomega.Equal("Ready"), "Feature Store CR did not reach 'Ready' state in time")
 
 	fmt.Printf("✅ Feature Store CR %s/%s is in Ready state\n", namespace, crName)
 }
@@ -648,30 +648,30 @@ func ValidateFeatureStoreCRStatus(namespace, crName string) {
 func validateFeatureStoreYaml(namespace, deployment string) {
 	cmd := exec.Command("kubectl", "exec", "deploy/"+deployment, "-n", namespace, "-c", "online", "--", "cat", "feature_store.yaml")
 	output, err := cmd.CombinedOutput()
-	Expect(err).NotTo(HaveOccurred(), "Failed to read feature_store.yaml")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to read feature_store.yaml")
 
 	content := string(output)
-	Expect(content).To(ContainSubstring("offline_store:\n    type: duckdb"))
-	Expect(content).To(ContainSubstring("online_store:\n    type: redis"))
-	Expect(content).To(ContainSubstring("registry_type: sql"))
+	gomega.Expect(content).To(gomega.ContainSubstring("offline_store:\n    type: duckdb"))
+	gomega.Expect(content).To(gomega.ContainSubstring("online_store:\n    type: redis"))
+	gomega.Expect(content).To(gomega.ContainSubstring("registry_type: sql"))
 }
 
 // apply and verifies the Feast deployment becomes available, the CR status is "Ready
 func ApplyFeastYamlAndVerify(namespace string, testDir string, feastDeploymentName string, feastCRName string, feastYAMLFilePath string) {
-	By("Applying Feast yaml for secrets and Feature store CR")
+	ginkgo.By("Applying Feast yaml for secrets and Feature store CR")
 	cmd := exec.Command("kubectl", "apply", "-n", namespace,
 		"-f", feastYAMLFilePath)
 	_, err := Run(cmd, testDir)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	checkDeployment(namespace, feastDeploymentName)
 
-	By("Verify Feature Store CR is in Ready state")
+	ginkgo.By("Verify Feature Store CR is in Ready state")
 	ValidateFeatureStoreCRStatus(namespace, feastCRName)
 
-	By("Verifying that the Postgres DB contains the expected Feast tables")
+	ginkgo.By("Verifying that the Postgres DB contains the expected Feast tables")
 	cmd = exec.Command("kubectl", "exec", "deploy/postgres", "-n", namespace, "--", "psql", "-h", "localhost", "-U", "feast", "feast", "-c", `\dt`)
 	output, err := cmd.CombinedOutput()
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get tables from Postgres. Output:\n%s", output))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to get tables from Postgres. Output:\n%s", output))
 	outputStr := string(output)
 	fmt.Println("Postgres Tables:\n", outputStr)
 	// List of expected tables
@@ -681,18 +681,18 @@ func ApplyFeastYamlAndVerify(namespace string, testDir string, feastDeploymentNa
 		"saved_datasets", "stream_feature_views", "validation_references",
 	}
 	for _, table := range expectedTables {
-		Expect(outputStr).To(ContainSubstring(table), fmt.Sprintf("Expected table %q not found in output:\n%s", table, outputStr))
+		gomega.Expect(outputStr).To(gomega.ContainSubstring(table), fmt.Sprintf("Expected table %q not found in output:\n%s", table, outputStr))
 	}
 
-	By("Verifying that the Feast repo was successfully cloned by the init container")
+	ginkgo.By("Verifying that the Feast repo was successfully cloned by the init container")
 	cmd = exec.Command("kubectl", "logs", "-f", "-n", namespace, "deploy/"+feastDeploymentName, "-c", "feast-init")
 	output, err = cmd.CombinedOutput()
-	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to get logs from init container. Output:\n%s", output))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to get logs from init container. Output:\n%s", output))
 	outputStr = string(output)
 	fmt.Println("Init Container Logs:\n", outputStr)
 	// Assert that the logs contain success indicators
-	Expect(outputStr).To(ContainSubstring("Feast repo creation complete"), "Expected Feast repo creation message not found")
+	gomega.Expect(outputStr).To(gomega.ContainSubstring("Feast repo creation complete"), "Expected Feast repo creation message not found")
 
-	By("Verifying client feature_store.yaml for expected store types")
+	ginkgo.By("Verifying client feature_store.yaml for expected store types")
 	validateFeatureStoreYaml(namespace, feastDeploymentName)
 }

--- a/infra/feast-operator/test/utils/utils.go
+++ b/infra/feast-operator/test/utils/utils.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
+	ginkgo "github.com/onsi/ginkgo/v2"
 )
 
 const (
@@ -35,7 +35,7 @@ const (
 )
 
 func warnError(err error) {
-	_, _ = fmt.Fprintf(GinkgoWriter, "warning: %v\n", err)
+	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "warning: %v\n", err)
 }
 
 // InstallPrometheusOperator installs the prometheus Operator to be used to export the enabled metrics.
@@ -52,12 +52,12 @@ func Run(cmd *exec.Cmd, testDir string) ([]byte, error) {
 	cmd.Dir = dir
 
 	if err := os.Chdir(cmd.Dir); err != nil {
-		_, _ = fmt.Fprintf(GinkgoWriter, "chdir dir: %s\n", err)
+		_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "chdir dir: %s\n", err)
 	}
 
 	cmd.Env = append(os.Environ(), "GO111MODULE=on")
 	command := strings.Join(cmd.Args, " ")
-	_, _ = fmt.Fprintf(GinkgoWriter, "running: %s\n", command)
+	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, "running: %s\n", command)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return output, fmt.Errorf("%s failed with error: (%v) %s", command, err, string(output))
@@ -136,6 +136,6 @@ func GetProjectDir(projectDir string) (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, projectDir, "", -1)
+	wd = strings.ReplaceAll(wd, projectDir, "")
 	return wd, nil
 }


### PR DESCRIPTION
Fixes #6062

**Description**
This PR integrates the `kube-api-linter` into the `feast-operator` to enforce Kubernetes API Conventions, addressing the requirements laid out in #6062.

**Changes made:**
- Created `infra/feast-operator/.custom-gcl.yml` to enable `kubeapilinter`.
- Updated `infra/feast-operator/.golangci.yml` to scope the linter to the `api/` directory.
- Fixed numerous API convention violations in `api/v1/featurestore_types.go` and `api/v1alpha1/featurestore_types.go` (including adding missing `+optional` tags, fixing JSON camelCase, and correcting field comments).
- Refactored downstream tests (`services_test.go`, `test_util.go`) that were broken by the struct modifications.
- Integrated the custom linter step into `.github/workflows/operator_pr.yml` to prevent future regressions.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
