### PR TITLE
feat: Data Quality Monitoring added in feast UI

### DIFF
--- a/docs/how-to-guides/feature-monitoring.md
+++ b/docs/how-to-guides/feature-monitoring.md
@@ -43,16 +43,16 @@ Done!
 The baseline reads all available source data and stores the resulting statistics with `is_baseline=TRUE`. This serves as the reference distribution for future drift detection.
 
 Baseline computation is:
-- **Non-blocking** — `feast apply` returns immediately; computation runs asynchronously
+- **Threaded** — runs in a background thread but completes before `feast apply` exits
 - **Idempotent** — only features without existing baselines are computed; re-running `feast apply` won't recompute existing baselines
 
-### Disabling auto-baseline
+### Enabling auto-baseline
 
-To skip automatic baseline computation on `feast apply`, set the DQM config in `feature_store.yaml`:
+To enable automatic baseline computation on `feast apply`, set the DQM config in `feature_store.yaml`:
 
 ```yaml
-DataQualityMonitoring:
-  auto_baseline: false
+data_quality_monitoring:
+  auto_baseline: true
 ```
 
 When using the Feast operator, set this in the `FeatureStore` CR:
@@ -63,8 +63,10 @@ kind: FeatureStore
 spec:
   feastProject: my_project
   dataQualityMonitoring:
