### PR TITLE
fix: Add subprocess timeouts to prevent test_e2e_local hanging on Dask atexit handler

### DIFF
--- a/sdk/python/feast/infra/offline_stores/dask.py
+++ b/sdk/python/feast/infra/offline_stores/dask.py
@@ -402,15 +402,22 @@ class DaskOfflineStore(OfflineStore):
         # Create lazy function that is only called from the RetrievalJob object
         source_df = _read_datasource(data_source, config.repo_path)
 
-        source_df = _normalize_timestamp(
-            source_df, timestamp_field, created_timestamp_column
-        )
-
+        # Validate join keys against source columns BEFORE calling _normalize_timestamp.
+        # _normalize_timestamp ends with df.persist() which initialises Dask's global
+        # ThreadPoolExecutor.  When the process subsequently exits (e.g. after raising
+        # FeastJoinKeysDuringMaterialization), Python's atexit handler calls
+        # ThreadPoolExecutor.shutdown(wait=True) which can block indefinitely, hanging
+        # the subprocess and preventing the parent from reading its output.
+        # df.columns is derived from the Parquet schema metadata — no computation needed.
         source_columns = set(source_df.columns)
         if not set(join_key_columns).issubset(source_columns):
             raise FeastJoinKeysDuringMaterialization(
                 data_source.path, set(join_key_columns), source_columns
             )
+
+        source_df = _normalize_timestamp(
+            source_df, timestamp_field, created_timestamp_column
+        )
 
         # try-catch block is added to deal with this issue https://github.com/dask/dask/issues/8939.
         # TODO(kevjumba): remove try catch when fix is merged upstream in Dask.

--- a/sdk/python/tests/unit/local_feast_tests/test_e2e_local.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_e2e_local.py
@@ -23,6 +23,7 @@ from tests.utils.feature_records import validate_online_features
     platform.system() == "Darwin" and os.environ.get("CI") == "true",
     reason="Skip on macOS CI due to Ray/uv subprocess compatibility issues",
 )
+@pytest.mark.timeout(600)
 def test_e2e_local() -> None:
     """
     Tests the end-to-end workflow of apply, materialize, and online retrieval.

--- a/sdk/python/tests/utils/cli_repo_creator.py
+++ b/sdk/python/tests/utils/cli_repo_creator.py
@@ -1,12 +1,22 @@
 """
 CLI test utilities for Feast testing.
 
