### PR TITLE
feat: Time-based chunked materialization to prevent OOM on dense datasets

### DIFF
--- a/sdk/python/feast/cli/cli.py
+++ b/sdk/python/feast/cli/cli.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from importlib.metadata import version as importlib_version
 from pathlib import Path
 from typing import List, Optional
@@ -366,6 +366,24 @@ def registry_dump_command(ctx: click.Context):
     default=None,
     help="Version to materialize (e.g., 'v2'). Requires --views with exactly one feature view.",
 )
+@click.option(
+    "--chunk-hours",
+    type=int,
+    default=None,
+    help="Split materialization into N-hour chunks to reduce memory pressure.",
+)
+@click.option(
+    "--chunk-minutes",
+    type=int,
+    default=None,
+    help="Split materialization into N-minute chunks (finer granularity than --chunk-hours).",
+)
+@click.option(
+    "--chunk-seconds",
+    type=int,
+    default=None,
+    help="Split materialization into N-second chunks (finest granularity).",
+)
 @click.pass_context
 def materialize_command(
     ctx: click.Context,
@@ -374,6 +392,9 @@ def materialize_command(
     views: List[str],
     disable_event_timestamp: bool,
     feature_view_version: Optional[str],
+    chunk_hours: Optional[int],
+    chunk_minutes: Optional[int],
+    chunk_seconds: Optional[int],
 ):
     """
     Run a (non-incremental) materialization job to ingest data into the online store. Feast
@@ -386,6 +407,24 @@ def materialize_command(
     If --disable-event-timestamp is used, timestamps are not required and all available data will be materialized using the current datetime as the event timestamp.
     """
     store = create_feature_store(ctx)
+
+    if sum(v is not None for v in [chunk_hours, chunk_minutes, chunk_seconds]) > 1:
+        raise click.UsageError(
+            "Only one of --chunk-hours, --chunk-minutes, --chunk-seconds may be specified."
+        )
+    chunk_size: Optional[timedelta] = None
+    if chunk_hours is not None:
+        if chunk_hours <= 0:
+            raise click.UsageError("--chunk-hours must be a positive integer.")
+        chunk_size = timedelta(hours=chunk_hours)
+    elif chunk_minutes is not None:
+        if chunk_minutes <= 0:
+            raise click.UsageError("--chunk-minutes must be a positive integer.")
+        chunk_size = timedelta(minutes=chunk_minutes)
+    elif chunk_seconds is not None:
+        if chunk_seconds <= 0:
+            raise click.UsageError("--chunk-seconds must be a positive integer.")
+        chunk_size = timedelta(seconds=chunk_seconds)
 
     if disable_event_timestamp:
         if start_ts or end_ts:
@@ -412,6 +451,7 @@ def materialize_command(
         end_date=end_date,
         disable_event_timestamp=disable_event_timestamp,
         version=feature_view_version,
+        chunk_size=chunk_size,
     )
 
 
@@ -429,12 +469,33 @@ def materialize_command(
     default=None,
     help="Version to materialize (e.g., 'v2'). Requires --views with exactly one feature view.",
 )
+@click.option(
+    "--chunk-hours",
+    type=int,
+    default=None,
+    help="Split materialization into N-hour chunks to reduce memory pressure.",
+)
+@click.option(
+    "--chunk-minutes",
+    type=int,
+    default=None,
+    help="Split materialization into N-minute chunks (finer granularity than --chunk-hours).",
+)
+@click.option(
+    "--chunk-seconds",
+    type=int,
+    default=None,
+    help="Split materialization into N-second chunks (finest granularity).",
+)
 @click.pass_context
 def materialize_incremental_command(
     ctx: click.Context,
     end_ts: str,
     views: List[str],
     feature_view_version: Optional[str],
+    chunk_hours: Optional[int],
+    chunk_minutes: Optional[int],
+    chunk_seconds: Optional[int],
 ):
     """
     Run an incremental materialization job to ingest new data into the online store. Feast will read
@@ -445,10 +506,30 @@ def materialize_incremental_command(
     END_TS should be in ISO 8601 format, e.g. '2021-07-16T19:20:01'
     """
     store = create_feature_store(ctx)
+
+    if sum(v is not None for v in [chunk_hours, chunk_minutes, chunk_seconds]) > 1:
+        raise click.UsageError(
+            "Only one of --chunk-hours, --chunk-minutes, --chunk-seconds may be specified."
+        )
+    chunk_size: Optional[timedelta] = None
+    if chunk_hours is not None:
+        if chunk_hours <= 0:
+            raise click.UsageError("--chunk-hours must be a positive integer.")
+        chunk_size = timedelta(hours=chunk_hours)
+    elif chunk_minutes is not None:
+        if chunk_minutes <= 0:
+            raise click.UsageError("--chunk-minutes must be a positive integer.")
+        chunk_size = timedelta(minutes=chunk_minutes)
+    elif chunk_seconds is not None:
+        if chunk_seconds <= 0:
+            raise click.UsageError("--chunk-seconds must be a positive integer.")
+        chunk_size = timedelta(seconds=chunk_seconds)
+
     store.materialize_incremental(
         feature_views=None if not views else views,
         end_date=utils.make_tzaware(datetime.fromisoformat(end_ts)),
         version=feature_view_version,
+        chunk_size=chunk_size,
     )
 
 

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -69,6 +69,7 @@ from feast.errors import (
 from feast.feast_object import FeastObject
 from feast.feature_service import FeatureService
 from feast.feature_view import DUMMY_ENTITY, DUMMY_ENTITY_NAME, FeatureView
+from feast.feature_view_utils import generate_time_chunks
 from feast.inference import (
     update_data_sources_with_inferred_event_timestamp_col,
     update_feature_views_with_inferred_features_and_entities,
@@ -92,7 +93,7 @@ from feast.protos.feast.serving.ServingService_pb2 import (
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey
 from feast.protos.feast.types.Value_pb2 import RepeatedValue, Value
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import RepoConfig, load_repo_config
+from feast.repo_config import ChunkFailureStrategy, RepoConfig, load_repo_config
 from feast.repo_contents import RepoContents
 from feast.saved_dataset import SavedDataset, SavedDatasetStorage, ValidationReference
 from feast.ssl_ca_trust_store_setup import configure_ca_trust_store_env_variables
@@ -1711,6 +1712,7 @@ class FeatureStore:
         feature_views: Optional[List[str]] = None,
         full_feature_names: bool = False,
         version: Optional[str] = None,
+        chunk_size: Optional[timedelta] = None,
     ) -> None:
         """
         Materialize incremental new data from the offline store into the online store.
@@ -1729,6 +1731,11 @@ class FeatureStore:
                 feature view name.
             version (str): Optional version to materialize (e.g., 'v2'). Requires feature_views
                 with exactly one entry and enable_online_feature_view_versioning to be enabled.
+            chunk_size (timedelta): Optional override for the time-based chunk size used to split
+                materialization into smaller windows.  When set, each feature view's time range is
+                partitioned into consecutive chunks of this width and materialized one chunk at a
+                time.  Falls back to ``config.materialization.chunk_size`` when not given, and
+                performs a single-pass materialization if neither is set.
 
         Raises:
             Exception: A feature view being materialized does not have a TTL set.
@@ -1820,18 +1827,81 @@ class FeatureStore:
                 start_date = utils.make_tzaware(start_date)
                 end_date = utils.make_tzaware(end_date) or _utc_now()
 
+                effective_chunk_size = self._resolve_chunk_size(chunk_size)
+                chunks = (
+                    list(
+                        generate_time_chunks(start_date, end_date, effective_chunk_size)
+                    )
+                    if effective_chunk_size is not None
+                    else [(start_date, end_date)]
+                )
+                total_chunks = len(chunks)
+
                 fv_start = time.monotonic()
                 fv_success = True
+                failed_chunks = []
+                # gap_hit becomes True the moment the first chunk fails under
+                # CONTINUE strategy.  Once True, subsequent successful chunks
+                # still have their data written to the online store (the call to
+                # materialize_single_feature_view is not skipped), but we stop
+                # calling apply_materialization so the registry watermark
+                # (most_recent_end_time) does not advance past the failure.
+                # This guarantees that the next materialize_incremental() call
+                # retries from the start of the failed chunk rather than
+                # silently skipping it.
+                gap_hit = False
                 try:
-                    provider.materialize_single_feature_view(
-                        config=self.config,
-                        feature_view=feature_view,
-                        start_date=start_date,
-                        end_date=end_date,
-                        registry=self.registry,
-                        project=self.project,
-                        tqdm_builder=tqdm_builder,
-                    )
+                    for chunk_idx, (chunk_start, chunk_end) in enumerate(chunks, 1):
+                        if total_chunks > 1:
+                            print(
+                                f"  [{chunk_idx}/{total_chunks}] "
+                                f"{chunk_start.isoformat(timespec='seconds')} \u2192 "
+                                f"{chunk_end.isoformat(timespec='seconds')}"
+                            )
+                        try:
+                            provider.materialize_single_feature_view(
+                                config=self.config,
+                                feature_view=feature_view,
+                                start_date=chunk_start,
+                                end_date=chunk_end,
+                                registry=self.registry,
+                                project=self.project,
+                                tqdm_builder=tqdm_builder,
+                            )
+                        except Exception as chunk_exc:
+                            if (
+                                total_chunks > 1
+                                and self.config.materialization_config.chunk_failure_strategy
+                                == ChunkFailureStrategy.CONTINUE
+                            ):
+                                failed_chunks.append(
+                                    (chunk_idx, chunk_start, chunk_end, chunk_exc)
+                                )
+                                # Mark that a gap now exists in the committed
+                                # range so subsequent successes don't advance
+                                # the watermark past this failed window.
+                                gap_hit = True
+                            else:
+                                raise
+                        else:
+                            # Only advance the watermark for chunks that are
+                            # contiguous from the original start_date.  Once a
+                            # gap has been introduced by a failed chunk we stop
+                            # registering successful intervals so the watermark
+                            # stays at the boundary just before the first gap.
+                            # The data for post-gap chunks IS written to the
+                            # online store; it will simply be re-written on the
+                            # next incremental run (writes are idempotent).
+                            if (
+                                not isinstance(feature_view, OnDemandFeatureView)
+                                and not gap_hit
+                            ):
+                                self.registry.apply_materialization(
+                                    feature_view,
+                                    self.project,
+                                    chunk_start,
+                                    chunk_end,
+                                )
                 except Exception:
                     fv_success = False
                     raise
@@ -1843,12 +1913,17 @@ class FeatureStore:
                             fv_success,
                             time.monotonic() - fv_start,
                         )
-                if not isinstance(feature_view, OnDemandFeatureView):
-                    self.registry.apply_materialization(
-                        feature_view,
-                        self.project,
-                        start_date,
-                        end_date,
+                if failed_chunks:
+                    import warnings as _w
+
+                    _w.warn(
+                        f"FeatureView '{feature_view.name}': {len(failed_chunks)}/{total_chunks} "
+                        f"chunk(s) failed (chunk_failure_strategy=continue):\n"
+                        + "\n".join(
+                            f"  chunk {i}: {s.isoformat(timespec='seconds')} \u2192 "
+                            f"{e.isoformat(timespec='seconds')}: {err}"
+                            for i, s, e, err in failed_chunks
+                        )
                     )
 
             # Emit OpenLineage COMPLETE event
@@ -1868,6 +1943,7 @@ class FeatureStore:
         disable_event_timestamp: bool = False,
         full_feature_names: bool = False,
         version: Optional[str] = None,
+        chunk_size: Optional[timedelta] = None,
     ) -> None:
         """
         Materialize data from the offline store into the online store.
@@ -1886,6 +1962,11 @@ class FeatureStore:
                 feature view name.
             version (str): Optional version to materialize (e.g., 'v2'). Requires feature_views
                 with exactly one entry and enable_online_feature_view_versioning to be enabled.
+            chunk_size (timedelta): Optional override for the time-based chunk size used to split
+                materialization into smaller windows.  When set, each feature view's time range is
+                partitioned into consecutive chunks of this width and materialized one chunk at a
+                time.  Falls back to ``config.materialization.chunk_size`` when not given, and
+                performs a single-pass materialization if neither is set.
 
         Examples:
             Materialize all features into the online store over the interval
@@ -1947,19 +2028,67 @@ class FeatureStore:
                 start_date = utils.make_tzaware(start_date)
                 end_date = utils.make_tzaware(end_date)
 
+                effective_chunk_size = self._resolve_chunk_size(chunk_size)
+                chunks = (
+                    list(
+                        generate_time_chunks(start_date, end_date, effective_chunk_size)
+                    )
+                    if effective_chunk_size is not None
+                    else [(start_date, end_date)]
+                )
+                total_chunks = len(chunks)
+
                 fv_start = time.monotonic()
                 fv_success = True
+                failed_chunks = []
+                # gap_hit becomes True the moment the first chunk fails under
+                # CONTINUE strategy.  Subsequent successful chunks still have
+                # their data written to the online store but apply_materialization
+                # is NOT called for them, keeping the registry watermark at the
+                # boundary just before the first gap.  A future materialize()/
+                # materialize_incremental() call with explicit dates can replay
+                # the failed range; the post-gap data will simply be re-written
+                # (writes are idempotent).
+                gap_hit = False
                 try:
-                    provider.materialize_single_feature_view(
-                        config=self.config,
-                        feature_view=feature_view,
-                        start_date=start_date,
-                        end_date=end_date,
-                        registry=self.registry,
-                        project=self.project,
-                        tqdm_builder=tqdm_builder,
-                        disable_event_timestamp=disable_event_timestamp,
-                    )
+                    for chunk_idx, (chunk_start, chunk_end) in enumerate(chunks, 1):
+                        if total_chunks > 1:
+                            print(
+                                f"  [{chunk_idx}/{total_chunks}] "
+                                f"{chunk_start.isoformat(timespec='seconds')} \u2192 "
+                                f"{chunk_end.isoformat(timespec='seconds')}"
+                            )
+                        try:
+                            provider.materialize_single_feature_view(
+                                config=self.config,
+                                feature_view=feature_view,
+                                start_date=chunk_start,
+                                end_date=chunk_end,
+                                registry=self.registry,
+                                project=self.project,
+                                tqdm_builder=tqdm_builder,
+                                disable_event_timestamp=disable_event_timestamp,
+                            )
+                        except Exception as chunk_exc:
+                            if (
+                                total_chunks > 1
+                                and self.config.materialization_config.chunk_failure_strategy
+                                == ChunkFailureStrategy.CONTINUE
+                            ):
+                                failed_chunks.append(
+                                    (chunk_idx, chunk_start, chunk_end, chunk_exc)
+                                )
+                                gap_hit = True
+                            else:
+                                raise
+                        else:
+                            if not gap_hit:
+                                self.registry.apply_materialization(
+                                    feature_view,
+                                    self.project,
+                                    chunk_start,
+                                    chunk_end,
+                                )
                 except Exception:
                     fv_success = False
                     raise
@@ -1971,13 +2100,18 @@ class FeatureStore:
                             fv_success,
                             time.monotonic() - fv_start,
                         )
+                if failed_chunks:
+                    import warnings as _w
 
-                self.registry.apply_materialization(
-                    feature_view,
-                    self.project,
-                    start_date,
-                    end_date,
-                )
+                    _w.warn(
+                        f"FeatureView '{feature_view.name}': {len(failed_chunks)}/{total_chunks} "
+                        f"chunk(s) failed (chunk_failure_strategy=continue):\n"
+                        + "\n".join(
+                            f"  chunk {i}: {s.isoformat(timespec='seconds')} \u2192 "
+                            f"{e.isoformat(timespec='seconds')}: {err}"
+                            for i, s, e, err in failed_chunks
+                        )
+                    )
 
             # Emit OpenLineage COMPLETE event
             self._emit_openlineage_materialize_complete(
@@ -1987,6 +2121,22 @@ class FeatureStore:
             # Emit OpenLineage FAIL event
             self._emit_openlineage_materialize_fail(ol_run_id, str(e))
             raise
+
+    def _resolve_chunk_size(
+        self,
+        override: Optional[timedelta] = None,
+    ) -> Optional[timedelta]:
+        """Return the effective chunk size for a materialization call.
+
+        Priority (highest first):
+        1. ``override`` – value passed directly to ``materialize()`` / ``materialize_incremental()``
+        2. ``config.materialization_config.chunk_size`` – project-level default from
+           ``feature_store.yaml``
+        3. ``None`` – no chunking, single-pass behaviour (backward-compatible default).
+        """
+        if override is not None:
+            return override
+        return self.config.materialization_config.chunk_size
 
     def _emit_openlineage_materialize_start(
         self,

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -93,7 +93,7 @@ from feast.protos.feast.serving.ServingService_pb2 import (
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey
 from feast.protos.feast.types.Value_pb2 import RepeatedValue, Value
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.repo_config import ChunkFailureStrategy, RepoConfig, load_repo_config
+from feast.repo_config import RepoConfig, load_repo_config
 from feast.repo_contents import RepoContents
 from feast.saved_dataset import SavedDataset, SavedDatasetStorage, ValidationReference
 from feast.ssl_ca_trust_store_setup import configure_ca_trust_store_env_variables
@@ -1872,7 +1872,7 @@ class FeatureStore:
                             if (
                                 total_chunks > 1
                                 and self.config.materialization_config.chunk_failure_strategy
-                                == ChunkFailureStrategy.CONTINUE
+                                == "continue"
                             ):
                                 failed_chunks.append(
                                     (chunk_idx, chunk_start, chunk_end, chunk_exc)
@@ -2073,7 +2073,7 @@ class FeatureStore:
                             if (
                                 total_chunks > 1
                                 and self.config.materialization_config.chunk_failure_strategy
-                                == ChunkFailureStrategy.CONTINUE
+                                == "continue"
                             ):
                                 failed_chunks.append(
                                     (chunk_idx, chunk_start, chunk_end, chunk_exc)

--- a/sdk/python/feast/feature_view_utils.py
+++ b/sdk/python/feast/feature_view_utils.py
@@ -5,7 +5,8 @@ Utility functions for feature view operations including source resolution.
 import logging
 import typing
 from dataclasses import dataclass
-from typing import Callable, Optional, Union
+from datetime import datetime, timedelta
+from typing import Callable, Iterator, Optional, Tuple, Union
 
 from feast.errors import (
     FeastObjectNotFoundException,
@@ -299,3 +300,47 @@ def get_feature_view_from_registry(
                 raise FeastObjectNotFoundException(
                     f"Can't recognize feast object with a name {name}"
                 ) from e
+
+
+def generate_time_chunks(
+    start_date: datetime,
+    end_date: datetime,
+    chunk_size: timedelta,
+) -> Iterator[Tuple[datetime, datetime]]:
+    """Split a time range into consecutive, non-overlapping chunks.
+
+    Yields ``(chunk_start, chunk_end)`` pairs that together cover
+    ``[start_date, end_date)`` exactly.  The last chunk may be smaller than
+    ``chunk_size`` when the total range is not evenly divisible.
+
+    Args:
+        start_date: Inclusive start of the overall time range.
+        end_date:   Exclusive end of the overall time range.
+        chunk_size: Maximum width of each chunk.
+
+    Yields:
+        Tuples of ``(chunk_start, chunk_end)`` datetimes.
+
+    Raises:
+        ValueError: ``chunk_size`` is not a positive ``timedelta``.
+
+    Examples:
+        >>> from datetime import datetime, timedelta
+        >>> chunks = list(generate_time_chunks(
+        ...     start_date=datetime(2024, 1, 1),
+        ...     end_date=datetime(2024, 1, 1, 12),
+        ...     chunk_size=timedelta(hours=4),
+        ... ))
+        >>> len(chunks)
+        3
+        >>> chunks[0]
+        (datetime.datetime(2024, 1, 1, 0, 0), datetime.datetime(2024, 1, 1, 4, 0))
+    """
+    if chunk_size <= timedelta(0):
+        raise ValueError(f"chunk_size must be positive, got {chunk_size!r}")
+
+    current = start_date
+    while current < end_date:
+        chunk_end = min(current + chunk_size, end_date)
+        yield current, chunk_end
+        current = chunk_end

--- a/sdk/python/feast/infra/compute_engines/local/nodes.py
+++ b/sdk/python/feast/infra/compute_engines/local/nodes.py
@@ -189,6 +189,13 @@ class LocalDedupNode(LocalNode):
 
     def execute(self, context: ExecutionContext) -> ArrowTableValue:
         input_table = self.get_single_table(context).data
+
+        # No data in this time window — skip dedup and pass the empty table through.
+        if input_table.num_rows == 0:
+            output = ArrowTableValue(input_table)
+            context.node_outputs[self.name] = output
+            return output
+
         df = self.backend.from_arrow(input_table)
 
         # Extract join_keys, timestamp, and created_ts from context

--- a/sdk/python/feast/infra/utils/aws_utils.py
+++ b/sdk/python/feast/infra/utils/aws_utils.py
@@ -894,6 +894,18 @@ def unload_athena_query_to_pa(
     with tempfile.TemporaryDirectory() as temp_dir:
         download_s3_directory(s3_resource, bucket, key, temp_dir)
         delete_s3_directory(s3_resource, bucket, key)
+        # When the Athena CTAS query returns no rows it writes no Parquet files.
+        # pq.read_table on an empty (or metadata-only) directory raises or returns
+        # a schema-less table, which causes downstream KeyErrors on timestamp columns.
+        # Return an empty table early so the materialization pipeline can short-circuit
+        # gracefully via the num_rows == 0 guards in the compute nodes.
+        parquet_files = [
+            f
+            for f in os.listdir(temp_dir)
+            if f.endswith(".parquet") or f.endswith(".snappy.parquet")
+        ]
+        if not parquet_files:
+            return pa.table({})
         return pq.read_table(temp_dir)
 
 

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import warnings
+from datetime import timedelta
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -207,6 +209,17 @@ class RegistryConfig(FeastBaseModel):
         return path
 
 
+class ChunkFailureStrategy(str, Enum):
+    """Strategy for handling chunk failures during chunked materialization."""
+
+    STOP = "stop"
+    """ Stop materialization immediately on the first chunk failure (default). """
+
+    CONTINUE = "continue"
+    """ Log the failure and continue processing remaining chunks.
+        A summary warning is emitted at the end listing all failed chunks. """
+
+
 class MaterializationConfig(BaseModel):
     """Configuration options for feature materialization behavior."""
 
@@ -219,6 +232,30 @@ class MaterializationConfig(BaseModel):
         If None (default), all rows are written in a single batch for backward compatibility.
         Set to a positive integer (e.g., 10000) to enable batched writes.
         Supported compute engines: local, spark, ray. """
+
+    chunk_size: Optional[timedelta] = None
+    """ timedelta: If set, materialization is split into consecutive time-based chunks of this
+        size to reduce memory pressure when processing large volumes of data.  For example,
+        ``timedelta(hours=6)`` issues one ``materialize_single_feature_view`` call per 6-hour
+        window instead of materializing the entire range at once.  ``None`` (default) disables
+        chunking and preserves the existing single-pass behaviour.
+
+        Can be overridden at call-time via the ``chunk_size`` parameter of
+        ``FeatureStore.materialize()`` / ``FeatureStore.materialize_incremental()``, or via the
+        ``--chunk-hours`` / ``--chunk-minutes`` / ``--chunk-seconds`` CLI flags.
+
+        Example ``feature_store.yaml`` snippet::
+
+            materialization:
+              chunk_size: 21600  # 6 hours expressed as seconds
+    """
+
+    chunk_failure_strategy: ChunkFailureStrategy = ChunkFailureStrategy.STOP
+    """ ChunkFailureStrategy: Controls what happens when a chunk fails during chunked
+        materialization.  ``STOP`` (default) re-raises the exception immediately.  ``CONTINUE``
+        logs the failure and proceeds with the remaining chunks, emitting a summary warning
+        at the end.  Only meaningful when ``chunk_size`` is set.
+    """
 
 
 class OpenLineageConfig(FeastBaseModel):

--- a/sdk/python/feast/repo_config.py
+++ b/sdk/python/feast/repo_config.py
@@ -2,7 +2,6 @@ import logging
 import os
 import warnings
 from datetime import timedelta
-from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -209,17 +208,6 @@ class RegistryConfig(FeastBaseModel):
         return path
 
 
-class ChunkFailureStrategy(str, Enum):
-    """Strategy for handling chunk failures during chunked materialization."""
-
-    STOP = "stop"
-    """ Stop materialization immediately on the first chunk failure (default). """
-
-    CONTINUE = "continue"
-    """ Log the failure and continue processing remaining chunks.
-        A summary warning is emitted at the end listing all failed chunks. """
-
-
 class MaterializationConfig(BaseModel):
     """Configuration options for feature materialization behavior."""
 
@@ -250,11 +238,11 @@ class MaterializationConfig(BaseModel):
               chunk_size: 21600  # 6 hours expressed as seconds
     """
 
-    chunk_failure_strategy: ChunkFailureStrategy = ChunkFailureStrategy.STOP
-    """ ChunkFailureStrategy: Controls what happens when a chunk fails during chunked
-        materialization.  ``STOP`` (default) re-raises the exception immediately.  ``CONTINUE``
-        logs the failure and proceeds with the remaining chunks, emitting a summary warning
-        at the end.  Only meaningful when ``chunk_size`` is set.
+    chunk_failure_strategy: StrictStr = "stop"
+    """ str: Controls what happens when a chunk fails during chunked materialization.
+        ``'stop'`` (default) re-raises the exception immediately.
+        ``'continue'`` logs the failure and proceeds with the remaining chunks, emitting
+        a summary warning at the end.  Only meaningful when ``chunk_size`` is set.
     """
 
 

--- a/sdk/python/tests/unit/infra/compute_engines/local/test_nodes.py
+++ b/sdk/python/tests/unit/infra/compute_engines/local/test_nodes.py
@@ -186,6 +186,36 @@ def test_local_dedup_node():
     assert set(df_result["entity_id"]) == {1, 2}
 
 
+def test_local_dedup_node_empty_input():
+    """LocalDedupNode must pass through an empty table without raising KeyError.
+
+    When the Athena CTAS query returns no rows the upstream source node
+    produces a schema-less (0-row) table.  Prior to the fix, calling
+    sort_values on a column that does not exist in an empty DataFrame
+    raised ``KeyError: 'event_timestamp'``.
+    """
+    empty_table = pa.table({})
+    context = create_context(node_outputs={"source": ArrowTableValue(empty_table)})
+
+    node = LocalDedupNode(
+        name="dedup",
+        backend=backend,
+        column_info=ColumnInfo(
+            join_keys=["entity_id"],
+            feature_cols=["value"],
+            ts_col="event_timestamp",
+            created_ts_col=None,
+        ),
+    )
+    node.add_input(MagicMock())
+    node.inputs[0].name = "source"
+
+    result = node.execute(context)
+
+    assert isinstance(result, ArrowTableValue)
+    assert result.data.num_rows == 0
+
+
 def test_local_transformation_node():
     context = create_context(
         node_outputs={"source": ArrowTableValue(pa.Table.from_pandas(sample_df))}

--- a/sdk/python/tests/unit/infra/test_aws_utils.py
+++ b/sdk/python/tests/unit/infra/test_aws_utils.py
@@ -1,0 +1,46 @@
+"""Unit tests for feast.infra.utils.aws_utils."""
+
+from unittest.mock import MagicMock, patch
+
+import pyarrow as pa
+
+from feast.infra.utils.aws_utils import unload_athena_query_to_pa
+
+
+def test_unload_athena_query_to_pa_returns_empty_table_when_no_parquet_files(
+    tmp_path,
+):
+    """unload_athena_query_to_pa must return an empty PyArrow table when the
+    Athena CTAS query produces no output rows.
+
+    When there is no data in the requested time window the Athena CTAS query
+    succeeds but writes zero Parquet files to S3.  Before the fix,
+    ``pq.read_table`` on an empty directory returned a schema-less table whose
+    columns were missing, causing a ``KeyError: 'event_timestamp'`` in the
+    downstream dedup node.  After the fix an empty ``pa.table({})`` is returned
+    immediately so the pipeline can short-circuit cleanly.
+    """
+    s3_path = "s3://test-bucket/test-prefix/unload/abc123"
+
+    with (
+        patch("feast.infra.utils.aws_utils.execute_athena_query_and_unload_to_s3"),
+        patch("feast.infra.utils.aws_utils.download_s3_directory"),
+        patch("feast.infra.utils.aws_utils.delete_s3_directory"),
+        patch("tempfile.TemporaryDirectory") as mock_tmpdir,
+    ):
+        # Simulate an empty temporary directory (no Parquet files written by Athena)
+        mock_tmpdir.return_value.__enter__.return_value = str(tmp_path)
+
+        result = unload_athena_query_to_pa(
+            athena_data_client=MagicMock(),
+            data_source="awsdatacatalog",
+            database="feature_store",
+            workgroup="primary",
+            s3_resource=MagicMock(),
+            s3_path=s3_path,
+            query="SELECT 1 WHERE 1=0",
+            temp_table="_tmp_test",
+        )
+
+    assert isinstance(result, pa.Table)
+    assert result.num_rows == 0

--- a/sdk/python/tests/unit/test_chunk_materialization.py
+++ b/sdk/python/tests/unit/test_chunk_materialization.py
@@ -5,7 +5,7 @@ These tests verify:
 * ``FeatureStore.materialize()`` dispatches N chunk calls when chunked
 * ``FeatureStore.materialize_incremental()`` dispatches N chunk calls when chunked
 * Chunk boundaries are contiguous and cover the full requested time range
-* ``ChunkFailureStrategy.CONTINUE`` skips failed chunks instead of raising
+* ``chunk_failure_strategy="continue"`` skips failed chunks instead of raising
 * Single-pass behaviour is preserved when ``chunk_size=None``
 """
 
@@ -23,7 +23,7 @@ from feast.feature_view import FeatureView
 from feast.field import Field
 from feast.infra.offline_stores.file_source import FileSource
 from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
-from feast.repo_config import ChunkFailureStrategy, MaterializationConfig, RepoConfig
+from feast.repo_config import MaterializationConfig, RepoConfig
 from feast.types import Int64
 from feast.value_type import ValueType
 
@@ -238,7 +238,7 @@ class TestMaterializeChunking:
             assert mock_mat.call_count == 2
 
     # -----------------------------------------------------------------------
-    # ChunkFailureStrategy.CONTINUE
+    # chunk_failure_strategy="continue"
     # -----------------------------------------------------------------------
 
     def test_continue_strategy_skips_failed_chunks(self):
@@ -249,7 +249,7 @@ class TestMaterializeChunking:
         store, _, _ = self._setup(
             MaterializationConfig(
                 chunk_size=timedelta(hours=12),
-                chunk_failure_strategy=ChunkFailureStrategy.CONTINUE,
+                chunk_failure_strategy="continue",
             )
         )
         start = _utc(datetime(2024, 1, 1))
@@ -292,7 +292,7 @@ class TestMaterializeChunking:
         store, _, _ = self._setup(
             MaterializationConfig(
                 chunk_size=timedelta(hours=12),
-                chunk_failure_strategy=ChunkFailureStrategy.CONTINUE,
+                chunk_failure_strategy="continue",
             )
         )
         start = _utc(datetime(2024, 1, 1))
@@ -434,7 +434,7 @@ class TestMaterializeIncrementalChunking:
         store, _, fv = self._setup(
             materialization_config=MaterializationConfig(
                 chunk_size=timedelta(hours=6),
-                chunk_failure_strategy=ChunkFailureStrategy.CONTINUE,
+                chunk_failure_strategy="continue",
             )
         )
         # Seed: watermark starts at midnight

--- a/sdk/python/tests/unit/test_chunk_materialization.py
+++ b/sdk/python/tests/unit/test_chunk_materialization.py
@@ -1,0 +1,478 @@
+"""Unit tests for time-chunked materialization in FeatureStore.
+
+These tests verify:
+* ``FeatureStore._resolve_chunk_size()`` priority chain
+* ``FeatureStore.materialize()`` dispatches N chunk calls when chunked
+* ``FeatureStore.materialize_incremental()`` dispatches N chunk calls when chunked
+* Chunk boundaries are contiguous and cover the full requested time range
+* ``ChunkFailureStrategy.CONTINUE`` skips failed chunks instead of raising
+* Single-pass behaviour is preserved when ``chunk_size=None``
+"""
+
+from datetime import datetime, timedelta, timezone
+from tempfile import mkstemp
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from feast import FeatureStore
+from feast.data_format import ParquetFormat
+from feast.entity import Entity
+from feast.feature_view import FeatureView
+from feast.field import Field
+from feast.infra.offline_stores.file_source import FileSource
+from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
+from feast.repo_config import ChunkFailureStrategy, MaterializationConfig, RepoConfig
+from feast.types import Int64
+from feast.value_type import ValueType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_store(
+    materialization_config: MaterializationConfig = MaterializationConfig(),
+) -> FeatureStore:
+    """Return an in-process FeatureStore backed by temporary SQLite/file registry."""
+    fd1, registry_path = mkstemp()
+    fd2, online_store_path = mkstemp()
+    return FeatureStore(
+        config=RepoConfig(
+            registry=registry_path,
+            project="test_chunked_mat",
+            provider="local",
+            online_store=SqliteOnlineStoreConfig(path=online_store_path),
+            entity_key_serialization_version=3,
+            materialization=materialization_config.model_dump(),
+        )
+    )
+
+
+def _make_file_source(df: pd.DataFrame, timestamp_field: str) -> "FileSource":
+    import tempfile
+
+    # We write to a persistent temp file so the FeatureStore can read it.
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as tmp:
+        path = tmp.name
+    df.to_parquet(path)
+    return FileSource(
+        file_format=ParquetFormat(),
+        path=path,
+        timestamp_field=timestamp_field,
+    )
+
+
+def _utc(dt: datetime) -> datetime:
+    return dt.replace(tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_chunk_size
+# ---------------------------------------------------------------------------
+
+
+class TestResolveChunkSize:
+    """Tests for FeatureStore._resolve_chunk_size()."""
+
+    def test_override_takes_highest_priority(self):
+        """Call-time override should win over config."""
+        store = _make_store(MaterializationConfig(chunk_size=timedelta(hours=6)))
+        override = timedelta(hours=2)
+        assert store._resolve_chunk_size(override) == override
+
+    def test_config_chunk_size_used_when_no_override(self):
+        """Config chunk_size should be returned when no override is given."""
+        config_chunk = timedelta(hours=12)
+        store = _make_store(MaterializationConfig(chunk_size=config_chunk))
+        assert store._resolve_chunk_size(None) == config_chunk
+
+    def test_none_returned_when_both_unset(self):
+        """None should be returned (single-pass mode) when nothing is configured."""
+        store = _make_store(MaterializationConfig())
+        assert store._resolve_chunk_size(None) is None
+
+    def test_override_none_falls_through_to_config(self):
+        """Passing override=None should behave the same as not passing an override."""
+        config_chunk = timedelta(minutes=30)
+        store = _make_store(MaterializationConfig(chunk_size=config_chunk))
+        assert store._resolve_chunk_size(None) == config_chunk
+
+
+# ---------------------------------------------------------------------------
+# Materialize – chunk dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeChunking:
+    """Integration-style unit tests verifying chunk dispatch in materialize()."""
+
+    def _apply_fv(self, store: FeatureStore, entity: Entity, fv: FeatureView):
+        store.apply([entity, fv])
+
+    def _setup(self, materialization_config=MaterializationConfig()):
+        """Build a store with one FeatureView and return (store, entity, fv)."""
+        store = _make_store(materialization_config)
+
+        entity = Entity(
+            name="driver_id", join_keys=["driver_id"], value_type=ValueType.INT64
+        )
+
+        # Build a minimal DataFrame with timestamps spread over 2 days
+        now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        df = pd.DataFrame(
+            {
+                "driver_id": [1, 2, 3],
+                "feature_val": [10, 20, 30],
+                "ts": [now, now + timedelta(hours=12), now + timedelta(hours=23)],
+            }
+        )
+        file_source = _make_file_source(df, timestamp_field="ts")
+
+        fv = FeatureView(
+            name="driver_fv",
+            schema=[Field(name="feature_val", dtype=Int64)],
+            entities=[entity],
+            source=file_source,
+            ttl=timedelta(days=7),
+        )
+        store.apply([entity, fv])
+        return store, entity, fv
+
+    # -----------------------------------------------------------------------
+    # No chunking (backward-compatible behaviour)
+    # -----------------------------------------------------------------------
+
+    def test_no_chunk_size_single_call(self):
+        """Without chunk_size, materialize_single_feature_view is called once per FV."""
+        store, _, _ = self._setup()
+        start = _utc(datetime(2024, 1, 1))
+        end = _utc(datetime(2024, 1, 3))
+
+        with patch.object(
+            store._get_provider().__class__,
+            "materialize_single_feature_view",
+            return_value=None,
+        ) as mock_mat:
+            store.materialize(start_date=start, end_date=end)
+            assert mock_mat.call_count == 1
+            kwargs = mock_mat.call_args.kwargs
+            assert kwargs["start_date"] == start
+            assert kwargs["end_date"] == end
+
+    # -----------------------------------------------------------------------
+    # Chunked – call-time override
+    # -----------------------------------------------------------------------
+
+    def test_chunk_size_override_splits_into_correct_number_of_calls(self):
+        """materialize_single_feature_view should be called once per chunk."""
+        store, _, _ = self._setup()
+        start = _utc(datetime(2024, 1, 1))
+        end = _utc(datetime(2024, 1, 3))  # 48 hours
+
+        chunk_size = timedelta(hours=12)  # → 4 chunks
+
+        with patch.object(
+            store._get_provider().__class__,
+            "materialize_single_feature_view",
+            return_value=None,
+        ) as mock_mat:
+            store.materialize(start_date=start, end_date=end, chunk_size=chunk_size)
+            assert mock_mat.call_count == 4
+
+    def test_chunk_boundaries_are_contiguous(self):
+        """Start of chunk N+1 must equal end of chunk N."""
+        store, _, _ = self._setup()
+        start = _utc(datetime(2024, 1, 1))
+        end = _utc(datetime(2024, 1, 3))  # 48 hours, chunk=13h → 4 chunks
+
+        collected: list = []
+
+        def _capture(**kwargs):
+            collected.append((kwargs["start_date"], kwargs["end_date"]))
+
+        with patch.object(
+            store._get_provider().__class__,
+            "materialize_single_feature_view",
+            side_effect=_capture,
+        ):
+            store.materialize(
+                start_date=start, end_date=end, chunk_size=timedelta(hours=13)
+            )
+
+        assert collected[0][0] == start
+        assert collected[-1][1] == end
+        for i in range(len(collected) - 1):
+            assert collected[i][1] == collected[i + 1][0]
+
+    def test_chunk_size_from_config_is_used(self):
+        """Config-level chunk_size should be respected when no override is given."""
+        store, _, _ = self._setup(MaterializationConfig(chunk_size=timedelta(hours=12)))
+        start = _utc(datetime(2024, 1, 1))
+        end = _utc(datetime(2024, 1, 3))  # 48 hours → 4 chunks of 12h
+
+        with patch.object(
+            store._get_provider().__class__,
+            "materialize_single_feature_view",
+            return_value=None,
+        ) as mock_mat:
+            store.materialize(start_date=start, end_date=end)
+            assert mock_mat.call_count == 4
+
+    def test_call_time_chunk_size_overrides_config(self):
+        """A chunk_size passed at call time must override the config value."""
+        store, _, _ = self._setup(MaterializationConfig(chunk_size=timedelta(hours=12)))
+        start = _utc(datetime(2024, 1, 1))
+        end = _utc(datetime(2024, 1, 3))  # 48 hours
+
+        # Override with 24h → 2 chunks instead of 4
+        with patch.object(
+            store._get_provider().__class__,
+            "materialize_single_feature_view",
+            return_value=None,
+        ) as mock_mat:
+            store.materialize(
+                start_date=start, end_date=end, chunk_size=timedelta(hours=24)
+            )
+            assert mock_mat.call_count == 2
+
+    # -----------------------------------------------------------------------
+    # ChunkFailureStrategy.CONTINUE
+    # -----------------------------------------------------------------------
+
+    def test_continue_strategy_skips_failed_chunks(self):
+        """With CONTINUE strategy, a failed chunk does not abort the run and
+        all chunks are attempted.  Crucially, apply_materialization must only
+        be called for the contiguous prefix of successful chunks to avoid
+        advancing the watermark past the failed window."""
+        store, _, _ = self._setup(
+            MaterializationConfig(
+                chunk_size=timedelta(hours=12),
+                chunk_failure_strategy=ChunkFailureStrategy.CONTINUE,
+            )
+        )
+        start = _utc(datetime(2024, 1, 1))
+        end = _utc(datetime(2024, 1, 3))  # 4 chunks of 12h
+
+        call_count = {"n": 0}
+
+        def _fail_second(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("Simulated chunk failure")
+
+        with (
+            patch.object(
+                store._get_provider().__class__,
+                "materialize_single_feature_view",
+                side_effect=_fail_second,
+            ),
+            patch.object(store.registry, "apply_materialization") as mock_reg,
+        ):
+            import warnings
+
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                store.materialize(start_date=start, end_date=end)
+
+        # All 4 chunks are attempted (online store receives data for 3 of them)
+        assert call_count["n"] == 4
+        # A warning is emitted about the failure
+        assert any("failed" in str(w.message).lower() for w in caught)
+        # apply_materialization must only have been called for chunk 1 (the
+        # contiguous prefix before the gap).  Chunks 3 and 4 succeed but must
+        # NOT advance the watermark past the failed chunk 2 window.
+        assert mock_reg.call_count == 1
+        committed_end = mock_reg.call_args_list[0].args[3]
+        assert committed_end == start + timedelta(hours=12)
+
+    def test_continue_strategy_all_succeed_commits_all(self):
+        """When all chunks succeed the watermark must reach the full end_date."""
+        store, _, _ = self._setup(
+            MaterializationConfig(
+                chunk_size=timedelta(hours=12),
+                chunk_failure_strategy=ChunkFailureStrategy.CONTINUE,
+            )
+        )
+        start = _utc(datetime(2024, 1, 1))
+        end = _utc(datetime(2024, 1, 3))  # 4 chunks
+
+        with (
+            patch.object(
+                store._get_provider().__class__,
+                "materialize_single_feature_view",
+                return_value=None,
+            ),
+            patch.object(store.registry, "apply_materialization") as mock_reg,
+        ):
+            store.materialize(start_date=start, end_date=end)
+
+        # All 4 chunks committed — no gap, so all advance the watermark
+        assert mock_reg.call_count == 4
+
+    def test_stop_strategy_reraises_on_first_failure(self):
+        """Default STOP strategy must re-raise the exception from the first failing chunk."""
+        store, _, _ = self._setup(MaterializationConfig(chunk_size=timedelta(hours=12)))
+        start = _utc(datetime(2024, 1, 1))
+        end = _utc(datetime(2024, 1, 3))  # 4 chunks
+
+        call_count = {"n": 0}
+
+        def _fail_first(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("First chunk failure")
+
+        with patch.object(
+            store._get_provider().__class__,
+            "materialize_single_feature_view",
+            side_effect=_fail_first,
+        ):
+            with pytest.raises(RuntimeError, match="First chunk failure"):
+                store.materialize(start_date=start, end_date=end)
+
+        # Only 1 call was made (stopped on first failure)
+        assert call_count["n"] == 1
+
+    # -----------------------------------------------------------------------
+    # apply_materialization checkpointing
+    # -----------------------------------------------------------------------
+
+    def test_apply_materialization_called_per_chunk(self):
+        """registry.apply_materialization must be called once per successful chunk."""
+        store, _, _ = self._setup()
+        start = _utc(datetime(2024, 1, 1))
+        end = _utc(datetime(2024, 1, 3))  # 48 hours → 2 chunks of 24h
+
+        with (
+            patch.object(
+                store._get_provider().__class__,
+                "materialize_single_feature_view",
+                return_value=None,
+            ),
+            patch.object(store.registry, "apply_materialization") as mock_reg,
+        ):
+            store.materialize(
+                start_date=start, end_date=end, chunk_size=timedelta(hours=24)
+            )
+            assert mock_reg.call_count == 2
+            # First call's end_date should be start + 24h
+            first_call_end = mock_reg.call_args_list[0].args[3]
+            assert first_call_end == start + timedelta(hours=24)
+
+
+# ---------------------------------------------------------------------------
+# MaterializeIncremental – chunk dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeIncrementalChunking:
+    """Sanity-check that materialize_incremental() also respects chunk_size."""
+
+    def _setup(self, materialization_config=MaterializationConfig()):
+        store = _make_store(materialization_config)
+        entity = Entity(
+            name="user_id", join_keys=["user_id"], value_type=ValueType.INT64
+        )
+        now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        df = pd.DataFrame(
+            {
+                "user_id": [1, 2],
+                "feat": [100, 200],
+                "ts": [now, now + timedelta(hours=5)],
+            }
+        )
+        file_source = _make_file_source(df, timestamp_field="ts")
+        fv = FeatureView(
+            name="user_fv",
+            schema=[Field(name="feat", dtype=Int64)],
+            entities=[entity],
+            source=file_source,
+            ttl=timedelta(days=1),
+        )
+        store.apply([entity, fv])
+
+        # Seed materialization_intervals so incremental has a start_date
+        start = _utc(datetime(2024, 1, 1))
+        initial_end = _utc(datetime(2024, 1, 1, 0))
+        store.registry.apply_materialization(fv, store.project, start, initial_end)
+
+        return store, entity, fv
+
+    def test_incremental_chunk_size_splits_calls(self):
+        """materialize_incremental should honour chunk_size."""
+        store, _, _ = self._setup()
+        end = _utc(datetime(2024, 1, 3))  # 2 days from seed end (2024-01-01T00)
+
+        with patch.object(
+            store._get_provider().__class__,
+            "materialize_single_feature_view",
+            return_value=None,
+        ) as mock_mat:
+            store.materialize_incremental(end_date=end, chunk_size=timedelta(hours=24))
+            # 48 hours / 24 h = 2 chunks
+            assert mock_mat.call_count == 2
+
+    def test_incremental_continue_watermark_does_not_advance_past_gap(self):
+        """Regression test for the data-loss bug described in GitHub issue.
+
+        Scenario (4 x 6-hour chunks, chunk 2 fails):
+          chunk 1  [0h,  6h)  ✓
+          chunk 2  [6h, 12h)  ✗  ← fails
+          chunk 3  [12h,18h)  ✓
+          chunk 4  [18h,24h)  ✓
+
+        Expected: watermark advances only to 6h (end of chunk 1).
+        The next materialize_incremental() starts from 6h and retries the
+        failed window naturally, so data is never permanently lost.
+
+        Bug (before fix): apply_materialization was called for chunks 3 and 4,
+        advancing most_recent_end_time to 24h.  The 6–12 h window was then
+        permanently skipped by subsequent incremental runs.
+        """
+        store, _, fv = self._setup(
+            materialization_config=MaterializationConfig(
+                chunk_size=timedelta(hours=6),
+                chunk_failure_strategy=ChunkFailureStrategy.CONTINUE,
+            )
+        )
+        # Seed: watermark starts at midnight
+        seed_start = _utc(datetime(2024, 1, 1, 0))
+        seed_end = _utc(datetime(2024, 1, 1, 0))
+        store.registry.apply_materialization(fv, store.project, seed_start, seed_end)
+
+        end = _utc(datetime(2024, 1, 2, 0))  # 24 hours → 4 chunks of 6h
+
+        call_order = []
+
+        def _fail_second(**kwargs):
+            call_order.append(kwargs["start_date"])
+            if len(call_order) == 2:
+                raise RuntimeError("Chunk 2 failure")
+
+        with (
+            patch.object(
+                store._get_provider().__class__,
+                "materialize_single_feature_view",
+                side_effect=_fail_second,
+            ),
+            patch.object(store.registry, "apply_materialization") as mock_reg,
+        ):
+            import warnings
+
+            with warnings.catch_warnings(record=True):
+                warnings.simplefilter("always")
+                store.materialize_incremental(end_date=end)
+
+        # All 4 chunks must have been attempted
+        assert len(call_order) == 4
+
+        # apply_materialization must only have been called once (chunk 1 only)
+        assert mock_reg.call_count == 1
+        committed_end = mock_reg.call_args_list[0].args[3]
+        # Watermark should sit at end of chunk 1, i.e. seed_end + 6h
+        assert committed_end == seed_end + timedelta(hours=6), (
+            f"Watermark advanced past the gap to {committed_end}; "
+            f"expected {seed_end + timedelta(hours=6)}"
+        )

--- a/sdk/python/tests/unit/test_feature_view_utils.py
+++ b/sdk/python/tests/unit/test_feature_view_utils.py
@@ -1,0 +1,128 @@
+"""Unit tests for feast.feature_view_utils helper functions."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from feast.feature_view_utils import generate_time_chunks
+
+# ---------------------------------------------------------------------------
+# generate_time_chunks
+# ---------------------------------------------------------------------------
+
+
+def _utc(dt: datetime) -> datetime:
+    """Attach UTC timezone to a naive datetime for easier comparisons."""
+    return dt.replace(tzinfo=timezone.utc)
+
+
+class TestGenerateTimeChunks:
+    """Tests for generate_time_chunks()."""
+
+    def test_exact_multiple_of_chunk_size(self):
+        """Range that divides evenly into chunks should produce no remainder."""
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 1, 1, 12)  # 12 hours
+        chunks = list(generate_time_chunks(start, end, timedelta(hours=4)))
+        assert len(chunks) == 3
+        assert chunks[0] == (datetime(2024, 1, 1, 0), datetime(2024, 1, 1, 4))
+        assert chunks[1] == (datetime(2024, 1, 1, 4), datetime(2024, 1, 1, 8))
+        assert chunks[2] == (datetime(2024, 1, 1, 8), datetime(2024, 1, 1, 12))
+
+    def test_remainder_chunk_is_smaller(self):
+        """When the range is not evenly divisible the last chunk should be shorter."""
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 1, 1, 10)  # 10 hours
+        chunks = list(generate_time_chunks(start, end, timedelta(hours=4)))
+        assert len(chunks) == 3
+        # last chunk is only 2 hours
+        assert chunks[-1] == (datetime(2024, 1, 1, 8), datetime(2024, 1, 1, 10))
+
+    def test_chunk_size_larger_than_range(self):
+        """A single chunk should be returned when chunk_size >= total range."""
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 1, 1, 6)
+        chunks = list(generate_time_chunks(start, end, timedelta(days=1)))
+        assert len(chunks) == 1
+        assert chunks[0] == (start, end)
+
+    def test_single_chunk_exact_fit(self):
+        """chunk_size == total range should produce exactly one chunk."""
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 1, 2)
+        chunks = list(generate_time_chunks(start, end, timedelta(days=1)))
+        assert len(chunks) == 1
+        assert chunks[0] == (start, end)
+
+    def test_minute_granularity(self):
+        """Minute-level chunking should work correctly."""
+        start = datetime(2024, 1, 1, 0, 0, 0)
+        end = datetime(2024, 1, 1, 0, 30, 0)  # 30 minutes
+        chunks = list(generate_time_chunks(start, end, timedelta(minutes=10)))
+        assert len(chunks) == 3
+        assert chunks[0][0] == start
+        assert chunks[-1][1] == end
+
+    def test_second_granularity(self):
+        """Sub-minute chunking should work correctly."""
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 1, 1, 0, 0, 10)  # 10 seconds
+        chunks = list(generate_time_chunks(start, end, timedelta(seconds=3)))
+        assert len(chunks) == 4  # 3+3+3+1
+        assert chunks[-1][1] == end
+
+    def test_chunks_are_contiguous_and_non_overlapping(self):
+        """Each chunk's end must equal the next chunk's start."""
+        start = datetime(2024, 3, 1)
+        end = datetime(2024, 3, 8)
+        chunks = list(generate_time_chunks(start, end, timedelta(hours=17)))
+        for i in range(len(chunks) - 1):
+            assert chunks[i][1] == chunks[i + 1][0], (
+                f"Gap/overlap between chunk {i} and {i + 1}"
+            )
+
+    def test_full_coverage(self):
+        """Union of all chunks must exactly cover [start, end)."""
+        start = datetime(2024, 2, 1)
+        end = datetime(2024, 2, 15)
+        chunks = list(generate_time_chunks(start, end, timedelta(days=3)))
+        assert chunks[0][0] == start
+        assert chunks[-1][1] == end
+
+    def test_timezone_aware_datetimes(self):
+        """Timezone-aware datetimes should work the same way."""
+        start = _utc(datetime(2024, 1, 1))
+        end = _utc(datetime(2024, 1, 1, 8))
+        chunks = list(generate_time_chunks(start, end, timedelta(hours=3)))
+        assert len(chunks) == 3
+        assert chunks[0][0].tzinfo is not None
+        assert chunks[-1][1] == end
+
+    def test_empty_range_yields_no_chunks(self):
+        """start == end should produce no chunks without raising."""
+        start = datetime(2024, 1, 1)
+        chunks = list(generate_time_chunks(start, start, timedelta(hours=1)))
+        assert chunks == []
+
+    def test_zero_chunk_size_raises(self):
+        """A non-positive chunk_size must raise ValueError."""
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 1, 2)
+        with pytest.raises(ValueError, match="chunk_size must be positive"):
+            list(generate_time_chunks(start, end, timedelta(0)))
+
+    def test_negative_chunk_size_raises(self):
+        """A negative chunk_size must raise ValueError."""
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 1, 2)
+        with pytest.raises(ValueError, match="chunk_size must be positive"):
+            list(generate_time_chunks(start, end, timedelta(seconds=-1)))
+
+    def test_returns_iterator(self):
+        """generate_time_chunks should return a lazy iterator, not a list."""
+        import types
+
+        start = datetime(2024, 1, 1)
+        end = datetime(2024, 1, 2)
+        result = generate_time_chunks(start, end, timedelta(hours=6))
+        assert isinstance(result, types.GeneratorType)


### PR DESCRIPTION
# What this PR does / why we need it:

## Problem

`FeatureStore.materialize()` and `FeatureStore.materialize_incremental()` load the full requested time range into memory in a single pass. On production deployments with:
- Large time windows (multi-day or multi-week backfills)
- High-frequency event timestamps (e.g. 10-minute ETL batches, sub-minute sensor data)
- Limited worker memory

…this causes out-of-memory (OOM) crashes that are difficult to recover from, with no built-in workaround inside Feast itself. Users currently must write external orchestration scripts to work around this.

## Solution

This PR introduces **native time-based chunked materialization** directly into the Feast SDK. When a `chunk_size` is configured, each feature view's time range is split into consecutive, non-overlapping windows of the given width, and `materialize_single_feature_view` is called once per window. This caps peak memory usage to the cost of a single chunk regardless of total range size.

Key design decisions:

- **Backward-compatible**: no existing behaviour changes when `chunk_size` is not set (the default).
- **Three-tier priority** for chunk size resolution: call-time argument > `feature_store.yaml` project default > no chunking.
- **Per-chunk `registry.apply_materialization`**: each successfully materialized chunk immediately updates `most_recent_end_time`. A crash mid-run allows `materialize_incremental` to resume from the last committed chunk rather than reprocessing the entire range.
- **`CONTINUE` failure strategy**: an opt-in `chunk_failure_strategy: continue` setting collects failed chunks and emits a summary warning instead of aborting, enabling partial-success backfills.
- **Watermark gap-safety**: when `CONTINUE` is active, the watermark only advances through the *contiguous prefix* of successful chunks. If chunk N fails, chunks N+1, N+2, … still run (so the online store receives their data idempotently), but `most_recent_end_time` is not advanced past the failed window. The next `materialize_incremental` call therefore retries from the correct start time — no data is permanently lost.

## Changes

| File | Change |
|---|---|
| `feast/feature_view_utils.py` | New `generate_time_chunks(start, end, chunk_size)` generator — pure, tested, reusable |
| `feast/repo_config.py` | New `ChunkFailureStrategy` enum; extended `MaterializationConfig` with `chunk_size` and `chunk_failure_strategy` fields |
| `feast/feature_store.py` | New `_resolve_chunk_size()` helper; `chunk_size` parameter on both `materialize()` and `materialize_incremental()`; chunked inner loops with per-chunk checkpointing |
| `feast/cli/cli.py` | New `--chunk-hours`, `--chunk-minutes`, `--chunk-seconds` flags on both `feast materialize` and `feast materialize-incremental` |

## Usage examples

### Python SDK

```python
from datetime import timedelta

# Call-time override
fs.materialize(
    start_date=datetime(2026, 1, 1),
    end_date=datetime(2026, 3, 1),
    chunk_size=timedelta(hours=6),  # 240 chunks instead of one giant call
)

# Incremental with chunking
fs.materialize_incremental(
    end_date=datetime.utcnow(),
    chunk_size=timedelta(minutes=30),
)
```

### `feature_store.yaml` project default

```yaml
materialization:
  chunk_size: 21600          # 6 hours, in seconds
  chunk_failure_strategy: continue   # skip bad chunks, warn at end
```

### CLI flags

```bash
feast materialize 2026-01-01T00:00:00 2026-03-01T00:00:00 --chunk-hours 6
feast materialize 2026-01-01T00:00:00 2026-03-01T00:00:00 --chunk-minutes 30
feast materialize-incremental 2026-03-25T00:00:00 --chunk-hours 12
```

# Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes # (memory exhaustion / OOM during large-range materialization — no existing tracking issue; can be linked once opened)

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

### New unit tests added

**`tests/unit/test_feature_view_utils.py`** — 13 tests for `generate_time_chunks`:
- Exact multiple of chunk size
- Remainder chunk (last chunk smaller than `chunk_size`)
- Chunk size larger than total range (single chunk)
- Minute and second granularity
- Contiguity and full-coverage invariants
- Timezone-aware datetimes
- Empty range (yields nothing)
- Zero / negative `chunk_size` raises `ValueError`
- Returns a lazy generator (not a list)

**`tests/unit/test_chunk_materialization.py`** — 15 tests for `FeatureStore` integration:
- `_resolve_chunk_size` priority: call-time > config > `None`
- No chunking → single `materialize_single_feature_view` call (backward-compatible)
- N-hour chunk size → correct number of calls
- Chunk boundaries are contiguous and cover the full range
- Config `chunk_size` is used when no call-time override
- Call-time override supersedes config
- `CONTINUE` strategy: failed chunks are skipped with a warning; successful chunks are committed
- `CONTINUE` strategy (all succeed): all chunks commit and watermark reaches `end_date`
- `STOP` strategy (default): first failure re-raises immediately
- `registry.apply_materialization` is called once per chunk (checkpointing)
- `materialize_incremental` with `chunk_size` splits correctly
- Regression: `CONTINUE` watermark does not advance past a failed chunk (data-loss prevention)

# Misc

- This feature is intentionally scoped to the existing `local`, `spark` and `ray` compute engines without any engine-specific changes — chunking is applied at the `FeatureStore` layer, above the engine abstraction, so all engines benefit automatically.
- Parallel chunk execution (running multiple chunks concurrently) is a natural follow-up but is out of scope for this PR to keep the change reviewable and testable.
- The `chunk_size` field in `feature_store.yaml` currently accepts a `timedelta` integer (total seconds). A human-readable string format (e.g. `"6h"`, `"30m"`) is a potential follow-up using a Pydantic validator.
