### PR TITLE
docs: Update type system reference with missing types

### DIFF
--- a/docs/getting-started/concepts/feast-types.md
+++ b/docs/getting-started/concepts/feast-types.md
@@ -8,8 +8,9 @@ Feast's type system is built on top of [protobuf](https://github.com/protocolbuf
 Feast supports the following categories of data types:
 
 - **Primitive types**: numerical values (`Int32`, `Int64`, `Float32`, `Float64`), `String`, `Bytes`, `Bool`, and `UnixTimestamp`.
+- **Domain-specific primitives**: `PdfBytes` (PDF binary data for RAG/document pipelines) and `ImageBytes` (image binary data for multimodal pipelines). These are semantic aliases over `Bytes` and must be explicitly declared in schema — no backend infers them.
 - **Array types**: ordered lists of any primitive type, e.g. `Array(Int64)`, `Array(String)`.
-- **Set types**: unordered collections of unique values for any primitive type, e.g. `Set(String)`, `Set(Int64)`.
+- **Set types**: unordered collections of unique values for any primitive type, e.g. `Set(String)`, `Set(Int64)`. Set types are not inferred by any backend and must be explicitly declared. They are best suited for online serving use cases.
 - **Map types**: dictionary-like structures with string keys and values that can be any supported Feast type (including nested maps), e.g. `Map`, `Array(Map)`.
 - **JSON type**: opaque JSON data stored as a string at the proto level but semantically distinct from `String` — backends use native JSON types (`jsonb`, `VARIANT`, etc.), e.g. `Json`, `Array(Json)`.
 - **Struct type**: schema-aware structured type with named, typed fields. Unlike `Map` (which is schema-free), a `Struct` declares its field names and their types, enabling schema validation, e.g. `Struct({"name": String, "age": Int32})`.

--- a/docs/reference/data-sources/overview.md
+++ b/docs/reference/data-sources/overview.md
@@ -5,7 +5,7 @@
 In Feast, each batch data source is associated with corresponding offline stores.
 For example, a `SnowflakeSource` can only be processed by the Snowflake offline store, while a `FileSource` can be processed by both File and DuckDB offline stores.
 Otherwise, the primary difference between batch data sources is the set of supported types.
-Feast has an internal type system, and aims to support eight primitive types (`bytes`, `string`, `int32`, `int64`, `float32`, `float64`, `bool`, and `timestamp`) along with the corresponding array types.
+Feast has an internal type system that supports primitive types (`bytes`, `string`, `int32`, `int64`, `float32`, `float64`, `bool`, `timestamp`), array types, set types, map/JSON types, and struct types.
 However, not every batch data source supports all of these types.
 
 For more details on the Feast type system, see [here](../type-system.md).
@@ -29,3 +29,9 @@ Below is a matrix indicating which data sources support which types.
 | `bool`      | yes | yes | yes       | yes | yes | yes | yes | yes |
 | `timestamp` | yes | yes | yes       | yes | yes | yes | yes | yes |
 | array types | yes | yes | yes       | no  | yes | yes | yes | no  |
+| `Map`       | yes | no  | yes       | yes | yes | yes | yes | no  |
+| `Json`      | yes | yes | yes       | yes | yes | no  | no  | no  |
+| `Struct`    | yes | yes | no        | no  | yes | yes | no  | no  |
+| set types   | yes* | no | no       | no  | no  | no  | no  | no  |
+
+\* **Set types** are defined in Feast's proto and Python type system but are **not inferred** by any backend. They must be explicitly declared in the feature view schema and are best suited for online serving use cases. See [Type System](../type-system.md#set-types) for details.

--- a/docs/reference/type-system.md
+++ b/docs/reference/type-system.md
@@ -3,7 +3,7 @@
 ## Motivation
 
 Feast uses an internal type system to provide guarantees on training and serving data.
