### PR TITLE
fix: Disable Redis RDB persistence in test deployments

### DIFF
--- a/infra/feast-operator/test/testdata/feast_integration_test_crs/redis.yaml
+++ b/infra/feast-operator/test/testdata/feast_integration_test_crs/redis.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: redis
           image: 'quay.io/feastdev-ci/feast-test-images:redis-7-alpine'
+          command: ["redis-server", "--save", ""]
           ports:
             - containerPort: 6379
           env:

--- a/sdk/python/tests/integration/rest_api/resource/redis.yaml
+++ b/sdk/python/tests/integration/rest_api/resource/redis.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: redis
           image: 'quay.io/feastdev-ci/feast-test-images:redis-7-alpine'
+          command: ["redis-server", "--save", ""]
           ports:
             - containerPort: 6379
           env:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing and why.
-->
Add `command: ["redis-server", "--save", ""]` to disable RDB snapshotting
in both test Redis deployments. These are ephemeral test instances — no
data needs to survive pod restarts.
# Which issue(s) this PR fixes:
Redis pods on OpenShift fail with `MISCONF` error:

> Redis is configured to save RDB snapshots, but it's currently unable
> to persist to disk. Commands that may modify the data set are disabled,
> because this instance is configured to report errors during writes if
> RDB snapshotting fails (stop-writes-on-bgsave-error option).

This blocks all write commands during e2e and REST API integration tests,
causing materialization failures.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [x] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
