### PR TITLE
fix: SSL/TLS mode by default for postgres connection

### DIFF
--- a/docs/reference/offline-stores/postgres.md
+++ b/docs/reference/offline-stores/postgres.md
@@ -38,7 +38,7 @@ online_store:
 ```
 {% endcode %}
 
-Note that `sslmode`, `sslkey_path`, `sslcert_path`, and `sslrootcert_path` are optional parameters.
+Note that `sslmode` defaults to `require`, which encrypts the connection without certificate verification. To disable SSL (e.g. for local development), set `sslmode: disable`. For certificate verification, set `sslmode` to `verify-ca` or `verify-full` and provide the corresponding `sslrootcert_path` (and optionally `sslcert_path` and `sslkey_path` for mutual TLS).
 The full set of configuration options is available in [PostgreSQLOfflineStoreConfig](https://rtd.feast.dev/en/master/#feast.infra.offline_stores.contrib.postgres_offline_store.postgres.PostgreSQLOfflineStoreConfig).
 
 Additionally, a new optional parameter `entity_select_mode` was added to tell how Postgres should load the entity data. By default(`temp_table`), a temporary table is created and the entity data frame or sql is loaded into that table. A new value of `embed_query` was added to allow directly loading the SQL query into a CTE, providing improved performance and skipping the need to CREATE and DROP the temporary table.

--- a/docs/reference/online-stores/postgres.md
+++ b/docs/reference/online-stores/postgres.md
@@ -6,7 +6,7 @@ The PostgreSQL online store provides support for materializing feature values in
 
 * Only the latest feature values are persisted
 
-* sslmode, sslkey_path, sslcert_path, and sslrootcert_path are optional
+* `sslmode` defaults to `require`, which encrypts the connection without certificate verification. To disable SSL (e.g. for local development), set `sslmode: disable`. For certificate verification, set `sslmode` to `verify-ca` or `verify-full` and provide the corresponding `sslrootcert_path` (and optionally `sslcert_path` and `sslkey_path` for mutual TLS)
 
 ## Getting started
 In order to use this online store, you'll need to run `pip install 'feast[postgres]'`. You can get started by then running `feast init -t postgres`.

--- a/go/internal/feast/onlinestore/postgresonlinestore.go
+++ b/go/internal/feast/onlinestore/postgresonlinestore.go
@@ -166,7 +166,7 @@ func buildPostgresConnString(config map[string]interface{}) string {
 	if sslMode, ok := config["sslmode"].(string); ok && sslMode != "" {
 		query.Set("sslmode", sslMode)
 	} else {
-		query.Set("sslmode", "disable")
+		query.Set("sslmode", "require")
 	}
 
 	if v, ok := config["sslcert_path"].(string); ok && v != "" {

--- a/go/internal/feast/onlinestore/postgresonlinestore_test.go
+++ b/go/internal/feast/onlinestore/postgresonlinestore_test.go
@@ -34,7 +34,7 @@ func TestBuildPostgresConnStringDefaults(t *testing.T) {
 	}
 	connStr := buildPostgresConnString(config)
 	assert.Contains(t, connStr, "localhost:5432")
-	assert.Contains(t, connStr, "sslmode=disable")
+	assert.Contains(t, connStr, "sslmode=require")
 }
 
 func TestBuildPostgresConnStringWithSSL(t *testing.T) {

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/data_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/tests/data_source.py
@@ -85,6 +85,7 @@ class PostgreSQLDataSourceCreator(DataSourceCreator, OnlineStoreCreator):
             db_schema="public",
             user=self.container.env["POSTGRES_USER"],
             password=self.container.env["POSTGRES_PASSWORD"],
+            sslmode="disable",
         )
 
     def create_data_source(
@@ -124,6 +125,7 @@ class PostgreSQLDataSourceCreator(DataSourceCreator, OnlineStoreCreator):
             db_schema="feature_store",
             user=POSTGRES_USER,
             password=POSTGRES_PASSWORD,
+            sslmode="disable",
         )
 
     def create_saved_dataset_destination(self):

--- a/sdk/python/feast/infra/utils/postgres/postgres_config.py
+++ b/sdk/python/feast/infra/utils/postgres/postgres_config.py
@@ -21,7 +21,7 @@ class PostgreSQLConfig(FeastConfigBaseModel):
     db_schema: StrictStr = "public"
     user: StrictStr
     password: StrictStr
-    sslmode: Optional[StrictStr] = None
+    sslmode: Optional[StrictStr] = "require"
     sslkey_path: Optional[StrictStr] = None
     sslcert_path: Optional[StrictStr] = None
     sslrootcert_path: Optional[StrictStr] = None

--- a/sdk/python/feast/templates/postgres/bootstrap.py
+++ b/sdk/python/feast/templates/postgres/bootstrap.py
@@ -29,11 +29,25 @@ def bootstrap():
     postgres_schema = click.prompt("Postgres schema", default="public")
     postgres_user = click.prompt("Postgres user")
     postgres_password = click.prompt("Postgres password", hide_input=True)
+    postgres_sslmode = click.prompt(
+        "Postgres sslmode (disable, allow, prefer, require, verify-ca, verify-full)",
+        default="require",
+    )
 
     if click.confirm(
         'Should I upload example data to Postgres (overwriting "feast_driver_hourly_stats" table)?',
         default=True,
     ):
+        config = PostgreSQLConfig(
+            host=postgres_host,
+            port=int(postgres_port),
+            database=postgres_database,
+            db_schema=postgres_schema,
+            user=postgres_user,
+            password=postgres_password,
+            sslmode=postgres_sslmode,
+        )
+
         db_connection = psycopg.connect(
             conninfo=(
                 f"postgresql://{postgres_user}"
@@ -42,6 +56,7 @@ def bootstrap():
                 f":{int(postgres_port)}"
                 f"/{postgres_database}"
             ),
+            sslmode=postgres_sslmode,
             options=f"-c search_path={postgres_schema}",
         )
 
@@ -49,14 +64,7 @@ def bootstrap():
             cur.execute('DROP TABLE IF EXISTS "feast_driver_hourly_stats"')
 
         df_to_postgres_table(
-            config=PostgreSQLConfig(
-                host=postgres_host,
-                port=int(postgres_port),
-                database=postgres_database,
-                db_schema=postgres_schema,
-                user=postgres_user,
-                password=postgres_password,
-            ),
+            config=config,
             df=driver_df,
             table_name="feast_driver_hourly_stats",
         )
@@ -67,6 +75,7 @@ def bootstrap():
     replace_str_in_file(config_file, "DB_SCHEMA", postgres_schema)
     replace_str_in_file(config_file, "DB_USERNAME", postgres_user)
     replace_str_in_file(config_file, "DB_PASSWORD", postgres_password)
+    replace_str_in_file(config_file, "DB_SSLMODE", postgres_sslmode)
 
 
 if __name__ == "__main__":

--- a/sdk/python/feast/templates/postgres/feature_repo/feature_store.yaml
+++ b/sdk/python/feast/templates/postgres/feature_repo/feature_store.yaml
@@ -2,7 +2,7 @@ project: my_project
 provider: local
 registry:
     registry_type: sql
-    path: postgresql://DB_USERNAME:DB_PASSWORD@DB_HOST:DB_PORT/DB_NAME
+    path: postgresql://DB_USERNAME:DB_PASSWORD@DB_HOST:DB_PORT/DB_NAME?sslmode=DB_SSLMODE
     cache_ttl_seconds: 60
     sqlalchemy_config_kwargs:
         echo: false
@@ -15,6 +15,7 @@ online_store:
     db_schema: DB_SCHEMA
     user: DB_USERNAME
     password: DB_PASSWORD
+    sslmode: DB_SSLMODE
 offline_store:
     type: postgres
     host: DB_HOST
@@ -23,4 +24,5 @@ offline_store:
     db_schema: DB_SCHEMA
     user: DB_USERNAME
     password: DB_PASSWORD
+    sslmode: DB_SSLMODE
 entity_key_serialization_version: 3


### PR DESCRIPTION

# What this PR does / why we need it:

The sslmode in the PostgreSQL configuration was set to Optional and defaulted to None (Python SDK) / disable (Go feature server), meaning connections were unencrypted by default. This violates the Secure by Default design principle, as users had to explicitly opt-in to encryption.

This PR changes the default sslmode to require, ensuring all PostgreSQL connections are encrypted out of the box.

**Breaking change note**

Users connecting to PostgreSQL servers that do not support SSL will need to explicitly set `sslmode: disable` in their feature_store.yaml. This is intentional - unencrypted connections should be a conscious opt-in, not a silent default.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
