### PR TITLE
fix: Harden informer cache with label selectors and memory optimizations

### DIFF
--- a/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
+++ b/infra/feast-operator/bundle/manifests/feast-operator.clusterserviceversion.yaml
@@ -266,6 +266,8 @@ spec:
                 command:
                 - /manager
                 env:
+                - name: GOMEMLIMIT
+                  value: "230MiB"
                 - name: RELATED_IMAGE_FEATURE_SERVER
                   value: quay.io/feastdev/feature-server:0.62.0
                 - name: RELATED_IMAGE_CRON_JOB

--- a/infra/feast-operator/cmd/main.go
+++ b/infra/feast-operator/cmd/main.go
@@ -178,9 +178,23 @@ func main() {
 		Cache: newCacheOptions(),
 		Client: client.Options{
 			Cache: &client.CacheOptions{
+				// Bypass the label-filtered informer cache for all reads so that
+				// pre-existing resources without the managed-by label are still
+				// visible to the reconciler. The ByObject cache filter above still
+				// restricts the watch to managed-by-labeled objects, limiting
+				// memory usage while avoiding upgrade deadlocks.
 				DisableFor: []client.Object{
 					&corev1.ConfigMap{},
 					&corev1.Secret{},
+					&appsv1.Deployment{},
+					&corev1.Service{},
+					&corev1.ServiceAccount{},
+					&corev1.PersistentVolumeClaim{},
+					&rbacv1.RoleBinding{},
+					&rbacv1.Role{},
+					&batchv1.CronJob{},
+					&autoscalingv2.HorizontalPodAutoscaler{},
+					&policyv1.PodDisruptionBudget{},
 				},
 			},
 		},

--- a/infra/feast-operator/cmd/main.go
+++ b/infra/feast-operator/cmd/main.go
@@ -25,11 +25,18 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -57,6 +64,29 @@ func init() {
 	utilruntime.Must(feastdevv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(feastdevv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
+}
+
+func newCacheOptions() cache.Options {
+	managedBySelector := labels.SelectorFromSet(labels.Set{
+		services.ManagedByLabelKey: services.ManagedByLabelValue,
+	})
+	managedByFilter := cache.ByObject{Label: managedBySelector}
+
+	return cache.Options{
+		DefaultTransform: cache.TransformStripManagedFields(),
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.ConfigMap{}:                      managedByFilter,
+			&appsv1.Deployment{}:                     managedByFilter,
+			&corev1.Service{}:                        managedByFilter,
+			&corev1.ServiceAccount{}:                 managedByFilter,
+			&corev1.PersistentVolumeClaim{}:          managedByFilter,
+			&rbacv1.RoleBinding{}:                    managedByFilter,
+			&rbacv1.Role{}:                           managedByFilter,
+			&batchv1.CronJob{}:                       managedByFilter,
+			&autoscalingv2.HorizontalPodAutoscaler{}: managedByFilter,
+			&policyv1.PodDisruptionBudget{}:          managedByFilter,
+		},
+	}
 }
 
 func main() {
@@ -145,6 +175,7 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		Cache: newCacheOptions(),
 		Client: client.Options{
 			Cache: &client.CacheOptions{
 				DisableFor: []client.Object{

--- a/infra/feast-operator/config/default/related_image_fs_patch.tmpl
+++ b/infra/feast-operator/config/default/related_image_fs_patch.tmpl
@@ -1,16 +1,14 @@
-- op: test
-  path: "/spec/template/spec/containers/0/env/1/name"
-  value: RELATED_IMAGE_FEATURE_SERVER
-- op: replace
-  path: "/spec/template/spec/containers/0/env/1"
-  value:
-    name: RELATED_IMAGE_FEATURE_SERVER
-    value: ${FS_IMG}
-- op: test
-  path: "/spec/template/spec/containers/0/env/2/name"
-  value: RELATED_IMAGE_CRON_JOB
-- op: replace
-  path: "/spec/template/spec/containers/0/env/2"
-  value:
-    name: RELATED_IMAGE_CRON_JOB
-    value: ${CJ_IMG}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: RELATED_IMAGE_FEATURE_SERVER
+          value: ${FS_IMG}
+        - name: RELATED_IMAGE_CRON_JOB
+          value: ${CJ_IMG}

--- a/infra/feast-operator/config/default/related_image_fs_patch.tmpl
+++ b/infra/feast-operator/config/default/related_image_fs_patch.tmpl
@@ -1,10 +1,16 @@
+- op: test
+  path: "/spec/template/spec/containers/0/env/1/name"
+  value: RELATED_IMAGE_FEATURE_SERVER
 - op: replace
-  path: "/spec/template/spec/containers/0/env/0"
+  path: "/spec/template/spec/containers/0/env/1"
   value:
     name: RELATED_IMAGE_FEATURE_SERVER
     value: ${FS_IMG}
+- op: test
+  path: "/spec/template/spec/containers/0/env/2/name"
+  value: RELATED_IMAGE_CRON_JOB
 - op: replace
-  path: "/spec/template/spec/containers/0/env/1"
+  path: "/spec/template/spec/containers/0/env/2"
   value:
     name: RELATED_IMAGE_CRON_JOB
     value: ${CJ_IMG}

--- a/infra/feast-operator/config/default/related_image_fs_patch.yaml
+++ b/infra/feast-operator/config/default/related_image_fs_patch.yaml
@@ -1,16 +1,14 @@
-- op: test
-  path: "/spec/template/spec/containers/0/env/1/name"
-  value: RELATED_IMAGE_FEATURE_SERVER
-- op: replace
-  path: "/spec/template/spec/containers/0/env/1"
-  value:
-    name: RELATED_IMAGE_FEATURE_SERVER
-    value: quay.io/feastdev/feature-server:0.62.0
-- op: test
-  path: "/spec/template/spec/containers/0/env/2/name"
-  value: RELATED_IMAGE_CRON_JOB
-- op: replace
-  path: "/spec/template/spec/containers/0/env/2"
-  value:
-    name: RELATED_IMAGE_CRON_JOB
-    value: quay.io/openshift/origin-cli:4.17
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: RELATED_IMAGE_FEATURE_SERVER
+          value: quay.io/feastdev/feature-server:0.62.0
+        - name: RELATED_IMAGE_CRON_JOB
+          value: quay.io/openshift/origin-cli:4.17

--- a/infra/feast-operator/config/default/related_image_fs_patch.yaml
+++ b/infra/feast-operator/config/default/related_image_fs_patch.yaml
@@ -1,10 +1,16 @@
+- op: test
+  path: "/spec/template/spec/containers/0/env/1/name"
+  value: RELATED_IMAGE_FEATURE_SERVER
 - op: replace
-  path: "/spec/template/spec/containers/0/env/0"
+  path: "/spec/template/spec/containers/0/env/1"
   value:
     name: RELATED_IMAGE_FEATURE_SERVER
     value: quay.io/feastdev/feature-server:0.62.0
+- op: test
+  path: "/spec/template/spec/containers/0/env/2/name"
+  value: RELATED_IMAGE_CRON_JOB
 - op: replace
-  path: "/spec/template/spec/containers/0/env/1"
+  path: "/spec/template/spec/containers/0/env/2"
   value:
     name: RELATED_IMAGE_CRON_JOB
     value: quay.io/openshift/origin-cli:4.17

--- a/infra/feast-operator/config/manager/manager.yaml
+++ b/infra/feast-operator/config/manager/manager.yaml
@@ -73,6 +73,8 @@ spec:
             drop:
             - "ALL"
         env:
+        - name: GOMEMLIMIT
+          value: "230MiB"
         - name: RELATED_IMAGE_FEATURE_SERVER
           value: feast:latest
         - name: RELATED_IMAGE_CRON_JOB

--- a/infra/feast-operator/dist/install.yaml
+++ b/infra/feast-operator/dist/install.yaml
@@ -20864,6 +20864,8 @@ spec:
         command:
         - /manager
         env:
+        - name: GOMEMLIMIT
+          value: 230MiB
         - name: RELATED_IMAGE_FEATURE_SERVER
           value: quay.io/feastdev/feature-server:0.62.0
         - name: RELATED_IMAGE_CRON_JOB

--- a/infra/feast-operator/dist/install.yaml
+++ b/infra/feast-operator/dist/install.yaml
@@ -20864,12 +20864,12 @@ spec:
         command:
         - /manager
         env:
-        - name: GOMEMLIMIT
-          value: 230MiB
         - name: RELATED_IMAGE_FEATURE_SERVER
           value: quay.io/feastdev/feature-server:0.62.0
         - name: RELATED_IMAGE_CRON_JOB
           value: quay.io/openshift/origin-cli:4.17
+        - name: GOMEMLIMIT
+          value: 230MiB
         - name: OIDC_ISSUER_URL
           value: ""
         image: quay.io/feastdev/feast-operator:0.62.0

--- a/infra/feast-operator/internal/controller/authz/authz.go
+++ b/infra/feast-operator/internal/controller/authz/authz.go
@@ -331,6 +331,7 @@ func (authz *FeastAuthorization) getLabels() map[string]string {
 	return map[string]string{
 		services.NameLabelKey:        authz.Handler.FeatureStore.Name,
 		services.ServiceTypeLabelKey: string(services.AuthzFeastType),
+		services.ManagedByLabelKey:   services.ManagedByLabelValue,
 	}
 }
 

--- a/infra/feast-operator/internal/controller/services/namespace_registry.go
+++ b/infra/feast-operator/internal/controller/services/namespace_registry.go
@@ -179,6 +179,7 @@ func (feast *FeastServices) setNamespaceRegistryRoleBinding(rb *rbacv1.RoleBindi
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleName,
 			Namespace: rb.Namespace,
+			Labels:    feast.getLabels(),
 		},
 	}
 	role.Rules = desiredRules
@@ -205,6 +206,7 @@ func (feast *FeastServices) setNamespaceRegistryRoleBinding(rb *rbacv1.RoleBindi
 		}
 	}
 
+	rb.Labels = feast.getLabels()
 	rb.RoleRef = rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "Role",

--- a/infra/feast-operator/internal/controller/services/namespace_registry.go
+++ b/infra/feast-operator/internal/controller/services/namespace_registry.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -179,31 +178,16 @@ func (feast *FeastServices) setNamespaceRegistryRoleBinding(rb *rbacv1.RoleBindi
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleName,
 			Namespace: rb.Namespace,
-			Labels:    feast.getLabels(),
 		},
 	}
-	role.Rules = desiredRules
+	role.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("Role"))
 
-	// Attempt to create; tolerate AlreadyExists so concurrent reconcilers don't fail.
-	if err := feast.Handler.Client.Create(feast.Handler.Context, role); err != nil && !apierrors.IsAlreadyExists(err) {
-		return fmt.Errorf("failed to create namespace registry Role: %w", err)
-	}
-
-	// Re-fetch the authoritative copy to compare rules and obtain the latest resourceVersion.
-	existingRole := &rbacv1.Role{}
-	if err := feast.Handler.Client.Get(feast.Handler.Context, types.NamespacedName{
-		Name:      roleName,
-		Namespace: rb.Namespace,
-	}, existingRole); err != nil {
-		return fmt.Errorf("failed to get namespace registry Role: %w", err)
-	}
-
-	if !reflect.DeepEqual(existingRole.Rules, desiredRules) {
-		existingRole.Rules = desiredRules
-		// On conflict the reconciler will re-queue automatically.
-		if err := feast.Handler.Client.Update(feast.Handler.Context, existingRole); err != nil {
-			return fmt.Errorf("failed to update namespace registry Role: %w", err)
-		}
+	if _, err := controllerutil.CreateOrUpdate(feast.Handler.Context, feast.Handler.Client, role, func() error {
+		role.Labels = feast.getLabels()
+		role.Rules = desiredRules
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile namespace registry Role: %w", err)
 	}
 
 	rb.Labels = feast.getLabels()

--- a/infra/feast-operator/internal/controller/services/scaling.go
+++ b/infra/feast-operator/internal/controller/services/scaling.go
@@ -231,7 +231,7 @@ func (feast *FeastServices) buildPDBApplyConfig() *pdbac.PodDisruptionBudgetAppl
 				WithBlockOwnerDeletion(true),
 		).
 		WithSpec(pdbac.PodDisruptionBudgetSpec().
-			WithSelector(metaac.LabelSelector().WithMatchLabels(feast.getLabels())),
+			WithSelector(metaac.LabelSelector().WithMatchLabels(feast.getSelectorLabels())),
 		)
 
 	if pdbConfig.MinAvailable != nil {
@@ -249,8 +249,7 @@ func (feast *FeastServices) updateScalingStatus(deploy *appsv1.Deployment) {
 	cr := feast.Handler.FeatureStore
 
 	cr.Status.Replicas = deploy.Status.ReadyReplicas
-	labels := feast.getLabels()
-	cr.Status.Selector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(labels))
+	cr.Status.Selector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(feast.getSelectorLabels()))
 
 	if !isScalingEnabled(cr) {
 		cr.Status.ScalingStatus = nil

--- a/infra/feast-operator/internal/controller/services/services.go
+++ b/infra/feast-operator/internal/controller/services/services.go
@@ -384,10 +384,13 @@ func (feast *FeastServices) createPVC(pvcCreate *feastdevv1.PvcCreate, feastType
 	}
 
 	// PVCs are immutable, so we only create... we don't update an existing one.
+	// Treat AlreadyExists as success: a pre-existing PVC without the managed-by label
+	// won't appear in the filtered cache (Client.Get returns NotFound), but Create
+	// will hit AlreadyExists on the API server — both cases mean the PVC is present.
 	err = feast.Handler.Client.Get(feast.Handler.Context, client.ObjectKeyFromObject(pvc), pvc)
 	if err != nil && apierrors.IsNotFound(err) {
 		err = feast.Handler.Client.Create(feast.Handler.Context, pvc)
-		if err != nil {
+		if err != nil && !apierrors.IsAlreadyExists(err) {
 			return err
 		}
 		logger.Info("Successfully created", "PersistentVolumeClaim", pvc.Name)
@@ -1001,10 +1004,10 @@ func (feast *FeastServices) applyAffinity(podSpec *corev1.PodSpec) {
 				Weight: 100,
 				PodAffinityTerm: corev1.PodAffinityTerm{
 					TopologyKey:   "kubernetes.io/hostname",
-				LabelSelector: metav1.SetAsLabelSelector(feast.getSelectorLabels()),
-			},
-		}},
-	},
+					LabelSelector: metav1.SetAsLabelSelector(feast.getSelectorLabels()),
+				},
+			}},
+		},
 	}
 }
 

