### PR TITLE
feat: Add versioning support for FAISS online store

### DIFF
--- a/sdk/python/feast/errors.py
+++ b/sdk/python/feast/errors.py
@@ -142,7 +142,7 @@ class VersionedOnlineReadNotSupported(FeastError):
     def __init__(self, store_name: str, version: int):
         super().__init__(
             f"Versioned feature reads (@v{version}) are not yet supported by {store_name}. "
-            f"Currently only SQLite supports version-qualified feature references. "
+            f"Currently only SQLite and FAISS support version-qualified feature references. "
         )
 
 

--- a/sdk/python/feast/infra/online_stores/faiss_online_store.py
+++ b/sdk/python/feast/infra/online_stores/faiss_online_store.py
@@ -66,9 +66,7 @@ class FaissOnlineStore(OnlineStore):
         self._in_memory_stores: Dict[str, InMemoryStore] = {}
         self._config: Optional[FaissOnlineStoreConfig] = None
 
-    def _get_index(
-        self, table_key: str
-    ) -> Optional[faiss.IndexIVFFlat]:
+    def _get_index(self, table_key: str) -> Optional[faiss.IndexIVFFlat]:
         return self._indices.get(table_key)
 
     def update(
@@ -95,9 +93,7 @@ class FaissOnlineStore(OnlineStore):
 
             if table_key not in self._indices or not partial:
                 quantizer = faiss.IndexFlatL2(dimension)
-                index = faiss.IndexIVFFlat(
-                    quantizer, dimension, self._config.nlist
-                )
+                index = faiss.IndexIVFFlat(quantizer, dimension, self._config.nlist)
                 index.train(
                     np.random.rand(self._config.nlist * 100, dimension).astype(
                         np.float32
@@ -202,13 +198,9 @@ class FaissOnlineStore(OnlineStore):
         ]
         mask = np.array(existing_indices) != -1
         if np.any(mask):
-            index.remove_ids(
-                np.array([idx for idx in existing_indices if idx != -1])
-            )
+            index.remove_ids(np.array([idx for idx in existing_indices if idx != -1]))
 
-        new_indices = np.arange(
-            index.ntotal, index.ntotal + len(feature_vectors_array)
-        )
+        new_indices = np.arange(index.ntotal, index.ntotal + len(feature_vectors_array))
         index.add(feature_vectors_array)
 
         for sk, idx in zip(serialized_keys, new_indices):

--- a/sdk/python/feast/infra/online_stores/faiss_online_store.py
+++ b/sdk/python/feast/infra/online_stores/faiss_online_store.py
@@ -43,16 +43,30 @@ class InMemoryStore:
         self.entity_keys = {}
 
 
+def _table_id(project: str, table: FeatureView, enable_versioning: bool = False) -> str:
+    """Compute the table key, including version suffix when versioning is enabled."""
+    name = table.name
+    if enable_versioning:
+        # Prefer version_tag from the projection (set by version-qualified refs like @v2)
+        # over current_version_number (the FV's active version in metadata).
+        version = getattr(table.projection, "version_tag", None)
+        if version is None:
+            version = getattr(table, "current_version_number", None)
+        if version is not None and version > 0:
+            name = f"{table.name}_v{version}"
+    return f"{project}_{name}"
+
+
 class FaissOnlineStore(OnlineStore):
-    _index: Optional[faiss.IndexIVFFlat] = None
-    _in_memory_store: InMemoryStore = InMemoryStore()
+    _indices: Dict[str, faiss.IndexIVFFlat] = {}
+    _in_memory_stores: Dict[str, InMemoryStore] = {}
     _config: Optional[FaissOnlineStoreConfig] = None
     _logger: logging.Logger = logging.getLogger(__name__)
 
-    def _get_index(self, config: RepoConfig) -> faiss.IndexIVFFlat:
-        if self._index is None or self._config is None:
-            raise ValueError("Index is not initialized")
-        return self._index
+    def _get_index(
+        self, table_key: str
+    ) -> Optional[faiss.IndexIVFFlat]:
+        return self._indices.get(table_key)
 
     def update(
         self,
@@ -63,23 +77,33 @@ class FaissOnlineStore(OnlineStore):
         entities_to_keep: Sequence[Entity],
         partial: bool,
     ):
-        feature_views = tables_to_keep
-        if not feature_views:
-            return
-
-        feature_names = [f.name for f in feature_views[0].features]
-        dimension = len(feature_names)
-
         self._config = FaissOnlineStoreConfig(**config.online_store.dict())
-        if self._index is None or not partial:
-            quantizer = faiss.IndexFlatL2(dimension)
-            self._index = faiss.IndexIVFFlat(quantizer, dimension, self._config.nlist)
-            self._index.train(
-                np.random.rand(self._config.nlist * 100, dimension).astype(np.float32)
-            )
-            self._in_memory_store = InMemoryStore()
+        versioning = config.registry.enable_online_feature_view_versioning
 
-        self._in_memory_store.update(feature_names, {})
+        for table in tables_to_delete:
+            table_key = _table_id(config.project, table, versioning)
+            self._indices.pop(table_key, None)
+            self._in_memory_stores.pop(table_key, None)
+
+        for table in tables_to_keep:
+            table_key = _table_id(config.project, table, versioning)
+            feature_names = [f.name for f in table.features]
+            dimension = len(feature_names)
+
+            if table_key not in self._indices or not partial:
+                quantizer = faiss.IndexFlatL2(dimension)
+                index = faiss.IndexIVFFlat(
+                    quantizer, dimension, self._config.nlist
+                )
+                index.train(
+                    np.random.rand(self._config.nlist * 100, dimension).astype(
+                        np.float32
+                    )
+                )
+                self._indices[table_key] = index
+                self._in_memory_stores[table_key] = InMemoryStore()
+
+            self._in_memory_stores[table_key].update(feature_names, {})
 
     def teardown(
         self,
@@ -87,8 +111,13 @@ class FaissOnlineStore(OnlineStore):
         tables: Sequence[FeatureView],
         entities: Sequence[Entity],
     ):
-        self._index = None
-        self._in_memory_store.teardown()
+        versioning = config.registry.enable_online_feature_view_versioning
+        for table in tables:
+            table_key = _table_id(config.project, table, versioning)
+            self._indices.pop(table_key, None)
+            store = self._in_memory_stores.pop(table_key, None)
+            if store is not None:
+                store.teardown()
 
     def online_read(
         self,
@@ -97,7 +126,12 @@ class FaissOnlineStore(OnlineStore):
         entity_keys: List[EntityKeyProto],
         requested_features: Optional[List[str]] = None,
     ) -> List[Tuple[Optional[datetime], Optional[Dict[str, ValueProto]]]]:
-        if self._index is None:
+        versioning = config.registry.enable_online_feature_view_versioning
+        table_key = _table_id(config.project, table, versioning)
+        index = self._get_index(table_key)
+        in_memory_store = self._in_memory_stores.get(table_key)
+
+        if index is None or in_memory_store is None:
             return [(None, None)] * len(entity_keys)
 
         results: List[Tuple[Optional[datetime], Optional[Dict[str, Any]]]] = []
@@ -105,15 +139,15 @@ class FaissOnlineStore(OnlineStore):
             serialized_key = serialize_entity_key(
                 entity_key, config.entity_key_serialization_version
             ).hex()
-            idx = self._in_memory_store.entity_keys.get(serialized_key, -1)
+            idx = in_memory_store.entity_keys.get(serialized_key, -1)
             if idx == -1:
                 results.append((None, None))
             else:
-                feature_vector = self._index.reconstruct(int(idx))
+                feature_vector = index.reconstruct(int(idx))
                 feature_dict = {
                     name: ValueProto(double_val=value)
                     for name, value in zip(
-                        self._in_memory_store.feature_names, feature_vector
+                        in_memory_store.feature_names, feature_vector
                     )
                 }
                 results.append((None, feature_dict))
@@ -128,8 +162,16 @@ class FaissOnlineStore(OnlineStore):
         ],
         progress: Optional[Callable[[int], Any]],
     ) -> None:
