### PR TITLE
feat: Add SingleStore online store support for feature view versioning

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1510,7 +1510,7 @@
         "filename": "sdk/python/tests/universal/feature_repos/universal/online_store/postgres.py",
         "hashed_secret": "95433727ea51026e1e0dc8deadaabd4a3baaaaf4",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 21
       }
     ],
     "sdk/python/tests/universal/feature_repos/universal/online_store/singlestore.py": [

--- a/infra/feast-operator/Dockerfile
+++ b/infra/feast-operator/Dockerfile
@@ -1,10 +1,8 @@
 # Build the manager binary
-FROM golang:1.22.9 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ENV GOTOOLCHAIN=auto
-
-WORKDIR /workspace
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -25,8 +23,9 @@ COPY internal/controller/ internal/controller/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-FROM gcr.io/distroless/base-debian12:nonroot
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /opt/app-root/src/manager .
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/infra/feast-operator/Dockerfile
+++ b/infra/feast-operator/Dockerfile
@@ -1,8 +1,10 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM golang:1.22.9 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ENV GOTOOLCHAIN=auto
+
+WORKDIR /workspace
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -23,9 +25,8 @@ COPY internal/controller/ internal/controller/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM gcr.io/distroless/base-debian12:nonroot
 WORKDIR /
-COPY --from=builder /opt/app-root/src/manager .
-USER 65532:65532
+COPY --from=builder /workspace/manager .
 
 ENTRYPOINT ["/manager"]

--- a/infra/feast-operator/Dockerfile
+++ b/infra/feast-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ENV GOTOOLCHAIN=auto

--- a/infra/scripts/compile-templates.py
+++ b/infra/scripts/compile-templates.py
@@ -28,7 +28,7 @@ repo_root = find_repo(__file__)
 # Template README.md
 ############################
 roadmap_path = repo_root / "docs" / "roadmap.md"
-with open(roadmap_path, "r") as f:
+with open(roadmap_path, "r", encoding="utf-8") as f:
     # skip first lines since it has the title
     roadmap_contents_lines = f.readlines()[2:]
 
@@ -36,7 +36,7 @@ with open(roadmap_path, "r") as f:
     roadmap_contents = "".join(roadmap_contents_lines)
 
 template_path = repo_root / "infra" / "templates" / "README.md.jinja2"
-with open(template_path) as f:
+with open(template_path, encoding="utf-8") as f:
     template = Template(f.read())
 
 # Compile template
@@ -49,5 +49,5 @@ readme_md = (
 )
 
 readme_path = repo_root / "README.md"
-with open(readme_path, "w") as f:
+with open(readme_path, "w", encoding="utf-8") as f:
     f.write(readme_md)

--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -142,7 +142,7 @@ class VersionedOnlineReadNotSupported(FeastError):
     def __init__(self, store_name: str, version: int):
         super().__init__(
             f"Versioned feature reads (@v{version}) are not yet supported by {store_name}. "
-            f"Currently only SQLite, PostgreSQL, MySQL, FAISS, Redis, and DynamoDB support version-qualified feature references. "
+            f"Currently only SQLite, PostgreSQL, MySQL, FAISS, Redis, DynamoDB, and SingleStore support version-qualified feature references. "
         )
 
 

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -1335,7 +1335,9 @@ class FeatureStore:
 
         entities = self.list_entities()
 
-        self._get_provider().teardown_infra(self.project, tables, entities)
+        self._get_provider().teardown_infra(
+            self.project, tables, entities, registry=self.registry
+        )
         self.registry.teardown()
 
     def get_historical_features(

--- a/sdk/python/feast/infra/online_stores/bigtable.py
+++ b/sdk/python/feast/infra/online_stores/bigtable.py
@@ -306,6 +306,7 @@ class BigtableOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ):
         # Because of historical reasons, Feast calls them tables. We use this alias for
         # readability.

--- a/sdk/python/feast/infra/online_stores/bigtable.py
+++ b/sdk/python/feast/infra/online_stores/bigtable.py
@@ -13,6 +13,7 @@ from feast import Entity, FeatureView, utils
 from feast.feature_view import DUMMY_ENTITY_NAME
 from feast.infra.online_stores.helpers import compute_entity_id
 from feast.infra.online_stores.online_store import OnlineStore
+from feast.infra.registry.base_registry import BaseRegistry
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import FeastConfigBaseModel, RepoConfig

--- a/sdk/python/feast/infra/online_stores/cassandra_online_store/cassandra_online_store.py
+++ b/sdk/python/feast/infra/online_stores/cassandra_online_store/cassandra_online_store.py
@@ -460,6 +460,7 @@ class CassandraOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         """
         Delete tables from the database.

--- a/sdk/python/feast/infra/online_stores/couchbase_online_store/couchbase.py
+++ b/sdk/python/feast/infra/online_stores/couchbase_online_store/couchbase.py
@@ -274,6 +274,7 @@ class CouchbaseOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         """
         Delete tables from the database.

--- a/sdk/python/feast/infra/online_stores/datastore.py
+++ b/sdk/python/feast/infra/online_stores/datastore.py
@@ -139,6 +139,7 @@ class DatastoreOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         online_config = config.online_store
         assert isinstance(online_config, DatastoreOnlineStoreConfig)

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -359,6 +359,7 @@ class DynamoDBOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         """
         Delete tables from the DynamoDB Online Store.

--- a/sdk/python/feast/infra/online_stores/dynamodb.py
+++ b/sdk/python/feast/infra/online_stores/dynamodb.py
@@ -124,6 +124,8 @@ class DynamoDBOnlineStore(OnlineStore):
         _type_deserializer: Cached TypeDeserializer instance for performance.
     """
 
+    supports_versioned_online_reads = True
+
     _dynamodb_client = None
     _dynamodb_resource = None
     # Class-level cached TypeDeserializer to avoid per-request instantiation

--- a/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
+++ b/sdk/python/feast/infra/online_stores/elasticsearch_online_store/elasticsearch.py
@@ -263,6 +263,7 @@ class ElasticSearchOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         project = config.project
         try:

--- a/sdk/python/feast/infra/online_stores/faiss_online_store.py
+++ b/sdk/python/feast/infra/online_stores/faiss_online_store.py
@@ -51,6 +51,8 @@ def _table_id(project: str, table: FeatureView, enable_versioning: bool = False)
 class FaissOnlineStore(OnlineStore):
     _logger: logging.Logger = logging.getLogger(__name__)
 
+    supports_versioned_online_reads = True
+
     def __init__(self):
         super().__init__()
         self._indices: Dict[str, faiss.IndexIVFFlat] = {}

--- a/sdk/python/feast/infra/online_stores/faiss_online_store.py
+++ b/sdk/python/feast/infra/online_stores/faiss_online_store.py
@@ -100,6 +100,7 @@ class FaissOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         versioning = config.registry.enable_online_feature_view_versioning
         for table in tables:

--- a/sdk/python/feast/infra/online_stores/hazelcast_online_store/hazelcast_online_store.py
+++ b/sdk/python/feast/infra/online_stores/hazelcast_online_store/hazelcast_online_store.py
@@ -299,6 +299,7 @@ class HazelcastOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         online_store_config = config.online_store
         if not isinstance(online_store_config, HazelcastOnlineStoreConfig):

--- a/sdk/python/feast/infra/online_stores/hbase_online_store/hbase.py
+++ b/sdk/python/feast/infra/online_stores/hbase_online_store/hbase.py
@@ -212,6 +212,7 @@ class HbaseOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         """
         Delete tables from the Hbase Online Store.

--- a/sdk/python/feast/infra/online_stores/helpers.py
+++ b/sdk/python/feast/infra/online_stores/helpers.py
@@ -1,6 +1,6 @@
 import struct
 from datetime import datetime, timezone
-from typing import Any, List
+from typing import Any, List, Optional
 
 import mmh3
 
@@ -11,6 +11,7 @@ from feast.infra.key_encoding_utils import (
 )
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+from feast.feature_view import FeatureView
 
 
 def get_online_store_from_config(online_store_config: Any) -> OnlineStore:
@@ -72,18 +73,23 @@ def _to_naive_utc(ts: datetime) -> datetime:
         return ts.astimezone(tz=timezone.utc).replace(tzinfo=None)
 
 
-def compute_versioned_name(table: Any, enable_versioning: bool = False) -> str:
-    """Return the table name with a ``_v{N}`` suffix when versioning is enabled."""
+def online_store_table_id(
+    project: str,
+    table: FeatureView,
+    enable_versioning: bool = False,
+    version: Optional[int] = None,
+) -> str:
     name = table.name
     if enable_versioning:
-        version = getattr(table.projection, "version_tag", None)
-        if version is None:
-            version = getattr(table, "current_version_number", None)
-        if version is not None and version > 0:
-            name = f"{table.name}_v{version}"
-    return name
+        resolved_version = version
+        if resolved_version is None:
+            resolved_version = getattr(table.projection, "version_tag", None)
+            if resolved_version is None:
+                resolved_version = getattr(table, "current_version_number", None)
+        if resolved_version is not None and resolved_version > 0:
+            name = f"{table.name}_v{resolved_version}"
+    return f"{project}_{name}"
 
 
 def compute_table_id(project: str, table: Any, enable_versioning: bool = False) -> str:
-    """Build the online-store table name, appending a version suffix when versioning is enabled."""
-    return f"{project}_{compute_versioned_name(table, enable_versioning)}"
+    return online_store_table_id(project, table, enable_versioning)

--- a/sdk/python/feast/infra/online_stores/helpers.py
+++ b/sdk/python/feast/infra/online_stores/helpers.py
@@ -91,5 +91,16 @@ def online_store_table_id(
     return f"{project}_{name}"
 
 
+def compute_versioned_name(table: FeatureView, enable_versioning: bool = False) -> str:
+    name = table.name
+    if enable_versioning:
+        version = getattr(table.projection, "version_tag", None)
+        if version is None:
+            version = getattr(table, "current_version_number", None)
+        if version is not None and version > 0:
+            name = f"{table.name}_v{version}"
+    return name
+
+
 def compute_table_id(project: str, table: Any, enable_versioning: bool = False) -> str:
     return online_store_table_id(project, table, enable_versioning)

--- a/sdk/python/feast/infra/online_stores/helpers.py
+++ b/sdk/python/feast/infra/online_stores/helpers.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 
 import mmh3
 
+from feast.feature_view import FeatureView
 from feast.importer import import_class
 from feast.infra.key_encoding_utils import (
     serialize_entity_key,
@@ -11,7 +12,6 @@ from feast.infra.key_encoding_utils import (
 )
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
-from feast.feature_view import FeatureView
 
 
 def get_online_store_from_config(online_store_config: Any) -> OnlineStore:

--- a/sdk/python/feast/infra/online_stores/hybrid_online_store/hybrid_online_store.py
+++ b/sdk/python/feast/infra/online_stores/hybrid_online_store/hybrid_online_store.py
@@ -294,32 +294,34 @@ class HybridOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
-        registry=None,
     ):
-        """Teardown all managed online stores for the given FeatureViews and Entities."""
+        """
+        Teardown all managed online stores for the given FeatureViews and Entities.
 
-        self._initialize_online_stores(config)
-        tables_by_tribe: Dict[str, List[FeatureView]] = {}
+        Args:
+            config: Feast RepoConfig.
+            tables: Sequence of FeatureViews to teardown.
+            entities: Sequence of Entities to teardown.
+        """
+        # Use a set of (tribe, store_type, conf_id) to avoid duplicate teardowns for the same instance
+        tribes_seen = set()
+        online_stores_cfg = getattr(config.online_store, "online_stores", [])
+        tag_name = getattr(config.online_store, "routing_tag", "tribe")
         for table in tables:
-            tribe = self._get_routing_tag_value(table, config)
+            tribe = table.tags.get(tag_name)
             if not tribe:
-                tag_name = getattr(config.online_store, "routing_tag", "tribe")
-                raise ValueError(
-                    f"FeatureView must have a '{tag_name}' tag to use HybridOnlineStore."
-                )
-            tables_by_tribe.setdefault(tribe, []).append(table)
-
-        for tribe, tribe_tables in tables_by_tribe.items():
-            online_store = self._get_online_store(tribe, config)
-            if not online_store:
-                raise NotImplementedError(
-                    f"No online store found for {getattr(config.online_store, 'routing_tag', 'tribe')} tag '{tribe}'. Please check your configuration."
-                )
-
-            tribe_config = RepoConfig(**self._prepare_repo_conf(config, tribe))
-            online_store.teardown(
-                tribe_config,
-                tribe_tables,
-                entities,
-                registry=registry,
-            )
+                continue
+            # Find all store configs matching this tribe (supporting multiple instances of the same type)
+            for store_cfg in online_stores_cfg:
+                store_type = store_cfg.type
+                # Use id(store_cfg.conf) to distinguish different configs of the same type
+                key = (tribe, store_type, id(store_cfg.conf))
+                if key in tribes_seen:
+                    continue
+                tribes_seen.add(key)
+                # Only select the online store if tribe matches the type (or you can add a mapping in config for more flexibility)
+                if tribe.lower() == store_type.split(".")[-1].lower():
+                    online_store = self._get_online_store(tribe, config)
+                    if online_store:
+                        config = RepoConfig(**self._prepare_repo_conf(config, tribe))
+                        online_store.teardown(config, tables, entities)

--- a/sdk/python/feast/infra/online_stores/hybrid_online_store/hybrid_online_store.py
+++ b/sdk/python/feast/infra/online_stores/hybrid_online_store/hybrid_online_store.py
@@ -289,39 +289,20 @@ class HybridOnlineStore(OnlineStore):
                     f"No online store found for {getattr(config.online_store, 'routing_tag', 'tribe')} tag '{tribe}'. Please check your configuration."
                 )
 
+        tag_name = getattr(config.online_store, "routing_tag", "tribe")
+        raise ValueError(
+            f"FeatureView must have a '{tag_name}' tag to use HybridOnlineStore."
+        )
+
     def teardown(
         self,
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
-        """
-        Teardown all managed online stores for the given FeatureViews and Entities.
+        """Teardown all managed online stores for the given FeatureViews and Entities."""
 
-        Args:
-            config: Feast RepoConfig.
-            tables: Sequence of FeatureViews to teardown.
-            entities: Sequence of Entities to teardown.
-        """
-        # Use a set of (tribe, store_type, conf_id) to avoid duplicate teardowns for the same instance
-        tribes_seen = set()
-        online_stores_cfg = getattr(config.online_store, "online_stores", [])
-        tag_name = getattr(config.online_store, "routing_tag", "tribe")
-        for table in tables:
-            tribe = table.tags.get(tag_name)
-            if not tribe:
-                continue
-            # Find all store configs matching this tribe (supporting multiple instances of the same type)
-            for store_cfg in online_stores_cfg:
-                store_type = store_cfg.type
-                # Use id(store_cfg.conf) to distinguish different configs of the same type
-                key = (tribe, store_type, id(store_cfg.conf))
-                if key in tribes_seen:
-                    continue
-                tribes_seen.add(key)
-                # Only select the online store if tribe matches the type (or you can add a mapping in config for more flexibility)
-                if tribe.lower() == store_type.split(".")[-1].lower():
-                    online_store = self._get_online_store(tribe, config)
-                    if online_store:
-                        config = RepoConfig(**self._prepare_repo_conf(config, tribe))
-                        online_store.teardown(config, tables, entities)
+        self._initialize_online_stores(config)
+        for store in self.online_stores.values():
+            store.teardown(config, tables, entities, registry=registry)

--- a/sdk/python/feast/infra/online_stores/hybrid_online_store/hybrid_online_store.py
+++ b/sdk/python/feast/infra/online_stores/hybrid_online_store/hybrid_online_store.py
@@ -289,11 +289,6 @@ class HybridOnlineStore(OnlineStore):
                     f"No online store found for {getattr(config.online_store, 'routing_tag', 'tribe')} tag '{tribe}'. Please check your configuration."
                 )
 
-        tag_name = getattr(config.online_store, "routing_tag", "tribe")
-        raise ValueError(
-            f"FeatureView must have a '{tag_name}' tag to use HybridOnlineStore."
-        )
-
     def teardown(
         self,
         config: RepoConfig,

--- a/sdk/python/feast/infra/online_stores/hybrid_online_store/hybrid_online_store.py
+++ b/sdk/python/feast/infra/online_stores/hybrid_online_store/hybrid_online_store.py
@@ -47,6 +47,7 @@ from pydantic import StrictStr
 from feast import Entity, FeatureView, RepoConfig
 from feast.infra.online_stores.helpers import get_online_store_from_config
 from feast.infra.online_stores.online_store import OnlineStore
+from feast.infra.registry.base_registry import BaseRegistry
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import FeastConfigBaseModel, get_online_config_from_type
@@ -294,6 +295,7 @@ class HybridOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ):
         """
         Teardown all managed online stores for the given FeatureViews and Entities.
@@ -324,4 +326,6 @@ class HybridOnlineStore(OnlineStore):
                     online_store = self._get_online_store(tribe, config)
                     if online_store:
                         config = RepoConfig(**self._prepare_repo_conf(config, tribe))
-                        online_store.teardown(config, tables, entities)
+                        online_store.teardown(
+                            config, tables, entities, registry=registry
+                        )

--- a/sdk/python/feast/infra/online_stores/hybrid_online_store/hybrid_online_store.py
+++ b/sdk/python/feast/infra/online_stores/hybrid_online_store/hybrid_online_store.py
@@ -299,5 +299,27 @@ class HybridOnlineStore(OnlineStore):
         """Teardown all managed online stores for the given FeatureViews and Entities."""
 
         self._initialize_online_stores(config)
-        for store in self.online_stores.values():
-            store.teardown(config, tables, entities, registry=registry)
+        tables_by_tribe: Dict[str, List[FeatureView]] = {}
+        for table in tables:
+            tribe = self._get_routing_tag_value(table, config)
+            if not tribe:
+                tag_name = getattr(config.online_store, "routing_tag", "tribe")
+                raise ValueError(
+                    f"FeatureView must have a '{tag_name}' tag to use HybridOnlineStore."
+                )
+            tables_by_tribe.setdefault(tribe, []).append(table)
+
+        for tribe, tribe_tables in tables_by_tribe.items():
+            online_store = self._get_online_store(tribe, config)
+            if not online_store:
+                raise NotImplementedError(
+                    f"No online store found for {getattr(config.online_store, 'routing_tag', 'tribe')} tag '{tribe}'. Please check your configuration."
+                )
+
+            tribe_config = RepoConfig(**self._prepare_repo_conf(config, tribe))
+            online_store.teardown(
+                tribe_config,
+                tribe_tables,
+                entities,
+                registry=registry,
+            )

--- a/sdk/python/feast/infra/online_stores/milvus_online_store/milvus.py
+++ b/sdk/python/feast/infra/online_stores/milvus_online_store/milvus.py
@@ -509,6 +509,7 @@ class MilvusOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         self.client = self._connect(config)
         for table in tables:

--- a/sdk/python/feast/infra/online_stores/mongodb_online_store/mongodb.py
+++ b/sdk/python/feast/infra/online_stores/mongodb_online_store/mongodb.py
@@ -260,6 +260,7 @@ class MongoDBOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         """
         Drop the backing collection and close the client.

--- a/sdk/python/feast/infra/online_stores/mysql_online_store/mysql.py
+++ b/sdk/python/feast/infra/online_stores/mysql_online_store/mysql.py
@@ -100,7 +100,7 @@ class MySQLOnlineStore(OnlineStore):
                 if progress:
                     progress(1)
         else:
-            batch_size = config.online_store.bacth_size
+            batch_size = config.online_store.batch_size
             if not batch_size or batch_size < 2:
                 raise ValueError("Batch size must be at least 2")
             insert_values = []
@@ -296,6 +296,7 @@ class MySQLOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ) -> None:
         conn = self._get_conn(config)
         cur = conn.cursor()

--- a/sdk/python/feast/infra/online_stores/mysql_online_store/mysql.py
+++ b/sdk/python/feast/infra/online_stores/mysql_online_store/mysql.py
@@ -83,7 +83,7 @@ class MySQLOnlineStore(OnlineStore):
             for entity_key, values, timestamp, created_ts in data:
                 entity_key_bin = serialize_entity_key(
                     entity_key,
-                    entity_key_serialization_version=3,
+                    entity_key_serialization_version=config.entity_key_serialization_version,
                 ).hex()
                 timestamp = to_naive_utc(timestamp)
                 if created_ts is not None:
@@ -112,7 +112,7 @@ class MySQLOnlineStore(OnlineStore):
             for entity_key, values, timestamp, created_ts in data:
                 entity_key_bin = serialize_entity_key(
                     entity_key,
-                    entity_key_serialization_version=2,
+                    entity_key_serialization_version=config.entity_key_serialization_version,
                 ).hex()
                 timestamp = to_naive_utc(timestamp)
                 if created_ts is not None:
@@ -228,7 +228,7 @@ class MySQLOnlineStore(OnlineStore):
         for entity_key in entity_keys:
             entity_key_bin = serialize_entity_key(
                 entity_key,
-                entity_key_serialization_version=3,
+                entity_key_serialization_version=config.entity_key_serialization_version,
             ).hex()
 
             cur.execute(

--- a/sdk/python/feast/infra/online_stores/mysql_online_store/mysql.py
+++ b/sdk/python/feast/infra/online_stores/mysql_online_store/mysql.py
@@ -12,6 +12,7 @@ from feast import Entity, FeatureView, RepoConfig
 from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.helpers import compute_table_id
 from feast.infra.online_stores.online_store import OnlineStore
+from feast.infra.registry.base_registry import BaseRegistry
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import FeastConfigBaseModel

--- a/sdk/python/feast/infra/online_stores/mysql_online_store/mysql.py
+++ b/sdk/python/feast/infra/online_stores/mysql_online_store/mysql.py
@@ -44,6 +44,10 @@ class MySQLOnlineStore(OnlineStore):
 
     _conn: Optional[Connection] = None
 
+    @property
+    def supports_versioned_online_reads(self) -> bool:
+        return True
+
     def _get_conn(self, config: RepoConfig) -> Connection:
         online_store_config = config.online_store
         assert isinstance(online_store_config, MySQLOnlineStoreConfig)

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -40,6 +40,10 @@ class OnlineStore(ABC):
     """
 
     @property
+    def supports_versioned_online_reads(self) -> bool:
+        return False
+
+    @property
     def async_supported(self) -> SupportedAsyncMethods:
         return SupportedAsyncMethods()
 

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -473,6 +473,7 @@ class OnlineStore(ABC):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ):
         """
         Tears down all cloud resources for the specified set of Feast objects.

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -189,7 +189,7 @@ class OnlineStore(ABC):
         )
 
         # Check for versioned reads on unsupported stores
-        self._check_versioned_read_support(grouped_refs)
+        self._check_versioned_read_support(grouped_refs, config)
         _track_read = False
         try:
             from feast.metrics import _config as _metrics_config
@@ -253,54 +253,35 @@ class OnlineStore(ABC):
         )
         return OnlineResponse(online_features_response, feature_types=feature_types)
 
-    def _check_versioned_read_support(self, grouped_refs):
+    def _check_versioned_read_support(
+        self, grouped_refs, config: Optional[RepoConfig] = None
+    ):
         """Raise an error if versioned reads are attempted on unsupported stores."""
         from feast.infra.online_stores.sqlite import SqliteOnlineStore
 
-        supported_types: list[type] = [SqliteOnlineStore]
-        try:
-            from feast.infra.online_stores.mysql_online_store.mysql import (
-                MySQLOnlineStore,
-            )
-
-            supported_types.append(MySQLOnlineStore)
-        except ImportError:
-            pass
-        try:
-            from feast.infra.online_stores.postgres_online_store.postgres import (
-                PostgreSQLOnlineStore,
-            )
-
-            supported_types.append(PostgreSQLOnlineStore)
-        except ImportError:
-            pass
-        try:
-            from feast.infra.online_stores.faiss_online_store import FaissOnlineStore
-
-            supported_types.append(FaissOnlineStore)
-        except ImportError:
-            pass
-        try:
-            from feast.infra.online_stores.redis import RedisOnlineStore
-
-            supported_types.append(RedisOnlineStore)
-        except Exception:
-            pass
-        try:
-            from feast.infra.online_stores.dynamodb import DynamoDBOnlineStore
-
-            supported_types.append(DynamoDBOnlineStore)
-        except Exception:
-            pass
-
-        if isinstance(self, tuple(supported_types)):
+        if config is None:
             return
+
         for table, _ in grouped_refs:
             version_tag = getattr(table.projection, "version_tag", None)
-            if version_tag is not None:
+            if version_tag is None:
+                continue
+
+            # Version-qualified refs (e.g. @v2) are only supported when online versioning is enabled.
+            if not config.registry.enable_online_feature_view_versioning:
                 raise VersionedOnlineReadNotSupported(
                     self.__class__.__name__, version_tag
                 )
+
+            # Online versioning enabled: allow stores that implement versioned routing.
+            if self.supports_versioned_online_reads:
+                continue
+
+            # SQLite is always allowed, since it is the reference implementation.
+            if isinstance(self, SqliteOnlineStore):
+                continue
+
+            raise VersionedOnlineReadNotSupported(self.__class__.__name__, version_tag)
 
     async def get_online_features_async(
         self,
@@ -346,7 +327,7 @@ class OnlineStore(ABC):
         )
 
         # Check for versioned reads on unsupported stores
-        self._check_versioned_read_support(grouped_refs)
+        self._check_versioned_read_support(grouped_refs, config)
 
         async def query_table(table, requested_features):
             # Get the correct set of entity values with the correct join keys.

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -265,7 +265,6 @@ class OnlineStore(ABC):
 
         if config is None:
             return
-
         for table, _ in grouped_refs:
             version_tag = getattr(table.projection, "version_tag", None)
             if version_tag is None:

--- a/sdk/python/feast/infra/online_stores/postgres_online_store/postgres.py
+++ b/sdk/python/feast/infra/online_stores/postgres_online_store/postgres.py
@@ -385,6 +385,7 @@ class PostgreSQLOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         project = config.project
         schema_name = config.online_store.db_schema or config.online_store.user

--- a/sdk/python/feast/infra/online_stores/postgres_online_store/postgres.py
+++ b/sdk/python/feast/infra/online_stores/postgres_online_store/postgres.py
@@ -56,6 +56,10 @@ class PostgreSQLOnlineStore(OnlineStore):
     _conn_async: Optional[AsyncConnection] = None
     _conn_pool_async: Optional[AsyncConnectionPool] = None
 
+    @property
+    def supports_versioned_online_reads(self) -> bool:
+        return True
+
     @contextlib.contextmanager
     def _get_conn(
         self, config: RepoConfig, autocommit: bool = False

--- a/sdk/python/feast/infra/online_stores/qdrant_online_store/qdrant.py
+++ b/sdk/python/feast/infra/online_stores/qdrant_online_store/qdrant.py
@@ -247,6 +247,7 @@ class QdrantOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry=None,
     ):
         project = config.project
         try:

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -39,6 +39,7 @@ from feast.infra.online_stores.helpers import (
     compute_versioned_name,
 )
 from feast.infra.online_stores.online_store import OnlineStore
+from feast.infra.registry.base_registry import BaseRegistry
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import FeastConfigBaseModel

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -109,6 +109,8 @@ class RedisOnlineStore(OnlineStore):
         None
     )
 
+    supports_versioned_online_reads = True
+
     def delete_entity_values(self, config: RepoConfig, join_keys: List[str]):
         client = self._get_client(config.online_store)
         deleted_count = 0

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -190,6 +190,7 @@ class RedisOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ):
         """
         We delete the keys in redis for tables/views being removed.

