### PR TITLE
fix: Add website build check for PRs and fix blog frontmatter YAML error

### DIFF
--- a/.github/workflows/pr_website_build.yml
+++ b/.github/workflows/pr_website_build.yml
@@ -1,0 +1,32 @@
+name: Website Build Check
+
+on:
+  pull_request:
+    paths:
+      - 'infra/website/**'
+
+concurrency:
+  group: "pr-website-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: infra/website/package-lock.json
+
+      - name: Install dependencies
+        working-directory: infra/website
+        run: npm ci
+
+      - name: Build site
+        working-directory: infra/website
+        run: npm run build

--- a/infra/website/docs/blog/feast-mlflow-kubeflow.md
+++ b/infra/website/docs/blog/feast-mlflow-kubeflow.md
@@ -1,5 +1,5 @@
 ---
-title: Feast + MLflow + Kubeflow: A Unified AI/ML Lifecycle
+title: "Feast + MLflow + Kubeflow: A Unified AI/ML Lifecycle"
 description: Learn how to use Feast, MLflow, and Kubeflow to power your AI/ML Lifecycle
 date: 2026-02-23
 authors: ["Francisco Javier Arceo", "Nikhil Kathole"]


### PR DESCRIPTION
# What this PR does / why we need it:


- Add a CI workflow (pr_website_build.yml) that runs npm run build on PRs touching infra/website/** to catch build errors before they reach master.
- Fix YAML frontmatter parsing error in feast-mlflow-kubeflow.md where an unquoted colon in the title field caused js-yaml to fail with "bad indentation of a mapping entry".
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
