### PR TITLE
refactor: Extract common non-entity date range computation into shared utility

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/clickhouse_offline_store/clickhouse.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/clickhouse_offline_store/clickhouse.py
@@ -31,7 +31,7 @@ from feast.infra.registry.base_registry import BaseRegistry
 from feast.infra.utils.clickhouse.clickhouse_config import ClickhouseConfig
 from feast.infra.utils.clickhouse.connection_utils import get_client
 from feast.saved_dataset import SavedDatasetStorage
-from feast.utils import _utc_now, make_tzaware
+from feast.utils import compute_non_entity_date_range
 
 
 class ClickhouseOfflineStoreConfig(ClickhouseConfig):
@@ -56,12 +56,11 @@ class ClickhouseOfflineStore(OfflineStore):
 
         # Handle non-entity retrieval mode
         if entity_df is None:
-            end_date = kwargs.get("end_date", None)
-            if end_date is None:
-                end_date = _utc_now()
-            else:
-                end_date = make_tzaware(end_date)
-
+            start_date, end_date = compute_non_entity_date_range(
+                feature_views,
+                start_date=kwargs.get("start_date"),
+                end_date=kwargs.get("end_date"),
+            )
             entity_df = pd.DataFrame({"event_timestamp": [end_date]})
 
         entity_schema = _get_entity_schema(entity_df, config)

--- a/sdk/python/feast/infra/offline_stores/contrib/oracle_offline_store/oracle.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/oracle_offline_store/oracle.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, List, Literal, Optional, Union
 
