### PR TITLE
feat: Add agent skills and Cursor/Claude rules for Feast development

### DIFF
--- a/.claude/rules/feast-components.md
+++ b/.claude/rules/feast-components.md
@@ -1,0 +1,44 @@
+---
+paths:
+  - sdk/python/feast/infra/online_stores/**
+  - sdk/python/feast/infra/offline_stores/**
+  - sdk/python/feast/infra/registry/**
+  - sdk/python/tests/unit/infra/**
+  - go/**
+  - infra/feast-operator/**
+---
+
+Read `skills/feast-architecture/SKILL.md` for the relevant component section:
+
+| Working in… | Read section |
+|---|---|
+| `online_stores/` | Online Store — config pattern, entity key serialization, async support, registration |
+| `offline_stores/` | Offline Store — interface, PIT join, pull_latest, adding a new backend |
+| `infra/registry/` | Registry — proto vs SQL backend, caching, adding new object types |
+| `go/` | Go Feature Server — entry point, serving path, online store interface, build commands |
+| `infra/feast-operator/` | Feast Operator — CRD spec, reconcile loop, RBAC markers, dev workflow |
+
+For testing patterns and debugging, also read `skills/feast-testing/SKILL.md`.
+
+## When making any component change
+
+- **Unit tests**: add or update tests in `sdk/python/tests/unit/infra/<subsystem>/`
+- **Integration tests**: run `make test-python-integration-local`; add a universal test case in `sdk/python/tests/integration/` if the change affects retrieval or materialization behavior
+- **Protos**: if you add a field to a proto message, recompile with `make protos` and update serialization helpers in `proto_registry_utils.py`
+- **Both SDKs**: if the change affects online serving, check whether the Go server (`go/`) also needs updating
+- **Skills/Rules**: if the change introduces new patterns, interfaces, or conventions that agents should follow, update the relevant section in `skills/feast-architecture/SKILL.md` (and `skills/feast-testing/SKILL.md` if testing patterns changed)
+
+## Documentation — where to add/update
+
+| Change type | Doc location | Also update |
+|---|---|---|
+| New **online store** | `docs/reference/online-stores/<name>.md` (copy an existing one as template) | `docs/reference/online-stores/README.md`, `docs/SUMMARY.md` (under "Online stores") |
+| New **offline store** | `docs/reference/offline-stores/<name>.md` | `docs/reference/offline-stores/README.md`, `docs/reference/offline-stores/overview.md`, `docs/SUMMARY.md` |
+| New **registry backend** | `docs/reference/registries/<name>.md` | `docs/SUMMARY.md` |
+| Config option change | `docs/reference/feature-store-yaml.md` | — |
+| New CLI flag or command | `docs/reference/feast-cli-commands.md` | — |
+| How-to / integration guide | `docs/how-to-guides/customizing-feast/` or `docs/how-to-guides/` | `docs/SUMMARY.md` |
+| Architecture / concept | `docs/getting-started/architecture/` or `docs/getting-started/components/` | `docs/SUMMARY.md` |
+| Blog post | `/infra/website/docs/blog/` (NOT `docs/blog/`) | — |
+
+All `docs/` pages are rendered by GitBook via `docs/SUMMARY.md`. Any new page must be added to `SUMMARY.md` or it won't appear in the site navigation.

--- a/.claude/rules/feast-skills-maintenance.md
+++ b/.claude/rules/feast-skills-maintenance.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - skills/**
+  - AGENTS.md
+  - .cursor/rules/**
+  - .claude/rules/**
+---
+
+## When editing skills or rules
+
+Skills and rules are only useful if they accurately reflect the real codebase. Before finalising any skill/rule edit:
+
+**Verify against source code:**
+- Command examples (lint, test, type-check) — confirm they still match `Makefile` targets and `pyproject.toml`
+- File paths and class names — confirm they exist in the repo
+- Interface signatures (e.g. `OnlineStore`, `OfflineStore`, `BaseRegistry`) — confirm against the actual base class files
+- Config field names — confirm against `RepoConfig` and `FeastConfigBaseModel` subclasses in `sdk/python/feast/repo_config.py`
+
+**Keep scope consistent:**
+- `AGENTS.md` — entry point only; commands, skills table, code style. Max ~120 lines.
+- `skills/feast-architecture/SKILL.md` — how each component works internally; data flows; adding new backends
+- `skills/feast-testing/SKILL.md` — how to run, write, and debug tests
+- `skills/feast-dev/SKILL.md` — contributor workflow; setup; Docker; docs locations; PR process
+- `skills/feast-user-guide/SKILL.md` — how to use Feast as an end user; feature definitions; retrieval; RAG
+- `.cursor/rules/feast-components.mdc` / `.claude/rules/feast-components.md` — component checklist (tests, docs, skills); keep in sync with each other
+
+**Keep the two rule files in sync:**
+`.cursor/rules/feast-components.mdc` and `.claude/rules/feast-components.md` contain the same content with only different frontmatter (`globs:` vs `paths:`). Any content change must be applied to both.

--- a/.claude/skills/feast-architecture/SKILL.md
+++ b/.claude/skills/feast-architecture/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/feast-architecture/SKILL.md

--- a/.claude/skills/feast-dev/SKILL.md
+++ b/.claude/skills/feast-dev/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/feast-dev/SKILL.md

--- a/.claude/skills/feast-testing/SKILL.md
+++ b/.claude/skills/feast-testing/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/feast-testing/SKILL.md

--- a/.claude/skills/feast-user-guide/SKILL.md
+++ b/.claude/skills/feast-user-guide/SKILL.md
@@ -1,0 +1,1 @@
+../../../../skills/feast-user-guide/SKILL.md

--- a/.cursor/rules/feast-components.mdc
+++ b/.cursor/rules/feast-components.mdc
@@ -1,0 +1,40 @@
+---
+description: Component-level guidance for Feast subsystems
+globs: sdk/python/feast/infra/online_stores/**,sdk/python/feast/infra/offline_stores/**,sdk/python/feast/infra/registry/**,sdk/python/tests/unit/infra/**,go/**,infra/feast-operator/**
+alwaysApply: false
+---
+
+Read `skills/feast-architecture/SKILL.md` for the relevant component section:
+
+| Working in… | Read section |
+|---|---|
+| `online_stores/` | Online Store — config pattern, entity key serialization, async support, registration |
+| `offline_stores/` | Offline Store — interface, PIT join, pull_latest, adding a new backend |
+| `infra/registry/` | Registry — proto vs SQL backend, caching, adding new object types |
+| `go/` | Go Feature Server — entry point, serving path, online store interface, build commands |
+| `infra/feast-operator/` | Feast Operator — CRD spec, reconcile loop, RBAC markers, dev workflow |
+
+For testing patterns and debugging, also read `skills/feast-testing/SKILL.md`.
+
+## When making any component change
+
+- **Unit tests**: add or update tests in `sdk/python/tests/unit/infra/<subsystem>/`
+- **Integration tests**: run `make test-python-integration-local`; add a universal test case in `sdk/python/tests/integration/` if the change affects retrieval or materialization behavior
+- **Protos**: if you add a field to a proto message, recompile with `make protos` and update serialization helpers in `proto_registry_utils.py`
+- **Both SDKs**: if the change affects online serving, check whether the Go server (`go/`) also needs updating
+- **Skills/Rules**: if the change introduces new patterns, interfaces, or conventions that agents should follow, update the relevant section in `skills/feast-architecture/SKILL.md` (and `skills/feast-testing/SKILL.md` if testing patterns changed)
+
+## Documentation — where to add/update
+
+| Change type | Doc location | Also update |
+|---|---|---|
+| New **online store** | `docs/reference/online-stores/<name>.md` (copy an existing one as template) | `docs/reference/online-stores/README.md`, `docs/SUMMARY.md` (under "Online stores") |
+| New **offline store** | `docs/reference/offline-stores/<name>.md` | `docs/reference/offline-stores/README.md`, `docs/reference/offline-stores/overview.md`, `docs/SUMMARY.md` |
+| New **registry backend** | `docs/reference/registries/<name>.md` | `docs/SUMMARY.md` |
+| Config option change | `docs/reference/feature-store-yaml.md` | — |
+| New CLI flag or command | `docs/reference/feast-cli-commands.md` | — |
+| How-to / integration guide | `docs/how-to-guides/customizing-feast/` or `docs/how-to-guides/` | `docs/SUMMARY.md` |
+| Architecture / concept | `docs/getting-started/architecture/` or `docs/getting-started/components/` | `docs/SUMMARY.md` |
+| Blog post | `/infra/website/docs/blog/` (NOT `docs/blog/`) | — |
+
+All `docs/` pages are rendered by GitBook via `docs/SUMMARY.md`. Any new page must be added to `SUMMARY.md` or it won't appear in the site navigation.

--- a/.cursor/rules/feast-skills-maintenance.mdc
+++ b/.cursor/rules/feast-skills-maintenance.mdc
@@ -1,0 +1,26 @@
+---
+description: Guidance for keeping skills and rules accurate and up to date
+globs: skills/**,AGENTS.md,.cursor/rules/**,.claude/rules/**
+alwaysApply: false
+---
+
+## When editing skills or rules
+
+Skills and rules are only useful if they accurately reflect the real codebase. Before finalising any skill/rule edit:
+
+**Verify against source code:**
+- Command examples (lint, test, type-check) — confirm they still match `Makefile` targets and `pyproject.toml`
+- File paths and class names — confirm they exist in the repo
+- Interface signatures (e.g. `OnlineStore`, `OfflineStore`, `BaseRegistry`) — confirm against the actual base class files
+- Config field names — confirm against `RepoConfig` and `FeastConfigBaseModel` subclasses in `sdk/python/feast/repo_config.py`
+
+**Keep scope consistent:**
+- `AGENTS.md` — entry point only; commands, skills table, code style. Max ~120 lines.
+- `skills/feast-architecture/SKILL.md` — how each component works internally; data flows; adding new backends
+- `skills/feast-testing/SKILL.md` — how to run, write, and debug tests
+- `skills/feast-dev/SKILL.md` — contributor workflow; setup; Docker; docs locations; PR process
+- `skills/feast-user-guide/SKILL.md` — how to use Feast as an end user; feature definitions; retrieval; RAG
+- `.cursor/rules/feast-components.mdc` / `.claude/rules/feast-components.md` — component checklist (tests, docs, skills); keep in sync with each other
+
+**Keep the two rule files in sync:**
+`.cursor/rules/feast-components.mdc` and `.claude/rules/feast-components.md` contain the same content with only different frontmatter (`globs:` vs `paths:`). Any content change must be applied to both.

--- a/.gitignore
+++ b/.gitignore
@@ -266,4 +266,7 @@ Desktop.ini
 .agentready/
 
 # Claude Code project settings
-.claude/
+# Claude Code local state (conversation history, credentials, cache)
+.claude/settings.local.json
+.claude/todos/
+.claude/cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,98 +17,51 @@ Feast (Feature Store) is a Python-based project that provides:
 
 ### Setup
 ```bash
-# Install development dependencies
 make install-python-dependencies-dev
-
-# Install minimal dependencies
 make install-python-dependencies-minimal
 ```
 
 ### Code Quality
 ```bash
-# Format Python code
+# Format Python code (entire codebase)
 make format-python
 
-# Lint Python code
+# Lint Python code (entire codebase)
 make lint-python
 
-# Type check
-cd sdk/python && python -m mypy feast
+# Full type check (entire codebase)
+uv run bash -c "cd sdk/python && mypy feast"
+
+# Full type check including tests
+make mypy-full
+```
+
+#### Single-file lint and type-check
+When working on a specific file, run checks scoped to that file to get fast feedback:
+```bash
+uv run ruff check sdk/python/feast/path/to/file.py          # lint
+uv run ruff check --fix sdk/python/feast/path/to/file.py    # lint + auto-fix
+uv run ruff format sdk/python/feast/path/to/file.py         # format
+uv run bash -c "cd sdk/python && mypy feast/path/to/file.py" # type-check
 ```
 
 ### Testing
 ```bash
-# Run unit tests
-make test-python-unit
-
-# Run integration tests (local)
-make test-python-integration-local
-
-# Run integration tests (CI)
-make test-python-integration
-
-# Run all Python tests
-make test-python-universal
+make test-python-unit                  # unit tests
+make test-python-integration-local    # integration tests (local)
+make test-python-integration          # integration tests (CI)
+make test-python-universal            # all Python tests
 ```
 
 ### Protobuf Compilation
 ```bash
-# Compile Python protobuf files
-make compile-protos-python
-
-# Compile all protos
-make protos
+make compile-protos-python   # Python protobufs
+make protos                  # all protos
 ```
 
 ### Go Development
 ```bash
-# Build Go code
-make build-go
-
-# Test Go code
-make test-go
-
-# Format Go code
-make format-go
-
-# Lint Go code
-make lint-go
-```
-
-### Docker
-```bash
-# Build all Docker images
-make build-docker
-
-# Build feature server Docker image
-make build-feature-server-docker
-```
-
-### Documentation
-```bash
-# Build Sphinx documentation
-make build-sphinx
-
-# Build templates
-make build-templates
-
-# Build Helm docs
-make build-helm-docs
-```
-
-## Project Structure
-
-```
-feast/
-├── sdk/python/          # Python SDK and core implementation
-├── go/                 # Go implementation
-├── ui/                 # Web UI
-├── docs/               # Documentation
-├── examples/           # Example projects
-├── infra/              # Infrastructure and deployment
-│   ├── charts/         # Helm charts
-│   └── feast-operator/ # Kubernetes operator
-└── protos/             # Protocol buffer definitions
+make build-go && make test-go && make format-go && make lint-go
 ```
 
 ## Key Technologies
@@ -120,24 +73,30 @@ feast/
 - **Offline Stores**: BigQuery, Snowflake, Redshift, Spark, Dask, DuckDB
 - **Cloud Providers**: AWS, GCP, Azure
 
-## Common Development Tasks
+## Agent Skills
 
-### Running Tests
-The project uses pytest for Python testing with extensive integration test suites for different data sources and stores.
+The `skills/` directory contains tool-agnostic skills (compatible with Claude Code, OpenAI Codex, and other agent tools):
 
-### Code Style
+| Skill | Path | Use when… |
+|---|---|---|
+| **feast-user-guide** | `skills/feast-user-guide/SKILL.md` | Working with Feast as a user: defining features, retrieval, CLI, RAG |
+| **feast-dev** | `skills/feast-dev/SKILL.md` | Contributing to Feast: setup, tests, Docker, docs, PR workflow |
+| **feast-architecture** | `skills/feast-architecture/SKILL.md` | Understanding how each component works: registry, materialization, feature server, data flows |
+| **feast-testing** | `skills/feast-testing/SKILL.md` | Writing tests, running targeted tests, debugging registry/online store issues |
+
+Reference docs: `skills/references/` — feature definitions, configuration, retrieval & RAG.
+
+Architecture & design intent: `docs/getting-started/architecture/` (overview, write patterns, RBAC), `docs/getting-started/components/` (per-component pages), `docs/adr/` (design decisions).
+
+## Code Style
+
 - Use type hints on all Python function signatures
 - Follow existing patterns in the module you are modifying
 - PR titles must follow semantic conventions: `feat:`, `fix:`, `ci:`, `chore:`, `docs:`
 - Sign off commits with `git commit -s` (DCO requirement)
-- Uses `ruff` for Python linting and formatting
-- Go uses standard `gofmt`
-
-### Protobuf Development
-Protocol buffers are used for data serialization and gRPC APIs. Recompile protos after making changes to `.proto` files.
-
-### Multi-language Support
-Feast supports Python and Go SDKs. Changes to core functionality may require updates across both languages.
+- Uses `ruff` for Python linting and formatting; Go uses standard `gofmt`
+- Recompile protos after making changes to `.proto` files (`make protos`)
+- Changes to core functionality may require updates across both Python and Go SDKs
 
 ## Documentation and Blog Posts
 

--- a/skills/feast-architecture/SKILL.md
+++ b/skills/feast-architecture/SKILL.md
@@ -1,0 +1,378 @@
+---
+name: feast-architecture
+description: Internals of the Feast codebase — how each component works, where the key abstractions live, and the data flow through the system. Use when asked how feast apply works, how the registry stores data, how materialization moves data, how get_online_features retrieves features, how the feature server works, how the Kubernetes operator manages deployments, or when navigating the codebase to understand where to make a change.
+license: Apache-2.0
+compatibility: Works with Claude Code, OpenAI Codex, and any Agent Skills compatible tool.
+metadata:
+  author: feast-dev
+  version: "1.0"
+---
+
+# Feast Architecture Internals
+
+## Full Component Map
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Feast Deployment Modes                       │
+│                                                                   │
+│  Local / Python SDK          Kubernetes (feast-operator)          │
+│  ─────────────────           ─────────────────────────────────   │
+│  feature_store.yaml    ←──   FeatureStore CR (CRD)               │
+│        │                            │                             │
+│        ▼                            ▼                             │
+│  FeatureStore (Python)      Operator deploys services:            │
+│    ├── Registry               - feature-server (Go or Python)     │
+│    ├── Provider               - offline-store-server              │
+│    │   ├── OnlineStore        - registry-server                   │
+│    │   └── OfflineStore     + manages feature_store.yaml config   │
+│    └── FeatureServer                                              │
+│        (Python FastAPI or                                         │
+│         Go gRPC/HTTP)                                             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Python SDK Core
+
+### FeatureStore — the orchestrator
+
+**File**: `sdk/python/feast/feature_store.py`
+
+`FeatureStore` is the single entry point for all operations. It never reads/writes data
+directly — it delegates to the registry (for metadata) and the provider (for infrastructure
+and data movement).
+
+```python
+FeatureStore(repo_path=".")   # loads feature_store.yaml
+store.apply(objects)           # register feature definitions
+store.materialize(...)         # offline → online
+store.get_online_features(...) # serve
+store.get_historical_features(...) # training data
+```
+
+**File**: `sdk/python/feast/repo_config.py` — parses `feature_store.yaml` into typed `RepoConfig`.
+All component classes (online store, offline store, registry) are loaded dynamically from the
+`type:` string via `repo_config.ONLINE_STORE_TYPE_MAP` / `OFFLINE_STORE_TYPE_MAP`.
+
+---
+
+### Registry
+
+**Purpose**: Metadata store — persists definitions of entities, feature views, data sources,
+feature services, permissions.
+
+**Backends and their files:**
+
+| Backend | File | Notes |
+|---|---|---|
+| File/GCS/S3 (default) | `infra/registry/registry.py` | Single proto blob, cached in memory |
+| SQL | `infra/registry/sql.py` | Per-object tables via SQLAlchemy |
+| Snowflake | `infra/registry/snowflake.py` | Snowflake tables |
+| Remote | `infra/registry/remote.py` | Delegates to a remote registry server over gRPC |
+
+**How the proto/file backend works:**
+1. All metadata is serialized into one `Registry` protobuf (`protos/feast/core/Registry.proto`)
+2. The proto blob is stored at the configured `registry:` path
+3. In-memory `cached_registry_proto` is refreshed on a TTL (default 10s)
+4. Writes re-serialize and overwrite the full blob — no partial updates
+
+**Key pattern — apply:**
+```python
+# Python object → proto → stored in registry blob
+registry.apply_feature_view(feature_view, project)
+# → feature_view.to_proto()
+# → upserts into cached_registry_proto.feature_views
+# → registry_store.update_registry_proto(proto)
+```
+
+**Supporting files:**
+- `infra/registry/base_registry.py` — abstract interface
+- `infra/registry/proto_registry_utils.py` — proto serialization helpers
+- `infra/registry/caching_registry.py` — adds TTL caching on top of any backend
+
+---
+
+### Provider
+
+**Purpose**: Infrastructure lifecycle — creates/updates/tears down online store tables.
+Also dispatches `online_write_batch` and `get_historical_features`.
+
+**File**: `sdk/python/feast/infra/provider.py`
+
+Built-in providers (set via `provider:` in `feature_store.yaml`):
+- `local` — SQLite online store, file offline (dev default)
+- `gcp` — Datastore/Bigtable online, BigQuery offline
+- `aws` — DynamoDB online, Redshift offline
+
+Custom providers extend `Provider` and override `update_infra` / `teardown_infra`.
+
+---
+
+### Online Store
+
+**Purpose**: Low-latency feature serving. Stores the latest feature values per entity key.
+
+**Interface**: `sdk/python/feast/infra/online_stores/online_store.py`
+**Implementations**: `sdk/python/feast/infra/online_stores/` (redis, dynamodb, sqlite, bigtable, postgres, snowflake, …)
+
+Key methods:
+- `online_write_batch` — write entity→feature values
+- `online_read` — read by entity keys
+- `update` — provision/deprovision tables on `feast apply`
+- `teardown` — clean up on `feast teardown`
+
+---
+
+### Offline Store
+
+**Purpose**: Historical feature retrieval and training data generation (point-in-time joins).
+
+**Interface**: `sdk/python/feast/infra/offline_stores/offline_store.py`
+**Implementations**: `sdk/python/feast/infra/offline_stores/` (bigquery, snowflake, redshift, duckdb, file, …)
+
+Returns a `RetrievalJob` (lazy) — no data moves until `.to_df()` or `.to_arrow()` is called.
+
+PIT join logic (shared): `sdk/python/feast/infra/offline_stores/offline_utils.py`
+
+**Key methods to implement for a new backend:**
+```python
+class MyOfflineStore(OfflineStore):
+    def get_historical_features(self, config, feature_views, feature_refs,
+                                entity_df, registry, project, ...) -> RetrievalJob: ...
+    def pull_latest_from_table_or_query(self, config, data_source,
+                                        join_key_columns, feature_name_columns,
+                                        timestamp_field, created_timestamp_column,
+                                        start_date, end_date) -> RetrievalJob: ...
+    def pull_all_from_table_or_query(self, config, data_source, join_key_columns,
+                                     feature_name_columns, timestamp_field,
+                                     start_date, end_date) -> RetrievalJob: ...
+    def write_logged_features(self, config, data, source, logging_config,
+                              registry) -> None: ...  # optional
+```
+
+**Config class**: subclass `FeastConfigBaseModel` with a `type` Literal (short alias + full dotted path). Register in `OFFLINE_STORE_TYPE_MAP` in `sdk/python/feast/repo_config.py`.
+
+**Data source**: each offline store backend pairs with a `DataSource` subclass (e.g. `BigQuerySource`, `FileSource`). Add it to `sdk/python/feast/data_sources/` and register in `DATA_SOURCE_CLASS_FOR_TYPE`.
+
+---
+
+## Data Flows
+
+### `feast apply`
+```
+feast apply  (CLI → repo_operations.py)
+  ├── Parse Python files → collect FeastObjects
+  ├── store.apply(objects)
+  │     ├── diff against registry (diff/registry_diff.py)
+  │     ├── update registry metadata for changed objects
+  │     └── provider.update_infra(tables_to_keep, tables_to_delete)
+  │           └── online_store.update(...)  ← create/drop tables
+  └── Write updated registry to storage
+```
+
+### `feast materialize`
+```
+store.materialize(start_date, end_date)
+  ├── Load feature views from registry
+  ├── For each feature view:
+  │     ├── offline_store.pull_latest_from_table_or_query(...)
+  │     │     └── Returns RetrievalJob (lazy)
+  │     ├── job.to_arrow()  ← executes query, fetches Arrow table
+  │     └── provider.online_write_batch(...)
+  │           └── online_store.online_write_batch(config, table, data, progress)
+  └── Update last_updated_timestamp in registry
+```
+
+### `get_online_features`
+```
+store.get_online_features(features, entity_rows)
+  ├── Resolve feature refs → FeatureViews from registry
+  ├── online_store.online_read(config, table, entity_rows, requested_features)
+  │     └── Deserialize ValueProto → Python dict
+  ├── Apply OnDemandFeatureView transformations (if any)
+  └── Return OnlineFeaturesResponse
+```
+
+### `get_historical_features`
+```
+store.get_historical_features(entity_df, features)
+  ├── Resolve feature refs → FeatureViews from registry
+  ├── offline_store.get_historical_features(config, feature_views, entity_df)
+  │     └── Point-in-time join:
+  │           for each entity row, find latest values where
+  │           event_timestamp ≤ entity_df.event_timestamp
+  │           (prevents data leakage in training)
+  └── Returns RetrievalJob → .to_df() / .to_arrow()
+```
+
+---
+
+## Feature Servers
+
+### Python Feature Server (FastAPI)
+
+**File**: `sdk/python/feast/feature_server.py`
+
+A FastAPI app that wraps `FeatureStore`. Started with `feast serve`.
+
+Endpoints:
+- `POST /get-online-features` — online feature retrieval
+- `POST /push` — push features to online/offline store
+- `POST /materialize` — trigger materialization
+- `GET /health` — health check
+
+The app loads `feature_store.yaml` at startup, creates a `FeatureStore`, and periodically
+refreshes the registry in the background (async timer).
+
+### Go Feature Server
+
+**Directory**: `go/`
+**Entry point**: `go/main.go`
+
+A high-performance alternative to the Python feature server, written in Go.
+Supports HTTP, HTTPS, and gRPC transports:
+
+```bash
+go run go/main.go -type http  -port 6566
+go run go/main.go -type grpc  -port 6566
+```
+
+Key packages:
+- `go/internal/feast/` — Go port of FeatureStore (reads feature_store.yaml, calls online store)
+- `go/internal/feast/server/` — HTTP and gRPC server implementations
+- `go/internal/feast/server/logging/` — feature logging to offline store
+
+The Go server reads the registry directly (proto file or remote) and calls the online store.
+It does not support `feast apply` or materialization — those remain Python-only.
+
+---
+
+## Feast Operator (Kubernetes)
+
+**Directory**: `infra/feast-operator/`
+**Language**: Go (controller-runtime / kubebuilder)
+
+The operator manages the full lifecycle of a Feast deployment on Kubernetes via a
+`FeatureStore` Custom Resource Definition (CRD).
+
+### CRD: FeatureStore
+
+**API version**: `feast.dev/v1`
+**File**: `infra/feast-operator/api/v1/featurestore_types.go`
+
+```yaml
+apiVersion: feast.dev/v1
+kind: FeatureStore
+metadata:
+  name: my-feast
+spec:
+  feastProjectName: my_project
+  services:
+    offlineStore:
+      persistence:
+        file:
+          type: dask
+    onlineStore:
+      persistence:
+        store:
+          type: redis
+          secretRef:
+            name: redis-credentials
+    registry:
+      local:
+        persistence:
+          file:
+            path: /data/registry.db
+```
+
+### What the operator manages
+
+| Service | What it deploys |
+|---|---|
+| **Online Store server** | Deployment + Service for the feature server (Go or Python) |
+| **Offline Store server** | Deployment + Service for the offline feature server |
+| **Registry server** | Deployment + Service for the registry gRPC server |
+| **feature_store.yaml** | ConfigMap auto-generated from the CR spec |
+| **Materialization jobs** | CronJob (`spec.services.onlineStore.cronJob`) |
+| **TLS** | Certificate management via `spec.services.*.tls` |
+| **Auth** | OIDC / Kubernetes RBAC via `spec.authz` |
+
+### Reconcile loop
+
+**File**: `infra/feast-operator/internal/controller/featurestore_controller.go`
+
+The `FeatureStoreReconciler.Reconcile` method runs on every CR change:
+1. Fetches the `FeatureStore` CR
+2. Calls `deployFeast()` → creates/updates Deployments, Services, ConfigMaps
+3. Updates CR status conditions (`OfflineStore`, `OnlineStore`, `Registry` ready conditions)
+4. Watches owned resources; re-reconciles on any change
+
+Supporting services logic: `infra/feast-operator/internal/controller/services/`
+
+---
+
+## Serialization Layer
+
+All persistent metadata and the feature server wire format use **Protocol Buffers**.
+
+```
+Python object (FeatureView, Entity, ...)
+    ├── .to_proto()   → Protobuf message → stored in registry or sent over gRPC
+    └── .from_proto() ← Protobuf message
+
+Proto definitions:
+  protos/feast/core/    # registry objects (FeatureView, Entity, DataSource, …)
+  protos/feast/serving/ # serving API (GetOnlineFeaturesRequest/Response)
+  protos/feast/types/   # Value, EntityKey, Field
+```
+
+When adding a new field to a Feast object:
+1. Update the `.proto` file
+2. Run `make compile-protos-python` (and `make compile-protos-go` if applicable)
+3. Update `.to_proto()` and `.from_proto()` in the Python class
+
+---
+
+## Key Files Quick Reference
+
+| Concern | Key file(s) |
+|---|---|
+| User-facing Python API | `sdk/python/feast/feature_store.py` |
+| Config parsing | `sdk/python/feast/repo_config.py` |
+| `feast apply` CLI logic | `sdk/python/feast/repo_operations.py` |
+| Registry diff | `sdk/python/feast/diff/registry_diff.py` |
+| Registry (proto/file) | `sdk/python/feast/infra/registry/registry.py` |
+| Registry (SQL) | `sdk/python/feast/infra/registry/sql.py` |
+| PIT join | `sdk/python/feast/infra/offline_stores/offline_utils.py` |
+| Online store interface | `sdk/python/feast/infra/online_stores/online_store.py` |
+| Entity key serialization | `sdk/python/feast/infra/online_stores/helpers.py` |
+| Python feature server | `sdk/python/feast/feature_server.py` |
+| Go feature server | `go/main.go`, `go/internal/feast/server/` |
+| Operator CRD types | `infra/feast-operator/api/v1/featurestore_types.go` |
+| Operator controller | `infra/feast-operator/internal/controller/featurestore_controller.go` |
+| Operator services | `infra/feast-operator/internal/controller/services/` |
+| Proto definitions | `protos/feast/` |
+| Web UI | `ui/` (React) |
+
+---
+
+## Official Architecture Documentation
+
+The `docs/` directory contains user-facing architecture documentation that complements this skill:
+
+| Topic | Doc |
+|---|---|
+| Architecture overview | `docs/getting-started/architecture/overview.md` |
+| Push vs pull model | `docs/getting-started/architecture/push-vs-pull-model.md` |
+| Write patterns | `docs/getting-started/architecture/write-patterns.md` |
+| Feature transformation | `docs/getting-started/architecture/feature-transformation.md` |
+| RBAC / authorization | `docs/getting-started/architecture/rbac.md` |
+| Online store component | `docs/getting-started/components/online-store.md` |
+| Offline store component | `docs/getting-started/components/offline-store.md` |
+| Registry component | `docs/getting-started/components/registry.md` |
+| Feature server component | `docs/getting-started/components/feature-server.md` |
+| Provider component | `docs/getting-started/components/provider.md` |
+| Compute engine | `docs/getting-started/components/compute-engine.md` |
+| ADRs (design decisions) | `docs/adr/` |

--- a/skills/feast-dev/SKILL.md
+++ b/skills/feast-dev/SKILL.md
@@ -58,8 +58,11 @@ make lint-python
 # Run all precommit checks (format + lint)
 make precommit-check
 
-# Type checking
-cd sdk/python && python -m mypy feast
+# Type checking (entire codebase)
+uv run bash -c "cd sdk/python && mypy feast"
+
+# Type-check a single file
+uv run bash -c "cd sdk/python && mypy feast/path/to/file.py"
 ```
 
 ## Code Style
@@ -71,11 +74,44 @@ cd sdk/python && python -m mypy feast
 - Add a GitHub label to PRs (e.g. `kind/bug`, `kind/feature`, `kind/housekeeping`)
 - Sign off commits with `git commit -s` (DCO requirement)
 
+## Docker Images
+
+```bash
+# Build all Docker images
+make build-docker
+
+# Build feature server Docker image
+make build-feature-server-docker
+```
+
+## Documentation
+
+```bash
+# Build Sphinx documentation
+make build-sphinx
+
+# Build templates
+make build-templates
+
+# Build Helm docs
+make build-helm-docs
+```
+
 ## Documentation and Blog Posts
 
 - **Blog posts must be placed in `/infra/website/docs/blog/`** — do NOT place them under `docs/blog/` or elsewhere.
 - Blog post files must include YAML frontmatter with `title`, `description`, `date`, and `authors` fields matching the format of existing posts in that directory.
-- All other reference documentation (concepts, how-tos, reference pages) goes under `docs/`.
+- All other docs go under `docs/` and **must be added to `docs/SUMMARY.md`** (GitBook navigation) or they won't appear on the website.
+
+| Change type | Doc location |
+|---|---|
+| New online store | `docs/reference/online-stores/<name>.md` + update `README.md` and `SUMMARY.md` |
+| New offline store | `docs/reference/offline-stores/<name>.md` + update `README.md`, `overview.md`, `SUMMARY.md` |
+| New registry backend | `docs/reference/registries/<name>.md` + update `SUMMARY.md` |
+| Config option | `docs/reference/feature-store-yaml.md` |
+| CLI flag/command | `docs/reference/feast-cli-commands.md` |
+| How-to / integration | `docs/how-to-guides/customizing-feast/` or `docs/how-to-guides/` + update `SUMMARY.md` |
+| Architecture / concept | `docs/getting-started/architecture/` or `docs/getting-started/components/` |
 
 ## Project Structure
 

--- a/skills/feast-testing/SKILL.md
+++ b/skills/feast-testing/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: feast-testing
+description: How to test and debug Feast — running targeted tests, writing unit tests for new components, debugging registry and online store issues, and inspecting live feature store state. Use when writing tests for a new feature, debugging a failing test, investigating a runtime error, or verifying that a change works correctly end-to-end.
+license: Apache-2.0
+compatibility: Works with Claude Code, OpenAI Codex, and any Agent Skills compatible tool.
+metadata:
+  author: feast-dev
+  version: "1.0"
+---
+
+# Testing and Debugging Feast
+
+## Test Organization
+
+```
+sdk/python/tests/
+├── unit/                        # Fast tests, no external deps, run locally
+│   ├── infra/
+│   │   ├── online_store/        # Per-store unit tests (redis, dynamodb, etc.)
+│   │   ├── offline_stores/      # Offline store unit tests
+│   │   └── registry/            # Registry unit tests
+│   ├── test_unit_feature_store.py  # Core FeatureStore behavior
+│   ├── test_feature_views.py    # Feature view validation
+│   └── test_on_demand_*.py      # On-demand transformation tests
+└── integration/                 # Requires real infrastructure (run in CI)
+    ├── feature_repos/           # Sample repos used as test fixtures
+    └── test_universal_*.py      # Cross-store compatibility tests
+```
+
+**Rule of thumb**: if a test needs mocks for an external service, it belongs in `unit/`.
+If it spins up real infra (Redis, DynamoDB, BigQuery), it belongs in `integration/`.
+
+---
+
+## Running Tests
+
+### Targeted unit tests
+
+```bash
+# Run a single test file
+python -m pytest sdk/python/tests/unit/infra/online_store/test_dynamodb_online_store.py -v
+
+# Run a single test by name
+python -m pytest sdk/python/tests/unit/test_unit_feature_store.py -k "test_apply" -v
+
+# Run all unit tests for one subsystem
+python -m pytest sdk/python/tests/unit/infra/online_store/ -v
+
+# Run all unit tests (fast, no infra needed)
+make test-python-unit
+```
+
+### Integration tests (local)
+
+```bash
+# Run local integration tests (SQLite online, file offline)
+make test-python-integration-local
+
+# Run specific integration test with verbose output
+python -m pytest sdk/python/tests/integration/ -k "test_online_retrieval" -v -s
+```
+
+### Running a single test file fast (skip slow markers)
+
+```bash
+python -m pytest sdk/python/tests/unit/infra/online_store/test_redis.py -v --no-header -q
+```
+
+---
+
+## Writing Unit Tests for a New Component
+
+### Pattern: testing an online store
+
+Follow `sdk/python/tests/unit/infra/online_store/test_dynamodb_online_store.py` or `test_redis.py`.
+
+```python
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from feast.infra.online_stores.mystore import MyStore, MyStoreConfig
+from feast.repo_config import RepoConfig
+
+def make_config(store_config: dict) -> RepoConfig:
+    return RepoConfig(
+        project="test_project",
+        registry="data/registry.db",
+        provider="local",
+        online_store=store_config,
+    )
+
+@patch("feast.infra.online_stores.mystore.MyClient")
+def test_online_write_batch(mock_client_cls):
+    mock_client = MagicMock()
+    mock_client_cls.return_value = mock_client
+
+    config = make_config({"type": "mystore", "host": "localhost"})
+    store = MyStore()
+    feature_view = MagicMock()
+    feature_view.name = "driver_stats"
+
+    store.online_write_batch(config, feature_view, data=[...], progress=None)
+
+    mock_client.set.assert_called_once()
+
+# For async methods:
+def test_online_write_batch_async():
+    async def _run():
+        store = MyStore()
+        await store.online_write_batch_async(config, feature_view, data, progress=None)
+    asyncio.run(_run())
+```
+
+### Pattern: testing registry operations
+
+Follow `sdk/python/tests/unit/infra/registry/test_registry.py`.
+
+```python
+from feast.infra.registry.registry import Registry
+from feast.repo_config import RegistryConfig
+
+def test_apply_feature_view(tmp_path):
+    config = RegistryConfig(path=str(tmp_path / "registry.db"))
+    registry = Registry("test_project", config, repo_path=None)
+
+    entity = Entity(name="driver_id", value_type=ValueType.INT64)
+    registry.apply_entity(entity, project="test_project")
+
+    stored = registry.get_entity("driver_id", project="test_project")
+    assert stored.name == "driver_id"
+```
+
+### Pattern: testing FeatureStore end-to-end (unit level)
+
+```python
+from feast import FeatureStore
+from feast.repo_config import RepoConfig
+
+def test_get_online_features(tmp_path):
+    config = RepoConfig(
+        project="test",
+        registry=str(tmp_path / "registry.db"),
+        provider="local",
+        online_store={"type": "sqlite", "path": str(tmp_path / "online.db")},
+        offline_store={"type": "file"},
+    )
+    store = FeatureStore(config=config)
+    # apply objects, write data, then assert retrieval
+```
+
+---
+
+## Debugging Common Issues
+
+### Registry out of sync / stale metadata
+
+```bash
+# Inspect the live registry
+feast registry-dump  # prints full proto as JSON
+
+# Or from Python:
+from feast import FeatureStore
+store = FeatureStore(repo_path=".")
+store.registry.list_feature_views(project=store.project)
+store.registry.list_entities(project=store.project)
+```
+
+**Symptom**: `FeatureView not found` or stale feature definitions.
+**Fix**: Re-run `feast apply`. If using a cached registry (TTL > 0), wait for cache expiry or force refresh by restarting the process.
+
+### Online store returns None for all features
+
+```bash
+# Check if materialization has run
+feast feature-views list     # shows last_updated_timestamp
+
+# Check entity key format
+# Entity keys are serialized — if the serialization_version doesn't match, lookups fail.
+# Check entity_key_serialization_version in feature_store.yaml
+```
+
+**Symptom**: `get_online_features` returns all `None` values despite materialization running.
+**Cause**: Entity key serialization version mismatch, wrong project name, or wrong TTL causing data to expire.
+
+### Type errors from mypy
+
+```bash
+# Type-check only the file you changed
+uv run bash -c "cd sdk/python && mypy feast/infra/online_stores/mystore.py"
+
+# Common fix: add Optional[] around return types, use cast() for dynamic lookups
+```
+
+### Test imports fail / module not found
+
+```bash
+# Ensure you're running from repo root with dev dependencies installed
+make install-python-dependencies-dev
+
+# Run with uv to use the pinned venv
+uv run python -m pytest sdk/python/tests/unit/... -v
+```
+
+### Protobuf deserialization errors
+
+**Symptom**: `DecodeError` or unexpected field values when reading registry.
+**Cause**: Proto schema changed without recompiling.
+**Fix**:
+```bash
+make compile-protos-python
+```
+
+### Feature server returns 500
+
+```bash
+# Start the feature server locally and check logs
+feast serve --host 0.0.0.0 --port 6566
+
+# Test directly
+curl -X POST http://localhost:6566/get-online-features \
+  -H "Content-Type: application/json" \
+  -d '{"features": ["driver_stats:conv_rate"], "entities": {"driver_id": [1001]}}'
+```
+
+---
+
+## Useful CLI Commands for Inspection
+
+```bash
+feast entities list                  # list all registered entities
+feast feature-views list             # list feature views + last materialization time
+feast feature-services list          # list feature services
+feast on-demand-feature-views list   # list ODFVs
+feast registry-dump                  # dump full registry as JSON (debug)
+feast plan                           # preview what feast apply would change (dry run)
+```
+
+---
+
+## Test Utilities
+
+| Utility | Location | Purpose |
+|---|---|---|
+| `get_feature_view()` helpers | `tests/unit/infra/online_store/test_*.py` | Build minimal FeatureView mocks |
+| `LocalRegistry` fixture | `tests/unit/infra/registry/test_registry.py` | In-memory registry for unit tests |
+| `integration/feature_repos/` | `tests/integration/` | Sample repos for integration test scenarios |
+| `conftest.py` fixtures | Various `tests/` subdirs | Shared pytest fixtures per subsystem |

--- a/skills/feast-user-guide/SKILL.md
+++ b/skills/feast-user-guide/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: feast-user-guide
+description: Guide for working with Feast (Feature Store) — defining features, configuring feature_store.yaml, retrieving features online/offline, using the CLI, and building RAG retrieval pipelines. Use when the user asks about creating entities, feature views, on-demand feature views, stream feature views, feature services, data sources, feature_store.yaml configuration, feast apply/materialize commands, online or historical feature retrieval, or vector-based document retrieval with Feast.
+license: Apache-2.0
+compatibility: Works with Claude Code, OpenAI Codex, and any Agent Skills compatible tool.
+metadata:
+  author: feast-dev
+  version: "1.0"
+---
+
+# Feast User Guide
+
+## Quick Start
+
+A Feast project requires:
+1. A `feature_store.yaml` config file
+2. Python files defining entities, data sources, feature views, and feature services
+3. Running `feast apply` to register definitions
+
+```bash
+feast init my_project
+cd my_project
+feast apply
+```
+
+## Core Concepts
+
+### Entity
+An entity is a collection of semantically related features (e.g., a customer, a driver). Entities have join keys used to look up features.
+
+```python
+from feast import Entity
+from feast.value_type import ValueType
+
+driver = Entity(
+    name="driver_id",
+    description="Driver identifier",
+    value_type=ValueType.INT64,
+)
+```
+
+### Data Sources
+Data sources describe where raw feature data lives.
+
+```python
+from feast import FileSource, BigQuerySource, KafkaSource, PushSource, RequestSource
+from feast.data_format import ParquetFormat
+
+# Batch source (file)
+driver_stats_source = FileSource(
+    name="driver_stats_source",
+    path="data/driver_stats.parquet",
+    timestamp_field="event_timestamp",
+    created_timestamp_column="created",
+)
+
+# Request source (for on-demand features)
+input_request = RequestSource(
+    name="vals_to_add",
+    schema=[Field(name="val_to_add", dtype=Float64)],
+)
+```
+
+### FeatureView
+Maps features from a data source to entities with a schema, TTL, and online/offline settings.
+
+```python
+from feast import FeatureView, Field
+from feast.types import Float32, Int64, String
+from datetime import timedelta
+
+driver_hourly_stats = FeatureView(
+    name="driver_hourly_stats",
+    entities=[driver],
+    ttl=timedelta(days=365),
+    schema=[
+        Field(name="conv_rate", dtype=Float32),
+        Field(name="acc_rate", dtype=Float32),
+        Field(name="avg_daily_trips", dtype=Int64),
+    ],
+    online=True,
+    source=driver_stats_source,
+)
+```
+
+### OnDemandFeatureView
+Computes features at request time from other feature views and/or request data.
+
+```python
+from feast import on_demand_feature_view
+import pandas as pd
+
+@on_demand_feature_view(
+    sources=[driver_hourly_stats, input_request],
+    schema=[Field(name="conv_rate_plus_val", dtype=Float64)],
+    mode="pandas",
+)
+def transformed_conv_rate(inputs: pd.DataFrame) -> pd.DataFrame:
+    df = pd.DataFrame()
+    df["conv_rate_plus_val"] = inputs["conv_rate"] + inputs["val_to_add"]
+    return df
+```
+
+### FeatureService
+Groups features from multiple views for retrieval.
+
+```python
+from feast import FeatureService
+
+driver_fs = FeatureService(
+    name="driver_ranking",
+    features=[driver_hourly_stats, transformed_conv_rate],
+)
+```
+
+## Feature Retrieval
+
+### Online (low-latency)
+```python
+from feast import FeatureStore
+
+store = FeatureStore(repo_path=".")
+
+features = store.get_online_features(
+    features=[
+        "driver_hourly_stats:conv_rate",
+        "driver_hourly_stats:acc_rate",
+    ],
+    entity_rows=[{"driver_id": 1001}, {"driver_id": 1002}],
+).to_dict()
+```
+
+### Historical (training data with point-in-time joins)
+```python
+entity_df = pd.DataFrame({
+    "driver_id": [1001, 1002],
+    "event_timestamp": [datetime(2023, 1, 1), datetime(2023, 1, 2)],
+})
+
+training_df = store.get_historical_features(
+    entity_df=entity_df,
+    features=["driver_hourly_stats:conv_rate", "driver_hourly_stats:acc_rate"],
+).to_df()
+```
+
+Or use a FeatureService:
+```python
+training_df = store.get_historical_features(
+    entity_df=entity_df,
+    features=driver_fs,
+).to_df()
+```
+
+## Materialization
+
+Load features from offline store into online store:
+
+```bash
+# Full materialization over a time range
+feast materialize 2023-01-01T00:00:00 2023-12-31T23:59:59
+
+# Incremental (from last materialized timestamp)
+feast materialize-incremental $(date -u +"%Y-%m-%dT%H:%M:%S")
+```
+
+Python API:
+```python
+from datetime import datetime
+store.materialize(start_date=datetime(2023, 1, 1), end_date=datetime(2023, 12, 31))
+store.materialize_incremental(end_date=datetime.utcnow())
+```
+
+## CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `feast init [DIR]` | Create new feature repository |
+| `feast apply` | Register/update feature definitions |
+| `feast plan` | Preview changes without applying |
+| `feast materialize START END` | Materialize features to online store |
+| `feast materialize-incremental END` | Incremental materialization |
+| `feast entities list` | List registered entities |
+| `feast feature-views list` | List feature views |
+| `feast feature-services list` | List feature services |
+| `feast on-demand-feature-views list` | List on-demand feature views |
+| `feast teardown` | Remove infrastructure resources |
+| `feast version` | Show SDK version |
+
+Options: `--chdir` / `-c` (run in different directory), `--feature-store-yaml` / `-f` (override config path).
+
+## Vector Search / RAG
+
+Define a feature view with vector fields for similarity search:
+
+```python
+from feast.types import Array, Float32
+
+wiki_passages = FeatureView(
+    name="wiki_passages",
+    entities=[passage_entity],
+    schema=[
+        Field(name="passage_text", dtype=String),
+        Field(
+            name="embedding",
+            dtype=Array(Float32),
+            vector_index=True,
+            vector_length=384,
+            vector_search_metric="COSINE",
+        ),
+    ],
+    source=passages_source,
+    online=True,
+)
+```
+
+Retrieve similar documents:
+```python
+results = store.retrieve_online_documents(
+    feature="wiki_passages:embedding",
+    query=query_embedding,
+    top_k=5,
+)
+```
+
+## feature_store.yaml Minimal Config
+
+```yaml
+project: my_project
+registry: data/registry.db
+provider: local
+online_store:
+  type: sqlite
+  path: data/online_store.db
+```
+
+## Common Imports
+
+```python
+from feast import (
+    Entity, FeatureView, OnDemandFeatureView, FeatureService,
+    Field, FileSource, RequestSource, FeatureStore,
+)
+from feast.on_demand_feature_view import on_demand_feature_view
+from feast.types import Float32, Float64, Int64, String, Bool, Array
+from feast.value_type import ValueType
+from datetime import timedelta
+```
+
+## Detailed References
+
+- **Feature definitions** (all types, parameters, patterns): See [references/feature-definitions.md](../references/feature-definitions.md)
+- **Configuration** (feature_store.yaml, all store types, auth): See [references/configuration.md](../references/configuration.md)
+- **Retrieval & RAG** (online/offline retrieval, vector search, RAG retriever): See [references/retrieval-and-rag.md](../references/retrieval-and-rag.md)


### PR DESCRIPTION
# What this PR does / why we need it:

Add tool-agnostic agent skills (compatible with Claude Code, Cursor, OpenAI Codex, and similar AI tools):

- **skills/feast-architecture/SKILL.md**: internals of each component (registry, provider, online/offline store, feature server, operator, data flows, serialization)
- **skills/feast-dev/SKILL.md**: contributor workflow, setup, Docker, docs
- **skills/feast-testing/SKILL.md**: how to run and write tests
- **skills/feast-user-guide/SKILL.md**: using Feast as an end user

Add Cursor rules (.cursor/rules/) and Claude rules (.claude/rules/) with symlinks to the shared skill files so each tool picks up the same guidance automatically.

Update AGENTS.md to reference the new skills table and tighten the command examples. Update .gitignore to track .claude rules/skills while still ignoring ephemeral local-state files.