-        if self._index is None:
-            self._logger.warning("Index is not initialized. Skipping write operation.")
+        versioning = config.registry.enable_online_feature_view_versioning
+        table_key = _table_id(config.project, table, versioning)
+        index = self._get_index(table_key)
+        in_memory_store = self._in_memory_stores.get(table_key)
+
+        if index is None or in_memory_store is None:
+            self._logger.warning(
+                "Index for table '%s' is not initialized. Skipping write operation.",
+                table_key,
+            )
             return
 
         feature_vectors = []
@@ -142,7 +184,7 @@ class FaissOnlineStore(OnlineStore):
             feature_vector = np.array(
                 [
                     feature_dict[name].double_val
-                    for name in self._in_memory_store.feature_names
+                    for name in in_memory_store.feature_names
                 ],
                 dtype=np.float32,
             )
@@ -153,21 +195,21 @@ class FaissOnlineStore(OnlineStore):
         feature_vectors_array = np.array(feature_vectors)
 
         existing_indices = [
-            self._in_memory_store.entity_keys.get(sk, -1) for sk in serialized_keys
+            in_memory_store.entity_keys.get(sk, -1) for sk in serialized_keys
         ]
         mask = np.array(existing_indices) != -1
         if np.any(mask):
-            self._index.remove_ids(
+            index.remove_ids(
                 np.array([idx for idx in existing_indices if idx != -1])
             )
 
         new_indices = np.arange(
-            self._index.ntotal, self._index.ntotal + len(feature_vectors_array)
+            index.ntotal, index.ntotal + len(feature_vectors_array)
         )
-        self._index.add(feature_vectors_array)
+        index.add(feature_vectors_array)
 
         for sk, idx in zip(serialized_keys, new_indices):
-            self._in_memory_store.entity_keys[sk] = idx
+            in_memory_store.entity_keys[sk] = idx
 
         if progress:
             progress(len(data))
@@ -189,12 +231,16 @@ class FaissOnlineStore(OnlineStore):
             Optional[ValueProto],
         ]
     ]:
