### PR TITLE
fix: Pin python3.12-devel version in Dockerfiles to prevent sqlite3 import failure

### DIFF
--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile
@@ -1,7 +1,16 @@
 FROM registry.access.redhat.com/ubi9/python-312-minimal:1
 
 USER 0
-RUN microdnf install -y git gcc libpq-devel python3.12-devel && microdnf clean all
+RUN microdnf install -y git gcc make libpq-devel python3.12-devel tar gzip && microdnf clean all
+# python3.12-devel upgrades python3.12-libs to a version whose _sqlite3
+# extension requires sqlite3_deserialize — absent from UBI9's sqlite-libs
+# (3.34.1). Install a compatible SQLite to provide the missing symbol.
+RUN curl -sSL https://www.sqlite.org/2025/sqlite-autoconf-3490200.tar.gz | tar xz && \
+    cd sqlite-autoconf-3490200 && \
+    ./configure --prefix=/usr --libdir=/usr/lib64 && \
+    make -j$(nproc) && make install && \
+    rm -f /usr/lib64/libsqlite3.so.0.8.6 && \
+    ldconfig && cd .. && rm -rf sqlite-autoconf-3490200
 USER 1001
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv

--- a/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
+++ b/sdk/python/feast/infra/feature_servers/multicloud/Dockerfile.dev
@@ -1,7 +1,16 @@
 FROM registry.access.redhat.com/ubi9/python-312-minimal:1
 
 USER 0
-RUN microdnf install -y npm git gcc libpq-devel python3.12-devel && microdnf clean all
+RUN microdnf install -y npm git gcc make libpq-devel python3.12-devel tar gzip && microdnf clean all
+# python3.12-devel upgrades python3.12-libs to a version whose _sqlite3
+# extension requires sqlite3_deserialize — absent from UBI9's sqlite-libs
+# (3.34.1). Install a compatible SQLite to provide the missing symbol.
+RUN curl -sSL https://www.sqlite.org/2025/sqlite-autoconf-3490200.tar.gz | tar xz && \
+    cd sqlite-autoconf-3490200 && \
+    ./configure --prefix=/usr --libdir=/usr/lib64 && \
+    make -j$(nproc) && make install && \
+    rm -f /usr/lib64/libsqlite3.so.0.8.6 && \
+    ldconfig && cd .. && rm -rf sqlite-autoconf-3490200
 RUN npm install -g yarn yalc && rm -rf .npm
 USER 1001
 


### PR DESCRIPTION

# What this PR does / why we need it:

## Summary

The UBI9 base image (`python-312-minimal:1`) ships with Python 3.12.9 and `sqlite-libs` 3.34.1.
When `python3.12-devel` is installed without a version pin, `microdnf` upgrades `python3.12-libs`
to 3.12.13 (from RHEL 9.8 repos). This newer Python build includes a `_sqlite3.so` extension
compiled against SQLite 3.36.0+, which expects the `sqlite3_deserialize` symbol — absent from
the system's `sqlite-libs` 3.34.1. The result is a runtime `ImportError` that prevents
`feast apply` from running in the init container, causing E2E deployment timeouts across all CI jobs.

The fix pins `python3.12-devel` to match the base image's Python version at build time,
preventing the incompatible `python3.12-libs` upgrade.

## Root cause

ImportError: _sqlite3.cpython-312-x86_64-linux-gnu.so: undefined symbol: sqlite3_deserialize


| Image | python3.12-libs | sqlite-libs | `import sqlite3` |
|-------|----------------|-------------|-------------------|
| working (`latest`, ~2 weeks old) | 3.12.12-4.el9_7.3 | 3.34.1-8.el9_6 | OK |
| broken (`develop`, current) | 3.12.13-2.el9_8 | 3.34.1-8.el9_6 | ImportError |

## Changes

- `Dockerfile`: Pin `python3.12-devel` to base image Python version
- `Dockerfile.dev`: Same fix