### PR TITLE
feat: Bump redis-py version cap from <5 to <8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,8 +123,8 @@ ray = [
 'codeflare-sdk>=0.31.1; python_version > "3.10"'
 ]
 redis = [
-    "redis>=4.2.2,<5",
-    "hiredis>=2.0.0,<3",
+    "redis>=4.2.2,<8",
+    "hiredis>=2.0.0,<4",
 ]
 singlestore = ["singlestoredb<1.8.0"]
 snowflake = [
@@ -245,7 +245,6 @@ packages = {find = {where = ["sdk/python"], exclude = ["java", "infra", "sdk/pyt
 # Regex modified from default tag regex in:
 # https://github.com/pypa/setuptools_scm/blob/2a1b46d38fb2b8aeac09853e660bcd0d7c1bc7be/src/setuptools_scm/config.py#L9
 tag_regex = "^(?:[\\/\\w-]+)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"
-
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
## Summary

- Bumps `redis` dependency from `>=4.2.2,<5` to `>=4.2.2,<8`
- Bumps `hiredis` dependency from `>=2.0.0,<3` to `>=2.0.0,<4`

## Motivation

The current `redis<5` pin prevents downstream servers that depend on Feast from using redis-py 5+. Since redis-py is now at version 7.4.0, this is an increasingly painful constraint for users who need newer redis-py features or have other dependencies requiring redis-py 5+.

## Compatibility Analysis

Feast uses only one file that imports redis (`sdk/python/feast/infra/online_stores/redis.py`). The APIs used are all stable across v4 through v7:

- `Redis`, `RedisCluster`, `Sentinel` client classes
- `redis.asyncio` module (Redis, RedisCluster, Sentinel)
- `pipeline()`, `hset()`, `hmget()`, `hgetall()`, `scan_iter()`, `delete()`, `hdel()`, `expire()`

All imports and method signatures are unchanged from redis-py 4.x to 7.x.

The `hiredis` cap is bumped from `<3` to `<4` because redis-py 5+ requires `hiredis>=3.0` when the hiredis extra is used.

## Test plan

- [x] Verified all redis imports work with redis-py 7.4.0
- [x] Verified all redis API methods used by Feast exist and are compatible
- [x] All 19 redis unit tests pass with redis-py 7.4.0 (1 test errored due to unrelated missing `dask` dep in test fixture)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
