### PR TITLE
feat: Provision minimal TokenReview RBAC for OIDC auth and add SSL error logging in token parser

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -934,11 +934,7 @@
         "filename": "infra/feast-operator/api/v1/featurestore_types.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
-<<<<<<< HEAD
-        "line_number": 877
-=======
-        "line_number": 763
->>>>>>> 15c8ec529 (feat(operator): Provision minimal TokenReview RBAC for OIDC auth)
+        "line_number": 879
       }
     ],
     "infra/feast-operator/api/v1/zz_generated.deepcopy.go": [
@@ -1543,5 +1539,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-30T13:56:37Z"
+  "generated_at": "2026-04-30T20:52:53Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -934,7 +934,11 @@
         "filename": "infra/feast-operator/api/v1/featurestore_types.go",
         "hashed_secret": "44e17306b837162269a410204daaa5ecee4ec22c",
         "is_verified": false,
+<<<<<<< HEAD
         "line_number": 877
+=======
+        "line_number": 763
+>>>>>>> 15c8ec529 (feat(operator): Provision minimal TokenReview RBAC for OIDC auth)
       }
     ],
     "infra/feast-operator/api/v1/zz_generated.deepcopy.go": [
@@ -1122,7 +1126,7 @@
         "filename": "infra/feast-operator/internal/controller/featurestore_controller_oidc_auth_test.go",
         "hashed_secret": "a1f14fc6f33ba39a8b6d006fefa6fe0fe8d60ae2",
         "is_verified": false,
-        "line_number": 447
+        "line_number": 450
       }
     ],
     "infra/feast-operator/internal/controller/featurestore_controller_test_utils_test.go": [

--- a/infra/feast-operator/api/v1/featurestore_types.go
+++ b/infra/feast-operator/api/v1/featurestore_types.go
@@ -52,6 +52,7 @@ const (
 	ClientFailedReason           = "ClientDeploymentFailed"
 	CronJobFailedReason          = "CronJobDeploymentFailed"
 	KubernetesAuthzFailedReason  = "KubernetesAuthorizationDeploymentFailed"
+	OidcAuthzFailedReason        = "OidcAuthorizationDeploymentFailed"
 
 	// Feast condition messages:
 	ReadyMessage                  = "FeatureStore installation complete"
@@ -62,6 +63,7 @@ const (
 	ClientReadyMessage            = "Client installation complete"
 	CronJobReadyMessage           = "CronJob installation complete"
 	KubernetesAuthzReadyMessage   = "Kubernetes authorization installation complete"
+	OidcAuthzReadyMessage         = "OIDC authorization installation complete"
 	DeploymentNotAvailableMessage = "Deployment is not available"
 
 	// entity_key_serialization_version

--- a/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
+++ b/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-04-08T14:26:31Z"
+    createdAt: "2026-04-21T14:06:03Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: feast-operator.v0.62.0
@@ -78,6 +78,36 @@ spec:
     spec:
       clusterPermissions:
       - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - persistentvolumeclaims
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          - pods
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/exec
+          verbs:
+          - create
         - apiGroups:
           - apps
           resources:
@@ -119,36 +149,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - persistentvolumeclaims
-          - serviceaccounts
-          - services
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          - pods
-          - secrets
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - pods/exec
-          verbs:
-          - create
         - apiGroups:
           - feast.dev
           resources:

--- a/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
+++ b/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
@@ -50,7 +50,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2026-04-21T14:06:03Z"
+    createdAt: "2026-04-30T09:51:36Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: feast-operator.v0.62.0
@@ -266,12 +266,12 @@ spec:
                 command:
                 - /manager
                 env:
-                - name: GOMEMLIMIT
-                  value: "230MiB"
                 - name: RELATED_IMAGE_FEATURE_SERVER
                   value: quay.io/feastdev/feature-server:0.62.0
                 - name: RELATED_IMAGE_CRON_JOB
                   value: quay.io/openshift/origin-cli:4.17
+                - name: GOMEMLIMIT
+                  value: 230MiB
                 - name: OIDC_ISSUER_URL
                 image: quay.io/feastdev/feast-operator:0.62.0
                 livenessProbe:

--- a/infra/feast-operator/bundle/manifests/feast.dev_featurestores.yaml
+++ b/infra/feast-operator/bundle/manifests/feast.dev_featurestores.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   name: featurestores.feast.dev
 spec:
@@ -167,8 +167,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -267,7 +266,7 @@ spec:
                       envFrom:
                         items:
                           description: EnvFromSource represents the source of a set
-                            of ConfigMaps
+                            of ConfigMaps or Secrets
                           properties:
                             configMapRef:
                               description: The ConfigMap to select from
@@ -286,8 +285,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: Optional text to prepend to the name of
+                                each environment variable. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -333,6 +332,10 @@ spec:
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used.
                                   type: string
+                                request:
+                                  description: Request is the name chosen for a request
+                                    in the referenced claim.
+                                  type: string
                               required:
                               - name
                               type: object
@@ -374,7 +377,7 @@ spec:
                       activeDeadlineSeconds:
                         description: |-
                           Specifies the duration in seconds relative to the startTime that the job
-                          may be continuously active before the system tr
+                          may be continuously active before the system...
                         format: int64
                         type: integer
                       backoffLimit:
@@ -557,8 +560,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -657,7 +659,7 @@ spec:
                       envFrom:
                         items:
                           description: EnvFromSource represents the source of a set
-                            of ConfigMaps
+                            of ConfigMaps or Secrets
                           properties:
                             configMapRef:
                               description: The ConfigMap to select from
@@ -676,8 +678,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: Optional text to prepend to the name of
+                                each environment variable. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -762,7 +764,7 @@ spec:
                           preferredDuringSchedulingIgnoredDuringExecution:
                             description: |-
                               The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but i
+                              the affinity expressions specified by this field, but...
                             items:
                               description: |-
                                 An empty preferred scheduling term matches all objects with implicit weight 0
@@ -848,9 +850,9 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: "If the affinity requirements specified by
-                              this field are not met at\nscheduling time, the pod
-                              will not be scheduled onto "
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto...
                             properties:
                               nodeSelectorTerms:
                                 description: Required. A list of node selector terms.
@@ -939,7 +941,7 @@ spec:
                           preferredDuringSchedulingIgnoredDuringExecution:
                             description: |-
                               The scheduler will prefer to schedule pods to nodes that satisfy
-                              the affinity expressions specified by this field, but i
+                              the affinity expressions specified by this field, but...
                             items:
                               description: The weights of all of the matched WeightedPodAffinityTerm
                                 fields are added per-node to find the most preferred
@@ -1064,7 +1066,7 @@ spec:
                                     topologyKey:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                        the labelSelector in t
+                                        the labelSelector in...
                                       type: string
                                   required:
                                   - topologyKey
@@ -1082,13 +1084,13 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: "If the affinity requirements specified by
-                              this field are not met at\nscheduling time, the pod
-                              will not be scheduled onto "
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto...
                             items:
-                              description: "Defines a set of pods (namely those matching
-                                the labelSelector\nrelative to the given namespace(s))
-                                that this pod should "
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should...
                               properties:
                                 labelSelector:
                                   description: |-
@@ -1205,7 +1207,7 @@ spec:
                                 topologyKey:
                                   description: |-
                                     This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in t
+                                    the labelSelector in...
                                   type: string
                               required:
                               - topologyKey
@@ -1218,9 +1220,9 @@ spec:
                           (e.g. avoid putting this pod in the same node, zone, etc.
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
-                            description: "The scheduler will prefer to schedule pods
-                              to nodes that satisfy\nthe anti-affinity expressions
-                              specified by this field, "
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field,...
                             items:
                               description: The weights of all of the matched WeightedPodAffinityTerm
                                 fields are added per-node to find the most preferred
@@ -1345,7 +1347,7 @@ spec:
                                     topologyKey:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                        the labelSelector in t
+                                        the labelSelector in...
                                       type: string
                                   required:
                                   - topologyKey
@@ -1363,13 +1365,13 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
-                            description: "If the anti-affinity requirements specified
-                              by this field are not met at\nscheduling time, the pod
-                              will not be scheduled "
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled...
                             items:
-                              description: "Defines a set of pods (namely those matching
-                                the labelSelector\nrelative to the given namespace(s))
-                                that this pod should "
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should...
                               properties:
                                 labelSelector:
                                   description: |-
@@ -1486,7 +1488,7 @@ spec:
                                 topologyKey:
                                   description: |-
                                     This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                    the labelSelector in t
+                                    the labelSelector in...
                                   type: string
                               required:
                               - topologyKey
@@ -1684,8 +1686,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -1785,7 +1786,7 @@ spec:
                           envFrom:
                             items:
                               description: EnvFromSource represents the source of
-                                a set of ConfigMaps
+                                a set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -1804,8 +1805,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: Optional text to prepend to the name
+                                    of each environment variable. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -1866,6 +1867,10 @@ spec:
                                       description: |-
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used.
+                                      type: string
+                                    request:
+                                      description: Request is the name chosen for
+                                        a request in the referenced claim.
                                       type: string
                                   required:
                                   - name
@@ -2194,8 +2199,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -2295,7 +2299,7 @@ spec:
                           envFrom:
                             items:
                               description: EnvFromSource represents the source of
-                                a set of ConfigMaps
+                                a set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -2314,8 +2318,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: Optional text to prepend to the name
+                                    of each environment variable. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -2376,6 +2380,10 @@ spec:
                                       description: |-
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used.
+                                      type: string
+                                    request:
+                                      description: Request is the name chosen for
+                                        a request in the referenced claim.
                                       type: string
                                   required:
                                   - name
@@ -2752,8 +2760,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -2856,7 +2863,7 @@ spec:
                               envFrom:
                                 items:
                                   description: EnvFromSource represents the source
-                                    of a set of ConfigMaps
+                                    of a set of ConfigMaps or Secrets
                                   properties:
                                     configMapRef:
                                       description: The ConfigMap to select from
@@ -2875,8 +2882,9 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: An optional identifier to prepend
-                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      description: Optional text to prepend to the
+                                        name of each environment variable. Must be
+                                        a C_IDENTIFIER.
                                       type: string
                                     secretRef:
                                       description: The Secret to select from
@@ -2941,6 +2949,10 @@ spec:
                                           description: |-
                                             Name must match the name of one entry in pod.spec.resourceClaims of
                                             the Pod where this field is used.
+                                          type: string
+                                        request:
+                                          description: Request is the name chosen
+                                            for a request in the referenced claim.
                                           type: string
                                       required:
                                       - name
@@ -3223,9 +3235,18 @@ spec:
                                   stabilizationWindowSeconds:
                                     description: |-
                                       stabilizationWindowSeconds is the number of seconds for which past recommendations should be
-                                      considered while scaling up
+                                      considered while scaling...
                                     format: int32
                                     type: integer
+                                  tolerance:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      tolerance is the tolerance on the ratio between the current and desired
+                                      metric value under which no updates are made to...
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                 type: object
                               scaleUp:
                                 description: scaleUp is scaling policy for scaling
@@ -3270,9 +3291,18 @@ spec:
                                   stabilizationWindowSeconds:
                                     description: |-
                                       stabilizationWindowSeconds is the number of seconds for which past recommendations should be
-                                      considered while scaling up
+                                      considered while scaling...
                                     format: int32
                                     type: integer
+                                  tolerance:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      tolerance is the tolerance on the ratio between the current and desired
+                                      metric value under which no updates are made to...
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
                                 type: object
                             type: object
                           maxReplicas:
@@ -3287,12 +3317,12 @@ spec:
                             items:
                               description: |-
                                 MetricSpec specifies how to scale based on a single metric
-                                (only `type` and one other matching field should be set at on
+                                (only `type` and one other matching field should be set at...
                               properties:
                                 containerResource:
                                   description: |-
                                     containerResource refers to a resource metric (such as those specified in
-                                    requests and limits) known to Kubernetes descr
+                                    requests and limits) known to Kubernetes...
                                   properties:
                                     container:
                                       description: container is the name of the container
@@ -3307,10 +3337,9 @@ spec:
                                         for the given metric
                                       properties:
                                         averageUtilization:
-                                          description: "averageUtilization is the
-                                            target value of the average of the\nresource
-                                            metric across all relevant pods, represented
-                                            as a "
+                                          description: |-
+                                            averageUtilization is the target value of the average of the
+                                            resource metric across all relevant pods, represented as a...
                                           format: int32
                                           type: integer
                                         averageValue:
@@ -3357,10 +3386,9 @@ spec:
                                             metric
                                           type: string
                                         selector:
-                                          description: "selector is the string-encoded
-                                            form of a standard kubernetes label selector
-                                            for the given metric\nWhen set, it is
-                                            passed "
+                                          description: |-
+                                            selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                            When set, it is passed...
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -3411,10 +3439,9 @@ spec:
                                         for the given metric
                                       properties:
                                         averageUtilization:
-                                          description: "averageUtilization is the
-                                            target value of the average of the\nresource
-                                            metric across all relevant pods, represented
-                                            as a "
+                                          description: |-
+                                            averageUtilization is the target value of the average of the
+                                            resource metric across all relevant pods, represented as a...
                                           format: int32
                                           type: integer
                                         averageValue:
@@ -3480,10 +3507,9 @@ spec:
                                             metric
                                           type: string
                                         selector:
-                                          description: "selector is the string-encoded
-                                            form of a standard kubernetes label selector
-                                            for the given metric\nWhen set, it is
-                                            passed "
+                                          description: |-
+                                            selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                            When set, it is passed...
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -3534,10 +3560,9 @@ spec:
                                         for the given metric
                                       properties:
                                         averageUtilization:
-                                          description: "averageUtilization is the
-                                            target value of the average of the\nresource
-                                            metric across all relevant pods, represented
-                                            as a "
+                                          description: |-
+                                            averageUtilization is the target value of the average of the
+                                            resource metric across all relevant pods, represented as a...
                                           format: int32
                                           type: integer
                                         averageValue:
@@ -3573,7 +3598,7 @@ spec:
                                 pods:
                                   description: |-
                                     pods refers to a metric describing each pod in the current scale target
-                                    (for example, transactions-processed-per-second)
+                                    (for example,...
                                   properties:
                                     metric:
                                       description: metric identifies the target metric
@@ -3584,10 +3609,9 @@ spec:
                                             metric
                                           type: string
                                         selector:
-                                          description: "selector is the string-encoded
-                                            form of a standard kubernetes label selector
-                                            for the given metric\nWhen set, it is
-                                            passed "
+                                          description: |-
+                                            selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                            When set, it is passed...
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -3638,10 +3662,9 @@ spec:
                                         for the given metric
                                       properties:
                                         averageUtilization:
-                                          description: "averageUtilization is the
-                                            target value of the average of the\nresource
-                                            metric across all relevant pods, represented
-                                            as a "
+                                          description: |-
+                                            averageUtilization is the target value of the average of the
+                                            resource metric across all relevant pods, represented as a...
                                           format: int32
                                           type: integer
                                         averageValue:
@@ -3676,7 +3699,7 @@ spec:
                                 resource:
                                   description: |-
                                     resource refers to a resource metric (such as those specified in
-                                    requests and limits) known to Kubernetes describing eac
+                                    requests and limits) known to Kubernetes describing...
                                   properties:
                                     name:
                                       description: name is the name of the resource
@@ -3687,10 +3710,9 @@ spec:
                                         for the given metric
                                       properties:
                                         averageUtilization:
-                                          description: "averageUtilization is the
-                                            target value of the average of the\nresource
-                                            metric across all relevant pods, represented
-                                            as a "
+                                          description: |-
+                                            averageUtilization is the target value of the average of the
+                                            resource metric across all relevant pods, represented as a...
                                           format: int32
                                           type: integer
                                         averageValue:
@@ -3784,6 +3806,10 @@ spec:
                           Defaults to user specified in image metadata if unspecified.
                         format: int64
                         type: integer
+                      seLinuxChangePolicy:
+                        description: seLinuxChangePolicy defines how the container's
+                          SELinux label is applied to all volumes used by the Pod.
+                        type: string
                       seLinuxOptions:
                         description: The SELinux context to be applied to all containers.
                         properties:
@@ -3822,13 +3848,18 @@ spec:
                         type: object
                       supplementalGroups:
                         description: |-
-                          A list of groups applied to the first process run in each container, in addition
-                          to the container's primary GID, the fsG
+                          A list of groups applied to the first process run in each container, in
+                          addition to the container's primary GID and...
                         items:
                           format: int64
                           type: integer
                         type: array
                         x-kubernetes-list-type: atomic
+                      supplementalGroupsPolicy:
+                        description: |-
+                          Defines how supplemental groups of the first container processes are calculated.
+                          Valid values are "Merge" and "Strict".
+                        type: string
                       sysctls:
                         description: Sysctls hold a list of namespaced sysctls used
                           for the pod.
@@ -3939,7 +3970,7 @@ spec:
                         nodeAffinityPolicy:
                           description: |-
                             NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                            when calculating pod topology spread skew
+                            when calculating pod topology spread...
                           type: string
                         nodeTaintsPolicy:
                           description: |-
@@ -3975,8 +4006,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -4075,7 +4105,7 @@ spec:
                       envFrom:
                         items:
                           description: EnvFromSource represents the source of a set
-                            of ConfigMaps
+                            of ConfigMaps or Secrets
                           properties:
                             configMapRef:
                               description: The ConfigMap to select from
@@ -4094,8 +4124,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: Optional text to prepend to the name of
+                                each environment variable. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -4155,6 +4185,10 @@ spec:
                                   description: |-
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used.
+                                  type: string
+                                request:
+                                  description: Request is the name chosen for a request
+                                    in the referenced claim.
                                   type: string
                               required:
                               - name
@@ -4324,7 +4358,7 @@ spec:
                         awsElasticBlockStore:
                           description: |-
                             awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                            kubelet's host machine and then exposed to th
+                            kubelet's host machine and then exposed to...
                           properties:
                             fsType:
                               description: fsType is the filesystem type of the volume
@@ -4366,6 +4400,7 @@ spec:
                                 blob storage
                               type: string
                             fsType:
+                              default: ext4
                               description: |-
                                 fsType is Filesystem type to mount.
                                 Must be a filesystem type supported by the host operating system.
@@ -4374,9 +4409,10 @@ spec:
                             kind:
                               description: 'kind expected values are Shared: multiple
                                 blob disks per storage account  Dedicated: single
-                                blob disk per storage accoun'
+                                blob disk per storage...'
                               type: string
                             readOnly:
+                              default: false
                               description: |-
                                 readOnly Defaults to false (read/write). ReadOnly here will force
                                 the ReadOnly setting in VolumeMounts.
@@ -4407,7 +4443,7 @@ spec:
                           type: object
                         cephfs:
                           description: cephFS represents a Ceph FS mount on the host
-                            that shares a pod's lifetime
+                            that shares a pod's lifetime.
                           properties:
                             monitors:
                               description: |-
@@ -4455,7 +4491,7 @@ spec:
                         cinder:
                           description: |-
                             cinder represents a cinder volume attached and mounted on kubelets host machine.
-                            More info: https://examples.k8s.
+                            Deprecated: Cinder is deprecated.
                           properties:
                             fsType:
                               description: |-
@@ -4501,7 +4537,7 @@ spec:
                             items:
                               description: |-
                                 items if unspecified, each key-value pair in the Data field of the referenced
-                                ConfigMap will be projected into the volum
+                                ConfigMap will be projected into the...
                               items:
                                 description: Maps a string key to a path within a
                                   volume.
@@ -4541,7 +4577,7 @@ spec:
                         csi:
                           description: csi (Container Storage Interface) represents
                             ephemeral storage that is handled by certain external
-                            CSI drivers (Beta fea
+                            CSI drivers.
                           properties:
                             driver:
                               description: driver is the name of the CSI driver that
@@ -4553,7 +4589,7 @@ spec:
                             nodePublishSecretRef:
                               description: |-
                                 nodePublishSecretRef is a reference to the secret object containing
-                                sensitive information to pass to the CSI driver to c
+                                sensitive information to pass to the CSI driver to...
                               properties:
                                 name:
                                   default: ""
@@ -4615,7 +4651,7 @@ spec:
                                   mode:
                                     description: |-
                                       Optional: mode bits used to set permissions on this file, must be an octal value
-                                      between 0000 and 0777 or a decimal valu
+                                      between 0000 and 0777 or a decimal...
                                     format: int32
                                     type: integer
                                   path:
@@ -4864,9 +4900,9 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             wwids:
-                              description: "wwids Optional: FC volume world wide identifiers
-                                (wwids)\nEither wwids or combination of targetWWNs
-                                and lun must be set, "
+                              description: |-
+                                wwids Optional: FC volume world wide identifiers (wwids)
+                                Either wwids or combination of targetWWNs and lun must be set,...
                               items:
                                 type: string
                               type: array
@@ -4901,7 +4937,7 @@ spec:
                             secretRef:
                               description: |-
                                 secretRef is Optional: secretRef is reference to the secret object containing
-                                sensitive information to pass to the plugi
+                                sensitive information to pass to the...
                               properties:
                                 name:
                                   default: ""
@@ -4922,7 +4958,7 @@ spec:
                             datasetName:
                               description: |-
                                 datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                should be considered as depreca
+                                should be considered as...
                               type: string
                             datasetUUID:
                               description: datasetUUID is the UUID of the dataset.
@@ -4932,7 +4968,7 @@ spec:
                         gcePersistentDisk:
                           description: |-
                             gcePersistentDisk represents a GCE Disk resource that is attached to a
-                            kubelet's host machine and then exposed to the po
+                            kubelet's host machine and then exposed to the...
                           properties:
                             fsType:
                               description: fsType is filesystem type of the volume
@@ -4961,7 +4997,7 @@ spec:
                         gitRepo:
                           description: |-
                             gitRepo represents a git repository at a particular revision.
-                            DEPRECATED: GitRepo is deprecated.
+                            Deprecated: GitRepo is deprecated.
                           properties:
                             directory:
                               description: |-
@@ -4979,9 +5015,8 @@ spec:
                           - repository
                           type: object
                         glusterfs:
-                          description: |-
-                            glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                            More info: https://examples.k8s.
+                          description: glusterfs represents a Glusterfs mount on the
+                            host that shares a pod's lifetime.
                           properties:
                             endpoints:
                               description: |-
@@ -5021,6 +5056,22 @@ spec:
                           required:
                           - path
                           type: object
+                        image:
+                          description: image represents an OCI object (a container
+                            image or artifact) pulled and mounted on the kubelet's
+                            host machine.
+                          properties:
+                            pullPolicy:
+                              description: |-
+                                Policy for pulling OCI objects. Possible values are:
+                                Always: the kubelet always attempts to pull the reference.
+                              type: string
+                            reference:
+                              description: |-
+                                Required: Image or artifact reference to be used.
+                                Behaves in the same way as pod.spec.containers[*].image.
+                              type: string
+                          type: object
                         iscsi:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
@@ -5046,6 +5097,7 @@ spec:
                               description: iqn is the target iSCSI Qualified Name.
                               type: string
                             iscsiInterface:
+                              default: default
                               description: |-
                                 iscsiInterface is the interface Name that uses an iSCSI transport.
                                 Defaults to 'default' (tcp).
@@ -5136,7 +5188,7 @@ spec:
                         photonPersistentDisk:
                           description: photonPersistentDisk represents a PhotonController
                             persistent disk attached and mounted on kubelets host
-                            machine
+                            machine.
                           properties:
                             fsType:
                               description: |-
@@ -5153,7 +5205,7 @@ spec:
                           type: object
                         portworxVolume:
                           description: portworxVolume represents a portworx volume
-                            attached and mounted on kubelets host machine
+                            attached and mounted on kubelets host machine.
                           properties:
                             fsType:
                               description: |-
@@ -5183,10 +5235,13 @@ spec:
                               format: int32
                               type: integer
                             sources:
-                              description: sources is the list of volume projections
+                              description: |-
+                                sources is the list of volume projections. Each entry in this list
+                                handles one source.
                               items:
-                                description: Projection that may be projected along
-                                  with other supported volume types
+                                description: |-
+                                  Projection that may be projected along with other supported volume types.
+                                  Exactly one of these fields must be set.
                                 properties:
                                   clusterTrustBundle:
                                     description: ClusterTrustBundle allows a pod to
@@ -5266,7 +5321,7 @@ spec:
                                       items:
                                         description: |-
                                           items if unspecified, each key-value pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volum
+                                          ConfigMap will be projected into the...
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -5337,7 +5392,7 @@ spec:
                                             mode:
                                               description: |-
                                                 Optional: mode bits used to set permissions on this file, must be an octal value
-                                                between 0000 and 0777 or a decimal valu
+                                                between 0000 and 0777 or a decimal...
                                               format: int32
                                               type: integer
                                             path:
@@ -5386,7 +5441,7 @@ spec:
                                       items:
                                         description: |-
                                           items if unspecified, each key-value pair in the Data field of the referenced
-                                          Secret will be projected into the volume a
+                                          Secret will be projected into the volume...
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -5452,7 +5507,7 @@ spec:
                           type: object
                         quobyte:
                           description: quobyte represents a Quobyte mount on the host
-                            that shares a pod's lifetime
+                            that shares a pod's lifetime.
                           properties:
                             group:
                               description: |-
@@ -5467,12 +5522,12 @@ spec:
                             registry:
                               description: |-
                                 registry represents a single or multiple Quobyte Registry services
-                                specified as a string as host:port pair (multiple ent
+                                specified as a string as host:port pair (multiple...
                               type: string
                             tenant:
                               description: |-
                                 tenant owning the given Quobyte volume in the Backend
-                                Used with dynamically provisioned Quobyte volumes, value is set by
+                                Used with dynamically provisioned Quobyte volumes, value is set...
                               type: string
                             user:
                               description: |-
@@ -5488,9 +5543,8 @@ spec:
                           - volume
                           type: object
                         rbd:
-                          description: |-
-                            rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                            More info: https://examples.k8s.
+                          description: rbd represents a Rados Block Device mount on
+                            the host that shares a pod's lifetime.
                           properties:
                             fsType:
                               description: fsType is the filesystem type of the volume
@@ -5502,6 +5556,7 @@ spec:
                                 More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                               type: string
                             keyring:
+                              default: /etc/ceph/keyring
                               description: |-
                                 keyring is the path to key ring for RBDUser.
                                 Default is /etc/ceph/keyring.
@@ -5516,6 +5571,7 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             pool:
+                              default: rbd
                               description: |-
                                 pool is the rados pool name.
                                 Default is rbd.
@@ -5543,6 +5599,7 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             user:
+                              default: admin
                               description: |-
                                 user is the rados user name.
                                 Default is admin.
@@ -5557,6 +5614,7 @@ spec:
                             attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
+                              default: xfs
                               description: |-
                                 fsType is the filesystem type to mount.
                                 Must be a filesystem type supported by the host operating system.
@@ -5594,6 +5652,7 @@ spec:
                                 with Gateway, default false
                               type: boolean
                             storageMode:
+                              default: ThinProvisioned
                               description: storageMode indicates whether the storage
                                 for a volume should be ThickProvisioned or ThinProvisioned.
                               type: string
@@ -5628,7 +5687,7 @@ spec:
                             items:
                               description: |-
                                 items If unspecified, each key-value pair in the Data field of the referenced
-                                Secret will be projected into the volume a
+                                Secret will be projected into the volume...
                               items:
                                 description: Maps a string key to a path within a
                                   volume.
@@ -5703,7 +5762,7 @@ spec:
                           type: object
                         vsphereVolume:
                           description: vsphereVolume represents a vSphere volume attached
-                            and mounted on kubelets host machine
+                            and mounted on kubelets host machine.
                           properties:
                             fsType:
                               description: |-
@@ -5898,8 +5957,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -5999,7 +6057,7 @@ spec:
                           envFrom:
                             items:
                               description: EnvFromSource represents the source of
-                                a set of ConfigMaps
+                                a set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -6018,8 +6076,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: Optional text to prepend to the name
+                                    of each environment variable. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -6066,6 +6124,10 @@ spec:
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used.
                                       type: string
+                                    request:
+                                      description: Request is the name chosen for
+                                        a request in the referenced claim.
+                                      type: string
                                   required:
                                   - name
                                   type: object
@@ -6107,7 +6169,7 @@ spec:
                           activeDeadlineSeconds:
                             description: |-
                               Specifies the duration in seconds relative to the startTime that the job
-                              may be continuously active before the system tr
+                              may be continuously active before the system...
                             format: int64
                             type: integer
                           backoffLimit:
@@ -6293,8 +6355,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -6394,7 +6455,7 @@ spec:
                           envFrom:
                             items:
                               description: EnvFromSource represents the source of
-                                a set of ConfigMaps
+                                a set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -6413,8 +6474,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: Optional text to prepend to the name
+                                    of each environment variable. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -6500,7 +6561,7 @@ spec:
                               preferredDuringSchedulingIgnoredDuringExecution:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
-                                  the affinity expressions specified by this field, but i
+                                  the affinity expressions specified by this field, but...
                                 items:
                                   description: |-
                                     An empty preferred scheduling term matches all objects with implicit weight 0
@@ -6587,9 +6648,9 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: "If the affinity requirements specified
-                                  by this field are not met at\nscheduling time, the
-                                  pod will not be scheduled onto "
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto...
                                 properties:
                                   nodeSelectorTerms:
                                     description: Required. A list of node selector
@@ -6678,7 +6739,7 @@ spec:
                               preferredDuringSchedulingIgnoredDuringExecution:
                                 description: |-
                                   The scheduler will prefer to schedule pods to nodes that satisfy
-                                  the affinity expressions specified by this field, but i
+                                  the affinity expressions specified by this field, but...
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -6806,7 +6867,7 @@ spec:
                                         topologyKey:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                            the labelSelector in t
+                                            the labelSelector in...
                                           type: string
                                       required:
                                       - topologyKey
@@ -6824,13 +6885,13 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: "If the affinity requirements specified
-                                  by this field are not met at\nscheduling time, the
-                                  pod will not be scheduled onto "
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto...
                                 items:
-                                  description: "Defines a set of pods (namely those
-                                    matching the labelSelector\nrelative to the given
-                                    namespace(s)) that this pod should "
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -6947,7 +7008,7 @@ spec:
                                     topologyKey:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                        the labelSelector in t
+                                        the labelSelector in...
                                       type: string
                                   required:
                                   - topologyKey
@@ -6961,9 +7022,9 @@ spec:
                               etc.
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: "The scheduler will prefer to schedule
-                                  pods to nodes that satisfy\nthe anti-affinity expressions
-                                  specified by this field, "
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field,...
                                 items:
                                   description: The weights of all of the matched WeightedPodAffinityTerm
                                     fields are added per-node to find the most preferred
@@ -7091,7 +7152,7 @@ spec:
                                         topologyKey:
                                           description: |-
                                             This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                            the labelSelector in t
+                                            the labelSelector in...
                                           type: string
                                       required:
                                       - topologyKey
@@ -7109,13 +7170,13 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: "If the anti-affinity requirements specified
-                                  by this field are not met at\nscheduling time, the
-                                  pod will not be scheduled "
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled...
                                 items:
-                                  description: "Defines a set of pods (namely those
-                                    matching the labelSelector\nrelative to the given
-                                    namespace(s)) that this pod should "
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should...
                                   properties:
                                     labelSelector:
                                       description: |-
@@ -7232,7 +7293,7 @@ spec:
                                     topologyKey:
                                       description: |-
                                         This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
-                                        the labelSelector in t
+                                        the labelSelector in...
                                       type: string
                                   required:
                                   - topologyKey
@@ -7433,8 +7494,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -7537,7 +7597,7 @@ spec:
                               envFrom:
                                 items:
                                   description: EnvFromSource represents the source
-                                    of a set of ConfigMaps
+                                    of a set of ConfigMaps or Secrets
                                   properties:
                                     configMapRef:
                                       description: The ConfigMap to select from
@@ -7556,8 +7616,9 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: An optional identifier to prepend
-                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      description: Optional text to prepend to the
+                                        name of each environment variable. Must be
+                                        a C_IDENTIFIER.
                                       type: string
                                     secretRef:
                                       description: The Secret to select from
@@ -7618,6 +7679,10 @@ spec:
                                           description: |-
                                             Name must match the name of one entry in pod.spec.resourceClaims of
                                             the Pod where this field is used.
+                                          type: string
+                                        request:
+                                          description: Request is the name chosen
+                                            for a request in the referenced claim.
                                           type: string
                                       required:
                                       - name
@@ -7951,8 +8016,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -8055,7 +8119,7 @@ spec:
                               envFrom:
                                 items:
                                   description: EnvFromSource represents the source
-                                    of a set of ConfigMaps
+                                    of a set of ConfigMaps or Secrets
                                   properties:
                                     configMapRef:
                                       description: The ConfigMap to select from
@@ -8074,8 +8138,9 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: An optional identifier to prepend
-                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      description: Optional text to prepend to the
+                                        name of each environment variable. Must be
+                                        a C_IDENTIFIER.
                                       type: string
                                     secretRef:
                                       description: The Secret to select from
@@ -8136,6 +8201,10 @@ spec:
                                           description: |-
                                             Name must match the name of one entry in pod.spec.resourceClaims of
                                             the Pod where this field is used.
+                                          type: string
+                                        request:
+                                          description: Request is the name chosen
+                                            for a request in the referenced claim.
                                           type: string
                                       required:
                                       - name
@@ -8521,8 +8590,7 @@ spec:
                                         value:
                                           description: |-
                                             Variable references $(VAR_NAME) are expanded
-                                            using the previously defined environment variables in the container and
-                                            any
+                                            using the previously defined environment variables in the container and...
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -8627,7 +8695,7 @@ spec:
                                   envFrom:
                                     items:
                                       description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                        of a set of ConfigMaps or Secrets
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
@@ -8646,9 +8714,9 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be
-                                            a C_IDENTIFIER.
+                                          description: Optional text to prepend to
+                                            the name of each environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
@@ -8713,6 +8781,10 @@ spec:
                                               description: |-
                                                 Name must match the name of one entry in pod.spec.resourceClaims of
                                                 the Pod where this field is used.
+                                              type: string
+                                            request:
+                                              description: Request is the name chosen
+                                                for a request in the referenced claim.
                                               type: string
                                           required:
                                           - name
@@ -9004,9 +9076,18 @@ spec:
                                       stabilizationWindowSeconds:
                                         description: |-
                                           stabilizationWindowSeconds is the number of seconds for which past recommendations should be
-                                          considered while scaling up
+                                          considered while scaling...
                                         format: int32
                                         type: integer
+                                      tolerance:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          tolerance is the tolerance on the ratio between the current and desired
+                                          metric value under which no updates are made to...
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
                                     type: object
                                   scaleUp:
                                     description: scaleUp is scaling policy for scaling
@@ -9052,9 +9133,18 @@ spec:
                                       stabilizationWindowSeconds:
                                         description: |-
                                           stabilizationWindowSeconds is the number of seconds for which past recommendations should be
-                                          considered while scaling up
+                                          considered while scaling...
                                         format: int32
                                         type: integer
+                                      tolerance:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          tolerance is the tolerance on the ratio between the current and desired
+                                          metric value under which no updates are made to...
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
                                     type: object
                                 type: object
                               maxReplicas:
@@ -9069,12 +9159,12 @@ spec:
                                 items:
                                   description: |-
                                     MetricSpec specifies how to scale based on a single metric
-                                    (only `type` and one other matching field should be set at on
+                                    (only `type` and one other matching field should be set at...
                                   properties:
                                     containerResource:
                                       description: |-
                                         containerResource refers to a resource metric (such as those specified in
-                                        requests and limits) known to Kubernetes descr
+                                        requests and limits) known to Kubernetes...
                                       properties:
                                         container:
                                           description: container is the name of the
@@ -9089,10 +9179,9 @@ spec:
                                             value for the given metric
                                           properties:
                                             averageUtilization:
-                                              description: "averageUtilization is
-                                                the target value of the average of
-                                                the\nresource metric across all relevant
-                                                pods, represented as a "
+                                              description: |-
+                                                averageUtilization is the target value of the average of the
+                                                resource metric across all relevant pods, represented as a...
                                               format: int32
                                               type: integer
                                             averageValue:
@@ -9139,10 +9228,9 @@ spec:
                                                 given metric
                                               type: string
                                             selector:
-                                              description: "selector is the string-encoded
-                                                form of a standard kubernetes label
-                                                selector for the given metric\nWhen
-                                                set, it is passed "
+                                              description: |-
+                                                selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                                When set, it is passed...
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -9193,10 +9281,9 @@ spec:
                                             value for the given metric
                                           properties:
                                             averageUtilization:
-                                              description: "averageUtilization is
-                                                the target value of the average of
-                                                the\nresource metric across all relevant
-                                                pods, represented as a "
+                                              description: |-
+                                                averageUtilization is the target value of the average of the
+                                                resource metric across all relevant pods, represented as a...
                                               format: int32
                                               type: integer
                                             averageValue:
@@ -9263,10 +9350,9 @@ spec:
                                                 given metric
                                               type: string
                                             selector:
-                                              description: "selector is the string-encoded
-                                                form of a standard kubernetes label
-                                                selector for the given metric\nWhen
-                                                set, it is passed "
+                                              description: |-
+                                                selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                                When set, it is passed...
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -9317,10 +9403,9 @@ spec:
                                             value for the given metric
                                           properties:
                                             averageUtilization:
-                                              description: "averageUtilization is
-                                                the target value of the average of
-                                                the\nresource metric across all relevant
-                                                pods, represented as a "
+                                              description: |-
+                                                averageUtilization is the target value of the average of the
+                                                resource metric across all relevant pods, represented as a...
                                               format: int32
                                               type: integer
                                             averageValue:
@@ -9356,7 +9441,7 @@ spec:
                                     pods:
                                       description: |-
                                         pods refers to a metric describing each pod in the current scale target
-                                        (for example, transactions-processed-per-second)
+                                        (for example,...
                                       properties:
                                         metric:
                                           description: metric identifies the target
@@ -9367,10 +9452,9 @@ spec:
                                                 given metric
                                               type: string
                                             selector:
-                                              description: "selector is the string-encoded
-                                                form of a standard kubernetes label
-                                                selector for the given metric\nWhen
-                                                set, it is passed "
+                                              description: |-
+                                                selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                                When set, it is passed...
                                               properties:
                                                 matchExpressions:
                                                   description: matchExpressions is
@@ -9421,10 +9505,9 @@ spec:
                                             value for the given metric
                                           properties:
                                             averageUtilization:
-                                              description: "averageUtilization is
-                                                the target value of the average of
-                                                the\nresource metric across all relevant
-                                                pods, represented as a "
+                                              description: |-
+                                                averageUtilization is the target value of the average of the
+                                                resource metric across all relevant pods, represented as a...
                                               format: int32
                                               type: integer
                                             averageValue:
@@ -9459,7 +9542,7 @@ spec:
                                     resource:
                                       description: |-
                                         resource refers to a resource metric (such as those specified in
-                                        requests and limits) known to Kubernetes describing eac
+                                        requests and limits) known to Kubernetes describing...
                                       properties:
                                         name:
                                           description: name is the name of the resource
@@ -9470,10 +9553,9 @@ spec:
                                             value for the given metric
                                           properties:
                                             averageUtilization:
-                                              description: "averageUtilization is
-                                                the target value of the average of
-                                                the\nresource metric across all relevant
-                                                pods, represented as a "
+                                              description: |-
+                                                averageUtilization is the target value of the average of the
+                                                resource metric across all relevant pods, represented as a...
                                               format: int32
                                               type: integer
                                             averageValue:
@@ -9567,6 +9649,11 @@ spec:
                               Defaults to user specified in image metadata if unspecified.
                             format: int64
                             type: integer
+                          seLinuxChangePolicy:
+                            description: seLinuxChangePolicy defines how the container's
+                              SELinux label is applied to all volumes used by the
+                              Pod.
+                            type: string
                           seLinuxOptions:
                             description: The SELinux context to be applied to all
                               containers.
@@ -9606,13 +9693,18 @@ spec:
                             type: object
                           supplementalGroups:
                             description: |-
-                              A list of groups applied to the first process run in each container, in addition
-                              to the container's primary GID, the fsG
+                              A list of groups applied to the first process run in each container, in
+                              addition to the container's primary GID and...
                             items:
                               format: int64
                               type: integer
                             type: array
                             x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            description: |-
+                              Defines how supplemental groups of the first container processes are calculated.
+                              Valid values are "Merge" and "Strict".
+                            type: string
                           sysctls:
                             description: Sysctls hold a list of namespaced sysctls
                               used for the pod.
@@ -9726,7 +9818,7 @@ spec:
                             nodeAffinityPolicy:
                               description: |-
                                 NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
-                                when calculating pod topology spread skew
+                                when calculating pod topology spread...
                               type: string
                             nodeTaintsPolicy:
                               description: |-
@@ -9762,8 +9854,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -9863,7 +9954,7 @@ spec:
                           envFrom:
                             items:
                               description: EnvFromSource represents the source of
-                                a set of ConfigMaps
+                                a set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -9882,8 +9973,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: Optional text to prepend to the name
+                                    of each environment variable. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -9944,6 +10035,10 @@ spec:
                                       description: |-
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used.
+                                      type: string
+                                    request:
+                                      description: Request is the name chosen for
+                                        a request in the referenced claim.
                                       type: string
                                   required:
                                   - name
@@ -10113,7 +10208,7 @@ spec:
                             awsElasticBlockStore:
                               description: |-
                                 awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to th
+                                kubelet's host machine and then exposed to...
                               properties:
                                 fsType:
                                   description: fsType is the filesystem type of the
@@ -10155,6 +10250,7 @@ spec:
                                     the blob storage
                                   type: string
                                 fsType:
+                                  default: ext4
                                   description: |-
                                     fsType is Filesystem type to mount.
                                     Must be a filesystem type supported by the host operating system.
@@ -10163,9 +10259,10 @@ spec:
                                 kind:
                                   description: 'kind expected values are Shared: multiple
                                     blob disks per storage account  Dedicated: single
-                                    blob disk per storage accoun'
+                                    blob disk per storage...'
                                   type: string
                                 readOnly:
+                                  default: false
                                   description: |-
                                     readOnly Defaults to false (read/write). ReadOnly here will force
                                     the ReadOnly setting in VolumeMounts.
@@ -10196,7 +10293,7 @@ spec:
                               type: object
                             cephfs:
                               description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
+                                host that shares a pod's lifetime.
                               properties:
                                 monitors:
                                   description: |-
@@ -10245,7 +10342,7 @@ spec:
                             cinder:
                               description: |-
                                 cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.
+                                Deprecated: Cinder is deprecated.
                               properties:
                                 fsType:
                                   description: |-
@@ -10291,7 +10388,7 @@ spec:
                                 items:
                                   description: |-
                                     items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volum
+                                    ConfigMap will be projected into the...
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -10331,7 +10428,7 @@ spec:
                             csi:
                               description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
-                                CSI drivers (Beta fea
+                                CSI drivers.
                               properties:
                                 driver:
                                   description: driver is the name of the CSI driver
@@ -10344,7 +10441,7 @@ spec:
                                 nodePublishSecretRef:
                                   description: |-
                                     nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to c
+                                    sensitive information to pass to the CSI driver to...
                                   properties:
                                     name:
                                       default: ""
@@ -10408,7 +10505,7 @@ spec:
                                       mode:
                                         description: |-
                                           Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal valu
+                                          between 0000 and 0777 or a decimal...
                                         format: int32
                                         type: integer
                                       path:
@@ -10660,9 +10757,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 wwids:
-                                  description: "wwids Optional: FC volume world wide
-                                    identifiers (wwids)\nEither wwids or combination
-                                    of targetWWNs and lun must be set, "
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set,...
                                   items:
                                     type: string
                                   type: array
@@ -10697,7 +10794,7 @@ spec:
                                 secretRef:
                                   description: |-
                                     secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugi
+                                    sensitive information to pass to the...
                                   properties:
                                     name:
                                       default: ""
@@ -10718,7 +10815,7 @@ spec:
                                 datasetName:
                                   description: |-
                                     datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as depreca
+                                    should be considered as...
                                   type: string
                                 datasetUUID:
                                   description: datasetUUID is the UUID of the dataset.
@@ -10728,7 +10825,7 @@ spec:
                             gcePersistentDisk:
                               description: |-
                                 gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the po
+                                kubelet's host machine and then exposed to the...
                               properties:
                                 fsType:
                                   description: fsType is filesystem type of the volume
@@ -10757,7 +10854,7 @@ spec:
                             gitRepo:
                               description: |-
                                 gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated.
+                                Deprecated: GitRepo is deprecated.
                               properties:
                                 directory:
                                   description: |-
@@ -10775,9 +10872,8 @@ spec:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.
+                              description: glusterfs represents a Glusterfs mount
+                                on the host that shares a pod's lifetime.
                               properties:
                                 endpoints:
                                   description: |-
@@ -10817,6 +10913,22 @@ spec:
                               required:
                               - path
                               type: object
+                            image:
+                              description: image represents an OCI object (a container
+                                image or artifact) pulled and mounted on the kubelet's
+                                host machine.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                  type: string
+                              type: object
                             iscsi:
                               description: |-
                                 iscsi represents an ISCSI Disk resource that is attached to a
@@ -10842,6 +10954,7 @@ spec:
                                   description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
+                                  default: default
                                   description: |-
                                     iscsiInterface is the interface Name that uses an iSCSI transport.
                                     Defaults to 'default' (tcp).
@@ -10933,7 +11046,7 @@ spec:
                             photonPersistentDisk:
                               description: photonPersistentDisk represents a PhotonController
                                 persistent disk attached and mounted on kubelets host
-                                machine
+                                machine.
                               properties:
                                 fsType:
                                   description: |-
@@ -10950,7 +11063,7 @@ spec:
                               type: object
                             portworxVolume:
                               description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
+                                attached and mounted on kubelets host machine.
                               properties:
                                 fsType:
                                   description: |-
@@ -10980,10 +11093,13 @@ spec:
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
+                                  description: |-
+                                    sources is the list of volume projections. Each entry in this list
+                                    handles one source.
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
+                                    description: |-
+                                      Projection that may be projected along with other supported volume types.
+                                      Exactly one of these fields must be set.
                                     properties:
                                       clusterTrustBundle:
                                         description: ClusterTrustBundle allows a pod
@@ -11064,7 +11180,7 @@ spec:
                                           items:
                                             description: |-
                                               items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volum
+                                              ConfigMap will be projected into the...
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -11137,7 +11253,7 @@ spec:
                                                 mode:
                                                   description: |-
                                                     Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal valu
+                                                    between 0000 and 0777 or a decimal...
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -11186,7 +11302,7 @@ spec:
                                           items:
                                             description: |-
                                               items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume a
+                                              Secret will be projected into the volume...
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -11252,7 +11368,7 @@ spec:
                               type: object
                             quobyte:
                               description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
+                                host that shares a pod's lifetime.
                               properties:
                                 group:
                                   description: |-
@@ -11267,12 +11383,12 @@ spec:
                                 registry:
                                   description: |-
                                     registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple ent
+                                    specified as a string as host:port pair (multiple...
                                   type: string
                                 tenant:
                                   description: |-
                                     tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by
+                                    Used with dynamically provisioned Quobyte volumes, value is set...
                                   type: string
                                 user:
                                   description: |-
@@ -11288,9 +11404,8 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.
+                              description: rbd represents a Rados Block Device mount
+                                on the host that shares a pod's lifetime.
                               properties:
                                 fsType:
                                   description: fsType is the filesystem type of the
@@ -11302,6 +11417,7 @@ spec:
                                     More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
+                                  default: /etc/ceph/keyring
                                   description: |-
                                     keyring is the path to key ring for RBDUser.
                                     Default is /etc/ceph/keyring.
@@ -11316,6 +11432,7 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 pool:
+                                  default: rbd
                                   description: |-
                                     pool is the rados pool name.
                                     Default is rbd.
@@ -11343,6 +11460,7 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
+                                  default: admin
                                   description: |-
                                     user is the rados user name.
                                     Default is admin.
@@ -11357,6 +11475,7 @@ spec:
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
+                                  default: xfs
                                   description: |-
                                     fsType is the filesystem type to mount.
                                     Must be a filesystem type supported by the host operating system.
@@ -11394,6 +11513,7 @@ spec:
                                     communication with Gateway, default false
                                   type: boolean
                                 storageMode:
+                                  default: ThinProvisioned
                                   description: storageMode indicates whether the storage
                                     for a volume should be ThickProvisioned or ThinProvisioned.
                                   type: string
@@ -11428,7 +11548,7 @@ spec:
                                 items:
                                   description: |-
                                     items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume a
+                                    Secret will be projected into the volume...
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -11503,7 +11623,7 @@ spec:
                               type: object
                             vsphereVolume:
                               description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
+                                attached and mounted on kubelets host machine.
                               properties:
                                 fsType:
                                   description: |-
@@ -11608,10 +11728,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -11782,8 +11899,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -11882,7 +11998,7 @@ spec:
                       envFrom:
                         items:
                           description: EnvFromSource represents the source of a set
-                            of ConfigMaps
+                            of ConfigMaps or Secrets
                           properties:
                             configMapRef:
                               description: The ConfigMap to select from
@@ -11901,8 +12017,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: Optional text to prepend to the name of
+                                each environment variable. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -11948,6 +12064,10 @@ spec:
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used.
                                   type: string
+                                request:
+                                  description: Request is the name chosen for a request
+                                    in the referenced claim.
+                                  type: string
                               required:
                               - name
                               type: object
@@ -11989,7 +12109,7 @@ spec:
                       activeDeadlineSeconds:
                         description: |-
                           Specifies the duration in seconds relative to the startTime that the job
-                          may be continuously active before the system tr
+                          may be continuously active before the system...
                         format: int64
                         type: integer
                       backoffLimit:
@@ -12172,8 +12292,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -12272,7 +12391,7 @@ spec:
                       envFrom:
                         items:
                           description: EnvFromSource represents the source of a set
-                            of ConfigMaps
+                            of ConfigMaps or Secrets
                           properties:
                             configMapRef:
                               description: The ConfigMap to select from
@@ -12291,8 +12410,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: Optional text to prepend to the name of
+                                each environment variable. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -12546,8 +12665,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -12647,7 +12765,7 @@ spec:
                           envFrom:
                             items:
                               description: EnvFromSource represents the source of
-                                a set of ConfigMaps
+                                a set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -12666,8 +12784,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: Optional text to prepend to the name
+                                    of each environment variable. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -12728,6 +12846,10 @@ spec:
                                       description: |-
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used.
+                                      type: string
+                                    request:
+                                      description: Request is the name chosen for
+                                        a request in the referenced claim.
                                       type: string
                                   required:
                                   - name
@@ -13056,8 +13178,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -13157,7 +13278,7 @@ spec:
                           envFrom:
                             items:
                               description: EnvFromSource represents the source of
-                                a set of ConfigMaps
+                                a set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -13176,8 +13297,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: Optional text to prepend to the name
+                                    of each environment variable. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -13238,6 +13359,10 @@ spec:
                                       description: |-
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used.
+                                      type: string
+                                    request:
+                                      description: Request is the name chosen for
+                                        a request in the referenced claim.
                                       type: string
                                   required:
                                   - name
@@ -13584,8 +13709,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -13688,7 +13812,7 @@ spec:
                               envFrom:
                                 items:
                                   description: EnvFromSource represents the source
-                                    of a set of ConfigMaps
+                                    of a set of ConfigMaps or Secrets
                                   properties:
                                     configMapRef:
                                       description: The ConfigMap to select from
@@ -13707,8 +13831,9 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: An optional identifier to prepend
-                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      description: Optional text to prepend to the
+                                        name of each environment variable. Must be
+                                        a C_IDENTIFIER.
                                       type: string
                                     secretRef:
                                       description: The Secret to select from
@@ -13773,6 +13898,10 @@ spec:
                                           description: |-
                                             Name must match the name of one entry in pod.spec.resourceClaims of
                                             the Pod where this field is used.
+                                          type: string
+                                        request:
+                                          description: Request is the name chosen
+                                            for a request in the referenced claim.
                                           type: string
                                       required:
                                       - name
@@ -14044,6 +14173,10 @@ spec:
                           Defaults to user specified in image metadata if unspecified.
                         format: int64
                         type: integer
+                      seLinuxChangePolicy:
+                        description: seLinuxChangePolicy defines how the container's
+                          SELinux label is applied to all volumes used by the Pod.
+                        type: string
                       seLinuxOptions:
                         description: The SELinux context to be applied to all containers.
                         properties:
@@ -14082,13 +14215,18 @@ spec:
                         type: object
                       supplementalGroups:
                         description: |-
-                          A list of groups applied to the first process run in each container, in addition
-                          to the container's primary GID, the fsG
+                          A list of groups applied to the first process run in each container, in
+                          addition to the container's primary GID and...
                         items:
                           format: int64
                           type: integer
                         type: array
                         x-kubernetes-list-type: atomic
+                      supplementalGroupsPolicy:
+                        description: |-
+                          Defines how supplemental groups of the first container processes are calculated.
+                          Valid values are "Merge" and "Strict".
+                        type: string
                       sysctls:
                         description: Sysctls hold a list of namespaced sysctls used
                           for the pod.
@@ -14145,8 +14283,7 @@ spec:
                             value:
                               description: |-
                                 Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables in the container and
-                                any
+                                using the previously defined environment variables in the container and...
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -14245,7 +14382,7 @@ spec:
                       envFrom:
                         items:
                           description: EnvFromSource represents the source of a set
-                            of ConfigMaps
+                            of ConfigMaps or Secrets
                           properties:
                             configMapRef:
                               description: The ConfigMap to select from
@@ -14264,8 +14401,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: Optional text to prepend to the name of
+                                each environment variable. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -14325,6 +14462,10 @@ spec:
                                   description: |-
                                     Name must match the name of one entry in pod.spec.resourceClaims of
                                     the Pod where this field is used.
+                                  type: string
+                                request:
+                                  description: Request is the name chosen for a request
+                                    in the referenced claim.
                                   type: string
                               required:
                               - name
@@ -14494,7 +14635,7 @@ spec:
                         awsElasticBlockStore:
                           description: |-
                             awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                            kubelet's host machine and then exposed to th
+                            kubelet's host machine and then exposed to...
                           properties:
                             fsType:
                               description: fsType is the filesystem type of the volume
@@ -14536,6 +14677,7 @@ spec:
                                 blob storage
                               type: string
                             fsType:
+                              default: ext4
                               description: |-
                                 fsType is Filesystem type to mount.
                                 Must be a filesystem type supported by the host operating system.
@@ -14544,9 +14686,10 @@ spec:
                             kind:
                               description: 'kind expected values are Shared: multiple
                                 blob disks per storage account  Dedicated: single
-                                blob disk per storage accoun'
+                                blob disk per storage...'
                               type: string
                             readOnly:
+                              default: false
                               description: |-
                                 readOnly Defaults to false (read/write). ReadOnly here will force
                                 the ReadOnly setting in VolumeMounts.
@@ -14577,7 +14720,7 @@ spec:
                           type: object
                         cephfs:
                           description: cephFS represents a Ceph FS mount on the host
-                            that shares a pod's lifetime
+                            that shares a pod's lifetime.
                           properties:
                             monitors:
                               description: |-
@@ -14625,7 +14768,7 @@ spec:
                         cinder:
                           description: |-
                             cinder represents a cinder volume attached and mounted on kubelets host machine.
-                            More info: https://examples.k8s.
+                            Deprecated: Cinder is deprecated.
                           properties:
                             fsType:
                               description: |-
@@ -14671,7 +14814,7 @@ spec:
                             items:
                               description: |-
                                 items if unspecified, each key-value pair in the Data field of the referenced
-                                ConfigMap will be projected into the volum
+                                ConfigMap will be projected into the...
                               items:
                                 description: Maps a string key to a path within a
                                   volume.
@@ -14711,7 +14854,7 @@ spec:
                         csi:
                           description: csi (Container Storage Interface) represents
                             ephemeral storage that is handled by certain external
-                            CSI drivers (Beta fea
+                            CSI drivers.
                           properties:
                             driver:
                               description: driver is the name of the CSI driver that
@@ -14723,7 +14866,7 @@ spec:
                             nodePublishSecretRef:
                               description: |-
                                 nodePublishSecretRef is a reference to the secret object containing
-                                sensitive information to pass to the CSI driver to c
+                                sensitive information to pass to the CSI driver to...
                               properties:
                                 name:
                                   default: ""
@@ -14785,7 +14928,7 @@ spec:
                                   mode:
                                     description: |-
                                       Optional: mode bits used to set permissions on this file, must be an octal value
-                                      between 0000 and 0777 or a decimal valu
+                                      between 0000 and 0777 or a decimal...
                                     format: int32
                                     type: integer
                                   path:
@@ -15034,9 +15177,9 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             wwids:
-                              description: "wwids Optional: FC volume world wide identifiers
-                                (wwids)\nEither wwids or combination of targetWWNs
-                                and lun must be set, "
+                              description: |-
+                                wwids Optional: FC volume world wide identifiers (wwids)
+                                Either wwids or combination of targetWWNs and lun must be set,...
                               items:
                                 type: string
                               type: array
@@ -15071,7 +15214,7 @@ spec:
                             secretRef:
                               description: |-
                                 secretRef is Optional: secretRef is reference to the secret object containing
-                                sensitive information to pass to the plugi
+                                sensitive information to pass to the...
                               properties:
                                 name:
                                   default: ""
@@ -15092,7 +15235,7 @@ spec:
                             datasetName:
                               description: |-
                                 datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                should be considered as depreca
+                                should be considered as...
                               type: string
                             datasetUUID:
                               description: datasetUUID is the UUID of the dataset.
@@ -15102,7 +15245,7 @@ spec:
                         gcePersistentDisk:
                           description: |-
                             gcePersistentDisk represents a GCE Disk resource that is attached to a
-                            kubelet's host machine and then exposed to the po
+                            kubelet's host machine and then exposed to the...
                           properties:
                             fsType:
                               description: fsType is filesystem type of the volume
@@ -15131,7 +15274,7 @@ spec:
                         gitRepo:
                           description: |-
                             gitRepo represents a git repository at a particular revision.
-                            DEPRECATED: GitRepo is deprecated.
+                            Deprecated: GitRepo is deprecated.
                           properties:
                             directory:
                               description: |-
@@ -15149,9 +15292,8 @@ spec:
                           - repository
                           type: object
                         glusterfs:
-                          description: |-
-                            glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                            More info: https://examples.k8s.
+                          description: glusterfs represents a Glusterfs mount on the
+                            host that shares a pod's lifetime.
                           properties:
                             endpoints:
                               description: |-
@@ -15191,6 +15333,22 @@ spec:
                           required:
                           - path
                           type: object
+                        image:
+                          description: image represents an OCI object (a container
+                            image or artifact) pulled and mounted on the kubelet's
+                            host machine.
+                          properties:
+                            pullPolicy:
+                              description: |-
+                                Policy for pulling OCI objects. Possible values are:
+                                Always: the kubelet always attempts to pull the reference.
+                              type: string
+                            reference:
+                              description: |-
+                                Required: Image or artifact reference to be used.
+                                Behaves in the same way as pod.spec.containers[*].image.
+                              type: string
+                          type: object
                         iscsi:
                           description: |-
                             iscsi represents an ISCSI Disk resource that is attached to a
@@ -15216,6 +15374,7 @@ spec:
                               description: iqn is the target iSCSI Qualified Name.
                               type: string
                             iscsiInterface:
+                              default: default
                               description: |-
                                 iscsiInterface is the interface Name that uses an iSCSI transport.
                                 Defaults to 'default' (tcp).
@@ -15306,7 +15465,7 @@ spec:
                         photonPersistentDisk:
                           description: photonPersistentDisk represents a PhotonController
                             persistent disk attached and mounted on kubelets host
-                            machine
+                            machine.
                           properties:
                             fsType:
                               description: |-
@@ -15323,7 +15482,7 @@ spec:
                           type: object
                         portworxVolume:
                           description: portworxVolume represents a portworx volume
-                            attached and mounted on kubelets host machine
+                            attached and mounted on kubelets host machine.
                           properties:
                             fsType:
                               description: |-
@@ -15353,10 +15512,13 @@ spec:
                               format: int32
                               type: integer
                             sources:
-                              description: sources is the list of volume projections
+                              description: |-
+                                sources is the list of volume projections. Each entry in this list
+                                handles one source.
                               items:
-                                description: Projection that may be projected along
-                                  with other supported volume types
+                                description: |-
+                                  Projection that may be projected along with other supported volume types.
+                                  Exactly one of these fields must be set.
                                 properties:
                                   clusterTrustBundle:
                                     description: ClusterTrustBundle allows a pod to
@@ -15436,7 +15598,7 @@ spec:
                                       items:
                                         description: |-
                                           items if unspecified, each key-value pair in the Data field of the referenced
-                                          ConfigMap will be projected into the volum
+                                          ConfigMap will be projected into the...
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -15507,7 +15669,7 @@ spec:
                                             mode:
                                               description: |-
                                                 Optional: mode bits used to set permissions on this file, must be an octal value
-                                                between 0000 and 0777 or a decimal valu
+                                                between 0000 and 0777 or a decimal...
                                               format: int32
                                               type: integer
                                             path:
@@ -15556,7 +15718,7 @@ spec:
                                       items:
                                         description: |-
                                           items if unspecified, each key-value pair in the Data field of the referenced
-                                          Secret will be projected into the volume a
+                                          Secret will be projected into the volume...
                                         items:
                                           description: Maps a string key to a path
                                             within a volume.
@@ -15622,7 +15784,7 @@ spec:
                           type: object
                         quobyte:
                           description: quobyte represents a Quobyte mount on the host
-                            that shares a pod's lifetime
+                            that shares a pod's lifetime.
                           properties:
                             group:
                               description: |-
@@ -15637,12 +15799,12 @@ spec:
                             registry:
                               description: |-
                                 registry represents a single or multiple Quobyte Registry services
-                                specified as a string as host:port pair (multiple ent
+                                specified as a string as host:port pair (multiple...
                               type: string
                             tenant:
                               description: |-
                                 tenant owning the given Quobyte volume in the Backend
-                                Used with dynamically provisioned Quobyte volumes, value is set by
+                                Used with dynamically provisioned Quobyte volumes, value is set...
                               type: string
                             user:
                               description: |-
@@ -15658,9 +15820,8 @@ spec:
                           - volume
                           type: object
                         rbd:
-                          description: |-
-                            rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                            More info: https://examples.k8s.
+                          description: rbd represents a Rados Block Device mount on
+                            the host that shares a pod's lifetime.
                           properties:
                             fsType:
                               description: fsType is the filesystem type of the volume
@@ -15672,6 +15833,7 @@ spec:
                                 More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                               type: string
                             keyring:
+                              default: /etc/ceph/keyring
                               description: |-
                                 keyring is the path to key ring for RBDUser.
                                 Default is /etc/ceph/keyring.
@@ -15686,6 +15848,7 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             pool:
+                              default: rbd
                               description: |-
                                 pool is the rados pool name.
                                 Default is rbd.
@@ -15713,6 +15876,7 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             user:
+                              default: admin
                               description: |-
                                 user is the rados user name.
                                 Default is admin.
@@ -15727,6 +15891,7 @@ spec:
                             attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
+                              default: xfs
                               description: |-
                                 fsType is the filesystem type to mount.
                                 Must be a filesystem type supported by the host operating system.
@@ -15764,6 +15929,7 @@ spec:
                                 with Gateway, default false
                               type: boolean
                             storageMode:
+                              default: ThinProvisioned
                               description: storageMode indicates whether the storage
                                 for a volume should be ThickProvisioned or ThinProvisioned.
                               type: string
@@ -15798,7 +15964,7 @@ spec:
                             items:
                               description: |-
                                 items If unspecified, each key-value pair in the Data field of the referenced
-                                Secret will be projected into the volume a
+                                Secret will be projected into the volume...
                               items:
                                 description: Maps a string key to a path within a
                                   volume.
@@ -15873,7 +16039,7 @@ spec:
                           type: object
                         vsphereVolume:
                           description: vsphereVolume represents a vSphere volume attached
-                            and mounted on kubelets host machine
+                            and mounted on kubelets host machine.
                           properties:
                             fsType:
                               description: |-
@@ -15989,8 +16155,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -16090,7 +16255,7 @@ spec:
                           envFrom:
                             items:
                               description: EnvFromSource represents the source of
-                                a set of ConfigMaps
+                                a set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -16109,8 +16274,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: Optional text to prepend to the name
+                                    of each environment variable. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -16157,6 +16322,10 @@ spec:
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used.
                                       type: string
+                                    request:
+                                      description: Request is the name chosen for
+                                        a request in the referenced claim.
+                                      type: string
                                   required:
                                   - name
                                   type: object
@@ -16198,7 +16367,7 @@ spec:
                           activeDeadlineSeconds:
                             description: |-
                               Specifies the duration in seconds relative to the startTime that the job
-                              may be continuously active before the system tr
+                              may be continuously active before the system...
                             format: int64
                             type: integer
                           backoffLimit:
@@ -16384,8 +16553,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -16485,7 +16653,7 @@ spec:
                           envFrom:
                             items:
                               description: EnvFromSource represents the source of
-                                a set of ConfigMaps
+                                a set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -16504,8 +16672,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: Optional text to prepend to the name
+                                    of each environment variable. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -16763,8 +16931,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -16867,7 +17034,7 @@ spec:
                               envFrom:
                                 items:
                                   description: EnvFromSource represents the source
-                                    of a set of ConfigMaps
+                                    of a set of ConfigMaps or Secrets
                                   properties:
                                     configMapRef:
                                       description: The ConfigMap to select from
@@ -16886,8 +17053,9 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: An optional identifier to prepend
-                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      description: Optional text to prepend to the
+                                        name of each environment variable. Must be
+                                        a C_IDENTIFIER.
                                       type: string
                                     secretRef:
                                       description: The Secret to select from
@@ -16948,6 +17116,10 @@ spec:
                                           description: |-
                                             Name must match the name of one entry in pod.spec.resourceClaims of
                                             the Pod where this field is used.
+                                          type: string
+                                        request:
+                                          description: Request is the name chosen
+                                            for a request in the referenced claim.
                                           type: string
                                       required:
                                       - name
@@ -17281,8 +17453,7 @@ spec:
                                     value:
                                       description: |-
                                         Variable references $(VAR_NAME) are expanded
-                                        using the previously defined environment variables in the container and
-                                        any
+                                        using the previously defined environment variables in the container and...
                                       type: string
                                     valueFrom:
                                       description: Source for the environment variable's
@@ -17385,7 +17556,7 @@ spec:
                               envFrom:
                                 items:
                                   description: EnvFromSource represents the source
-                                    of a set of ConfigMaps
+                                    of a set of ConfigMaps or Secrets
                                   properties:
                                     configMapRef:
                                       description: The ConfigMap to select from
@@ -17404,8 +17575,9 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: An optional identifier to prepend
-                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      description: Optional text to prepend to the
+                                        name of each environment variable. Must be
+                                        a C_IDENTIFIER.
                                       type: string
                                     secretRef:
                                       description: The Secret to select from
@@ -17466,6 +17638,10 @@ spec:
                                           description: |-
                                             Name must match the name of one entry in pod.spec.resourceClaims of
                                             the Pod where this field is used.
+                                          type: string
+                                        request:
+                                          description: Request is the name chosen
+                                            for a request in the referenced claim.
                                           type: string
                                       required:
                                       - name
@@ -17821,8 +17997,7 @@ spec:
                                         value:
                                           description: |-
                                             Variable references $(VAR_NAME) are expanded
-                                            using the previously defined environment variables in the container and
-                                            any
+                                            using the previously defined environment variables in the container and...
                                           type: string
                                         valueFrom:
                                           description: Source for the environment
@@ -17927,7 +18102,7 @@ spec:
                                   envFrom:
                                     items:
                                       description: EnvFromSource represents the source
-                                        of a set of ConfigMaps
+                                        of a set of ConfigMaps or Secrets
                                       properties:
                                         configMapRef:
                                           description: The ConfigMap to select from
@@ -17946,9 +18121,9 @@ spec:
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         prefix:
-                                          description: An optional identifier to prepend
-                                            to each key in the ConfigMap. Must be
-                                            a C_IDENTIFIER.
+                                          description: Optional text to prepend to
+                                            the name of each environment variable.
+                                            Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
                                           description: The Secret to select from
@@ -18013,6 +18188,10 @@ spec:
                                               description: |-
                                                 Name must match the name of one entry in pod.spec.resourceClaims of
                                                 the Pod where this field is used.
+                                              type: string
+                                            request:
+                                              description: Request is the name chosen
+                                                for a request in the referenced claim.
                                               type: string
                                           required:
                                           - name
@@ -18292,6 +18471,11 @@ spec:
                               Defaults to user specified in image metadata if unspecified.
                             format: int64
                             type: integer
+                          seLinuxChangePolicy:
+                            description: seLinuxChangePolicy defines how the container's
+                              SELinux label is applied to all volumes used by the
+                              Pod.
+                            type: string
                           seLinuxOptions:
                             description: The SELinux context to be applied to all
                               containers.
@@ -18331,13 +18515,18 @@ spec:
                             type: object
                           supplementalGroups:
                             description: |-
-                              A list of groups applied to the first process run in each container, in addition
-                              to the container's primary GID, the fsG
+                              A list of groups applied to the first process run in each container, in
+                              addition to the container's primary GID and...
                             items:
                               format: int64
                               type: integer
                             type: array
                             x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            description: |-
+                              Defines how supplemental groups of the first container processes are calculated.
+                              Valid values are "Merge" and "Strict".
+                            type: string
                           sysctls:
                             description: Sysctls hold a list of namespaced sysctls
                               used for the pod.
@@ -18395,8 +18584,7 @@ spec:
                                 value:
                                   description: |-
                                     Variable references $(VAR_NAME) are expanded
-                                    using the previously defined environment variables in the container and
-                                    any
+                                    using the previously defined environment variables in the container and...
                                   type: string
                                 valueFrom:
                                   description: Source for the environment variable's
@@ -18496,7 +18684,7 @@ spec:
                           envFrom:
                             items:
                               description: EnvFromSource represents the source of
-                                a set of ConfigMaps
+                                a set of ConfigMaps or Secrets
                               properties:
                                 configMapRef:
                                   description: The ConfigMap to select from
@@ -18515,8 +18703,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: Optional text to prepend to the name
+                                    of each environment variable. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -18577,6 +18765,10 @@ spec:
                                       description: |-
                                         Name must match the name of one entry in pod.spec.resourceClaims of
                                         the Pod where this field is used.
+                                      type: string
+                                    request:
+                                      description: Request is the name chosen for
+                                        a request in the referenced claim.
                                       type: string
                                   required:
                                   - name
@@ -18746,7 +18938,7 @@ spec:
                             awsElasticBlockStore:
                               description: |-
                                 awsElasticBlockStore represents an AWS Disk resource that is attached to a
-                                kubelet's host machine and then exposed to th
+                                kubelet's host machine and then exposed to...
                               properties:
                                 fsType:
                                   description: fsType is the filesystem type of the
@@ -18788,6 +18980,7 @@ spec:
                                     the blob storage
                                   type: string
                                 fsType:
+                                  default: ext4
                                   description: |-
                                     fsType is Filesystem type to mount.
                                     Must be a filesystem type supported by the host operating system.
@@ -18796,9 +18989,10 @@ spec:
                                 kind:
                                   description: 'kind expected values are Shared: multiple
                                     blob disks per storage account  Dedicated: single
-                                    blob disk per storage accoun'
+                                    blob disk per storage...'
                                   type: string
                                 readOnly:
+                                  default: false
                                   description: |-
                                     readOnly Defaults to false (read/write). ReadOnly here will force
                                     the ReadOnly setting in VolumeMounts.
@@ -18829,7 +19023,7 @@ spec:
                               type: object
                             cephfs:
                               description: cephFS represents a Ceph FS mount on the
-                                host that shares a pod's lifetime
+                                host that shares a pod's lifetime.
                               properties:
                                 monitors:
                                   description: |-
@@ -18878,7 +19072,7 @@ spec:
                             cinder:
                               description: |-
                                 cinder represents a cinder volume attached and mounted on kubelets host machine.
-                                More info: https://examples.k8s.
+                                Deprecated: Cinder is deprecated.
                               properties:
                                 fsType:
                                   description: |-
@@ -18924,7 +19118,7 @@ spec:
                                 items:
                                   description: |-
                                     items if unspecified, each key-value pair in the Data field of the referenced
-                                    ConfigMap will be projected into the volum
+                                    ConfigMap will be projected into the...
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -18964,7 +19158,7 @@ spec:
                             csi:
                               description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
-                                CSI drivers (Beta fea
+                                CSI drivers.
                               properties:
                                 driver:
                                   description: driver is the name of the CSI driver
@@ -18977,7 +19171,7 @@ spec:
                                 nodePublishSecretRef:
                                   description: |-
                                     nodePublishSecretRef is a reference to the secret object containing
-                                    sensitive information to pass to the CSI driver to c
+                                    sensitive information to pass to the CSI driver to...
                                   properties:
                                     name:
                                       default: ""
@@ -19041,7 +19235,7 @@ spec:
                                       mode:
                                         description: |-
                                           Optional: mode bits used to set permissions on this file, must be an octal value
-                                          between 0000 and 0777 or a decimal valu
+                                          between 0000 and 0777 or a decimal...
                                         format: int32
                                         type: integer
                                       path:
@@ -19293,9 +19487,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 wwids:
-                                  description: "wwids Optional: FC volume world wide
-                                    identifiers (wwids)\nEither wwids or combination
-                                    of targetWWNs and lun must be set, "
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set,...
                                   items:
                                     type: string
                                   type: array
@@ -19330,7 +19524,7 @@ spec:
                                 secretRef:
                                   description: |-
                                     secretRef is Optional: secretRef is reference to the secret object containing
-                                    sensitive information to pass to the plugi
+                                    sensitive information to pass to the...
                                   properties:
                                     name:
                                       default: ""
@@ -19351,7 +19545,7 @@ spec:
                                 datasetName:
                                   description: |-
                                     datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
-                                    should be considered as depreca
+                                    should be considered as...
                                   type: string
                                 datasetUUID:
                                   description: datasetUUID is the UUID of the dataset.
@@ -19361,7 +19555,7 @@ spec:
                             gcePersistentDisk:
                               description: |-
                                 gcePersistentDisk represents a GCE Disk resource that is attached to a
-                                kubelet's host machine and then exposed to the po
+                                kubelet's host machine and then exposed to the...
                               properties:
                                 fsType:
                                   description: fsType is filesystem type of the volume
@@ -19390,7 +19584,7 @@ spec:
                             gitRepo:
                               description: |-
                                 gitRepo represents a git repository at a particular revision.
-                                DEPRECATED: GitRepo is deprecated.
+                                Deprecated: GitRepo is deprecated.
                               properties:
                                 directory:
                                   description: |-
@@ -19408,9 +19602,8 @@ spec:
                               - repository
                               type: object
                             glusterfs:
-                              description: |-
-                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.
+                              description: glusterfs represents a Glusterfs mount
+                                on the host that shares a pod's lifetime.
                               properties:
                                 endpoints:
                                   description: |-
@@ -19450,6 +19643,22 @@ spec:
                               required:
                               - path
                               type: object
+                            image:
+                              description: image represents an OCI object (a container
+                                image or artifact) pulled and mounted on the kubelet's
+                                host machine.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                  type: string
+                              type: object
                             iscsi:
                               description: |-
                                 iscsi represents an ISCSI Disk resource that is attached to a
@@ -19475,6 +19684,7 @@ spec:
                                   description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
+                                  default: default
                                   description: |-
                                     iscsiInterface is the interface Name that uses an iSCSI transport.
                                     Defaults to 'default' (tcp).
@@ -19566,7 +19776,7 @@ spec:
                             photonPersistentDisk:
                               description: photonPersistentDisk represents a PhotonController
                                 persistent disk attached and mounted on kubelets host
-                                machine
+                                machine.
                               properties:
                                 fsType:
                                   description: |-
@@ -19583,7 +19793,7 @@ spec:
                               type: object
                             portworxVolume:
                               description: portworxVolume represents a portworx volume
-                                attached and mounted on kubelets host machine
+                                attached and mounted on kubelets host machine.
                               properties:
                                 fsType:
                                   description: |-
@@ -19613,10 +19823,13 @@ spec:
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: sources is the list of volume projections
+                                  description: |-
+                                    sources is the list of volume projections. Each entry in this list
+                                    handles one source.
                                   items:
-                                    description: Projection that may be projected
-                                      along with other supported volume types
+                                    description: |-
+                                      Projection that may be projected along with other supported volume types.
+                                      Exactly one of these fields must be set.
                                     properties:
                                       clusterTrustBundle:
                                         description: ClusterTrustBundle allows a pod
@@ -19697,7 +19910,7 @@ spec:
                                           items:
                                             description: |-
                                               items if unspecified, each key-value pair in the Data field of the referenced
-                                              ConfigMap will be projected into the volum
+                                              ConfigMap will be projected into the...
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -19770,7 +19983,7 @@ spec:
                                                 mode:
                                                   description: |-
                                                     Optional: mode bits used to set permissions on this file, must be an octal value
-                                                    between 0000 and 0777 or a decimal valu
+                                                    between 0000 and 0777 or a decimal...
                                                   format: int32
                                                   type: integer
                                                 path:
@@ -19819,7 +20032,7 @@ spec:
                                           items:
                                             description: |-
                                               items if unspecified, each key-value pair in the Data field of the referenced
-                                              Secret will be projected into the volume a
+                                              Secret will be projected into the volume...
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
@@ -19885,7 +20098,7 @@ spec:
                               type: object
                             quobyte:
                               description: quobyte represents a Quobyte mount on the
-                                host that shares a pod's lifetime
+                                host that shares a pod's lifetime.
                               properties:
                                 group:
                                   description: |-
@@ -19900,12 +20113,12 @@ spec:
                                 registry:
                                   description: |-
                                     registry represents a single or multiple Quobyte Registry services
-                                    specified as a string as host:port pair (multiple ent
+                                    specified as a string as host:port pair (multiple...
                                   type: string
                                 tenant:
                                   description: |-
                                     tenant owning the given Quobyte volume in the Backend
-                                    Used with dynamically provisioned Quobyte volumes, value is set by
+                                    Used with dynamically provisioned Quobyte volumes, value is set...
                                   type: string
                                 user:
                                   description: |-
@@ -19921,9 +20134,8 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: |-
-                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
-                                More info: https://examples.k8s.
+                              description: rbd represents a Rados Block Device mount
+                                on the host that shares a pod's lifetime.
                               properties:
                                 fsType:
                                   description: fsType is the filesystem type of the
@@ -19935,6 +20147,7 @@ spec:
                                     More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                   type: string
                                 keyring:
+                                  default: /etc/ceph/keyring
                                   description: |-
                                     keyring is the path to key ring for RBDUser.
                                     Default is /etc/ceph/keyring.
@@ -19949,6 +20162,7 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 pool:
+                                  default: rbd
                                   description: |-
                                     pool is the rados pool name.
                                     Default is rbd.
@@ -19976,6 +20190,7 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 user:
+                                  default: admin
                                   description: |-
                                     user is the rados user name.
                                     Default is admin.
@@ -19990,6 +20205,7 @@ spec:
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
+                                  default: xfs
                                   description: |-
                                     fsType is the filesystem type to mount.
                                     Must be a filesystem type supported by the host operating system.
@@ -20027,6 +20243,7 @@ spec:
                                     communication with Gateway, default false
                                   type: boolean
                                 storageMode:
+                                  default: ThinProvisioned
                                   description: storageMode indicates whether the storage
                                     for a volume should be ThickProvisioned or ThinProvisioned.
                                   type: string
@@ -20061,7 +20278,7 @@ spec:
                                 items:
                                   description: |-
                                     items If unspecified, each key-value pair in the Data field of the referenced
-                                    Secret will be projected into the volume a
+                                    Secret will be projected into the volume...
                                   items:
                                     description: Maps a string key to a path within
                                       a volume.
@@ -20136,7 +20353,7 @@ spec:
                               type: object
                             vsphereVolume:
                               description: vsphereVolume represents a vSphere volume
-                                attached and mounted on kubelets host machine
+                                attached and mounted on kubelets host machine.
                               properties:
                                 fsType:
                                   description: |-
@@ -20210,10 +20427,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string

--- a/infra/feast-operator/internal/controller/authz/authz.go
+++ b/infra/feast-operator/internal/controller/authz/authz.go
@@ -399,6 +399,9 @@ func (authz *FeastAuthorization) cleanupOidcRbac() {
 func (authz *FeastAuthorization) cleanupKubernetesClusterRbac() {
 	crb := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: authz.getFeastClusterRoleBindingName()}}
 	crb.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"))
+	if err := authz.Handler.Client.Get(authz.Handler.Context, client.ObjectKeyFromObject(crb), crb); err != nil {
+		return
+	}
 	_ = authz.Handler.Client.Delete(authz.Handler.Context, crb)
 }
 

--- a/infra/feast-operator/internal/controller/authz/authz.go
+++ b/infra/feast-operator/internal/controller/authz/authz.go
@@ -18,22 +18,32 @@ import (
 // Deploy the feast authorization
 func (authz *FeastAuthorization) Deploy() error {
 	if authz.isKubernetesAuth() {
+		authz.cleanupOidcRbac()
 		return authz.deployKubernetesAuth()
 	}
 
+	// Clean up namespace-scoped Kubernetes auth resources
 	authz.removeOrphanedRoles()
 	_ = authz.Handler.DeleteOwnedFeastObj(authz.initFeastRole())
 	_ = authz.Handler.DeleteOwnedFeastObj(authz.initFeastRoleBinding())
 	apimeta.RemoveStatusCondition(&authz.Handler.FeatureStore.Status.Conditions, feastKubernetesAuthConditions[metav1.ConditionTrue].Type)
 
+	// Clean up cluster-scoped Kubernetes auth CRB (handles Kubernetes→OIDC or Kubernetes→no-auth transitions)
+	authz.cleanupKubernetesClusterRbac()
+
 	if authz.isOidcAuth() {
-		if err := authz.createFeastClusterRole(); err != nil {
-			return err
+		if err := authz.createOidcClusterRole(); err != nil {
+			return authz.setFeastOidcAuthCondition(err)
 		}
-		if err := authz.createFeastClusterRoleBinding(); err != nil {
-			return err
+		if err := authz.createOidcClusterRoleBinding(); err != nil {
+			return authz.setFeastOidcAuthCondition(err)
 		}
+		return authz.setFeastOidcAuthCondition(nil)
 	}
+
+	// No auth - clean up OIDC RBAC and remove condition
+	authz.cleanupOidcRbac()
+	apimeta.RemoveStatusCondition(&authz.Handler.FeatureStore.Status.Conditions, feastOidcAuthConditions[metav1.ConditionTrue].Type)
 
 	return nil
 }
@@ -327,12 +337,104 @@ func (authz *FeastAuthorization) setAuthRole(role *rbacv1.Role) error {
 	return controllerutil.SetControllerReference(authz.Handler.FeatureStore, role, authz.Handler.Scheme)
 }
 
+func (authz *FeastAuthorization) createOidcClusterRole() error {
+	logger := log.FromContext(authz.Handler.Context)
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: authz.getOidcClusterRoleName()},
+	}
+	clusterRole.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRole"))
+	if op, err := controllerutil.CreateOrUpdate(authz.Handler.Context, authz.Handler.Client, clusterRole, controllerutil.MutateFn(func() error {
+		clusterRole.Labels = authz.getSharedOidcClusterRoleLabels()
+		clusterRole.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"authentication.k8s.io"},
+				Resources: []string{"tokenreviews"},
+				Verbs:     []string{"create"},
+			},
+		}
+		return nil
+	})); err != nil {
+		return err
+	} else if op == controllerutil.OperationResultCreated || op == controllerutil.OperationResultUpdated {
+		logger.Info("Successfully reconciled", "ClusterRole", clusterRole.Name, "operation", op)
+	}
+	return nil
+}
+
+func (authz *FeastAuthorization) createOidcClusterRoleBinding() error {
+	logger := log.FromContext(authz.Handler.Context)
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: authz.getOidcClusterRoleBindingName()},
+	}
+	crb.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"))
+	if op, err := controllerutil.CreateOrUpdate(authz.Handler.Context, authz.Handler.Client, crb, controllerutil.MutateFn(func() error {
+		crb.Labels = authz.getLabels()
+		crb.Subjects = []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      authz.getFeastServiceAccountName(),
+				Namespace: authz.Handler.FeatureStore.Namespace,
+			},
+		}
+		crb.RoleRef = rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     authz.getOidcClusterRoleName(),
+		}
+		return nil
+	})); err != nil {
+		return err
+	} else if op == controllerutil.OperationResultCreated || op == controllerutil.OperationResultUpdated {
+		logger.Info("Successfully reconciled", "ClusterRoleBinding", crb.Name, "operation", op)
+	}
+	return nil
+}
+
+func (authz *FeastAuthorization) cleanupOidcRbac() {
+	crb := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: authz.getOidcClusterRoleBindingName()}}
+	crb.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"))
+	_ = authz.Handler.Client.Delete(authz.Handler.Context, crb)
+}
+
+func (authz *FeastAuthorization) cleanupKubernetesClusterRbac() {
+	crb := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: authz.getFeastClusterRoleBindingName()}}
+	crb.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"))
+	_ = authz.Handler.Client.Delete(authz.Handler.Context, crb)
+}
+
+func (authz *FeastAuthorization) getOidcClusterRoleName() string {
+	return "feast-oidc-token-review"
+}
+
+func (authz *FeastAuthorization) getOidcClusterRoleBindingName() string {
+	return services.GetFeastName(authz.Handler.FeatureStore) + "-oidc-token-review"
+}
+
 func (authz *FeastAuthorization) getLabels() map[string]string {
 	return map[string]string{
 		services.NameLabelKey:        authz.Handler.FeatureStore.Name,
 		services.ServiceTypeLabelKey: string(services.AuthzFeastType),
 		services.ManagedByLabelKey:   services.ManagedByLabelValue,
 	}
+}
+
+func (authz *FeastAuthorization) getSharedOidcClusterRoleLabels() map[string]string {
+	return map[string]string{
+		services.ServiceTypeLabelKey: string(services.AuthzFeastType),
+	}
+}
+
+func (authz *FeastAuthorization) setFeastOidcAuthCondition(err error) error {
+	if err != nil {
+		logger := log.FromContext(authz.Handler.Context)
+		cond := feastOidcAuthConditions[metav1.ConditionFalse]
+		cond.Message = "Error: " + err.Error()
+		apimeta.SetStatusCondition(&authz.Handler.FeatureStore.Status.Conditions, cond)
+		logger.Error(err, "Error deploying the OIDC authorization")
+		return err
+	}
+	apimeta.SetStatusCondition(&authz.Handler.FeatureStore.Status.Conditions, feastOidcAuthConditions[metav1.ConditionTrue])
+	return nil
 }
 
 func (authz *FeastAuthorization) setFeastKubernetesAuthCondition(err error) error {

--- a/infra/feast-operator/internal/controller/authz/authz.go
+++ b/infra/feast-operator/internal/controller/authz/authz.go
@@ -421,6 +421,7 @@ func (authz *FeastAuthorization) getLabels() map[string]string {
 func (authz *FeastAuthorization) getSharedOidcClusterRoleLabels() map[string]string {
 	return map[string]string{
 		services.ServiceTypeLabelKey: string(services.AuthzFeastType),
+		services.ManagedByLabelKey:   services.ManagedByLabelValue,
 	}
 }
 

--- a/infra/feast-operator/internal/controller/authz/authz_types.go
+++ b/infra/feast-operator/internal/controller/authz/authz_types.go
@@ -25,4 +25,17 @@ var (
 			Reason: feastdevv1.KubernetesAuthzFailedReason,
 		},
 	}
+	feastOidcAuthConditions = map[metav1.ConditionStatus]metav1.Condition{
+		metav1.ConditionTrue: {
+			Type:    feastdevv1.AuthorizationReadyType,
+			Status:  metav1.ConditionTrue,
+			Reason:  feastdevv1.ReadyReason,
+			Message: feastdevv1.OidcAuthzReadyMessage,
+		},
+		metav1.ConditionFalse: {
+			Type:   feastdevv1.AuthorizationReadyType,
+			Status: metav1.ConditionFalse,
+			Reason: feastdevv1.OidcAuthzFailedReason,
+		},
+	}
 )

--- a/infra/feast-operator/internal/controller/featurestore_controller_oidc_auth_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_oidc_auth_test.go
@@ -179,7 +179,10 @@ var _ = Describe("FeatureStore Controller-OIDC authorization", func() {
 			Expect(cond.Message).To(Equal(feastdevv1.DeploymentNotAvailableMessage))
 
 			cond = apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1.AuthorizationReadyType)
-			Expect(cond).To(BeNil())
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(feastdevv1.ReadyReason))
+			Expect(cond.Message).To(Equal(feastdevv1.OidcAuthzReadyMessage))
 
 			cond = apimeta.FindStatusCondition(resource.Status.Conditions, feastdevv1.RegistryReadyType)
 			Expect(cond).ToNot(BeNil())


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing and why.
-->When `authz: oidc` is configured, the Feast server delegates Kubernetes service account (SA) tokens to a lightweight TokenReview for validation and namespace extraction. This requires the server SA to have `tokenreviews/create` permission. Previously, this RBAC was not provisioned automatically by the operator for OIDC deployments (only for `authz: kubernetes`), requiring manual ClusterRole creation.

## Operator: OIDC TokenReview RBAC

The operator now provisions a dedicated `feast-oidc-token-review` ClusterRole and ClusterRoleBinding when `authz: oidc` is configured. The ClusterRole contains exactly one rule:

* `authentication.k8s.io/tokenreviews/create`

This is the minimum permission needed for the SA token delegation path. No additional RBAC queries (rolebindings, clusterroles, namespaces) are granted, unlike the `authz: kubernetes` path which needs broader permissions for `KubernetesTokenParser`.

Cleanup is handled automatically when switching auth types:

* OIDC to kubernetes: OIDC ClusterRole + ClusterRoleBinding deleted
* OIDC to no_auth: OIDC ClusterRole + ClusterRoleBinding deleted
* kubernetes/no_auth to OIDC: OIDC ClusterRole + ClusterRoleBinding created

## SDK: SSL Error Logging

When `verify_ssl: true` is set but the OIDC provider uses self-signed certificates without a configured `ca_cert_path`, the server fails to reach the JWKS/discovery endpoints. Previously, this produced a generic "Invalid token" log with no indication of the root cause. The token parser now detects SSL errors in the exception chain and logs a clear, actionable message:

```
OIDC provider SSL certificate verification failed. If using a self-signed certificate,
set verify_ssl: false or provide a CA certificate via ca_cert_path.
```

This applies to both the discovery endpoint (`_validate_token`) and the JWKS endpoint (`_decode_token`) error paths.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Follow up to #6089

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