-    autoBaseline: false
+    autoBaseline: true
 ```
+
+To disable it, set `auto_baseline: false` (or `autoBaseline: false` in the CR).
 
 ## 3. Scheduled monitoring with the CLI
 

--- a/sdk/python/feast/api/registry/rest/monitoring.py
+++ b/sdk/python/feast/api/registry/rest/monitoring.py
@@ -77,29 +77,6 @@ def get_monitoring_router(grpc_handler, store=None):
             )
         return store
 
-    @router.get("/monitoring/config", tags=["Monitoring"])
-    def monitoring_config():
-        """Report whether DQM is configured, checking the live config file."""
-        import os
-
-        import yaml
-
-        s = _get_store()
-        dqm = getattr(s.config, "data_quality_monitoring_config", None)
-        if dqm is not None:
-            return {"enabled": True}
-
-        repo_path = getattr(s, "repo_path", None)
-        if repo_path:
-            cfg_file = os.path.join(str(repo_path), "feature_store.yaml")
-            if os.path.exists(cfg_file):
-                with open(cfg_file) as f:
-                    cfg = yaml.safe_load(f)
-                if cfg and cfg.get("data_quality_monitoring"):
-                    return {"enabled": True}
-
-        return {"enabled": False}
-
     # ------------------------------------------------------------------ #
     #  DQM Job: submit and track
     # ------------------------------------------------------------------ #

--- a/sdk/python/feast/api/registry/rest/monitoring.py
+++ b/sdk/python/feast/api/registry/rest/monitoring.py
@@ -77,6 +77,29 @@ def get_monitoring_router(grpc_handler, store=None):
             )
         return store
 
+    @router.get("/monitoring/config", tags=["Monitoring"])
+    def monitoring_config():
+        """Report whether DQM is configured, checking the live config file."""
+        import os
+
+        import yaml
+
+        s = _get_store()
+        dqm = getattr(s.config, "data_quality_monitoring_config", None)
+        if dqm is not None:
+            return {"enabled": True}
+
+        repo_path = getattr(s, "repo_path", None)
+        if repo_path:
+            cfg_file = os.path.join(str(repo_path), "feature_store.yaml")
+            if os.path.exists(cfg_file):
+                with open(cfg_file) as f:
+                    cfg = yaml.safe_load(f)
+                if cfg and cfg.get("data_quality_monitoring"):
+                    return {"enabled": True}
+
+        return {"enabled": False}
+
     # ------------------------------------------------------------------ #
     #  DQM Job: submit and track
     # ------------------------------------------------------------------ #

--- a/sdk/python/feast/monitoring/monitoring_service.py
+++ b/sdk/python/feast/monitoring/monitoring_service.py
@@ -367,7 +367,7 @@ class MonitoringService:
                     feature_view=fv,
                     metrics_list=metrics_list,
                     metric_date=date.today(),
-                    granularity="daily",
+                    granularity="baseline",
                     set_baseline=True,
                     now=now,
                 )

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -81,7 +81,7 @@ def _setup_rest_mode(app: FastAPI, store: "feast.FeatureStore"):
     grpc_handler = RegistryServer(store.registry)
 
     rest_app = FastAPI(root_path="/api/v1")
-    register_all_routes(rest_app, grpc_handler)
+    register_all_routes(rest_app, grpc_handler, store=store)
 
     class PushRequest(BaseModel):
         push_source_name: str

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -113,128 +113,126 @@ const FeastUISansProvidersInner = ({
     <EuiProvider colorMode={colorMode}>
       <EuiErrorBoundary>
         <DataModeContext.Provider value={dataModeConfig}>
-          <MonitoringContext.Provider
-            value={
-              feastUIConfigs?.monitoringConfig || {
-                apiBaseUrl: "/api/v1",
-                enabled: true,
-              }
-            }
+          <TabsRegistryContext.Provider
+            value={{
+              RegularFeatureViewCustomTabs: [
+                {
+                  label: "CURL Generator",
+                  path: "curl-generator",
+                  Component: CurlGeneratorTab,
+                },
+                ...(feastUIConfigs?.tabsRegistry
+                  ?.RegularFeatureViewCustomTabs || []),
+              ],
+              OnDemandFeatureViewCustomTabs:
+                feastUIConfigs?.tabsRegistry?.OnDemandFeatureViewCustomTabs ||
+                [],
+              StreamFeatureViewCustomTabs:
+                feastUIConfigs?.tabsRegistry?.StreamFeatureViewCustomTabs || [],
+              FeatureServiceCustomTabs:
+                feastUIConfigs?.tabsRegistry?.FeatureServiceCustomTabs || [],
+              FeatureCustomTabs:
+                feastUIConfigs?.tabsRegistry?.FeatureCustomTabs || [],
+              DataSourceCustomTabs:
+                feastUIConfigs?.tabsRegistry?.DataSourceCustomTabs || [],
+              EntityCustomTabs:
+                feastUIConfigs?.tabsRegistry?.EntityCustomTabs || [],
+              DatasetCustomTabs:
+                feastUIConfigs?.tabsRegistry?.DatasetCustomTabs || [],
+            }}
           >
-            <TabsRegistryContext.Provider
-              value={{
-                RegularFeatureViewCustomTabs: [
-                  {
-                    label: "CURL Generator",
-                    path: "curl-generator",
-                    Component: CurlGeneratorTab,
-                  },
-                  ...(feastUIConfigs?.tabsRegistry
-                    ?.RegularFeatureViewCustomTabs || []),
-                ],
-                OnDemandFeatureViewCustomTabs:
-                  feastUIConfigs?.tabsRegistry?.OnDemandFeatureViewCustomTabs ||
-                  [],
-                StreamFeatureViewCustomTabs:
-                  feastUIConfigs?.tabsRegistry?.StreamFeatureViewCustomTabs || [],
-                FeatureServiceCustomTabs:
-                  feastUIConfigs?.tabsRegistry?.FeatureServiceCustomTabs || [],
-                FeatureCustomTabs:
-                  feastUIConfigs?.tabsRegistry?.FeatureCustomTabs || [],
-                DataSourceCustomTabs:
-                  feastUIConfigs?.tabsRegistry?.DataSourceCustomTabs || [],
-                EntityCustomTabs:
-                  feastUIConfigs?.tabsRegistry?.EntityCustomTabs || [],
-                DatasetCustomTabs:
-                  feastUIConfigs?.tabsRegistry?.DatasetCustomTabs || [],
-              }}
+            <FeatureFlagsContext.Provider
+              value={feastUIConfigs?.featureFlags || {}}
             >
-              <FeatureFlagsContext.Provider
-                value={feastUIConfigs?.featureFlags || {}}
+              <MonitoringContext.Provider
+                value={
+                  feastUIConfigs?.monitoringConfig || {
+                    apiBaseUrl: "/api/v1",
+                    enabled: true,
+                  }
+                }
               >
                 <ProjectListContext.Provider value={projectListContext}>
                   <Routes>
                     <Route path="/" element={<Layout />}>
                       <Route index element={<RootProjectSelectionPage />} />
-                      <Route path="/p/:projectName/*" element={<NoProjectGuard />}>
+                      <Route
+                        path="/p/:projectName/*"
+                        element={<NoProjectGuard />}
+                      >
                         <Route index element={<ProjectOverviewPage />} />
-                        <Route path="data-source/" element={<DatasourceIndex />} />
                         <Route
-                          path="/p/:projectName/*"
-                          element={<NoProjectGuard />}
-                        >
-                          <Route index element={<ProjectOverviewPage />} />
-                          <Route
-                            path="data-source/"
-                            element={<DatasourceIndex />}
-                          />
-                          <Route
-                            path="data-source/:dataSourceName/*"
-                            element={<DataSourceInstance />}
-                          />
-                          <Route path="features/" element={<FeatureListPage />} />
-                          <Route
-                            path="feature-view/"
-                            element={<FeatureViewIndex />}
-                          />
-                          <Route
-                            path="feature-view/:featureViewName/*"
-                            element={<FeatureViewInstance />}
-                          ></Route>
-                          <Route
-                            path="feature-view/:FeatureViewName/feature/:FeatureName/*"
-                            element={<FeatureInstance />}
-                          />
-                          <Route
-                            path="feature-service/"
-                            element={<FeatureServiceIndex />}
-                          />
-                          <Route
-                            path="feature-service/:featureServiceName/*"
-                            element={<FeatureServiceInstance />}
-                          />
-                          <Route path="entity/" element={<EntityIndex />} />
-                          <Route
-                            path="entity/:entityName/*"
-                            element={<EntityInstance />}
-                          />
-
-                          <Route path="label-view/" element={<LabelViewIndex />} />
-                          <Route
-                            path="label-view/:labelViewName/*"
-                            element={<LabelViewInstance />}
-                          />
-                          <Route
-                            path="label-view/:FeatureViewName/label/:FeatureName/*"
-                            element={<FeatureInstance />}
-                          />
-                          <Route path="data-set/" element={<DatasetIndex />} />
-                          <Route
-                            path="data-set/:datasetName/*"
-                            element={<DatasetInstance />}
-                          />
-                          <Route path="permissions/" element={<PermissionsIndex />} />
-                          <Route path="lineage/" element={<LineageIndex />} />
-                          <Route
-                            path="monitoring/"
-                            element={<MonitoringIndex />}
-                          />
-                          <Route
-                            path="monitoring/feature/:featureViewName/:featureName"
-                            element={<FeatureMetricsDetail />}
-                          />
-                        </Route>
+                          path="data-source/"
+                          element={<DatasourceIndex />}
+                        />
+                        <Route
+                          path="data-source/:dataSourceName/*"
+                          element={<DataSourceInstance />}
+                        />
+                        <Route path="features/" element={<FeatureListPage />} />
+                        <Route
+                          path="feature-view/"
+                          element={<FeatureViewIndex />}
+                        />
+                        <Route
+                          path="feature-view/:featureViewName/*"
+                          element={<FeatureViewInstance />}
+                        ></Route>
+                        <Route
+                          path="feature-view/:FeatureViewName/feature/:FeatureName/*"
+                          element={<FeatureInstance />}
+                        />
+                        <Route
+                          path="feature-service/"
+                          element={<FeatureServiceIndex />}
+                        />
+                        <Route
+                          path="feature-service/:featureServiceName/*"
+                          element={<FeatureServiceInstance />}
+                        />
+                        <Route path="entity/" element={<EntityIndex />} />
+                        <Route
+                          path="entity/:entityName/*"
+                          element={<EntityInstance />}
+                        />
+                        <Route path="label-view/" element={<LabelViewIndex />} />
+                        <Route
+                          path="label-view/:labelViewName/*"
+                          element={<LabelViewInstance />}
+                        />
+                        <Route
+                          path="label-view/:FeatureViewName/label/:FeatureName/*"
+                          element={<FeatureInstance />}
+                        />
+                        <Route path="data-set/" element={<DatasetIndex />} />
+                        <Route
+                          path="data-set/:datasetName/*"
+                          element={<DatasetInstance />}
+                        />
+                        <Route
+                          path="permissions/"
+                          element={<PermissionsIndex />}
+                        />
+                        <Route path="lineage/" element={<LineageIndex />} />
+                        <Route
+                          path="monitoring/"
+                          element={<MonitoringIndex />}
+                        />
+                        <Route
+                          path="monitoring/feature/:featureViewName/:featureName"
+                          element={<FeatureMetricsDetail />}
+                        />
                       </Route>
                     </Route>
                     <Route path="*" element={<NoMatch />} />
                   </Routes>
                 </ProjectListContext.Provider>
-              </FeatureFlagsContext.Provider>
-            </TabsRegistryContext.Provider>
-          </MonitoringContext.Provider>
+              </MonitoringContext.Provider>
+            </FeatureFlagsContext.Provider>
+          </TabsRegistryContext.Provider>
         </DataModeContext.Provider>
-    </EuiErrorBoundary>
-  </EuiProvider>
+      </EuiErrorBoundary>
+    </EuiProvider>
   );
 };
 

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 
 import "./index.css";
 
@@ -109,21 +109,10 @@ const FeastUISansProvidersInner = ({
     fetchOptions: feastUIConfigs?.fetchOptions,
   };
 
-  const [autoMonitoringEnabled, setAutoMonitoringEnabled] = useState(false);
-  useEffect(() => {
-    if (feastUIConfigs?.monitoringConfig) return;
-    fetch("/api/v1/monitoring/config")
-      .then((r) => r.json())
-      .then((data) => {
-        if (data?.enabled) setAutoMonitoringEnabled(true);
-      })
-      .catch(() => {});
-  }, [feastUIConfigs?.monitoringConfig]);
-
   const monitoringConfig: MonitoringConfig =
     feastUIConfigs?.monitoringConfig || {
       apiBaseUrl: "/api/v1",
-      enabled: autoMonitoringEnabled,
+      enabled: true,
     };
 
   return (

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import "./index.css";
 
@@ -109,6 +109,23 @@ const FeastUISansProvidersInner = ({
     fetchOptions: feastUIConfigs?.fetchOptions,
   };
 
+  const [autoMonitoringEnabled, setAutoMonitoringEnabled] = useState(false);
+  useEffect(() => {
+    if (feastUIConfigs?.monitoringConfig) return;
+    fetch("/api/v1/monitoring/config")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data?.enabled) setAutoMonitoringEnabled(true);
+      })
+      .catch(() => {});
+  }, [feastUIConfigs?.monitoringConfig]);
+
+  const monitoringConfig: MonitoringConfig =
+    feastUIConfigs?.monitoringConfig || {
+      apiBaseUrl: "/api/v1",
+      enabled: autoMonitoringEnabled,
+    };
+
   return (
     <EuiProvider colorMode={colorMode}>
       <EuiErrorBoundary>
@@ -144,14 +161,7 @@ const FeastUISansProvidersInner = ({
             <FeatureFlagsContext.Provider
               value={feastUIConfigs?.featureFlags || {}}
             >
-              <MonitoringContext.Provider
-                value={
-                  feastUIConfigs?.monitoringConfig || {
-                    apiBaseUrl: "/api/v1",
-                    enabled: true,
-                  }
-                }
-              >
+              <MonitoringContext.Provider value={monitoringConfig}>
                 <ProjectListContext.Provider value={projectListContext}>
                   <Routes>
                     <Route path="/" element={<Layout />}>
@@ -195,7 +205,10 @@ const FeastUISansProvidersInner = ({
                           path="entity/:entityName/*"
                           element={<EntityInstance />}
                         />
-                        <Route path="label-view/" element={<LabelViewIndex />} />
+                        <Route
+                          path="label-view/"
+                          element={<LabelViewIndex />}
+                        />
                         <Route
                           path="label-view/:labelViewName/*"
                           element={<LabelViewInstance />}

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -27,10 +27,15 @@ import LabelViewInstance from "./pages/label-views/LabelViewInstance";
 import PermissionsIndex from "./pages/permissions/Index";
 import LineageIndex from "./pages/lineage/Index";
 import NoProjectGuard from "./components/NoProjectGuard";
+import MonitoringIndex from "./pages/monitoring/Index";
+import FeatureMetricsDetail from "./pages/monitoring/FeatureMetricsDetail";
 
 import TabsRegistryContext, {
   FeastTabsRegistryInterface,
 } from "./custom-tabs/TabsRegistryContext";
+import MonitoringContext, {
+  MonitoringConfig,
+} from "./contexts/MonitoringContext";
 import CurlGeneratorTab from "./pages/feature-views/CurlGeneratorTab";
 import FeatureFlagsContext, {
   FeatureFlags,
@@ -47,6 +52,7 @@ interface FeastUIConfigs {
   featureFlags?: FeatureFlags;
   projectListPromise?: Promise<any>;
   fetchOptions?: FetchOptions;
+  monitoringConfig?: MonitoringConfig;
 }
 
 const defaultProjectListPromise = (basename: string) => {
@@ -107,110 +113,128 @@ const FeastUISansProvidersInner = ({
     <EuiProvider colorMode={colorMode}>
       <EuiErrorBoundary>
         <DataModeContext.Provider value={dataModeConfig}>
-          <TabsRegistryContext.Provider
-            value={{
-              RegularFeatureViewCustomTabs: [
-                {
-                  label: "CURL Generator",
-                  path: "curl-generator",
-                  Component: CurlGeneratorTab,
-                },
-                ...(feastUIConfigs?.tabsRegistry
-                  ?.RegularFeatureViewCustomTabs || []),
-              ],
-              OnDemandFeatureViewCustomTabs:
-                feastUIConfigs?.tabsRegistry?.OnDemandFeatureViewCustomTabs ||
-                [],
-              StreamFeatureViewCustomTabs:
-                feastUIConfigs?.tabsRegistry?.StreamFeatureViewCustomTabs || [],
-              FeatureServiceCustomTabs:
-                feastUIConfigs?.tabsRegistry?.FeatureServiceCustomTabs || [],
-              FeatureCustomTabs:
-                feastUIConfigs?.tabsRegistry?.FeatureCustomTabs || [],
-              DataSourceCustomTabs:
-                feastUIConfigs?.tabsRegistry?.DataSourceCustomTabs || [],
-              EntityCustomTabs:
-                feastUIConfigs?.tabsRegistry?.EntityCustomTabs || [],
-              DatasetCustomTabs:
-                feastUIConfigs?.tabsRegistry?.DatasetCustomTabs || [],
-            }}
+          <MonitoringContext.Provider
+            value={
+              feastUIConfigs?.monitoringConfig || {
+                apiBaseUrl: "/api/v1",
+                enabled: true,
+              }
+            }
           >
-            <FeatureFlagsContext.Provider
-              value={feastUIConfigs?.featureFlags || {}}
+            <TabsRegistryContext.Provider
+              value={{
+                RegularFeatureViewCustomTabs: [
+                  {
+                    label: "CURL Generator",
+                    path: "curl-generator",
+                    Component: CurlGeneratorTab,
+                  },
+                  ...(feastUIConfigs?.tabsRegistry
+                    ?.RegularFeatureViewCustomTabs || []),
+                ],
+                OnDemandFeatureViewCustomTabs:
+                  feastUIConfigs?.tabsRegistry?.OnDemandFeatureViewCustomTabs ||
+                  [],
+                StreamFeatureViewCustomTabs:
+                  feastUIConfigs?.tabsRegistry?.StreamFeatureViewCustomTabs || [],
+                FeatureServiceCustomTabs:
+                  feastUIConfigs?.tabsRegistry?.FeatureServiceCustomTabs || [],
+                FeatureCustomTabs:
+                  feastUIConfigs?.tabsRegistry?.FeatureCustomTabs || [],
+                DataSourceCustomTabs:
+                  feastUIConfigs?.tabsRegistry?.DataSourceCustomTabs || [],
+                EntityCustomTabs:
+                  feastUIConfigs?.tabsRegistry?.EntityCustomTabs || [],
+                DatasetCustomTabs:
+                  feastUIConfigs?.tabsRegistry?.DatasetCustomTabs || [],
+              }}
             >
-              <ProjectListContext.Provider value={projectListContext}>
-                <Routes>
-                  <Route path="/" element={<Layout />}>
-                    <Route index element={<RootProjectSelectionPage />} />
-                    <Route
-                      path="/p/:projectName/*"
-                      element={<NoProjectGuard />}
-                    >
-                      <Route index element={<ProjectOverviewPage />} />
-                      <Route
-                        path="data-source/"
-                        element={<DatasourceIndex />}
-                      />
-                      <Route
-                        path="data-source/:dataSourceName/*"
-                        element={<DataSourceInstance />}
-                      />
-                      <Route path="features/" element={<FeatureListPage />} />
-                      <Route
-                        path="feature-view/"
-                        element={<FeatureViewIndex />}
-                      />
-                      <Route
-                        path="feature-view/:featureViewName/*"
-                        element={<FeatureViewInstance />}
-                      ></Route>
-                      <Route
-                        path="feature-view/:FeatureViewName/feature/:FeatureName/*"
-                        element={<FeatureInstance />}
-                      />
-                      <Route
-                        path="feature-service/"
-                        element={<FeatureServiceIndex />}
-                      />
-                      <Route
-                        path="feature-service/:featureServiceName/*"
-                        element={<FeatureServiceInstance />}
-                      />
-                      <Route path="entity/" element={<EntityIndex />} />
-                      <Route
-                        path="entity/:entityName/*"
-                        element={<EntityInstance />}
-                      />
+              <FeatureFlagsContext.Provider
+                value={feastUIConfigs?.featureFlags || {}}
+              >
+                <ProjectListContext.Provider value={projectListContext}>
+                  <Routes>
+                    <Route path="/" element={<Layout />}>
+                      <Route index element={<RootProjectSelectionPage />} />
+                      <Route path="/p/:projectName/*" element={<NoProjectGuard />}>
+                        <Route index element={<ProjectOverviewPage />} />
+                        <Route path="data-source/" element={<DatasourceIndex />} />
+                        <Route
+                          path="/p/:projectName/*"
+                          element={<NoProjectGuard />}
+                        >
+                          <Route index element={<ProjectOverviewPage />} />
+                          <Route
+                            path="data-source/"
+                            element={<DatasourceIndex />}
+                          />
+                          <Route
+                            path="data-source/:dataSourceName/*"
+                            element={<DataSourceInstance />}
+                          />
+                          <Route path="features/" element={<FeatureListPage />} />
+                          <Route
+                            path="feature-view/"
+                            element={<FeatureViewIndex />}
+                          />
+                          <Route
+                            path="feature-view/:featureViewName/*"
+                            element={<FeatureViewInstance />}
+                          ></Route>
+                          <Route
+                            path="feature-view/:FeatureViewName/feature/:FeatureName/*"
+                            element={<FeatureInstance />}
+                          />
+                          <Route
+                            path="feature-service/"
+                            element={<FeatureServiceIndex />}
+                          />
+                          <Route
+                            path="feature-service/:featureServiceName/*"
+                            element={<FeatureServiceInstance />}
+                          />
+                          <Route path="entity/" element={<EntityIndex />} />
+                          <Route
+                            path="entity/:entityName/*"
+                            element={<EntityInstance />}
+                          />
 
-                      <Route path="label-view/" element={<LabelViewIndex />} />
-                      <Route
-                        path="label-view/:labelViewName/*"
-                        element={<LabelViewInstance />}
-                      />
-                      <Route
-                        path="label-view/:FeatureViewName/label/:FeatureName/*"
-                        element={<FeatureInstance />}
-                      />
-                      <Route path="data-set/" element={<DatasetIndex />} />
-                      <Route
-                        path="data-set/:datasetName/*"
-                        element={<DatasetInstance />}
-                      />
-                      <Route
-                        path="permissions/"
-                        element={<PermissionsIndex />}
-                      />
-                      <Route path="lineage/" element={<LineageIndex />} />
+                          <Route path="label-view/" element={<LabelViewIndex />} />
+                          <Route
+                            path="label-view/:labelViewName/*"
+                            element={<LabelViewInstance />}
+                          />
+                          <Route
+                            path="label-view/:FeatureViewName/label/:FeatureName/*"
+                            element={<FeatureInstance />}
+                          />
+                          <Route path="data-set/" element={<DatasetIndex />} />
+                          <Route
+                            path="data-set/:datasetName/*"
+                            element={<DatasetInstance />}
+                          />
+                          <Route path="permissions/" element={<PermissionsIndex />} />
+                          <Route path="lineage/" element={<LineageIndex />} />
+                          <Route
+                            path="monitoring/"
+                            element={<MonitoringIndex />}
+                          />
+                          <Route
+                            path="monitoring/feature/:featureViewName/:featureName"
+                            element={<FeatureMetricsDetail />}
+                          />
+                        </Route>
+                      </Route>
                     </Route>
-                  </Route>
-                  <Route path="*" element={<NoMatch />} />
-                </Routes>
-              </ProjectListContext.Provider>
-            </FeatureFlagsContext.Provider>
-          </TabsRegistryContext.Provider>
+                    <Route path="*" element={<NoMatch />} />
+                  </Routes>
+                </ProjectListContext.Provider>
+              </FeatureFlagsContext.Provider>
+            </TabsRegistryContext.Provider>
+          </MonitoringContext.Provider>
         </DataModeContext.Provider>
-      </EuiErrorBoundary>
-    </EuiProvider>
+    </EuiErrorBoundary>
+  </EuiProvider>
   );
 };
 

--- a/ui/src/contexts/MonitoringContext.ts
+++ b/ui/src/contexts/MonitoringContext.ts
@@ -7,7 +7,7 @@ interface MonitoringConfig {
 
 const MonitoringContext = React.createContext<MonitoringConfig>({
   apiBaseUrl: "/api/v1",
-  enabled: true,
+  enabled: false,
 });
 
 export default MonitoringContext;

--- a/ui/src/contexts/MonitoringContext.ts
+++ b/ui/src/contexts/MonitoringContext.ts
@@ -1,0 +1,14 @@
+import React from "react";
+
+interface MonitoringConfig {
+  apiBaseUrl: string;
+  enabled: boolean;
+}
+
+const MonitoringContext = React.createContext<MonitoringConfig>({
+  apiBaseUrl: "/api/v1",
+  enabled: true,
+});
+
+export default MonitoringContext;
+export type { MonitoringConfig };

--- a/ui/src/pages/Sidebar.tsx
+++ b/ui/src/pages/Sidebar.tsx
@@ -177,6 +177,24 @@ const SideNav = () => {
           isSelected: useMatchSubpath(`${baseUrl}/data-set`),
         },
         {
+          name: "Monitoring",
+          id: htmlIdGenerator("monitoring")(),
+          icon: <EuiIcon type="monitoringApp" />,
+          renderItem: (props) => (
+            <Link {...props} to={`${baseUrl}/monitoring`} />
+          ),
+          isSelected: useMatchSubpath(`${baseUrl}/monitoring`),
+        },
+        {
+          name: "Data Labeling",
+          id: htmlIdGenerator("dataLabeling")(),
+          icon: <EuiIcon type="documentEdit" color="#006BB4" />,
+          renderItem: (props) => (
+            <Link {...props} to={`${baseUrl}/data-labeling`} />
+          ),
+          isSelected: useMatchSubpath(`${baseUrl}/data-labeling`),
+        },
+        {
           name: "Permissions",
           id: htmlIdGenerator("permissions")(),
           icon: <EuiIcon type={PermissionsIcon} />,

--- a/ui/src/pages/Sidebar.tsx
+++ b/ui/src/pages/Sidebar.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 
 import { EuiIcon, EuiSideNav, htmlIdGenerator } from "@elastic/eui";
 import { Link, useParams } from "react-router-dom";
 import { useMatchSubpath } from "../hooks/useMatchSubpath";
+import MonitoringContext from "../contexts/MonitoringContext";
 import useResourceQuery, {
   entityListPath,
   featureViewListPath,
@@ -84,6 +85,8 @@ const SideNav = () => {
     restSelect: restLabelViewsFromResponse,
   });
 
+  const { enabled: monitoringEnabled } = useContext(MonitoringContext);
+
   const [isSideNavOpenOnMobile, setisSideNavOpenOnMobile] = useState(false);
 
   const toggleOpenOnMobile = () => {
@@ -99,6 +102,7 @@ const SideNav = () => {
   const labelViewsLabel = `Label Views ${lvSuccess && labelViews && labelViews.length > 0 ? `(${labelViews.length})` : ""}`;
 
   const baseUrl = `/p/${projectName}`;
+  const monitoringSelected = useMatchSubpath(`${baseUrl}/monitoring`);
 
   const sideNav: React.ComponentProps<typeof EuiSideNav>["items"] = [
     {
@@ -176,24 +180,19 @@ const SideNav = () => {
           renderItem: (props) => <Link {...props} to={`${baseUrl}/data-set`} />,
           isSelected: useMatchSubpath(`${baseUrl}/data-set`),
         },
-        {
-          name: "Monitoring",
-          id: htmlIdGenerator("monitoring")(),
-          icon: <EuiIcon type="monitoringApp" />,
-          renderItem: (props) => (
-            <Link {...props} to={`${baseUrl}/monitoring`} />
-          ),
-          isSelected: useMatchSubpath(`${baseUrl}/monitoring`),
-        },
-        {
-          name: "Data Labeling",
-          id: htmlIdGenerator("dataLabeling")(),
-          icon: <EuiIcon type="documentEdit" color="#006BB4" />,
-          renderItem: (props) => (
-            <Link {...props} to={`${baseUrl}/data-labeling`} />
-          ),
-          isSelected: useMatchSubpath(`${baseUrl}/data-labeling`),
-        },
+        ...(monitoringEnabled
+          ? [
+              {
+                name: "Monitoring",
+                id: htmlIdGenerator("monitoring")(),
+                icon: <EuiIcon type="monitoringApp" />,
+                renderItem: (props: any) => (
+                  <Link {...props} to={`${baseUrl}/monitoring`} />
+                ),
+                isSelected: monitoringSelected,
+              },
+            ]
+          : []),
         {
           name: "Permissions",
           id: htmlIdGenerator("permissions")(),

--- a/ui/src/pages/Sidebar.tsx
+++ b/ui/src/pages/Sidebar.tsx
@@ -1,9 +1,8 @@
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 
 import { EuiIcon, EuiSideNav, htmlIdGenerator } from "@elastic/eui";
 import { Link, useParams } from "react-router-dom";
 import { useMatchSubpath } from "../hooks/useMatchSubpath";
-import MonitoringContext from "../contexts/MonitoringContext";
 import useResourceQuery, {
   entityListPath,
   featureViewListPath,
@@ -84,8 +83,6 @@ const SideNav = () => {
     restPath: labelViewListPath(projectName),
     restSelect: restLabelViewsFromResponse,
   });
-
-  const { enabled: monitoringEnabled } = useContext(MonitoringContext);
 
   const [isSideNavOpenOnMobile, setisSideNavOpenOnMobile] = useState(false);
 
@@ -180,19 +177,6 @@ const SideNav = () => {
           renderItem: (props) => <Link {...props} to={`${baseUrl}/data-set`} />,
           isSelected: useMatchSubpath(`${baseUrl}/data-set`),
         },
-        ...(monitoringEnabled
-          ? [
-              {
-                name: "Monitoring",
-                id: htmlIdGenerator("monitoring")(),
-                icon: <EuiIcon type="monitoringApp" />,
-                renderItem: (props: any) => (
-                  <Link {...props} to={`${baseUrl}/monitoring`} />
-                ),
-                isSelected: monitoringSelected,
-              },
-            ]
-          : []),
         {
           name: "Permissions",
           id: htmlIdGenerator("permissions")(),
@@ -201,6 +185,15 @@ const SideNav = () => {
             <Link {...props} to={`${baseUrl}/permissions`} />
           ),
           isSelected: useMatchSubpath(`${baseUrl}/permissions`),
+        },
+        {
+          name: "Monitoring",
+          id: htmlIdGenerator("monitoring")(),
+          icon: <EuiIcon type="monitoringApp" />,
+          renderItem: (props: any) => (
+            <Link {...props} to={`${baseUrl}/monitoring`} />
+          ),
+          isSelected: monitoringSelected,
         },
       ],
     },

--- a/ui/src/pages/features/FeatureInstance.tsx
+++ b/ui/src/pages/features/FeatureInstance.tsx
@@ -3,8 +3,9 @@ import { Route, Routes, useNavigate, useParams } from "react-router-dom";
 import { EuiPageTemplate } from "@elastic/eui";
 
 import { FeatureIcon } from "../../graphics/FeatureIcon";
-import { useMatchExact } from "../../hooks/useMatchSubpath";
+import { useMatchExact, useMatchSubpath } from "../../hooks/useMatchSubpath";
 import FeatureOverviewTab from "./FeatureOverviewTab";
+import FeatureMonitoringTab from "./FeatureMonitoringTab";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import {
   useFeatureCustomTabs,
@@ -34,12 +35,20 @@ const FeatureInstance = () => {
               navigate("");
             },
           },
+          {
+            label: "Monitoring",
+            isSelected: useMatchSubpath("monitoring"),
+            onClick: () => {
+              navigate("monitoring");
+            },
+          },
           ...customNavigationTabs,
         ]}
       />
       <EuiPageTemplate.Section>
         <Routes>
           <Route path="/" element={<FeatureOverviewTab />} />
+          <Route path="/monitoring" element={<FeatureMonitoringTab />} />
           {CustomTabRoutes}
         </Routes>
       </EuiPageTemplate.Section>

--- a/ui/src/pages/features/FeatureMonitoringTab.tsx
+++ b/ui/src/pages/features/FeatureMonitoringTab.tsx
@@ -49,15 +49,11 @@ const FeatureMonitoringTab = () => {
     if (!metrics || metrics.length === 0) return null;
     const withData = metrics.filter((m) => m.row_count > 0);
     const candidates = withData.length > 0 ? withData : metrics;
-    return candidates.reduce((a, b) =>
-      a.metric_date > b.metric_date ? a : b,
-    );
+    return candidates.reduce((a, b) => (a.metric_date > b.metric_date ? a : b));
   })();
 
   const baselineMetric =
-    baselineMetrics && baselineMetrics.length > 0
-      ? baselineMetrics[0]
-      : null;
+    baselineMetrics && baselineMetrics.length > 0 ? baselineMetrics[0] : null;
 
   if (isError || !latestMetric) {
     return (
@@ -66,15 +62,12 @@ const FeatureMonitoringTab = () => {
         title={<h3>No Monitoring Data</h3>}
         body={
           <p>
-            No monitoring metrics available for this feature. Run a
-            monitoring compute job to generate data quality metrics.
+            No monitoring metrics available for this feature. Run a monitoring
+            compute job to generate data quality metrics.
           </p>
         }
         actions={
-          <EuiButton
-            size="s"
-            href={`/p/${projectName}/monitoring`}
-          >
+          <EuiButton size="s" href={`/p/${projectName}/monitoring`}>
             Go to Monitoring
           </EuiButton>
         }
@@ -91,9 +84,7 @@ const FeatureMonitoringTab = () => {
           {isNumeric && latestMetric.histogram && (
             <NumericHistogramChart
               histogram={latestMetric.histogram as NumericHistogram}
-              baseline={
-                baselineMetric?.histogram as NumericHistogram | null
-              }
+              baseline={baselineMetric?.histogram as NumericHistogram | null}
               title="Distribution"
             />
           )}

--- a/ui/src/pages/features/FeatureMonitoringTab.tsx
+++ b/ui/src/pages/features/FeatureMonitoringTab.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiSkeletonText,
+  EuiEmptyPrompt,
+  EuiButton,
+} from "@elastic/eui";
+import {
+  useFeatureMetrics,
+  useBaselineMetrics,
+} from "../../queries/useMonitoringApi";
+import type {
+  NumericHistogram,
+  CategoricalHistogram,
+} from "../../queries/useMonitoringApi";
+import {
+  NumericHistogramChart,
+  CategoricalHistogramChart,
+} from "../monitoring/components/HistogramChart";
+import StatsPanel from "../monitoring/components/StatsPanel";
+
+const FeatureMonitoringTab = () => {
+  const { projectName, FeatureViewName, FeatureName } = useParams();
+
+  const {
+    data: metrics,
+    isLoading,
+    isError,
+  } = useFeatureMetrics({
+    project: projectName || "",
+    feature_view_name: FeatureViewName,
+    feature_name: FeatureName,
+  });
+
+  const { data: baselineMetrics } = useBaselineMetrics(
+    projectName || "",
+    FeatureViewName,
+    FeatureName,
+  );
+
+  if (isLoading) {
+    return <EuiSkeletonText lines={6} />;
+  }
+
+  const latestMetric = (() => {
+    if (!metrics || metrics.length === 0) return null;
+    const withData = metrics.filter((m) => m.row_count > 0);
+    const candidates = withData.length > 0 ? withData : metrics;
+    return candidates.reduce((a, b) =>
+      a.metric_date > b.metric_date ? a : b,
+    );
+  })();
+
+  const baselineMetric =
+    baselineMetrics && baselineMetrics.length > 0
+      ? baselineMetrics[0]
+      : null;
+
+  if (isError || !latestMetric) {
+    return (
+      <EuiEmptyPrompt
+        iconType="monitoringApp"
+        title={<h3>No Monitoring Data</h3>}
+        body={
+          <p>
+            No monitoring metrics available for this feature. Run a
+            monitoring compute job to generate data quality metrics.
+          </p>
+        }
+        actions={
+          <EuiButton
+            size="s"
+            href={`/p/${projectName}/monitoring`}
+          >
+            Go to Monitoring
+          </EuiButton>
+        }
+      />
+    );
+  }
+
+  const isNumeric = latestMetric.feature_type === "numeric";
+
+  return (
+    <>
+      <EuiFlexGroup gutterSize="l">
+        <EuiFlexItem grow={2}>
+          {isNumeric && latestMetric.histogram && (
+            <NumericHistogramChart
+              histogram={latestMetric.histogram as NumericHistogram}
+              baseline={
+                baselineMetric?.histogram as NumericHistogram | null
+              }
+              title="Distribution"
+            />
+          )}
+          {!isNumeric && latestMetric.histogram && (
+            <CategoricalHistogramChart
+              histogram={latestMetric.histogram as CategoricalHistogram}
+              title="Category Distribution"
+            />
+          )}
+          {!latestMetric.histogram && (
+            <EuiEmptyPrompt
+              title={<h3>No Histogram</h3>}
+              body={<p>Histogram data is not available.</p>}
+            />
+          )}
+        </EuiFlexItem>
+        <EuiFlexItem grow={1}>
+          <StatsPanel metric={latestMetric} baseline={baselineMetric} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer />
+    </>
+  );
+};
+
+export default FeatureMonitoringTab;

--- a/ui/src/pages/monitoring/FeatureMetricsDetail.tsx
+++ b/ui/src/pages/monitoring/FeatureMetricsDetail.tsx
@@ -1,0 +1,249 @@
+import React from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  EuiPageTemplate,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiSkeletonText,
+  EuiEmptyPrompt,
+  EuiButton,
+  EuiBreadcrumbs,
+} from "@elastic/eui";
+import { FeatureIcon } from "../../graphics/FeatureIcon";
+import {
+  useFeatureMetrics,
+  useBaselineMetrics,
+} from "../../queries/useMonitoringApi";
+import type {
+  NumericHistogram,
+  CategoricalHistogram,
+} from "../../queries/useMonitoringApi";
+import {
+  NumericHistogramChart,
+  CategoricalHistogramChart,
+} from "./components/HistogramChart";
+import StatsPanel from "./components/StatsPanel";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
+
+const FeatureMetricsDetail = () => {
+  const { projectName, featureViewName, featureName } = useParams();
+  const navigate = useNavigate();
+
+  useDocumentTitle(
+    `${featureName} Monitoring | ${featureViewName} | Feast`,
+  );
+
+  const {
+    data: metrics,
+    isLoading,
+    isError,
+  } = useFeatureMetrics({
+    project: projectName || "",
+    feature_view_name: featureViewName,
+    feature_name: featureName,
+  });
+
+  const { data: baselineMetrics } = useBaselineMetrics(
+    projectName || "",
+    featureViewName,
+    featureName,
+  );
+
+  const latestMetric = (() => {
+    if (!metrics || metrics.length === 0) return null;
+    const withData = metrics.filter((m) => m.row_count > 0);
+    const candidates = withData.length > 0 ? withData : metrics;
+    return candidates.reduce((a, b) =>
+      a.metric_date > b.metric_date ? a : b,
+    );
+  })();
+
+  const baselineMetric =
+    baselineMetrics && baselineMetrics.length > 0
+      ? baselineMetrics[0]
+      : null;
+
+  const breadcrumbs = [
+    {
+      text: "Monitoring",
+      onClick: () => navigate(`/p/${projectName}/monitoring`),
+    },
+    {
+      text: featureViewName || "",
+    },
+    {
+      text: featureName || "",
+    },
+  ];
+
+  if (isLoading) {
+    return (
+      <EuiPageTemplate panelled>
+        <EuiPageTemplate.Section>
+          <EuiSkeletonText lines={8} />
+        </EuiPageTemplate.Section>
+      </EuiPageTemplate>
+    );
+  }
+
+  if (isError || !latestMetric) {
+    return (
+      <EuiPageTemplate panelled>
+        <EuiPageTemplate.Section>
+          <EuiBreadcrumbs breadcrumbs={breadcrumbs} />
+          <EuiSpacer />
+          <EuiEmptyPrompt
+            iconType="alert"
+            title={<h2>No Metrics Available</h2>}
+            body={
+              <p>
+                No monitoring metrics found for feature{" "}
+                <strong>{featureName}</strong> in feature view{" "}
+                <strong>{featureViewName}</strong>. Run a monitoring
+                compute job first.
+              </p>
+            }
+            actions={
+              <EuiButton
+                onClick={() => navigate(`/p/${projectName}/monitoring`)}
+              >
+                Back to Monitoring
+              </EuiButton>
+            }
+          />
+        </EuiPageTemplate.Section>
+      </EuiPageTemplate>
+    );
+  }
+
+  const isNumeric = latestMetric.feature_type === "numeric";
+
+  return (
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
+        restrictWidth
+        iconType={FeatureIcon}
+        pageTitle={`${featureName}`}
+        description={`Monitoring metrics for ${featureViewName} / ${featureName}`}
+        rightSideItems={[
+          <EuiButton
+            key="back"
+            size="s"
+            onClick={() => navigate(`/p/${projectName}/monitoring`)}
+          >
+            Back to Monitoring
+          </EuiButton>,
+        ]}
+      />
+      <EuiPageTemplate.Section>
+        <EuiBreadcrumbs breadcrumbs={breadcrumbs} />
+        <EuiSpacer />
+
+        <EuiFlexGroup gutterSize="l">
+          <EuiFlexItem grow={2}>
+            {isNumeric && latestMetric.histogram && (
+              <NumericHistogramChart
+                histogram={latestMetric.histogram as NumericHistogram}
+                baseline={
+                  baselineMetric?.histogram as NumericHistogram | null
+                }
+                title="Distribution"
+              />
+            )}
+            {!isNumeric && latestMetric.histogram && (
+              <CategoricalHistogramChart
+                histogram={latestMetric.histogram as CategoricalHistogram}
+                title="Category Distribution"
+              />
+            )}
+            {!latestMetric.histogram && (
+              <EuiEmptyPrompt
+                title={<h3>No Histogram Data</h3>}
+                body={<p>Histogram data is not available for this metric.</p>}
+              />
+            )}
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={1}>
+            <StatsPanel
+              metric={latestMetric}
+              baseline={baselineMetric}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        {metrics && metrics.length > 1 && (
+          <>
+            <EuiSpacer size="xl" />
+            <NullRateTimeline metrics={metrics} />
+          </>
+        )}
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
+  );
+};
+
+const NullRateTimeline = ({
+  metrics,
+}: {
+  metrics: { metric_date: string; null_rate: number }[];
+}) => {
+  const sorted = [...metrics].sort(
+    (a, b) => a.metric_date.localeCompare(b.metric_date),
+  );
+  const maxRate = Math.max(...sorted.map((m) => m.null_rate), 0.01);
+  const chartWidth = Math.max(sorted.length * 50, 200);
+  const chartHeight = 80;
+
+  const points = sorted.map((m, i) => {
+    const x = (i / Math.max(sorted.length - 1, 1)) * (chartWidth - 20) + 10;
+    const y = chartHeight - (m.null_rate / maxRate) * (chartHeight - 10);
+    return { x, y, ...m };
+  });
+
+  const polyline = points.map((p) => `${p.x},${p.y}`).join(" ");
+
+  return (
+    <div>
+      <h4 style={{ fontSize: 14, fontWeight: 600, marginBottom: 8 }}>
+        Null Rate Over Time
+      </h4>
+      <svg width={chartWidth} height={chartHeight + 20} role="img">
+        <polyline
+          points={polyline}
+          fill="none"
+          stroke="#006BB4"
+          strokeWidth={2}
+        />
+        {points.map((p, i) => (
+          <circle key={i} cx={p.x} cy={p.y} r={3} fill="#006BB4" />
+        ))}
+        <line
+          x1={10}
+          y1={chartHeight}
+          x2={chartWidth - 10}
+          y2={chartHeight}
+          stroke="#D3DAE6"
+        />
+        {points.length > 0 && (
+          <>
+            <text x={10} y={chartHeight + 14} fontSize={9} fill="#69707D">
+              {points[0].metric_date}
+            </text>
+            <text
+              x={chartWidth - 80}
+              y={chartHeight + 14}
+              fontSize={9}
+              fill="#69707D"
+            >
+              {points[points.length - 1].metric_date}
+            </text>
+          </>
+        )}
+      </svg>
+    </div>
+  );
+};
+
+export default FeatureMetricsDetail;

--- a/ui/src/pages/monitoring/FeatureMetricsDetail.tsx
+++ b/ui/src/pages/monitoring/FeatureMetricsDetail.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
   EuiPageTemplate,
@@ -9,6 +9,8 @@ import {
   EuiEmptyPrompt,
   EuiButton,
   EuiBreadcrumbs,
+  EuiSuperSelect,
+  EuiFormRow,
 } from "@elastic/eui";
 import { FeatureIcon } from "../../graphics/FeatureIcon";
 import {
@@ -16,6 +18,7 @@ import {
   useBaselineMetrics,
 } from "../../queries/useMonitoringApi";
 import type {
+  FeatureMetric,
   NumericHistogram,
   CategoricalHistogram,
 } from "../../queries/useMonitoringApi";
@@ -24,11 +27,24 @@ import {
   CategoricalHistogramChart,
 } from "./components/HistogramChart";
 import StatsPanel from "./components/StatsPanel";
+import TimeSeriesAnalysis from "./components/TimeSeriesAnalysis";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
+
+const BASELINE_KEY = "__baseline__";
+
+const GRANULARITY_LABELS: Record<string, string> = {
+  daily: "Daily",
+  weekly: "Weekly",
+  biweekly: "Biweekly",
+  monthly: "Monthly",
+  quarterly: "Quarterly",
+  [BASELINE_KEY]: "Baseline",
+};
 
 const FeatureMetricsDetail = () => {
   const { projectName, featureViewName, featureName } = useParams();
   const navigate = useNavigate();
+  const [selectedGranularity, setSelectedGranularity] = useState("");
 
   useDocumentTitle(
     `${featureName} Monitoring | ${featureViewName} | Feast`,
@@ -50,19 +66,58 @@ const FeatureMetricsDetail = () => {
     featureName,
   );
 
-  const latestMetric = (() => {
-    if (!metrics || metrics.length === 0) return null;
-    const withData = metrics.filter((m) => m.row_count > 0);
-    const candidates = withData.length > 0 ? withData : metrics;
-    return candidates.reduce((a, b) =>
-      a.metric_date > b.metric_date ? a : b,
-    );
-  })();
-
   const baselineMetric =
     baselineMetrics && baselineMetrics.length > 0
       ? baselineMetrics[0]
       : null;
+
+  const availableGranularities = useMemo(() => {
+    const granularities = new Set<string>();
+    if (metrics) {
+      for (const m of metrics) {
+        if (m.row_count > 0) granularities.add(m.granularity);
+      }
+    }
+    return Array.from(granularities).sort();
+  }, [metrics]);
+
+  const granularityOptions = useMemo(() => {
+    const options = availableGranularities.map((g) => ({
+      value: g,
+      inputDisplay: GRANULARITY_LABELS[g] || g,
+      dropdownDisplay: GRANULARITY_LABELS[g] || g,
+    }));
+    if (baselineMetric) {
+      options.push({
+        value: BASELINE_KEY,
+        inputDisplay: "Baseline",
+        dropdownDisplay: "Baseline (all data)",
+      });
+    }
+    return options;
+  }, [availableGranularities, baselineMetric]);
+
+  const effectiveGranularity = selectedGranularity || availableGranularities[0] || "";
+
+  const activeMetric = useMemo(() => {
+    if (effectiveGranularity === BASELINE_KEY && baselineMetric) {
+      return baselineMetric;
+    }
+    if (!metrics || metrics.length === 0) return null;
+    const matching = metrics.filter(
+      (m) => m.granularity === effectiveGranularity && m.row_count > 0,
+    );
+    if (matching.length === 0) {
+      const withData = metrics.filter((m) => m.row_count > 0);
+      const candidates = withData.length > 0 ? withData : metrics;
+      return candidates.reduce((a, b) =>
+        a.metric_date > b.metric_date ? a : b,
+      );
+    }
+    return matching.reduce((a, b) =>
+      a.metric_date > b.metric_date ? a : b,
+    );
+  }, [metrics, effectiveGranularity, baselineMetric]);
 
   const breadcrumbs = [
     {
@@ -87,7 +142,7 @@ const FeatureMetricsDetail = () => {
     );
   }
 
-  if (isError || !latestMetric) {
+  if (isError || !activeMetric) {
     return (
       <EuiPageTemplate panelled>
         <EuiPageTemplate.Section>
@@ -117,7 +172,7 @@ const FeatureMetricsDetail = () => {
     );
   }
 
-  const isNumeric = latestMetric.feature_type === "numeric";
+  const isNumeric = activeMetric.feature_type === "numeric";
 
   return (
     <EuiPageTemplate panelled>
@@ -140,24 +195,47 @@ const FeatureMetricsDetail = () => {
         <EuiBreadcrumbs breadcrumbs={breadcrumbs} />
         <EuiSpacer />
 
+        {granularityOptions.length > 0 && (
+          <>
+            <EuiFlexGroup alignItems="flexEnd">
+              <EuiFlexItem grow={false} style={{ minWidth: 200 }}>
+                <EuiFormRow label="View" display="columnCompressed">
+                  <EuiSuperSelect
+                    options={granularityOptions}
+                    valueOfSelected={effectiveGranularity}
+                    onChange={(val) => setSelectedGranularity(val)}
+                    compressed
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="m" />
+          </>
+        )}
+
         <EuiFlexGroup gutterSize="l">
           <EuiFlexItem grow={2}>
-            {isNumeric && latestMetric.histogram && (
+            {isNumeric && activeMetric.histogram && (
               <NumericHistogramChart
-                histogram={latestMetric.histogram as NumericHistogram}
-                baseline={
-                  baselineMetric?.histogram as NumericHistogram | null
+                histogram={activeMetric.histogram as NumericHistogram}
+                title={
+                  effectiveGranularity === BASELINE_KEY
+                    ? "Baseline Distribution"
+                    : "Distribution"
                 }
-                title="Distribution"
               />
             )}
-            {!isNumeric && latestMetric.histogram && (
+            {!isNumeric && activeMetric.histogram && (
               <CategoricalHistogramChart
-                histogram={latestMetric.histogram as CategoricalHistogram}
-                title="Category Distribution"
+                histogram={activeMetric.histogram as CategoricalHistogram}
+                title={
+                  effectiveGranularity === BASELINE_KEY
+                    ? "Baseline Category Distribution"
+                    : "Category Distribution"
+                }
               />
             )}
-            {!latestMetric.histogram && (
+            {!activeMetric.histogram && (
               <EuiEmptyPrompt
                 title={<h3>No Histogram Data</h3>}
                 body={<p>Histogram data is not available for this metric.</p>}
@@ -167,8 +245,7 @@ const FeatureMetricsDetail = () => {
 
           <EuiFlexItem grow={1}>
             <StatsPanel
-              metric={latestMetric}
-              baseline={baselineMetric}
+              metric={activeMetric}
             />
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -176,73 +253,14 @@ const FeatureMetricsDetail = () => {
         {metrics && metrics.length > 1 && (
           <>
             <EuiSpacer size="xl" />
-            <NullRateTimeline metrics={metrics} />
+            <TimeSeriesAnalysis
+              metrics={metrics}
+              featureType={activeMetric.feature_type}
+            />
           </>
         )}
       </EuiPageTemplate.Section>
     </EuiPageTemplate>
-  );
-};
-
-const NullRateTimeline = ({
-  metrics,
-}: {
-  metrics: { metric_date: string; null_rate: number }[];
-}) => {
-  const sorted = [...metrics].sort(
-    (a, b) => a.metric_date.localeCompare(b.metric_date),
-  );
-  const maxRate = Math.max(...sorted.map((m) => m.null_rate), 0.01);
-  const chartWidth = Math.max(sorted.length * 50, 200);
-  const chartHeight = 80;
-
-  const points = sorted.map((m, i) => {
-    const x = (i / Math.max(sorted.length - 1, 1)) * (chartWidth - 20) + 10;
-    const y = chartHeight - (m.null_rate / maxRate) * (chartHeight - 10);
-    return { x, y, ...m };
-  });
-
-  const polyline = points.map((p) => `${p.x},${p.y}`).join(" ");
-
-  return (
-    <div>
-      <h4 style={{ fontSize: 14, fontWeight: 600, marginBottom: 8 }}>
-        Null Rate Over Time
-      </h4>
-      <svg width={chartWidth} height={chartHeight + 20} role="img">
-        <polyline
-          points={polyline}
-          fill="none"
-          stroke="#006BB4"
-          strokeWidth={2}
-        />
-        {points.map((p, i) => (
-          <circle key={i} cx={p.x} cy={p.y} r={3} fill="#006BB4" />
-        ))}
-        <line
-          x1={10}
-          y1={chartHeight}
-          x2={chartWidth - 10}
-          y2={chartHeight}
-          stroke="#D3DAE6"
-        />
-        {points.length > 0 && (
-          <>
-            <text x={10} y={chartHeight + 14} fontSize={9} fill="#69707D">
-              {points[0].metric_date}
-            </text>
-            <text
-              x={chartWidth - 80}
-              y={chartHeight + 14}
-              fontSize={9}
-              fill="#69707D"
-            >
-              {points[points.length - 1].metric_date}
-            </text>
-          </>
-        )}
-      </svg>
-    </div>
   );
 };
 

--- a/ui/src/pages/monitoring/FeatureMetricsDetail.tsx
+++ b/ui/src/pages/monitoring/FeatureMetricsDetail.tsx
@@ -46,9 +46,7 @@ const FeatureMetricsDetail = () => {
   const navigate = useNavigate();
   const [selectedGranularity, setSelectedGranularity] = useState("");
 
-  useDocumentTitle(
-    `${featureName} Monitoring | ${featureViewName} | Feast`,
-  );
+  useDocumentTitle(`${featureName} Monitoring | ${featureViewName} | Feast`);
 
   const {
     data: metrics,
@@ -67,9 +65,7 @@ const FeatureMetricsDetail = () => {
   );
 
   const baselineMetric =
-    baselineMetrics && baselineMetrics.length > 0
-      ? baselineMetrics[0]
-      : null;
+    baselineMetrics && baselineMetrics.length > 0 ? baselineMetrics[0] : null;
 
   const availableGranularities = useMemo(() => {
     const granularities = new Set<string>();
@@ -97,7 +93,8 @@ const FeatureMetricsDetail = () => {
     return options;
   }, [availableGranularities, baselineMetric]);
 
-  const effectiveGranularity = selectedGranularity || availableGranularities[0] || "";
+  const effectiveGranularity =
+    selectedGranularity || availableGranularities[0] || "";
 
   const activeMetric = useMemo(() => {
     if (effectiveGranularity === BASELINE_KEY && baselineMetric) {
@@ -114,9 +111,7 @@ const FeatureMetricsDetail = () => {
         a.metric_date > b.metric_date ? a : b,
       );
     }
-    return matching.reduce((a, b) =>
-      a.metric_date > b.metric_date ? a : b,
-    );
+    return matching.reduce((a, b) => (a.metric_date > b.metric_date ? a : b));
   }, [metrics, effectiveGranularity, baselineMetric]);
 
   const breadcrumbs = [
@@ -155,8 +150,8 @@ const FeatureMetricsDetail = () => {
               <p>
                 No monitoring metrics found for feature{" "}
                 <strong>{featureName}</strong> in feature view{" "}
-                <strong>{featureViewName}</strong>. Run a monitoring
-                compute job first.
+                <strong>{featureViewName}</strong>. Run a monitoring compute job
+                first.
               </p>
             }
             actions={
@@ -244,9 +239,7 @@ const FeatureMetricsDetail = () => {
           </EuiFlexItem>
 
           <EuiFlexItem grow={1}>
-            <StatsPanel
-              metric={activeMetric}
-            />
+            <StatsPanel metric={activeMetric} />
           </EuiFlexItem>
         </EuiFlexGroup>
 

--- a/ui/src/pages/monitoring/FeatureMetricsTable.tsx
+++ b/ui/src/pages/monitoring/FeatureMetricsTable.tsx
@@ -3,9 +3,15 @@ import {
   EuiBasicTable,
   EuiBasicTableColumn,
   EuiBadge,
+  EuiButtonIcon,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
   EuiHealth,
   EuiLink,
+  EuiPopover,
   EuiProgress,
+  EuiTitle,
   EuiToolTip,
   Criteria,
 } from "@elastic/eui";
@@ -31,6 +37,27 @@ const formatNum = (val: number | null, decimals = 2): string => {
   if (val === null || val === undefined) return "—";
   if (Number.isInteger(val)) return val.toLocaleString();
   return val.toFixed(decimals);
+};
+
+const formatFreshness = (computedAt: string | null): string => {
+  if (!computedAt) return "—";
+  const diff = Date.now() - new Date(computedAt).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return `${Math.floor(days / 30)}mo ago`;
+};
+
+const freshnessColor = (computedAt: string | null): string => {
+  if (!computedAt) return "subdued";
+  const hrs = (Date.now() - new Date(computedAt).getTime()) / 3_600_000;
+  if (hrs < 24) return "success";
+  if (hrs < 72) return "warning";
+  return "danger";
 };
 
 const MiniHistogram = ({ metric }: { metric: FeatureMetric }) => {
@@ -179,6 +206,22 @@ const FeatureMetricsTable = ({
     }
   };
 
+  const [isLegendOpen, setIsLegendOpen] = useState(false);
+
+  const columnLegend = [
+    { title: "Feature", description: "Name of the individual feature. Click to view full distribution and detailed statistics." },
+    { title: "Feature View", description: "The feature view this feature belongs to — a logical grouping of related features sharing the same data source." },
+    { title: "Type", description: "Data type: numeric (continuous/discrete numbers) or categorical (strings/labels)." },
+    { title: "Distribution", description: "Compact histogram showing the value distribution. Blue bars = numeric, orange bars = categorical." },
+    { title: "Rows", description: "Total number of rows (data points) observed for this feature in the computed time window." },
+    { title: "Null Rate", description: "Percentage of rows with missing (null) values. Shown as a progress bar colored by severity." },
+    { title: "Health", description: "Data quality indicator based on null rate: Healthy (< 10%), Moderate (10–49%), High (>= 50%)." },
+    { title: "Mean", description: "Arithmetic mean of the feature values. Only shown for numeric features." },
+    { title: "Std Dev", description: "Standard deviation — measures how spread out the values are from the mean. Only for numeric features." },
+    { title: "Freshness", description: "Recency of the underlying data. Green (< 24h old), Yellow (24–72h), Red (> 72h). Hover for the data date." },
+    { title: "Source", description: "Data source type used for metric computation (e.g. batch, stream)." },
+  ];
+
   const columns: EuiBasicTableColumn<FeatureMetric>[] = [
     {
       field: "feature_name",
@@ -261,6 +304,19 @@ const FeatureMetricsTable = ({
       render: (val: number | null) => formatNum(val),
     },
     {
+      field: "metric_date",
+      name: "Freshness",
+      sortable: true,
+      width: "110px",
+      render: (val: string) => (
+        <EuiToolTip content={val ? `Data from: ${val}` : "Unknown"}>
+          <EuiHealth color={freshnessColor(val)}>
+            {formatFreshness(val)}
+          </EuiHealth>
+        </EuiToolTip>
+      ),
+    },
+    {
       field: "data_source_type",
       name: "Source",
       width: "80px",
@@ -269,27 +325,59 @@ const FeatureMetricsTable = ({
   ];
 
   return (
-    <EuiBasicTable
-      items={pageOfItems}
-      columns={columns}
-      loading={isLoading}
-      pagination={pagination}
-      sorting={{
-        sort: {
-          field: sortField,
-          direction: sortDirection,
-        },
-      }}
-      onChange={onTableChange}
-      rowProps={(item: FeatureMetric) => ({
-        "data-test-subj": `row-${item.feature_name}`,
-      })}
-      noItemsMessage={
-        isLoading
-          ? "Loading metrics..."
-          : "No metrics found. Run a monitoring compute job to generate metrics."
-      }
-    />
+    <>
+      <EuiFlexGroup justifyContent="flexEnd" gutterSize="none">
+        <EuiFlexItem grow={false}>
+          <EuiPopover
+            button={
+              <EuiButtonIcon
+                iconType="questionInCircle"
+                aria-label="Column legend"
+                color="text"
+                onClick={() => setIsLegendOpen(!isLegendOpen)}
+              />
+            }
+            isOpen={isLegendOpen}
+            closePopover={() => setIsLegendOpen(false)}
+            anchorPosition="downRight"
+            panelPaddingSize="m"
+            panelStyle={{ maxWidth: 420 }}
+          >
+            <EuiTitle size="xxs">
+              <h4>Column Legend</h4>
+            </EuiTitle>
+            <EuiDescriptionList
+              type="column"
+              compressed
+              listItems={columnLegend}
+              style={{ marginTop: 8 }}
+              titleProps={{ style: { fontWeight: 600, width: 100 } }}
+            />
+          </EuiPopover>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiBasicTable
+        items={pageOfItems}
+        columns={columns}
+        loading={isLoading}
+        pagination={pagination}
+        sorting={{
+          sort: {
+            field: sortField,
+            direction: sortDirection,
+          },
+        }}
+        onChange={onTableChange}
+        rowProps={(item: FeatureMetric) => ({
+          "data-test-subj": `row-${item.feature_name}`,
+        })}
+        noItemsMessage={
+          isLoading
+            ? "Loading metrics..."
+            : "No metrics found. Run a monitoring compute job to generate metrics."
+        }
+      />
+    </>
   );
 };
 

--- a/ui/src/pages/monitoring/FeatureMetricsTable.tsx
+++ b/ui/src/pages/monitoring/FeatureMetricsTable.tsx
@@ -209,17 +209,61 @@ const FeatureMetricsTable = ({
   const [isLegendOpen, setIsLegendOpen] = useState(false);
 
   const columnLegend = [
-    { title: "Feature", description: "Name of the individual feature. Click to view full distribution and detailed statistics." },
-    { title: "Feature View", description: "The feature view this feature belongs to — a logical grouping of related features sharing the same data source." },
-    { title: "Type", description: "Data type: numeric (continuous/discrete numbers) or categorical (strings/labels)." },
-    { title: "Distribution", description: "Compact histogram showing the value distribution. Blue bars = numeric, orange bars = categorical." },
-    { title: "Rows", description: "Total number of rows (data points) observed for this feature in the computed time window." },
-    { title: "Null Rate", description: "Percentage of rows with missing (null) values. Shown as a progress bar colored by severity." },
-    { title: "Health", description: "Data quality indicator based on null rate: Healthy (< 10%), Moderate (10–49%), High (>= 50%)." },
-    { title: "Mean", description: "Arithmetic mean of the feature values. Only shown for numeric features." },
-    { title: "Std Dev", description: "Standard deviation — measures how spread out the values are from the mean. Only for numeric features." },
-    { title: "Freshness", description: "Recency of the underlying data. Green (< 24h old), Yellow (24–72h), Red (> 72h). Hover for the data date." },
-    { title: "Source", description: "Data source type used for metric computation (e.g. batch, stream)." },
+    {
+      title: "Feature",
+      description:
+        "Name of the individual feature. Click to view full distribution and detailed statistics.",
+    },
+    {
+      title: "Feature View",
+      description:
+        "The feature view this feature belongs to — a logical grouping of related features sharing the same data source.",
+    },
+    {
+      title: "Type",
+      description:
+        "Data type: numeric (continuous/discrete numbers) or categorical (strings/labels).",
+    },
+    {
+      title: "Distribution",
+      description:
+        "Compact histogram showing the value distribution. Blue bars = numeric, orange bars = categorical.",
+    },
+    {
+      title: "Rows",
+      description:
+        "Total number of rows (data points) observed for this feature in the computed time window.",
+    },
+    {
+      title: "Null Rate",
+      description:
+        "Percentage of rows with missing (null) values. Shown as a progress bar colored by severity.",
+    },
+    {
+      title: "Health",
+      description:
+        "Data quality indicator based on null rate: Healthy (< 10%), Moderate (10–49%), High (>= 50%).",
+    },
+    {
+      title: "Mean",
+      description:
+        "Arithmetic mean of the feature values. Only shown for numeric features.",
+    },
+    {
+      title: "Std Dev",
+      description:
+        "Standard deviation — measures how spread out the values are from the mean. Only for numeric features.",
+    },
+    {
+      title: "Freshness",
+      description:
+        "Recency of the underlying data. Green (< 24h old), Yellow (24–72h), Red (> 72h). Hover for the data date.",
+    },
+    {
+      title: "Source",
+      description:
+        "Data source type used for metric computation (e.g. batch, stream).",
+    },
   ];
 
   const columns: EuiBasicTableColumn<FeatureMetric>[] = [
@@ -228,9 +272,7 @@ const FeatureMetricsTable = ({
       name: "Feature",
       sortable: true,
       render: (name: string, item: FeatureMetric) => (
-        <EuiLink
-          onClick={() => onFeatureClick(item.feature_view_name, name)}
-        >
+        <EuiLink onClick={() => onFeatureClick(item.feature_view_name, name)}>
           {name}
         </EuiLink>
       ),

--- a/ui/src/pages/monitoring/FeatureMetricsTable.tsx
+++ b/ui/src/pages/monitoring/FeatureMetricsTable.tsx
@@ -1,0 +1,296 @@
+import React, { useState, useMemo, useEffect } from "react";
+import {
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiBadge,
+  EuiHealth,
+  EuiLink,
+  EuiProgress,
+  EuiToolTip,
+  Criteria,
+} from "@elastic/eui";
+import type {
+  FeatureMetric,
+  NumericHistogram,
+  CategoricalHistogram,
+} from "../../queries/useMonitoringApi";
+
+const healthColor = (nullRate: number): string => {
+  if (nullRate >= 0.5) return "danger";
+  if (nullRate >= 0.1) return "warning";
+  return "success";
+};
+
+const healthLabel = (nullRate: number): string => {
+  if (nullRate >= 0.5) return "High null rate";
+  if (nullRate >= 0.1) return "Moderate null rate";
+  return "Healthy";
+};
+
+const formatNum = (val: number | null, decimals = 2): string => {
+  if (val === null || val === undefined) return "—";
+  if (Number.isInteger(val)) return val.toLocaleString();
+  return val.toFixed(decimals);
+};
+
+const MiniHistogram = ({ metric }: { metric: FeatureMetric }) => {
+  if (!metric.histogram) return <span style={{ color: "#98A2B3" }}>—</span>;
+
+  const width = 120;
+  const height = 28;
+
+  if (metric.feature_type === "numeric") {
+    const hist = metric.histogram as NumericHistogram;
+    const maxCount = Math.max(...hist.counts, 1);
+    const barW = Math.max(Math.floor(width / hist.counts.length) - 1, 2);
+
+    return (
+      <EuiToolTip content="Click feature name for full distribution">
+        <svg width={width} height={height} style={{ display: "block" }}>
+          {hist.counts.map((count, i) => {
+            const h = (count / maxCount) * (height - 2);
+            return (
+              <rect
+                key={i}
+                x={i * (barW + 1)}
+                y={height - h}
+                width={barW}
+                height={Math.max(h, 1)}
+                fill="#006BB4"
+                opacity={0.8}
+                rx={1}
+              />
+            );
+          })}
+        </svg>
+      </EuiToolTip>
+    );
+  }
+
+  const hist = metric.histogram as CategoricalHistogram;
+  const maxCount = Math.max(...hist.values.map((v) => v.count), 1);
+  const barW = Math.max(
+    Math.floor(width / Math.min(hist.values.length, 10)) - 1,
+    6,
+  );
+
+  return (
+    <EuiToolTip content="Click feature name for full distribution">
+      <svg width={width} height={height} style={{ display: "block" }}>
+        {hist.values.slice(0, 10).map((v, i) => {
+          const h = (v.count / maxCount) * (height - 2);
+          return (
+            <rect
+              key={i}
+              x={i * (barW + 1)}
+              y={height - h}
+              width={barW}
+              height={Math.max(h, 1)}
+              fill="#E7664C"
+              opacity={0.8}
+              rx={1}
+            />
+          );
+        })}
+      </svg>
+    </EuiToolTip>
+  );
+};
+
+interface FeatureMetricsTableProps {
+  metrics: FeatureMetric[];
+  isLoading: boolean;
+  onFeatureClick: (fvName: string, featureName: string) => void;
+}
+
+const PAGE_SIZE_OPTIONS = [10, 20, 50];
+
+const FeatureMetricsTable = ({
+  metrics,
+  isLoading,
+  onFeatureClick,
+}: FeatureMetricsTableProps) => {
+  const [sortField, setSortField] =
+    useState<keyof FeatureMetric>("feature_view_name");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(20);
+
+  useEffect(() => {
+    setPageIndex(0);
+  }, [metrics]);
+
+  const latestMetrics = useMemo(() => {
+    const byKey = new Map<string, FeatureMetric>();
+    for (const m of metrics) {
+      const key = `${m.feature_view_name}::${m.feature_name}`;
+      const existing = byKey.get(key);
+      if (!existing) {
+        byKey.set(key, m);
+      } else {
+        const preferNew =
+          m.row_count > 0 && existing.row_count === 0
+            ? true
+            : existing.row_count > 0 && m.row_count === 0
+              ? false
+              : m.metric_date > existing.metric_date;
+        if (preferNew) byKey.set(key, m);
+      }
+    }
+    return Array.from(byKey.values());
+  }, [metrics]);
+
+  const sortedItems = useMemo(() => {
+    return [...latestMetrics].sort((a, b) => {
+      const aVal = a[sortField];
+      const bVal = b[sortField];
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return 1;
+      if (bVal == null) return -1;
+      if (aVal < bVal) return sortDirection === "asc" ? -1 : 1;
+      if (aVal > bVal) return sortDirection === "asc" ? 1 : -1;
+      return 0;
+    });
+  }, [latestMetrics, sortField, sortDirection]);
+
+  const pageOfItems = useMemo(() => {
+    const start = pageIndex * pageSize;
+    return sortedItems.slice(start, start + pageSize);
+  }, [sortedItems, pageIndex, pageSize]);
+
+  const pagination = useMemo(
+    () => ({
+      pageIndex,
+      pageSize,
+      totalItemCount: sortedItems.length,
+      pageSizeOptions: PAGE_SIZE_OPTIONS,
+    }),
+    [pageIndex, pageSize, sortedItems.length],
+  );
+
+  const onTableChange = ({ sort, page }: Criteria<FeatureMetric>) => {
+    if (sort) {
+      setSortField(sort.field as keyof FeatureMetric);
+      setSortDirection(sort.direction);
+    }
+    if (page) {
+      setPageIndex(page.index);
+      setPageSize(page.size);
+    }
+  };
+
+  const columns: EuiBasicTableColumn<FeatureMetric>[] = [
+    {
+      field: "feature_name",
+      name: "Feature",
+      sortable: true,
+      render: (name: string, item: FeatureMetric) => (
+        <EuiLink
+          onClick={() => onFeatureClick(item.feature_view_name, name)}
+        >
+          {name}
+        </EuiLink>
+      ),
+    },
+    {
+      field: "feature_view_name",
+      name: "Feature View",
+      sortable: true,
+    },
+    {
+      field: "feature_type",
+      name: "Type",
+      sortable: true,
+      width: "100px",
+      render: (type: string) => (
+        <EuiBadge color={type === "numeric" ? "primary" : "accent"}>
+          {type}
+        </EuiBadge>
+      ),
+    },
+    {
+      name: "Distribution",
+      width: "140px",
+      render: (item: FeatureMetric) => <MiniHistogram metric={item} />,
+    },
+    {
+      field: "row_count",
+      name: "Rows",
+      sortable: true,
+      width: "90px",
+      render: (val: number) => formatNum(val, 0),
+    },
+    {
+      field: "null_rate",
+      name: "Null Rate",
+      sortable: true,
+      width: "150px",
+      render: (val: number) => (
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <EuiProgress
+            value={val * 100}
+            max={100}
+            color={healthColor(val) as any}
+            size="m"
+            style={{ width: 60 }}
+          />
+          <span>{(val * 100).toFixed(1)}%</span>
+        </div>
+      ),
+    },
+    {
+      field: "null_rate",
+      name: "Health",
+      width: "130px",
+      render: (val: number) => (
+        <EuiHealth color={healthColor(val)}>{healthLabel(val)}</EuiHealth>
+      ),
+    },
+    {
+      field: "mean",
+      name: "Mean",
+      sortable: true,
+      width: "100px",
+      render: (val: number | null) => formatNum(val),
+    },
+    {
+      field: "stddev",
+      name: "Std Dev",
+      sortable: true,
+      width: "100px",
+      render: (val: number | null) => formatNum(val),
+    },
+    {
+      field: "data_source_type",
+      name: "Source",
+      width: "80px",
+      render: (val: string) => <EuiBadge color="hollow">{val}</EuiBadge>,
+    },
+  ];
+
+  return (
+    <EuiBasicTable
+      items={pageOfItems}
+      columns={columns}
+      loading={isLoading}
+      pagination={pagination}
+      sorting={{
+        sort: {
+          field: sortField,
+          direction: sortDirection,
+        },
+      }}
+      onChange={onTableChange}
+      rowProps={(item: FeatureMetric) => ({
+        "data-test-subj": `row-${item.feature_name}`,
+      })}
+      noItemsMessage={
+        isLoading
+          ? "Loading metrics..."
+          : "No metrics found. Run a monitoring compute job to generate metrics."
+      }
+    />
+  );
+};
+
+export default FeatureMetricsTable;

--- a/ui/src/pages/monitoring/FeatureServiceMetricsPanel.tsx
+++ b/ui/src/pages/monitoring/FeatureServiceMetricsPanel.tsx
@@ -117,9 +117,7 @@ const FeatureServiceMetricsPanel = ({
       field: "data_source_type",
       name: "Source",
       width: "80px",
-      render: (val: string) => (
-        <EuiBadge color="hollow">{val}</EuiBadge>
-      ),
+      render: (val: string) => <EuiBadge color="hollow">{val}</EuiBadge>,
     },
   ];
 
@@ -213,7 +211,10 @@ const SortableFSTable = ({
       items={sortedItems}
       columns={columns}
       sorting={{
-        sort: { field: sortField as keyof FeatureServiceMetric, direction: sortDirection },
+        sort: {
+          field: sortField as keyof FeatureServiceMetric,
+          direction: sortDirection,
+        },
       }}
       onChange={onTableChange}
       compressed

--- a/ui/src/pages/monitoring/FeatureServiceMetricsPanel.tsx
+++ b/ui/src/pages/monitoring/FeatureServiceMetricsPanel.tsx
@@ -1,0 +1,224 @@
+import React, { useState, useMemo } from "react";
+import {
+  EuiPanel,
+  EuiTitle,
+  EuiSpacer,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiStat,
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiProgress,
+  EuiBadge,
+  EuiSkeletonText,
+  Criteria,
+} from "@elastic/eui";
+import type { FeatureServiceMetric } from "../../queries/useMonitoringApi";
+
+const healthColor = (nullRate: number): string => {
+  if (nullRate >= 0.5) return "danger";
+  if (nullRate >= 0.1) return "warning";
+  return "success";
+};
+
+interface FeatureServiceMetricsPanelProps {
+  metrics: FeatureServiceMetric[];
+  isLoading: boolean;
+}
+
+const FeatureServiceMetricsPanel = ({
+  metrics,
+  isLoading,
+}: FeatureServiceMetricsPanelProps) => {
+  if (isLoading) {
+    return (
+      <EuiPanel hasBorder>
+        <EuiTitle size="xs">
+          <h3>Feature Service Metrics</h3>
+        </EuiTitle>
+        <EuiSpacer size="m" />
+        <EuiSkeletonText lines={4} />
+      </EuiPanel>
+    );
+  }
+
+  const latestByFS = new Map<string, FeatureServiceMetric>();
+  for (const m of metrics) {
+    const existing = latestByFS.get(m.feature_service_name);
+    if (!existing || m.metric_date > existing.metric_date) {
+      latestByFS.set(m.feature_service_name, m);
+    }
+  }
+  const latestMetrics = Array.from(latestByFS.values());
+
+  const totalViews = latestMetrics.reduce(
+    (sum, m) => sum + (m.total_feature_views || 0),
+    0,
+  );
+  const totalFeatures = latestMetrics.reduce(
+    (sum, m) => sum + (m.total_features || 0),
+    0,
+  );
+  const avgNullRate =
+    latestMetrics.length > 0
+      ? latestMetrics.reduce((sum, m) => sum + (m.avg_null_rate || 0), 0) /
+        latestMetrics.length
+      : 0;
+
+  const columns: EuiBasicTableColumn<FeatureServiceMetric>[] = [
+    {
+      field: "feature_service_name",
+      name: "Feature Service",
+      sortable: true,
+    },
+    {
+      field: "total_feature_views",
+      name: "Feature Views",
+      sortable: true,
+      width: "110px",
+    },
+    {
+      field: "total_features",
+      name: "Features",
+      sortable: true,
+      width: "80px",
+    },
+    {
+      field: "avg_null_rate",
+      name: "Avg Null Rate",
+      sortable: true,
+      render: (val: number) => (
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <EuiProgress
+            value={(val || 0) * 100}
+            max={100}
+            color={healthColor(val || 0) as any}
+            size="s"
+            style={{ width: 50 }}
+          />
+          <span>{((val || 0) * 100).toFixed(1)}%</span>
+        </div>
+      ),
+    },
+    {
+      field: "max_null_rate",
+      name: "Max Null Rate",
+      sortable: true,
+      width: "110px",
+      render: (val: number) => `${((val || 0) * 100).toFixed(1)}%`,
+    },
+    {
+      field: "metric_date",
+      name: "Date",
+      sortable: true,
+      width: "110px",
+    },
+    {
+      field: "data_source_type",
+      name: "Source",
+      width: "80px",
+      render: (val: string) => (
+        <EuiBadge color="hollow">{val}</EuiBadge>
+      ),
+    },
+  ];
+
+  return (
+    <EuiPanel hasBorder>
+      <EuiTitle size="xs">
+        <h3>Feature Service Metrics</h3>
+      </EuiTitle>
+      <p style={{ color: "#69707D", fontSize: 13, marginTop: 4 }}>
+        Aggregated data quality metrics across feature services.
+      </p>
+      <EuiSpacer size="m" />
+
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <EuiStat
+            title={latestMetrics.length.toString()}
+            description="Services"
+            titleSize="s"
+            textAlign="center"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={totalViews.toString()}
+            description="Feature Views"
+            titleSize="s"
+            textAlign="center"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={totalFeatures.toString()}
+            description="Features"
+            titleSize="s"
+            textAlign="center"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={`${(avgNullRate * 100).toFixed(1)}%`}
+            description="Avg Null Rate"
+            titleSize="s"
+            titleColor={healthColor(avgNullRate)}
+            textAlign="center"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="m" />
+
+      {latestMetrics.length > 0 && (
+        <SortableFSTable items={latestMetrics} columns={columns} />
+      )}
+    </EuiPanel>
+  );
+};
+
+const SortableFSTable = ({
+  items,
+  columns,
+}: {
+  items: FeatureServiceMetric[];
+  columns: EuiBasicTableColumn<FeatureServiceMetric>[];
+}) => {
+  const [sortField, setSortField] = useState<string>("feature_service_name");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
+
+  const sortedItems = useMemo(() => {
+    return [...items].sort((a, b) => {
+      const aVal = (a as any)[sortField];
+      const bVal = (b as any)[sortField];
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return 1;
+      if (bVal == null) return -1;
+      if (aVal < bVal) return sortDirection === "asc" ? -1 : 1;
+      if (aVal > bVal) return sortDirection === "asc" ? 1 : -1;
+      return 0;
+    });
+  }, [items, sortField, sortDirection]);
+
+  const onTableChange = ({ sort }: Criteria<FeatureServiceMetric>) => {
+    if (sort) {
+      setSortField(sort.field as string);
+      setSortDirection(sort.direction);
+    }
+  };
+
+  return (
+    <EuiBasicTable
+      items={sortedItems}
+      columns={columns}
+      sorting={{
+        sort: { field: sortField as keyof FeatureServiceMetric, direction: sortDirection },
+      }}
+      onChange={onTableChange}
+      compressed
+    />
+  );
+};
+
+export default FeatureServiceMetricsPanel;

--- a/ui/src/pages/monitoring/FeatureViewMetricsPanel.tsx
+++ b/ui/src/pages/monitoring/FeatureViewMetricsPanel.tsx
@@ -1,0 +1,240 @@
+import React, { useState, useMemo } from "react";
+import {
+  EuiPanel,
+  EuiTitle,
+  EuiSpacer,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiStat,
+  EuiBasicTable,
+  EuiBasicTableColumn,
+  EuiProgress,
+  EuiBadge,
+  EuiSkeletonText,
+  Criteria,
+} from "@elastic/eui";
+import type { FeatureViewMetric } from "../../queries/useMonitoringApi";
+
+const healthColor = (nullRate: number): string => {
+  if (nullRate >= 0.5) return "danger";
+  if (nullRate >= 0.1) return "warning";
+  return "success";
+};
+
+interface FeatureViewMetricsPanelProps {
+  metrics: FeatureViewMetric[];
+  isLoading: boolean;
+  title: string;
+  description?: string;
+}
+
+const FeatureViewMetricsPanel = ({
+  metrics,
+  isLoading,
+  title,
+  description,
+}: FeatureViewMetricsPanelProps) => {
+  if (isLoading) {
+    return (
+      <EuiPanel hasBorder>
+        <EuiTitle size="xs">
+          <h3>{title}</h3>
+        </EuiTitle>
+        <EuiSpacer size="m" />
+        <EuiSkeletonText lines={4} />
+      </EuiPanel>
+    );
+  }
+
+  const latestByFV = new Map<string, FeatureViewMetric>();
+  for (const m of metrics) {
+    const existing = latestByFV.get(m.feature_view_name);
+    if (!existing || m.metric_date > existing.metric_date) {
+      latestByFV.set(m.feature_view_name, m);
+    }
+  }
+  const latestMetrics = Array.from(latestByFV.values());
+
+  const totalRows = latestMetrics.reduce(
+    (sum, m) => sum + (m.total_row_count || 0),
+    0,
+  );
+  const totalFeatures = latestMetrics.reduce(
+    (sum, m) => sum + (m.total_features || 0),
+    0,
+  );
+  const avgNullRate =
+    latestMetrics.length > 0
+      ? latestMetrics.reduce((sum, m) => sum + (m.avg_null_rate || 0), 0) /
+        latestMetrics.length
+      : 0;
+  const healthyViews = latestMetrics.filter(
+    (m) => m.avg_null_rate < 0.1,
+  ).length;
+
+  const columns: EuiBasicTableColumn<FeatureViewMetric>[] = [
+    {
+      field: "feature_view_name",
+      name: "Feature View",
+      sortable: true,
+    },
+    {
+      field: "total_row_count",
+      name: "Total Rows",
+      sortable: true,
+      render: (val: number) => (val || 0).toLocaleString(),
+    },
+    {
+      field: "total_features",
+      name: "Features",
+      sortable: true,
+      width: "80px",
+    },
+    {
+      field: "features_with_nulls",
+      name: "With Nulls",
+      sortable: true,
+      width: "90px",
+    },
+    {
+      field: "avg_null_rate",
+      name: "Avg Null Rate",
+      sortable: true,
+      render: (val: number) => (
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <EuiProgress
+            value={(val || 0) * 100}
+            max={100}
+            color={healthColor(val || 0) as any}
+            size="s"
+            style={{ width: 50 }}
+          />
+          <span>{((val || 0) * 100).toFixed(1)}%</span>
+        </div>
+      ),
+    },
+    {
+      field: "max_null_rate",
+      name: "Max Null Rate",
+      sortable: true,
+      width: "110px",
+      render: (val: number) => `${((val || 0) * 100).toFixed(1)}%`,
+    },
+    {
+      field: "metric_date",
+      name: "Date",
+      sortable: true,
+      width: "110px",
+    },
+    {
+      field: "data_source_type",
+      name: "Source",
+      width: "80px",
+      render: (val: string) => (
+        <EuiBadge color="hollow">{val}</EuiBadge>
+      ),
+    },
+  ];
+
+  return (
+    <EuiPanel hasBorder>
+      <EuiTitle size="xs">
+        <h3>{title}</h3>
+      </EuiTitle>
+      {description && (
+        <p style={{ color: "#69707D", fontSize: 13, marginTop: 4 }}>
+          {description}
+        </p>
+      )}
+      <EuiSpacer size="m" />
+
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <EuiStat
+            title={totalRows.toLocaleString()}
+            description="Total Rows"
+            titleSize="s"
+            textAlign="center"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={totalFeatures.toString()}
+            description="Total Features"
+            titleSize="s"
+            textAlign="center"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={`${(avgNullRate * 100).toFixed(1)}%`}
+            description="Avg Null Rate"
+            titleSize="s"
+            titleColor={healthColor(avgNullRate)}
+            textAlign="center"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={`${healthyViews}/${latestMetrics.length}`}
+            description="Healthy Views"
+            titleSize="s"
+            titleColor="success"
+            textAlign="center"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="m" />
+
+      {latestMetrics.length > 0 && (
+        <SortableTable items={latestMetrics} columns={columns} />
+      )}
+    </EuiPanel>
+  );
+};
+
+const SortableTable = ({
+  items,
+  columns,
+}: {
+  items: FeatureViewMetric[];
+  columns: EuiBasicTableColumn<FeatureViewMetric>[];
+}) => {
+  const [sortField, setSortField] = useState<string>("feature_view_name");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
+
+  const sortedItems = useMemo(() => {
+    return [...items].sort((a, b) => {
+      const aVal = (a as any)[sortField];
+      const bVal = (b as any)[sortField];
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return 1;
+      if (bVal == null) return -1;
+      if (aVal < bVal) return sortDirection === "asc" ? -1 : 1;
+      if (aVal > bVal) return sortDirection === "asc" ? 1 : -1;
+      return 0;
+    });
+  }, [items, sortField, sortDirection]);
+
+  const onTableChange = ({ sort }: Criteria<FeatureViewMetric>) => {
+    if (sort) {
+      setSortField(sort.field as string);
+      setSortDirection(sort.direction);
+    }
+  };
+
+  return (
+    <EuiBasicTable
+      items={sortedItems}
+      columns={columns}
+      sorting={{
+        sort: { field: sortField as keyof FeatureViewMetric, direction: sortDirection },
+      }}
+      onChange={onTableChange}
+      compressed
+    />
+  );
+};
+
+export default FeatureViewMetricsPanel;

--- a/ui/src/pages/monitoring/FeatureViewMetricsPanel.tsx
+++ b/ui/src/pages/monitoring/FeatureViewMetricsPanel.tsx
@@ -130,9 +130,7 @@ const FeatureViewMetricsPanel = ({
       field: "data_source_type",
       name: "Source",
       width: "80px",
-      render: (val: string) => (
-        <EuiBadge color="hollow">{val}</EuiBadge>
-      ),
+      render: (val: string) => <EuiBadge color="hollow">{val}</EuiBadge>,
     },
   ];
 
@@ -229,7 +227,10 @@ const SortableTable = ({
       items={sortedItems}
       columns={columns}
       sorting={{
-        sort: { field: sortField as keyof FeatureViewMetric, direction: sortDirection },
+        sort: {
+          field: sortField as keyof FeatureViewMetric,
+          direction: sortDirection,
+        },
       }}
       onChange={onTableChange}
       compressed

--- a/ui/src/pages/monitoring/Index.tsx
+++ b/ui/src/pages/monitoring/Index.tsx
@@ -1,0 +1,265 @@
+import React, { useState, useContext, useMemo } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  EuiPageTemplate,
+  EuiSpacer,
+  EuiTabbedContent,
+  EuiTabbedContentTab,
+  EuiEmptyPrompt,
+  EuiButton,
+  EuiCallOut,
+} from "@elastic/eui";
+
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
+import useLoadRegistry from "../../queries/useLoadRegistry";
+import RegistryPathContext from "../../contexts/RegistryPathContext";
+import {
+  useFeatureMetrics,
+  useFeatureViewMetrics,
+  useFeatureServiceMetrics,
+  useComputeMetrics,
+} from "../../queries/useMonitoringApi";
+import FeatureMetricsTable from "./FeatureMetricsTable";
+import FeatureViewMetricsPanel from "./FeatureViewMetricsPanel";
+import FeatureServiceMetricsPanel from "./FeatureServiceMetricsPanel";
+import MetricsFilters from "./components/MetricsFilters";
+
+const MonitoringIndex = () => {
+  useDocumentTitle("Monitoring | Feast");
+
+  const { projectName } = useParams();
+  const navigate = useNavigate();
+  const registryUrl = useContext(RegistryPathContext);
+  const { data: registryData } = useLoadRegistry(registryUrl, projectName);
+
+  const [selectedFV, setSelectedFV] = useState("");
+  const [granularity, setGranularity] = useState("");
+  const [dataSourceType, setDataSourceType] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const filters = useMemo(
+    () => ({
+      project: projectName || "",
+      feature_view_name: selectedFV || undefined,
+      granularity: granularity || undefined,
+      data_source_type: dataSourceType || undefined,
+      start_date: startDate || undefined,
+      end_date: endDate || undefined,
+    }),
+    [projectName, selectedFV, granularity, dataSourceType, startDate, endDate],
+  );
+
+  const featureQuery = useFeatureMetrics(filters);
+  const fvQuery = useFeatureViewMetrics(filters);
+  const fsQuery = useFeatureServiceMetrics({
+    project: projectName || "",
+    granularity: granularity || undefined,
+    data_source_type: dataSourceType || undefined,
+    start_date: startDate || undefined,
+    end_date: endDate || undefined,
+  });
+  const computeMutation = useComputeMetrics();
+
+  const featureViews = useMemo(() => {
+    if (!registryData?.mergedFVList) return [];
+    return registryData.mergedFVList.map((fv: any) => fv.name as string);
+  }, [registryData]);
+
+  const handleFeatureClick = (fvName: string, featureName: string) => {
+    navigate(
+      `/p/${projectName}/monitoring/feature/${fvName}/${featureName}`,
+    );
+  };
+
+  const uniqueFeatureCount = useMemo(() => {
+    if (!featureQuery.data) return 0;
+    const seen = new Set<string>();
+    for (const m of featureQuery.data) {
+      seen.add(`${m.feature_view_name}::${m.feature_name}`);
+    }
+    return seen.size;
+  }, [featureQuery.data]);
+
+  const handleRefresh = () => {
+    featureQuery.refetch();
+    fvQuery.refetch();
+    fsQuery.refetch();
+  };
+
+  const handleCompute = () => {
+    computeMutation.mutate({
+      project: projectName || "",
+      feature_view_name: selectedFV || undefined,
+    });
+  };
+
+  const hasError =
+    featureQuery.isError && fvQuery.isError && fsQuery.isError;
+  const hasData =
+    (featureQuery.data && featureQuery.data.length > 0) ||
+    (fvQuery.data && fvQuery.data.length > 0);
+
+  const tabs: EuiTabbedContentTab[] = [
+    {
+      id: "features",
+      name: `Features${uniqueFeatureCount > 0 ? ` (${uniqueFeatureCount})` : ""}`,
+      content: (
+        <>
+          <EuiSpacer size="m" />
+          <FeatureMetricsTable
+            metrics={featureQuery.data || []}
+            isLoading={featureQuery.isLoading}
+            onFeatureClick={handleFeatureClick}
+          />
+        </>
+      ),
+    },
+    {
+      id: "feature-views",
+      name: "Feature Views",
+      content: (
+        <>
+          <EuiSpacer size="m" />
+          <FeatureViewMetricsPanel
+            metrics={fvQuery.data || []}
+            isLoading={fvQuery.isLoading}
+            title="Feature View Data Quality"
+            description="Aggregated data quality metrics per feature view — tracks null rates, row counts, and feature health."
+          />
+        </>
+      ),
+    },
+    {
+      id: "feature-services",
+      name: "Feature Services",
+      content: (
+        <>
+          <EuiSpacer size="m" />
+          <FeatureServiceMetricsPanel
+            metrics={fsQuery.data || []}
+            isLoading={fsQuery.isLoading}
+          />
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
+        restrictWidth
+        iconType="monitoringApp"
+        pageTitle="Monitoring"
+        description="Feature quality and data health metrics for your feature store."
+        rightSideItems={[
+          <EuiButton
+            key="compute"
+            fill
+            size="s"
+            iconType="playFilled"
+            onClick={handleCompute}
+            isLoading={computeMutation.isLoading}
+          >
+            Compute Metrics
+          </EuiButton>,
+        ]}
+      />
+      <EuiPageTemplate.Section>
+        {hasError && (
+          <>
+            <EuiCallOut
+              title="Monitoring service unavailable"
+              color="warning"
+              iconType="alert"
+            >
+              <p>
+                Could not connect to the monitoring API. Make sure the Feast
+                registry server is running with monitoring enabled.
+              </p>
+            </EuiCallOut>
+            <EuiSpacer />
+          </>
+        )}
+
+        <MetricsFilters
+          featureViews={featureViews}
+          selectedFeatureView={selectedFV}
+          onFeatureViewChange={setSelectedFV}
+          granularity={granularity}
+          onGranularityChange={setGranularity}
+          dataSourceType={dataSourceType}
+          onDataSourceTypeChange={setDataSourceType}
+          startDate={startDate}
+          onStartDateChange={setStartDate}
+          endDate={endDate}
+          onEndDateChange={setEndDate}
+          onRefresh={handleRefresh}
+          isLoading={featureQuery.isLoading}
+        />
+
+        <EuiSpacer />
+
+        {!hasData && !featureQuery.isLoading && !hasError && (
+          <EuiEmptyPrompt
+            iconType="monitoringApp"
+            title={<h2>No Metrics Yet</h2>}
+            body={
+              <p>
+                No monitoring data has been computed for this project. Click
+                &quot;Compute Metrics&quot; to run data quality analysis on your
+                feature views, or use the CLI:{" "}
+                <code>feast monitor run --data-source batch</code>
+              </p>
+            }
+            actions={
+              <EuiButton
+                fill
+                iconType="playFilled"
+                onClick={handleCompute}
+                isLoading={computeMutation.isLoading}
+              >
+                Compute Metrics
+              </EuiButton>
+            }
+          />
+        )}
+
+        {(hasData || featureQuery.isLoading) && (
+          <EuiTabbedContent tabs={tabs} initialSelectedTab={tabs[0]} />
+        )}
+
+        {computeMutation.isSuccess && (
+          <>
+            <EuiSpacer />
+            <EuiCallOut
+              title="Metrics computed successfully"
+              color="success"
+              iconType="check"
+            >
+              <p>
+                Data quality metrics have been computed. The table above has
+                been refreshed.
+              </p>
+            </EuiCallOut>
+          </>
+        )}
+
+        {computeMutation.isError && (
+          <>
+            <EuiSpacer />
+            <EuiCallOut
+              title="Failed to compute metrics"
+              color="danger"
+              iconType="alert"
+            >
+              <p>{(computeMutation.error as Error)?.message}</p>
+            </EuiCallOut>
+          </>
+        )}
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
+  );
+};
+
+export default MonitoringIndex;

--- a/ui/src/pages/monitoring/Index.tsx
+++ b/ui/src/pages/monitoring/Index.tsx
@@ -33,31 +33,35 @@ const MonitoringIndex = () => {
   const { data: registryData } = useLoadRegistry(registryUrl, projectName);
 
   const [selectedFV, setSelectedFV] = useState("");
-  const [granularity, setGranularity] = useState("");
+  const [granularity, setGranularity] = useState("baseline");
   const [dataSourceType, setDataSourceType] = useState("");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
+
+  const isBaseline = granularity === "baseline";
 
   const filters = useMemo(
     () => ({
       project: projectName || "",
       feature_view_name: selectedFV || undefined,
-      granularity: granularity || undefined,
+      granularity: isBaseline ? undefined : granularity || undefined,
       data_source_type: dataSourceType || undefined,
       start_date: startDate || undefined,
       end_date: endDate || undefined,
+      is_baseline: isBaseline || undefined,
     }),
-    [projectName, selectedFV, granularity, dataSourceType, startDate, endDate],
+    [projectName, selectedFV, granularity, isBaseline, dataSourceType, startDate, endDate],
   );
 
   const featureQuery = useFeatureMetrics(filters);
   const fvQuery = useFeatureViewMetrics(filters);
   const fsQuery = useFeatureServiceMetrics({
     project: projectName || "",
-    granularity: granularity || undefined,
+    granularity: isBaseline ? undefined : granularity || undefined,
     data_source_type: dataSourceType || undefined,
     start_date: startDate || undefined,
     end_date: endDate || undefined,
+    is_baseline: isBaseline || undefined,
   });
   const computeMutation = useComputeMetrics();
 

--- a/ui/src/pages/monitoring/Index.tsx
+++ b/ui/src/pages/monitoring/Index.tsx
@@ -40,17 +40,33 @@ const MonitoringIndex = () => {
 
   const isBaseline = granularity === "baseline";
 
+  const handleGranularityChange = (g: string) => {
+    setGranularity(g);
+    if (g === "baseline") {
+      setStartDate("");
+      setEndDate("");
+    }
+  };
+
   const filters = useMemo(
     () => ({
       project: projectName || "",
       feature_view_name: selectedFV || undefined,
       granularity: isBaseline ? undefined : granularity || undefined,
       data_source_type: dataSourceType || undefined,
-      start_date: startDate || undefined,
-      end_date: endDate || undefined,
+      start_date: isBaseline ? undefined : startDate || undefined,
+      end_date: isBaseline ? undefined : endDate || undefined,
       is_baseline: isBaseline || undefined,
     }),
-    [projectName, selectedFV, granularity, isBaseline, dataSourceType, startDate, endDate],
+    [
+      projectName,
+      selectedFV,
+      granularity,
+      isBaseline,
+      dataSourceType,
+      startDate,
+      endDate,
+    ],
   );
 
   const featureQuery = useFeatureMetrics(filters);
@@ -71,9 +87,7 @@ const MonitoringIndex = () => {
   }, [registryData]);
 
   const handleFeatureClick = (fvName: string, featureName: string) => {
-    navigate(
-      `/p/${projectName}/monitoring/feature/${fvName}/${featureName}`,
-    );
+    navigate(`/p/${projectName}/monitoring/feature/${fvName}/${featureName}`);
   };
 
   const uniqueFeatureCount = useMemo(() => {
@@ -98,8 +112,7 @@ const MonitoringIndex = () => {
     });
   };
 
-  const hasError =
-    featureQuery.isError && fvQuery.isError && fsQuery.isError;
+  const hasError = featureQuery.isError && fvQuery.isError && fsQuery.isError;
   const hasData =
     (featureQuery.data && featureQuery.data.length > 0) ||
     (fvQuery.data && fvQuery.data.length > 0);
@@ -191,7 +204,7 @@ const MonitoringIndex = () => {
           selectedFeatureView={selectedFV}
           onFeatureViewChange={setSelectedFV}
           granularity={granularity}
-          onGranularityChange={setGranularity}
+          onGranularityChange={handleGranularityChange}
           dataSourceType={dataSourceType}
           onDataSourceTypeChange={setDataSourceType}
           startDate={startDate}
@@ -200,6 +213,7 @@ const MonitoringIndex = () => {
           onEndDateChange={setEndDate}
           onRefresh={handleRefresh}
           isLoading={featureQuery.isLoading}
+          datesDisabled={isBaseline}
         />
 
         <EuiSpacer />

--- a/ui/src/pages/monitoring/components/HistogramChart.tsx
+++ b/ui/src/pages/monitoring/components/HistogramChart.tsx
@@ -1,0 +1,245 @@
+import React from "react";
+import {
+  EuiPanel,
+  EuiTitle,
+  EuiSpacer,
+  EuiText,
+} from "@elastic/eui";
+import type {
+  NumericHistogram,
+  CategoricalHistogram,
+} from "../../../queries/useMonitoringApi";
+
+const BAR_COLOR = "#006BB4";
+const BAR_COLOR_BASELINE = "#BD271E55";
+const CHART_HEIGHT = 160;
+const AXIS_HEIGHT = 24;
+const LEFT_PAD = 50;
+
+const NumericHistogramChart = ({
+  histogram,
+  baseline,
+  title,
+}: {
+  histogram: NumericHistogram;
+  baseline?: NumericHistogram | null;
+  title?: string;
+}) => {
+  const maxCount = Math.max(...histogram.counts, 1);
+  const numBars = histogram.counts.length;
+  const barWidth = Math.max(Math.floor(460 / numBars) - 2, 6);
+  const barsWidth = (barWidth + 2) * numBars;
+  const svgWidth = LEFT_PAD + barsWidth + 20;
+
+  const yTicks = [0, 0.25, 0.5, 0.75, 1].map((f) => ({
+    value: Math.round(maxCount * f),
+    y: CHART_HEIGHT - f * CHART_HEIGHT,
+  }));
+
+  return (
+    <EuiPanel hasBorder>
+      {title && (
+        <>
+          <EuiTitle size="xxs">
+            <h4>{title}</h4>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+        </>
+      )}
+      <div style={{ overflowX: "auto" }}>
+        <svg
+          width={Math.max(svgWidth, 280)}
+          height={CHART_HEIGHT + AXIS_HEIGHT}
+          role="img"
+          aria-label="Histogram"
+        >
+          {yTicks.map((t) => (
+            <g key={t.value}>
+              <line
+                x1={LEFT_PAD}
+                y1={t.y}
+                x2={LEFT_PAD + barsWidth}
+                y2={t.y}
+                stroke="#EDF0F5"
+                strokeWidth={1}
+              />
+              <text
+                x={LEFT_PAD - 6}
+                y={t.y + 4}
+                fontSize={10}
+                fill="#98A2B3"
+                textAnchor="end"
+              >
+                {t.value.toLocaleString()}
+              </text>
+            </g>
+          ))}
+          {histogram.counts.map((count, i) => {
+            const height = (count / maxCount) * CHART_HEIGHT;
+            const x = LEFT_PAD + i * (barWidth + 2);
+            const binStart = histogram.bins[i];
+            const binEnd =
+              i < histogram.bins.length - 1
+                ? histogram.bins[i + 1]
+                : binStart + histogram.bin_width;
+            const baselineHeight =
+              baseline && baseline.counts[i]
+                ? (baseline.counts[i] / maxCount) * CHART_HEIGHT
+                : 0;
+
+            return (
+              <g key={i}>
+                {baselineHeight > 0 && (
+                  <rect
+                    x={x}
+                    y={CHART_HEIGHT - baselineHeight}
+                    width={barWidth}
+                    height={baselineHeight}
+                    fill={BAR_COLOR_BASELINE}
+                    rx={1}
+                  />
+                )}
+                <rect
+                  x={x}
+                  y={CHART_HEIGHT - height}
+                  width={barWidth}
+                  height={Math.max(height, 1)}
+                  fill={BAR_COLOR}
+                  rx={1}
+                  opacity={0.85}
+                >
+                  <title>{`${binStart.toFixed(2)} – ${binEnd.toFixed(2)}: ${count.toLocaleString()}`}</title>
+                </rect>
+              </g>
+            );
+          })}
+          <line
+            x1={LEFT_PAD}
+            y1={CHART_HEIGHT}
+            x2={LEFT_PAD + barsWidth}
+            y2={CHART_HEIGHT}
+            stroke="#D3DAE6"
+            strokeWidth={1}
+          />
+          <text
+            x={LEFT_PAD}
+            y={CHART_HEIGHT + 16}
+            fontSize={10}
+            fill="#69707D"
+          >
+            {histogram.bins[0]?.toLocaleString(undefined, { maximumFractionDigits: 1 })}
+          </text>
+          <text
+            x={LEFT_PAD + barsWidth}
+            y={CHART_HEIGHT + 16}
+            fontSize={10}
+            fill="#69707D"
+            textAnchor="end"
+          >
+            {histogram.bins[histogram.bins.length - 1]?.toLocaleString(undefined, { maximumFractionDigits: 1 })}
+          </text>
+        </svg>
+      </div>
+      {baseline && (
+        <EuiText size="xs" color="subdued">
+          <span
+            style={{
+              display: "inline-block",
+              width: 10,
+              height: 10,
+              backgroundColor: BAR_COLOR_BASELINE,
+              marginRight: 4,
+            }}
+          />
+          Baseline
+        </EuiText>
+      )}
+    </EuiPanel>
+  );
+};
+
+const LABEL_WIDTH = 60;
+const BAR_MAX_WIDTH = 320;
+const COUNT_PAD = 80;
+const CAT_SVG_WIDTH = LABEL_WIDTH + BAR_MAX_WIDTH + COUNT_PAD;
+
+const CategoricalHistogramChart = ({
+  histogram,
+  title,
+}: {
+  histogram: CategoricalHistogram;
+  title?: string;
+}) => {
+  const maxCount = Math.max(
+    ...histogram.values.map((v) => v.count),
+    1,
+  );
+  const barHeight = 24;
+  const rowHeight = barHeight + 6;
+  const chartHeight = histogram.values.length * rowHeight;
+
+  return (
+    <EuiPanel hasBorder>
+      {title && (
+        <>
+          <EuiTitle size="xxs">
+            <h4>{title}</h4>
+          </EuiTitle>
+          <EuiSpacer size="s" />
+        </>
+      )}
+      <div style={{ overflowX: "auto" }}>
+        <svg
+          width={CAT_SVG_WIDTH}
+          height={chartHeight}
+          role="img"
+          aria-label="Category chart"
+        >
+          {histogram.values.map((v, i) => {
+            const width = (v.count / maxCount) * BAR_MAX_WIDTH;
+            const y = i * rowHeight;
+            return (
+              <g key={v.value}>
+                <text
+                  x={LABEL_WIDTH - 8}
+                  y={y + 16}
+                  fontSize={12}
+                  fill="#343741"
+                  textAnchor="end"
+                >
+                  {v.value.length > 8 ? v.value.slice(0, 8) + "…" : v.value}
+                </text>
+                <rect
+                  x={LABEL_WIDTH}
+                  y={y + 2}
+                  width={Math.max(width, 2)}
+                  height={barHeight - 4}
+                  fill={BAR_COLOR}
+                  rx={2}
+                  opacity={0.85}
+                >
+                  <title>{`${v.value}: ${v.count.toLocaleString()}`}</title>
+                </rect>
+                <text
+                  x={LABEL_WIDTH + width + 6}
+                  y={y + 16}
+                  fontSize={11}
+                  fill="#69707D"
+                >
+                  {v.count.toLocaleString()}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <EuiText size="xs" color="subdued">
+        {histogram.unique_count} unique values
+        {histogram.other_count > 0 &&
+          ` (${histogram.other_count.toLocaleString()} in other categories)`}
+      </EuiText>
+    </EuiPanel>
+  );
+};
+
+export { NumericHistogramChart, CategoricalHistogramChart };

--- a/ui/src/pages/monitoring/components/HistogramChart.tsx
+++ b/ui/src/pages/monitoring/components/HistogramChart.tsx
@@ -59,7 +59,8 @@ const formatNumber = (val: number, compact: boolean): string => {
   const abs = Math.abs(val);
   if (compact && abs >= 1_000_000) return (val / 1_000_000).toFixed(1) + "M";
   if (compact && abs >= 1_000) return (val / 1_000).toFixed(1) + "K";
-  if (abs >= 1) return val.toLocaleString(undefined, { maximumFractionDigits: 1 });
+  if (abs >= 1)
+    return val.toLocaleString(undefined, { maximumFractionDigits: 1 });
   if (abs >= 0.01) return val.toFixed(2);
   return val.toExponential(1);
 };
@@ -210,7 +211,11 @@ const NumericHistogramChart = ({
   return (
     <>
       <EuiPanel hasBorder>
-        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="none">
+        <EuiFlexGroup
+          justifyContent="spaceBetween"
+          alignItems="center"
+          gutterSize="none"
+        >
           <EuiFlexItem grow={false}>
             {title && (
               <EuiTitle size="xxs">
@@ -310,7 +315,12 @@ const renderCategoricalSvg = (
   const chartHeight = histogram.values.length * rowHeight;
 
   return (
-    <svg width={totalW} height={chartHeight} role="img" aria-label="Category chart">
+    <svg
+      width={totalW}
+      height={chartHeight}
+      role="img"
+      aria-label="Category chart"
+    >
       {histogram.values.map((v, i) => {
         const width = (v.count / maxCount) * barMax;
         const y = i * rowHeight;
@@ -323,7 +333,9 @@ const renderCategoricalSvg = (
               fill="#343741"
               textAnchor="end"
             >
-              {v.value.length > truncLen ? v.value.slice(0, truncLen) + "…" : v.value}
+              {v.value.length > truncLen
+                ? v.value.slice(0, truncLen) + "…"
+                : v.value}
             </text>
             <rect
               x={labelW}
@@ -363,7 +375,11 @@ const CategoricalHistogramChart = ({
   return (
     <>
       <EuiPanel hasBorder>
-        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="none">
+        <EuiFlexGroup
+          justifyContent="spaceBetween"
+          alignItems="center"
+          gutterSize="none"
+        >
           <EuiFlexItem grow={false}>
             {title && (
               <EuiTitle size="xxs">
@@ -397,7 +413,9 @@ const CategoricalHistogramChart = ({
       {expanded && (
         <EuiModal onClose={() => setExpanded(false)} maxWidth={960}>
           <EuiModalHeader>
-            <EuiModalHeaderTitle>{title || "Category Distribution"}</EuiModalHeaderTitle>
+            <EuiModalHeaderTitle>
+              {title || "Category Distribution"}
+            </EuiModalHeaderTitle>
           </EuiModalHeader>
           <EuiModalBody>
             <div style={{ overflowX: "auto" }}>

--- a/ui/src/pages/monitoring/components/HistogramChart.tsx
+++ b/ui/src/pages/monitoring/components/HistogramChart.tsx
@@ -1,9 +1,17 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   EuiPanel,
   EuiTitle,
   EuiSpacer,
   EuiText,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiButtonIcon,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiToolTip,
 } from "@elastic/eui";
 import type {
   NumericHistogram,
@@ -12,9 +20,181 @@ import type {
 
 const BAR_COLOR = "#006BB4";
 const BAR_COLOR_BASELINE = "#BD271E55";
-const CHART_HEIGHT = 160;
-const AXIS_HEIGHT = 24;
-const LEFT_PAD = 50;
+
+interface ChartDimensions {
+  chartHeight: number;
+  axisHeight: number;
+  leftPad: number;
+  barGap: number;
+  minBarWidth: number;
+  targetBarsWidth: number;
+  fontSize: number;
+  xTickCount: number;
+}
+
+const COMPACT: ChartDimensions = {
+  chartHeight: 160,
+  axisHeight: 28,
+  leftPad: 54,
+  barGap: 2,
+  minBarWidth: 6,
+  targetBarsWidth: 460,
+  fontSize: 10,
+  xTickCount: 2,
+};
+
+const EXPANDED: ChartDimensions = {
+  chartHeight: 400,
+  axisHeight: 48,
+  leftPad: 72,
+  barGap: 3,
+  minBarWidth: 12,
+  targetBarsWidth: 800,
+  fontSize: 12,
+  xTickCount: 6,
+};
+
+const formatNumber = (val: number, compact: boolean): string => {
+  if (val === 0) return "0";
+  const abs = Math.abs(val);
+  if (compact && abs >= 1_000_000) return (val / 1_000_000).toFixed(1) + "M";
+  if (compact && abs >= 1_000) return (val / 1_000).toFixed(1) + "K";
+  if (abs >= 1) return val.toLocaleString(undefined, { maximumFractionDigits: 1 });
+  if (abs >= 0.01) return val.toFixed(2);
+  return val.toExponential(1);
+};
+
+const renderNumericSvg = (
+  histogram: NumericHistogram,
+  baseline: NumericHistogram | null | undefined,
+  dim: ChartDimensions,
+) => {
+  const maxCount = Math.max(
+    ...histogram.counts,
+    ...(baseline ? baseline.counts : []),
+    1,
+  );
+  const numBars = histogram.counts.length;
+  const barWidth = Math.max(
+    Math.floor(dim.targetBarsWidth / numBars) - dim.barGap,
+    dim.minBarWidth,
+  );
+  const barsWidth = (barWidth + dim.barGap) * numBars;
+  const svgWidth = dim.leftPad + barsWidth + 24;
+  const isCompact = dim === COMPACT;
+
+  const yTickFractions = [0, 0.25, 0.5, 0.75, 1];
+  const yTicks = yTickFractions.map((f) => ({
+    label: formatNumber(Math.round(maxCount * f), isCompact),
+    y: dim.chartHeight - f * dim.chartHeight,
+  }));
+
+  const xTickStep = Math.max(1, Math.floor(numBars / dim.xTickCount));
+  const xTicks: { label: string; x: number }[] = [];
+  for (let i = 0; i < numBars; i += xTickStep) {
+    xTicks.push({
+      label: formatNumber(histogram.bins[i], isCompact),
+      x: dim.leftPad + i * (barWidth + dim.barGap) + barWidth / 2,
+    });
+  }
+  if (numBars > 0) {
+    const lastBin = histogram.bins[histogram.bins.length - 1];
+    xTicks.push({
+      label: formatNumber(lastBin, isCompact),
+      x: dim.leftPad + (numBars - 1) * (barWidth + dim.barGap) + barWidth / 2,
+    });
+  }
+
+  return (
+    <svg
+      width={Math.max(svgWidth, 280)}
+      height={dim.chartHeight + dim.axisHeight}
+      role="img"
+      aria-label="Histogram"
+    >
+      {yTicks.map((t, i) => (
+        <g key={i}>
+          <line
+            x1={dim.leftPad}
+            y1={t.y}
+            x2={dim.leftPad + barsWidth}
+            y2={t.y}
+            stroke="#EDF0F5"
+            strokeWidth={1}
+          />
+          <text
+            x={dim.leftPad - 6}
+            y={t.y + 4}
+            fontSize={dim.fontSize}
+            fill="#98A2B3"
+            textAnchor="end"
+          >
+            {t.label}
+          </text>
+        </g>
+      ))}
+      {histogram.counts.map((count, i) => {
+        const height = (count / maxCount) * dim.chartHeight;
+        const x = dim.leftPad + i * (barWidth + dim.barGap);
+        const binStart = histogram.bins[i];
+        const binEnd =
+          i < histogram.bins.length - 1
+            ? histogram.bins[i + 1]
+            : binStart + histogram.bin_width;
+        const baselineHeight =
+          baseline && baseline.counts[i]
+            ? (baseline.counts[i] / maxCount) * dim.chartHeight
+            : 0;
+
+        return (
+          <g key={i}>
+            {baselineHeight > 0 && (
+              <rect
+                x={x}
+                y={dim.chartHeight - baselineHeight}
+                width={barWidth}
+                height={baselineHeight}
+                fill={BAR_COLOR_BASELINE}
+                rx={1}
+              />
+            )}
+            <rect
+              x={x}
+              y={dim.chartHeight - height}
+              width={barWidth}
+              height={Math.max(height, 1)}
+              fill={BAR_COLOR}
+              rx={1}
+              opacity={0.85}
+            >
+              <title>{`${formatNumber(binStart, false)} – ${formatNumber(binEnd, false)}: ${count.toLocaleString()}`}</title>
+            </rect>
+          </g>
+        );
+      })}
+      <line
+        x1={dim.leftPad}
+        y1={dim.chartHeight}
+        x2={dim.leftPad + barsWidth}
+        y2={dim.chartHeight}
+        stroke="#D3DAE6"
+        strokeWidth={1}
+      />
+      {xTicks.map((t, i) => (
+        <text
+          key={i}
+          x={t.x}
+          y={dim.chartHeight + dim.fontSize + 6}
+          fontSize={dim.fontSize}
+          fill="#69707D"
+          textAnchor="middle"
+        >
+          {t.label}
+        </text>
+      ))}
+    </svg>
+  );
+};
 
 const NumericHistogramChart = ({
   histogram,
@@ -25,136 +205,81 @@ const NumericHistogramChart = ({
   baseline?: NumericHistogram | null;
   title?: string;
 }) => {
-  const maxCount = Math.max(...histogram.counts, 1);
-  const numBars = histogram.counts.length;
-  const barWidth = Math.max(Math.floor(460 / numBars) - 2, 6);
-  const barsWidth = (barWidth + 2) * numBars;
-  const svgWidth = LEFT_PAD + barsWidth + 20;
-
-  const yTicks = [0, 0.25, 0.5, 0.75, 1].map((f) => ({
-    value: Math.round(maxCount * f),
-    y: CHART_HEIGHT - f * CHART_HEIGHT,
-  }));
+  const [expanded, setExpanded] = useState(false);
 
   return (
-    <EuiPanel hasBorder>
-      {title && (
-        <>
-          <EuiTitle size="xxs">
-            <h4>{title}</h4>
-          </EuiTitle>
-          <EuiSpacer size="s" />
-        </>
-      )}
-      <div style={{ overflowX: "auto" }}>
-        <svg
-          width={Math.max(svgWidth, 280)}
-          height={CHART_HEIGHT + AXIS_HEIGHT}
-          role="img"
-          aria-label="Histogram"
-        >
-          {yTicks.map((t) => (
-            <g key={t.value}>
-              <line
-                x1={LEFT_PAD}
-                y1={t.y}
-                x2={LEFT_PAD + barsWidth}
-                y2={t.y}
-                stroke="#EDF0F5"
-                strokeWidth={1}
+    <>
+      <EuiPanel hasBorder>
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="none">
+          <EuiFlexItem grow={false}>
+            {title && (
+              <EuiTitle size="xxs">
+                <h4>{title}</h4>
+              </EuiTitle>
+            )}
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content="Expand histogram">
+              <EuiButtonIcon
+                iconType="expand"
+                aria-label="Expand histogram"
+                size="s"
+                color="text"
+                onClick={() => setExpanded(true)}
               />
-              <text
-                x={LEFT_PAD - 6}
-                y={t.y + 4}
-                fontSize={10}
-                fill="#98A2B3"
-                textAnchor="end"
-              >
-                {t.value.toLocaleString()}
-              </text>
-            </g>
-          ))}
-          {histogram.counts.map((count, i) => {
-            const height = (count / maxCount) * CHART_HEIGHT;
-            const x = LEFT_PAD + i * (barWidth + 2);
-            const binStart = histogram.bins[i];
-            const binEnd =
-              i < histogram.bins.length - 1
-                ? histogram.bins[i + 1]
-                : binStart + histogram.bin_width;
-            const baselineHeight =
-              baseline && baseline.counts[i]
-                ? (baseline.counts[i] / maxCount) * CHART_HEIGHT
-                : 0;
+            </EuiToolTip>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        {title && <EuiSpacer size="s" />}
+        <div style={{ overflowX: "auto" }}>
+          {renderNumericSvg(histogram, baseline, COMPACT)}
+        </div>
+        {baseline && (
+          <EuiText size="xs" color="subdued">
+            <span
+              style={{
+                display: "inline-block",
+                width: 10,
+                height: 10,
+                backgroundColor: BAR_COLOR_BASELINE,
+                marginRight: 4,
+              }}
+            />
+            Baseline
+          </EuiText>
+        )}
+      </EuiPanel>
 
-            return (
-              <g key={i}>
-                {baselineHeight > 0 && (
-                  <rect
-                    x={x}
-                    y={CHART_HEIGHT - baselineHeight}
-                    width={barWidth}
-                    height={baselineHeight}
-                    fill={BAR_COLOR_BASELINE}
-                    rx={1}
+      {expanded && (
+        <EuiModal onClose={() => setExpanded(false)} maxWidth={960}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>{title || "Histogram"}</EuiModalHeaderTitle>
+          </EuiModalHeader>
+          <EuiModalBody>
+            <div style={{ overflowX: "auto" }}>
+              {renderNumericSvg(histogram, baseline, EXPANDED)}
+            </div>
+            {baseline && (
+              <>
+                <EuiSpacer size="s" />
+                <EuiText size="xs" color="subdued">
+                  <span
+                    style={{
+                      display: "inline-block",
+                      width: 10,
+                      height: 10,
+                      backgroundColor: BAR_COLOR_BASELINE,
+                      marginRight: 4,
+                    }}
                   />
-                )}
-                <rect
-                  x={x}
-                  y={CHART_HEIGHT - height}
-                  width={barWidth}
-                  height={Math.max(height, 1)}
-                  fill={BAR_COLOR}
-                  rx={1}
-                  opacity={0.85}
-                >
-                  <title>{`${binStart.toFixed(2)} – ${binEnd.toFixed(2)}: ${count.toLocaleString()}`}</title>
-                </rect>
-              </g>
-            );
-          })}
-          <line
-            x1={LEFT_PAD}
-            y1={CHART_HEIGHT}
-            x2={LEFT_PAD + barsWidth}
-            y2={CHART_HEIGHT}
-            stroke="#D3DAE6"
-            strokeWidth={1}
-          />
-          <text
-            x={LEFT_PAD}
-            y={CHART_HEIGHT + 16}
-            fontSize={10}
-            fill="#69707D"
-          >
-            {histogram.bins[0]?.toLocaleString(undefined, { maximumFractionDigits: 1 })}
-          </text>
-          <text
-            x={LEFT_PAD + barsWidth}
-            y={CHART_HEIGHT + 16}
-            fontSize={10}
-            fill="#69707D"
-            textAnchor="end"
-          >
-            {histogram.bins[histogram.bins.length - 1]?.toLocaleString(undefined, { maximumFractionDigits: 1 })}
-          </text>
-        </svg>
-      </div>
-      {baseline && (
-        <EuiText size="xs" color="subdued">
-          <span
-            style={{
-              display: "inline-block",
-              width: 10,
-              height: 10,
-              backgroundColor: BAR_COLOR_BASELINE,
-              marginRight: 4,
-            }}
-          />
-          Baseline
-        </EuiText>
+                  Baseline
+                </EuiText>
+              </>
+            )}
+          </EuiModalBody>
+        </EuiModal>
       )}
-    </EuiPanel>
+    </>
   );
 };
 
@@ -163,6 +288,69 @@ const BAR_MAX_WIDTH = 320;
 const COUNT_PAD = 80;
 const CAT_SVG_WIDTH = LABEL_WIDTH + BAR_MAX_WIDTH + COUNT_PAD;
 
+const LABEL_WIDTH_EXP = 120;
+const BAR_MAX_WIDTH_EXP = 560;
+const COUNT_PAD_EXP = 100;
+const CAT_SVG_WIDTH_EXP = LABEL_WIDTH_EXP + BAR_MAX_WIDTH_EXP + COUNT_PAD_EXP;
+
+const renderCategoricalSvg = (
+  histogram: CategoricalHistogram,
+  isExpanded: boolean,
+) => {
+  const labelW = isExpanded ? LABEL_WIDTH_EXP : LABEL_WIDTH;
+  const barMax = isExpanded ? BAR_MAX_WIDTH_EXP : BAR_MAX_WIDTH;
+  const countPad = isExpanded ? COUNT_PAD_EXP : COUNT_PAD;
+  const totalW = labelW + barMax + countPad;
+  const truncLen = isExpanded ? 20 : 8;
+  const fontSize = isExpanded ? 13 : 12;
+  const barHeight = isExpanded ? 30 : 24;
+  const rowHeight = barHeight + 6;
+
+  const maxCount = Math.max(...histogram.values.map((v) => v.count), 1);
+  const chartHeight = histogram.values.length * rowHeight;
+
+  return (
+    <svg width={totalW} height={chartHeight} role="img" aria-label="Category chart">
+      {histogram.values.map((v, i) => {
+        const width = (v.count / maxCount) * barMax;
+        const y = i * rowHeight;
+        return (
+          <g key={v.value}>
+            <text
+              x={labelW - 8}
+              y={y + barHeight / 2 + 4}
+              fontSize={fontSize}
+              fill="#343741"
+              textAnchor="end"
+            >
+              {v.value.length > truncLen ? v.value.slice(0, truncLen) + "…" : v.value}
+            </text>
+            <rect
+              x={labelW}
+              y={y + 2}
+              width={Math.max(width, 2)}
+              height={barHeight - 4}
+              fill={BAR_COLOR}
+              rx={2}
+              opacity={0.85}
+            >
+              <title>{`${v.value}: ${v.count.toLocaleString()}`}</title>
+            </rect>
+            <text
+              x={labelW + width + 6}
+              y={y + barHeight / 2 + 4}
+              fontSize={fontSize - 1}
+              fill="#69707D"
+            >
+              {v.count.toLocaleString()}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+};
+
 const CategoricalHistogramChart = ({
   histogram,
   title,
@@ -170,75 +358,61 @@ const CategoricalHistogramChart = ({
   histogram: CategoricalHistogram;
   title?: string;
 }) => {
-  const maxCount = Math.max(
-    ...histogram.values.map((v) => v.count),
-    1,
-  );
-  const barHeight = 24;
-  const rowHeight = barHeight + 6;
-  const chartHeight = histogram.values.length * rowHeight;
+  const [expanded, setExpanded] = useState(false);
 
   return (
-    <EuiPanel hasBorder>
-      {title && (
-        <>
-          <EuiTitle size="xxs">
-            <h4>{title}</h4>
-          </EuiTitle>
-          <EuiSpacer size="s" />
-        </>
+    <>
+      <EuiPanel hasBorder>
+        <EuiFlexGroup justifyContent="spaceBetween" alignItems="center" gutterSize="none">
+          <EuiFlexItem grow={false}>
+            {title && (
+              <EuiTitle size="xxs">
+                <h4>{title}</h4>
+              </EuiTitle>
+            )}
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content="Expand chart">
+              <EuiButtonIcon
+                iconType="expand"
+                aria-label="Expand chart"
+                size="s"
+                color="text"
+                onClick={() => setExpanded(true)}
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        {title && <EuiSpacer size="s" />}
+        <div style={{ overflowX: "auto" }}>
+          {renderCategoricalSvg(histogram, false)}
+        </div>
+        <EuiText size="xs" color="subdued">
+          {histogram.unique_count} unique values
+          {histogram.other_count > 0 &&
+            ` (${histogram.other_count.toLocaleString()} in other categories)`}
+        </EuiText>
+      </EuiPanel>
+
+      {expanded && (
+        <EuiModal onClose={() => setExpanded(false)} maxWidth={960}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>{title || "Category Distribution"}</EuiModalHeaderTitle>
+          </EuiModalHeader>
+          <EuiModalBody>
+            <div style={{ overflowX: "auto" }}>
+              {renderCategoricalSvg(histogram, true)}
+            </div>
+            <EuiSpacer size="s" />
+            <EuiText size="xs" color="subdued">
+              {histogram.unique_count} unique values
+              {histogram.other_count > 0 &&
+                ` (${histogram.other_count.toLocaleString()} in other categories)`}
+            </EuiText>
+          </EuiModalBody>
+        </EuiModal>
       )}
-      <div style={{ overflowX: "auto" }}>
-        <svg
-          width={CAT_SVG_WIDTH}
-          height={chartHeight}
-          role="img"
-          aria-label="Category chart"
-        >
-          {histogram.values.map((v, i) => {
-            const width = (v.count / maxCount) * BAR_MAX_WIDTH;
-            const y = i * rowHeight;
-            return (
-              <g key={v.value}>
-                <text
-                  x={LABEL_WIDTH - 8}
-                  y={y + 16}
-                  fontSize={12}
-                  fill="#343741"
-                  textAnchor="end"
-                >
-                  {v.value.length > 8 ? v.value.slice(0, 8) + "…" : v.value}
-                </text>
-                <rect
-                  x={LABEL_WIDTH}
-                  y={y + 2}
-                  width={Math.max(width, 2)}
-                  height={barHeight - 4}
-                  fill={BAR_COLOR}
-                  rx={2}
-                  opacity={0.85}
-                >
-                  <title>{`${v.value}: ${v.count.toLocaleString()}`}</title>
-                </rect>
-                <text
-                  x={LABEL_WIDTH + width + 6}
-                  y={y + 16}
-                  fontSize={11}
-                  fill="#69707D"
-                >
-                  {v.count.toLocaleString()}
-                </text>
-              </g>
-            );
-          })}
-        </svg>
-      </div>
-      <EuiText size="xs" color="subdued">
-        {histogram.unique_count} unique values
-        {histogram.other_count > 0 &&
-          ` (${histogram.other_count.toLocaleString()} in other categories)`}
-      </EuiText>
-    </EuiPanel>
+    </>
   );
 };
 

--- a/ui/src/pages/monitoring/components/MetricsFilters.tsx
+++ b/ui/src/pages/monitoring/components/MetricsFilters.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSelect,
+  EuiFieldText,
+  EuiFormRow,
+  EuiButton,
+} from "@elastic/eui";
+
+interface MetricsFiltersProps {
+  featureViews: string[];
+  selectedFeatureView: string;
+  onFeatureViewChange: (fv: string) => void;
+  granularity: string;
+  onGranularityChange: (g: string) => void;
+  dataSourceType: string;
+  onDataSourceTypeChange: (ds: string) => void;
+  startDate: string;
+  onStartDateChange: (d: string) => void;
+  endDate: string;
+  onEndDateChange: (d: string) => void;
+  onRefresh: () => void;
+  isLoading?: boolean;
+}
+
+const GRANULARITY_OPTIONS = [
+  { value: "", text: "All" },
+  { value: "daily", text: "Daily" },
+  { value: "weekly", text: "Weekly" },
+  { value: "biweekly", text: "Biweekly" },
+  { value: "monthly", text: "Monthly" },
+  { value: "quarterly", text: "Quarterly" },
+];
+
+const DATA_SOURCE_OPTIONS = [
+  { value: "", text: "All Sources" },
+  { value: "batch", text: "Batch" },
+  { value: "log", text: "Log" },
+];
+
+const MetricsFilters = ({
+  featureViews,
+  selectedFeatureView,
+  onFeatureViewChange,
+  granularity,
+  onGranularityChange,
+  dataSourceType,
+  onDataSourceTypeChange,
+  startDate,
+  onStartDateChange,
+  endDate,
+  onEndDateChange,
+  onRefresh,
+  isLoading,
+}: MetricsFiltersProps) => {
+  const fvOptions = [
+    { value: "", text: "All Feature Views" },
+    ...featureViews.map((fv) => ({ value: fv, text: fv })),
+  ];
+
+  return (
+    <EuiFlexGroup gutterSize="m" alignItems="flexEnd" wrap>
+      <EuiFlexItem grow={2}>
+        <EuiFormRow label="Feature View">
+          <EuiSelect
+            options={fvOptions}
+            value={selectedFeatureView}
+            onChange={(e) => onFeatureViewChange(e.target.value)}
+            compressed
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem grow={1}>
+        <EuiFormRow label="Granularity">
+          <EuiSelect
+            options={GRANULARITY_OPTIONS}
+            value={granularity}
+            onChange={(e) => onGranularityChange(e.target.value)}
+            compressed
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem grow={1}>
+        <EuiFormRow label="Source">
+          <EuiSelect
+            options={DATA_SOURCE_OPTIONS}
+            value={dataSourceType}
+            onChange={(e) => onDataSourceTypeChange(e.target.value)}
+            compressed
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem grow={1}>
+        <EuiFormRow label="Start Date">
+          <EuiFieldText
+            type="date"
+            value={startDate}
+            onChange={(e) => onStartDateChange(e.target.value)}
+            compressed
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem grow={1}>
+        <EuiFormRow label="End Date">
+          <EuiFieldText
+            type="date"
+            value={endDate}
+            onChange={(e) => onEndDateChange(e.target.value)}
+            compressed
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiButton
+          size="s"
+          iconType="refresh"
+          onClick={onRefresh}
+          isLoading={isLoading}
+        >
+          Refresh
+        </EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};
+
+export default MetricsFilters;

--- a/ui/src/pages/monitoring/components/MetricsFilters.tsx
+++ b/ui/src/pages/monitoring/components/MetricsFilters.tsx
@@ -25,7 +25,7 @@ interface MetricsFiltersProps {
 }
 
 const GRANULARITY_OPTIONS = [
-  { value: "", text: "All" },
+  { value: "baseline", text: "Baseline" },
   { value: "daily", text: "Daily" },
   { value: "weekly", text: "Weekly" },
   { value: "biweekly", text: "Biweekly" },

--- a/ui/src/pages/monitoring/components/MetricsFilters.tsx
+++ b/ui/src/pages/monitoring/components/MetricsFilters.tsx
@@ -22,6 +22,7 @@ interface MetricsFiltersProps {
   onEndDateChange: (d: string) => void;
   onRefresh: () => void;
   isLoading?: boolean;
+  datesDisabled?: boolean;
 }
 
 const GRANULARITY_OPTIONS = [
@@ -53,6 +54,7 @@ const MetricsFilters = ({
   onEndDateChange,
   onRefresh,
   isLoading,
+  datesDisabled,
 }: MetricsFiltersProps) => {
   const fvOptions = [
     { value: "", text: "All Feature Views" },
@@ -92,22 +94,30 @@ const MetricsFilters = ({
         </EuiFormRow>
       </EuiFlexItem>
       <EuiFlexItem grow={1}>
-        <EuiFormRow label="Start Date">
+        <EuiFormRow
+          label="Start Date"
+          helpText={datesDisabled ? "N/A for baseline" : undefined}
+        >
           <EuiFieldText
             type="date"
             value={startDate}
             onChange={(e) => onStartDateChange(e.target.value)}
             compressed
+            disabled={datesDisabled}
           />
         </EuiFormRow>
       </EuiFlexItem>
       <EuiFlexItem grow={1}>
-        <EuiFormRow label="End Date">
+        <EuiFormRow
+          label="End Date"
+          helpText={datesDisabled ? "N/A for baseline" : undefined}
+        >
           <EuiFieldText
             type="date"
             value={endDate}
             onChange={(e) => onEndDateChange(e.target.value)}
             compressed
+            disabled={datesDisabled}
           />
         </EuiFormRow>
       </EuiFlexItem>

--- a/ui/src/pages/monitoring/components/StatsPanel.tsx
+++ b/ui/src/pages/monitoring/components/StatsPanel.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import {
+  EuiPanel,
+  EuiTitle,
+  EuiSpacer,
+  EuiDescriptionList,
+  EuiDescriptionListTitle,
+  EuiDescriptionListDescription,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiBadge,
+} from "@elastic/eui";
+import type { FeatureMetric } from "../../../queries/useMonitoringApi";
+
+const formatNumber = (val: number | null, decimals = 4): string => {
+  if (val === null || val === undefined) return "—";
+  if (Number.isInteger(val)) return val.toLocaleString();
+  return val.toFixed(decimals);
+};
+
+const formatPercent = (val: number | null): string => {
+  if (val === null || val === undefined) return "—";
+  return `${(val * 100).toFixed(2)}%`;
+};
+
+const StatsPanel = ({
+  metric,
+  baseline,
+}: {
+  metric: FeatureMetric;
+  baseline?: FeatureMetric | null;
+}) => {
+  const isNumeric = metric.feature_type === "numeric";
+
+  return (
+    <EuiPanel hasBorder>
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xxs">
+            <h4>Statistics</h4>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiBadge color={isNumeric ? "primary" : "accent"}>
+            {metric.feature_type}
+          </EuiBadge>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="s" />
+      <EuiDescriptionList compressed>
+        <EuiDescriptionListTitle>Row Count</EuiDescriptionListTitle>
+        <EuiDescriptionListDescription>
+          {formatNumber(metric.row_count, 0)}
+          {baseline && (
+            <span style={{ color: "#69707D", marginLeft: 8 }}>
+              (baseline: {formatNumber(baseline.row_count, 0)})
+            </span>
+          )}
+        </EuiDescriptionListDescription>
+
+        <EuiDescriptionListTitle>Null Rate</EuiDescriptionListTitle>
+        <EuiDescriptionListDescription>
+          <span
+            style={{
+              color: metric.null_rate > 0.1 ? "#BD271E" : "inherit",
+              fontWeight: metric.null_rate > 0.1 ? 600 : 400,
+            }}
+          >
+            {formatPercent(metric.null_rate)}
+          </span>
+          {baseline && (
+            <span style={{ color: "#69707D", marginLeft: 8 }}>
+              (baseline: {formatPercent(baseline.null_rate)})
+            </span>
+          )}
+        </EuiDescriptionListDescription>
+
+        {isNumeric && (
+          <>
+            <EuiDescriptionListTitle>Mean</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {formatNumber(metric.mean)}
+              {baseline && (
+                <span style={{ color: "#69707D", marginLeft: 8 }}>
+                  (baseline: {formatNumber(baseline.mean)})
+                </span>
+              )}
+            </EuiDescriptionListDescription>
+
+            <EuiDescriptionListTitle>Std Dev</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {formatNumber(metric.stddev)}
+            </EuiDescriptionListDescription>
+
+            <EuiDescriptionListTitle>Min / Max</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {formatNumber(metric.min_val)} / {formatNumber(metric.max_val)}
+            </EuiDescriptionListDescription>
+
+            <EuiDescriptionListTitle>Percentiles</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              P50: {formatNumber(metric.p50)} | P75: {formatNumber(metric.p75)}{" "}
+              | P90: {formatNumber(metric.p90)} | P95:{" "}
+              {formatNumber(metric.p95)} | P99: {formatNumber(metric.p99)}
+            </EuiDescriptionListDescription>
+          </>
+        )}
+
+        <EuiDescriptionListTitle>Data Source</EuiDescriptionListTitle>
+        <EuiDescriptionListDescription>
+          {metric.data_source_type}
+        </EuiDescriptionListDescription>
+
+        <EuiDescriptionListTitle>Granularity</EuiDescriptionListTitle>
+        <EuiDescriptionListDescription>
+          {metric.granularity}
+        </EuiDescriptionListDescription>
+
+        <EuiDescriptionListTitle>Computed At</EuiDescriptionListTitle>
+        <EuiDescriptionListDescription>
+          {metric.computed_at
+            ? new Date(metric.computed_at).toLocaleString()
+            : "—"}
+        </EuiDescriptionListDescription>
+      </EuiDescriptionList>
+    </EuiPanel>
+  );
+};
+
+export default StatsPanel;

--- a/ui/src/pages/monitoring/components/TimeSeriesAnalysis.tsx
+++ b/ui/src/pages/monitoring/components/TimeSeriesAnalysis.tsx
@@ -12,7 +12,16 @@ import type {
   CategoricalHistogram,
 } from "../../../queries/useMonitoringApi";
 
-const COLORS = ["#006BB4", "#54B399", "#E7664C", "#9170B8", "#D36086", "#6092C0", "#D6BF57", "#B9A888"];
+const COLORS = [
+  "#006BB4",
+  "#54B399",
+  "#E7664C",
+  "#9170B8",
+  "#D36086",
+  "#6092C0",
+  "#D6BF57",
+  "#B9A888",
+];
 
 const RANGE_OPTIONS = [
   { value: "24h", inputDisplay: "Last 24 hours" },
@@ -75,6 +84,7 @@ const niceYTicks = (min: number, max: number, count = 5): number[] => {
 interface LineSeriesData {
   label: string;
   color: string;
+  dashArray?: string;
   points: { x: number; y: number; date: string; value: number }[];
 }
 
@@ -172,18 +182,29 @@ const renderMultiLineChart = (
         if (s.points.length === 0) return null;
         const sorted = [...s.points].sort((a, b) => a.x - b.x);
         const pathD = sorted
-          .map((p, i) => `${i === 0 ? "M" : "L"} ${scaleX(p.x)} ${scaleY(p.value)}`)
+          .map(
+            (p, i) =>
+              `${i === 0 ? "M" : "L"} ${scaleX(p.x)} ${scaleY(p.value)}`,
+          )
           .join(" ");
         return (
           <g key={si}>
-            <path d={pathD} fill="none" stroke={s.color} strokeWidth={2} />
+            <path
+              d={pathD}
+              fill="none"
+              stroke={s.color}
+              strokeWidth={2}
+              strokeDasharray={s.dashArray}
+            />
             {sorted.map((p, i) => (
               <circle
                 key={i}
                 cx={scaleX(p.x)}
                 cy={scaleY(p.value)}
-                r={3}
+                r={s.dashArray ? 4 : 3}
                 fill={s.color}
+                stroke={s.dashArray ? "#fff" : undefined}
+                strokeWidth={s.dashArray ? 1 : undefined}
               />
             ))}
           </g>
@@ -292,7 +313,11 @@ const renderAreaChart = (
   );
 };
 
-const Legend = ({ items }: { items: { label: string; color: string }[] }) => (
+const Legend = ({
+  items,
+}: {
+  items: { label: string; color: string; dashed?: boolean }[];
+}) => (
   <div
     style={{
       display: "flex",
@@ -304,14 +329,28 @@ const Legend = ({ items }: { items: { label: string; color: string }[] }) => (
   >
     {items.map((item, i) => (
       <div key={i} style={{ display: "flex", alignItems: "center", gap: 4 }}>
-        <div
-          style={{
-            width: 12,
-            height: 12,
-            backgroundColor: item.color,
-            borderRadius: 2,
-          }}
-        />
+        {item.dashed ? (
+          <svg width={16} height={12}>
+            <line
+              x1={0}
+              y1={6}
+              x2={16}
+              y2={6}
+              stroke={item.color}
+              strokeWidth={2}
+              strokeDasharray="4,2"
+            />
+          </svg>
+        ) : (
+          <div
+            style={{
+              width: 12,
+              height: 12,
+              backgroundColor: item.color,
+              borderRadius: 2,
+            }}
+          />
+        )}
         <span style={{ fontSize: 12, color: "#343741" }}>{item.label}</span>
       </div>
     ))}
@@ -323,7 +362,10 @@ interface TimeSeriesAnalysisProps {
   featureType: string;
 }
 
-const TimeSeriesAnalysis = ({ metrics, featureType }: TimeSeriesAnalysisProps) => {
+const TimeSeriesAnalysis = ({
+  metrics,
+  featureType,
+}: TimeSeriesAnalysisProps) => {
   const [range, setRange] = useState("all");
 
   const filteredMetrics = useMemo(() => {
@@ -342,7 +384,7 @@ const TimeSeriesAnalysis = ({ metrics, featureType }: TimeSeriesAnalysisProps) =
 
   const toX = (m: FeatureMetric) => new Date(m.metric_date).getTime();
   const isNumeric = featureType === "numeric";
-  const hasData = sorted.length >= 2;
+  const hasData = sorted.length >= 1;
 
   return (
     <EuiPanel hasBorder>
@@ -368,8 +410,16 @@ const TimeSeriesAnalysis = ({ metrics, featureType }: TimeSeriesAnalysisProps) =
       <EuiSpacer size="m" />
 
       {!hasData ? (
-        <p style={{ color: "#69707D", fontSize: 13, textAlign: "center", padding: 24 }}>
-          No data points available for the selected time range. Try a wider range.
+        <p
+          style={{
+            color: "#69707D",
+            fontSize: 13,
+            textAlign: "center",
+            padding: 24,
+          }}
+        >
+          No data points available for the selected time range. Try a wider
+          range.
         </p>
       ) : isNumeric ? (
         <NumericTimeSeries metrics={sorted} toX={toX} />
@@ -392,9 +442,11 @@ const NumericTimeSeries = ({
       label: string,
       color: string,
       accessor: (m: FeatureMetric) => number | null,
+      dashArray?: string,
     ): LineSeriesData => ({
       label,
       color,
+      dashArray,
       points: metrics
         .filter((m) => accessor(m) !== null)
         .map((m) => ({
@@ -405,7 +457,7 @@ const NumericTimeSeries = ({
         })),
     });
     return [
-      build("Mean", COLORS[0], (m) => m.mean),
+      build("Mean", COLORS[0], (m) => m.mean, "6,3"),
       build("P50", COLORS[1], (m) => m.p50),
       build("P95", COLORS[2], (m) => m.p95),
     ];
@@ -431,7 +483,7 @@ const NumericTimeSeries = ({
       </div>
       <Legend
         items={[
-          { label: "Mean", color: COLORS[0] },
+          { label: "Mean", color: COLORS[0], dashed: true },
           { label: "P50", color: COLORS[1] },
           { label: "P95", color: COLORS[2] },
         ]}
@@ -564,7 +616,12 @@ const CategoricalTimeSeries = ({
         Top category share over time (%)
       </h4>
       <div style={{ overflowX: "auto" }}>
-        {renderMultiLineChart(shareSeries, DIMS, "Percentage (%)", shareYFormatter)}
+        {renderMultiLineChart(
+          shareSeries,
+          DIMS,
+          "Percentage (%)",
+          shareYFormatter,
+        )}
       </div>
       <Legend
         items={topCategories.map((cat, i) => ({

--- a/ui/src/pages/monitoring/components/TimeSeriesAnalysis.tsx
+++ b/ui/src/pages/monitoring/components/TimeSeriesAnalysis.tsx
@@ -1,0 +1,594 @@
+import React, { useState, useMemo } from "react";
+import {
+  EuiPanel,
+  EuiTitle,
+  EuiSpacer,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSuperSelect,
+} from "@elastic/eui";
+import type {
+  FeatureMetric,
+  CategoricalHistogram,
+} from "../../../queries/useMonitoringApi";
+
+const COLORS = ["#006BB4", "#54B399", "#E7664C", "#9170B8", "#D36086", "#6092C0", "#D6BF57", "#B9A888"];
+
+const RANGE_OPTIONS = [
+  { value: "24h", inputDisplay: "Last 24 hours" },
+  { value: "7d", inputDisplay: "Last 7 days" },
+  { value: "30d", inputDisplay: "Last 30 days" },
+  { value: "90d", inputDisplay: "Last 90 days" },
+  { value: "all", inputDisplay: "All time" },
+];
+
+const rangeToMs: Record<string, number> = {
+  "24h": 24 * 3600_000,
+  "7d": 7 * 86400_000,
+  "30d": 30 * 86400_000,
+  "90d": 90 * 86400_000,
+  all: Infinity,
+};
+
+interface ChartDims {
+  width: number;
+  height: number;
+  padLeft: number;
+  padRight: number;
+  padTop: number;
+  padBottom: number;
+}
+
+const DIMS: ChartDims = {
+  width: 860,
+  height: 220,
+  padLeft: 60,
+  padRight: 20,
+  padTop: 10,
+  padBottom: 30,
+};
+
+const formatDate = (d: string): string => {
+  const dt = new Date(d);
+  const mm = String(dt.getMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getDate()).padStart(2, "0");
+  const hh = String(dt.getHours()).padStart(2, "0");
+  const mi = String(dt.getMinutes()).padStart(2, "0");
+  return `${mm}-${dd} ${hh}:${mi}`;
+};
+
+const formatAxisVal = (v: number): string => {
+  if (v === 0) return "0";
+  const abs = Math.abs(v);
+  if (abs >= 1_000_000) return (v / 1_000_000).toFixed(1) + "M";
+  if (abs >= 1_000) return (v / 1_000).toFixed(1) + "K";
+  if (abs >= 1) return v.toFixed(1);
+  return (v * 100).toFixed(1) + "%";
+};
+
+const niceYTicks = (min: number, max: number, count = 5): number[] => {
+  if (max === min) return [min];
+  const step = (max - min) / (count - 1);
+  return Array.from({ length: count }, (_, i) => min + step * i);
+};
+
+interface LineSeriesData {
+  label: string;
+  color: string;
+  points: { x: number; y: number; date: string; value: number }[];
+}
+
+const renderMultiLineChart = (
+  series: LineSeriesData[],
+  dims: ChartDims,
+  yLabel: string,
+  yFormatter: (v: number) => string = formatAxisVal,
+) => {
+  const allPoints = series.flatMap((s) => s.points);
+  if (allPoints.length === 0) return null;
+
+  const xMin = Math.min(...allPoints.map((p) => p.x));
+  const xMax = Math.max(...allPoints.map((p) => p.x));
+  const yMin = Math.min(...allPoints.map((p) => p.value), 0);
+  const yMax = Math.max(...allPoints.map((p) => p.value), 0.01);
+
+  const plotW = dims.width - dims.padLeft - dims.padRight;
+  const plotH = dims.height - dims.padTop - dims.padBottom;
+
+  const scaleX = (x: number) =>
+    xMax === xMin
+      ? dims.padLeft + plotW / 2
+      : dims.padLeft + ((x - xMin) / (xMax - xMin)) * plotW;
+  const scaleY = (v: number) =>
+    dims.padTop + plotH - ((v - yMin) / (yMax - yMin || 1)) * plotH;
+
+  const yTicks = niceYTicks(yMin, yMax);
+  const xDates = allPoints
+    .map((p) => ({ x: p.x, date: p.date }))
+    .filter((v, i, arr) => arr.findIndex((a) => a.date === v.date) === i)
+    .sort((a, b) => a.x - b.x);
+
+  const maxXLabels = Math.floor(plotW / 80);
+  const xStep = Math.max(1, Math.ceil(xDates.length / maxXLabels));
+  const xLabels = xDates.filter((_, i) => i % xStep === 0);
+
+  return (
+    <svg width={dims.width} height={dims.height} style={{ display: "block" }}>
+      {/* Y axis grid + labels */}
+      {yTicks.map((v, i) => {
+        const y = scaleY(v);
+        return (
+          <g key={`y-${i}`}>
+            <line
+              x1={dims.padLeft}
+              y1={y}
+              x2={dims.width - dims.padRight}
+              y2={y}
+              stroke="#E0E5EE"
+              strokeDasharray="3,3"
+            />
+            <text
+              x={dims.padLeft - 6}
+              y={y + 4}
+              textAnchor="end"
+              fontSize={10}
+              fill="#69707D"
+            >
+              {yFormatter(v)}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* Y axis label */}
+      <text
+        x={14}
+        y={dims.padTop + plotH / 2}
+        textAnchor="middle"
+        fontSize={11}
+        fill="#E7664C"
+        fontWeight={600}
+        transform={`rotate(-90, 14, ${dims.padTop + plotH / 2})`}
+      >
+        {yLabel}
+      </text>
+
+      {/* X axis labels */}
+      {xLabels.map((xl, i) => (
+        <text
+          key={`x-${i}`}
+          x={scaleX(xl.x)}
+          y={dims.height - 4}
+          textAnchor="middle"
+          fontSize={10}
+          fill="#69707D"
+        >
+          {formatDate(xl.date)}
+        </text>
+      ))}
+
+      {/* Lines */}
+      {series.map((s, si) => {
+        if (s.points.length === 0) return null;
+        const sorted = [...s.points].sort((a, b) => a.x - b.x);
+        const pathD = sorted
+          .map((p, i) => `${i === 0 ? "M" : "L"} ${scaleX(p.x)} ${scaleY(p.value)}`)
+          .join(" ");
+        return (
+          <g key={si}>
+            <path d={pathD} fill="none" stroke={s.color} strokeWidth={2} />
+            {sorted.map((p, i) => (
+              <circle
+                key={i}
+                cx={scaleX(p.x)}
+                cy={scaleY(p.value)}
+                r={3}
+                fill={s.color}
+              />
+            ))}
+          </g>
+        );
+      })}
+    </svg>
+  );
+};
+
+const renderAreaChart = (
+  points: { x: number; value: number; date: string }[],
+  dims: ChartDims,
+  yLabel: string,
+  lineColor: string,
+  fillColor: string,
+) => {
+  if (points.length === 0) return null;
+
+  const sorted = [...points].sort((a, b) => a.x - b.x);
+  const xMin = Math.min(...sorted.map((p) => p.x));
+  const xMax = Math.max(...sorted.map((p) => p.x));
+  const yMin = 0;
+  const yMax = Math.max(...sorted.map((p) => p.value), 0.01);
+
+  const plotW = dims.width - dims.padLeft - dims.padRight;
+  const plotH = dims.height - dims.padTop - dims.padBottom;
+
+  const scaleX = (x: number) =>
+    xMax === xMin
+      ? dims.padLeft + plotW / 2
+      : dims.padLeft + ((x - xMin) / (xMax - xMin)) * plotW;
+  const scaleY = (v: number) =>
+    dims.padTop + plotH - ((v - yMin) / (yMax - yMin || 1)) * plotH;
+
+  const yTicks = niceYTicks(yMin, yMax);
+  const baseline = scaleY(0);
+
+  const areaPath =
+    `M ${scaleX(sorted[0].x)} ${baseline} ` +
+    sorted.map((p) => `L ${scaleX(p.x)} ${scaleY(p.value)}`).join(" ") +
+    ` L ${scaleX(sorted[sorted.length - 1].x)} ${baseline} Z`;
+
+  const linePath = sorted
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${scaleX(p.x)} ${scaleY(p.value)}`)
+    .join(" ");
+
+  const maxXLabels = Math.floor(plotW / 80);
+  const xStep = Math.max(1, Math.ceil(sorted.length / maxXLabels));
+  const xLabels = sorted.filter((_, i) => i % xStep === 0);
+
+  return (
+    <svg width={dims.width} height={dims.height} style={{ display: "block" }}>
+      {yTicks.map((v, i) => {
+        const y = scaleY(v);
+        return (
+          <g key={`y-${i}`}>
+            <line
+              x1={dims.padLeft}
+              y1={y}
+              x2={dims.width - dims.padRight}
+              y2={y}
+              stroke="#E0E5EE"
+              strokeDasharray="3,3"
+            />
+            <text
+              x={dims.padLeft - 6}
+              y={y + 4}
+              textAnchor="end"
+              fontSize={10}
+              fill="#69707D"
+            >
+              {(v * 100).toFixed(0)}%
+            </text>
+          </g>
+        );
+      })}
+
+      <text
+        x={14}
+        y={dims.padTop + plotH / 2}
+        textAnchor="middle"
+        fontSize={11}
+        fill="#E7664C"
+        fontWeight={600}
+        transform={`rotate(-90, 14, ${dims.padTop + plotH / 2})`}
+      >
+        {yLabel}
+      </text>
+
+      {xLabels.map((xl, i) => (
+        <text
+          key={`x-${i}`}
+          x={scaleX(xl.x)}
+          y={dims.height - 4}
+          textAnchor="middle"
+          fontSize={10}
+          fill="#69707D"
+        >
+          {formatDate(xl.date)}
+        </text>
+      ))}
+
+      <path d={areaPath} fill={fillColor} />
+      <path d={linePath} fill="none" stroke={lineColor} strokeWidth={2} />
+    </svg>
+  );
+};
+
+const Legend = ({ items }: { items: { label: string; color: string }[] }) => (
+  <div
+    style={{
+      display: "flex",
+      flexWrap: "wrap",
+      gap: 16,
+      justifyContent: "center",
+      marginTop: 8,
+    }}
+  >
+    {items.map((item, i) => (
+      <div key={i} style={{ display: "flex", alignItems: "center", gap: 4 }}>
+        <div
+          style={{
+            width: 12,
+            height: 12,
+            backgroundColor: item.color,
+            borderRadius: 2,
+          }}
+        />
+        <span style={{ fontSize: 12, color: "#343741" }}>{item.label}</span>
+      </div>
+    ))}
+  </div>
+);
+
+interface TimeSeriesAnalysisProps {
+  metrics: FeatureMetric[];
+  featureType: string;
+}
+
+const TimeSeriesAnalysis = ({ metrics, featureType }: TimeSeriesAnalysisProps) => {
+  const [range, setRange] = useState("all");
+
+  const filteredMetrics = useMemo(() => {
+    if (range === "all") return metrics;
+    const cutoff = Date.now() - rangeToMs[range];
+    return metrics.filter((m) => new Date(m.metric_date).getTime() >= cutoff);
+  }, [metrics, range]);
+
+  const sorted = useMemo(
+    () =>
+      [...filteredMetrics]
+        .filter((m) => m.row_count > 0)
+        .sort((a, b) => a.metric_date.localeCompare(b.metric_date)),
+    [filteredMetrics],
+  );
+
+  const toX = (m: FeatureMetric) => new Date(m.metric_date).getTime();
+  const isNumeric = featureType === "numeric";
+  const hasData = sorted.length >= 2;
+
+  return (
+    <EuiPanel hasBorder>
+      <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xs">
+            <h3>Time-Series Analysis</h3>
+          </EuiTitle>
+          <p style={{ color: "#69707D", fontSize: 12, marginTop: 2 }}>
+            Historical trends for central aggregates and quality signals.
+          </p>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false} style={{ minWidth: 160 }}>
+          <EuiSuperSelect
+            options={RANGE_OPTIONS}
+            valueOfSelected={range}
+            onChange={setRange}
+            compressed
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="m" />
+
+      {!hasData ? (
+        <p style={{ color: "#69707D", fontSize: 13, textAlign: "center", padding: 24 }}>
+          No data points available for the selected time range. Try a wider range.
+        </p>
+      ) : isNumeric ? (
+        <NumericTimeSeries metrics={sorted} toX={toX} />
+      ) : (
+        <CategoricalTimeSeries metrics={sorted} toX={toX} />
+      )}
+    </EuiPanel>
+  );
+};
+
+const NumericTimeSeries = ({
+  metrics,
+  toX,
+}: {
+  metrics: FeatureMetric[];
+  toX: (m: FeatureMetric) => number;
+}) => {
+  const driftSeries: LineSeriesData[] = useMemo(() => {
+    const build = (
+      label: string,
+      color: string,
+      accessor: (m: FeatureMetric) => number | null,
+    ): LineSeriesData => ({
+      label,
+      color,
+      points: metrics
+        .filter((m) => accessor(m) !== null)
+        .map((m) => ({
+          x: toX(m),
+          y: 0,
+          value: accessor(m)!,
+          date: m.metric_date,
+        })),
+    });
+    return [
+      build("Mean", COLORS[0], (m) => m.mean),
+      build("P50", COLORS[1], (m) => m.p50),
+      build("P95", COLORS[2], (m) => m.p95),
+    ];
+  }, [metrics, toX]);
+
+  const nullPoints = useMemo(
+    () =>
+      metrics.map((m) => ({
+        x: toX(m),
+        value: m.null_rate,
+        date: m.metric_date,
+      })),
+    [metrics, toX],
+  );
+
+  return (
+    <>
+      <h4 style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
+        Aggregate Metrics Drift (Mean/P50/P95)
+      </h4>
+      <div style={{ overflowX: "auto" }}>
+        {renderMultiLineChart(driftSeries, DIMS, "Metric Value")}
+      </div>
+      <Legend
+        items={[
+          { label: "Mean", color: COLORS[0] },
+          { label: "P50", color: COLORS[1] },
+          { label: "P95", color: COLORS[2] },
+        ]}
+      />
+
+      <EuiSpacer size="l" />
+
+      <h4 style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
+        Null Rate Evolution (%)
+      </h4>
+      <div style={{ overflowX: "auto" }}>
+        {renderAreaChart(
+          nullPoints,
+          { ...DIMS, height: 160 },
+          "Percentage (%)",
+          "#BD271E",
+          "rgba(189, 39, 30, 0.15)",
+        )}
+      </div>
+    </>
+  );
+};
+
+const CategoricalTimeSeries = ({
+  metrics,
+  toX,
+}: {
+  metrics: FeatureMetric[];
+  toX: (m: FeatureMetric) => number;
+}) => {
+  const { cardinalitySeries, shareSeries, topCategories } = useMemo(() => {
+    const catCounts = new Map<string, number>();
+    for (const m of metrics) {
+      const hist = m.histogram as CategoricalHistogram | null;
+      if (!hist) continue;
+      for (const v of hist.values) {
+        catCounts.set(v.value, (catCounts.get(v.value) || 0) + v.count);
+      }
+    }
+    const topCats = Array.from(catCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([v]) => v);
+
+    const cardSeries: LineSeriesData[] = [
+      {
+        label: "Cardinality",
+        color: COLORS[0],
+        points: metrics
+          .filter((m) => m.histogram)
+          .map((m) => ({
+            x: toX(m),
+            y: 0,
+            value: (m.histogram as CategoricalHistogram).unique_count || 0,
+            date: m.metric_date,
+          })),
+      },
+      ...topCats.map((cat, i) => ({
+        label: cat,
+        color: COLORS[(i + 1) % COLORS.length],
+        points: metrics
+          .filter((m) => m.histogram)
+          .map((m) => {
+            const hist = m.histogram as CategoricalHistogram;
+            const entry = hist.values.find((v) => v.value === cat);
+            return {
+              x: toX(m),
+              y: 0,
+              value: entry?.count || 0,
+              date: m.metric_date,
+            };
+          }),
+      })),
+    ];
+
+    const shrSeries: LineSeriesData[] = topCats.map((cat, i) => ({
+      label: cat,
+      color: COLORS[(i + 1) % COLORS.length],
+      points: metrics
+        .filter((m) => m.histogram && m.row_count > 0)
+        .map((m) => {
+          const hist = m.histogram as CategoricalHistogram;
+          const entry = hist.values.find((v) => v.value === cat);
+          return {
+            x: toX(m),
+            y: 0,
+            value: ((entry?.count || 0) / m.row_count) * 100,
+            date: m.metric_date,
+          };
+        }),
+    }));
+
+    return {
+      cardinalitySeries: cardSeries,
+      shareSeries: shrSeries,
+      topCategories: topCats,
+    };
+  }, [metrics, toX]);
+
+  const nullPoints = useMemo(
+    () =>
+      metrics.map((m) => ({
+        x: toX(m),
+        value: m.null_rate,
+        date: m.metric_date,
+      })),
+    [metrics, toX],
+  );
+
+  const shareYFormatter = (v: number) => `${v.toFixed(0)}%`;
+
+  return (
+    <>
+      <h4 style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
+        Cardinality over time
+      </h4>
+      <div style={{ overflowX: "auto" }}>
+        {renderMultiLineChart(cardinalitySeries, DIMS, "Count")}
+      </div>
+      <Legend
+        items={cardinalitySeries.map((s) => ({
+          label: s.label,
+          color: s.color,
+        }))}
+      />
+
+      <EuiSpacer size="l" />
+
+      <h4 style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
+        Top category share over time (%)
+      </h4>
+      <div style={{ overflowX: "auto" }}>
+        {renderMultiLineChart(shareSeries, DIMS, "Percentage (%)", shareYFormatter)}
+      </div>
+      <Legend
+        items={topCategories.map((cat, i) => ({
+          label: cat,
+          color: COLORS[(i + 1) % COLORS.length],
+        }))}
+      />
+
+      <EuiSpacer size="l" />
+
+      <h4 style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
+        Null Rate Evolution (%)
+      </h4>
+      <div style={{ overflowX: "auto" }}>
+        {renderAreaChart(
+          nullPoints,
+          { ...DIMS, height: 160 },
+          "Percentage (%)",
+          "#BD271E",
+          "rgba(189, 39, 30, 0.15)",
+        )}
+      </div>
+    </>
+  );
+};
+
+export default TimeSeriesAnalysis;

