### PR TITLE
feat(cli): Add `feast projects delete` command

### DIFF
--- a/sdk/python/feast/cli/projects.py
+++ b/sdk/python/feast/cli/projects.py
@@ -3,16 +3,15 @@ import yaml
 
 from feast import utils
 from feast.cli.cli_options import tagsOption
-from feast.errors import FeastObjectNotFoundException
+from feast.errors import FeastObjectNotFoundException, ProjectNotFoundException
 from feast.repo_operations import create_feature_store
 
 
 @click.group(name="projects")
 def projects_cmd():
     """
-    Access projects
+    Access and manage projects
     """
-    pass
 
 
 @projects_cmd.command("describe")
@@ -27,8 +26,8 @@ def project_describe(ctx: click.Context, name: str):
     try:
         project = store.get_project(name)
     except FeastObjectNotFoundException as e:
-        print(e)
-        exit(1)
+        print(str(e))
+        raise SystemExit(1)
 
     print(
         yaml.dump(
@@ -58,7 +57,7 @@ def project_current(ctx: click.Context):
     )
 
 
-@projects_cmd.command(name="list")
+@projects_cmd.command("list")
 @tagsOption
 @click.pass_context
 def project_list(ctx: click.Context, tags: list[str]):
@@ -75,6 +74,44 @@ def project_list(ctx: click.Context, tags: list[str]):
 
     print(
         tabulate(
-            table, headers=["NAME", "DESCRIPTION", "TAGS", "OWNER"], tablefmt="plain"
+            table,
+            headers=["NAME", "DESCRIPTION", "TAGS", "OWNER"],
+            tablefmt="plain",
         )
     )
+
+
+@projects_cmd.command("delete")
+@click.argument("name", type=click.STRING)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip confirmation prompt and delete immediately.",
+)
+@click.pass_context
+def project_delete(ctx: click.Context, name: str, yes: bool):
+    """
+    Delete a project and all its resources from the registry.
+
+    This removes the project entry from the registry. Individual objects
+    (feature views, entities, data sources) that belong to the project
+    are also purged when commit=True (the default).
+    """
+    store = create_feature_store(ctx)
+
+    if not yes:
+        click.confirm(
+            f"Are you sure you want to delete project '{name}'? "
+            "This will remove all associated resources from the registry.",
+            abort=True,
+        )
+
+    try:
+        assert store._registry is not None
+        store._registry.delete_project(name, commit=True)
+    except (FeastObjectNotFoundException, ProjectNotFoundException) as e:
+        print(str(e))
+        raise SystemExit(1)
+
+    print(f"Project '{name}' deleted successfully.")

--- a/sdk/python/feast/cli/projects.py
+++ b/sdk/python/feast/cli/projects.py
@@ -108,8 +108,7 @@ def project_delete(ctx: click.Context, name: str, yes: bool):
         )
 
     try:
-        assert store._registry is not None
-        store._registry.delete_project(name, commit=True)
+        store.registry.delete_project(name, commit=True)
     except (FeastObjectNotFoundException, ProjectNotFoundException) as e:
         print(str(e))
         raise SystemExit(1)


### PR DESCRIPTION
## Summary

Closes #5095

Exposes project deletion through the CLI by adding a new `feast projects delete <name>` subcommand to the existing `projects` group.

### What's changed

Added `project_delete` command to `sdk/python/feast/cli/projects.py`:

```
Usage: feast projects delete [OPTIONS] NAME

  Delete a project and all its resources from the registry.

  This removes the project entry from the registry. Individual objects
  (feature views, entities, data sources) that belong to the project
  are also purged when commit=True (the default).

Options:
  -y, --yes  Skip confirmation prompt and delete immediately.
  --help     Show this message and exit.
```

### Design notes

- Uses `store._registry.delete_project(name, commit=True)` directly since `FeatureStore` does not yet expose a `delete_project` public method (the abstract method exists in `BaseRegistry` and is implemented in all concrete registries)
- Adds an interactive confirmation prompt with `click.confirm` — can be skipped with `--yes` / `-y` for scripting
- Raises `SystemExit(1)` on `FeastObjectNotFoundException` to match the pattern used by `describe`

### Example

```bash
# Interactive (prompts for confirmation)
feast projects delete my-project

# Non-interactive
feast projects delete my-project --yes
```

### Checklist
- [x] Added `delete` command to `projects_cmd` group
- [x] Confirmation prompt with `--yes` bypass flag
- [x] Error handling for non-existent projects
- [x] Follows existing CLI patterns in `projects.py`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
