### PR TITLE
fix: Fix ValueError in signal handling for Trino worker threads

### DIFF
--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/test_trino_queries.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/test_trino_queries.py
@@ -1,0 +1,37 @@
+import threading
+from unittest.mock import MagicMock
+
+from feast.infra.offline_stores.contrib.trino_offline_store.trino_queries import (
+    Query,
+)
+
+
+def test_query_init_in_main_thread_registers_signals():
+    """signal.signal() should work fine in main thread."""
+    cursor = MagicMock()
+    # Should not raise any exception in main thread
+    query = Query(query_text="SELECT 1", cursor=cursor)
+    assert query.query_text == "SELECT 1"
+
+
+def test_query_init_in_worker_thread_does_not_raise():
+    """Regression test: signal.signal() fails in non-main threads."""
+    # signal.signal() raises ValueError when called outside the main thread.
+    # This test verifies the fix guards against that by running Query.__init__
+    # in a worker thread and ensuring no exception is raised.
+
+    errors = []
+    cursor = MagicMock()
+
+    def create_query():
+        try:
+            query = Query(query_text="SELECT 1", cursor=cursor)
+            assert query.query_text == "SELECT 1"
+        except ValueError as e:
+            errors.append(e)
+
+    thread = threading.Thread(target=create_query)
+    thread.start()
+    thread.join()
+
+    assert not errors, f"Unexpected ValueError in worker thread: {errors[0]}"

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/test_trino_queries.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/test_trino_queries.py
@@ -1,3 +1,4 @@
+import signal
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -11,11 +12,16 @@ def test_query_init_in_main_thread_registers_signals():
 
     # Should not raise any exception in main thread
     cursor = MagicMock()
+
     with patch("signal.signal") as mock_signal:
+        query = Query(query_text="SELECT 1", cursor=cursor)
+        assert query.query_text == "SELECT 1"
+
         # Verify signal handlers are registered correctly
-        assert mock_signal.call_count == 2
         mock_signal.assert_any_call(signal.SIGINT, query.cancel)
         mock_signal.assert_any_call(signal.SIGTERM, query.cancel)
+
+        # Expected signal.signal to be called twice for SIGINT and SIGTERM
         assert mock_signal.call_count == 2
 
 
@@ -39,4 +45,4 @@ def test_query_init_in_worker_thread_does_not_raise():
     thread.start()
     thread.join()
 
-    assert not errors, f"Unexpected ValueError in worker thread: {errors[0]}"
+    assert not errors, f"Unexpected ValueError in worker thread: {errors}"

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/test_trino_queries.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/test_trino_queries.py
@@ -1,5 +1,5 @@
 import threading
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from feast.infra.offline_stores.contrib.trino_offline_store.trino_queries import (
     Query,
@@ -8,10 +8,14 @@ from feast.infra.offline_stores.contrib.trino_offline_store.trino_queries import
 
 def test_query_init_in_main_thread_registers_signals():
     """signal.signal() should work fine in main thread."""
-    cursor = MagicMock()
+
     # Should not raise any exception in main thread
-    query = Query(query_text="SELECT 1", cursor=cursor)
-    assert query.query_text == "SELECT 1"
+    cursor = MagicMock()
+    with patch("signal.signal") as mock_signal:
+        query = Query(query_text="SELECT 1", cursor=cursor)
+        assert query.query_text == "SELECT 1"
+        # Expected signal.signal to be called twice for SIGINT and SIGTERM
+        assert mock_signal.call_count == 2
 
 
 def test_query_init_in_worker_thread_does_not_raise():

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/test_trino_queries.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/tests/test_trino_queries.py
@@ -12,9 +12,10 @@ def test_query_init_in_main_thread_registers_signals():
     # Should not raise any exception in main thread
     cursor = MagicMock()
     with patch("signal.signal") as mock_signal:
-        query = Query(query_text="SELECT 1", cursor=cursor)
-        assert query.query_text == "SELECT 1"
-        # Expected signal.signal to be called twice for SIGINT and SIGTERM
+        # Verify signal handlers are registered correctly
+        assert mock_signal.call_count == 2
+        mock_signal.assert_any_call(signal.SIGINT, query.cancel)
+        mock_signal.assert_any_call(signal.SIGTERM, query.cancel)
         assert mock_signal.call_count == 2
 
 

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_queries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import signal
+import threading
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -92,8 +93,9 @@ class Query(object):
         self.status = QueryStatus.PENDING
         self._cursor = cursor
 
-        signal.signal(signal.SIGINT, self.cancel)
-        signal.signal(signal.SIGTERM, self.cancel)
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGINT, self.cancel)
+            signal.signal(signal.SIGTERM, self.cancel)
 
     def execute(self) -> Results:
         try:


### PR DESCRIPTION
# What this PR does / why we need it:
Guards `signal.signal()` calls in `Query.__init__()` with a `threading.current_thread() is threading.main_thread()` check.

When the Trino offline store is served via Arrow Flight, `Query.__init__()` runs in a worker thread. Python restricts `signal.signal()` to the main thread only, causing:
`ValueError: signal only works in main thread of the main interpreter`

# Which issue(s) this PR fixes:
Fixes #6424

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows conventional commits format

## Testing Strategy
- [x] Unit tests

# Misc
Added regression tests covering both main thread and worker thread scenarios.
Signal handling is preserved for CLI/interactive usage. Worker thread usage silently skips signal registration, which is the correct behavior when running under Arrow Flight.