--- a/ui/src/queries/useMonitoringApi.ts
+++ b/ui/src/queries/useMonitoringApi.ts
@@ -1,0 +1,250 @@
+import { useContext } from "react";
+import { useQuery, useMutation, useQueryClient } from "react-query";
+import MonitoringContext from "../contexts/MonitoringContext";
+
+interface FeatureMetric {
+  project_id: string;
+  feature_view_name: string;
+  feature_name: string;
+  metric_date: string;
+  granularity: string;
+  data_source_type: string;
+  computed_at: string;
+  is_baseline: boolean;
+  feature_type: string;
+  row_count: number;
+  null_count: number;
+  null_rate: number;
+  mean: number | null;
+  stddev: number | null;
+  min_val: number | null;
+  max_val: number | null;
+  p50: number | null;
+  p75: number | null;
+  p90: number | null;
+  p95: number | null;
+  p99: number | null;
+  histogram: NumericHistogram | CategoricalHistogram | null;
+}
+
+interface NumericHistogram {
+  bins: number[];
+  counts: number[];
+  bin_width: number;
+}
+
+interface CategoricalHistogram {
+  values: { value: string; count: number }[];
+  other_count: number;
+  unique_count: number;
+}
+
+interface FeatureViewMetric {
+  project_id: string;
+  feature_view_name: string;
+  metric_date: string;
+  granularity: string;
+  data_source_type: string;
+  computed_at: string;
+  is_baseline: boolean;
+  total_row_count: number;
+  total_features: number;
+  features_with_nulls: number;
+  avg_null_rate: number;
+  max_null_rate: number;
+}
+
+interface FeatureServiceMetric {
+  project_id: string;
+  feature_service_name: string;
+  metric_date: string;
+  granularity: string;
+  data_source_type: string;
+  computed_at: string;
+  is_baseline: boolean;
+  total_feature_views: number;
+  total_features: number;
+  avg_null_rate: number;
+  max_null_rate: number;
+}
+
+interface MonitoringFilters {
+  project: string;
+  feature_view_name?: string;
+  feature_name?: string;
+  feature_service_name?: string;
+  granularity?: string;
+  data_source_type?: string;
+  start_date?: string;
+  end_date?: string;
+}
+
+const toQueryParams = (
+  filters: MonitoringFilters,
+): Record<string, string | undefined> => {
+  return {
+    project: filters.project,
+    feature_view_name: filters.feature_view_name,
+    feature_name: filters.feature_name,
+    feature_service_name: filters.feature_service_name,
+    granularity: filters.granularity,
+    data_source_type: filters.data_source_type,
+    start_date: filters.start_date,
+    end_date: filters.end_date,
+  };
+};
+
+const buildQueryString = (params: Record<string, string | undefined>) => {
+  const entries = Object.entries(params).filter(
+    ([, v]) => v !== undefined && v !== "",
+  );
+  if (entries.length === 0) return "";
+  return "?" + entries.map(([k, v]) => `${k}=${encodeURIComponent(v!)}`).join("&");
+};
+
+const fetchMonitoring = async <T>(
+  baseUrl: string,
+  path: string,
+  params: Record<string, string | undefined>,
+): Promise<T> => {
+  const qs = buildQueryString(params);
+  const res = await fetch(`${baseUrl}${path}${qs}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${path}: ${res.status} ${res.statusText}`);
+  }
+  const text = await res.text();
+  const sanitized = text.replace(/:\s*NaN/g, ": null").replace(/:\s*Infinity/g, ": null").replace(/:\s*-Infinity/g, ": null");
+  return JSON.parse(sanitized);
+};
+
+const STALE_TIME = 30_000;
+
+const useFeatureMetrics = (filters: MonitoringFilters) => {
+  const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  return useQuery<FeatureMetric[]>(
+    ["monitoring-features", filters],
+    () =>
+      fetchMonitoring<FeatureMetric[]>(
+        apiBaseUrl,
+        "/monitoring/metrics/features",
+        toQueryParams(filters),
+      ),
+    { staleTime: STALE_TIME, enabled, retry: 1 },
+  );
+};
+
+const useFeatureViewMetrics = (filters: MonitoringFilters) => {
+  const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  return useQuery<FeatureViewMetric[]>(
+    ["monitoring-feature-views", filters],
+    () =>
+      fetchMonitoring<FeatureViewMetric[]>(
+        apiBaseUrl,
+        "/monitoring/metrics/feature_views",
+        toQueryParams(filters),
+      ),
+    { staleTime: STALE_TIME, enabled, retry: 1 },
+  );
+};
+
+const useFeatureServiceMetrics = (filters: MonitoringFilters) => {
+  const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  return useQuery<FeatureServiceMetric[]>(
+    ["monitoring-feature-services", filters],
+    () =>
+      fetchMonitoring<FeatureServiceMetric[]>(
+        apiBaseUrl,
+        "/monitoring/metrics/feature_services",
+        toQueryParams(filters),
+      ),
+    { staleTime: STALE_TIME, enabled, retry: 1 },
+  );
+};
+
+const useBaselineMetrics = (
+  project: string,
+  featureViewName?: string,
+  featureName?: string,
+  dataSourceType?: string,
+) => {
+  const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  return useQuery<FeatureMetric[]>(
+    ["monitoring-baseline", project, featureViewName, featureName],
+    () =>
+      fetchMonitoring<FeatureMetric[]>(
+        apiBaseUrl,
+        "/monitoring/metrics/baseline",
+        {
+          project,
+          feature_view_name: featureViewName,
+          feature_name: featureName,
+          data_source_type: dataSourceType,
+        },
+      ),
+    { staleTime: STALE_TIME, enabled, retry: 1 },
+  );
+};
+
+const useTimeseriesMetrics = (filters: MonitoringFilters) => {
+  const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  return useQuery<FeatureMetric[]>(
+    ["monitoring-timeseries", filters],
+    () =>
+      fetchMonitoring<FeatureMetric[]>(
+        apiBaseUrl,
+        "/monitoring/metrics/timeseries",
+        toQueryParams(filters),
+      ),
+    { staleTime: STALE_TIME, enabled, retry: 1 },
+  );
+};
+
+const useComputeMetrics = () => {
+  const { apiBaseUrl } = useContext(MonitoringContext);
+  const queryClient = useQueryClient();
+  return useMutation(
+    async (body: {
+      project: string;
+      feature_view_name?: string;
+      feature_names?: string[];
+      start_date?: string;
+      end_date?: string;
+      granularity?: string;
+      set_baseline?: boolean;
+    }) => {
+      const res = await fetch(`${apiBaseUrl}/monitoring/compute`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to trigger compute: ${res.status}`);
+      }
+      return res.json();
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries("monitoring-features");
+        queryClient.invalidateQueries("monitoring-feature-views");
+        queryClient.invalidateQueries("monitoring-feature-services");
+      },
+    },
+  );
+};
+
+export {
+  useFeatureMetrics,
+  useFeatureViewMetrics,
+  useFeatureServiceMetrics,
+  useBaselineMetrics,
+  useTimeseriesMetrics,
+  useComputeMetrics,
+};
+export type {
+  FeatureMetric,
+  FeatureViewMetric,
+  FeatureServiceMetric,
+  NumericHistogram,
+  CategoricalHistogram,
+  MonitoringFilters,
+};

--- a/ui/src/queries/useMonitoringApi.ts
+++ b/ui/src/queries/useMonitoringApi.ts
@@ -1,6 +1,8 @@
 import { useContext } from "react";
 import { useQuery, useMutation, useQueryClient } from "react-query";
 import MonitoringContext from "../contexts/MonitoringContext";
+import { useDataMode } from "../contexts/DataModeContext";
+import type { FetchOptions } from "../contexts/DataModeContext";
 
 interface FeatureMetric {
   project_id: string;
@@ -101,21 +103,34 @@ const buildQueryString = (params: Record<string, string | undefined>) => {
     ([, v]) => v !== undefined && v !== "",
   );
   if (entries.length === 0) return "";
-  return "?" + entries.map(([k, v]) => `${k}=${encodeURIComponent(v!)}`).join("&");
+  return (
+    "?" + entries.map(([k, v]) => `${k}=${encodeURIComponent(v!)}`).join("&")
+  );
 };
 
 const fetchMonitoring = async <T>(
   baseUrl: string,
   path: string,
   params: Record<string, string | undefined>,
+  fetchOptions?: FetchOptions,
 ): Promise<T> => {
   const qs = buildQueryString(params);
-  const res = await fetch(`${baseUrl}${path}${qs}`);
+  const res = await fetch(`${baseUrl}${path}${qs}`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      ...fetchOptions?.headers,
+    },
+    credentials: fetchOptions?.credentials,
+  });
   if (!res.ok) {
     throw new Error(`Failed to fetch ${path}: ${res.status} ${res.statusText}`);
   }
   const text = await res.text();
-  const sanitized = text.replace(/:\s*NaN/g, ": null").replace(/:\s*Infinity/g, ": null").replace(/:\s*-Infinity/g, ": null");
+  const sanitized = text
+    .replace(/:\s*NaN/g, ": null")
+    .replace(/:\s*Infinity/g, ": null")
+    .replace(/:\s*-Infinity/g, ": null");
   return JSON.parse(sanitized);
 };
 
@@ -123,6 +138,7 @@ const STALE_TIME = 30_000;
 
 const useFeatureMetrics = (filters: MonitoringFilters) => {
   const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  const { fetchOptions } = useDataMode();
   const path = filters.is_baseline
     ? "/monitoring/metrics/baseline"
     : "/monitoring/metrics/features";
@@ -133,6 +149,7 @@ const useFeatureMetrics = (filters: MonitoringFilters) => {
         apiBaseUrl,
         path,
         toQueryParams(filters),
+        fetchOptions,
       ),
     { staleTime: STALE_TIME, enabled, retry: 1 },
   );
@@ -165,14 +182,14 @@ const aggregateToFeatureViewMetrics = (
         nullRates.length > 0
           ? nullRates.reduce((a, b) => a + b, 0) / nullRates.length
           : 0,
-      max_null_rate:
-        nullRates.length > 0 ? Math.max(...nullRates) : 0,
+      max_null_rate: nullRates.length > 0 ? Math.max(...nullRates) : 0,
     };
   });
 };
 
 const useFeatureViewMetrics = (filters: MonitoringFilters) => {
   const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  const { fetchOptions } = useDataMode();
   const isBaseline = !!filters.is_baseline;
   return useQuery<FeatureViewMetric[]>(
     ["monitoring-feature-views", filters],
@@ -182,6 +199,7 @@ const useFeatureViewMetrics = (filters: MonitoringFilters) => {
           apiBaseUrl,
           "/monitoring/metrics/baseline",
           toQueryParams(filters),
+          fetchOptions,
         );
         return aggregateToFeatureViewMetrics(features);
       }
@@ -189,6 +207,7 @@ const useFeatureViewMetrics = (filters: MonitoringFilters) => {
         apiBaseUrl,
         "/monitoring/metrics/feature_views",
         toQueryParams(filters),
+        fetchOptions,
       );
     },
     { staleTime: STALE_TIME, enabled, retry: 1 },
@@ -197,6 +216,7 @@ const useFeatureViewMetrics = (filters: MonitoringFilters) => {
 
 const useFeatureServiceMetrics = (filters: MonitoringFilters) => {
   const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  const { fetchOptions } = useDataMode();
   return useQuery<FeatureServiceMetric[]>(
     ["monitoring-feature-services", filters],
     () =>
@@ -204,6 +224,7 @@ const useFeatureServiceMetrics = (filters: MonitoringFilters) => {
         apiBaseUrl,
         "/monitoring/metrics/feature_services",
         toQueryParams(filters),
+        fetchOptions,
       ),
     { staleTime: STALE_TIME, enabled, retry: 1 },
   );
@@ -216,6 +237,7 @@ const useBaselineMetrics = (
   dataSourceType?: string,
 ) => {
   const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  const { fetchOptions } = useDataMode();
   return useQuery<FeatureMetric[]>(
     ["monitoring-baseline", project, featureViewName, featureName],
     () =>
@@ -228,20 +250,7 @@ const useBaselineMetrics = (
           feature_name: featureName,
           data_source_type: dataSourceType,
         },
-      ),
-    { staleTime: STALE_TIME, enabled, retry: 1 },
-  );
-};
-
-const useTimeseriesMetrics = (filters: MonitoringFilters) => {
-  const { apiBaseUrl, enabled } = useContext(MonitoringContext);
-  return useQuery<FeatureMetric[]>(
-    ["monitoring-timeseries", filters],
-    () =>
-      fetchMonitoring<FeatureMetric[]>(
-        apiBaseUrl,
-        "/monitoring/metrics/timeseries",
-        toQueryParams(filters),
+        fetchOptions,
       ),
     { staleTime: STALE_TIME, enabled, retry: 1 },
   );
@@ -249,15 +258,17 @@ const useTimeseriesMetrics = (filters: MonitoringFilters) => {
 
 const useComputeMetrics = () => {
   const { apiBaseUrl } = useContext(MonitoringContext);
+  const { fetchOptions } = useDataMode();
   const queryClient = useQueryClient();
   return useMutation(
-    async (body: {
-      project: string;
-      feature_view_name?: string;
-    }) => {
+    async (body: { project: string; feature_view_name?: string }) => {
       const res = await fetch(`${apiBaseUrl}/monitoring/auto_compute`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...fetchOptions?.headers,
+        },
+        credentials: fetchOptions?.credentials,
         body: JSON.stringify(body),
       });
       if (!res.ok) {
@@ -280,7 +291,6 @@ export {
   useFeatureViewMetrics,
   useFeatureServiceMetrics,
   useBaselineMetrics,
-  useTimeseriesMetrics,
   useComputeMetrics,
 };
 export type {

--- a/ui/src/queries/useMonitoringApi.ts
+++ b/ui/src/queries/useMonitoringApi.ts
@@ -137,7 +137,7 @@ const fetchMonitoring = async <T>(
 const STALE_TIME = 30_000;
 
 const useFeatureMetrics = (filters: MonitoringFilters) => {
-  const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  const { apiBaseUrl } = useContext(MonitoringContext);
   const { fetchOptions } = useDataMode();
   const path = filters.is_baseline
     ? "/monitoring/metrics/baseline"
@@ -151,7 +151,7 @@ const useFeatureMetrics = (filters: MonitoringFilters) => {
         toQueryParams(filters),
         fetchOptions,
       ),
-    { staleTime: STALE_TIME, enabled, retry: 1 },
+    { staleTime: STALE_TIME, retry: 1 },
   );
 };
 
@@ -188,7 +188,7 @@ const aggregateToFeatureViewMetrics = (
 };
 
 const useFeatureViewMetrics = (filters: MonitoringFilters) => {
-  const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  const { apiBaseUrl } = useContext(MonitoringContext);
   const { fetchOptions } = useDataMode();
   const isBaseline = !!filters.is_baseline;
   return useQuery<FeatureViewMetric[]>(
@@ -210,12 +210,12 @@ const useFeatureViewMetrics = (filters: MonitoringFilters) => {
         fetchOptions,
       );
     },
-    { staleTime: STALE_TIME, enabled, retry: 1 },
+    { staleTime: STALE_TIME, retry: 1 },
   );
 };
 
 const useFeatureServiceMetrics = (filters: MonitoringFilters) => {
-  const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  const { apiBaseUrl } = useContext(MonitoringContext);
   const { fetchOptions } = useDataMode();
   return useQuery<FeatureServiceMetric[]>(
     ["monitoring-feature-services", filters],
@@ -226,7 +226,7 @@ const useFeatureServiceMetrics = (filters: MonitoringFilters) => {
         toQueryParams(filters),
         fetchOptions,
       ),
-    { staleTime: STALE_TIME, enabled, retry: 1 },
+    { staleTime: STALE_TIME, retry: 1 },
   );
 };
 
@@ -236,7 +236,7 @@ const useBaselineMetrics = (
   featureName?: string,
   dataSourceType?: string,
 ) => {
-  const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  const { apiBaseUrl } = useContext(MonitoringContext);
   const { fetchOptions } = useDataMode();
   return useQuery<FeatureMetric[]>(
     ["monitoring-baseline", project, featureViewName, featureName],
@@ -252,7 +252,7 @@ const useBaselineMetrics = (
         },
         fetchOptions,
       ),
-    { staleTime: STALE_TIME, enabled, retry: 1 },
+    { staleTime: STALE_TIME, retry: 1 },
   );
 };
 

--- a/ui/src/queries/useMonitoringApi.ts
+++ b/ui/src/queries/useMonitoringApi.ts
@@ -77,6 +77,7 @@ interface MonitoringFilters {
   data_source_type?: string;
   start_date?: string;
   end_date?: string;
+  is_baseline?: boolean;
 }
 
 const toQueryParams = (
@@ -91,6 +92,7 @@ const toQueryParams = (
     data_source_type: filters.data_source_type,
     start_date: filters.start_date,
     end_date: filters.end_date,
+    is_baseline: filters.is_baseline ? "true" : undefined,
   };
 };
 
@@ -121,12 +123,15 @@ const STALE_TIME = 30_000;
 
 const useFeatureMetrics = (filters: MonitoringFilters) => {
   const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  const path = filters.is_baseline
+    ? "/monitoring/metrics/baseline"
+    : "/monitoring/metrics/features";
   return useQuery<FeatureMetric[]>(
     ["monitoring-features", filters],
     () =>
       fetchMonitoring<FeatureMetric[]>(
         apiBaseUrl,
-        "/monitoring/metrics/features",
+        path,
         toQueryParams(filters),
       ),
     { staleTime: STALE_TIME, enabled, retry: 1 },
@@ -135,12 +140,15 @@ const useFeatureMetrics = (filters: MonitoringFilters) => {
 
 const useFeatureViewMetrics = (filters: MonitoringFilters) => {
   const { apiBaseUrl, enabled } = useContext(MonitoringContext);
+  const path = filters.is_baseline
+    ? "/monitoring/metrics/baseline"
+    : "/monitoring/metrics/feature_views";
   return useQuery<FeatureViewMetric[]>(
     ["monitoring-feature-views", filters],
     () =>
       fetchMonitoring<FeatureViewMetric[]>(
         apiBaseUrl,
-        "/monitoring/metrics/feature_views",
+        path,
         toQueryParams(filters),
       ),
     { staleTime: STALE_TIME, enabled, retry: 1 },
@@ -206,13 +214,8 @@ const useComputeMetrics = () => {
     async (body: {
       project: string;
       feature_view_name?: string;
-      feature_names?: string[];
-      start_date?: string;
-      end_date?: string;
-      granularity?: string;
-      set_baseline?: boolean;
     }) => {
-      const res = await fetch(`${apiBaseUrl}/monitoring/compute`, {
+      const res = await fetch(`${apiBaseUrl}/monitoring/auto_compute`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),

--- a/ui/src/queries/useMonitoringApi.ts
+++ b/ui/src/queries/useMonitoringApi.ts
@@ -138,19 +138,59 @@ const useFeatureMetrics = (filters: MonitoringFilters) => {
   );
 };
 
+const aggregateToFeatureViewMetrics = (
+  features: FeatureMetric[],
+): FeatureViewMetric[] => {
+  const grouped = new Map<string, FeatureMetric[]>();
+  for (const f of features) {
+    const key = f.feature_view_name;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key)!.push(f);
+  }
+  return Array.from(grouped.entries()).map(([fvName, feats]) => {
+    const nullRates = feats.map((f) => f.null_rate ?? 0);
+    const maxRowCount = Math.max(...feats.map((f) => f.row_count ?? 0));
+    return {
+      project_id: feats[0].project_id,
+      feature_view_name: fvName,
+      metric_date: feats[0].metric_date,
+      granularity: feats[0].granularity,
+      data_source_type: feats[0].data_source_type,
+      computed_at: feats[0].computed_at,
+      is_baseline: feats[0].is_baseline,
+      total_row_count: maxRowCount,
+      total_features: feats.length,
+      features_with_nulls: feats.filter((f) => (f.null_count ?? 0) > 0).length,
+      avg_null_rate:
+        nullRates.length > 0
+          ? nullRates.reduce((a, b) => a + b, 0) / nullRates.length
+          : 0,
+      max_null_rate:
+        nullRates.length > 0 ? Math.max(...nullRates) : 0,
+    };
+  });
+};
+
 const useFeatureViewMetrics = (filters: MonitoringFilters) => {
   const { apiBaseUrl, enabled } = useContext(MonitoringContext);
-  const path = filters.is_baseline
-    ? "/monitoring/metrics/baseline"
-    : "/monitoring/metrics/feature_views";
+  const isBaseline = !!filters.is_baseline;
   return useQuery<FeatureViewMetric[]>(
     ["monitoring-feature-views", filters],
-    () =>
-      fetchMonitoring<FeatureViewMetric[]>(
+    async () => {
+      if (isBaseline) {
+        const features = await fetchMonitoring<FeatureMetric[]>(
+          apiBaseUrl,
+          "/monitoring/metrics/baseline",
+          toQueryParams(filters),
+        );
+        return aggregateToFeatureViewMetrics(features);
+      }
+      return fetchMonitoring<FeatureViewMetric[]>(
         apiBaseUrl,
-        path,
+        "/monitoring/metrics/feature_views",
         toQueryParams(filters),
-      ),
+      );
+    },
     { staleTime: STALE_TIME, enabled, retry: 1 },
   );
 };


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a Data Quality Monitoring UI to the Feast web interface. Users can view feature-level metrics (distributions, null rates, statistics), feature view aggregates, and feature service health — all from a new **Monitoring** sidebar section.

Key additions:
- Monitoring dashboard with paginated feature metrics table, inline mini-histograms, and health indicators
- Feature detail view with full numeric/categorical distribution charts, stats panel, and null rate timeline
- Monitoring tab on individual feature pages for contextual access
- Feature View and Feature Service aggregate metrics panels
- Filters for feature view, granularity, data source, and date range
- API hooks (`react-query`) for all monitoring REST endpoints

## Which issue(s) this PR fixes:

Part of the Feast monitoring initiative — provides the UI counterpart for the monitoring backend APIs.

## Other PR that needs to be merged first

https://github.com/feast-dev/feast/pull/6202

## Screenshots

1. All Features:

<img width="1612" height="943" alt="Screenshot 2026-06-12 at 7 06 42 PM" src="https://github.com/user-attachments/assets/7df8e28b-52e2-41e6-b993-8baf86e44c06" />

2. Numerical Feature

<img width="1612" height="943" alt="Screenshot 2026-06-12 at 7 06 52 PM" src="https://github.com/user-attachments/assets/5c0dfe61-f9e1-48f9-b4fd-0d646223344f" />


3. Categorical Feature

<img width="1612" height="943" alt="Screenshot 2026-06-12 at 7 07 09 PM" src="https://github.com/user-attachments/assets/7d8ca428-479f-4ddb-bd03-ab71ac55baed" />


## Checks

- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows conventional commits format

## Testing Strategy

- [x] Manual tests
