### PR TITLE
feat: Add comprehensive Ruff lint configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,9 +251,6 @@ tag_regex = "^(?:[\\/\\w-]+)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+
 line-length = 88
 target-version = "py310"
 include = ["*.py", "*.pyi"]
-
-[tool.ruff.format]
-# exclude a few common directories in the root of the project
 exclude = [
   ".eggs",
   ".git",
@@ -265,10 +262,41 @@ exclude = [
   "buck-out",
   "build",
   "dist",
-  "pb2.py",
-  ".pyi",
-  "protos",
-  "sdk/python/feast/embedded_go/lib"]
+  "sdk/python/feast/protos",
+  "sdk/python/feast/embedded_go/lib",
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP"]
+ignore = [
+  "E203",  # whitespace before ':'
+  "E266",  # too many leading '#' for block comment
+  "E501",  # line too long (handled by formatter)
+  "E721",  # do not compare types, use isinstance()
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["feast", "feast_serving_server", "feast_core_server"]
+default-section = "third-party"
+
+[tool.ruff.lint.pyupgrade]
+keep-runtime-typing = true
+
+[tool.ruff.format]
+exclude = [
+  ".eggs",
+  ".git",
+  ".hg",
+  ".mypy_cache",
+  ".tox",
+  ".venv",
+  "_build",
+  "buck-out",
+  "build",
+  "dist",
+  "sdk/python/feast/protos",
+  "sdk/python/feast/embedded_go/lib",
+]
 
 [dependency-groups]
 dev = [

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -2,12 +2,15 @@
 exclude = [".git","__pycache__","docs/conf.py","dist","feast/protos","feast/embedded_go/lib","feast/infra/utils/snowflake/snowpark/snowflake_udfs.py"]
 
 [tool.ruff.lint]
-select = ["E","F","W","I"]
+select = ["E", "F", "W", "I", "UP"]
 ignore = ["E203", "E266", "E501", "E721"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["feast", "feast_serving_server", "feast_core_server"]
 default-section = "third-party"
+
+[tool.ruff.lint.pyupgrade]
+keep-runtime-typing = true
 
 [tool.mypy]
 files = ["feast", "tests"]


### PR DESCRIPTION
## Summary

Adds comprehensive Ruff linting configuration to the root `pyproject.toml` as part of the migration to Ruff (refs #5788).

- **Root `pyproject.toml`**: Added `[tool.ruff.lint]` section with rule sets `E`, `W`, `F` (pycodestyle/pyflakes), `I` (isort), and `UP` (pyupgrade). Migrated ignore rules and isort config from `sdk/python/pyproject.toml`. Added `[tool.ruff.lint.pyupgrade]` with `keep-runtime-typing = true` to avoid breaking runtime type annotations. Consolidated exclude patterns to properly reference `sdk/python/feast/protos` and `sdk/python/feast/embedded_go/lib`.
- **`sdk/python/pyproject.toml`**: Added `UP` rule set and pyupgrade config for consistency with root config.

The pre-commit hooks and Makefile targets already use Ruff via `uv run ruff`, so no changes were needed there. This PR focuses on completing the Ruff lint configuration; auto-fixing existing violations is left for a follow-up to keep the diff reviewable.

## Test plan

- [ ] Run `ruff check sdk/python/feast/ sdk/python/tests/` to verify configuration loads correctly
- [ ] Run `ruff format --check sdk/python/feast/ sdk/python/tests/` to verify format config
- [ ] Verify pre-commit hooks still work: `pre-commit run --all-files`
- [ ] Confirm no regressions in CI lint job
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
