### PR TITLE
fix: Fix registry Rest API tests intermittent failure

### DIFF
--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -302,15 +302,21 @@ class SqlRegistry(CachingRegistry):
             # Find object in feast_metadata_projects but not in projects
             projects_to_sync = set(feast_metadata_projects.keys()) - set(projects_set)
             for project_name in projects_to_sync:
-                self.apply_project(
-                    Project(
-                        name=project_name,
-                        created_timestamp=datetime.fromtimestamp(
-                            feast_metadata_projects[project_name], tz=timezone.utc
+                try:
+                    self.apply_project(
+                        Project(
+                            name=project_name,
+                            created_timestamp=datetime.fromtimestamp(
+                                feast_metadata_projects[project_name], tz=timezone.utc
+                            ),
                         ),
-                    ),
-                    commit=True,
-                )
+                        commit=True,
+                    )
+                except IntegrityError:
+                    logger.info(
+                        "Project %s already created in projects table by another process.",
+                        project_name,
+                    )
 
             if self.purge_feast_metadata:
                 with self.write_engine.begin() as conn:

--- a/sdk/python/tests/integration/rest_api/conftest.py
+++ b/sdk/python/tests/integration/rest_api/conftest.py
@@ -37,7 +37,12 @@ class FeastRestClient:
         return requests.get(url, params=params, verify=False)
 
 
-def _wait_for_http_ready(route_url: str, timeout: int = 180, interval: int = 5) -> None:
+def _wait_for_http_ready(
+    route_url: str,
+    timeout: int = 300,
+    interval: int = 5,
+    initial_delay: int = 30,
+) -> None:
     """
     Poll the HTTP endpoint until it returns a non-502 response.
 
@@ -46,9 +51,15 @@ def _wait_for_http_ready(route_url: str, timeout: int = 180, interval: int = 5) 
     start before the Feast server is ready, causing all requests to return 502.
     """
     health_url = f"{route_url}/api/v1/projects"
-    deadline = time.time() + timeout
     last_status = None
 
+    if initial_delay > 0:
+        print(
+            f"\n Waiting {initial_delay}s for backend to start after apply/dataset creation..."
+        )
+        time.sleep(initial_delay)
+
+    deadline = time.time() + timeout
     print(
         f"\n Waiting for HTTP endpoint to become ready (timeout={timeout}s): {health_url}"
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
Fixes https://github.com/feast-dev/feast/issues/5977

  - Wrapped the apply_project() call in a try-except block to catch IntegrityError
  - Increased HTTP readiness timeout from 180s to 300s
  - Added a 30-second initial delay before polling the endpoint to give the backend more time to initialize after dataset creation
  - Prevents premature connection attempts that result in 502 errors

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
