### PR TITLE
fix: scope data source operations by project in shared registry

### DIFF
--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -394,7 +394,10 @@ class Registry(BaseRegistry):
         registry = self._prepare_registry_for_changes(project)
 
         for idx, existing_data_source_proto in enumerate(registry.data_sources):
-            if existing_data_source_proto.name == data_source.name:
+            if (
+                existing_data_source_proto.name == data_source.name
+                and existing_data_source_proto.project == project
+            ):
                 existing_data_source = DataSource.from_proto(existing_data_source_proto)
                 # Check if the data source has actually changed
                 if existing_data_source == data_source:
@@ -423,7 +426,7 @@ class Registry(BaseRegistry):
         for idx, data_source_proto in enumerate(
             self.cached_registry_proto.data_sources
         ):
-            if data_source_proto.name == name:
+            if data_source_proto.name == name and data_source_proto.project == project:
                 del self.cached_registry_proto.data_sources[idx]
                 if commit:
                     self.commit()


### PR DESCRIPTION
## Summary

Fixes #6206

`apply_data_source` and `delete_data_source` in `Registry` match data sources by name only, without filtering by project. When multiple projects share the same registry and have data sources with the same name (e.g. the default `vals_to_add`), this causes cross-project overwrites.

## Fix

Add the `project` filter to both methods, consistent with how `apply_entity` (line 349-352), `apply_feature_service` (line 447-451), and `apply_feature_view` (line 779-781) already scope their lookups.

**apply_data_source**: `existing_data_source_proto.name == data_source.name and existing_data_source_proto.project == project`

**delete_data_source**: `data_source_proto.name == name and data_source_proto.project == project`

## Test plan

- [ ] `feast apply` for project A with data source `vals_to_add` does not overwrite project B's `vals_to_add`
- [ ] `feast apply` for the same project still correctly updates existing data sources
- [ ] Deleting a data source only removes the one in the specified project
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
