### PR TITLE
fix: Include git in feast server image and add label selector overlay

### DIFF
--- a/infra/feast-operator/config/overlays/odh/kustomization.yaml
+++ b/infra/feast-operator/config/overlays/odh/kustomization.yaml
@@ -11,6 +11,14 @@ resources:
 patches:
   # patch to remove default `system` namespace in ../../manager/manager.yaml
   - path: delete-namespace.yaml
+  # Remove app.kubernetes.io/name from the Deployment selector to avoid
+  # immutable spec.selector errors on upgrade. The label remains in the
+  # pod template so the metrics Service selector still targets only
+  # feast-operator pods.
+  - path: remove_selector_label_patch.yaml
+    target:
+      kind: Deployment
+      name: controller-manager
 
 configMapGenerator:
   - name:  feast-operator-parameters

--- a/infra/feast-operator/config/overlays/odh/remove_selector_label_patch.yaml
+++ b/infra/feast-operator/config/overlays/odh/remove_selector_label_patch.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/selector/matchLabels/app.kubernetes.io~1name

--- a/infra/feast-operator/config/overlays/rhoai/kustomization.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/kustomization.yaml
@@ -11,6 +11,14 @@ resources:
 patches:
   # patch to remove default `system` namespace in ../../manager/manager.yaml
   - path: delete-namespace.yaml
+  # Remove app.kubernetes.io/name from the Deployment selector to avoid
+  # immutable spec.selector errors on upgrade. The label remains in the
+  # pod template so the metrics Service selector still targets only
+  # feast-operator pods.
+  - path: remove_selector_label_patch.yaml
+    target:
+      kind: Deployment
+      name: controller-manager
 
 configMapGenerator:
   - name:  feast-operator-parameters

--- a/infra/feast-operator/config/overlays/rhoai/remove_selector_label_patch.yaml
+++ b/infra/feast-operator/config/overlays/rhoai/remove_selector_label_patch.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/selector/matchLabels/app.kubernetes.io~1name

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/python-312-minimal:1
 
 USER 0
-RUN microdnf install -y gcc libpq-devel python3.12-devel && microdnf clean all
+RUN microdnf install -y git gcc libpq-devel python3.12-devel && microdnf clean all
 USER 1001
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv


### PR DESCRIPTION
**Root cause:** [PR #6217](https://github.com/feast-dev/feast/pull/6217/) switched Docker images from ubi9/python-312:1 (full UBI) to ubi9/python-312-minimal:1. The full image includes git by default; the minimal image does not. The PR added other system packages (gcc, libpq-devel, etc.) via microdnf but missed git.

**Impact:** The feast operator's init container uses git clone to set up the feature repository when feastProjectDir.Git is configured (see setInitContainer in services.go). Without git in the image, this fails with git: command not found.

This PR also updates Kubernetes deployment configuration for feast-operator across multiple overlays to refine pod selector labels, ensuring consistent pod selection behavior during upgrades.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