-Note: This module contains workarounds for a known PySpark JVM cleanup issue on macOS
-with Python 3.11+. The 'feast teardown' command can hang indefinitely due to py4j
-(PySpark's Java bridge) not properly terminating JVM processes. This is a PySpark
-environmental issue, not a Feast logic error.
+Note: This module contains a workaround for a known subprocess hang issue:
 
-The timeout handling ensures tests fail gracefully rather than hanging CI.
+Dask atexit handler: when a Feast materialization fails mid-execution, Dask's
+global ThreadPoolExecutor registers an atexit.register(default_pool.shutdown)
+handler. If the pool has active or recently-used threads, shutdown(wait=True)
+can block for an extended period, preventing the subprocess from exiting. This
+causes the parent's subprocess.check_output / communicate() to block forever.
+
+The fix is to use subprocess.Popen with communicate(timeout=...) so we can kill
+the subprocess if it hangs and still recover any partial output (which contains
+the error message printed before the hang).
+
+Teardown is intentionally performed in-process (store.teardown()) rather than
+via a 'feast teardown' subprocess. This eliminates per-repo subprocess startup
+overhead and avoids atexit-handler (Dask thread pool, PySpark JVM) hang risks
+that can push the cumulative test time past the pytest global timeout budget.
 """
 
 import random
@@ -44,12 +54,9 @@ class CliRunner:
     """
 
     def run(self, args: List[str], cwd: Path) -> subprocess.CompletedProcess:
-        # Handle known PySpark JVM cleanup issue on macOS
-        # The 'feast teardown' command can hang indefinitely on macOS with Python 3.11+
-        # due to py4j (PySpark's Java bridge) not properly cleaning up JVM processes.
-        # This is a known environmental issue, not a test logic error.
-        # See: https://issues.apache.org/jira/browse/SPARK-XXXXX (PySpark JVM cleanup)
-        timeout = 120 if "teardown" in args else None
+        # Apply a conservative timeout to prevent CI hangs from Dask atexit-handler
+        # stalls or other subprocess blockages.
+        timeout = 120
 
         try:
             return subprocess.run(
@@ -59,41 +66,46 @@ class CliRunner:
                 timeout=timeout,
             )
         except subprocess.TimeoutExpired:
-            # For teardown timeouts, return a controlled failure rather than hanging CI.
-            # This allows the test to fail gracefully and continue with other tests.
-            if "teardown" in args:
-                return subprocess.CompletedProcess(
-                    args=[sys.executable, cli.__file__] + args,
-                    returncode=-1,
-                    stdout=b"",
-                    stderr=b"Teardown timed out (known PySpark JVM cleanup issue on macOS)",
-                )
-            else:
-                # For non-teardown commands, re-raise as this indicates a real issue
-                raise
+            return subprocess.CompletedProcess(
+                args=[sys.executable, cli.__file__] + args,
+                returncode=-1,
+                stdout=b"",
+                stderr=f"Command timed out after {timeout}s: {args}".encode(),
+            )
 
     def run_with_output(self, args: List[str], cwd: Path) -> Tuple[int, bytes]:
-        timeout = 120 if "teardown" in args else None
+        is_teardown = "teardown" in args
+        # Use subprocess.Popen + communicate(timeout=...) so that on a hang we can
+        # kill the process and still recover any output already buffered in the pipe.
+        # This matters when feast prints an error and then hangs in the Dask atexit
+        # handler — the error text is already in the pipe buffer and can be read after
+        # the process is killed.
+        timeout = 120 if is_teardown else 60
+
+        proc = subprocess.Popen(
+            [sys.executable, cli.__file__] + args,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
         try:
-            return (
-                0,
-                subprocess.check_output(
-                    [sys.executable, cli.__file__] + args,
-                    cwd=cwd,
-                    stderr=subprocess.STDOUT,
-                    timeout=timeout,
-                ),
-            )
-        except subprocess.CalledProcessError as e:
-            return e.returncode, e.output
+            stdout, _ = proc.communicate(timeout=timeout)
+            returncode = proc.returncode
+            if returncode != 0:
+                return returncode, stdout
+            return 0, stdout
         except subprocess.TimeoutExpired:
-            if "teardown" in args:
+            proc.kill()
+            stdout, _ = proc.communicate()
+            if is_teardown:
                 return (
                     -1,
                     b"Teardown timed out (known PySpark JVM cleanup issue on macOS)",
                 )
             else:
-                raise
+                # Return partial output (likely contains the error printed before hang)
+                # with a non-zero returncode so callers can inspect it.
+                return -1, stdout or b""
 
     @contextmanager
     def local_repo(
@@ -179,23 +191,13 @@ class CliRunner:
                     f"stdout: {result.stdout}\nstderr: {result.stderr}"
                 )
 
-            yield FeatureStore(repo_path=str(repo_path), config=None)
+            store_instance = FeatureStore(repo_path=str(repo_path), config=None)
+            yield store_instance
 
             if teardown:
-                result = self.run(["teardown"], cwd=repo_path)
-                stdout = result.stdout.decode("utf-8")
-                stderr = result.stderr.decode("utf-8")
-                print(f"Teardown stdout:\n{stdout}")
-                print(f"Teardown stderr:\n{stderr}")
-
-                # Handle PySpark JVM cleanup timeout gracefully on macOS
-                # This is a known environmental issue, not a test failure
-                if result.returncode == -1 and "PySpark JVM cleanup issue" in stderr:
-                    print(
-                        "Warning: Teardown timed out due to known PySpark JVM cleanup issue on macOS"
-                    )
-                    print("This is an environmental issue, not a test logic failure")
-                else:
-                    assert result.returncode == 0, (
-                        f"stdout: {result.stdout}\nstderr: {result.stderr}"
-                    )
+                # Use in-process teardown instead of a 'feast teardown' subprocess.
+                # Subprocess teardown adds per-repo startup overhead and risks
+                # blocking indefinitely in Dask/PySpark atexit handlers, which
+                # can push the cumulative test time past the pytest timeout budget.
+                # store.teardown() performs the same SQLite/registry cleanup directly.
+                store_instance.teardown()


### PR DESCRIPTION


# What this PR does / why we need it:

## Problem

`test_e2e_local` was intermittently crashing the pytest-xdist worker (`gw2 node down: Not properly terminated`) due to a subprocess hang, causing the test to exceed the 5-minute pytest timeout.

### Root Cause

The hang occurs in the `example_feature_repo_with_entity_join_key.py` test case, which intentionally triggers a `FeastJoinKeysDuringMaterialization` error during `feast materialize`. The error is raised correctly and printed to stderr, but the subprocess then **hangs indefinitely during Python interpreter shutdown**.

**dask.py fix** — Move the join-key validation to before _normalize_timestamp. Since dd.read_parquet() already knows column names from Parquet file footer metadata (zero computation required), the check is free. If the validation fails, the function raises immediately — _normalize_timestamp and df.persist() are never called, Dask's thread pool is never initialised, and the subprocess exits cleanly in < 1 second.





<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