--- a/sdk/python/feast/infra/online_stores/remote.py
+++ b/sdk/python/feast/infra/online_stores/remote.py
@@ -617,6 +617,7 @@ class RemoteOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ):
         pass
 

--- a/sdk/python/feast/infra/online_stores/remote.py
+++ b/sdk/python/feast/infra/online_stores/remote.py
@@ -24,6 +24,7 @@ from pydantic import StrictStr
 from feast import Entity, FeatureView, RepoConfig
 from feast.infra.online_stores.helpers import _to_naive_utc
 from feast.infra.online_stores.online_store import OnlineStore
+from feast.infra.registry.base_registry import BaseRegistry
 from feast.permissions.client.http_auth_requests_wrapper import HttpSessionManager
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto

--- a/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
+++ b/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
@@ -247,6 +247,7 @@ class SingleStoreOnlineStore(OnlineStore):
                         versions = []
 
                 if not versions:
+                    _drop_table_and_index(cur, project, table, enable_versioning=False)
                     _drop_table_and_index(cur, project, table, enable_versioning=True)
                     _drop_discovered_versioned_tables(cur, project, table)
                     continue

--- a/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
+++ b/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from collections import defaultdict
 from datetime import datetime
+import logging
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple
 
 import singlestoredb
@@ -17,6 +18,8 @@ from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import FeastConfigBaseModel
+
+logger = logging.getLogger(__name__)
 
 
 class SingleStoreOnlineStoreConfig(FeastConfigBaseModel):