@@ -24,6 +24,7 @@ from feast.infra.offline_stores.ibis import (
 from feast.infra.offline_stores.offline_store import OfflineStore, RetrievalJob
 from feast.infra.registry.base_registry import BaseRegistry
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
+from feast.utils import compute_non_entity_date_range
 
 
 def get_ibis_connection(config: RepoConfig):
@@ -153,35 +154,6 @@ class OracleOfflineStoreConfig(FeastConfigBaseModel):
         return self
 
 
-def _resolve_date_range(
-    start_date: Optional[datetime],
-    end_date: Optional[datetime],
-    feature_views: List[FeatureView],
-) -> tuple:
-    """Resolve start/end dates to a UTC-aware range, using TTL as a fallback window."""
-    if end_date is None:
-        end_date = datetime.now(tz=timezone.utc)
-    elif end_date.tzinfo is None:
-        end_date = end_date.replace(tzinfo=timezone.utc)
-
-    if start_date is None:
-        max_ttl_seconds = max(
-            (
-                int(fv.ttl.total_seconds())
-                for fv in feature_views
-                if fv.ttl and isinstance(fv.ttl, timedelta)
-            ),
-            default=0,
-        )
-        start_date = end_date - timedelta(
-            seconds=max_ttl_seconds if max_ttl_seconds > 0 else 30 * 86400
-        )
-    elif start_date.tzinfo is None:
-        start_date = start_date.replace(tzinfo=timezone.utc)
-
-    return start_date, end_date
-
-
 def _build_entity_df_from_feature_sources(
     con,
     feature_views: List[FeatureView],
@@ -254,10 +226,10 @@ class OracleOfflineStore(OfflineStore):
 
         # Handle non-entity retrieval mode (start_date/end_date only)
         if entity_df is None:
-            start_date, end_date = _resolve_date_range(
+            start_date, end_date = compute_non_entity_date_range(
+                feature_views,
                 start_date=kwargs.get("start_date"),
                 end_date=kwargs.get("end_date"),
-                feature_views=feature_views,
             )
             entity_df = _build_entity_df_from_feature_sources(
                 con, feature_views, start_date, end_date

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
@@ -1,6 +1,6 @@
 import contextlib
 from dataclasses import asdict
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from enum import Enum
 from typing import (
     Any,
@@ -46,7 +46,7 @@ from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.repo_config import RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
 from feast.type_map import pg_type_code_to_arrow
-from feast.utils import _utc_now, make_tzaware
+from feast.utils import compute_non_entity_date_range
 
 from .postgres_source import PostgreSQLSource
 
@@ -129,36 +129,16 @@ class PostgreSQLOfflineStore(OfflineStore):
         assert isinstance(config.offline_store, PostgreSQLOfflineStoreConfig)
         for fv in feature_views:
             assert isinstance(fv.batch_source, PostgreSQLSource)
-        start_date: Optional[datetime] = kwargs.get("start_date", None)
-        end_date: Optional[datetime] = kwargs.get("end_date", None)
+        start_date: Optional[datetime] = kwargs.get("start_date")
+        end_date: Optional[datetime] = kwargs.get("end_date")
 
         # Handle non-entity retrieval mode
         if entity_df is None:
-            # Default to current time if end_date not provided
-            if end_date is None:
-                end_date = _utc_now()
-            else:
-                end_date = make_tzaware(end_date)
-
-            # Calculate start_date from TTL if not provided
-
-            if start_date is None:
-                # Find the maximum TTL across all feature views to ensure we capture enough data
-                max_ttl_seconds = 0
-                for fv in feature_views:
-                    if fv.ttl and isinstance(fv.ttl, timedelta):
-                        ttl_seconds = int(fv.ttl.total_seconds())
-                        max_ttl_seconds = max(max_ttl_seconds, ttl_seconds)
-
-                if max_ttl_seconds > 0:
-                    # Start from (end_date - max_ttl) to ensure we capture all relevant features
-                    start_date = end_date - timedelta(seconds=max_ttl_seconds)
-                else:
-                    # If no TTL is set, default to 30 days before end_date
-                    start_date = end_date - timedelta(days=30)
-            else:
-                start_date = make_tzaware(start_date)
-
+            start_date, end_date = compute_non_entity_date_range(
+                feature_views,
+                start_date=start_date,
+                end_date=end_date,
+            )
             entity_df = pd.DataFrame({"event_timestamp": [end_date]})
 
         entity_schema = _get_entity_schema(entity_df, config)

--- a/sdk/python/feast/infra/offline_stores/contrib/ray_offline_store/ray.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/ray_offline_store/ray.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
@@ -59,7 +59,12 @@ from feast.type_map import (
     feast_value_type_to_pandas_type,
     pa_to_feast_value_type,
 )
-from feast.utils import _get_column_names, make_df_tzaware, make_tzaware
+from feast.utils import (
+    _get_column_names,
+    compute_non_entity_date_range,
+    make_df_tzaware,
+    make_tzaware,
+)
 
 logger = logging.getLogger(__name__)
 # Remote storage URI schemes supported by the Ray offline store
@@ -1203,37 +1208,6 @@ class RayRetrievalJob(RetrievalJob):
             return pa.Table.from_pandas(df).schema
 
 
-def _compute_non_entity_dates_ray(
-    feature_views: List[FeatureView],
-    start_date_opt: Optional[datetime],
-    end_date_opt: Optional[datetime],
-) -> Tuple[datetime, datetime]:
-    # Why: derive bounded time window when no entity_df is provided using explicit dates or max TTL fallback
-    end_date = (
-        make_tzaware(end_date_opt) if end_date_opt else make_tzaware(datetime.utcnow())
-    )
-    if start_date_opt is None:
-        max_ttl_seconds = 0
-        for fv in feature_views:
-            if getattr(fv, "ttl", None):
-                try:
-                    ttl_val = fv.ttl
-                    if isinstance(ttl_val, timedelta):
-                        max_ttl_seconds = max(
-                            max_ttl_seconds, int(ttl_val.total_seconds())
-                        )
-                except Exception:
-                    pass
-        start_date = (
-            end_date - timedelta(seconds=max_ttl_seconds)
-            if max_ttl_seconds > 0
-            else end_date - timedelta(days=30)
-        )
-    else:
-        start_date = make_tzaware(start_date_opt)
-    return start_date, end_date
-
-
 def _make_filter_range(timestamp_field: str, start_date: datetime, end_date: datetime):
     # Why: factory function for time-range filtering in Ray map_batches
     def _filter_range(batch: pd.DataFrame) -> pd.Series:
@@ -2067,8 +2041,10 @@ class RayOfflineStore(OfflineStore):
             # Non-entity mode: derive entity set from feature sources within a bounded time window
             # Preserves distinct (entity_keys, event_timestamp) combinations for proper PIT joins
             # This handles cases where multiple transactions per entity ID exist
-            start_date, end_date = _compute_non_entity_dates_ray(
-                feature_views, kwargs.get("start_date"), kwargs.get("end_date")
+            start_date, end_date = compute_non_entity_date_range(
+                feature_views,
+                start_date=kwargs.get("start_date"),
+                end_date=kwargs.get("end_date"),
             )
             per_view_entity_ds: List[Dataset] = []
             all_join_keys: List[str] = []

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -3,7 +3,7 @@ import tempfile
 import uuid
 import warnings
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -52,7 +52,7 @@ from feast.infra.registry.base_registry import BaseRegistry
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
 from feast.type_map import spark_schema_to_np_dtypes
-from feast.utils import _get_fields_with_aliases
+from feast.utils import _get_fields_with_aliases, compute_non_entity_date_range
 
 # Make sure spark warning doesn't raise more than once.
 warnings.simplefilter("once", RuntimeWarning)
@@ -183,8 +183,11 @@ class SparkOfflineStore(OfflineStore):
         # This makes date-range retrievals possible without enumerating entities upfront; sources remain bounded by time.
         non_entity_mode = entity_df is None
         if non_entity_mode:
-            # Why: derive bounded time window without requiring entities; uses max TTL fallback to constrain scans.
-            start_date, end_date = _compute_non_entity_dates(feature_views, kwargs)
+            start_date, end_date = compute_non_entity_date_range(
+                feature_views,
+                start_date=kwargs.get("start_date"),
+                end_date=kwargs.get("end_date"),
+            )
             entity_df_event_timestamp_range = (start_date, end_date)
 
             # Build query contexts so we can reuse entity names and per-view table info consistently.
@@ -617,29 +620,6 @@ def get_spark_session_or_start_new_with_repoconfig(
         spark_session = spark_builder.getOrCreate()
     spark_session.conf.set("spark.sql.parser.quotedRegexColumnNames", "true")
     return spark_session
-
-
-def _compute_non_entity_dates(
-    feature_views: List[FeatureView], kwargs: Dict[str, Any]
-) -> Tuple[datetime, datetime]:
-    # Why: bounds the scan window when no entity_df is provided using explicit dates or max TTL fallback.
-    start_date_opt = cast(Optional[datetime], kwargs.get("start_date"))
-    end_date_opt = cast(Optional[datetime], kwargs.get("end_date"))
-    end_date: datetime = end_date_opt or datetime.now(timezone.utc)
-
-    if start_date_opt is None:
-        max_ttl_seconds = 0
-        for fv in feature_views:
-            if fv.ttl and isinstance(fv.ttl, timedelta):
-                max_ttl_seconds = max(max_ttl_seconds, int(fv.ttl.total_seconds()))
-        start_date: datetime = (
-            end_date - timedelta(seconds=max_ttl_seconds)
-            if max_ttl_seconds > 0
-            else end_date - timedelta(days=30)
-        )
-    else:
-        start_date = start_date_opt
-    return (start_date, end_date)
 
 
 def _gather_all_entities(

--- a/sdk/python/feast/infra/offline_stores/dask.py
+++ b/sdk/python/feast/infra/offline_stores/dask.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
@@ -37,7 +37,10 @@ from feast.infra.registry.base_registry import BaseRegistry
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
-from feast.utils import _get_requested_feature_views_to_features_dict, make_tzaware
+from feast.utils import (
+    _get_requested_feature_views_to_features_dict,
+    compute_non_entity_date_range,
+)
 
 # DaskRetrievalJob will cast string objects to string[pyarrow] from dask version 2023.7.1
 # This is not the desired behavior for our use case, so we set the convert-string option to False
@@ -143,36 +146,14 @@ class DaskOfflineStore(OfflineStore):
         for fv in feature_views:
             assert isinstance(fv.batch_source, FileSource)
 
-        # Allow non-entity mode using start/end timestamps to enable bounded retrievals without an input entity_df.
-        # This synthesizes a minimal entity_df solely to drive the existing join and metadata plumbing without
-        # incurring source scans here; actual pushdowns can be layered in follow-ups if needed.
-        start_date: Optional[datetime] = kwargs.get("start_date", None)
-        end_date: Optional[datetime] = kwargs.get("end_date", None)
         non_entity_mode = entity_df is None
 
         if non_entity_mode:
-            # Default end_date to current time (UTC) to keep behavior predictable without extra parameters.
-            end_date = (
-                make_tzaware(end_date) if end_date else datetime.now(timezone.utc)
+            start_date, end_date = compute_non_entity_date_range(
+                feature_views,
+                start_date=kwargs.get("start_date"),
+                end_date=kwargs.get("end_date"),
             )
-
-            # When start_date is not provided, choose a conservative lower bound using max TTL, otherwise fall back.
-            if start_date is None:
-                max_ttl_seconds = 0
-                for fv in feature_views:
-                    if fv.ttl and isinstance(fv.ttl, timedelta):
-                        max_ttl_seconds = max(
-                            max_ttl_seconds, int(fv.ttl.total_seconds())
-                        )
-                if max_ttl_seconds > 0:
-                    start_date = end_date - timedelta(seconds=max_ttl_seconds)
-                else:
-                    # Keep default window bounded to avoid unbounded scans by default.
-                    start_date = end_date - timedelta(days=30)
-            start_date = make_tzaware(start_date)
-
-            # Minimal synthetic entity_df: one timestamp row; join keys are not materialized here on purpose to avoid
-            # accidental dependence on specific feature view schemas at this layer.
             entity_df = pd.DataFrame(
                 {DEFAULT_ENTITY_DF_EVENT_TIMESTAMP_COL: [end_date]}
             )

--- a/sdk/python/feast/utils.py
+++ b/sdk/python/feast/utils.py
@@ -4,7 +4,7 @@ import os
 import typing
 import warnings
 from collections import Counter, defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import (
     Any,
@@ -70,6 +70,38 @@ def make_tzaware(t: datetime) -> datetime:
         return t.replace(tzinfo=timezone.utc)
     else:
         return t
+
+
+def compute_non_entity_date_range(
+    feature_views: List["FeatureView"],
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+    default_window_days: int = 30,
+) -> Tuple[datetime, datetime]:
+
+    if end_date is None:
+        end_date = datetime.now(tz=timezone.utc)
+    else:
+        end_date = make_tzaware(end_date)
+
+    if start_date is None:
+        max_ttl_seconds = max(
+            (
+                int(fv.ttl.total_seconds())
+                for fv in feature_views
+                if fv.ttl and isinstance(fv.ttl, timedelta)
+            ),
+            default=0,
+        )
+        start_date = end_date - timedelta(
+            seconds=max_ttl_seconds
+            if max_ttl_seconds > 0
+            else default_window_days * 86400
+        )
+    else:
+        start_date = make_tzaware(start_date)
+
+    return start_date, end_date
 
 
 def make_df_tzaware(t: pd.DataFrame) -> pd.DataFrame:

--- a/sdk/python/tests/unit/infra/offline_stores/test_dask_non_entity.py
+++ b/sdk/python/tests/unit/infra/offline_stores/test_dask_non_entity.py
@@ -311,7 +311,7 @@ class TestNonEntityRetrieval:
         # Latest value should be 0.3 (from 2023-01-07)
         assert 0.3 in driver1_data["conv_rate"].values
 
-    @patch("feast.infra.offline_stores.dask.datetime")
+    @patch("feast.utils.datetime")
     def test_no_dates_provided_defaults_to_current_time_and_filters_data(
         self, mock_datetime, monkeypatch
     ):


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing
-->
- Added `compute_non_entity_date_range()` to `feast/utils.py` to consolidate duplicated start/end date resolution logic used by offline stores in non-entity retrieval mode.
- Replaced 5 identical inline/private implementations (dask, postgres, spark, ray, oracle) with calls to the shared utility.
- Fixed ClickHouse offline store which was missing `start_date`/TTL computation entirely in non-entity mode.
# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes :- [Comment](https://github.com/feast-dev/feast/pull/6108/changes/BASE..7ec2d22f0fb5c043f442a856ecc59799418f5a34#r2958401462)
# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
