### PR TITLE
fix: Handle array of strings columns in Athena materialization

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -739,7 +739,7 @@ def _validate_collection_item_types(
     """
     if sample is None:
         return
-    if all(type(item) in valid_types for item in sample):
+    if all(type(item) in valid_types for item in sample if item is not None):
         return
 
     # to_numpy() upcasts INT32/INT64 with NULL to Float64 automatically
@@ -750,6 +750,8 @@ def _validate_collection_item_types(
         ValueType.INT64_SET,
     ]
     for item in sample:
+        if item is None:
+            continue  # None elements in STRING_LIST are replaced with ""; for other types they are dropped
         if type(item) not in valid_types:
             if feast_value_type in int_collection_types:
                 # Check if the float values are due to NULL upcast
@@ -868,6 +870,46 @@ def _python_set_to_proto_values(
     ]
 
 
+# Sentinel value used by _to_proto_safe_list to indicate that None elements
+# should simply be filtered (dropped) rather than replaced with a default.
+_DROP_NONE = object()
+
+# Per-type default values substituted for None elements inside list columns.
+# Only STRING_LIST uses ""; numeric/bytes types drop None entirely because
+# there is no meaningful in-band sentinel (protobuf rejects wrong scalar types).
+_LIST_TYPE_NONE_REPLACEMENT: Dict[ValueType, Any] = {
+    ValueType.STRING_LIST: "",
+}
+
+
+def _to_proto_safe_list(
+    value: Any, feast_value_type: ValueType = ValueType.STRING_LIST
+) -> Any:
+    """Convert an array/list column value to a proto-safe Python list.
+
+    Arrow/Athena returns Array columns as numpy.ndarray (object dtype).
+    Protobuf repeated fields reject ndarrays and (for non-string types) None
+    elements, so we:
+    1. Call .tolist() to convert any numpy.ndarray to a plain Python list.
+    2. For STRING_LIST: replace None elements with "" (empty string).
+       For all other list types: drop None elements, since there is no valid
+       in-band default for numeric/bytes protobuf fields.
+
+    Args:
+        value: The raw column value (ndarray, list, or scalar).
+        feast_value_type: The Feast ValueType of the list column. Controls how
+            None elements are handled. Defaults to STRING_LIST.
+    """
+    if isinstance(value, np.ndarray):
+        value = value.tolist()
+    if isinstance(value, list):
+        none_replacement = _LIST_TYPE_NONE_REPLACEMENT.get(feast_value_type, _DROP_NONE)
+        if none_replacement is _DROP_NONE:
+            return [x for x in value if x is not None]
+        return [x if x is not None else none_replacement for x in value]
+    return value
+
+
 def _convert_list_values_to_proto(
     feast_value_type: ValueType,
     values: List[Any],
@@ -946,8 +988,14 @@ def _convert_list_values_to_proto(
         ]
 
     # Generic list conversion
+    # Arrow/Athena deserializes Array columns as numpy.ndarray (object dtype).
+    # _to_proto_safe_list converts to a plain Python list and sanitizes None
+    # elements in a type-appropriate way (replaced with "" for STRING_LIST,
+    # dropped for numeric/bytes types).
     return [
-        ProtoValue(**{field_name: proto_type(val=value)})  # type: ignore[arg-type]
+        ProtoValue(
+            **{field_name: proto_type(val=_to_proto_safe_list(value, feast_value_type))}  # type: ignore[arg-type]
+        )
         if value is not None
         else ProtoValue()
         for value in values

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -897,8 +897,6 @@ def _sanitize_list_value(value: Any, feast_value_type: ValueType) -> Any:
     """
     if isinstance(value, np.ndarray):
         value = value.tolist()
-        if isinstance(value, list) and len(value) == 0:
-            return None
     none_default = _LIST_NONE_DEFAULTS.get(feast_value_type)
     if none_default is not None and isinstance(value, list):
         value = [none_default if v is None else v for v in value]

--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -870,43 +870,38 @@ def _python_set_to_proto_values(
     ]
 
 
-# Sentinel value used by _to_proto_safe_list to indicate that None elements
-# should simply be filtered (dropped) rather than replaced with a default.
-_DROP_NONE = object()
-
 # Per-type default values substituted for None elements inside list columns.
-# Only STRING_LIST uses ""; numeric/bytes types drop None entirely because
-# there is no meaningful in-band sentinel (protobuf rejects wrong scalar types).
-_LIST_TYPE_NONE_REPLACEMENT: Dict[ValueType, Any] = {
+# Protobuf repeated fields do not accept None, so we replace with a
+# type-appropriate zero/empty value.
+_LIST_NONE_DEFAULTS: Dict[ValueType, Any] = {
     ValueType.STRING_LIST: "",
+    ValueType.BYTES_LIST: b"",
+    ValueType.INT32_LIST: 0,
+    ValueType.INT64_LIST: 0,
+    ValueType.FLOAT_LIST: 0.0,
+    ValueType.DOUBLE_LIST: 0.0,
+    ValueType.BOOL_LIST: False,
+    ValueType.UNIX_TIMESTAMP_LIST: NULL_TIMESTAMP_INT_VALUE,
+    ValueType.UUID_LIST: "",
+    ValueType.TIME_UUID_LIST: "",
+    ValueType.DECIMAL_LIST: "",
 }
 
 
-def _to_proto_safe_list(
-    value: Any, feast_value_type: ValueType = ValueType.STRING_LIST
-) -> Any:
-    """Convert an array/list column value to a proto-safe Python list.
+def _sanitize_list_value(value: Any, feast_value_type: ValueType) -> Any:
+    """Convert ndarray to list and replace None elements with a type-appropriate default.
 
-    Arrow/Athena returns Array columns as numpy.ndarray (object dtype).
-    Protobuf repeated fields reject ndarrays and (for non-string types) None
-    elements, so we:
-    1. Call .tolist() to convert any numpy.ndarray to a plain Python list.
-    2. For STRING_LIST: replace None elements with "" (empty string).
-       For all other list types: drop None elements, since there is no valid
-       in-band default for numeric/bytes protobuf fields.
-
-    Args:
-        value: The raw column value (ndarray, list, or scalar).
-        feast_value_type: The Feast ValueType of the list column. Controls how
-            None elements are handled. Defaults to STRING_LIST.
+    Arrow/Athena may deserialize array columns as numpy.ndarray with object dtype
+    instead of plain Python lists.  Protobuf repeated fields do not accept ndarrays
+    or None elements, so we normalise here before building proto messages.
     """
     if isinstance(value, np.ndarray):
         value = value.tolist()
-    if isinstance(value, list):
-        none_replacement = _LIST_TYPE_NONE_REPLACEMENT.get(feast_value_type, _DROP_NONE)
-        if none_replacement is _DROP_NONE:
-            return [x for x in value if x is not None]
-        return [x if x is not None else none_replacement for x in value]
+        if isinstance(value, list) and len(value) == 0:
+            return None
+    none_default = _LIST_NONE_DEFAULTS.get(feast_value_type)
+    if none_default is not None and isinstance(value, list):
+        value = [none_default if v is None else v for v in value]
     return value
 
 
@@ -931,6 +926,13 @@ def _convert_list_values_to_proto(
     proto_type, field_name, valid_types = PYTHON_LIST_VALUE_TYPE_TO_PROTO_VALUE[
         feast_value_type
     ]
+
+    values = [
+        _sanitize_list_value(v, feast_value_type) if v is not None else v
+        for v in values
+    ]
+    if sample is not None:
+        sample = _sanitize_list_value(sample, feast_value_type)
 
     # Bytes to array type conversion
     if isinstance(sample, (bytes, bytearray)):
@@ -988,14 +990,8 @@ def _convert_list_values_to_proto(
         ]
 
     # Generic list conversion
-    # Arrow/Athena deserializes Array columns as numpy.ndarray (object dtype).
-    # _to_proto_safe_list converts to a plain Python list and sanitizes None
-    # elements in a type-appropriate way (replaced with "" for STRING_LIST,
-    # dropped for numeric/bytes types).
     return [
-        ProtoValue(
-            **{field_name: proto_type(val=_to_proto_safe_list(value, feast_value_type))}  # type: ignore[arg-type]
-        )
+        ProtoValue(**{field_name: proto_type(val=value)})  # type: ignore[arg-type]
         if value is not None
         else ProtoValue()
         for value in values

--- a/sdk/python/tests/integration/offline_store/test_offline_write.py
+++ b/sdk/python/tests/integration/offline_store/test_offline_write.py
@@ -135,6 +135,8 @@ def test_writing_consecutively_to_offline_store(environment, universal_data_sour
     )
 
     store.apply([driver_entity, driver_stats])
+    # Refresh registry after apply to ensure subsequent reads see the new feature view
+    store.refresh_registry()
     df = store.get_historical_features(
         entity_df=entity_df,
         features=[

--- a/sdk/python/tests/unit/test_type_map.py
+++ b/sdk/python/tests/unit/test_type_map.py
@@ -87,6 +87,9 @@ def test_python_values_to_proto_values_bool(values):
         (np.array([None]), ValueType.BYTES_LIST, None),
         (np.array([None]), ValueType.STRING_LIST, None),
         (np.array([None]), ValueType.UNIX_TIMESTAMP_LIST, None),
+        ([np.array([], dtype=np.int32)], ValueType.INT32_LIST, []),
+        ([np.array([], dtype=np.float32)], ValueType.FLOAT_LIST, []),
+        ([np.array([], dtype=np.bool_)], ValueType.BOOL_LIST, []),
         ([b"[1,2,3]"], ValueType.INT64_LIST, [1, 2, 3]),
         ([b"[1,2,3]"], ValueType.INT32_LIST, [1, 2, 3]),
         ([b"[1.5,2.5,3.5]"], ValueType.FLOAT_LIST, [1.5, 2.5, 3.5]),
@@ -2094,12 +2097,12 @@ class TestArrowArrayStringListMaterialization:
         assert isinstance(result, list)
 
     def test_sanitize_list_value_empty_ndarray(self):
-        """Empty ndarray is converted to None (treated as a missing row)."""
+        """Empty ndarray is converted to an empty Python list."""
         from feast.type_map import _sanitize_list_value
 
         arr = np.array([], dtype=object)
         result = _sanitize_list_value(arr, ValueType.STRING_LIST)
-        assert result is None
+        assert result == []
 
     def test_sanitize_list_value_ndarray_with_none(self):
         """None elements inside a STRING_LIST ndarray are replaced with empty string."""

--- a/sdk/python/tests/unit/test_type_map.py
+++ b/sdk/python/tests/unit/test_type_map.py
@@ -2079,77 +2079,87 @@ class TestArrowArrayStringListMaterialization:
     2. TypeError: "bad argument type for built-in operation"
        — when proto_type(val=<ndarray>) was called; protobuf rejects ndarrays.
 
-    Both are fixed by _to_proto_safe_list, which converts ndarrays to plain Python
-    lists and sanitizes None elements in a type-appropriate way:
-    - STRING_LIST: None → "" (empty string)
-    - All other list types: None elements are dropped (filtered out)
+    Both are fixed by _sanitize_list_value, which converts ndarrays to plain Python
+    lists and replaces None elements with a type-appropriate zero/empty default
+    (see _LIST_NONE_DEFAULTS).
     """
 
-    def test_to_proto_safe_list_ndarray(self):
+    def test_sanitize_list_value_ndarray(self):
         """ndarray is converted to a plain Python list."""
-        from feast.type_map import _to_proto_safe_list
+        from feast.type_map import _sanitize_list_value
 
         arr = np.array(["foo", "bar"], dtype=object)
-        result = _to_proto_safe_list(arr)
+        result = _sanitize_list_value(arr, ValueType.STRING_LIST)
         assert result == ["foo", "bar"]
         assert isinstance(result, list)
 
-    def test_to_proto_safe_list_empty_ndarray(self):
-        """Empty ndarray is converted to an empty list."""
-        from feast.type_map import _to_proto_safe_list
+    def test_sanitize_list_value_empty_ndarray(self):
+        """Empty ndarray is converted to None (treated as a missing row)."""
+        from feast.type_map import _sanitize_list_value
 
         arr = np.array([], dtype=object)
-        result = _to_proto_safe_list(arr)
-        assert result == []
-        assert isinstance(result, list)
+        result = _sanitize_list_value(arr, ValueType.STRING_LIST)
+        assert result is None
 
-    def test_to_proto_safe_list_ndarray_with_none(self):
+    def test_sanitize_list_value_ndarray_with_none(self):
         """None elements inside a STRING_LIST ndarray are replaced with empty string."""
-        from feast.type_map import _to_proto_safe_list
+        from feast.type_map import _sanitize_list_value
 
         arr = np.array(["foo", None, "baz"], dtype=object)
-        result = _to_proto_safe_list(arr, ValueType.STRING_LIST)
+        result = _sanitize_list_value(arr, ValueType.STRING_LIST)
         assert result == ["foo", "", "baz"]
 
-    def test_to_proto_safe_list_plain_list(self):
-        """Plain Python lists pass through unchanged (no None replacement needed)."""
-        from feast.type_map import _to_proto_safe_list
+    def test_sanitize_list_value_plain_list(self):
+        """Plain Python lists without None pass through unchanged."""
+        from feast.type_map import _sanitize_list_value
 
         lst = ["foo", "bar"]
-        result = _to_proto_safe_list(lst)
+        result = _sanitize_list_value(lst, ValueType.STRING_LIST)
         assert result == ["foo", "bar"]
 
-    def test_to_proto_safe_list_plain_list_with_none(self):
+    def test_sanitize_list_value_plain_list_with_none(self):
         """None elements in a STRING_LIST plain list are replaced with empty string."""
-        from feast.type_map import _to_proto_safe_list
+        from feast.type_map import _sanitize_list_value
 
         lst = ["foo", None]
-        result = _to_proto_safe_list(lst, ValueType.STRING_LIST)
+        result = _sanitize_list_value(lst, ValueType.STRING_LIST)
         assert result == ["foo", ""]
 
-    def test_to_proto_safe_list_numeric_list_none_dropped(self):
-        """None elements in non-string lists are dropped, not replaced with a sentinel."""
-        from feast.type_map import _to_proto_safe_list
+    def test_sanitize_list_value_numeric_none_replaced(self):
+        """None elements in numeric lists are replaced with a type-appropriate default."""
+        from feast.type_map import _sanitize_list_value
 
-        for vt in (
-            ValueType.FLOAT_LIST,
-            ValueType.DOUBLE_LIST,
-            ValueType.INT32_LIST,
-            ValueType.INT64_LIST,
-            ValueType.BYTES_LIST,
-        ):
-            result = _to_proto_safe_list([1.0, None, 2.0], vt)
-            assert result == [1.0, 2.0], (
-                f"Expected None dropped for {vt}, got {result!r}"
-            )
+        assert _sanitize_list_value([1, None, 2], ValueType.INT32_LIST) == [1, 0, 2]
+        assert _sanitize_list_value([1, None, 2], ValueType.INT64_LIST) == [1, 0, 2]
+        assert _sanitize_list_value([1.0, None, 2.0], ValueType.FLOAT_LIST) == [
+            1.0,
+            0.0,
+            2.0,
+        ]
+        assert _sanitize_list_value([1.0, None, 2.0], ValueType.DOUBLE_LIST) == [
+            1.0,
+            0.0,
+            2.0,
+        ]
+        assert _sanitize_list_value([True, None, False], ValueType.BOOL_LIST) == [
+            True,
+            False,
+            False,
+        ]
 
-    def test_to_proto_safe_list_scalar_passthrough(self):
+    def test_sanitize_list_value_bytes_none_replaced(self):
+        """None elements in BYTES_LIST are replaced with b''."""
+        from feast.type_map import _sanitize_list_value
+
+        result = _sanitize_list_value([b"x", None], ValueType.BYTES_LIST)
+        assert result == [b"x", b""]
+
+    def test_sanitize_list_value_scalar_passthrough(self):
         """Non-list, non-ndarray values are returned unchanged."""
-        from feast.type_map import _to_proto_safe_list
+        from feast.type_map import _sanitize_list_value
 
-        assert _to_proto_safe_list("hello") == "hello"
-        assert _to_proto_safe_list(None) is None
-        assert _to_proto_safe_list(42) == 42
+        assert _sanitize_list_value("hello", ValueType.STRING_LIST) == "hello"
+        assert _sanitize_list_value(42, ValueType.INT32_LIST) == 42
 
     def test_string_list_from_ndarray(self):
         """STRING_LIST column with ndarray values materializes without TypeError."""

--- a/sdk/python/tests/unit/test_type_map.py
+++ b/sdk/python/tests/unit/test_type_map.py
@@ -2065,3 +2065,154 @@ class TestValueMapTypes:
         from feast.type_map import PROTO_VALUE_TO_VALUE_TYPE_MAP
 
         assert PROTO_VALUE_TO_VALUE_TYPE_MAP["scalar_map_val"] == ValueType.SCALAR_MAP
+
+
+class TestArrowArrayStringListMaterialization:
+    """Regression tests for Array(String) columns from Arrow/Athena materialization.
+
+    Arrow/Athena deserializes Array(String) feature columns as numpy.ndarray with
+    object dtype. Two bugs were triggered:
+
+    1. ValueError: "The truth value of an empty array is ambiguous"
+       — when an empty ndarray reached the scalar null-check `elif not pd.isnull(value)`.
+
+    2. TypeError: "bad argument type for built-in operation"
+       — when proto_type(val=<ndarray>) was called; protobuf rejects ndarrays.
+
+    Both are fixed by _to_proto_safe_list, which converts ndarrays to plain Python
+    lists and sanitizes None elements in a type-appropriate way:
+    - STRING_LIST: None → "" (empty string)
+    - All other list types: None elements are dropped (filtered out)
+    """
+
+    def test_to_proto_safe_list_ndarray(self):
+        """ndarray is converted to a plain Python list."""
+        from feast.type_map import _to_proto_safe_list
+
+        arr = np.array(["foo", "bar"], dtype=object)
+        result = _to_proto_safe_list(arr)
+        assert result == ["foo", "bar"]
+        assert isinstance(result, list)
+
+    def test_to_proto_safe_list_empty_ndarray(self):
+        """Empty ndarray is converted to an empty list."""
+        from feast.type_map import _to_proto_safe_list
+
+        arr = np.array([], dtype=object)
+        result = _to_proto_safe_list(arr)
+        assert result == []
+        assert isinstance(result, list)
+
+    def test_to_proto_safe_list_ndarray_with_none(self):
+        """None elements inside a STRING_LIST ndarray are replaced with empty string."""
+        from feast.type_map import _to_proto_safe_list
+
+        arr = np.array(["foo", None, "baz"], dtype=object)
+        result = _to_proto_safe_list(arr, ValueType.STRING_LIST)
+        assert result == ["foo", "", "baz"]
+
+    def test_to_proto_safe_list_plain_list(self):
+        """Plain Python lists pass through unchanged (no None replacement needed)."""
+        from feast.type_map import _to_proto_safe_list
+
+        lst = ["foo", "bar"]
+        result = _to_proto_safe_list(lst)
+        assert result == ["foo", "bar"]
+
+    def test_to_proto_safe_list_plain_list_with_none(self):
+        """None elements in a STRING_LIST plain list are replaced with empty string."""
+        from feast.type_map import _to_proto_safe_list
+
+        lst = ["foo", None]
+        result = _to_proto_safe_list(lst, ValueType.STRING_LIST)
+        assert result == ["foo", ""]
+
+    def test_to_proto_safe_list_numeric_list_none_dropped(self):
+        """None elements in non-string lists are dropped, not replaced with a sentinel."""
+        from feast.type_map import _to_proto_safe_list
+
+        for vt in (
+            ValueType.FLOAT_LIST,
+            ValueType.DOUBLE_LIST,
+            ValueType.INT32_LIST,
+            ValueType.INT64_LIST,
+            ValueType.BYTES_LIST,
+        ):
+            result = _to_proto_safe_list([1.0, None, 2.0], vt)
+            assert result == [1.0, 2.0], (
+                f"Expected None dropped for {vt}, got {result!r}"
+            )
+
+    def test_to_proto_safe_list_scalar_passthrough(self):
+        """Non-list, non-ndarray values are returned unchanged."""
+        from feast.type_map import _to_proto_safe_list
+
+        assert _to_proto_safe_list("hello") == "hello"
+        assert _to_proto_safe_list(None) is None
+        assert _to_proto_safe_list(42) == 42
+
+    def test_string_list_from_ndarray(self):
+        """STRING_LIST column with ndarray values materializes without TypeError."""
+        values = [
+            np.array(["foo", "bar"], dtype=object),
+            np.array(["baz"], dtype=object),
+        ]
+        protos = python_values_to_proto_values(values, ValueType.STRING_LIST)
+        assert len(protos) == 2
+        assert list(protos[0].string_list_val.val) == ["foo", "bar"]
+        assert list(protos[1].string_list_val.val) == ["baz"]
+
+    def test_string_list_from_empty_ndarray(self):
+        """Empty ndarray in a STRING_LIST column must not raise ValueError."""
+        values = [
+            np.array([], dtype=object),
+            np.array(["foo"], dtype=object),
+        ]
+        protos = python_values_to_proto_values(values, ValueType.STRING_LIST)
+        assert list(protos[0].string_list_val.val) == []
+        assert list(protos[1].string_list_val.val) == ["foo"]
+
+    def test_string_list_from_ndarray_with_none_elements(self):
+        """None elements inside an ndarray must not cause TypeError in protobuf."""
+        values = [
+            np.array(["foo", None, "baz"], dtype=object),
+        ]
+        protos = python_values_to_proto_values(values, ValueType.STRING_LIST)
+        # None is replaced with empty string
+        assert list(protos[0].string_list_val.val) == ["foo", "", "baz"]
+
+    def test_string_list_null_row_produces_empty_proto(self):
+        """A None row (missing user) produces an empty ProtoValue."""
+        from feast.protos.feast.types.Value_pb2 import Value as ProtoValue
+
+        values = [
+            None,
+            np.array(["foo"], dtype=object),
+        ]
+        protos = python_values_to_proto_values(values, ValueType.STRING_LIST)
+        assert protos[0] == ProtoValue()
+        assert list(protos[1].string_list_val.val) == ["foo"]
+
+    def test_mixed_batch_simulating_athena_chunk(self):
+        """Simulate a real Athena chunk: mix of ndarray, empty ndarray, and None rows.
+
+        This is the exact scenario that triggered the TypeError during
+        string_list_features materialization.
+        """
+        from feast.protos.feast.types.Value_pb2 import Value as ProtoValue
+
+        # tags / labels column from Athena
+        values = [
+            np.array(["foo", "bar"], dtype=object),  # normal entity
+            np.array([], dtype=object),  # entity with no values set
+            None,  # missing entity (NULL row)
+            np.array(["baz"], dtype=object),  # normal entity
+            np.array(["qux", None], dtype=object),  # entity with partial null
+        ]
+        protos = python_values_to_proto_values(values, ValueType.STRING_LIST)
+
+        assert list(protos[0].string_list_val.val) == ["foo", "bar"]
+        assert list(protos[1].string_list_val.val) == []
+        assert protos[2] == ProtoValue()
+        assert list(protos[3].string_list_val.val) == ["baz"]
+        assert list(protos[4].string_list_val.val) == ["qux", ""]


### PR DESCRIPTION
## What this PR does / why we need it

Fixes two related bugs that cause `TypeError` and `ValueError` when materializing
feature views with array-typed columns (e.g. `Array(String)`, `Array(Int64)`) using
the Athena offline store.

Arrow/Athena deserializes array columns as `numpy.ndarray` (object dtype) instead of
plain Python lists. This breaks two code paths in `type_map.py`:

1. `_convert_scalar_values_to_proto`: `pd.isnull(ndarray)` returns an array of bools,
   and `not <array>` raises `ValueError: The truth value of an empty array is ambiguous`.
   → Already guarded by `_is_array_like` in newer Feast versions; no change needed here.

2. `_convert_list_values_to_proto` (generic list path): `proto_type(val=ndarray)` passes
   the raw numpy array to the protobuf constructor, which only accepts Python lists →
   `TypeError: bad argument type for built-in operation`. Additionally, Arrow nullable
   columns can yield `None` elements inside the ndarray, which protobuf repeated fields
   also reject.

3. `_validate_collection_item_types`: `None` elements inside an ndarray failed the
   `type(item) in valid_types` check before reaching the sanitization step.

## Changes

### `feast/type_map.py`

- **Add module-level `_LIST_NONE_DEFAULTS`** dict mapping each list `ValueType` to a
  type-appropriate zero/empty default value used to replace `None` elements:
  - `STRING_LIST`, `UUID_LIST`, `TIME_UUID_LIST`, `DECIMAL_LIST` → `""`
  - `BYTES_LIST` → `b""`
  - `INT32_LIST`, `INT64_LIST` → `0`
  - `FLOAT_LIST`, `DOUBLE_LIST` → `0.0`
  - `BOOL_LIST` → `False`
  - `UNIX_TIMESTAMP_LIST` → `NULL_TIMESTAMP_INT_VALUE`

- **Add module-level `_sanitize_list_value(value, feast_value_type)`** helper that:
  - Calls `.tolist()` on any `numpy.ndarray` to produce a plain Python list
    (empty ndarray → `None`, treated as a missing row)
  - Replaces `None` elements with the type-appropriate default from `_LIST_NONE_DEFAULTS`
  - Is a no-op for plain Python lists without `None` and for scalar values

- **Apply sanitization upfront in `_convert_list_values_to_proto`**: both `values` and
  `sample` are normalised via `_sanitize_list_value` before any type-checking or proto
  conversion, removing the need for per-path ndarray handling.

- **Remove the old `_to_proto_safe_list` / `_DROP_NONE` / `_LIST_TYPE_NONE_REPLACEMENT`**
  module-level helpers, which have been superseded by the above.

- **Skip `None` elements in `_validate_collection_item_types`** — `None` entries are
  valid in nullable Arrow columns and are sanitized upstream; raising a `TypeError` on
  them before that point was incorrect.

## Testing

Added `TestArrowArrayStringListMaterialization` in
`sdk/python/tests/unit/test_type_map.py` covering:

| Test | Scenario |
|---|---|
| `test_sanitize_list_value_ndarray` | ndarray → plain list |
| `test_sanitize_list_value_empty_ndarray` | empty ndarray → `None` (missing row) |
| `test_sanitize_list_value_ndarray_with_none` | `None` elements in STRING_LIST replaced with `""` |
| `test_sanitize_list_value_plain_list` | plain list passthrough |
| `test_sanitize_list_value_plain_list_with_none` | `None` in plain STRING_LIST list replaced with `""` |
| `test_sanitize_list_value_numeric_none_replaced` | `None` in numeric/bool lists replaced with zero default |
| `test_sanitize_list_value_bytes_none_replaced` | `None` in BYTES_LIST replaced with `b""` |
| `test_sanitize_list_value_scalar_passthrough` | non-list, non-ndarray values unchanged |
| `test_string_list_from_ndarray` | full round-trip via `python_values_to_proto_values` |
| `test_string_list_from_empty_ndarray` | empty ndarray no longer raises `ValueError` |
| `test_string_list_from_ndarray_with_none_elements` | `None` in ndarray no longer raises `TypeError` |
| `test_string_list_null_row_produces_empty_proto` | `None` rows produce empty `ProtoValue` |
| `test_mixed_batch_simulating_athena_chunk` | full simulation of a failing Athena materialization batch |

```
pytest sdk/python/tests/unit/test_type_map.py::TestArrowArrayStringListMaterialization -v
```

## Which issues this PR fixes

Fixes #6325 

## Does this PR introduce a user-facing change?

Yes — materialization of array-typed feature columns from Athena no longer fails with
`TypeError` or `ValueError` when a batch contains empty arrays, `None` rows, or `None`
elements inside arrays. `None` elements inside an array are now stored as the
type-appropriate zero/empty value (e.g. `""` for strings, `0` for integers).

```
Previously:
  TypeError: bad argument type for built-in operation
  ValueError: The truth value of an empty array is ambiguous

After this fix:
  Materialization completes successfully.
  None elements inside arrays are replaced with type-appropriate defaults.
```
