### PR TITLE
fix: Fixed intermittent failures in get_historical_features

### DIFF
--- a/sdk/python/feast/arrow_error_handler.py
+++ b/sdk/python/feast/arrow_error_handler.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from functools import wraps
 
 import pyarrow.flight as fl
@@ -7,17 +8,45 @@ from feast.errors import FeastError
 
 logger = logging.getLogger(__name__)
 
+BACKOFF_FACTOR = 0.5
+
 
 def arrow_client_error_handling_decorator(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except Exception as e:
-            mapped_error = FeastError.from_error_detail(_get_exception_data(e.args[0]))
-            if mapped_error is not None:
-                raise mapped_error
-            raise e
+        # Retry only applies to FeastFlightClient methods where args[0] (self)
+        # carries _connection_retries from RemoteOfflineStoreConfig.
+        # Standalone stream functions (write_table, read_all) get 0 retries:
+        # broken streams can't be reused and retrying risks duplicate writes.
+        max_retries = max(0, getattr(args[0], "_connection_retries", 0)) if args else 0
+
+        for attempt in range(max_retries + 1):
+            try:
+                return func(*args, **kwargs)
+            except fl.FlightUnavailableError as e:
+                if attempt < max_retries:
+                    wait_time = BACKOFF_FACTOR * (2**attempt)
+                    logger.warning(
+                        "Transient Arrow Flight error on attempt %d/%d, "
+                        "retrying in %.1fs: %s",
+                        attempt + 1,
+                        max_retries + 1,
+                        wait_time,
+                        e,
+                    )
+                    time.sleep(wait_time)
+                    continue
+                mapped_error = FeastError.from_error_detail(_get_exception_data(str(e)))
+                if mapped_error is not None:
+                    raise mapped_error
+                raise e
+            except Exception as e:
+                mapped_error = FeastError.from_error_detail(
+                    _get_exception_data(e.args[0])
+                )
+                if mapped_error is not None:
+                    raise mapped_error
+                raise e
 
     return wrapper
 

--- a/sdk/python/feast/infra/offline_stores/remote.py
+++ b/sdk/python/feast/infra/offline_stores/remote.py
@@ -12,7 +12,7 @@ import pyarrow.flight as fl
 import pyarrow.parquet
 from pyarrow import Schema
 from pyarrow._flight import FlightCallOptions, FlightDescriptor, Ticket
-from pydantic import StrictInt, StrictStr
+from pydantic import Field, StrictInt, StrictStr
 
 from feast import OnDemandFeatureView
 from feast.arrow_error_handler import arrow_client_error_handling_decorator
@@ -42,6 +42,10 @@ logger = logging.getLogger(__name__)
 
 
 class FeastFlightClient(fl.FlightClient):
+    def __init__(self, *args, connection_retries: int = 3, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._connection_retries = max(0, connection_retries)
+
     @arrow_client_error_handling_decorator
     def get_flight_info(
         self, descriptor: FlightDescriptor, options: FlightCallOptions = None
@@ -71,7 +75,12 @@ class FeastFlightClient(fl.FlightClient):
 
 
 def build_arrow_flight_client(
-    scheme: str, host: str, port, auth_config: AuthConfig, cert: str = ""
+    scheme: str,
+    host: str,
+    port,
+    auth_config: AuthConfig,
+    cert: str = "",
+    connection_retries: int = 3,
 ):
     arrow_scheme = "grpc+tcp"
     if scheme == "https":
@@ -88,10 +97,17 @@ def build_arrow_flight_client(
     if auth_config.type != AuthType.NONE.value:
         middlewares = [FlightAuthInterceptorFactory(auth_config)]
         return FeastFlightClient(
-            f"{arrow_scheme}://{host}:{port}", middleware=middlewares, **kwargs
+            f"{arrow_scheme}://{host}:{port}",
+            middleware=middlewares,
+            connection_retries=connection_retries,
+            **kwargs,
         )
 
-    return FeastFlightClient(f"{arrow_scheme}://{host}:{port}", **kwargs)
+    return FeastFlightClient(
+        f"{arrow_scheme}://{host}:{port}",
+        connection_retries=connection_retries,
+        **kwargs,
+    )
 
 
 class RemoteOfflineStoreConfig(FeastConfigBaseModel):
@@ -108,6 +124,9 @@ class RemoteOfflineStoreConfig(FeastConfigBaseModel):
     cert: StrictStr = ""
     """ str: Path to the public certificate when the offline server starts in TLS(SSL) mode. This may be needed if the offline server started with a self-signed certificate, typically this file ends with `*.crt`, `*.cer`, or `*.pem`.
     If type is 'remote', then this configuration is needed to connect to remote offline server in TLS mode. """
+
+    connection_retries: int = Field(default=3, ge=0)
+    """ int: Number of retries for transient Arrow Flight errors with exponential backoff (default 3). """
 
 
 class RemoteRetrievalJob(RetrievalJob):
@@ -207,6 +226,7 @@ class RemoteOfflineStore(OfflineStore):
             port=config.offline_store.port,
             auth_config=config.auth_config,
             cert=config.offline_store.cert,
+            connection_retries=config.offline_store.connection_retries,
         )
 
         feature_view_names = [fv.name for fv in feature_views]
@@ -257,6 +277,7 @@ class RemoteOfflineStore(OfflineStore):
             port=config.offline_store.port,
             auth_config=config.auth_config,
             cert=config.offline_store.cert,
+            connection_retries=config.offline_store.connection_retries,
         )
 
         api_parameters = {
@@ -295,6 +316,7 @@ class RemoteOfflineStore(OfflineStore):
             config.offline_store.port,
             config.auth_config,
             cert=config.offline_store.cert,
+            connection_retries=config.offline_store.connection_retries,
         )
 
         api_parameters = {
@@ -334,6 +356,7 @@ class RemoteOfflineStore(OfflineStore):
             config.offline_store.port,
             config.auth_config,
             config.offline_store.cert,
+            connection_retries=config.offline_store.connection_retries,
         )
 
         api_parameters = {
@@ -364,6 +387,7 @@ class RemoteOfflineStore(OfflineStore):
             config.offline_store.port,
             config.auth_config,
             config.offline_store.cert,
+            connection_retries=config.offline_store.connection_retries,
         )
 
         feature_view_names = [feature_view.name]
@@ -396,6 +420,7 @@ class RemoteOfflineStore(OfflineStore):
             config.offline_store.port,
             config.auth_config,
             config.offline_store.cert,
+            connection_retries=config.offline_store.connection_retries,
         )
 
         api_parameters = {
@@ -421,6 +446,7 @@ class RemoteOfflineStore(OfflineStore):
             config.offline_store.port,
             config.auth_config,
             config.offline_store.cert,
+            connection_retries=config.offline_store.connection_retries,
         )
 
         api_parameters = {

--- a/sdk/python/tests/unit/test_arrow_error_decorator.py
+++ b/sdk/python/tests/unit/test_arrow_error_decorator.py
@@ -1,8 +1,12 @@
+from unittest.mock import MagicMock, patch
+
 import pyarrow.flight as fl
 import pytest
+from pydantic import ValidationError
 
 from feast.arrow_error_handler import arrow_client_error_handling_decorator
 from feast.errors import PermissionNotFoundException
+from feast.infra.offline_stores.remote import RemoteOfflineStoreConfig
 
 permissionError = PermissionNotFoundException("dummy_name", "dummy_project")
 
@@ -31,3 +35,147 @@ def test_rest_error_handling_with_feast_exception(error, expected_raised_error):
         match=str(expected_raised_error),
     ):
         decorated_method(error)
+
+
+class TestArrowClientRetry:
+    @patch("feast.arrow_error_handler.time.sleep")
+    def test_retries_on_flight_unavailable_error(self, mock_sleep):
+        client = MagicMock()
+        client._connection_retries = 3
+        call_count = 0
+
+        @arrow_client_error_handling_decorator
+        def flaky_method(self_arg):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise fl.FlightUnavailableError("Connection refused")
+            return "success"
+
+        result = flaky_method(client)
+        assert result == "success"
+        assert call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch("feast.arrow_error_handler.time.sleep")
+    def test_raises_after_max_retries_exhausted(self, mock_sleep):
+        client = MagicMock()
+        client._connection_retries = 3
+
+        @arrow_client_error_handling_decorator
+        def always_unavailable(self_arg):
+            raise fl.FlightUnavailableError("Connection refused")
+
+        with pytest.raises(fl.FlightUnavailableError, match="Connection refused"):
+            always_unavailable(client)
+        assert mock_sleep.call_count == 3
+
+    @patch("feast.arrow_error_handler.time.sleep")
+    def test_respects_connection_retries_from_client(self, mock_sleep):
+        client = MagicMock()
+        client._connection_retries = 1
+        call_count = 0
+
+        @arrow_client_error_handling_decorator
+        def method_on_client(self_arg):
+            nonlocal call_count
+            call_count += 1
+            raise fl.FlightUnavailableError("Connection refused")
+
+        with pytest.raises(fl.FlightUnavailableError):
+            method_on_client(client)
+
+        assert call_count == 2  # 1 initial + 1 retry
+        assert mock_sleep.call_count == 1
+
+    @patch("feast.arrow_error_handler.time.sleep")
+    def test_no_retry_on_non_transient_errors(self, mock_sleep):
+        client = MagicMock()
+        client._connection_retries = 3
+        call_count = 0
+
+        @arrow_client_error_handling_decorator
+        def method_with_error(self_arg):
+            nonlocal call_count
+            call_count += 1
+            raise fl.FlightError("Permanent error")
+
+        with pytest.raises(fl.FlightError, match="Permanent error"):
+            method_with_error(client)
+
+        assert call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("feast.arrow_error_handler.time.sleep")
+    def test_exponential_backoff_timing(self, mock_sleep):
+        client = MagicMock()
+        client._connection_retries = 3
+
+        @arrow_client_error_handling_decorator
+        def always_unavailable(self_arg):
+            raise fl.FlightUnavailableError("Connection refused")
+
+        with pytest.raises(fl.FlightUnavailableError):
+            always_unavailable(client)
+
+        wait_times = [call.args[0] for call in mock_sleep.call_args_list]
+        assert wait_times == [0.5, 1.0, 2.0]
+
+    @patch("feast.arrow_error_handler.time.sleep")
+    def test_zero_retries_disables_retry(self, mock_sleep):
+        client = MagicMock()
+        client._connection_retries = 0
+        call_count = 0
+
+        @arrow_client_error_handling_decorator
+        def method_on_client(self_arg):
+            nonlocal call_count
+            call_count += 1
+            raise fl.FlightUnavailableError("Connection refused")
+
+        with pytest.raises(fl.FlightUnavailableError):
+            method_on_client(client)
+
+        assert call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("feast.arrow_error_handler.time.sleep")
+    def test_no_retry_for_standalone_stream_functions(self, mock_sleep):
+        """Standalone functions (write_table, read_all) where args[0] is a
+        writer/reader should not retry since broken streams can't be reused."""
+        writer = MagicMock(spec=[])  # no _connection_retries attribute
+        call_count = 0
+
+        @arrow_client_error_handling_decorator
+        def write_table(w):
+            nonlocal call_count
+            call_count += 1
+            raise fl.FlightUnavailableError("stream broken")
+
+        with pytest.raises(fl.FlightUnavailableError, match="stream broken"):
+            write_table(writer)
+
+        assert call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("feast.arrow_error_handler.time.sleep")
+    def test_negative_connection_retries_treated_as_zero(self, mock_sleep):
+        """Negative _connection_retries must not skip function execution."""
+        client = MagicMock()
+        client._connection_retries = -1
+        call_count = 0
+
+        @arrow_client_error_handling_decorator
+        def method_on_client(self_arg):
+            nonlocal call_count
+            call_count += 1
+            return "ok"
+
+        result = method_on_client(client)
+        assert result == "ok"
+        assert call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_config_rejects_negative_connection_retries(self):
+        with pytest.raises(ValidationError):
+            RemoteOfflineStoreConfig(host="localhost", connection_retries=-1)


### PR DESCRIPTION

# Which issue(s) this PR fixes:

The remote offline store's Arrow Flight client had no retry logic for transient gRPC failures. The error grpc_status:14 (UNAVAILABLE) is a classic transient error indicating the server momentarily cannot accept connections (connection refused, busy processing, connection churn after a write operation).

In contrast, the remote online store already has proper retry with exponential backoff via HttpSessionManager and urllib3.util.retry.Retry. The offline store's Arrow Flight path had zero resilience for transient failures.

The arrow_client_error_handling_decorator now catches FlightUnavailableError (gRPC UNAVAILABLE/status 14) and retries with exponential backoff (0.5s, 1.0s, 2.0s). It reads the retry count from the client's _connection_retries attribute when available, otherwise defaults to 3 retries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