--- a/infra/feast-operator/internal/controller/services/services.go
+++ b/infra/feast-operator/internal/controller/services/services.go
@@ -408,9 +408,10 @@ func (feast *FeastServices) setDeployment(deploy *appsv1.Deployment) error {
 	}
 
 	deploy.Labels = feast.getLabels()
+	selectorLabels := feast.getSelectorLabels()
 	deploy.Spec = appsv1.DeploymentSpec{
 		Replicas: replicas,
-		Selector: metav1.SetAsLabelSelector(deploy.GetLabels()),
+		Selector: metav1.SetAsLabelSelector(selectorLabels),
 		Strategy: feast.getDeploymentStrategy(),
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
@@ -818,7 +819,7 @@ func (feast *FeastServices) setService(svc *corev1.Service, feastType FeastServi
 	}
 
 	svc.Spec = corev1.ServiceSpec{
-		Selector: feast.getLabels(),
+		Selector: feast.getSelectorLabels(),
 		Type:     corev1.ServiceTypeClusterIP,
 		Ports: []corev1.ServicePort{
 			{
@@ -868,6 +869,7 @@ func (feast *FeastServices) setServiceAccount(sa *corev1.ServiceAccount) error {
 
 func (feast *FeastServices) createNewPVC(pvcCreate *feastdevv1.PvcCreate, feastType FeastServiceType) (*corev1.PersistentVolumeClaim, error) {
 	pvc := feast.initPVC(feastType)
+	pvc.Labels = feast.getFeastTypeLabels(feastType)
 
 	pvc.Spec = corev1.PersistentVolumeClaimSpec{
 		AccessModes: pvcCreate.AccessModes,
@@ -976,7 +978,7 @@ func (feast *FeastServices) applyTopologySpread(podSpec *corev1.PodSpec) {
 		MaxSkew:           1,
 		TopologyKey:       "topology.kubernetes.io/zone",
 		WhenUnsatisfiable: corev1.ScheduleAnyway,
-		LabelSelector:     metav1.SetAsLabelSelector(feast.getLabels()),
+		LabelSelector:     metav1.SetAsLabelSelector(feast.getSelectorLabels()),
 	}}
 }
 
@@ -999,10 +1001,10 @@ func (feast *FeastServices) applyAffinity(podSpec *corev1.PodSpec) {
 				Weight: 100,
 				PodAffinityTerm: corev1.PodAffinityTerm{
 					TopologyKey:   "kubernetes.io/hostname",
-					LabelSelector: metav1.SetAsLabelSelector(feast.getLabels()),
-				},
-			}},
-		},
+				LabelSelector: metav1.SetAsLabelSelector(feast.getSelectorLabels()),
+			},
+		}},
+	},
 	}
 }
 
