### PR TITLE
feat(cli): Add `feast projects delete` command (closes #5095)

### DIFF
--- a/sdk/python/feast/cli/projects.py
+++ b/sdk/python/feast/cli/projects.py
@@ -23,16 +23,16 @@ def project_describe(ctx: click.Context, name: str):
     Describe a project
     """
     store = create_feature_store(ctx)
-
     try:
         project = store.get_project(name)
     except FeastObjectNotFoundException as e:
         print(e)
         exit(1)
-
     print(
         yaml.dump(
-            yaml.safe_load(str(project)), default_flow_style=False, sort_keys=False
+            yaml.safe_load(str(project)),
+            default_flow_style=False,
+            sort_keys=False,
         )
     )
 
@@ -44,38 +44,16 @@ def project_current(ctx: click.Context):
     Returns the current project configured with FeatureStore object
     """
     store = create_feature_store(ctx)
-
     try:
         project = store.get_project(name=None)
     except FeastObjectNotFoundException as e:
         print(e)
         exit(1)
-
     print(
         yaml.dump(
-            yaml.safe_load(str(project)), default_flow_style=False, sort_keys=False
-        )
-    )
-
-
-@projects_cmd.command(name="list")
-@tagsOption
-@click.pass_context
-def project_list(ctx: click.Context, tags: list[str]):
-    """
-    List all projects
-    """
-    store = create_feature_store(ctx)
-    table = []
-    tags_filter = utils.tags_list_to_dict(tags)
-    for project in store.list_projects(tags=tags_filter):
-        table.append([project.name, project.description, project.tags, project.owner])
-
-    from tabulate import tabulate
-
-    print(
-        tabulate(
-            table, headers=["NAME", "DESCRIPTION", "TAGS", "OWNER"], tablefmt="plain"
+            yaml.safe_load(str(project)),
+            default_flow_style=False,
+            sort_keys=False,
         )
     )
 
@@ -104,9 +82,32 @@ def project_delete(ctx: click.Context, name: str, yes: bool):
         )
 
     try:
-        store.registry.delete_project(name, commit=True)
+        store.delete_project(name)
     except (FeastObjectNotFoundException, ProjectNotFoundException) as e:
         print(str(e))
         raise SystemExit(1)
 
     print(f"Project '{name}' deleted successfully.")
+
+
+@projects_cmd.command(name="list")
+@tagsOption
+@click.pass_context
+def project_list(ctx: click.Context, tags: list[str]):
+    """
+    List all projects
+    """
+    store = create_feature_store(ctx)
+    table = []
+    tags_filter = utils.tags_list_to_dict(tags)
+    for project in store.list_projects(tags=tags_filter):
+        table.append([project.name, project.description, project.tags, project.owner])
+    from tabulate import tabulate
+
+    print(
+        tabulate(
+            table,
+            headers=["NAME", "DESCRIPTION", "TAGS", "OWNER"],
+            tablefmt="plain",
+        )
+    )

--- a/sdk/python/feast/cli/projects.py
+++ b/sdk/python/feast/cli/projects.py
@@ -3,16 +3,15 @@ import yaml
 
 from feast import utils
 from feast.cli.cli_options import tagsOption
-from feast.errors import FeastObjectNotFoundException
+from feast.errors import FeastObjectNotFoundException, ProjectNotFoundException
 from feast.repo_operations import create_feature_store
 
 
 @click.group(name="projects")
 def projects_cmd():
     """
-    Access projects
+    Access and manage projects
     """
-    pass
 
 
 @projects_cmd.command("describe")
@@ -27,8 +26,8 @@ def project_describe(ctx: click.Context, name: str):
     try:
         project = store.get_project(name)
     except FeastObjectNotFoundException as e:
