### PR TITLE
docs: Add sphinx api docs for aggregation, dbt, and openlineage packages

### DIFF
--- a/sdk/python/docs/source/feast.aggregation.rst
+++ b/sdk/python/docs/source/feast.aggregation.rst
@@ -1,0 +1,18 @@
+feast.aggregation package
+=========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   feast.aggregation.tiling
+
+Module contents
+---------------
+
+.. automodule:: feast.aggregation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sdk/python/docs/source/feast.aggregation.rst
+++ b/sdk/python/docs/source/feast.aggregation.rst
@@ -14,5 +14,4 @@ Module contents
 
 .. automodule:: feast.aggregation
    :members:
-   :undoc-members:
    :show-inheritance:

--- a/sdk/python/docs/source/feast.aggregation.tiling.rst
+++ b/sdk/python/docs/source/feast.aggregation.tiling.rst
@@ -1,0 +1,37 @@
+feast.aggregation.tiling package
+=================================
+
+Submodules
+----------
+
+feast.aggregation.tiling.base module
+-------------------------------------
+
+.. automodule:: feast.aggregation.tiling.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast.aggregation.tiling.orchestrator module
+--------------------------------------------
+
+.. automodule:: feast.aggregation.tiling.orchestrator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast.aggregation.tiling.tile\_subtraction module
+-------------------------------------------------
+
+.. automodule:: feast.aggregation.tiling.tile_subtraction
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast.aggregation.tiling
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sdk/python/docs/source/feast.aggregation.tiling.rst
+++ b/sdk/python/docs/source/feast.aggregation.tiling.rst
@@ -1,37 +1,9 @@
 feast.aggregation.tiling package
 =================================
 
-Submodules
-----------
-
-feast.aggregation.tiling.base module
--------------------------------------
-
-.. automodule:: feast.aggregation.tiling.base
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-feast.aggregation.tiling.orchestrator module
---------------------------------------------
-
-.. automodule:: feast.aggregation.tiling.orchestrator
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-feast.aggregation.tiling.tile\_subtraction module
--------------------------------------------------
-
-.. automodule:: feast.aggregation.tiling.tile_subtraction
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 Module contents
 ---------------
 
 .. automodule:: feast.aggregation.tiling
    :members:
-   :undoc-members:
    :show-inheritance:

--- a/sdk/python/docs/source/feast.dbt.rst
+++ b/sdk/python/docs/source/feast.dbt.rst
@@ -1,0 +1,37 @@
+feast.dbt package
+=================
+
+Submodules
+----------
+
+feast.dbt.codegen module
+------------------------
+
+.. automodule:: feast.dbt.codegen
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast.dbt.mapper module
+-----------------------
+
+.. automodule:: feast.dbt.mapper
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast.dbt.parser module
+-----------------------
+
+.. automodule:: feast.dbt.parser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast.dbt
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sdk/python/docs/source/feast.diff.rst
+++ b/sdk/python/docs/source/feast.diff.rst
@@ -4,6 +4,14 @@ feast.diff package
 Submodules
 ----------
 
+feast.diff.apply\_progress module
+----------------------------------
+
+.. automodule:: feast.diff.apply_progress
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 feast.diff.infra\_diff module
 -----------------------------
 

--- a/sdk/python/docs/source/feast.openlineage.rst
+++ b/sdk/python/docs/source/feast.openlineage.rst
@@ -1,0 +1,53 @@
+feast.openlineage package
+=========================
+
+Submodules
+----------
+
+feast.openlineage.client module
+--------------------------------
+
+.. automodule:: feast.openlineage.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast.openlineage.config module
+--------------------------------
+
+.. automodule:: feast.openlineage.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast.openlineage.emitter module
+---------------------------------
+
+.. automodule:: feast.openlineage.emitter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast.openlineage.facets module
+--------------------------------
+
+.. automodule:: feast.openlineage.facets
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+feast.openlineage.mappers module
+---------------------------------
+
+.. automodule:: feast.openlineage.mappers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: feast.openlineage
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/sdk/python/docs/source/feast.openlineage.rst
+++ b/sdk/python/docs/source/feast.openlineage.rst
@@ -1,53 +1,9 @@
 feast.openlineage package
 =========================
 
-Submodules
-----------
-
-feast.openlineage.client module
---------------------------------
-
-.. automodule:: feast.openlineage.client
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-feast.openlineage.config module
---------------------------------
-
-.. automodule:: feast.openlineage.config
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-feast.openlineage.emitter module
----------------------------------
-
-.. automodule:: feast.openlineage.emitter
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-feast.openlineage.facets module
---------------------------------
-
-.. automodule:: feast.openlineage.facets
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-feast.openlineage.mappers module
----------------------------------
-
-.. automodule:: feast.openlineage.mappers
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 Module contents
 ---------------
 
 .. automodule:: feast.openlineage
    :members:
