### PR TITLE
fix(helm): Avoid nil pointer for metrics.enabled inside podAnnotations

### DIFF
--- a/infra/charts/feast-feature-server/templates/deployment.yaml
+++ b/infra/charts/feast-feature-server/templates/deployment.yaml
@@ -11,9 +11,11 @@ spec:
       {{- include "feast-feature-server.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
+    {{- if or .Values.podAnnotations .Values.metrics.enabled }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if $.Values.metrics.enabled }}
         instrumentation.opentelemetry.io/inject-python: "true"
         {{- end }}

--- a/infra/charts/feast-feature-server/templates/deployment.yaml
+++ b/infra/charts/feast-feature-server/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
-        {{- if .Values.metrics.enabled }}
+        {{- if $.Values.metrics.enabled }}
         instrumentation.opentelemetry.io/inject-python: "true"
         {{- end }}
     {{- end }}


### PR DESCRIPTION
- Fixes #6145
- In with .Values.podAnnotations, . becomes the annotations map; use $.Values.metrics.enabled to access root values.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
