### PR TITLE
feat: Add Claude Code agent skills for Feast

### DIFF
--- a/skills/feast-dev/SKILL.md
+++ b/skills/feast-dev/SKILL.md
@@ -75,7 +75,7 @@ cd sdk/python && python -m mypy feast
 
 ```
 sdk/python/feast/          # Main Python SDK
-  cli.py                   # CLI entry point (feast apply, feast materialize, etc.)
+  cli/cli.py               # CLI entry point (feast apply, feast materialize, etc.)
   feature_store.py         # FeatureStore class - core orchestration
   repo_config.py           # feature_store.yaml configuration parsing
   repo_operations.py       # feast apply / feast teardown logic


### PR DESCRIPTION
## What this PR does / why we need it

Adds Claude Code agent skills to the Feast repository, as requested in #5976.

Two skills are included:

**1. `feast-dev`** -- Development/contributor skill covering:
- Environment setup with uv
- Running unit and integration tests
- Linting, formatting, type checking
- Code style conventions and PR workflow (DCO, semantic titles, labels)
- Project structure overview and key abstractions

**2. `feast-feature-engineering`** -- User-facing skill covering:
- Feature store initialization and configuration
- Entity, FeatureView, and OnDemandFeatureView definitions
- Materialization commands
- Historical and online feature retrieval patterns
- CLI reference and supported infrastructure

Both skills use the `SKILL.md` format from [anthropics/skills](https://github.com/anthropics/skills) and are placed under `.claude/skills/` following the Claude Code convention.

## Which issue(s) this PR fixes

Closes #5976

## Does this PR introduce a user-facing change

NONE (developer tooling only)

## Release note

```release-note
NONE
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6081" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