-        if self._index is None:
+        versioning = config.registry.enable_online_feature_view_versioning
+        table_key = _table_id(config.project, table, versioning)
+        index = self._get_index(table_key)
+
+        if index is None:
             self._logger.warning("Index is not initialized. Returning empty result.")
             return []
 
         query_vector = np.array(embedding, dtype=np.float32).reshape(1, -1)
-        distances, indices = self._index.search(query_vector, top_k)
+        distances, indices = index.search(query_vector, top_k)
 
         results: List[
             Tuple[
@@ -209,7 +255,7 @@ class FaissOnlineStore(OnlineStore):
             if idx == -1:
                 continue
 
-            feature_vector = self._index.reconstruct(int(idx))
+            feature_vector = index.reconstruct(int(idx))
 
             timestamp = Timestamp()
             timestamp.GetCurrentTime()

--- a/sdk/python/feast/infra/online_stores/faiss_online_store.py
+++ b/sdk/python/feast/infra/online_stores/faiss_online_store.py
@@ -58,10 +58,13 @@ def _table_id(project: str, table: FeatureView, enable_versioning: bool = False)
 
 
 class FaissOnlineStore(OnlineStore):
-    _indices: Dict[str, faiss.IndexIVFFlat] = {}
-    _in_memory_stores: Dict[str, InMemoryStore] = {}
-    _config: Optional[FaissOnlineStoreConfig] = None
     _logger: logging.Logger = logging.getLogger(__name__)
+
+    def __init__(self):
+        super().__init__()
+        self._indices: Dict[str, faiss.IndexIVFFlat] = {}
+        self._in_memory_stores: Dict[str, InMemoryStore] = {}
+        self._config: Optional[FaissOnlineStoreConfig] = None
 
     def _get_index(
         self, table_key: str

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -256,10 +256,16 @@ class OnlineStore(ABC):
 
     def _check_versioned_read_support(self, grouped_refs):
         """Raise an error if versioned reads are attempted on unsupported stores."""
-        from feast.infra.online_stores.faiss_online_store import FaissOnlineStore
+        try:
+            from feast.infra.online_stores.faiss_online_store import FaissOnlineStore
+        except ImportError:
+            FaissOnlineStore = None
         from feast.infra.online_stores.sqlite import SqliteOnlineStore
 
-        if isinstance(self, (SqliteOnlineStore, FaissOnlineStore)):
+        supported = [SqliteOnlineStore]
+        if FaissOnlineStore is not None:
+            supported.append(FaissOnlineStore)
+        if isinstance(self, tuple(supported)):
             return
         for table, _ in grouped_refs:
             version_tag = getattr(table.projection, "version_tag", None)

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -256,9 +256,10 @@ class OnlineStore(ABC):
 
     def _check_versioned_read_support(self, grouped_refs):
         """Raise an error if versioned reads are attempted on unsupported stores."""
+        from feast.infra.online_stores.faiss_online_store import FaissOnlineStore
         from feast.infra.online_stores.sqlite import SqliteOnlineStore
 
-        if isinstance(self, SqliteOnlineStore):
+        if isinstance(self, (SqliteOnlineStore, FaissOnlineStore)):
             return
         for table, _ in grouped_refs:
             version_tag = getattr(table.projection, "version_tag", None)

--- a/sdk/python/tests/unit/test_faiss_online_store_versioning.py
+++ b/sdk/python/tests/unit/test_faiss_online_store_versioning.py
@@ -1,0 +1,243 @@
+"""Unit tests for versioned feature view support in FaissOnlineStore."""
+import sys
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from feast.entity import Entity
+from feast.feature_view import FeatureView
+from feast.field import Field
+from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+from feast.types import Float32
+
+# ---------------------------------------------------------------------------
+# Helpers to build lightweight FeatureView fixtures without faiss
+# ---------------------------------------------------------------------------
+
+
+def _make_feature_view(name: str, version_number=None, version_tag=None):
+    entity = Entity(name="driver_id", join_keys=["driver_id"])
+    fv = FeatureView(
+        name=name,
+        entities=[entity],
+        ttl=timedelta(days=1),
+        schema=[Field(name="feature_a", dtype=Float32)],
+    )
+    if version_number is not None:
+        fv.current_version_number = version_number
+    if version_tag is not None:
+        fv.projection.version_tag = version_tag
+    return fv
+
+
+# ---------------------------------------------------------------------------
+# _table_id tests (no faiss needed — we mock the import at module level)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _mock_faiss():
+    """Inject a minimal faiss mock so faiss_online_store can be imported."""
+    faiss_mock = MagicMock()
+    with patch.dict(sys.modules, {"faiss": faiss_mock}):
+        # Remove cached module so the patched version is used
+        sys.modules.pop("feast.infra.online_stores.faiss_online_store", None)
+        yield faiss_mock
+    sys.modules.pop("feast.infra.online_stores.faiss_online_store", None)
+
+
+class TestFaissTableId:
+    def test_no_versioning(self):
+        from feast.infra.online_stores.faiss_online_store import _table_id
+
+        fv = _make_feature_view("driver_stats")
+        assert _table_id("my_project", fv) == "my_project_driver_stats"
+
+    def test_versioning_disabled_ignores_version_number(self):
+        from feast.infra.online_stores.faiss_online_store import _table_id
+
+        fv = _make_feature_view("driver_stats", version_number=3)
+        assert _table_id("my_project", fv, enable_versioning=False) == "my_project_driver_stats"
+
+    def test_versioning_enabled_v0_no_suffix(self):
+        from feast.infra.online_stores.faiss_online_store import _table_id
+
+        fv = _make_feature_view("driver_stats", version_number=0)
+        # version 0 should NOT produce a suffix
+        assert _table_id("my_project", fv, enable_versioning=True) == "my_project_driver_stats"
+
+    def test_versioning_enabled_version_number(self):
+        from feast.infra.online_stores.faiss_online_store import _table_id
+
+        fv = _make_feature_view("driver_stats", version_number=2)
+        assert (
+            _table_id("my_project", fv, enable_versioning=True)
+            == "my_project_driver_stats_v2"
+        )
+
+    def test_versioning_enabled_version_tag_takes_precedence(self):
+        from feast.infra.online_stores.faiss_online_store import _table_id
+
+        # version_tag on the projection takes precedence over current_version_number
+        fv = _make_feature_view("driver_stats", version_number=1, version_tag=3)
+        assert (
+            _table_id("my_project", fv, enable_versioning=True)
+            == "my_project_driver_stats_v3"
+        )
+
+    def test_versioning_enabled_no_version_set(self):
+        from feast.infra.online_stores.faiss_online_store import _table_id
+
+        fv = _make_feature_view("driver_stats")
+        # No version information — falls back to bare name
+        assert (
+            _table_id("my_project", fv, enable_versioning=True)
+            == "my_project_driver_stats"
+        )
+
+
+# ---------------------------------------------------------------------------
+# FaissOnlineStore versioned write / read tests (faiss is mocked)
+# ---------------------------------------------------------------------------
+
+
+def _make_config(project: str = "test_project", versioning: bool = False):
+    """Build a minimal RepoConfig-like mock."""
+    config = MagicMock()
+    config.project = project
+    config.entity_key_serialization_version = 2
+    config.online_store.dict.return_value = {
+        "dimension": 1,
+        "index_path": "/tmp/test.index",
+        "index_type": "IVFFlat",
+        "nlist": 10,
+    }
+    config.registry.enable_online_feature_view_versioning = versioning
+    return config
+
+
+def _make_entity_key(driver_id: int = 1):
+    return EntityKeyProto(
+        join_keys=["driver_id"],
+        entity_values=[ValueProto(int64_val=driver_id)],
+    )
+
+
+class TestFaissOnlineStoreVersionedWrite:
+    def _make_store(self, faiss_mock, nlist: int = 10):
+        """Create a FaissOnlineStore with a real-enough faiss mock."""
+        # Make the index mock respond correctly
+        index_mock = MagicMock()
+        index_mock.ntotal = 0
+
+        def add_side_effect(vectors):
+            index_mock.ntotal += len(vectors)
+
+        index_mock.add.side_effect = add_side_effect
+
+        def reconstruct_side_effect(idx):
+            return np.array([float(idx)], dtype=np.float32)
+
+        index_mock.reconstruct.side_effect = reconstruct_side_effect
+
+        faiss_mock.IndexFlatL2.return_value = MagicMock()
+        faiss_mock.IndexIVFFlat.return_value = index_mock
+
+        from feast.infra.online_stores.faiss_online_store import FaissOnlineStore
+
+        store = FaissOnlineStore()
+        # Reset class-level dicts to avoid test pollution
+        store._indices = {}
+        store._in_memory_stores = {}
+        return store, index_mock
+
+    def test_write_and_read_without_versioning(self, _mock_faiss):
+        store, index_mock = self._make_store(_mock_faiss)
+        config = _make_config(versioning=False)
+        fv = _make_feature_view("driver_stats")
+
+        store.update(config, [], [fv], [], [], partial=False)
+
+        entity_key = _make_entity_key(driver_id=42)
+        data = [
+            (entity_key, {"feature_a": ValueProto(double_val=1.5)}, None, None)
+        ]
+        store.online_write_batch(config, fv, data, None)
+
+        results = store.online_read(config, fv, [entity_key])
+        assert len(results) == 1
+        ts, feature_dict = results[0]
+        assert feature_dict is not None
+        assert "feature_a" in feature_dict
+
+    def test_write_and_read_with_versioning(self, _mock_faiss):
+        store, index_mock = self._make_store(_mock_faiss)
+        config = _make_config(versioning=True)
+        fv_v2 = _make_feature_view("driver_stats", version_number=2)
+
+        store.update(config, [], [fv_v2], [], [], partial=False)
+
+        entity_key = _make_entity_key(driver_id=7)
+        data = [
+            (entity_key, {"feature_a": ValueProto(double_val=2.0)}, None, None)
+        ]
+        store.online_write_batch(config, fv_v2, data, None)
+
+        results = store.online_read(config, fv_v2, [entity_key])
+        assert len(results) == 1
+        _, feature_dict = results[0]
+        assert feature_dict is not None
+
+    def test_versioned_namespaces_are_isolated(self, _mock_faiss):
+        """Data written under v1 must not be visible when reading under v2."""
+        store, _ = self._make_store(_mock_faiss)
+        config = _make_config(versioning=True)
+
+        fv_v1 = _make_feature_view("driver_stats", version_number=1)
+        fv_v2 = _make_feature_view("driver_stats", version_number=2)
+
+        store.update(config, [], [fv_v1, fv_v2], [], [], partial=False)
+
+        entity_key = _make_entity_key(driver_id=99)
+        data = [
+            (entity_key, {"feature_a": ValueProto(double_val=9.9)}, None, None)
+        ]
+        # Write only to v1
+        store.online_write_batch(config, fv_v1, data, None)
+
+        # Reading from v2 should return (None, None)
+        results_v2 = store.online_read(config, fv_v2, [entity_key])
+        assert results_v2 == [(None, None)]
+
+        # Reading from v1 should return data
+        results_v1 = store.online_read(config, fv_v1, [entity_key])
+        assert results_v1[0][1] is not None
+
+    def test_missing_index_returns_none(self, _mock_faiss):
+        store, _ = self._make_store(_mock_faiss)
+        config = _make_config(versioning=True)
+        fv = _make_feature_view("driver_stats", version_number=5)
+        # No update called — index not initialised
+        entity_key = _make_entity_key(driver_id=1)
+        results = store.online_read(config, fv, [entity_key])
+        assert results == [(None, None)]
+
+    def test_teardown_removes_versioned_index(self, _mock_faiss):
+        store, _ = self._make_store(_mock_faiss)
+        config = _make_config(versioning=True)
+        fv = _make_feature_view("driver_stats", version_number=3)
+
+        store.update(config, [], [fv], [], [], partial=False)
+
+        entity_key = _make_entity_key(driver_id=1)
+        data = [(entity_key, {"feature_a": ValueProto(double_val=3.0)}, None, None)]
+        store.online_write_batch(config, fv, data, None)
+
+        store.teardown(config, [fv], [])
+
+        # After teardown, reads return None
+        results = store.online_read(config, fv, [entity_key])
+        assert results == [(None, None)]


### PR DESCRIPTION
# What this PR does / why we need it:
Closes #6173

Feature view versioning was introduced in #6101, but version-qualified feature references (e.g. `driver_stats@v2:trips_today`) only worked with the SQLite online store. All other online stores raised `VersionedOnlineReadNotSupported` when a versioned ref was used.

This PR adds versioned read/write support to the FAISS online store, following the same pattern as the SQLite reference implementation:

- **Write path**: when `enable_online_feature_view_versioning` is enabled, `_table_id` appends a `_v{N}` suffix to the in-memory key namespace (e.g. `project_driver_stats_v2`), routing materialization to the correct versioned index
- **Read path**: version-qualified lookups (`@v2`) set `projection.version_tag` on the feature view before `online_read` is called; `_table_id` picks this up and routes to the correct index. `projection.version_tag` takes priority over `current_version_number` so explicit version requests are always honoured
- **Multi-table support**: replaced single class-level `_index`/`_in_memory_store` with per-table `_indices`/`_in_memory_stores` dicts, so multiple feature views and versions can coexist in memory simultaneously
- **Gate**: `_check_versioned_read_support` in `online_store.py` now allows `FaissOnlineStore` through

All existing `online_read`, `online_write_batch`, `retrieve_online_documents`, `update`, and `teardown` methods are covered since every method resolves its namespace through `_table_id`.

# Which issue(s) this PR fixes:
Part of #2728

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

Added 11 unit tests covering `_table_id` with versioning disabled, `projection.version_tag` priority over `current_version_number`, version 0 edge case, no version info fallback, versioned write/read round trips, namespace isolation between versions, missing index handling, and teardown cleanup.

# Misc
- Removed `"type"` from mock config in tests to match `FaissOnlineStoreConfig`'s strict pydantic validation (no extra fields permitted)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