@@ -107,7 +110,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 current_batch = insert_values[i : i + batch_size]
                 cur.executemany(
                     f"""
-                    INSERT INTO {online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
+                    INSERT INTO {_quote_identifier(online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning))}
                     (entity_key, feature_name, value, event_ts, created_ts)
                     values (%s, %s, %s, %s, %s)
                     ON DUPLICATE KEY UPDATE
@@ -143,7 +146,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 entity_key_placeholders = ",".join(["%s" for _ in keys])
                 cur.execute(
                     f"""
-                    SELECT entity_key, feature_name, value, event_ts FROM {online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
+                    SELECT entity_key, feature_name, value, event_ts FROM {_quote_identifier(online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning))}
                     WHERE entity_key IN ({entity_key_placeholders})
                     ORDER BY event_ts;
                     """,
@@ -156,7 +159,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 )
                 cur.execute(
                     f"""
-                    SELECT entity_key, feature_name, value, event_ts FROM {online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
+                    SELECT entity_key, feature_name, value, event_ts FROM {_quote_identifier(online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning))}
                     WHERE entity_key IN ({entity_key_placeholders}) and feature_name IN ({requested_features_placeholders})
                     ORDER BY event_ts;
                     """,
@@ -202,13 +205,13 @@ class SingleStoreOnlineStore(OnlineStore):
             for table in tables_to_keep:
                 table_name = online_store_table_id(project, table, versioning)
                 cur.execute(
-                    f"""CREATE TABLE IF NOT EXISTS {table_name} (entity_key VARCHAR(512),
+                    f"""CREATE TABLE IF NOT EXISTS {_quote_identifier(table_name)} (entity_key VARCHAR(512),
                     feature_name VARCHAR(256),
                     value BLOB,
                     event_ts timestamp NULL DEFAULT NULL,
                     created_ts timestamp NULL DEFAULT NULL,
                     PRIMARY KEY(entity_key, feature_name),
-                    INDEX {table_name}_ek (entity_key))"""
+                    INDEX {_quote_identifier(table_name + '_ek')} (entity_key))"""
                 )
 
             for table in tables_to_delete:
@@ -257,11 +260,17 @@ class SingleStoreOnlineStore(OnlineStore):
                     versions = registry.list_feature_view_versions(
                         name=table.name, project=project
                     )
-                except Exception:
+                except Exception as e:
+                    logger.warning(
+                        "Failed to list feature view versions for %s during teardown; will fall back to dropping discovered versioned tables. Error: %s",
+                        table.name,
+                        e,
+                    )
                     versions = []
 
                 if not versions:
                     _drop_table_and_index(cur, project, table, enable_versioning=True)
+                    _drop_discovered_versioned_tables(cur, project, table)
                     continue
 
                 for record in versions:
@@ -276,6 +285,8 @@ class SingleStoreOnlineStore(OnlineStore):
                         version=version_number,
                     )
 
+                _drop_discovered_versioned_tables(cur, project, table)
+
 
 def _drop_table_and_index(
     cur: Cursor,
@@ -285,5 +296,38 @@ def _drop_table_and_index(
     version: Optional[int] = None,
 ) -> None:
     table_name = online_store_table_id(project, table, enable_versioning, version)
-    cur.execute(f"DROP INDEX IF EXISTS {table_name}_ek ON {table_name};")
-    cur.execute(f"DROP TABLE IF EXISTS {table_name}")
+    table_name_quoted = _quote_identifier(table_name)
+    index_name_quoted = _quote_identifier(f"{table_name}_ek")
+    cur.execute(f"DROP INDEX IF EXISTS {index_name_quoted} ON {table_name_quoted};")
+    cur.execute(f"DROP TABLE IF EXISTS {table_name_quoted}")
+
+
+def _quote_identifier(identifier: str) -> str:
+    """Quote a SingleStore/MySQL identifier safely using backticks.
+
+    Backticks are escaped by doubling them. This does not validate existence,
+    but prevents SQL injection through identifier interpolation.
+    """
+
+    escaped = identifier.replace("`", "``")
+    return f"`{escaped}`"
+
+
+def _drop_discovered_versioned_tables(cur: Cursor, project: str, table: FeatureView) -> None:
+    base_table_name = online_store_table_id(project, table, enable_versioning=False)
+    like_pattern = f"{base_table_name}_v%"
+    try:
+        cur.execute("SHOW TABLES LIKE %s", (like_pattern,))
+        rows = cur.fetchall() or []
+        for row in rows:
+            table_name = row[0]
+            cur.execute(
+                f"DROP INDEX IF EXISTS {_quote_identifier(table_name + '_ek')} ON {_quote_identifier(table_name)};"
+            )
+            cur.execute(f"DROP TABLE IF EXISTS {_quote_identifier(table_name)}")
+    except Exception as e:
+        logger.warning(
+            "Failed to discover/drop versioned tables for %s during teardown fallback. Error: %s",
+            table.name,
+            e,
+        )

--- a/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
+++ b/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
@@ -297,7 +297,7 @@ def _drop_discovered_versioned_tables(
     escaped_base_table_name = escaped_base_table_name.replace("_", "\\_")
     like_pattern = f"{escaped_base_table_name}\\_v%"
     try:
-        cur.execute("SHOW TABLES LIKE %s ESCAPE '\\\\'", (like_pattern,))
+        cur.execute("SHOW TABLES LIKE %s", (like_pattern,))
         rows = cur.fetchall() or []
         for row in rows:
             table_name = row[0]

--- a/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
+++ b/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
@@ -11,10 +11,10 @@ from singlestoredb.connection import Connection, Cursor
 from singlestoredb.exceptions import InterfaceError
 
 from feast import Entity, FeatureView, RepoConfig
-from feast.importer import import_class
 from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.helpers import _to_naive_utc, online_store_table_id
 from feast.infra.online_stores.online_store import OnlineStore
+from feast.infra.registry.base_registry import BaseRegistry
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import FeastConfigBaseModel
@@ -222,6 +222,7 @@ class SingleStoreOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ) -> None:
         project = config.project
         versioning = config.registry.enable_online_feature_view_versioning
@@ -232,41 +233,18 @@ class SingleStoreOnlineStore(OnlineStore):
                     continue
 
                 versions = []
-                try:
-                    from feast.repo_config import REGISTRY_CLASS_FOR_TYPE
-
-                    registry_type = getattr(config.registry, "registry_type", "file")
-                    registry_class_path = REGISTRY_CLASS_FOR_TYPE[registry_type]
-                    module_name, class_name = registry_class_path.rsplit(".", 1)
-                    registry_cls = import_class(module_name, class_name, "Registry")
-                    if registry_type == "file":
-                        registry = registry_cls(
-                            project=project,
-                            registry_config=config.registry,
-                            repo_path=config.repo_path,
+                if registry is not None:
+                    try:
+                        versions = registry.list_feature_view_versions(
+                            name=table.name, project=project
                         )
-                    elif registry_type in {"sql", "remote", "snowflake.registry"}:
-                        registry = registry_cls(
-                            registry_config=config.registry,
-                            project=project,
-                            repo_path=config.repo_path,
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to list feature view versions for %s during teardown; will fall back to dropping discovered versioned tables. Error: %s",
+                            table.name,
+                            e,
                         )
-                    else:
-                        registry = registry_cls(
-                            project=project,
-                            registry_config=config.registry,
-                            repo_path=config.repo_path,
-                        )
-                    versions = registry.list_feature_view_versions(
-                        name=table.name, project=project
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "Failed to list feature view versions for %s during teardown; will fall back to dropping discovered versioned tables. Error: %s",
-                        table.name,
-                        e,
-                    )
-                    versions = []
+                        versions = []
 
                 if not versions:
                     _drop_table_and_index(cur, project, table, enable_versioning=True)
@@ -303,19 +281,11 @@ def _drop_table_and_index(
 
 
 def _quote_identifier(identifier: str) -> str:
-    """Quote a SingleStore/MySQL identifier safely using backticks.
-
-    Backticks are escaped by doubling them. This does not validate existence,
-    but prevents SQL injection through identifier interpolation.
-    """
-
     escaped = identifier.replace("`", "``")
     return f"`{escaped}`"
 
 
-def _drop_discovered_versioned_tables(
-    cur: Cursor, project: str, table: FeatureView
-) -> None:
+def _drop_discovered_versioned_tables(cur: Cursor, project: str, table: FeatureView) -> None:
     base_table_name = online_store_table_id(project, table, enable_versioning=False)
     escaped_base_table_name = base_table_name.replace("\\", "\\\\")
     escaped_base_table_name = escaped_base_table_name.replace("%", "\\%")

--- a/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
+++ b/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
@@ -285,7 +285,9 @@ def _quote_identifier(identifier: str) -> str:
     return f"`{escaped}`"
 
 
-def _drop_discovered_versioned_tables(cur: Cursor, project: str, table: FeatureView) -> None:
+def _drop_discovered_versioned_tables(
+    cur: Cursor, project: str, table: FeatureView
+) -> None:
     base_table_name = online_store_table_id(project, table, enable_versioning=False)
     escaped_base_table_name = base_table_name.replace("\\", "\\\\")
     escaped_base_table_name = escaped_base_table_name.replace("%", "\\%")

--- a/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
+++ b/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
@@ -80,7 +80,7 @@ class SingleStoreOnlineStore(OnlineStore):
             for entity_key, values, timestamp, created_ts in data:
                 entity_key_bin = serialize_entity_key(
                     entity_key,
-                    entity_key_serialization_version=3,
+                    entity_key_serialization_version=config.entity_key_serialization_version,
                 ).hex()
                 timestamp = _to_naive_utc(timestamp)
                 if created_ts is not None:
@@ -102,7 +102,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 current_batch = insert_values[i : i + batch_size]
                 cur.executemany(
                     f"""
-                    INSERT INTO {_table_id(project, table)}
+                    INSERT INTO {_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
                     (entity_key, feature_name, value, event_ts, created_ts)
                     values (%s, %s, %s, %s, %s)
                     ON DUPLICATE KEY UPDATE
@@ -130,7 +130,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 keys.append(
                     serialize_entity_key(
                         entity_key,
-                        entity_key_serialization_version=3,
+                        entity_key_serialization_version=config.entity_key_serialization_version,
                     ).hex()
                 )
 
@@ -138,7 +138,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 entity_key_placeholders = ",".join(["%s" for _ in keys])
                 cur.execute(
                     f"""
-                    SELECT entity_key, feature_name, value, event_ts FROM {_table_id(project, table)}
+                    SELECT entity_key, feature_name, value, event_ts FROM {_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
                     WHERE entity_key IN ({entity_key_placeholders})
                     ORDER BY event_ts;
                     """,
@@ -151,7 +151,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 )
                 cur.execute(
                     f"""
-                    SELECT entity_key, feature_name, value, event_ts FROM {_table_id(project, table)}
+                    SELECT entity_key, feature_name, value, event_ts FROM {_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
                     WHERE entity_key IN ({entity_key_placeholders}) and feature_name IN ({requested_features_placeholders})
                     ORDER BY event_ts;
                     """,
@@ -191,21 +191,23 @@ class SingleStoreOnlineStore(OnlineStore):
         partial: bool,
     ) -> None:
         project = config.project
+        versioning = config.registry.enable_online_feature_view_versioning
         with self._get_cursor(config) as cur:
             # We don't create any special state for the entities in this implementation.
             for table in tables_to_keep:
+                table_name = _table_id(project, table, versioning)
                 cur.execute(
-                    f"""CREATE TABLE IF NOT EXISTS {_table_id(project, table)} (entity_key VARCHAR(512),
+                    f"""CREATE TABLE IF NOT EXISTS {table_name} (entity_key VARCHAR(512),
                     feature_name VARCHAR(256),
                     value BLOB,
                     event_ts timestamp NULL DEFAULT NULL,
                     created_ts timestamp NULL DEFAULT NULL,
                     PRIMARY KEY(entity_key, feature_name),
-                    INDEX {_table_id(project, table)}_ek (entity_key))"""
+                    INDEX {table_name}_ek (entity_key))"""
                 )
 
             for table in tables_to_delete:
-                _drop_table_and_index(cur, project, table)
+                _drop_table_and_index(cur, project, table, versioning)
 
     def teardown(
         self,
@@ -214,16 +216,26 @@ class SingleStoreOnlineStore(OnlineStore):
         entities: Sequence[Entity],
     ) -> None:
         project = config.project
+        versioning = config.registry.enable_online_feature_view_versioning
         with self._get_cursor(config) as cur:
             for table in tables:
-                _drop_table_and_index(cur, project, table)
+                _drop_table_and_index(cur, project, table, versioning)
 
 
-def _drop_table_and_index(cur: Cursor, project: str, table: FeatureView) -> None:
-    table_name = _table_id(project, table)
+def _drop_table_and_index(
+    cur: Cursor, project: str, table: FeatureView, enable_versioning: bool
+) -> None:
+    table_name = _table_id(project, table, enable_versioning)
     cur.execute(f"DROP INDEX {table_name}_ek ON {table_name};")
     cur.execute(f"DROP TABLE IF EXISTS {table_name}")
 
 
-def _table_id(project: str, table: FeatureView) -> str:
-    return f"{project}_{table.name}"
+def _table_id(project: str, table: FeatureView, enable_versioning: bool = False) -> str:
+    name = table.name
+    if enable_versioning:
+        version = getattr(table.projection, "version_tag", None)
+        if version is None:
+            version = getattr(table, "current_version_number", None)
+        if version is not None and version > 0:
+            name = f"{table.name}_v{version}"
+    return f"{project}_{name}"

--- a/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
+++ b/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
@@ -228,45 +228,10 @@ class SingleStoreOnlineStore(OnlineStore):
         versioning = config.registry.enable_online_feature_view_versioning
         with self._get_cursor(config) as cur:
             for table in tables:
-                if not versioning:
+                if versioning:
+                    _drop_all_version_tables(cur, project, table)
+                else:
                     _drop_table_and_index(cur, project, table, enable_versioning=False)
-                    continue
-
-                versions = []
-                if registry is not None:
-                    try:
-                        versions = registry.list_feature_view_versions(
-                            name=table.name, project=project
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            "Failed to list feature view versions for %s during teardown; will fall back to dropping discovered versioned tables. Error: %s",
-                            table.name,
-                            e,
-                        )
-                        versions = []
-
-                if not versions:
-                    _drop_table_and_index(cur, project, table, enable_versioning=False)
-                    _drop_table_and_index(cur, project, table, enable_versioning=True)
-                    _drop_discovered_versioned_tables(cur, project, table)
-                    continue
-
-                for record in versions:
-                    version_number = record.get("version_number")
-                    if version_number is None:
-                        continue
-                    _drop_table_and_index(
-                        cur,
-                        project,
-                        table,
-                        enable_versioning=True,
-                        version=version_number,
-                    )
-
-                # Always drop the base (unversioned) table as well
-                _drop_table_and_index(cur, project, table, enable_versioning=False)
-                _drop_discovered_versioned_tables(cur, project, table)
 
 
 def _drop_table_and_index(
@@ -281,6 +246,21 @@ def _drop_table_and_index(
     index_name_quoted = _quote_identifier(f"{table_name}_ek")
     cur.execute(f"DROP INDEX IF EXISTS {index_name_quoted} ON {table_name_quoted};")
     cur.execute(f"DROP TABLE IF EXISTS {table_name_quoted}")
+
+
+def _drop_all_version_tables(cur: Cursor, project: str, table: FeatureView) -> None:
+    base = online_store_table_id(project, table, enable_versioning=False)
+    cur.execute(
+        "SELECT table_name FROM information_schema.tables "
+        "WHERE table_schema = DATABASE() AND (table_name = %s OR table_name REGEXP %s)",
+        (base, f"^{base}_v[0-9]+$"),
+    )
+    for (name,) in cur.fetchall() or []:
+        index_name = f"{name}_ek"
+        cur.execute(
+            f"DROP INDEX IF EXISTS {_quote_identifier(index_name)} ON {_quote_identifier(name)};"
+        )
+        cur.execute(f"DROP TABLE IF EXISTS {_quote_identifier(name)}")
 
 
 def _quote_identifier(identifier: str) -> str:

--- a/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
+++ b/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
@@ -10,8 +10,9 @@ from singlestoredb.connection import Connection, Cursor
 from singlestoredb.exceptions import InterfaceError
 
 from feast import Entity, FeatureView, RepoConfig
+from feast.importer import import_class
 from feast.infra.key_encoding_utils import serialize_entity_key
-from feast.infra.online_stores.helpers import _to_naive_utc
+from feast.infra.online_stores.helpers import _to_naive_utc, online_store_table_id
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
@@ -40,6 +41,10 @@ class SingleStoreOnlineStore(OnlineStore):
     """
 
     _conn: Optional[Connection] = None
+
+    @property
+    def supports_versioned_online_reads(self) -> bool:
+        return True
 
     def _init_conn(self, config: RepoConfig) -> Connection:
         online_store_config = config.online_store
@@ -102,7 +107,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 current_batch = insert_values[i : i + batch_size]
                 cur.executemany(
                     f"""
-                    INSERT INTO {_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
+                    INSERT INTO {online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
                     (entity_key, feature_name, value, event_ts, created_ts)
                     values (%s, %s, %s, %s, %s)
                     ON DUPLICATE KEY UPDATE
@@ -138,7 +143,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 entity_key_placeholders = ",".join(["%s" for _ in keys])
                 cur.execute(
                     f"""
-                    SELECT entity_key, feature_name, value, event_ts FROM {_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
+                    SELECT entity_key, feature_name, value, event_ts FROM {online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
                     WHERE entity_key IN ({entity_key_placeholders})
                     ORDER BY event_ts;
                     """,
@@ -151,7 +156,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 )
                 cur.execute(
                     f"""
-                    SELECT entity_key, feature_name, value, event_ts FROM {_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
+                    SELECT entity_key, feature_name, value, event_ts FROM {online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning)}
                     WHERE entity_key IN ({entity_key_placeholders}) and feature_name IN ({requested_features_placeholders})
                     ORDER BY event_ts;
                     """,
@@ -195,7 +200,7 @@ class SingleStoreOnlineStore(OnlineStore):
         with self._get_cursor(config) as cur:
             # We don't create any special state for the entities in this implementation.
             for table in tables_to_keep:
-                table_name = _table_id(project, table, versioning)
+                table_name = online_store_table_id(project, table, versioning)
                 cur.execute(
                     f"""CREATE TABLE IF NOT EXISTS {table_name} (entity_key VARCHAR(512),
                     feature_name VARCHAR(256),
@@ -219,23 +224,66 @@ class SingleStoreOnlineStore(OnlineStore):
         versioning = config.registry.enable_online_feature_view_versioning
         with self._get_cursor(config) as cur:
             for table in tables:
-                _drop_table_and_index(cur, project, table, versioning)
+                if not versioning:
+                    _drop_table_and_index(cur, project, table, enable_versioning=False)
+                    continue
+
+                versions = []
+                try:
+                    from feast.repo_config import REGISTRY_CLASS_FOR_TYPE
+
+                    registry_type = getattr(config.registry, "registry_type", "file")
+                    registry_class_path = REGISTRY_CLASS_FOR_TYPE[registry_type]
+                    module_name, class_name = registry_class_path.rsplit(".", 1)
+                    registry_cls = import_class(module_name, class_name, "Registry")
+                    if registry_type == "file":
+                        registry = registry_cls(
+                            project=project,
+                            registry_config=config.registry,
+                            repo_path=config.repo_path,
+                        )
+                    elif registry_type in {"sql", "remote", "snowflake.registry"}:
+                        registry = registry_cls(
+                            registry_config=config.registry,
+                            project=project,
+                            repo_path=config.repo_path,
+                        )
+                    else:
+                        registry = registry_cls(
+                            project=project,
+                            registry_config=config.registry,
+                            repo_path=config.repo_path,
+                        )
+                    versions = registry.list_feature_view_versions(
+                        name=table.name, project=project
+                    )
+                except Exception:
+                    versions = []
+
+                if not versions:
+                    _drop_table_and_index(cur, project, table, enable_versioning=True)
+                    continue
+
+                for record in versions:
+                    version_number = record.get("version_number")
+                    if version_number is None:
+                        continue
+                    _drop_table_and_index(
+                        cur,
+                        project,
+                        table,
+                        enable_versioning=True,
+                        version=version_number,
+                    )
 
 
 def _drop_table_and_index(
-    cur: Cursor, project: str, table: FeatureView, enable_versioning: bool
+    cur: Cursor,
+    project: str,
+    table: FeatureView,
+    enable_versioning: bool,
+    version: Optional[int] = None,
 ) -> None:
-    table_name = _table_id(project, table, enable_versioning)
-    cur.execute(f"DROP INDEX {table_name}_ek ON {table_name};")
+    table_name = online_store_table_id(project, table, enable_versioning, version)
+    cur.execute(f"DROP INDEX IF EXISTS {table_name}_ek ON {table_name};")
     cur.execute(f"DROP TABLE IF EXISTS {table_name}")
-
-
-def _table_id(project: str, table: FeatureView, enable_versioning: bool = False) -> str:
-    name = table.name
-    if enable_versioning:
-        version = getattr(table.projection, "version_tag", None)
-        if version is None:
-            version = getattr(table, "current_version_number", None)
-        if version is not None and version > 0:
-            name = f"{table.name}_v{version}"
-    return f"{project}_{name}"

--- a/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
+++ b/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
+import logging
 from collections import defaultdict
 from datetime import datetime
-import logging
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple
 
 import singlestoredb
@@ -211,7 +211,7 @@ class SingleStoreOnlineStore(OnlineStore):
                     event_ts timestamp NULL DEFAULT NULL,
                     created_ts timestamp NULL DEFAULT NULL,
                     PRIMARY KEY(entity_key, feature_name),
-                    INDEX {_quote_identifier(table_name + '_ek')} (entity_key))"""
+                    INDEX {_quote_identifier(table_name + "_ek")} (entity_key))"""
                 )
 
             for table in tables_to_delete:
@@ -313,16 +313,22 @@ def _quote_identifier(identifier: str) -> str:
     return f"`{escaped}`"
 
 
-def _drop_discovered_versioned_tables(cur: Cursor, project: str, table: FeatureView) -> None:
+def _drop_discovered_versioned_tables(
+    cur: Cursor, project: str, table: FeatureView
+) -> None:
     base_table_name = online_store_table_id(project, table, enable_versioning=False)
-    like_pattern = f"{base_table_name}_v%"
+    escaped_base_table_name = base_table_name.replace("\\", "\\\\")
+    escaped_base_table_name = escaped_base_table_name.replace("%", "\\%")
+    escaped_base_table_name = escaped_base_table_name.replace("_", "\\_")
+    like_pattern = f"{escaped_base_table_name}\\_v%"
     try:
-        cur.execute("SHOW TABLES LIKE %s", (like_pattern,))
+        cur.execute("SHOW TABLES LIKE %s ESCAPE '\\\\'", (like_pattern,))
         rows = cur.fetchall() or []
         for row in rows:
             table_name = row[0]
+            index_name = f"{table_name}_ek"
             cur.execute(
-                f"DROP INDEX IF EXISTS {_quote_identifier(table_name + '_ek')} ON {_quote_identifier(table_name)};"
+                f"DROP INDEX IF EXISTS {_quote_identifier(index_name)} ON {_quote_identifier(table_name)};"
             )
             cur.execute(f"DROP TABLE IF EXISTS {_quote_identifier(table_name)}")
     except Exception as e:

--- a/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
+++ b/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
@@ -264,6 +264,8 @@ class SingleStoreOnlineStore(OnlineStore):
                         version=version_number,
                     )
 
+                # Always drop the base (unversioned) table as well
+                _drop_table_and_index(cur, project, table, enable_versioning=False)
                 _drop_discovered_versioned_tables(cur, project, table)
 
 

--- a/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
+++ b/sdk/python/feast/infra/online_stores/singlestore_online_store/singlestore.py
@@ -110,7 +110,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 current_batch = insert_values[i : i + batch_size]
                 cur.executemany(
                     f"""
-                    INSERT INTO {_quote_identifier(online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning))}
+                    INSERT INTO {_quote_identifier(_table_id(project, table, config.registry.enable_online_feature_view_versioning))}
                     (entity_key, feature_name, value, event_ts, created_ts)
                     values (%s, %s, %s, %s, %s)
                     ON DUPLICATE KEY UPDATE
@@ -146,7 +146,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 entity_key_placeholders = ",".join(["%s" for _ in keys])
                 cur.execute(
                     f"""
-                    SELECT entity_key, feature_name, value, event_ts FROM {_quote_identifier(online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning))}
+                    SELECT entity_key, feature_name, value, event_ts FROM {_quote_identifier(_table_id(project, table, config.registry.enable_online_feature_view_versioning))}
                     WHERE entity_key IN ({entity_key_placeholders})
                     ORDER BY event_ts;
                     """,
@@ -159,7 +159,7 @@ class SingleStoreOnlineStore(OnlineStore):
                 )
                 cur.execute(
                     f"""
-                    SELECT entity_key, feature_name, value, event_ts FROM {_quote_identifier(online_store_table_id(project, table, config.registry.enable_online_feature_view_versioning))}
+                    SELECT entity_key, feature_name, value, event_ts FROM {_quote_identifier(_table_id(project, table, config.registry.enable_online_feature_view_versioning))}
                     WHERE entity_key IN ({entity_key_placeholders}) and feature_name IN ({requested_features_placeholders})
                     ORDER BY event_ts;
                     """,
@@ -203,7 +203,7 @@ class SingleStoreOnlineStore(OnlineStore):
         with self._get_cursor(config) as cur:
             # We don't create any special state for the entities in this implementation.
             for table in tables_to_keep:
-                table_name = online_store_table_id(project, table, versioning)
+                table_name = _table_id(project, table, versioning)
                 cur.execute(
                     f"""CREATE TABLE IF NOT EXISTS {_quote_identifier(table_name)} (entity_key VARCHAR(512),
                     feature_name VARCHAR(256),
@@ -266,6 +266,15 @@ def _drop_all_version_tables(cur: Cursor, project: str, table: FeatureView) -> N
 def _quote_identifier(identifier: str) -> str:
     escaped = identifier.replace("`", "``")
     return f"`{escaped}`"
+
+
+def _table_id(
+    project: str,
+    table: FeatureView,
+    enable_versioning: bool = False,
+    version: Optional[int] = None,
+) -> str:
+    return online_store_table_id(project, table, enable_versioning, version)
 
 
 def _drop_discovered_versioned_tables(

--- a/sdk/python/feast/infra/online_stores/snowflake.py
+++ b/sdk/python/feast/infra/online_stores/snowflake.py
@@ -253,6 +253,7 @@ class SnowflakeOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ):
         assert isinstance(config.online_store, SnowflakeOnlineStoreConfig)
 

--- a/sdk/python/feast/infra/online_stores/snowflake.py
+++ b/sdk/python/feast/infra/online_stores/snowflake.py
@@ -10,6 +10,7 @@ from feast.entity import Entity
 from feast.feature_view import FeatureView
 from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.online_store import OnlineStore
+from feast.infra.registry.base_registry import BaseRegistry
 from feast.infra.utils.snowflake.snowflake_utils import (
     GetSnowflakeConnection,
     execute_snowflake_statement,

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -39,8 +39,6 @@ from feast.field import Field
 from feast.infra.infra_object import SQLITE_INFRA_OBJECT_CLASS_TYPE, InfraObject
 from feast.infra.key_encoding_utils import (
     deserialize_entity_key,
-    deserialize_f32,
-    deserialize_val,
     serialize_entity_key,
     serialize_f32,
 )

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -59,6 +59,7 @@ from feast.utils import (
     _serialize_vector_to_float_list,
     to_naive_utc,
 )
+from feast.infra.online_stores.helpers import online_store_table_id
 
 
 def adapt_date_iso(val: date):
@@ -124,6 +125,10 @@ class SqliteOnlineStore(OnlineStore):
     """
 
     _conn: Optional[sqlite3.Connection] = None
+
+    @property
+    def supports_versioned_online_reads(self) -> bool:
+        return True
 
     @staticmethod
     def _get_db_path(config: RepoConfig) -> str:

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -39,6 +39,8 @@ from feast.field import Field
 from feast.infra.infra_object import SQLITE_INFRA_OBJECT_CLASS_TYPE, InfraObject
 from feast.infra.key_encoding_utils import (
     deserialize_entity_key,
+    deserialize_f32,
+    deserialize_val,
     serialize_entity_key,
     serialize_f32,
 )
@@ -59,7 +61,6 @@ from feast.utils import (
     _serialize_vector_to_float_list,
     to_naive_utc,
 )
-from feast.infra.online_stores.helpers import online_store_table_id
 
 
 def adapt_date_iso(val: date):

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -46,6 +46,7 @@ from feast.infra.key_encoding_utils import (
 )
 from feast.infra.online_stores.helpers import compute_table_id
 from feast.infra.online_stores.online_store import OnlineStore
+from feast.infra.registry.base_registry import BaseRegistry
 from feast.infra.online_stores.vector_store import VectorStoreConfig
 from feast.protos.feast.core.InfraObject_pb2 import InfraObject as InfraObjectProto
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
@@ -345,6 +346,7 @@ class SqliteOnlineStore(OnlineStore):
         config: RepoConfig,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ):
         try:
             os.unlink(self._get_db_path(config))

--- a/sdk/python/feast/infra/online_stores/sqlite.py
+++ b/sdk/python/feast/infra/online_stores/sqlite.py
@@ -46,8 +46,8 @@ from feast.infra.key_encoding_utils import (
 )
 from feast.infra.online_stores.helpers import compute_table_id
 from feast.infra.online_stores.online_store import OnlineStore
-from feast.infra.registry.base_registry import BaseRegistry
 from feast.infra.online_stores.vector_store import VectorStoreConfig
+from feast.infra.registry.base_registry import BaseRegistry
 from feast.protos.feast.core.InfraObject_pb2 import InfraObject as InfraObjectProto
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.protos.feast.core.SqliteTable_pb2 import SqliteTable as SqliteTableProto

--- a/sdk/python/feast/infra/passthrough_provider.py
+++ b/sdk/python/feast/infra/passthrough_provider.py
@@ -178,9 +178,12 @@ class PassthroughProvider(Provider):
         project: str,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ) -> None:
         if self.online_store:
-            self.online_store.teardown(self.repo_config, tables, entities)
+            self.online_store.teardown(
+                self.repo_config, tables, entities, registry=registry
+            )
         if self.batch_engine:
             self.batch_engine.teardown_infra(project, tables, entities)
 

--- a/sdk/python/feast/infra/provider.py
+++ b/sdk/python/feast/infra/provider.py
@@ -109,6 +109,7 @@ class Provider(ABC):
         project: str,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ):
         """
         Tears down all cloud resources for the specified set of Feast objects.

--- a/sdk/python/feast/metrics.py
+++ b/sdk/python/feast/metrics.py
@@ -102,7 +102,33 @@ def _cleanup_multiprocess_dir():
 atexit.register(_cleanup_multiprocess_dir)
 
 # Now safe to import prometheus_client — it will detect the env var.
-from prometheus_client import Counter, Gauge, Histogram  # noqa: E402
+_prometheus_available = True
+try:
+    from prometheus_client import Counter, Gauge, Histogram  # noqa: E402
+except Exception:
+    _prometheus_available = False
+
+    class _NoOpMetric:
+        def labels(self, **kwargs):
+            return self
+
+        def inc(self, amount: float = 1):
+            return None
+
+        def observe(self, amount: float):
+            return None
+
+        def set(self, value: float):
+            return None
+
+    def Counter(*args, **kwargs):  # type: ignore
+        return _NoOpMetric()
+
+    def Gauge(*args, **kwargs):  # type: ignore
+        return _NoOpMetric()
+
+    def Histogram(*args, **kwargs):  # type: ignore
+        return _NoOpMetric()
 
 
 # ---------------------------------------------------------------------------
@@ -495,6 +521,12 @@ def start_metrics_server(
             per-worker monitoring instead.
     """
     global _config
+
+    if not _prometheus_available:
+        logger.warning(
+            "Prometheus metrics are unavailable because prometheus_client could not be imported."
+        )
+        return
 
     if metrics_config is not None:
         _config = metrics_config

--- a/sdk/python/feast/metrics.py
+++ b/sdk/python/feast/metrics.py
@@ -102,33 +102,7 @@ def _cleanup_multiprocess_dir():
 atexit.register(_cleanup_multiprocess_dir)
 
 # Now safe to import prometheus_client — it will detect the env var.
-_prometheus_available = True
-try:
-    from prometheus_client import Counter, Gauge, Histogram  # noqa: E402
-except Exception:
-    _prometheus_available = False
-
-    class _NoOpMetric:
-        def labels(self, **kwargs):
-            return self
-
-        def inc(self, amount: float = 1):
-            return None
-
-        def observe(self, amount: float):
-            return None
-
-        def set(self, value: float):
-            return None
-
-    def Counter(*args, **kwargs):  # type: ignore
-        return _NoOpMetric()
-
-    def Gauge(*args, **kwargs):  # type: ignore
-        return _NoOpMetric()
-
-    def Histogram(*args, **kwargs):  # type: ignore
-        return _NoOpMetric()
+from prometheus_client import Counter, Gauge, Histogram  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -521,12 +495,6 @@ def start_metrics_server(
             per-worker monitoring instead.
     """
     global _config
-
-    if not _prometheus_available:
-        logger.warning(
-            "Prometheus metrics are unavailable because prometheus_client could not be imported."
-        )
-        return
 
     if metrics_config is not None:
         _config = metrics_config

--- a/sdk/python/pytest.ini
+++ b/sdk/python/pytest.ini
@@ -4,7 +4,6 @@ env =
     IS_TEST=True
 filterwarnings =
     error::_pytest.warning_types.PytestConfigWarning
-    error::_pytest.warning_types.PytestUnhandledCoroutineWarning
     ignore::DeprecationWarning:pyspark.sql.pandas.*:
     ignore::DeprecationWarning:pyspark.sql.connect.*:
     ignore::DeprecationWarning:httpx.*:

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -85,7 +85,7 @@ for logger_name in logging.root.manager.loggerDict:  # type: ignore
 
 
 def pytest_configure(config):
-    if platform in ["darwin", "windows"]:
+    if platform in ["darwin"] or platform.startswith("win"):
         multiprocessing.set_start_method("spawn", force=True)
     else:
         multiprocessing.set_start_method("fork")

--- a/sdk/python/tests/foo_provider.py
+++ b/sdk/python/tests/foo_provider.py
@@ -67,6 +67,7 @@ class FooProvider(Provider):
         project: str,
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
+        registry: Optional[BaseRegistry] = None,
     ):
         pass
 

--- a/sdk/python/tests/integration/offline_store/test_s3_custom_endpoint.py
+++ b/sdk/python/tests/integration/offline_store/test_s3_custom_endpoint.py
@@ -31,7 +31,7 @@ def test_registration_and_retrieval_from_custom_s3_endpoint(
             "It may be better to deduplicate AWS configuration or use sub-processes for isolation"
         )
 
-    os.environ["AWS_ACCESS_KEY_ID"] = "AKIAIOSFODNN7EXAMPLE"
+    os.environ["AWS_ACCESS_KEY_ID"] = "AKIAIOSFODNN7EXAMPLE"  # pragma: allowlist secret
     os.environ["AWS_SECRET_ACCESS_KEY"] = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 
     with construct_test_environment(config) as environment:

--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -283,6 +283,77 @@ def test_write_to_online_store(environment, universal_data_sources):
     assertpy.assert_that(df["conv_rate"].iloc[0]).is_close_to(0.85, 1e-6)
 
 
+@pytest.mark.integration
+@pytest.mark.universal_online_stores(only=["singlestore"])
+def test_singlestore_versioned_online_reads(environment, universal_data_sources):
+    fs = environment.feature_store
+    fs.config.registry.enable_online_feature_view_versioning = True
+
+    entities, datasets, data_sources = universal_data_sources
+    driver_entity = driver()
+
+    # Apply v0
+    driver_hourly_stats_v0 = create_driver_hourly_stats_feature_view(
+        data_sources.driver
+    )
+    fs.apply([driver_hourly_stats_v0, driver_entity])
+
+    # Write v0 data
+    df_v0 = pd.DataFrame(
+        {
+            "driver_id": [1],
+            "conv_rate": [0.1],
+            "acc_rate": [0.2],
+            "avg_daily_trips": [10],
+            "driver_metadata": [None],
+            "driver_config": [None],
+            "driver_profile": [None],
+            "event_timestamp": [pd.Timestamp(_utc_now()).round("ms")],
+            "created": [pd.Timestamp(_utc_now()).round("ms")],
+        }
+    )
+    fs.write_to_online_store("driver_stats", df_v0)
+
+    # Apply a schema change to create v1
+    driver_hourly_stats_v1 = FeatureView(
+        name="driver_stats",
+        entities=[driver_entity],
+        schema=driver_hourly_stats_v0.schema
+        + [Field(name="new_feature", dtype=Float32)],
+        source=data_sources.driver,
+        ttl=driver_hourly_stats_v0.ttl,
+        tags=TAGS,
+    )
+    fs.apply([driver_hourly_stats_v1, driver_entity])
+
+    # Write v1 data
+    df_v1 = pd.DataFrame(
+        {
+            "driver_id": [1],
+            "conv_rate": [0.1],
+            "acc_rate": [0.2],
+            "avg_daily_trips": [20],
+            "new_feature": [1.0],
+            "driver_metadata": [None],
+            "driver_config": [None],
+            "driver_profile": [None],
+            "event_timestamp": [pd.Timestamp(_utc_now()).round("ms")],
+            "created": [pd.Timestamp(_utc_now()).round("ms")],
+        }
+    )
+    fs.write_to_online_store("driver_stats", df_v1)
+
+    # Read v0 and v1 explicitly
+    df = fs.get_online_features(
+        features=["driver_stats@v0:avg_daily_trips", "driver_stats@v1:avg_daily_trips"],
+        entity_rows=[{"driver_id": 1}],
+        full_feature_names=True,
+    ).to_df()
+
+    assertpy.assert_that(df["driver_stats@v0__avg_daily_trips"].iloc[0]).is_equal_to(10)
+    assertpy.assert_that(df["driver_stats@v1__avg_daily_trips"].iloc[0]).is_equal_to(20)
+
+
 def _get_online_features_dict_remotely(
     endpoint: str,
     features: Union[List[str], FeatureService],

--- a/sdk/python/tests/unit/infra/online_store/test_online_store_base.py
+++ b/sdk/python/tests/unit/infra/online_store/test_online_store_base.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from feast.infra.online_stores.online_store import OnlineStore
+from feast.infra.registry.base_registry import BaseRegistry
 from feast.infra.supported_async_methods import SupportedAsyncMethods
 
 
@@ -26,7 +27,7 @@ class ConcreteOnlineStore(OnlineStore):
     ):
         pass
 
-    def teardown(self, config, tables, entities):
+    def teardown(self, config, tables, entities, registry: BaseRegistry = None):
         pass
 
 

--- a/sdk/python/tests/universal/feature_repos/universal/online_store/postgres.py
+++ b/sdk/python/tests/universal/feature_repos/universal/online_store/postgres.py
@@ -1,6 +1,8 @@
 import os
+import time
 from typing import Any, Dict
 
+import psycopg
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 from testcontainers.postgres import PostgresContainer
@@ -55,20 +57,47 @@ class PGVectorOnlineStoreCreator(OnlineStoreCreator):
         self.container.start()
         log_string_to_wait_for = "database system is ready to accept connections"
         wait_for_logs(
-            container=self.container, predicate=log_string_to_wait_for, timeout=10
+            container=self.container, predicate=log_string_to_wait_for, timeout=60
         )
         init_log_string_to_wait_for = "PostgreSQL init process complete"
         wait_for_logs(
-            container=self.container, predicate=init_log_string_to_wait_for, timeout=10
+            container=self.container, predicate=init_log_string_to_wait_for, timeout=60
         )
+
+        host = "localhost"
+        port = int(self.container.get_exposed_port(5432))
+
+        deadline = time.time() + 60
+        last_exc: Exception | None = None
+        while time.time() < deadline:
+            try:
+                conn = psycopg.connect(
+                    host=host,
+                    port=port,
+                    user="root",
+                    password="test!@#$%",
+                    dbname="test",
+                    connect_timeout=2,
+                    sslmode="disable",
+                )
+                conn.close()
+                last_exc = None
+                break
+            except psycopg.OperationalError as e:
+                last_exc = e
+                time.sleep(1)
+
+        if last_exc is not None:
+            raise last_exc
+
         return {
-            "host": "localhost",
+            "host": host,
             "type": "postgres",
             "user": "root",
             "password": "test!@#$%",
             "database": "test",
             "vector_enabled": True,
-            "port": self.container.get_exposed_port(5432),
+            "port": port,
             "sslmode": "disable",
         }
 

--- a/sdk/python/tests/universal/feature_repos/universal/online_store/postgres.py
+++ b/sdk/python/tests/universal/feature_repos/universal/online_store/postgres.py
@@ -1,8 +1,6 @@
 import os
-import time
 from typing import Any, Dict
 
-import psycopg
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 from testcontainers.postgres import PostgresContainer
@@ -57,47 +55,20 @@ class PGVectorOnlineStoreCreator(OnlineStoreCreator):
         self.container.start()
         log_string_to_wait_for = "database system is ready to accept connections"
         wait_for_logs(
-            container=self.container, predicate=log_string_to_wait_for, timeout=60
+            container=self.container, predicate=log_string_to_wait_for, timeout=10
         )
         init_log_string_to_wait_for = "PostgreSQL init process complete"
         wait_for_logs(
-            container=self.container, predicate=init_log_string_to_wait_for, timeout=60
+            container=self.container, predicate=init_log_string_to_wait_for, timeout=10
         )
-
-        host = "localhost"
-        port = int(self.container.get_exposed_port(5432))
-
-        deadline = time.time() + 60
-        last_exc: Exception | None = None
-        while time.time() < deadline:
-            try:
-                conn = psycopg.connect(
-                    host=host,
-                    port=port,
-                    user="root",
-                    password="test!@#$%",
-                    dbname="test",
-                    connect_timeout=2,
-                    sslmode="disable",
-                )
-                conn.close()
-                last_exc = None
-                break
-            except psycopg.OperationalError as e:
-                last_exc = e
-                time.sleep(1)
-
-        if last_exc is not None:
-            raise last_exc
-
         return {
-            "host": host,
+            "host": "localhost",
             "type": "postgres",
             "user": "root",
             "password": "test!@#$%",
             "database": "test",
             "vector_enabled": True,
-            "port": port,
+            "port": self.container.get_exposed_port(5432),
             "sslmode": "disable",
         }
 


### PR DESCRIPTION
# What this PR does / why we need it:
This PR adds **online feature view versioning support** for the SingleStore online store when `registry.enable_online_feature_view_versioning` is enabled.

It updates SingleStore’s table routing to read/write from **versioned namespaces** (e.g. `{project}_{feature_view}_v{N}`) so version-qualified refs like `driver_stats@v1:avg_daily_trips` can be served from the correct underlying online table. It also updates the global online-store guard to allow version-qualified reads for SingleStore (and still reject unsupported stores) when versioning is enabled.

Additionally, it adds an integration/universal test covering SingleStore version-qualified reads.

# Which issue(s) this PR fixes:
Fixes https://github.com/feast-dev/feast/issues/6181

# Checks
- [ ] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [x] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
Notes:
- Version-qualified reads are only allowed when `registry.enable_online_feature_view_versioning` is enabled; otherwise `VersionedOnlineReadNotSupported` is raised.
- The new SingleStore integration/universal test may be skipped locally if the universal SingleStore environment is not part of the parametrized test matrix (it should run in CI where SingleStore is enabled).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
