### PR TITLE
feat: Add versioning support for DynamoDB online store

### DIFF
--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -1154,8 +1154,17 @@ def _initialize_dynamodb_resource(
 def _get_table_name(
     online_config: DynamoDBOnlineStoreConfig, config: RepoConfig, table: FeatureView
 ) -> str:
+    table_name = table.name
+    if config.registry.enable_online_feature_view_versioning:
+        # Prefer version_tag from the projection (set by version-qualified refs like @v2)
+        # over current_version_number (the FV's active version in metadata).
+        version = getattr(table.projection, "version_tag", None)
+        if version is None:
+            version = getattr(table, "current_version_number", None)
+        if version is not None and version > 0:
+            table_name = f"{table.name}_v{version}"
     return online_config.table_name_template.format(
-        project=config.project, table_name=table.name
+        project=config.project, table_name=table_name
     )
 
 

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -256,9 +256,10 @@ class OnlineStore(ABC):
 
     def _check_versioned_read_support(self, grouped_refs):
         """Raise an error if versioned reads are attempted on unsupported stores."""
+        from feast.infra.online_stores.dynamodb import DynamoDBOnlineStore
         from feast.infra.online_stores.sqlite import SqliteOnlineStore
 
-        if isinstance(self, SqliteOnlineStore):
+        if isinstance(self, (SqliteOnlineStore, DynamoDBOnlineStore)):
             return
         for table, _ in grouped_refs:
             version_tag = getattr(table.projection, "version_tag", None)

--- a/sdk/python/tests/unit/infra/online_store/test_dynamodb_online_store.py
+++ b/sdk/python/tests/unit/infra/online_store/test_dynamodb_online_store.py
@@ -12,6 +12,7 @@ from feast.infra.offline_stores.dask import DaskOfflineStoreConfig
 from feast.infra.online_stores.dynamodb import (
     DynamoDBOnlineStore,
     DynamoDBOnlineStoreConfig,
+    _get_table_name,
     _latest_data_to_write,
 )
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
@@ -1050,3 +1051,120 @@ def test_dynamodb_online_store_thread_safety_uses_shared_client(
         f"Expected 1 shared client for thread-safety, "
         f"got {len(set(dynamodb_clients))} unique clients"
     )
+
+
+@dataclass
+class MockProjection:
+    version_tag: Optional[int] = None
+
+
+@dataclass
+class MockFeatureViewWithProjection:
+    name: str
+    projection: MockProjection
+    current_version_number: Optional[int] = None
+    tags: Optional[dict] = None
+
+
+def _make_repo_config(enable_versioning: bool = False) -> RepoConfig:
+    from feast.repo_config import RegistryConfig
+
+    registry_cfg = RegistryConfig(
+        path="s3://test_registry/registry.db",
+        enable_online_feature_view_versioning=enable_versioning,
+    )
+    return RepoConfig(
+        registry=registry_cfg,
+        project=PROJECT,
+        provider=PROVIDER,
+        online_store=DynamoDBOnlineStoreConfig(region=REGION),
+        offline_store=DaskOfflineStoreConfig(),
+        entity_key_serialization_version=3,
+    )
+
+
+def test_get_table_name_no_versioning():
+    """Without versioning enabled, table name is always the plain template."""
+    config = _make_repo_config(enable_versioning=False)
+    online_config = config.online_store
+    fv = MockFeatureViewWithProjection(
+        name="driver_stats",
+        projection=MockProjection(version_tag=2),
+        current_version_number=2,
+    )
+    assert _get_table_name(online_config, config, fv) == f"{PROJECT}.driver_stats"
+
+
+def test_get_table_name_versioning_with_projection_version_tag():
+    """When versioning is enabled, projection.version_tag takes precedence."""
+    config = _make_repo_config(enable_versioning=True)
+    online_config = config.online_store
+    fv = MockFeatureViewWithProjection(
+        name="driver_stats",
+        projection=MockProjection(version_tag=2),
+        current_version_number=5,  # should be ignored in favour of projection tag
+    )
+    assert _get_table_name(online_config, config, fv) == f"{PROJECT}.driver_stats_v2"
+
+
+def test_get_table_name_versioning_falls_back_to_current_version_number():
+    """When projection.version_tag is None, current_version_number is used."""
+    config = _make_repo_config(enable_versioning=True)
+    online_config = config.online_store
+    fv = MockFeatureViewWithProjection(
+        name="driver_stats",
+        projection=MockProjection(version_tag=None),
+        current_version_number=3,
+    )
+    assert _get_table_name(online_config, config, fv) == f"{PROJECT}.driver_stats_v3"
+
+
+def test_get_table_name_versioning_version_zero_is_unversioned():
+    """A version value of 0 should not add a suffix (sentinel for 'no version')."""
+    config = _make_repo_config(enable_versioning=True)
+    online_config = config.online_store
+    fv = MockFeatureViewWithProjection(
+        name="driver_stats",
+        projection=MockProjection(version_tag=0),
+        current_version_number=0,
+    )
+    assert _get_table_name(online_config, config, fv) == f"{PROJECT}.driver_stats"
+
+
+def test_get_table_name_versioning_no_version_info():
+    """When versioning is enabled but no version is set, plain name is used."""
+    config = _make_repo_config(enable_versioning=True)
+    online_config = config.online_store
+    fv = MockFeatureViewWithProjection(
+        name="driver_stats",
+        projection=MockProjection(version_tag=None),
+        current_version_number=None,
+    )
+    assert _get_table_name(online_config, config, fv) == f"{PROJECT}.driver_stats"
+
+
+def test_get_table_name_custom_template_with_versioning():
+    """Custom table_name_template respects the versioned table_name fragment."""
+    from feast.repo_config import RegistryConfig
+
+    registry_cfg = RegistryConfig(
+        path="s3://test_registry/registry.db",
+        enable_online_feature_view_versioning=True,
+    )
+    config = RepoConfig(
+        registry=registry_cfg,
+        project=PROJECT,
+        provider=PROVIDER,
+        online_store=DynamoDBOnlineStoreConfig(
+            region=REGION,
+            table_name_template="{project}__{table_name}",
+        ),
+        offline_store=DaskOfflineStoreConfig(),
+        entity_key_serialization_version=3,
+    )
+    online_config = config.online_store
+    fv = MockFeatureViewWithProjection(
+        name="driver_stats",
+        projection=MockProjection(version_tag=4),
+    )
+    assert _get_table_name(online_config, config, fv) == f"{PROJECT}__driver_stats_v4"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->
---                      
  What this PR does / why we need it

  Closes #6163 
                                                                                                               
  Feature view versioning was introduced in #6101, but version-qualified feature references (e.g.
  driver_stats@v2:trips_today) only worked with the SQLite online store. All other online stores raised        
  VersionedOnlineReadNotSupported when a versioned ref was used.                                             
                                                                                                               
  This PR adds versioned read/write support to the DynamoDB online store, following the same pattern as the  
  SQLite reference implementation:

  - Write path: when enable_online_feature_view_versioning is enabled, _get_table_name appends a _v{N} suffix  
  to the DynamoDB table name (e.g. project.driver_stats_v2), routing materialization to the correct versioned
  table                                                                                                        
  - Read path: version-qualified lookups (@v2) set projection.version_tag on the feature view before         
  online_read is called; _get_table_name picks this up and routes to the correct table. projection.version_tag 
  takes priority over current_version_number so explicit version requests are always honoured
  - Gate: _check_versioned_read_support in online_store.py now allows DynamoDBOnlineStore through, covering    
  both sync and async read paths                                                                               
   
  All existing read/write/update/teardown methods are covered by the single change to _get_table_name since    
  every method routes through it.                                                                            
                                                                                                               
  Which issue(s) this PR fixes                                                                               

  Part of #2728

  Checks

  - I've made sure the tests are passing.
  - My commits are signed off (git commit -s)
  - My PR title follows conventional commits format                                                            
   
  Testing Strategy                                                                                             
                                                                                                             
  - Unit tests — 6 new unit tests for _get_table_name covering: versioning disabled, projection.version_tag    
  priority, current_version_number fallback, version 0 edge case, no version info, custom template
  - Manual tests — end-to-end smoke test using moto (mocked DynamoDB) exercising write → read round trips      
  across v1/v2 isolation, fallback behaviour, and missing entity handling                                      
   
  Misc                                                                                                         
                                                                                                             
  The version suffix is composed before the table_name_template is applied, so custom table_name_template      
  values (e.g. "{project}__{table_name}") continue to work correctly with versioning enabled.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
