### PR TITLE
feat: Add version indicators to lineage graph nodes

### DIFF
--- a/ui/src/components/RegistryVisualization.test.tsx
+++ b/ui/src/components/RegistryVisualization.test.tsx
@@ -304,21 +304,20 @@ describe("RegistryVisualization version indicators", () => {
           spec: { name: "my_entity" },
         }),
       ],
-      featureViewVersionHistory:
-        feast.core.FeatureViewVersionHistory.create({
-          records: [
-            feast.core.FeatureViewVersionRecord.create({
-              featureViewName: "versioned_fv",
-              versionNumber: 1,
-              description: "Initial version",
-            }),
-            feast.core.FeatureViewVersionRecord.create({
-              featureViewName: "versioned_fv",
-              versionNumber: 2,
-              description: "Added new features",
-            }),
-          ],
-        }),
+      featureViewVersionHistory: feast.core.FeatureViewVersionHistory.create({
+        records: [
+          feast.core.FeatureViewVersionRecord.create({
+            featureViewName: "versioned_fv",
+            versionNumber: 1,
+            description: "Initial version",
+          }),
+          feast.core.FeatureViewVersionRecord.create({
+            featureViewName: "versioned_fv",
+            versionNumber: 2,
+            description: "Added new features",
+          }),
+        ],
+      }),
     });
 
     const relationships = [

--- a/ui/src/components/RegistryVisualization.tsx
+++ b/ui/src/components/RegistryVisualization.tsx
@@ -122,8 +122,7 @@ const CustomNode = ({ data }: { data: NodeData }) => {
   const icon = getNodeIcon(data.type);
   const [isHovered, setIsHovered] = useState(false);
   const hasPermissions = data.permissions && data.permissions.length > 0;
-  const hasVersion =
-    data.versionNumber != null && data.versionNumber > 1;
+  const hasVersion = data.versionNumber != null && data.versionNumber > 1;
 
   const handleClick = () => {
     let path;
@@ -559,8 +558,10 @@ const registryToFlow = (
       const name = groupedNames[i];
       const records = grouped[name];
       records.sort(
-        (a: feast.core.IFeatureViewVersionRecord, b: feast.core.IFeatureViewVersionRecord) =>
-          (b.versionNumber ?? 0) - (a.versionNumber ?? 0),
+        (
+          a: feast.core.IFeatureViewVersionRecord,
+          b: feast.core.IFeatureViewVersionRecord,
+        ) => (b.versionNumber ?? 0) - (a.versionNumber ?? 0),
       );
       versionInfoMap.set(name, {
         totalVersions: records.length,


### PR DESCRIPTION
## Summary

- Adds version badges (`v2`, `v3`, etc.) to Feature View nodes in the lineage graph when they have `currentVersionNumber > 0`
- Hovering the badge shows a tooltip with the version number, total versions from history, and latest version description
- Adds a "Version Changed" entry to the lineage legend
- Fixes a pre-existing eslint warning (missing `permissions` dependency in `useEffect`)

## Screenshot
Notice the "Version Changed" in the Legend section and the bottom right corner of each Feature View.

<img width="1918" height="1191" alt="Screenshot 2026-03-27 at 9 15 48 AM" src="https://github.com/user-attachments/assets/01b8cd1b-cf9f-476f-b3a2-1fe0e2bed748" />


## Test plan
- [x] 7 new tests in `RegistryVisualization.test.tsx` covering:
  - Version badge renders for regular, on-demand, and stream feature views with `currentVersionNumber > 0`
  - No badge when version is `0` or absent
  - Version history data from `featureViewVersionHistory` is passed through
  - Legend shows "Version Changed" entry
- [x] All 11 existing UI tests continue to pass
- [x] Manual verification via `npm start` — lineage page shows badges on versioned nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