@@ -1060,9 +1062,21 @@ func (feast *FeastServices) getFeastTypeLabels(feastType FeastServiceType) map[s
 	return labels
 }
 
-func (feast *FeastServices) getLabels() map[string]string {
+// getSelectorLabels returns the minimal label set used for immutable selectors
+// (Deployment spec.selector, Service spec.selector, TopologySpreadConstraints, PodAffinity).
+// This must NOT change after initial resource creation.
+func (feast *FeastServices) getSelectorLabels() map[string]string {
 	return map[string]string{
 		NameLabelKey: feast.Handler.FeatureStore.Name,
+	}
+}
+
+// getLabels returns the full label set for mutable metadata (ObjectMeta.Labels).
+// Includes the managed-by label used by the informer cache filter.
+func (feast *FeastServices) getLabels() map[string]string {
+	return map[string]string{
+		NameLabelKey:      feast.Handler.FeatureStore.Name,
+		ManagedByLabelKey: ManagedByLabelValue,
 	}
 }
 
@@ -1438,10 +1452,10 @@ func IsDeploymentAvailable(conditions []appsv1.DeploymentCondition) bool {
 // container that is in a failing state. Returns empty string if no failure found.
 func (feast *FeastServices) GetPodContainerFailureMessage(deploy appsv1.Deployment) string {
 	podList := corev1.PodList{}
-	labels := feast.getLabels()
+	selectorLabels := feast.getSelectorLabels()
 	if err := feast.Handler.Client.List(feast.Handler.Context, &podList,
 		client.InNamespace(deploy.Namespace),
-		client.MatchingLabels(labels),
+		client.MatchingLabels(selectorLabels),
 	); err != nil {
 		return ""
 	}

--- a/infra/feast-operator/internal/controller/services/services_types.go
+++ b/infra/feast-operator/internal/controller/services/services_types.go
@@ -103,6 +103,11 @@ const (
 	OidcMissingSecretError string = "missing OIDC secret: %s"
 )
 
+const (
+	ManagedByLabelKey   = "app.kubernetes.io/managed-by"
+	ManagedByLabelValue = "feast-operator"
+)
+
 var (
 	DefaultImage          = "quay.io/feastdev/feature-server:" + feastversion.FeastVersion
 	DefaultCronJobImage   = "quay.io/openshift/origin-cli:4.17"


### PR DESCRIPTION
## Summary

The feast-operator's `Owns()` calls create cluster-wide informers for ConfigMaps, Deployments, Services, and other resource types. On clusters with a large number of these objects, the informer cache can grow beyond the operator's 256Mi memory limit, causing OOMKill and restarts.

## Changes

### `ByObject` label selectors for all owned resource types

Restrict informer caches to only objects with `app.kubernetes.io/managed-by: feast-operator`. Covers all 10 owned types: ConfigMap, Deployment, Service, ServiceAccount, PVC, RoleBinding, Role, CronJob, HPA, PDB. Extracted into `newCacheOptions()` for clarity.

### `DefaultTransform: cache.TransformStripManagedFields()`

Strip `managedFields` from all cached objects, reducing per-object memory footprint by ~30-50%.

### `GOMEMLIMIT=230MiB`

Set Go runtime soft memory limit (90% of 256Mi container limit). Triggers GC pressure before hard OOMKill as defense-in-depth.

### Additional changes

- Add `app.kubernetes.io/managed-by: feast-operator` label to `getLabels()` so all FeatureStore-managed resources carry it
- Introduce `getSelectorLabels()` for immutable selectors (Deployment `spec.selector`, Service `spec.selector`, TopologySpreadConstraints, PodAffinity) to avoid breaking existing resources on upgrade
- Standardize notebook controller's managed-by label to `app.kubernetes.io/managed-by`
- Use shared constants (`services.ManagedByLabelKey`/`Value`) throughout

## Test Results

Verified on cluster with a large number of ConfigMaps pre-loaded:

| Metric | Before | After |
|--------|--------|-------|
| **Memory usage** | 254Mi (at limit) | **25Mi** |
| **Stability** | OOMKilled, CrashLoopBackOff | Stable, no restarts |

## Test plan

- [x] Deploy fixed operator on RHOAI 3.3.0 cluster
- [x] Verify memory usage stays well below 256Mi limit under load
- [x] Verify no OOMKill or CrashLoopBackOff
- [x] Run existing unit tests (`make test`) — all pass
- [x] Verify `getSelectorLabels()` prevents immutable selector breakage on upgrade


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Operator cache now only watches/caches resources marked with the managed-by label, reducing resource usage.
  * Added GOMEMLIMIT=230MiB to the controller-manager container.
  * Standardized managed-by label constants and separated immutable selector labels from mutable metadata to improve stability.
* **Tests**
  * Updated tests to use the shared label constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
