### PR TITLE
feat: Add metadata statistics to registry api

### DIFF
--- a/sdk/python/feast/api/registry/rest/metrics.py
+++ b/sdk/python/feast/api/registry/rest/metrics.py
@@ -65,83 +65,155 @@ def get_metrics_router(grpc_handler, server=None) -> APIRouter:
         ),
         allow_cache: bool = Query(True),
     ):
-        def count_resources_for_project(project_name: str):
+        """
+        Resource counts and feature store inventory metadata.
+
+        Returns counts per resource type, plus enriched summaries:
+        feature services (names), feature views (with per-view feature
+        count and materialization info), project list, and the registry
+        last-updated timestamp.
+        """
+
+        def get_registry_last_updated() -> Optional[str]:
             try:
-                entities = grpc_call(
+                from google.protobuf.empty_pb2 import Empty as EmptyProto
+
+                registry_proto = grpc_call(grpc_handler.Proto, EmptyProto())
+                return registry_proto.get("lastUpdated", None)
+            except Exception:
+                return None
+
+        def _extract_fv_summary(any_fv: dict, project_name: str) -> Optional[Dict]:
+            fv = _extract_feature_view_from_any(any_fv)
+            if not fv:
+                return None
+            spec = fv.get("spec", {})
+            features = spec.get("features", [])
+            return {
+                "name": spec.get("name", ""),
+                "project": project_name,
+                "type": fv.get("type", "featureView"),
+                "featureCount": len(features) if isinstance(features, list) else 0,
+            }
+
+        def collect_resources_for_project(project_name: str) -> dict:
+            entities_list: list = []
+            try:
+                entities_resp = grpc_call(
                     grpc_handler.ListEntities,
                     RegistryServer_pb2.ListEntitiesRequest(
                         project=project_name, allow_cache=allow_cache
                     ),
                 )
+                entities_list = entities_resp.get("entities", [])
             except Exception:
-                entities = {"entities": []}
+                pass
+
+            data_sources_list: list = []
             try:
-                data_sources = grpc_call(
+                ds_resp = grpc_call(
                     grpc_handler.ListDataSources,
                     RegistryServer_pb2.ListDataSourcesRequest(
                         project=project_name, allow_cache=allow_cache
                     ),
                 )
+                data_sources_list = ds_resp.get("dataSources", [])
             except Exception:
-                data_sources = {"dataSources": []}
+                pass
+
+            saved_datasets_list: list = []
             try:
-                saved_datasets = grpc_call(
+                sd_resp = grpc_call(
                     grpc_handler.ListSavedDatasets,
                     RegistryServer_pb2.ListSavedDatasetsRequest(
                         project=project_name, allow_cache=allow_cache
                     ),
                 )
+                saved_datasets_list = sd_resp.get("savedDatasets", [])
             except Exception:
-                saved_datasets = {"savedDatasets": []}
+                pass
+
+            features_list: list = []
             try:
-                features = grpc_call(
+                feat_resp = grpc_call(
                     grpc_handler.ListFeatures,
                     RegistryServer_pb2.ListFeaturesRequest(
                         project=project_name, allow_cache=allow_cache
                     ),
                 )
+                features_list = feat_resp.get("features", [])
             except Exception:
-                features = {"features": []}
+                pass
+
+            raw_fv_list: list = []
+            fv_summaries: List[Dict] = []
             try:
-                feature_views = grpc_call(
+                fv_resp = grpc_call(
                     grpc_handler.ListAllFeatureViews,
                     RegistryServer_pb2.ListAllFeatureViewsRequest(
                         project=project_name, allow_cache=allow_cache
                     ),
                 )
+                raw_fv_list = fv_resp.get("featureViews", [])
+                for any_fv in raw_fv_list:
+                    summary = _extract_fv_summary(any_fv, project_name)
+                    if summary:
+                        fv_summaries.append(summary)
             except Exception:
-                feature_views = {"featureViews": []}
+                pass
+
+            fs_summaries: List[Dict] = []
+            raw_fs_list: list = []
             try:
-                feature_services = grpc_call(
+                fs_resp = grpc_call(
                     grpc_handler.ListFeatureServices,
                     RegistryServer_pb2.ListFeatureServicesRequest(
                         project=project_name, allow_cache=allow_cache
                     ),
                 )
+                raw_fs_list = fs_resp.get("featureServices", [])
+                for fs in raw_fs_list:
+                    spec = fs.get("spec", {})
+                    fs_summaries.append(
+                        {"name": spec.get("name", ""), "project": project_name}
+                    )
             except Exception:
-                feature_services = {"featureServices": []}
+                pass
+
             return {
-                "entities": len(entities.get("entities", [])),
-                "dataSources": len(data_sources.get("dataSources", [])),
-                "savedDatasets": len(saved_datasets.get("savedDatasets", [])),
-                "features": len(features.get("features", [])),
-                "featureViews": len(feature_views.get("featureViews", [])),
-                "featureServices": len(feature_services.get("featureServices", [])),
+                "counts": {
+                    "entities": len(entities_list),
+                    "dataSources": len(data_sources_list),
+                    "savedDatasets": len(saved_datasets_list),
+                    "features": len(features_list),
+                    "featureViews": len(fv_summaries),
+                    "featureServices": len(fs_summaries),
+                },
+                "featureServices": fs_summaries,
+                "featureViews": fv_summaries,
             }
 
+        registry_last_updated = get_registry_last_updated()
+
         if project:
-            counts = count_resources_for_project(project)
-            return {"project": project, "counts": counts}
+            resources = collect_resources_for_project(project)
+            return {
+                "project": project,
+                "counts": resources["counts"],
+                "featureServices": resources["featureServices"],
+                "featureViews": resources["featureViews"],
+                "projects": [{"name": project}],
+                "registryLastUpdated": registry_last_updated,
+            }
         else:
-            # List all projects via gRPC
             projects_resp = grpc_call(
                 grpc_handler.ListProjects,
                 RegistryServer_pb2.ListProjectsRequest(allow_cache=allow_cache),
             )
-            all_projects = [
-                p["spec"]["name"] for p in projects_resp.get("projects", [])
-            ]
-            all_counts = {}
+            all_projects = projects_resp.get("projects", [])
+            project_names = [p["spec"]["name"] for p in all_projects if "spec" in p]
+
+            all_counts: Dict[str, dict] = {}
             total_counts = {
                 "entities": 0,
                 "dataSources": 0,
@@ -150,12 +222,37 @@ def get_metrics_router(grpc_handler, server=None) -> APIRouter:
                 "featureViews": 0,
                 "featureServices": 0,
             }
-            for project_name in all_projects:
-                counts = count_resources_for_project(project_name)
-                all_counts[project_name] = counts
+            all_fs: List[Dict] = []
+            all_fv: List[Dict] = []
+            project_summaries: List[Dict] = []
+
+            for pname in project_names:
+                resources = collect_resources_for_project(pname)
+                counts = resources["counts"]
+                all_counts[pname] = counts
                 for k in total_counts:
                     total_counts[k] += counts[k]
-            return {"total": total_counts, "perProject": all_counts}
+                all_fs.extend(resources["featureServices"])
+                all_fv.extend(resources["featureViews"])
+                proj_info: Dict = next(
+                    (p for p in all_projects if p.get("spec", {}).get("name") == pname),
+                    {},
+                )
+                project_summaries.append(
+                    {
+                        "name": pname,
+                        "description": proj_info.get("spec", {}).get("description", ""),
+                    }
+                )
+
+            return {
+                "total": total_counts,
+                "perProject": all_counts,
+                "featureServices": all_fs,
+                "featureViews": all_fv,
+                "projects": project_summaries,
+                "registryLastUpdated": registry_last_updated,
+            }
 
     @router.get(
         "/metrics/popular_tags", tags=["Metrics"], response_model=PopularTagsResponse

--- a/sdk/python/tests/unit/api/test_api_rest_registry.py
+++ b/sdk/python/tests/unit/api/test_api_rest_registry.py
@@ -1503,10 +1503,49 @@ def test_metrics_resource_counts_via_rest(fastapi_test_app):
     assert "featureViews" in counts
     assert "featureServices" in counts
 
-    # Verify counts are integers
     for key, value in counts.items():
         assert isinstance(value, int)
         assert value >= 0
+
+    # Verify feature services summaries
+    assert "featureServices" in data
+    assert isinstance(data["featureServices"], list)
+    assert len(data["featureServices"]) == counts["featureServices"]
+    for fs in data["featureServices"]:
+        assert "name" in fs
+        assert "project" in fs
+        assert fs["project"] == "demo_project"
+    service_names = [fs["name"] for fs in data["featureServices"]]
+    assert "user_service" in service_names
+
+    # Verify feature views summaries with detail
+    assert "featureViews" in data
+    assert isinstance(data["featureViews"], list)
+    assert len(data["featureViews"]) == counts["featureViews"]
+    for fv in data["featureViews"]:
+        assert "name" in fv
+        assert "project" in fv
+        assert "type" in fv
+        assert "featureCount" in fv
+        assert isinstance(fv["featureCount"], int)
+        assert fv["featureCount"] >= 0
+        assert fv["project"] == "demo_project"
+    fv_names = [fv["name"] for fv in data["featureViews"]]
+    assert "user_profile" in fv_names
+    user_profile_fv = next(
+        fv for fv in data["featureViews"] if fv["name"] == "user_profile"
+    )
+    assert user_profile_fv["featureCount"] == 2
+
+    # Verify projects list
+    assert "projects" in data
+    assert isinstance(data["projects"], list)
+    assert len(data["projects"]) == 1
+    assert data["projects"][0]["name"] == "demo_project"
+
+    # Verify registry last updated
+    assert "registryLastUpdated" in data
+    assert data["registryLastUpdated"] is not None
 
     # Test without project parameter (should return all projects)
     response = fastapi_test_app.get("/metrics/resource_counts")
@@ -1526,6 +1565,28 @@ def test_metrics_resource_counts_via_rest(fastapi_test_app):
     per_project = data["perProject"]
     assert "demo_project" in per_project
     assert isinstance(per_project["demo_project"], dict)
+
+    # Verify metadata in all-projects mode
+    assert "featureServices" in data
+    assert isinstance(data["featureServices"], list)
+
+    assert "featureViews" in data
+    assert isinstance(data["featureViews"], list)
+    for fv in data["featureViews"]:
+        assert "name" in fv
+        assert "project" in fv
+        assert "type" in fv
+        assert "featureCount" in fv
+
+    assert "projects" in data
+    assert isinstance(data["projects"], list)
+    assert len(data["projects"]) >= 1
+    for proj in data["projects"]:
+        assert "name" in proj
+        assert "description" in proj
+
+    assert "registryLastUpdated" in data
+    assert data["registryLastUpdated"] is not None
 
 
 def test_metrics_resource_counts_with_permission_errors(fastapi_test_app):
@@ -1585,6 +1646,10 @@ def test_metrics_resource_counts_with_permission_errors(fastapi_test_app):
     assert counts["features"] == baseline_counts["features"]
     assert counts["savedDatasets"] == baseline_counts["savedDatasets"]
 
+    # Permitted metadata summaries should still be populated
+    assert len(data["featureViews"]) == baseline_counts["featureViews"]
+    assert len(data["featureServices"]) == baseline_counts["featureServices"]
+
     # Now test with ALL resource types denied
     def grpc_call_all_denied(handler_fn, request):
         handler_name = getattr(handler_fn, "__name__", "")
@@ -1606,6 +1671,10 @@ def test_metrics_resource_counts_with_permission_errors(fastapi_test_app):
         assert count == 0, (
             f"Expected 0 for {resource_type} when permission denied, got {count}"
         )
+
+    # Metadata summaries should be empty when all permissions are denied
+    assert data["featureViews"] == []
+    assert data["featureServices"] == []
 
 
 def test_feature_views_all_types_and_resource_counts_match(fastapi_test_app):
@@ -1931,3 +2000,19 @@ def test_all_endpoints_return_404_for_invalid_objects(fastapi_test_app):
     data = response.json()
     assert data["status_code"] == 404
     assert data["error_type"] == "FeastObjectNotFoundException"
+
+
+def test_metrics_resource_counts_nonexistent_project(fastapi_test_app):
+    """Test /metrics/resource_counts with a non-existent project returns empty data."""
+    response = fastapi_test_app.get(
+        "/metrics/resource_counts?project=nonexistent_project"
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    counts = data["counts"]
+    for value in counts.values():
+        assert value == 0
+    assert data["featureServices"] == []
+    assert data["featureViews"] == []
+    assert "registryLastUpdated" in data


### PR DESCRIPTION

# What this PR does / why we need it:

This PR enrich `/metrics/resource_counts` with feature store inventory metadata.

Extended the existing GET `/metrics/resource_counts` endpoint to include feature store inventory metadata alongside the existing resource counts, giving users a single-call view of their feature store without querying the registry directly.

The response now includes (in addition to the existing backward-compatible counts):

**featureServices** - list of registered services with name and project
**featureViews** - list of feature views with name, project, type (featureView/onDemandFeatureView/streamFeatureView), and per-view feature count
**projects** - list of projects (with description in all-projects mode)
**registryLastUpdated** - registry last-updated timestamp


```
{
  "total": {
    "entities": 4,
    "dataSources": 3,
    "savedDatasets": 0,
    "features": 20,
    "featureViews": 8,
    "featureServices": 6
  },
  "perProject": {
    "multiproject1": {
      "entities": 2,
      "dataSources": 3,
      "savedDatasets": 0,
      "features": 10,
      "featureViews": 4,
      "featureServices": 3
    },
    "multiproject2": {
      "entities": 2,
      "dataSources": 0,
      "savedDatasets": 0,
      "features": 10,
      "featureViews": 4,
      "featureServices": 3
    }
  },
  "featureServices": [
    {
      "name": "driver_activity_v2",
      "project": "multiproject1"
    },
    {
      "name": "driver_activity_v1",
      "project": "multiproject1"
    },
    {
      "name": "driver_activity_v3",
      "project": "multiproject1"
    },
    {
      "name": "driver_activity_v3",
      "project": "multiproject2"
    },
    {
      "name": "driver_activity_v1",
      "project": "multiproject2"
    },
    {
      "name": "driver_activity_v2",
      "project": "multiproject2"
    }
  ],
  "featureViews": [
    {
      "name": "driver_hourly_stats_fresh",
      "project": "multiproject1",
      "type": "featureView",
      "featureCount": 3
    },
    {
      "name": "driver_hourly_stats",
      "project": "multiproject1",
      "type": "featureView",
      "featureCount": 3
    },
    {
      "name": "transformed_conv_rate_fresh",
      "project": "multiproject1",
      "type": "onDemandFeatureView",
      "featureCount": 2
    },
    {
      "name": "transformed_conv_rate",
      "project": "multiproject1",
      "type": "onDemandFeatureView",
      "featureCount": 2
    },
    {
      "name": "driver_hourly_stats",
      "project": "multiproject2",
      "type": "featureView",
      "featureCount": 3
    },
    {
      "name": "driver_hourly_stats_fresh",
      "project": "multiproject2",
      "type": "featureView",
      "featureCount": 3
    },
    {
      "name": "transformed_conv_rate",
      "project": "multiproject2",
      "type": "onDemandFeatureView",
      "featureCount": 2
    },
    {
      "name": "transformed_conv_rate_fresh",
      "project": "multiproject2",
      "type": "onDemandFeatureView",
      "featureCount": 2
    }
  ],
  "projects": [
    {
      "name": "multiproject1",
      "description": "A project for driver statistics"
    },
    {
      "name": "multiproject2",
      "description": "A project for driver statistics"
    }
  ],
  "registryLastUpdated": "2026-03-26T07:43:11.019554Z"
}
```

# Which issue(s) this PR fixes:

Fixes https://github.com/feast-dev/feast/issues/5921 



# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Testing is not required for this change


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