-   :undoc-members:
    :show-inheritance:

--- a/sdk/python/docs/source/feast.rst
+++ b/sdk/python/docs/source/feast.rst
@@ -25,14 +25,6 @@ Subpackages
 Submodules
 ----------
 
-feast.aggregation module
-------------------------
-
-.. automodule:: feast.aggregation
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 feast.arrow\_error\_handler module
 ----------------------------------
 

--- a/sdk/python/docs/source/feast.rst
+++ b/sdk/python/docs/source/feast.rst
@@ -7,13 +7,16 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   feast.aggregation
    feast.api
    feast.cli
+   feast.dbt
    feast.diff
    feast.dqm
    feast.embedded_go
    feast.infra
    feast.lineage
+   feast.openlineage
    feast.permissions
    feast.protos
    feast.transformation

--- a/sdk/python/feast/openlineage/__init__.py
+++ b/sdk/python/feast/openlineage/__init__.py
@@ -35,27 +35,27 @@ Lineage Graph Structure:
 Usage:
     Simply configure OpenLineage in your feature_store.yaml:
 
-    ```yaml
-    project: my_project
-    # ... other config ...
+    .. code-block:: yaml
 
-    openlineage:
-      enabled: true
-      transport_type: http
-      transport_url: http://localhost:5000
-      transport_endpoint: api/v1/lineage
-      namespace: my_namespace  # Optional: defaults to project name
-    ```
+        project: my_project
+        # ... other config ...
+
+        openlineage:
+          enabled: true
+          transport_type: http
+          transport_url: http://localhost:5000
+          transport_endpoint: api/v1/lineage
+          namespace: my_namespace  # Optional: defaults to project name
 
     Then use Feast normally - lineage events are emitted automatically!
 
-    ```python
-    from feast import FeatureStore
+    .. code-block:: python
 
-    fs = FeatureStore(repo_path="feature_repo")
-    fs.apply([entity, feature_view, feature_service])  # Emits lineage
-    fs.materialize(start, end)  # Emits START/COMPLETE/FAIL events
-    ```
+        from feast import FeatureStore
+
+        fs = FeatureStore(repo_path="feature_repo")
+        fs.apply([entity, feature_view, feature_service])  # Emits lineage
+        fs.materialize(start, end)  # Emits START/COMPLETE/FAIL events
 """
 
 from feast.openlineage.client import FeastOpenLineageClient

--- a/sdk/python/feast/openlineage/client.py
+++ b/sdk/python/feast/openlineage/client.py
@@ -55,7 +55,8 @@ class FeastOpenLineageClient:
     from Feast operations like materialization, feature retrieval, and
     registry changes.
 
-    Example:
+    Example::
+
         from feast.openlineage import FeastOpenLineageClient, OpenLineageConfig
 
         config = OpenLineageConfig(

--- a/sdk/python/feast/openlineage/emitter.py
+++ b/sdk/python/feast/openlineage/emitter.py
@@ -644,10 +644,12 @@ class FeastOpenLineageEmitter:
         1. feast_feature_views_{project}: DataSources + Entities → FeatureViews
         2. feast_feature_services_{project}: FeatureViews → FeatureServices
 
-        This creates a lineage graph matching Feast UI:
+        This creates a lineage graph matching Feast UI::
+
             DataSource ──→ FeatureView ──→ FeatureService
                  ↑
               Entity
+
 
         Args:
             objects: List of Feast objects being applied

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -337,7 +337,7 @@ class RepoConfig(FeastBaseModel):
     """ MaterializationConfig: Configuration options for feature materialization behavior. """
 
     openlineage_config: Optional[OpenLineageConfig] = Field(None, alias="openlineage")
-    """ OpenLineageConfig: Configuration for OpenLineage data lineage integration (optional). """
+    """ Configuration for OpenLineage data lineage integration (optional). """
 
     def __init__(self, **data: Any):
         super().__init__(**data)


### PR DESCRIPTION
## Summary

- Add `feast.aggregation.rst` and `feast.aggregation.tiling.rst` for the aggregation package and its tiling sub-package
- Add `feast.dbt.rst` for the dbt integration (codegen, mapper, parser)
- Add `feast.openlineage.rst` for the OpenLineage integration (client, config, emitter, facets, mappers)
- Add missing `feast.diff.apply_progress` module to `feast.diff.rst`
- Update `feast.rst` toctree to include all three new top-level packages

Sphinx docs were falling behind as new modules were added. This addresses the gaps noted in #6266.

## Test plan

- [ ] Run `make build-sphinx` locally and confirm the new packages appear in the generated HTML docs
- [ ] Verify no new Sphinx warnings are introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