-        print(e)
-        exit(1)
+        print(str(e))
+        raise SystemExit(1)
 
     print(
         yaml.dump(
@@ -41,24 +40,13 @@ def project_describe(ctx: click.Context, name: str):
 @click.pass_context
 def project_current(ctx: click.Context):
     """
-    Returns the current project configured with FeatureStore object
+    Returns the current project configured with FeatureStore
     """
     store = create_feature_store(ctx)
-
-    try:
-        project = store.get_project(name=None)
-    except FeastObjectNotFoundException as e:
-        print(e)
-        exit(1)
-
-    print(
-        yaml.dump(
-            yaml.safe_load(str(project)), default_flow_style=False, sort_keys=False
-        )
-    )
+    print(store.project)
 
 
-@projects_cmd.command(name="list")
+@projects_cmd.command("list")
 @tagsOption
 @click.pass_context
 def project_list(ctx: click.Context, tags: list[str]):
@@ -66,15 +54,42 @@ def project_list(ctx: click.Context, tags: list[str]):
     List all projects
     """
     store = create_feature_store(ctx)
-    table = []
-    tags_filter = utils.tags_list_to_dict(tags)
-    for project in store.list_projects(tags=tags_filter):
-        table.append([project.name, project.description, project.tags, project.owner])
 
-    from tabulate import tabulate
-
-    print(
-        tabulate(
-            table, headers=["NAME", "DESCRIPTION", "TAGS", "OWNER"], tablefmt="plain"
-        )
+    projects = store.list_projects(
+        tags=dict(tag.split(":", 1) for tag in tags),
     )
+
+    for project in projects:
+        print(utils.py_object_to_proto(project).name)
+
+
+@projects_cmd.command("delete")
+@click.argument("name", type=click.STRING)
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Skip confirmation prompt and delete immediately.",
+)
+@click.pass_context
+def project_delete(ctx: click.Context, name: str, yes: bool):
+    """
+    Delete a project and all its resources from the registry.
+    """
+    store = create_feature_store(ctx)
+
+    if not yes:
+        click.confirm(
+            f"Are you sure you want to delete project '{name}'? "
+            "This will remove all associated resources from the registry.",
+            abort=True,
+        )
+
+    try:
+        store.registry.delete_project(name, commit=True)
+    except (FeastObjectNotFoundException, ProjectNotFoundException) as e:
+        print(str(e))
+        raise SystemExit(1)
+
+    print(f"Project '{name}' deleted successfully.")

--- a/sdk/python/feast/cli/projects.py
+++ b/sdk/python/feast/cli/projects.py
@@ -10,8 +10,9 @@ from feast.repo_operations import create_feature_store
 @click.group(name="projects")
 def projects_cmd():
     """
-    Access and manage projects
+    Access projects
     """
+    pass
 
 
 @projects_cmd.command("describe")
@@ -26,8 +27,8 @@ def project_describe(ctx: click.Context, name: str):
     try:
         project = store.get_project(name)
     except FeastObjectNotFoundException as e:
-        print(str(e))
-        raise SystemExit(1)
+        print(e)
+        exit(1)
 
     print(
         yaml.dump(
@@ -40,13 +41,24 @@ def project_describe(ctx: click.Context, name: str):
 @click.pass_context
 def project_current(ctx: click.Context):
     """
-    Returns the current project configured with FeatureStore
+    Returns the current project configured with FeatureStore object
     """
     store = create_feature_store(ctx)
-    print(store.project)
+
+    try:
+        project = store.get_project(name=None)
+    except FeastObjectNotFoundException as e:
+        print(e)
+        exit(1)
+
+    print(
+        yaml.dump(
+            yaml.safe_load(str(project)), default_flow_style=False, sort_keys=False
+        )
+    )
 
 
-@projects_cmd.command("list")
+@projects_cmd.command(name="list")
 @tagsOption
 @click.pass_context
 def project_list(ctx: click.Context, tags: list[str]):
@@ -54,13 +66,18 @@ def project_list(ctx: click.Context, tags: list[str]):
     List all projects
     """
     store = create_feature_store(ctx)
+    table = []
+    tags_filter = utils.tags_list_to_dict(tags)
+    for project in store.list_projects(tags=tags_filter):
+        table.append([project.name, project.description, project.tags, project.owner])
 
-    projects = store.list_projects(
-        tags=dict(tag.split(":", 1) for tag in tags),
+    from tabulate import tabulate
+
+    print(
+        tabulate(
+            table, headers=["NAME", "DESCRIPTION", "TAGS", "OWNER"], tablefmt="plain"
+        )
     )
-
-    for project in projects:
-        print(utils.py_object_to_proto(project).name)
 
 
 @projects_cmd.command("delete")

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -3414,7 +3414,7 @@ class FeatureStore:
         """
         return self.registry.delete_project(name, commit=commit)
 
-        def list_saved_datasets(
+    def list_saved_datasets(
         self, allow_cache: bool = False, tags: Optional[dict[str, str]] = None
     ) -> List[SavedDataset]:
         """

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -3401,7 +3401,20 @@ class FeatureStore:
         """
         return self.registry.get_project(name or self.project)
 
-    def list_saved_datasets(
+    def delete_project(self, name: str, commit: bool = True) -> None:
+        """
+        Deletes a project from the registry.
+
+        Args:
+            name: Name of the project to delete.
+            commit: Whether the change should be persisted immediately.
+
+        Raises:
+            ProjectNotFoundException: The project could not be found.
+        """
+        return self.registry.delete_project(name, commit=commit)
+
+        def list_saved_datasets(
         self, allow_cache: bool = False, tags: Optional[dict[str, str]] = None
     ) -> List[SavedDataset]:
         """


### PR DESCRIPTION
## Summary

Closes #5095

Exposes project deletion through the CLI by adding a new `feast projects delete <name>` subcommand to the existing `projects` group.

### What's changed

Added `project_delete` command to `sdk/python/feast/cli/projects.py`:

```
Usage: feast projects delete [OPTIONS] NAME

  Delete a project and all its resources from the registry.

Options:
  -y, --yes  Skip confirmation prompt and delete immediately.
  --help     Show this message and exit.
```

### Design notes

- Uses `store.registry.delete_project(name, commit=True)` via the lazy-init `registry` property (the abstract method exists in `BaseRegistry` and is implemented in all concrete registries)
- Adds an interactive confirmation prompt with `click.confirm` — can be skipped with `--yes` / `-y` for scripting
- Catches both `FeastObjectNotFoundException` and `ProjectNotFoundException` so the CLI exits cleanly (exit code 1) for either variant raised by concrete registry implementations
- Follows existing CLI patterns in `projects.py`

### Example

```bash
# Interactive (prompts for confirmation)
feast projects delete my-project

# Non-interactive
feast projects delete my-project --yes
```

### Checklist

- [x] Added `delete` command to `projects_cmd` group
- [x] Confirmation prompt with `--yes` bypass flag
- [x] Error handling for non-existent projects
- [x] Follows existing CLI patterns in `projects.py`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
