### PR TITLE
feat: Add RBAC aggregation labels to FeatureStore ClusterRoles

### DIFF
--- a/infra/feast-operator/bundle/manifests/feast-operator-featurestore-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/infra/feast-operator/bundle/manifests/feast-operator-featurestore-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: feast-operator
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: feast-operator-featurestore-editor-role
 rules:
 - apiGroups:

--- a/infra/feast-operator/bundle/manifests/feast-operator-featurestore-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/infra/feast-operator/bundle/manifests/feast-operator-featurestore-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: feast-operator
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: feast-operator-featurestore-viewer-role
 rules:
 - apiGroups:

--- a/infra/feast-operator/config/rbac/featurestore_editor_role.yaml
+++ b/infra/feast-operator/config/rbac/featurestore_editor_role.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app.kubernetes.io/name: feast-operator
     app.kubernetes.io/managed-by: kustomize
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: featurestore-editor-role
 rules:
 - apiGroups:

--- a/infra/feast-operator/config/rbac/featurestore_viewer_role.yaml
+++ b/infra/feast-operator/config/rbac/featurestore_viewer_role.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: feast-operator
     app.kubernetes.io/managed-by: kustomize
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: featurestore-viewer-role
 rules:
 - apiGroups:

--- a/infra/feast-operator/dist/install.yaml
+++ b/infra/feast-operator/dist/install.yaml
@@ -20262,6 +20262,8 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: feast-operator
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: feast-operator-featurestore-editor-role
 rules:
 - apiGroups:
@@ -20289,6 +20291,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: feast-operator
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: feast-operator-featurestore-viewer-role
 rules:
 - apiGroups:


### PR DESCRIPTION
# What this PR does / why we need it:

The Feast operator ships two ClusterRoles for end users (featurestore-editor-role and featurestore-viewer-role), but these roles are not automatically available to users who already have the standard Kubernetes admin, edit, or view roles in a namespace.

This means that a namespace admin who should be able to manage FeatureStore CRDs cannot do so until a cluster administrator manually creates a separate RoleBinding to one of the Feast-specific ClusterRoles. This creates an extra manual step and is inconsistent with how most operators expose their CRD permissions.

This PR adds standard Kubernetes RBAC aggregation labels to the existing FeatureStore ClusterRoles:

**featurestore-editor-role**:

```
rbac.authorization.k8s.io/aggregate-to-admin: "true"
rbac.authorization.k8s.io/aggregate-to-edit: "true"
```

**featurestore-viewer-role**:

`rbac.authorization.k8s.io/aggregate-to-view: "true"`

These labels cause Kubernetes to automatically aggregate the permissions into the built-in admin, edit, and view ClusterRoles ([Kubernetes docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles))
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
