### PR TITLE
fix: Add avg alias and fix aggregation group_by_keys

### DIFF
--- a/sdk/python/feast/aggregation/__init__.py
+++ b/sdk/python/feast/aggregation/__init__.py
@@ -120,6 +120,7 @@ class Aggregation:
 
 _FUNCTION_ALIASES: Dict[str, str] = {
     "count_distinct": "nunique",
+    "avg": "mean",
 }
 
 

--- a/sdk/python/feast/infra/compute_engines/local/feature_builder.py
+++ b/sdk/python/feast/infra/compute_engines/local/feature_builder.py
@@ -65,7 +65,8 @@ class LocalFeatureBuilder(FeatureBuilder):
                 "Time window aggregation is not supported in the local compute engine."
             ),
         )
-        group_by_keys = view.entities
+        column_info = self.get_column_info(view)
+        group_by_keys = column_info.join_keys
         node = LocalAggregationNode(
             "agg", self.backend, group_by_keys, agg_ops, inputs=[input_node]
         )


### PR DESCRIPTION
- Add "avg" -> "mean" function alias for aggregation
- Fix group_by_keys retrieval in LocalFeatureBuilder to use column_info.join_keys

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
