### PR TITLE
fix: Disable snowflake tests temporarily in CI

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1460,14 +1460,14 @@
         "filename": "sdk/python/tests/universal/feature_repos/repo_configuration.py",
         "hashed_secret": "d90e76ef629fb00c95f4e84fec29fbda111e2392",
         "is_verified": false,
-        "line_number": 459
+        "line_number": 466
       },
       {
         "type": "Secret Keyword",
         "filename": "sdk/python/tests/universal/feature_repos/repo_configuration.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 461
+        "line_number": 468
       }
     ],
     "sdk/python/tests/universal/feature_repos/universal/data_sources/file.py": [
@@ -1539,5 +1539,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-30T20:52:53Z"
+  "generated_at": "2026-05-01T07:12:24Z"
 }

--- a/sdk/python/tests/integration/materialization/test_snowflake.py
+++ b/sdk/python/tests/integration/materialization/test_snowflake.py
@@ -20,6 +20,11 @@ from tests.universal.feature_repos.universal.data_sources.snowflake import (
 )
 from tests.utils.e2e_test_validation import validate_offline_online_store_consistency
 
+pytestmark = pytest.mark.skipif(
+    not os.getenv("SNOWFLAKE_CI_DEPLOYMENT"),
+    reason="Snowflake account not configured in CI (SNOWFLAKE_CI_DEPLOYMENT not set)",
+)
+
 SNOWFLAKE_ENGINE_CONFIG = {
     "type": "snowflake.engine",
     "account": os.getenv("SNOWFLAKE_CI_DEPLOYMENT", ""),

--- a/sdk/python/tests/universal/feature_repos/repo_configuration.py
+++ b/sdk/python/tests/universal/feature_repos/repo_configuration.py
@@ -120,28 +120,35 @@ if os.getenv("FEAST_IS_LOCAL_TEST", "False") != "True":
     from tests.universal.feature_repos.universal.data_sources.redshift import (
         RedshiftDataSourceCreator,
     )
-    from tests.universal.feature_repos.universal.data_sources.snowflake import (
-        SnowflakeDataSourceCreator,
-    )
 
     AVAILABLE_OFFLINE_STORES.extend(
         [
             ("gcp", BigQueryDataSourceCreator),
             ("aws", RedshiftDataSourceCreator),
-            ("aws", SnowflakeDataSourceCreator),
         ]
     )
 
     OFFLINE_STORE_TO_PROVIDER_CONFIG["bigquery"] = ("gcp", BigQueryDataSourceCreator)
     OFFLINE_STORE_TO_PROVIDER_CONFIG["redshift"] = ("aws", RedshiftDataSourceCreator)
-    OFFLINE_STORE_TO_PROVIDER_CONFIG["snowflake"] = ("aws", SnowflakeDataSourceCreator)
 
     AVAILABLE_ONLINE_STORES["redis"] = (REDIS_CONFIG, None)
     AVAILABLE_ONLINE_STORES["dynamodb"] = (DYNAMO_CONFIG, None)
     AVAILABLE_ONLINE_STORES["datastore"] = ("datastore", None)
-    AVAILABLE_ONLINE_STORES["snowflake"] = (SNOWFLAKE_CONFIG, None)
     AVAILABLE_ONLINE_STORES["bigtable"] = (BIGTABLE_CONFIG, None)
     AVAILABLE_ONLINE_STORES["milvus"] = (MILVUS_CONFIG, None)
+
+    # Snowflake is disabled temporarily
+    if os.getenv("SNOWFLAKE_CI_DEPLOYMENT"):
+        from tests.universal.feature_repos.universal.data_sources.snowflake import (
+            SnowflakeDataSourceCreator,
+        )
+
+        AVAILABLE_OFFLINE_STORES.extend([("aws", SnowflakeDataSourceCreator)])
+        OFFLINE_STORE_TO_PROVIDER_CONFIG["snowflake"] = (
+            "aws",
+            SnowflakeDataSourceCreator,
+        )
+        AVAILABLE_ONLINE_STORES["snowflake"] = (SNOWFLAKE_CONFIG, None)
 
 
 full_repo_configs_module = os.environ.get(FULL_REPO_CONFIGS_MODULE_ENV_NAME)


### PR DESCRIPTION

# What this PR does / why we need it:

This PR disables snowflake tests temporarily due to unavailability of snowflake account for CI, we will revert this when account details updated in CI. 