-Feast supports primitive types, array types, set types, and map types for feature values.
+Feast supports primitive types, array types, set types, map types, JSON, and struct types for feature values.
 Null types are not supported, although the `UNIX_TIMESTAMP` type is nullable.
 The type system is controlled by [`Value.proto`](https://github.com/feast-dev/feast/blob/master/protos/feast/types/Value.proto) in protobuf and by [`types.py`](https://github.com/feast-dev/feast/blob/master/sdk/python/feast/types.py) in Python.
 Type conversion logic can be found in [`type_map.py`](https://github.com/feast-dev/feast/blob/master/sdk/python/feast/type_map.py).
@@ -25,6 +25,19 @@ Feast supports the following data types:
 | `Bool` | `bool` | Boolean value |
 | `UnixTimestamp` | `datetime` | Unix timestamp (nullable) |
 
+### Domain-Specific Primitive Types
+
+These types are semantic aliases over `Bytes` for domain-specific use cases (e.g., RAG pipelines, image processing). They are stored as `bytes` at the proto level.
+
+| Feast Type | Python Type | Description |
+|------------|-------------|-------------|
+| `PdfBytes` | `bytes` | PDF document binary data (used in RAG / document processing pipelines) |
+| `ImageBytes` | `bytes` | Image binary data (used in image processing / multimodal pipelines) |
+
+{% hint style="warning" %}
+`PdfBytes` and `ImageBytes` are not natively supported by any backend's type inference. You must explicitly declare them in your feature view schema. Backend storage treats them as raw `bytes`.
+{% endhint %}
+
 ### Array Types
 
 All primitive types have corresponding array (list) types:
@@ -42,7 +55,7 @@ All primitive types have corresponding array (list) types:
 
 ### Set Types
 
-All primitive types (except Map) have corresponding set types for storing unique values:
+All primitive types (except `Map` and `Json`) have corresponding set types for storing unique values:
 
 | Feast Type | Python Type | Description |
 |------------|-------------|-------------|
@@ -57,16 +70,95 @@ All primitive types (except Map) have corresponding set types for storing unique
 
 **Note:** Set types automatically remove duplicate values. When converting from lists or other iterables to sets, duplicates are eliminated.
 
+{% hint style="warning" %}
+**Backend limitations for Set types:**
+
+- **No backend infers Set types from schema.** No offline store (BigQuery, Snowflake, Redshift, PostgreSQL, Spark, Athena, MSSQL) maps its native types to Feast Set types. You **must** explicitly declare Set types in your feature view schema.
+- **No native PyArrow set type.** Feast converts Sets to `pyarrow.list_()` internally, but `feast_value_type_to_pa()` in `type_map.py` does not include Set mappings, which can cause errors in some code paths.
+- **Online stores** that serialize proto bytes (e.g., SQLite, Redis, DynamoDB) handle Sets correctly.
+- **Offline stores** may not handle Set types correctly during retrieval. For example, the Ray offline store only special-cases `_LIST` types, not `_SET`.
+- Set types are best suited for **online serving** use cases where feature values are written as Python sets and retrieved via `get_online_features`.
+{% endhint %}
+
 ### Map Types
 
 Map types allow storing dictionary-like data structures:
 
 | Feast Type | Python Type | Description |
 |------------|-------------|-------------|
-| `Map` | `Dict[str, Any]` | Dictionary with string keys and any supported Feast type as values (including nested maps) |
+| `Map` | `Dict[str, Any]` | Dictionary with string keys and values of any supported Feast type (including nested maps) |
 | `Array(Map)` | `List[Dict[str, Any]]` | List of dictionaries |
 
-**Note:** Map keys must always be strings. Map values can be any supported Feast type, including primitives, arrays, or nested maps.
+**Note:** Map keys must always be strings. Map values can be any supported Feast type, including primitives, arrays, or nested maps at the proto level. However, the PyArrow representation is `map<string, string>`, which means backends that rely on PyArrow schemas (e.g., during materialization) treat Map as string-to-string.
+
+**Backend support for Map:**
+
+| Backend | Native Type | Notes |
+|---------|-------------|-------|
+| PostgreSQL | `jsonb`, `jsonb[]` | `jsonb` → `Map`, `jsonb[]` → `Array(Map)` |
+| Snowflake | `VARIANT`, `OBJECT` | Inferred as `Map` |
+| Redshift | `SUPER` | Inferred as `Map` |
+| Spark | `map<string,string>` | `map<>` → `Map`, `array<map<>>` → `Array(Map)` |
+| Athena | `map` | Inferred as `Map` |
+| MSSQL | `nvarchar(max)` | Serialized as string |
+| DynamoDB / Redis | Proto bytes | Full proto Map support |
+
+### JSON Type
+
+The `Json` type represents opaque JSON data. Unlike `Map`, which is schema-free key-value storage, `Json` is stored as a string at the proto level but backends use native JSON types where available.
+
+| Feast Type | Python Type | Description |
+|------------|-------------|-------------|
+| `Json` | `str` (JSON-encoded) | JSON data stored as a string at the proto level |
+| `Array(Json)` | `List[str]` | List of JSON strings |
+
+**Backend support for Json:**
+
+| Backend | Native Type |
+|---------|-------------|
+| PostgreSQL | `jsonb` |
+| Snowflake | `JSON` / `VARIANT` |
+| Redshift | `json` |
+| BigQuery | `JSON` |
+| Spark | Not natively distinguished from `String` |
+| MSSQL | `nvarchar(max)` |
+
+{% hint style="info" %}
+When a backend's native type is ambiguous (e.g., PostgreSQL `jsonb` could be `Map` or `Json`), **the schema-declared Feast type takes precedence**. The backend-to-Feast mappings are only used during schema inference when no explicit type is provided.
+{% endhint %}
+
+### Struct Type
+
+The `Struct` type represents a schema-aware structured type with named, typed fields. Unlike `Map` (which is schema-free), a `Struct` declares its field names and their types, enabling schema validation.
+
+| Feast Type | Python Type | Description |
+|------------|-------------|-------------|
+| `Struct({"field": Type, ...})` | `Dict[str, Any]` | Named fields with typed values |
+| `Array(Struct({"field": Type, ...}))` | `List[Dict[str, Any]]` | List of structs |
+
+**Example:**
+```python
+from feast.types import Struct, String, Int32, Array
+
+# Struct with named, typed fields
+address_type = Struct({"street": String, "city": String, "zip": Int32})
+Field(name="address", dtype=address_type)
+
+# Array of structs
+items_type = Array(Struct({"name": String, "quantity": Int32}))
+Field(name="order_items", dtype=items_type)
+```
+
+**Backend support for Struct:**
+
+| Backend | Native Type |
+|---------|-------------|
+| BigQuery | `STRUCT` / `RECORD` |
+| Spark | `struct<...>` / `array<struct<...>>` |
+| PostgreSQL | `jsonb` (serialized) |
+| Snowflake | `VARIANT` (serialized) |
+| MSSQL | `nvarchar(max)` (serialized) |
+| DynamoDB / Redis | Proto bytes |
 
 ## Complete Feature View Example
 
@@ -77,7 +169,7 @@ from datetime import timedelta
 from feast import Entity, FeatureView, Field, FileSource
 from feast.types import (
     Int32, Int64, Float32, Float64, String, Bytes, Bool, UnixTimestamp,
-    Array, Set, Map
+    Array, Set, Map, Json, Struct
 )
 
 # Define a data source
@@ -107,7 +199,7 @@ user_features = FeatureView(
         Field(name="profile_picture", dtype=Bytes),
         Field(name="is_active", dtype=Bool),
         Field(name="last_login", dtype=UnixTimestamp),
-        
+
         # Array types
         Field(name="daily_steps", dtype=Array(Int32)),
         Field(name="transaction_history", dtype=Array(Int64)),
@@ -117,17 +209,24 @@ user_features = FeatureView(
         Field(name="document_hashes", dtype=Array(Bytes)),
         Field(name="notification_settings", dtype=Array(Bool)),
         Field(name="login_timestamps", dtype=Array(UnixTimestamp)),
-        
-        # Set types (unique values only)
+
+        # Set types (unique values only — see backend caveats above)
         Field(name="visited_pages", dtype=Set(String)),
         Field(name="unique_categories", dtype=Set(Int32)),
         Field(name="tag_ids", dtype=Set(Int64)),
         Field(name="preferred_languages", dtype=Set(String)),
-        
+
         # Map types
         Field(name="user_preferences", dtype=Map),
         Field(name="metadata", dtype=Map),
         Field(name="activity_log", dtype=Array(Map)),
+
+        # JSON type
+        Field(name="raw_event", dtype=Json),
+
+        # Struct type
+        Field(name="address", dtype=Struct({"street": String, "city": String, "zip": Int32})),
+        Field(name="order_items", dtype=Array(Struct({"name": String, "qty": Int32}))),
     ],
     source=user_features_source,
 )
@@ -184,6 +283,42 @@ activity_log = [
 ]
 ```
 
+### JSON Type Usage Examples
+
+Feast's `Json` type stores values as JSON strings at the proto level. You can pass either a
+pre-serialized JSON string or a Python dict/list — Feast will call `json.dumps()` automatically
+when the value is not already a string:
+
+```python
+import json
+
+# Option 1: pass a Python dict — Feast calls json.dumps() internally during proto conversion
+raw_event = {"type": "click", "target": "button_1", "metadata": {"page": "home"}}
+
+# Option 2: pass an already-serialized JSON string — Feast validates it via json.loads()
+raw_event = '{"type": "click", "target": "button_1", "metadata": {"page": "home"}}'
+
+# When building a DataFrame for store.push(), values must be strings since
+# Pandas/PyArrow columns expect uniform types:
+import pandas as pd
+event_df = pd.DataFrame({
+    "user_id": ["user_1"],
+    "event_timestamp": [datetime.now()],
+    "raw_event": [json.dumps({"type": "click", "target": "button_1"})],
+})
+store.push("event_push_source", event_df)
+```
+
+### Struct Type Usage Examples
+
+```python
+# Struct — schema-aware, fields and types are declared
+from feast.types import Struct, String, Int32
+
+address = Struct({"street": String, "city": String, "zip": Int32})
+# Value: {"street": "123 Main St", "city": "Springfield", "zip": 62704}
+```
+
 ## Type System in Practice
 
 The sections below explain how Feast uses its type system in different contexts.
@@ -195,7 +330,11 @@ For example, if the `schema` parameter is not specified for a feature view, Feas
 Each of these columns must be associated with a Feast type, which requires conversion from the data source type system to the Feast type system.
 * The feature inference logic calls `_infer_features_and_entities`.
 * `_infer_features_and_entities` calls `source_datatype_to_feast_value_type`.
-* `source_datatype_to_feast_value_type` cals the appropriate method in `type_map.py`. For example, if a `SnowflakeSource` is being examined, `snowflake_python_type_to_feast_value_type` from `type_map.py` will be called.
+* `source_datatype_to_feast_value_type` calls the appropriate method in `type_map.py`. For example, if a `SnowflakeSource` is being examined, `snowflake_python_type_to_feast_value_type` from `type_map.py` will be called.
+
+{% hint style="info" %}
+**Types that cannot be inferred:** `Set`, `Json`, `Struct`, `PdfBytes`, and `ImageBytes` types are never inferred from backend schemas. If you use these types, you must declare them explicitly in your feature view schema.
+{% endhint %}
 
 ### Materialization
 


### PR DESCRIPTION

# What this PR does / why we need it:

- Add missing types (`Json`, `Struct`, `PdfBytes`, `ImageBytes`) to the main type system reference page (`docs/reference/type-system.md`) with backend support tables, usage examples, and import guidance.
- Document backend limitations for `Set` types — no backend infers them, `feast_value_type_to_pa()` lacks Set mappings, and offline stores only handle `_LIST` types. Sets are best suited for online serving with explicitly declared schemas.
- Expand the data source functionality matrix (`docs/reference/data-sources/overview.md`) to include `Map`, `Json`, `Struct`, and `Set` type support per backend.
- Add `PdfBytes` and `ImageBytes` as domain-specific primitives in the concepts page (`docs/getting-started/concepts/feast-types.md`).


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
