### PR TITLE
fix: Correct project_id scoping in get_user_metadata and delete_project

### DIFF
--- a/sdk/python/feast/infra/registry/snowflake.py
+++ b/sdk/python/feast/infra/registry/snowflake.py
@@ -1116,7 +1116,8 @@ class SnowflakeRegistry(BaseRegistry):
                 FROM
                     {self.registry_path}."{fv_table_str}"
                 WHERE
-                    {fv_column_name}_name = '{feature_view.name}'
+                    project_id = '{project}'
+                    AND {fv_column_name}_name = '{feature_view.name}'
                 LIMIT 1
             """
             df = execute_snowflake_statement(conn, query).fetch_pandas_all()
@@ -1322,7 +1323,7 @@ class SnowflakeRegistry(BaseRegistry):
                     query = f"""
                         DELETE FROM {self.registry_path}."{table}"
                         WHERE
-                            project_id = '{project}'
+                            project_id = '{name}'
                     """
                     execute_snowflake_statement(conn, query)
             return


### PR DESCRIPTION
## Summary

Two pre-existing SQL correctness bugs in `SnowflakeRegistry`, noticed while working on #6243.

**`get_user_metadata` (line 1119)**
The SELECT query filtered only by `{fv_column_name}_name`, without scoping to `project_id`. The primary key for feature view tables is `(feature_view_name, project_id)`, so in a shared Snowflake registry this could return user metadata from a different project's feature view with the same name. Fixed by adding `project_id = '{project}'` to the WHERE clause — consistent with `apply_user_metadata` which already does this correctly.

**`delete_project` (line 1326)**
The DELETE query interpolated `project`, which is a `Project` object returned by `self.get_project(name)`. `Project.__str__` returns `str(MessageToJson(self.to_proto()))` — a JSON blob — which never matches any `project_id` stored in the database. This made `delete_project` a silent no-op: all DELETE statements executed successfully but matched zero rows. Fixed by using the `name` string parameter directly.

## Testing

Both are SQL correctness fixes. The existing integration test suite in `test_universal_registry.py` covers both methods end-to-end; no new unit test surface is introduced by these changes.

Relates to #6243.