### PR TITLE
ci: Enforce local linting and commit conventions via pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,17 @@ repos:
         entry: uv run make build-templates
         pass_filenames: false
 
+      # Pre-push lint gate — check-only. Auto-fix omitted: pre-push cannot change committed objects.
+      # If blocked, run "make format-python", then amend/commit and push again.
+      - id: lint-push
+        name: Lint Before Push
+        stages: [push]
+        language: system
+        types: [python]
+        exclude: '_pb2\.py$'
+        entry: bash -c 'uv run ruff check "$@" && uv run ruff format --check "$@"' --
+        pass_filenames: true
+
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,12 @@ precommit-check: format-python lint-python ## Run all precommit checks
 	@echo "✅ All precommit checks passed"
 
 # Install precommit hooks with correct stages
-install-precommit: ## Install precommit hooks (runs on commit, not push)
+install-precommit: ## Install precommit hooks (runs on commit + commit-msg + pre-push)
 	uv pip install pre-commit
 	pre-commit install --hook-type pre-commit
-	@echo "✅ Precommit hooks installed (will run on commit, not push)"
+	pre-commit install --hook-type commit-msg
+	pre-commit install --hook-type pre-push
+	@echo "✅ Precommit hooks installed (lint on commit, commitlint on commit-msg, lint on push)"
 
 # Manual full type check
 mypy-full: ## Full MyPy type checking with all files
@@ -91,6 +93,7 @@ setup-scripts: ## Make helper scripts executable
 install-python-dependencies-dev: ## Install Python dev dependencies using uv (editable install)
 	uv pip sync --require-hashes sdk/python/requirements/py$(PYTHON_VERSION)-ci-requirements.txt
 	uv pip install --no-deps -e .
+	$(MAKE) install-precommit
 
 install-python-dependencies-minimal: ## Install minimal Python dependencies using uv (editable install)
 	uv pip sync --require-hashes sdk/python/requirements/py$(PYTHON_VERSION)-minimal-requirements.txt


### PR DESCRIPTION
# What this PR does / why we need it:

Contributors could push code and open PRs without any local linting or
commit message validation if they hadn't manually installed pre-commit
hooks. Specifically:

- `make install-python-dependencies-dev` (the standard dev setup command)
  did **not** install pre-commit hooks, so most contributors never had
  them active.
- `make install-precommit` only registered the `pre-commit` hook type,
  meaning the `commitlint` hook (which requires `commit-msg` stage) and
  any push-time checks were never wired up — even for contributors who
  ran `make install-precommit` explicitly.
- There was no push-time gate, so bad formatting could reach the remote
  even if the commit-time hook was bypassed (e.g. `--no-verify`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
