### PR TITLE
test: Expand MilvusOnlineStore integration test coverage

### DIFF
--- a/sdk/python/tests/integration/online_store/test_universal_online.py
+++ b/sdk/python/tests/integration/online_store/test_universal_online.py
@@ -921,13 +921,27 @@ def test_retrieve_online_milvus_documents(environment, fake_document_data):
     df, data_source = fake_document_data
     item_embeddings_feature_view = create_item_embeddings_feature_view(data_source)
     fs.apply([item_embeddings_feature_view, item()])
+
+    features = [
+        "item_embeddings:embedding_float",
+        "item_embeddings:item_id",
+        "item_embeddings:string_feature",
+    ]
+
+    # Empty-store query: collection exists but has no rows yet.
+    empty = fs.retrieve_online_documents_v2(
+        features=features,
+        query=[1.0, 2.0],
+        top_k=2,
+        distance_metric="L2",
+    ).to_dict()
+    assert len(empty["embedding_float"]) == 0
+    assert len(empty["item_id"]) == 0
+
     fs.write_to_online_store("item_embeddings", df)
+
     documents = fs.retrieve_online_documents_v2(
-        features=[
-            "item_embeddings:embedding_float",
-            "item_embeddings:item_id",
-            "item_embeddings:string_feature",
-        ],
+        features=features,
         query=[1.0, 2.0],
         top_k=2,
         distance_metric="L2",
@@ -947,6 +961,50 @@ def test_retrieve_online_milvus_documents(environment, fake_document_data):
         assert len(embedding) == query_dim, (
             f"Integration test: embedding {i} has {len(embedding)} dimensions, expected {query_dim}"
         )
+
+    # Oversized top_k: dataset has 3 rows, request 5 -> expect 3 back.
+    all_docs = fs.retrieve_online_documents_v2(
+        features=features,
+        query=[1.0, 2.0],
+        top_k=5,
+        distance_metric="L2",
+    ).to_dict()
+    assert len(all_docs["embedding_float"]) == 3
+    assert sorted(all_docs["item_id"]) == [1, 2, 3]
+
+    # Cosine-metric variant: separate FV so the Milvus collection is created
+    # with COSINE as its index metric.
+    cosine_fv = FeatureView(
+        name="item_embeddings_cosine",
+        entities=[item()],
+        schema=[
+            Field(
+                name="embedding_float",
+                dtype=Array(Float32),
+                vector_index=True,
+                vector_search_metric="COSINE",
+            ),
+            Field(name="string_feature", dtype=String),
+            Field(name="float_feature", dtype=Float32),
+        ],
+        source=data_source,
+        ttl=timedelta(hours=2),
+    )
+    fs.apply([cosine_fv])
+    fs.write_to_online_store("item_embeddings_cosine", df)
+
+    cosine_docs = fs.retrieve_online_documents_v2(
+        features=[
+            "item_embeddings_cosine:embedding_float",
+            "item_embeddings_cosine:item_id",
+            "item_embeddings_cosine:string_feature",
+        ],
+        query=[1.0, 2.0],
+        top_k=2,
+        distance_metric="COSINE",
+    ).to_dict()
+    assert len(cosine_docs["embedding_float"]) == 2
+    assert len(cosine_docs["item_id"]) == 2
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## What does this PR do?

Expands `test_retrieve_online_milvus_documents` (in `sdk/python/tests/integration/online_store/test_universal_online.py`) with three additional cases that exercise code paths adjacent to the bug fixes in #6275.

The existing test covered a single L2 vector query on a 3-row dataset with `top_k=2`. This PR adds:

### 1. Empty-store query

Queries `retrieve_online_documents_v2` **before** `write_to_online_store`, so the Milvus collection exists but is empty. Asserts 0 rows returned. Exercises the "no hits" path of the v2 retrieval code.

### 2. Oversized `top_k`

Queries with `top_k=5` on a 3-row dataset. Asserts all 3 rows are returned. Exercises the hit-parsing loop when the result set is smaller than the requested top_k — adjacent to the territory of bug #4 from #6275 (the `bytes.fromhex(None)` crash on a hit with a missing composite key).

### 3. Cosine-metric variant

Creates a second FeatureView (`item_embeddings_cosine`) with `vector_search_metric="COSINE"`, writes the same dataset, and queries with `distance_metric="COSINE"`. Verifies the cosine index is created and queried end to end. The existing test only covered the L2 path.

## Motivation

Bug #4 in #6275 (`TypeError: fromhex argument must be str, not None`) was caught by a unit test (`test_milvus_retrieve_online_documents_v2_missing_entity_key`), but the universal integration test for Milvus retrieval did not exercise any of the adjacent edges (empty results, trailing hits, non-L2 metric). This PR closes that gap.

## Tests

Verified locally against Milvus Lite:

```
FEAST_LOCAL_ONLINE_CONTAINER=True pytest --integration \
  sdk/python/tests/integration/online_store/test_universal_online.py::test_retrieve_online_milvus_documents

1 passed, 5 warnings in 1.79s
```

No new imports are added; all types (`FeatureView`, `Field`, `Array`, `Float32`, `String`, `timedelta`, `item`) were already imported in the module.

## Out of scope

- Adding Milvus to the `test_retrieve_online_documents_v2` universal parametrization: that test asserts a BM25-style `text_rank` contract that Milvus's current `LIKE`-based text search does not satisfy. A capability-matrix refactor of the universal v2 test is a larger design question and will be raised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
