### PR TITLE
fix: use ValueError and fix f-string interpolation in yaml_loader

### DIFF
--- a/sdk/python/feast/loaders/yaml.py
+++ b/sdk/python/feast/loaders/yaml.py
@@ -21,8 +21,8 @@ def yaml_loader(yml, load_single=False):
     # Return a single resource dict
     if load_single:
         if len(yaml_strings) > 1:
-            raise Exception(
-                f"More than one YAML file is being loaded when only a single file is supported: ${yaml_strings}"
+            raise ValueError(
+                f"More than one YAML file is being loaded when only a single file is supported: {yaml_strings}"
             )
         return _yaml_to_dict(yaml_strings[0])
 
@@ -56,7 +56,7 @@ def _get_yaml_contents(yml: str) -> str:
     elif isinstance(yml, str):
         yml_content = yml
     else:
-        raise Exception(
+        raise ValueError(
             f"Invalid YAML provided. Please provide either a file path or YAML string.\n"
             f"Provided YAML: {yml}"
         )


### PR DESCRIPTION
# What this PR does / why we need it:

Fixes two issues in `sdk/python/feast/loaders/yaml.py`:

1. **Broken f-string interpolation**: `${yaml_strings}` in the error message on line 25 does not interpolate in Python — the `$` prefix is invalid and the variable value was never included in the error string. Fixed to `{yaml_strings}`.
2. **Over-broad exception types**: Both `yaml_loader` and `_get_yaml_contents` raised bare `Exception` instead of `ValueError`, making it harder for callers to catch specific errors.

# Which issue(s) this PR fixes:

N/A

# Checks
- [ ] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change