### PR TITLE
fix: Include StreamFeatureView in freshness metric

### DIFF
--- a/sdk/python/feast/metrics.py
+++ b/sdk/python/feast/metrics.py
@@ -379,7 +379,7 @@ def update_feature_freshness(
     try:
         feature_views = store.list_feature_views(allow_cache=True)
         stream_feature_views = store.list_stream_feature_views(allow_cache=True)
-        all_views = list(feature_views) + list(stream_feature_views)
+        all_views = feature_views + stream_feature_views
         now = datetime.now(tz=timezone.utc)
         for fv in all_views:
             end_time = fv.most_recent_end_time

--- a/sdk/python/feast/metrics.py
+++ b/sdk/python/feast/metrics.py
@@ -378,8 +378,10 @@ def update_feature_freshness(
     """
     try:
         feature_views = store.list_feature_views(allow_cache=True)
+        stream_feature_views = store.list_stream_feature_views(allow_cache=True)
+        all_views = list(feature_views) + list(stream_feature_views)
         now = datetime.now(tz=timezone.utc)
-        for fv in feature_views:
+        for fv in all_views:
             end_time = fv.most_recent_end_time
             if end_time is not None:
                 if end_time.tzinfo is None:

--- a/sdk/python/tests/unit/test_metrics.py
+++ b/sdk/python/tests/unit/test_metrics.py
@@ -493,9 +493,16 @@ class TestUpdateFeatureFreshness:
             minutes=5
         )
 
+        mock_sfv = MagicMock()
+        mock_sfv.name = "test_sfv"
+        mock_sfv.most_recent_end_time = datetime.now(tz=timezone.utc) - timedelta(
+            minutes=5
+        )
+
         mock_store = MagicMock()
         mock_store.project = "test_project"
         mock_store.list_feature_views.return_value = [mock_fv]
+        mock_store.list_stream_feature_views.return_value = [mock_sfv]
 
         update_feature_freshness(mock_store)
 
@@ -503,6 +510,11 @@ class TestUpdateFeatureFreshness:
             feature_view="test_fv", project="test_project"
         )._value.get()
         assert 280 < staleness < 320
+
+        sfv_staleness = feature_freshness_seconds.labels(
+            feature_view="test_sfv", project="test_project"
+        )._value.get()
+        assert 280 < sfv_staleness < 320
 
     def test_skips_unmaterialized_views(self):
         mock_fv = MagicMock()
@@ -512,6 +524,7 @@ class TestUpdateFeatureFreshness:
         mock_store = MagicMock()
         mock_store.project = "test_project"
         mock_store.list_feature_views.return_value = [mock_fv]
+        mock_store.list_stream_feature_views.return_value = []
 
         update_feature_freshness(mock_store)
 
@@ -525,6 +538,7 @@ class TestUpdateFeatureFreshness:
         mock_store = MagicMock()
         mock_store.project = "test_project"
         mock_store.list_feature_views.return_value = [mock_fv]
+        mock_store.list_stream_feature_views.return_value = []
 
         update_feature_freshness(mock_store)
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing and why.
-->
`update_feature_freshness()` only called `store.list_feature_views()`, which excluded StreamFeatureView from the `feast_feature_freshness_seconds gauge`. This adds store.list_stream_feature_views() so both batch and stream feature views are tracked
# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [ ] I've made sure the tests are passing.
- [ ] My commits are signed off (`git commit -s`)
- [ ] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
