### PR TITLE
fix: Fix cache overwrite during batch feature view apply

### DIFF
--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -764,7 +764,7 @@ class Registry(BaseRegistry):
         self._prepare_registry_for_changes(project)
         assert self.cached_registry_proto
 
-        self._check_conflicting_feature_view_names(feature_view)
+        self._ensure_feature_view_name_is_unique(feature_view, project)
         existing_feature_views_of_same_type: RepeatedCompositeFieldContainer
         if isinstance(feature_view, StreamFeatureView):
             existing_feature_views_of_same_type = (
@@ -1359,26 +1359,6 @@ class Registry(BaseRegistry):
                     pass
 
             return registry_proto
-
-    def _check_conflicting_feature_view_names(self, feature_view: BaseFeatureView):
-        name_to_fv_protos = self._existing_feature_view_names_to_fvs()
-        if feature_view.name in name_to_fv_protos:
-            if not isinstance(
-                name_to_fv_protos.get(feature_view.name), feature_view.proto_class
-            ):
-                raise ConflictingFeatureViewNames(feature_view.name)
-
-    def _existing_feature_view_names_to_fvs(self) -> Dict[str, Message]:
-        assert self.cached_registry_proto
-        odfvs = {
-            fv.spec.name: fv
-            for fv in self.cached_registry_proto.on_demand_feature_views
-        }
-        fvs = {fv.spec.name: fv for fv in self.cached_registry_proto.feature_views}
-        sfv = {
-            fv.spec.name: fv for fv in self.cached_registry_proto.stream_feature_views
-        }
-        return {**odfvs, **fvs, **sfv}
 
     def get_permission(
         self, name: str, project: str, allow_cache: bool = False

--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -764,7 +764,10 @@ class Registry(BaseRegistry):
         self._prepare_registry_for_changes(project)
         assert self.cached_registry_proto
 
-        self._ensure_feature_view_name_is_unique(feature_view, project)
+        # allow_cache=True: _prepare_registry_for_changes (line above) already loaded the cache;
+        # using allow_cache=False would re-read from store and overwrite cached_registry_proto,
+        # discarding any uncommitted in-memory changes from prior commit=False calls.
+        self._ensure_feature_view_name_is_unique(feature_view, project, allow_cache=True)
         existing_feature_views_of_same_type: RepeatedCompositeFieldContainer
         if isinstance(feature_view, StreamFeatureView):
             existing_feature_views_of_same_type = (

--- a/sdk/python/tests/integration/registration/test_universal_registry.py
+++ b/sdk/python/tests/integration/registration/test_universal_registry.py
@@ -2299,6 +2299,7 @@ def test_cross_type_feature_view_odfv_conflict(test_registry: BaseRegistry):
     test_registry.teardown()
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "test_registry",
     all_fixtures,
@@ -2354,6 +2355,7 @@ def test_cross_project_feature_view_name_allowed(test_registry: BaseRegistry):
     test_registry.teardown()
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     "test_registry",
     all_fixtures,

--- a/sdk/python/tests/integration/registration/test_universal_registry.py
+++ b/sdk/python/tests/integration/registration/test_universal_registry.py
@@ -2352,3 +2352,67 @@ def test_cross_project_feature_view_name_allowed(test_registry: BaseRegistry):
     test_registry.delete_feature_view("shared_name", project_a)
     test_registry.delete_feature_view("shared_name", project_b)
     test_registry.teardown()
+
+
+@pytest.mark.parametrize(
+    "test_registry",
+    all_fixtures,
+)
+def test_batch_apply_preserves_all_feature_views(test_registry: BaseRegistry):
+    """
+    Regression test for cache overwrite during batch feature view apply.
+
+    Verifies that applying multiple feature views with commit=False in a loop
+    (as feature_store.apply() does) preserves all uncommitted in-memory changes.
+    Before the fix, each apply_feature_view call with commit=False would invoke
+    _ensure_feature_view_name_is_unique with allow_cache=False, causing
+    _get_registry_proto to re-read from the store and overwrite cached_registry_proto,
+    discarding previously applied feature views from the in-memory cache.
+    """
+    project = "project"
+
+    batch_source = FileSource(
+        name="batch_source",
+        file_format=ParquetFormat(),
+        path="file://feast/data.parquet",
+        timestamp_field="event_timestamp",
+    )
+
+    fv1 = FeatureView(
+        name="feature_view_1",
+        entities=[],
+        schema=[Field(name="feature_a", dtype=Float32)],
+        source=batch_source,
+    )
+    fv2 = FeatureView(
+        name="feature_view_2",
+        entities=[],
+        schema=[Field(name="feature_b", dtype=Float32)],
+        source=batch_source,
+    )
+    fv3 = FeatureView(
+        name="feature_view_3",
+        entities=[],
+        schema=[Field(name="feature_c", dtype=Float32)],
+        source=batch_source,
+    )
+
+    # Mimic feature_store.apply(): apply all objects with commit=False, then commit once.
+    # Without the allow_cache=True fix, each apply_feature_view call would overwrite
+    # cached_registry_proto from the store, causing previously applied FVs to be lost.
+    test_registry.apply_data_source(batch_source, project, commit=False)
+    for fv in [fv1, fv2, fv3]:
+        test_registry.apply_feature_view(fv, project, commit=False)
+    test_registry.commit()
+
+    # All three feature views must survive — any cache overwrite would cause missing entries.
+    stored_fvs = test_registry.list_feature_views(project)
+    stored_names = {fv.name for fv in stored_fvs}
+    assert "feature_view_1" in stored_names, "fv1 lost during batch apply (cache overwrite)"
+    assert "feature_view_2" in stored_names, "fv2 lost during batch apply (cache overwrite)"
+    assert "feature_view_3" in stored_names, "fv3 lost during batch apply (cache overwrite)"
+
+    stored_sources = test_registry.list_data_sources(project)
+    assert len(stored_sources) == 1, "data source lost during batch apply"
+
+    test_registry.teardown()

--- a/sdk/python/tests/integration/registration/test_universal_registry.py
+++ b/sdk/python/tests/integration/registration/test_universal_registry.py
@@ -2297,3 +2297,58 @@ def test_cross_type_feature_view_odfv_conflict(test_registry: BaseRegistry):
     # Cleanup
     test_registry.delete_feature_view("shared_odfv_name", project)
     test_registry.teardown()
+
+
+@pytest.mark.parametrize(
+    "test_registry",
+    all_fixtures,
+)
+def test_cross_project_feature_view_name_allowed(test_registry: BaseRegistry):
+    """
+    Test that different projects can use the same feature view names.
+    This is a regression test for issue #6209.
+    """
+    project_a = "project_a"
+    project_b = "project_b"
+
+    # Create a FeatureView in project A
+    feature_view_a = FeatureView(
+        name="shared_name",
+        entities=[],
+        schema=[Field(name="feature1", dtype=Float32)],
+        source=FileSource(path="data.parquet"),
+    )
+
+    # Create a StreamFeatureView with the same name in project B
+    stream_feature_view_b = StreamFeatureView(
+        name="shared_name",
+        entities=[],
+        schema=[Field(name="feature2", dtype=Float32)],
+        source=KafkaSource(
+            name="kafka_source",
+            kafka_bootstrap_servers="localhost:9092",
+            topic="test_topic",
+            timestamp_field="event_timestamp",
+            batch_source=FileSource(path="stream_data.parquet"),
+        ),
+        aggregations=[],
+    )
+
+    # Both should apply successfully without ConflictingFeatureViewNames error
+    test_registry.apply_feature_view(feature_view_a, project_a)
+    test_registry.apply_feature_view(stream_feature_view_b, project_b)
+
+    # Verify both exist in their respective projects
+    retrieved_fv_a = test_registry.get_feature_view("shared_name", project_a)
+    assert retrieved_fv_a.name == "shared_name"
+    assert isinstance(retrieved_fv_a, FeatureView)
+    assert not isinstance(retrieved_fv_a, StreamFeatureView)
+
+    retrieved_sfv_b = test_registry.get_stream_feature_view("shared_name", project_b)
+    assert retrieved_sfv_b.name == "shared_name"
+    assert isinstance(retrieved_sfv_b, StreamFeatureView)
+
+    # Cleanup
+    test_registry.delete_feature_view("shared_name", project_a)
+    test_registry.delete_feature_view("shared_name", project_b)
+    test_registry.teardown()


### PR DESCRIPTION
Fixes the cache overwrite issue in batch feature view apply operations.

## Summary

This PR fixes two related bugs in `sdk/python/feast/infra/registry/registry.py`:

**Bug 1 — Cache overwrite during batch apply (commit=False loop)**

`apply_feature_view` called `_ensure_feature_view_name_is_unique` with the default `allow_cache=False`, which triggered `_get_registry_proto` to re-read from the registry store and overwrite `self.cached_registry_proto`. This discarded any uncommitted in-memory changes from prior `commit=False` calls.

This was triggered in `feature_store.py:1199-1202` where `apply_feature_view` is called in a loop with `commit=False` after other uncommitted `apply_project` and `apply_data_source` calls. Each uniqueness check overwrote the cache, losing previously applied feature views.

**Fix:** Pass `allow_cache=True` to `_ensure_feature_view_name_is_unique` at line 758. Safe because `_prepare_registry_for_changes` (line 755) already prepared the cache with all necessary data.

**Bug 2 — Cross-project feature view name conflict (false positive)**

The old `_check_conflicting_feature_view_names` method scanned `cached_registry_proto` globally across all projects, causing false positive `ConflictingFeatureViewNames` errors when different projects used the same feature view name with different types.

**Fix:** Replace with `_ensure_feature_view_name_is_unique` from `BaseRegistry`, which correctly scopes conflict checks by project (aligns with SQL registry behavior).

## Changes

- `sdk/python/feast/infra/registry/registry.py:758`: Replace `_check_conflicting_feature_view_names` with `_ensure_feature_view_name_is_unique(feature_view, project, allow_cache=True)`
- Remove `_check_conflicting_feature_view_names` and `_existing_feature_view_names_to_fvs` methods (21 lines removed)
- `sdk/python/tests/integration/registration/test_universal_registry.py`: Add two regression tests

## Test Plan

- `test_batch_apply_preserves_all_feature_views` — applies 3 feature views with `commit=False` in a loop then commits; verifies all 3 survive (directly reproduces the cache overwrite bug)
- `test_cross_project_feature_view_name_allowed` — verifies same FV name is allowed across different projects
- All existing tests continue to pass (uniqueness checks still enforce conflicts within the same project)