### PR TITLE
feat: Allow to set gpu and worker scheduling params for ray remote tasks

### DIFF
--- a/docs/reference/compute-engine/ray.md
+++ b/docs/reference/compute-engine/ray.md
@@ -28,6 +28,7 @@ The Ray compute engine provides:
 - **Lazy Evaluation**: Deferred execution for optimal performance
 - **Resource Management**: Automatic scaling and resource optimization
 - **Point-in-Time Joins**: Efficient temporal joins for historical feature retrieval
+- **GPU Support**: Schedule transformation workers on GPU nodes via `num_gpus` config (all modes including KubeRay)
 
 ## Architecture
 
@@ -87,6 +88,9 @@ batch_engine:
 | `enable_distributed_joins` | boolean | true | Enable distributed joins for large datasets |
 | `staging_location` | string | None | Remote path for batch materialization jobs |
 | `ray_conf` | dict | None | Ray configuration parameters (memory, CPU limits) |
+| `num_gpus` | float | None | Number of GPUs to request per worker task. Requires GPU nodes in the Ray cluster. Fractional values (e.g. `0.5`) are supported. Supported in all modes including KubeRay. |
+| `gpu_batch_format` | string | `"pandas"` | Batch format for `map_batches` when `num_gpus` is set. Use `"numpy"` or `"pyarrow"` for GPU-native libraries (e.g. cuDF, PyTorch). |
+| `worker_task_options` | dict | None | Arbitrary Ray `.options()` kwargs applied to every worker task. See [Worker Resource Scheduling](#worker-resource-scheduling) for the full reference. |
 
 ### Mode Detection Precedence
 
@@ -344,11 +348,95 @@ import ray
 # Check cluster resources
 resources = ray.cluster_resources()
 print(f"Available CPUs: {resources.get('CPU', 0)}")
+print(f"Available GPUs: {resources.get('GPU', 0)}")
 print(f"Available memory: {resources.get('memory', 0) / 1e9:.2f} GB")
 
 # Monitor job progress
 job = store.get_historical_features(...)
 # Ray compute engine provides built-in progress tracking
+```
+
+## Worker Resource Scheduling
+
+`worker_task_options` is a passthrough dict of [Ray `.options()` kwargs](https://docs.ray.io/en/latest/ray-core/api/doc/ray.remote_function.RemoteFunction.options.html) applied to every worker task Feast dispatches. It pairs with `ray_conf` (cluster-level `ray.init` options) — `worker_task_options` targets individual worker tasks. Options are forwarded at two levels so Ray schedules correctly:
+
+1. On the `@ray.remote` orchestration task via `.options(**worker_task_options)` — controls node selection.
+2. Inside `map_batches` for the scheduling-relevant subset (`num_gpus`, `num_cpus`, `accelerator_type`, `resources`) — controls which nodes run the data workers.
+
+This is supported across **all execution modes**: local, remote, and KubeRay.
+
+### Common `worker_task_options` keys
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `num_cpus` | float | CPUs per task (default: 1). Fractional values supported. |
+| `memory` | int | Heap memory in **bytes** (e.g. `8589934592` for 8 GB). |
+| `accelerator_type` | string | Pin tasks to a specific GPU model — `"A100"`, `"T4"`, `"V100"`, etc. Useful on KubeRay clusters with mixed GPU node pools. |
+| `resources` | dict | Custom/Kubernetes extended resource labels, e.g. `{"intel.com/gpu": 1}`. |
+| `runtime_env` | dict | Per-task [Ray runtime environment](https://docs.ray.io/en/latest/ray-core/handling-dependencies.html) — `pip`, `conda`, `env_vars`, `working_dir`, etc. For KubeRay, use this to install packages on worker pods without rebuilding images. |
+| `max_retries` | int | Task retry count on worker failure (default: 3). |
+| `scheduling_strategy` | string | `"DEFAULT"`, `"SPREAD"`, or a placement group strategy. |
+
+> For the full list of supported keys see the [Ray RemoteFunction.options() API docs](https://docs.ray.io/en/latest/ray-core/api/doc/ray.remote_function.RemoteFunction.options.html).
+
+### GPU support
+
+`num_gpus` is the only first-class GPU field because it also drives `gpu_batch_format` selection inside Feast. Set it directly rather than inside `worker_task_options`:
+
+```yaml
+batch_engine:
+    type: ray.engine
+    num_gpus: 1               # GPUs per task (fractional values like 0.5 supported)
+    gpu_batch_format: numpy   # numpy/pyarrow for GPU-native libs (cuDF, PyTorch)
+```
+
+When `num_gpus` is set your transformation UDF runs on a GPU worker:
+
+```python
+import cudf  # RAPIDS cuDF – GPU-accelerated DataFrame library
+
+def gpu_transform(batch):
+    gpu_df = cudf.from_pandas(batch)
+    gpu_df["score"] = gpu_df["raw_value"] * 2.0
+    return gpu_df.to_pandas()
+```
+
+### Full example — KubeRay with GPU + all common options
+
+```yaml
+batch_engine:
+    type: ray.engine
+    use_kuberay: true
+    kuberay_conf:
+        cluster_name: "feast-gpu-cluster"
+        namespace: "feast-system"
+        auth_token: "${RAY_AUTH_TOKEN}"
+        auth_server: "https://api.openshift.com:6443"
+    num_gpus: 1
+    gpu_batch_format: numpy
+    worker_task_options:
+        num_cpus: 4
+        memory: 8589934592        # 8 GB
+        accelerator_type: "A100"  # pin to A100 nodes on mixed GPU pool
+        max_retries: 5
+        runtime_env:
+            pip:
+                - cudf-cu12==24.10.0
+                - torch==2.4.0
+            env_vars:
+                CUDA_VISIBLE_DEVICES: "0"
+```
+
+### Checking cluster resources
+
+```python
+import ray
+
+ray.init(address="auto")
+resources = ray.cluster_resources()
+print(f"Available CPUs: {resources.get('CPU', 0)}")
+print(f"Available GPUs: {resources.get('GPU', 0)}")
+print(f"Available memory: {resources.get('memory', 0) / 1e9:.2f} GB")
 ```
 
 ## Integration Examples

--- a/docs/reference/offline-stores/ray.md
+++ b/docs/reference/offline-stores/ray.md
@@ -31,6 +31,7 @@ The Ray offline store provides:
 - Efficient data filtering and column selection
 - Timestamp-based data processing with timezone awareness
 - Enterprise-ready KubeRay cluster support via CodeFlare SDK
+- **GPU support**: schedule worker tasks on GPU nodes via `num_gpus` config (all modes including KubeRay)
 
 
 ## Functionality Matrix
@@ -246,6 +247,9 @@ batch_engine:
 | `max_parallelism_multiplier` | int | 2 | Parallelism as multiple of CPU cores |
 | `target_partition_size_mb` | int | 64 | Target partition size (MB) |
 | `window_size_for_joins` | string | "1H" | Time window for distributed joins |
+| `num_gpus` | float | None | GPUs per worker task. Supported in all modes. See [Worker Resource Scheduling](../compute-engine/ray.md#worker-resource-scheduling). |
+| `gpu_batch_format` | string | `"pandas"` | Batch format for `map_batches` when `num_gpus` is set (`"numpy"` or `"pyarrow"` for GPU-native libs). |
+| `worker_task_options` | dict | None | Arbitrary Ray `.options()` kwargs (num_cpus, memory, accelerator_type, resources, runtime_env, …). See [Worker Resource Scheduling](../compute-engine/ray.md#worker-resource-scheduling) for the full reference. |
 
 #### Mode Detection Precedence
 
@@ -541,6 +545,12 @@ python your_feast_script.py
 - Namespace isolation
 - Secure communication between client and Ray cluster
 - Automatic cluster discovery
+
+### GPU Support
+
+The Ray offline store supports GPU scheduling via the `num_gpus` and `gpu_batch_format` config options. This works across all execution modes (local, remote, and KubeRay).
+
+For full configuration details, examples, and KubeRay GPU setup, see the [Ray Compute Engine GPU Support](../compute-engine/ray.md#gpu-support) section.
 
 ### Data Source Validation
 

--- a/sdk/python/feast/infra/compute_engines/ray/config.py
+++ b/sdk/python/feast/infra/compute_engines/ray/config.py
@@ -46,6 +46,51 @@ class RayComputeEngineConfig(FeastConfigBaseModel):
     enable_optimization: bool = True
     """Enable automatic performance optimizations."""
 
+    # Worker task resource configuration
+    num_gpus: Optional[float] = None
+    """Number of GPUs to request per worker task. Requires GPU nodes in the
+    Ray cluster. Fractional values (e.g. 0.5) are supported by Ray for GPU
+    sharing. Supported in all modes: local, remote, and KubeRay."""
+
+    gpu_batch_format: str = "pandas"
+    """Batch format for map_batches when num_gpus is set. Use 'numpy' or
+    'pyarrow' for GPU-native libraries (e.g. cuDF, PyTorch). Defaults to
+    'pandas'."""
+
+    worker_task_options: Optional[Dict[str, Any]] = None
+    """Arbitrary Ray task options passed verbatim to @ray.remote .options()
+    and map_batches for every worker task Feast dispatches. This is the
+    escape hatch for any Ray or CodeFlare SDK scheduling parameter not
+    covered by the dedicated fields above.
+
+    Pairs with ray_conf (which configures ray.init) — worker_task_options
+    targets the individual worker tasks rather than the cluster connection.
+
+    Common keys (see https://docs.ray.io/en/latest/ray-core/api/doc/ray.remote_function.RemoteFunction.options.html):
+      num_cpus          (float)  – CPUs per task (default: 1)
+      memory            (int)    – Heap memory in bytes (e.g. 8 * 1024**3 for 8 GB)
+      accelerator_type  (str)    – Specific GPU model, e.g. 'A100', 'T4', 'V100'.
+                                   Pins tasks to nodes advertising that type. Useful
+                                   on KubeRay clusters with mixed GPU pools.
+      resources         (dict)   – Custom/extended resource labels, e.g.
+                                   {'intel.com/gpu': 1} for Kubernetes extended resources.
+      runtime_env       (dict)   – Per-task runtime environment (pip, conda, env_vars,
+                                   working_dir, …). For KubeRay use this to install
+                                   extra packages on workers without rebuilding images.
+      max_retries       (int)    – Task retry count on worker failure (default: 3).
+      scheduling_strategy (str)  – 'DEFAULT', 'SPREAD', or a placement group strategy.
+
+    Example:
+      worker_task_options:
+        num_cpus: 4
+        memory: 8589934592       # 8 GB
+        accelerator_type: "A100"
+        max_retries: 5
+        runtime_env:
+          pip: ["cudf-cu12==24.10.0"]
+          env_vars: {CUDA_VISIBLE_DEVICES: "0"}
+    """
+
     @property
     def window_size_timedelta(self) -> timedelta:
         """Convert window size string to timedelta."""

--- a/sdk/python/feast/infra/compute_engines/ray/nodes.py
+++ b/sdk/python/feast/infra/compute_engines/ray/nodes.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import dill
 import pandas as pd
@@ -688,10 +688,36 @@ class RayTransformationNode(DAGNode):
 
                 return transformed_batch
 
+            num_gpus = getattr(self.config, "num_gpus", None) or None
+            task_options: Dict[str, Any] = dict(
+                getattr(self.config, "worker_task_options", None) or {}
+            )
+            if num_gpus:
+                task_options["num_gpus"] = num_gpus
+            batch_format = (
+                getattr(self.config, "gpu_batch_format", "pandas")
+                if num_gpus
+                else "pandas"
+            )
+            # Only the scheduling-relevant subset flows into map_batches
+            _MAP_BATCHES_RESOURCE_KEYS = {
+                "num_gpus",
+                "num_cpus",
+                "accelerator_type",
+                "resources",
+            }
+            map_kwargs: Dict[str, Any] = {
+                "batch_format": batch_format,
+                "concurrency": self.config.max_workers or 12,
+                **{
+                    k: v
+                    for k, v in task_options.items()
+                    if k in _MAP_BATCHES_RESOURCE_KEYS
+                },
+            }
             transformed_dataset = dataset.map_batches(
                 apply_transformation_with_serialized_udf,
-                batch_format="pandas",
-                concurrency=self.config.max_workers or 12,
+                **map_kwargs,
             )
 
         return DAGValue(

--- a/sdk/python/feast/infra/compute_engines/ray/utils.py
+++ b/sdk/python/feast/infra/compute_engines/ray/utils.py
@@ -5,6 +5,7 @@ Utility functions for Ray compute engine.
 import logging
 from typing import Callable, Dict, Union
 
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 
@@ -79,22 +80,54 @@ def write_to_online_store(
         logger.error(f"Failed to write to online store for {feature_view.name}: {e}")
 
 
-def safe_batch_processor(
-    func: Callable[[pd.DataFrame], pd.DataFrame],
-) -> Callable[[pd.DataFrame], pd.DataFrame]:
+# Ray Data batch type: pandas DataFrame, numpy dict, or pyarrow Table
+BatchType = Union[pd.DataFrame, Dict[str, np.ndarray], pa.Table]
+
+
+def _is_empty_batch(batch: BatchType) -> bool:
+    """Return True if the batch contains no rows, regardless of Ray Data batch format.
+
+    Ray Data delivers batches in three formats depending on the batch_format
+    argument passed to map_batches:
+      - "pandas"  → pd.DataFrame   (.empty attribute)
+      - "numpy"   → Dict[str, np.ndarray]  (check length of first array)
+      - "pyarrow" → pa.Table       (.num_rows attribute)
     """
-    Decorator for batch processing functions that handles empty batches and errors gracefully.
+    if isinstance(batch, pd.DataFrame):
+        return batch.empty
+    if isinstance(batch, dict):
+        if not batch:
+            return True
+        first = next(iter(batch.values()))
+        return len(first) == 0
+    if isinstance(batch, pa.Table):
+        return batch.num_rows == 0
+    return False
+
+
+def safe_batch_processor(
+    func: Callable[[BatchType], BatchType],
+) -> Callable[[BatchType], BatchType]:
+    """
+    Decorator for batch processing functions that handles empty batches and
+    exceptions gracefully across all Ray Data batch formats.
+
+    Ray Data can deliver batches as a pandas DataFrame (batch_format="pandas"),
+    a Dict[str, np.ndarray] (batch_format="numpy"), or a pa.Table
+    (batch_format="pyarrow"). The decorator handles all three so that callers
+    using gpu_batch_format="numpy" or "pyarrow" do not crash on the empty-batch
+    check.
 
     Args:
-        func: Function that processes a pandas DataFrame batch
+        func: Batch processing function. Receives and returns the same batch
+            type that Ray Data passes (pandas, numpy dict, or pyarrow Table).
 
     Returns:
-        Wrapped function that handles empty batches and exceptions
+        Wrapped function that skips empty batches and swallows exceptions.
     """
 
-    def wrapper(batch: pd.DataFrame) -> pd.DataFrame:
-        # Handle empty batches
-        if batch.empty:
+    def wrapper(batch: BatchType) -> BatchType:
+        if _is_empty_batch(batch):
             return batch
 
         try:

--- a/sdk/python/feast/infra/offline_stores/contrib/ray_offline_store/ray.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/ray_offline_store/ray.py
@@ -365,6 +365,51 @@ class RayOfflineStoreConfig(FeastConfigBaseModel):
     kuberay_conf: Optional[Dict[str, Any]] = None
     """KubeRay/CodeFlare configuration parameters (passed to CodeFlare SDK)"""
 
+    # Worker task resource configuration
+    num_gpus: Optional[float] = None
+    """Number of GPUs to request per worker task. Requires GPU nodes in the
+    Ray cluster. Fractional values (e.g. 0.5) are supported by Ray for GPU
+    sharing. Supported in all modes: local, remote, and KubeRay."""
+
+    gpu_batch_format: str = "pandas"
+    """Batch format for map_batches when num_gpus is set. Use 'numpy' or
+    'pyarrow' for GPU-native libraries (e.g. cuDF, PyTorch). Defaults to
+    'pandas'."""
+
+    worker_task_options: Optional[Dict[str, Any]] = None
+    """Arbitrary Ray task options passed verbatim to @ray.remote .options()
+    and map_batches for every worker task Feast dispatches. This is the
+    escape hatch for any Ray or CodeFlare SDK scheduling parameter not
+    covered by the dedicated fields above.
+
+    Pairs with ray_conf (which configures ray.init) — worker_task_options
+    targets the individual worker tasks rather than the cluster connection.
+
+    Common keys (see https://docs.ray.io/en/latest/ray-core/api/doc/ray.remote_function.RemoteFunction.options.html):
+      num_cpus          (float)  – CPUs per task (default: 1)
+      memory            (int)    – Heap memory in bytes (e.g. 8 * 1024**3 for 8 GB)
+      accelerator_type  (str)    – Specific GPU model, e.g. 'A100', 'T4', 'V100'.
+                                   Pins tasks to nodes advertising that type. Useful
+                                   on KubeRay clusters with mixed GPU pools.
+      resources         (dict)   – Custom/extended resource labels, e.g.
+                                   {'intel.com/gpu': 1} for Kubernetes extended resources.
+      runtime_env       (dict)   – Per-task runtime environment (pip, conda, env_vars,
+                                   working_dir, …). For KubeRay use this to install
+                                   extra packages on workers without rebuilding images.
+      max_retries       (int)    – Task retry count on worker failure (default: 3).
+      scheduling_strategy (str)  – 'DEFAULT', 'SPREAD', or a placement group strategy.
+
+    Example:
+      worker_task_options:
+        num_cpus: 4
+        memory: 8589934592       # 8 GB
+        accelerator_type: "A100"
+        max_retries: 5
+        runtime_env:
+          pip: ["cudf-cu12==24.10.0"]
+          env_vars: {CUDA_VISIBLE_DEVICES: "0"}
+    """
+
 
 class RayResourceManager:
     """
@@ -382,12 +427,14 @@ class RayResourceManager:
             self.cluster_resources = {"CPU": 4, "memory": 8 * 1024**3}
             self.available_memory = 8 * 1024**3
             self.available_cpus = 4
+            self.available_gpus = 0
             self.num_nodes = 1
             return
 
         self.cluster_resources = ray.cluster_resources()
         self.available_memory = self.cluster_resources.get("memory", 8 * 1024**3)
         self.available_cpus = int(self.cluster_resources.get("CPU", 4))
+        self.available_gpus = int(self.cluster_resources.get("GPU", 0))
         self.num_nodes = len(ray.nodes())
 
     def configure_ray_context(self) -> None:
@@ -421,6 +468,7 @@ class RayResourceManager:
         if getattr(self.config, "enable_ray_logging", False):
             logger.info(
                 f"Configured Ray context: {self.available_cpus} CPUs, "
+                f"{self.available_gpus} GPUs, "
                 f"{self.available_memory // 1024**3}GB memory, {self.num_nodes} nodes"
             )
 

--- a/sdk/python/feast/infra/ray_initializer.py
+++ b/sdk/python/feast/infra/ray_initializer.py
@@ -239,6 +239,8 @@ class CodeFlareRayWrapper:
         auth_server: str,
         skip_tls: bool = False,
         enable_logging: bool = False,
+        num_gpus: float = 0,
+        worker_task_options: Optional[Dict[str, Any]] = None,
     ):
         """Initialize CodeFlare Ray wrapper with cluster connection parameters."""
         self.cluster_name = cluster_name
@@ -247,6 +249,8 @@ class CodeFlareRayWrapper:
         self.auth_server = auth_server
         self.skip_tls = skip_tls
         self.enable_logging = enable_logging
+        self.num_gpus = num_gpus
+        self.worker_task_options = worker_task_options or {}
         self.cluster = None
 
         # Authenticate and setup Ray connection
@@ -307,6 +311,24 @@ class CodeFlareRayWrapper:
             logger.error(f"Ray connection failed: {e}")
             raise
 
+    def _get_task_options(self, include_gpu: bool = False) -> Dict[str, Any]:
+        """Build Ray .options() kwargs for a remote task dispatch.
+
+        Always includes the full worker_task_options passthrough dict.
+        num_gpus is merged in only when include_gpu=True, because I/O
+        operations (read_parquet, read_csv, from_pandas, from_arrow) are
+        pure data-movement and must not consume GPU slots.  Pass
+        include_gpu=True only for compute/transformation tasks.
+        """
+        opts: Dict[str, Any] = dict(self.worker_task_options)
+        if include_gpu and self.num_gpus:
+            opts["num_gpus"] = self.num_gpus
+        else:
+            # Guarantee no GPU slot is consumed for I/O tasks even if the
+            # caller placed num_gpus inside worker_task_options directly.
+            opts.pop("num_gpus", None)
+        return opts
+
     # Ray Data API methods - wrapped in @ray.remote to execute on cluster workers
     def read_parquet(self, path: Union[str, List[str]], **kwargs) -> Any:
         """Read parquet files - runs remotely on KubeRay cluster workers."""
@@ -318,7 +340,11 @@ class CodeFlareRayWrapper:
 
             return ray.data.read_parquet(file_path, **read_kwargs)
 
-        return RemoteDatasetProxy(_remote_read_parquet.remote(path, kwargs))
+        opts = self._get_task_options()
+        remote_fn = (
+            _remote_read_parquet.options(**opts) if opts else _remote_read_parquet
+        )
+        return RemoteDatasetProxy(remote_fn.remote(path, kwargs))
 
     def read_csv(self, path: Union[str, List[str]], **kwargs) -> Any:
         """Read CSV files - runs remotely on KubeRay cluster workers."""
@@ -330,7 +356,9 @@ class CodeFlareRayWrapper:
 
             return ray.data.read_csv(file_path, **read_kwargs)
 
-        return RemoteDatasetProxy(_remote_read_csv.remote(path, kwargs))
+        opts = self._get_task_options()
+        remote_fn = _remote_read_csv.options(**opts) if opts else _remote_read_csv
+        return RemoteDatasetProxy(remote_fn.remote(path, kwargs))
 
     def from_pandas(self, df: Any) -> Any:
         """Create dataset from pandas DataFrame - runs remotely on KubeRay cluster workers."""
@@ -342,7 +370,9 @@ class CodeFlareRayWrapper:
 
             return ray.data.from_pandas(dataframe)
 
-        return RemoteDatasetProxy(_remote_from_pandas.remote(df))
+        opts = self._get_task_options()
+        remote_fn = _remote_from_pandas.options(**opts) if opts else _remote_from_pandas
+        return RemoteDatasetProxy(remote_fn.remote(df))
 
     def from_arrow(self, table: Any) -> Any:
         """Create dataset from Arrow table - runs remotely on KubeRay cluster workers."""
@@ -354,7 +384,9 @@ class CodeFlareRayWrapper:
 
             return ray.data.from_arrow(arrow_table)
 
-        return RemoteDatasetProxy(_remote_from_arrow.remote(table))
+        opts = self._get_task_options()
+        remote_fn = _remote_from_arrow.options(**opts) if opts else _remote_from_arrow
+        return RemoteDatasetProxy(remote_fn.remote(table))
 
 
 # Global state tracking
@@ -551,6 +583,8 @@ def _initialize_kuberay(config: Any, enable_logging: bool = False) -> None:
         auth_server=kuberay_config["auth_server"],
         skip_tls=kuberay_config.get("skip_tls", False),
         enable_logging=enable_logging,
+        num_gpus=getattr(config, "num_gpus", 0) or 0,
+        worker_task_options=getattr(config, "worker_task_options", None),
     )
 
     logger.info("KubeRay cluster connection established via CodeFlare SDK")

--- a/sdk/python/feast/infra/ray_shared_utils.py
+++ b/sdk/python/feast/infra/ray_shared_utils.py
@@ -14,14 +14,75 @@ class RemoteDatasetProxy:
         """Initialize with a reference to the remote dataset."""
         self._dataset_ref = dataset_ref
 
-    def map_batches(self, func, **kwargs) -> "RemoteDatasetProxy":
-        """Execute map_batches remotely on cluster workers."""
+    def map_batches(
+        self,
+        func,
+        num_gpus: float = 0,
+        worker_task_options: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> "RemoteDatasetProxy":
+        """Execute map_batches remotely on cluster workers.
+
+        Resource options are applied at two levels:
+
+        1. **Orchestration task** (@ray.remote wrapper) — receives only the
+           non-compute keys from worker_task_options (runtime_env, max_retries,
+           scheduling_strategy, memory, …).  Compute-scheduling keys
+           (num_gpus, num_cpus, accelerator_type, resources) are intentionally
+           excluded: the orchestration task only calls dataset.map_batches()
+           and holds no GPU/CPU work itself.  Including num_gpus here would
+           waste a GPU slot for the entire operation duration and, on
+           GPU-constrained clusters, could cause deadlock where the orchestrator
+           holds a GPU while the data workers queue waiting for the same slots.
+
+        2. **Data workers** (inside dataset.map_batches) — receives the full
+           compute-scheduling subset (num_gpus, num_cpus, accelerator_type,
+           resources).  Ray Data propagates these to the actual processing tasks.
+
+        Args:
+            func: Batch transformation function.
+            num_gpus: Shorthand GPU count (merged into worker_task_options,
+                takes precedence). Kept first-class because it also drives
+                gpu_batch_format selection in the compute engine.
+            worker_task_options: Arbitrary Ray .options() kwargs (num_cpus,
+                memory, accelerator_type, resources, runtime_env,
+                max_retries, …).
+            **kwargs: Additional map_batches kwargs (batch_format, concurrency).
+        """
+        # Merge num_gpus into worker_task_options; dedicated field takes precedence
+        opts: Dict[str, Any] = dict(worker_task_options or {})
+        if num_gpus:
+            opts["num_gpus"] = num_gpus
+
+        # Keys accepted by Ray Data's map_batches for per-worker scheduling
+        _MAP_BATCHES_RESOURCE_KEYS = {
+            "num_gpus",
+            "num_cpus",
+            "accelerator_type",
+            "resources",
+        }
+
+        # Data workers get the compute-scheduling subset only
+        map_resource_kwargs = {
+            k: v for k, v in opts.items() if k in _MAP_BATCHES_RESOURCE_KEYS
+        }
+
+        # Orchestration task gets the remainder (non-compute keys only) so it
+        # never holds GPU/CPU slots it doesn't use
+        orchestration_opts = {
+            k: v for k, v in opts.items() if k not in _MAP_BATCHES_RESOURCE_KEYS
+        }
 
         @ray.remote
-        def _remote_map_batches(dataset, function, batch_kwargs):
-            return dataset.map_batches(function, **batch_kwargs)
+        def _remote_map_batches(dataset, function, batch_kwargs, resource_kwargs):
+            return dataset.map_batches(function, **batch_kwargs, **resource_kwargs)
 
-        new_ref = _remote_map_batches.remote(self._dataset_ref, func, kwargs)
+        remote_fn = (
+            _remote_map_batches.options(**orchestration_opts)
+            if orchestration_opts
+            else _remote_map_batches
+        )
+        new_ref = remote_fn.remote(self._dataset_ref, func, kwargs, map_resource_kwargs)
         return RemoteDatasetProxy(new_ref)
 
     def filter(self, fn) -> "RemoteDatasetProxy":

--- a/sdk/python/tests/component/ray/test_resource_scheduling.py
+++ b/sdk/python/tests/component/ray/test_resource_scheduling.py
@@ -1,0 +1,621 @@
+"""
+Tests for GPU and worker resource scheduling support in the Ray compute engine
+and offline store.
+
+Covers:
+- RayComputeEngineConfig / RayOfflineStoreConfig: worker_task_options + num_gpus fields
+- CodeFlareRayWrapper._get_task_options(): merge logic, num_gpus precedence
+- RemoteDatasetProxy.map_batches: .options() applied, map_batches key filtering
+- RayTransformationNode: worker_task_options threaded through map_batches
+- RayResourceManager: GPU count read from cluster resources
+- safe_batch_processor / _is_empty_batch: format-aware empty detection (regression
+  for AttributeError when gpu_batch_format is "numpy" or "pyarrow")
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pytest
+import ray
+
+from feast.infra.compute_engines.dag.model import DAGFormat
+from feast.infra.compute_engines.dag.node import DAGNode
+from feast.infra.compute_engines.dag.value import DAGValue
+from feast.infra.compute_engines.ray.config import RayComputeEngineConfig
+from feast.infra.compute_engines.ray.nodes import RayTransformationNode
+from feast.infra.compute_engines.ray.utils import _is_empty_batch, safe_batch_processor
+from feast.infra.offline_stores.contrib.ray_offline_store.ray import (
+    RayOfflineStoreConfig,
+    RayResourceManager,
+)
+from feast.infra.ray_initializer import CodeFlareRayWrapper
+from feast.infra.ray_shared_utils import RemoteDatasetProxy
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class DummyInputNode(DAGNode):
+    def __init__(self, name, output):
+        super().__init__(name)
+        self._output = output
+
+    def execute(self, context):
+        return self._output
+
+
+@pytest.fixture(scope="module")
+def ray_session():
+    if not ray.is_initialized():
+        ray.init(num_cpus=2, ignore_reinit_error=True, include_dashboard=False)
+    yield ray
+    ray.shutdown()
+
+
+@pytest.fixture
+def sample_df():
+    return pd.DataFrame(
+        {
+            "driver_id": [1, 2, 3],
+            "conv_rate": [0.8, 0.7, 0.6],
+            "event_timestamp": [datetime.now() - timedelta(hours=i) for i in range(3)],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Config field tests
+# ---------------------------------------------------------------------------
+
+
+class TestRayComputeEngineConfigTaskOptions:
+    def test_defaults(self):
+        config = RayComputeEngineConfig()
+        assert config.num_gpus is None
+        assert config.gpu_batch_format == "pandas"
+        assert config.worker_task_options is None
+
+    def test_num_gpus_set(self):
+        config = RayComputeEngineConfig(num_gpus=1)
+        assert config.num_gpus == 1
+
+    def test_fractional_num_gpus(self):
+        config = RayComputeEngineConfig(num_gpus=0.5)
+        assert config.num_gpus == 0.5
+
+    def test_gpu_batch_format(self):
+        config = RayComputeEngineConfig(num_gpus=1, gpu_batch_format="numpy")
+        assert config.gpu_batch_format == "numpy"
+
+    def test_worker_task_options_roundtrip(self):
+        opts = {
+            "num_cpus": 4,
+            "memory": 8 * 1024**3,
+            "accelerator_type": "A100",
+            "max_retries": 5,
+        }
+        config = RayComputeEngineConfig(worker_task_options=opts)
+        assert config.worker_task_options["accelerator_type"] == "A100"
+        assert config.worker_task_options["num_cpus"] == 4
+        assert config.worker_task_options["max_retries"] == 5
+
+    def test_worker_task_options_with_runtime_env(self):
+        config = RayComputeEngineConfig(
+            worker_task_options={
+                "runtime_env": {
+                    "pip": ["cudf-cu12==24.10.0"],
+                    "env_vars": {"CUDA_VISIBLE_DEVICES": "0"},
+                }
+            }
+        )
+        assert config.worker_task_options["runtime_env"]["pip"] == [
+            "cudf-cu12==24.10.0"
+        ]
+
+
+class TestRayOfflineStoreConfigTaskOptions:
+    def test_defaults(self):
+        config = RayOfflineStoreConfig()
+        assert config.num_gpus is None
+        assert config.gpu_batch_format == "pandas"
+        assert config.worker_task_options is None
+
+    def test_worker_task_options_roundtrip(self):
+        config = RayOfflineStoreConfig(
+            worker_task_options={"num_cpus": 2, "accelerator_type": "T4"}
+        )
+        assert config.worker_task_options["num_cpus"] == 2
+        assert config.worker_task_options["accelerator_type"] == "T4"
+
+
+# ---------------------------------------------------------------------------
+# CodeFlareRayWrapper._get_task_options() tests
+# ---------------------------------------------------------------------------
+
+
+class TestCodeFlareRayWrapperGetTaskOptions:
+    """Unit tests for _get_task_options() merge logic — no cluster connection needed."""
+
+    def _make_wrapper(self, num_gpus=0, worker_task_options=None):
+        """Construct a wrapper instance without triggering __init__ side-effects."""
+        wrapper = CodeFlareRayWrapper.__new__(CodeFlareRayWrapper)
+        wrapper.num_gpus = num_gpus
+        wrapper.worker_task_options = worker_task_options or {}
+        return wrapper
+
+    def test_empty_when_no_resources(self):
+        wrapper = self._make_wrapper()
+        assert wrapper._get_task_options() == {}
+
+    def test_io_tasks_exclude_num_gpus_by_default(self):
+        """include_gpu defaults to False so I/O methods never consume GPU slots."""
+        wrapper = self._make_wrapper(num_gpus=1)
+        opts = wrapper._get_task_options()  # default: include_gpu=False
+        assert "num_gpus" not in opts
+
+    def test_io_tasks_strip_num_gpus_from_worker_task_options(self):
+        """
+        Regression: num_gpus set inside worker_task_options must also be stripped
+        for I/O tasks. Previously _get_task_options only blocked the first-class
+        num_gpus field; a num_gpus key already present in the copied
+        worker_task_options dict would leak through to .options() on I/O tasks.
+        """
+        wrapper = self._make_wrapper(
+            num_gpus=0,  # first-class field not set
+            worker_task_options={"num_gpus": 1, "num_cpus": 4},
+        )
+        opts = wrapper._get_task_options()  # default: include_gpu=False
+        assert "num_gpus" not in opts
+        assert opts.get("num_cpus") == 4  # other keys unaffected
+
+    def test_num_gpus_added_when_include_gpu_true(self):
+        """include_gpu=True is used for compute tasks that actually need GPUs."""
+        wrapper = self._make_wrapper(num_gpus=1)
+        assert wrapper._get_task_options(include_gpu=True) == {"num_gpus": 1}
+
+    def test_worker_task_options_passthrough(self):
+        wrapper = self._make_wrapper(
+            worker_task_options={"num_cpus": 4, "accelerator_type": "A100"}
+        )
+        opts = wrapper._get_task_options()
+        assert opts["num_cpus"] == 4
+        assert opts["accelerator_type"] == "A100"
+
+    def test_num_gpus_takes_precedence_over_worker_task_options(self):
+        """First-class num_gpus must override worker_task_options['num_gpus']."""
+        wrapper = self._make_wrapper(num_gpus=2, worker_task_options={"num_gpus": 1})
+        opts = wrapper._get_task_options(include_gpu=True)
+        assert opts["num_gpus"] == 2
+
+    def test_combined_num_gpus_and_worker_task_options(self):
+        wrapper = self._make_wrapper(
+            num_gpus=1,
+            worker_task_options={
+                "num_cpus": 4,
+                "memory": 8 * 1024**3,
+                "max_retries": 5,
+            },
+        )
+        opts = wrapper._get_task_options(include_gpu=True)
+        assert opts["num_gpus"] == 1
+        assert opts["num_cpus"] == 4
+        assert opts["memory"] == 8 * 1024**3
+        assert opts["max_retries"] == 5
+
+    def test_zero_num_gpus_not_added(self):
+        """num_gpus=0 (falsy) must not be added to options."""
+        wrapper = self._make_wrapper(num_gpus=0, worker_task_options={"num_cpus": 2})
+        opts = wrapper._get_task_options(include_gpu=True)
+        assert "num_gpus" not in opts
+        assert opts["num_cpus"] == 2
+
+
+# ---------------------------------------------------------------------------
+# RemoteDatasetProxy.map_batches resource key filtering
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteDatasetProxyMapBatches:
+    """
+    Verifies that map_batches applies .options() correctly and only forwards
+    the scheduling-relevant subset of keys into the Ray Data map_batches call.
+    """
+
+    def test_no_options_when_empty(self, ray_session, sample_df):
+        dataset = ray.data.from_pandas(sample_df)
+        proxy = RemoteDatasetProxy(ray.put(dataset))
+
+        with patch.object(
+            ray.remote(lambda d, f, b, r: d.map_batches(f, **b, **r)),
+            "options",
+            wraps=lambda **kw: None,
+        ):
+            result = proxy.map_batches(lambda b: b, batch_format="pandas")
+        assert isinstance(result, RemoteDatasetProxy)
+
+    def test_map_batches_resource_keys_filtered(self):
+        """
+        The filtering set inside map_batches must pass only scheduling-relevant
+        keys (num_gpus, num_cpus, accelerator_type, resources) to Ray Data's
+        map_batches, and strip non-scheduling keys (max_retries, runtime_env,
+        memory, scheduling_strategy).
+        """
+        _MAP_BATCHES_RESOURCE_KEYS = {
+            "num_gpus",
+            "num_cpus",
+            "accelerator_type",
+            "resources",
+        }
+
+        all_task_options = {
+            "num_gpus": 1,
+            "num_cpus": 4,
+            "accelerator_type": "A100",
+            "resources": {"custom": 1},
+            "max_retries": 5,
+            "runtime_env": {"pip": ["cudf"]},
+            "memory": 8 * 1024**3,
+            "scheduling_strategy": "SPREAD",
+        }
+
+        map_resource_kwargs = {
+            k: v for k, v in all_task_options.items() if k in _MAP_BATCHES_RESOURCE_KEYS
+        }
+
+        # Should-be-present keys
+        assert "num_gpus" in map_resource_kwargs
+        assert "num_cpus" in map_resource_kwargs
+        assert "accelerator_type" in map_resource_kwargs
+        assert "resources" in map_resource_kwargs
+
+        # Should-be-absent keys
+        assert "max_retries" not in map_resource_kwargs
+        assert "runtime_env" not in map_resource_kwargs
+        assert "memory" not in map_resource_kwargs
+        assert "scheduling_strategy" not in map_resource_kwargs
+
+    def test_orchestration_task_excludes_compute_keys(self):
+        """
+        The @ray.remote orchestration wrapper must never hold compute-scheduling
+        resources (num_gpus, num_cpus, accelerator_type, resources). Only
+        non-scheduling keys (runtime_env, max_retries, memory, etc.) should
+        reach the orchestration task via .options(), avoiding the deadlock
+        where the orchestrator holds a GPU slot while waiting for data workers
+        that also need GPUs.
+        """
+        _MAP_BATCHES_RESOURCE_KEYS = {
+            "num_gpus",
+            "num_cpus",
+            "accelerator_type",
+            "resources",
+        }
+
+        all_opts = {
+            "num_gpus": 1,
+            "num_cpus": 4,
+            "accelerator_type": "A100",
+            "resources": {"custom": 1},
+            "max_retries": 5,
+            "runtime_env": {"pip": ["cudf"]},
+            "memory": 8 * 1024**3,
+            "scheduling_strategy": "SPREAD",
+        }
+
+        orchestration_opts = {
+            k: v for k, v in all_opts.items() if k not in _MAP_BATCHES_RESOURCE_KEYS
+        }
+
+        # Compute-scheduling keys must be absent from the orchestration task
+        assert "num_gpus" not in orchestration_opts
+        assert "num_cpus" not in orchestration_opts
+        assert "accelerator_type" not in orchestration_opts
+        assert "resources" not in orchestration_opts
+
+        # Non-scheduling keys must be present (orchestration task can use them)
+        assert orchestration_opts["max_retries"] == 5
+        assert orchestration_opts["runtime_env"] == {"pip": ["cudf"]}
+        assert orchestration_opts["memory"] == 8 * 1024**3
+        assert orchestration_opts["scheduling_strategy"] == "SPREAD"
+
+
+# ---------------------------------------------------------------------------
+# RayTransformationNode — task_options and num_gpus threaded through
+# ---------------------------------------------------------------------------
+
+
+class TestRayTransformationNodeResourceScheduling:
+    @pytest.fixture
+    def mock_context(self):
+        class DummyOfflineStore:
+            def offline_write_batch(self, *args, **kwargs):
+                pass
+
+        class Ctx:
+            registry = None
+            store = None
+            project = "test_project"
+            entity_data = None
+            config = None
+            node_outputs = {}
+            offline_store = DummyOfflineStore()
+
+        return Ctx()
+
+    def test_transformation_with_worker_task_options_executes(
+        self, ray_session, mock_context, sample_df
+    ):
+        """Node with worker_task_options runs end-to-end and produces correct output."""
+        config = RayComputeEngineConfig(
+            max_workers=2,
+            worker_task_options={"num_cpus": 1},
+        )
+        dataset = ray.data.from_pandas(sample_df)
+        input_value = DAGValue(data=dataset, format=DAGFormat.RAY)
+        input_node = DummyInputNode("inp", input_value)
+
+        def double_conv(df: pd.DataFrame) -> pd.DataFrame:
+            df["conv_rate"] = df["conv_rate"] * 2
+            return df
+
+        node = RayTransformationNode(
+            name="t", transformation=double_conv, config=config
+        )
+        node.add_input(input_node)
+        mock_context.node_outputs = {"inp": input_value}
+
+        result = node.execute(mock_context)
+        result_df = result.data.to_pandas()
+        assert len(result_df) == 3
+        assert (
+            abs(result_df["conv_rate"].iloc[0] - sample_df["conv_rate"].iloc[0] * 2)
+            < 1e-6
+        )
+
+    def test_transformation_gpu_batch_format_applied(
+        self, ray_session, mock_context, sample_df
+    ):
+        """
+        When num_gpus is set, gpu_batch_format is passed as batch_format and
+        num_gpus is included in the map_batches kwargs.
+
+        The UDF receives a numpy dict (Dict[str, np.ndarray]) when
+        batch_format="numpy". safe_batch_processor must handle this without
+        raising AttributeError on .empty — this test is the regression guard.
+        """
+        config = RayComputeEngineConfig(
+            max_workers=2,
+            num_gpus=1,
+            gpu_batch_format="numpy",
+        )
+        dataset = ray.data.from_pandas(sample_df)
+        input_value = DAGValue(data=dataset, format=DAGFormat.RAY)
+        input_node = DummyInputNode("inp", input_value)
+
+        # UDF receives Dict[str, np.ndarray] when batch_format="numpy"
+        def numpy_identity(batch):
+            return batch
+
+        node = RayTransformationNode(
+            name="t", transformation=numpy_identity, config=config
+        )
+        node.add_input(input_node)
+        mock_context.node_outputs = {"inp": input_value}
+
+        captured_kwargs = {}
+        original_map_batches = ray.data.Dataset.map_batches
+
+        def capturing_map_batches(self_ds, fn, **kwargs):
+            captured_kwargs.update(kwargs)
+            # Strip GPU-scheduling keys so local Ray (no GPU nodes, no batch_size
+            # requirement) can execute without raising ValueError. The correctness
+            # of safe_batch_processor on numpy dicts is covered by
+            # TestSafeBatchProcessorFormats — this test verifies config flow only.
+            safe_kwargs = {k: v for k, v in kwargs.items() if k not in ("num_gpus",)}
+            safe_kwargs.setdefault("batch_format", "pandas")
+            return original_map_batches(self_ds, fn, **safe_kwargs)
+
+        with patch.object(ray.data.Dataset, "map_batches", capturing_map_batches):
+            node.execute(mock_context)
+
+        assert captured_kwargs.get("batch_format") == "numpy"
+        assert captured_kwargs.get("num_gpus") == 1
+
+    def test_transformation_no_resource_keys_when_no_options(
+        self, ray_session, mock_context, sample_df
+    ):
+        """With no GPU/worker_task_options, map_batches only gets batch_format + concurrency."""
+        config = RayComputeEngineConfig(max_workers=2)
+        dataset = ray.data.from_pandas(sample_df)
+        input_value = DAGValue(data=dataset, format=DAGFormat.RAY)
+        input_node = DummyInputNode("inp", input_value)
+        node = RayTransformationNode(
+            name="t", transformation=lambda df: df, config=config
+        )
+        node.add_input(input_node)
+        mock_context.node_outputs = {"inp": input_value}
+
+        captured_kwargs = {}
+        original_map_batches = ray.data.Dataset.map_batches
+
+        def spy(self_ds, fn, **kwargs):
+            captured_kwargs.update(kwargs)
+            return original_map_batches(self_ds, fn, **kwargs)
+
+        with patch.object(ray.data.Dataset, "map_batches", spy):
+            node.execute(mock_context)
+
+        assert "num_gpus" not in captured_kwargs
+        assert "num_cpus" not in captured_kwargs
+        assert "accelerator_type" not in captured_kwargs
+        assert captured_kwargs.get("batch_format") == "pandas"
+
+
+# ---------------------------------------------------------------------------
+# RayResourceManager — GPU count from cluster resources
+# ---------------------------------------------------------------------------
+
+
+class TestRayResourceManagerGPU:
+    def test_reads_gpu_from_cluster_resources(self):
+        with (
+            patch("ray.is_initialized", return_value=True),
+            patch(
+                "ray.cluster_resources",
+                return_value={"CPU": 8, "GPU": 4, "memory": 32 * 1024**3},
+            ),
+            patch("ray.nodes", return_value=[{}, {}, {}, {}]),
+        ):
+            mgr = RayResourceManager()
+            assert mgr.available_gpus == 4
+            assert mgr.available_cpus == 8
+            assert mgr.num_nodes == 4
+
+    def test_available_gpus_zero_when_no_gpus(self):
+        with (
+            patch("ray.is_initialized", return_value=True),
+            patch(
+                "ray.cluster_resources",
+                return_value={"CPU": 4, "memory": 8 * 1024**3},
+            ),
+            patch("ray.nodes", return_value=[{}]),
+        ):
+            mgr = RayResourceManager()
+            assert mgr.available_gpus == 0
+
+    def test_available_gpus_zero_when_ray_not_initialized(self):
+        with patch("ray.is_initialized", return_value=False):
+            mgr = RayResourceManager()
+            assert mgr.available_gpus == 0
+
+
+# ---------------------------------------------------------------------------
+# safe_batch_processor / _is_empty_batch — format-aware empty detection
+# Regression tests for AttributeError when gpu_batch_format is "numpy"/"pyarrow"
+# ---------------------------------------------------------------------------
+
+
+class TestIsEmptyBatch:
+    """Unit tests for _is_empty_batch() across all Ray Data batch formats."""
+
+    def test_pandas_non_empty(self, sample_df):
+        assert _is_empty_batch(sample_df) is False
+
+    def test_pandas_empty(self):
+        assert _is_empty_batch(pd.DataFrame()) is True
+
+    def test_numpy_non_empty(self):
+        batch = {"col_a": np.array([1, 2, 3]), "col_b": np.array([4, 5, 6])}
+        assert _is_empty_batch(batch) is False
+
+    def test_numpy_empty_arrays(self):
+        batch = {"col_a": np.array([]), "col_b": np.array([])}
+        assert _is_empty_batch(batch) is True
+
+    def test_numpy_empty_dict(self):
+        assert _is_empty_batch({}) is True
+
+    def test_pyarrow_non_empty(self, sample_df):
+        table = pa.Table.from_pandas(sample_df)
+        assert _is_empty_batch(table) is False
+
+    def test_pyarrow_empty(self):
+        table = pa.table({"col_a": pa.array([], type=pa.int64())})
+        assert _is_empty_batch(table) is True
+
+
+class TestSafeBatchProcessorFormats:
+    """
+    Regression tests: safe_batch_processor must not raise AttributeError
+    when receiving non-pandas batches (numpy dict or pyarrow Table).
+    """
+
+    def test_pandas_batch_passes_through(self, sample_df):
+        @safe_batch_processor
+        def double_conv(batch: pd.DataFrame) -> pd.DataFrame:
+            batch = batch.copy()
+            batch["conv_rate"] = batch["conv_rate"] * 2
+            return batch
+
+        result = double_conv(sample_df)
+        assert isinstance(result, pd.DataFrame)
+        assert result["conv_rate"].iloc[0] == pytest.approx(
+            sample_df["conv_rate"].iloc[0] * 2
+        )
+
+    def test_pandas_empty_batch_returned_early(self):
+        called = []
+
+        @safe_batch_processor
+        def should_not_run(batch):
+            called.append(True)
+            return batch
+
+        result = should_not_run(pd.DataFrame())
+        assert called == []
+        assert isinstance(result, pd.DataFrame)
+
+    def test_numpy_batch_no_attribute_error(self):
+        """Regression: was raising AttributeError on batch.empty."""
+
+        @safe_batch_processor
+        def numpy_passthrough(batch):
+            return batch
+
+        batch = {
+            "driver_id": np.array([1, 2, 3]),
+            "conv_rate": np.array([0.8, 0.7, 0.6]),
+        }
+        # Must not raise AttributeError
+        result = numpy_passthrough(batch)
+        assert result is batch
+
+    def test_numpy_empty_batch_returned_early(self):
+        called = []
+
+        @safe_batch_processor
+        def should_not_run(batch):
+            called.append(True)
+            return batch
+
+        empty_batch = {"col": np.array([])}
+        result = should_not_run(empty_batch)
+        assert called == []
+        assert result is empty_batch
+
+    def test_pyarrow_batch_no_attribute_error(self, sample_df):
+        """Regression: was raising AttributeError on batch.empty."""
+
+        @safe_batch_processor
+        def pyarrow_passthrough(batch):
+            return batch
+
+        table = pa.Table.from_pandas(sample_df)
+        result = pyarrow_passthrough(table)
+        assert result is table
+
+    def test_pyarrow_empty_batch_returned_early(self):
+        called = []
+
+        @safe_batch_processor
+        def should_not_run(batch):
+            called.append(True)
+            return batch
+
+        empty_table = pa.table({"col": pa.array([], type=pa.int64())})
+        result = should_not_run(empty_table)
+        assert called == []
+        assert result is empty_table
+
+    def test_exception_in_func_returns_original_batch(self):
+        @safe_batch_processor
+        def always_raises(batch):
+            raise ValueError("simulated error")
+
+        df = pd.DataFrame({"x": [1, 2]})
+        result = always_raises(df)
+        # Should return the original batch, not propagate
+        assert result is df


### PR DESCRIPTION
# What this PR does / why we need it:

This PR adds first-class GPU support and a general `worker_task_options` escape
hatch for any Ray `.options()` scheduling parameter, wired consistently
through all execution modes (local, remote, KubeRay).

## Example config
```yaml
batch_engine:
    type: ray.engine
    num_gpus: 1
    gpu_batch_format: numpy
    worker_task_options:
        num_cpus: 4
        memory: 8589934592        # 8 GB
        accelerator_type: "A100"  # pin to A100 on mixed GPU pools (KubeRay)
        max_retries: 5
        runtime_env:
            pip: ["cudf-cu12==24.10.0"]
            env_vars: {CUDA_VISIBLE_DEVICES: "0"}
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
