### PR TITLE
feat: Extend enable/disable/set-state to all feature view types and REST APIs

### DIFF
--- a/sdk/python/feast/api/registry/rest/feature_views.py
+++ b/sdk/python/feast/api/registry/rest/feature_views.py
@@ -349,6 +349,160 @@ def get_feature_view_router(grpc_handler) -> APIRouter:
             },
         )
 
+    @router.put("/feature_views/{name}/enable")
+    def enable_feature_view(
+        name: str,
+        project: str = Query(...),
+    ):
+        from feast.feature_view import FeatureView
+        from feast.on_demand_feature_view import OnDemandFeatureView
+        from feast.stream_feature_view import StreamFeatureView
+
+        req = RegistryServer_pb2.GetAnyFeatureViewRequest(
+            name=name,
+            project=project,
+        )
+        resp = grpc_call(grpc_handler.GetAnyFeatureView, req)
+        any_fv = resp.any_feature_view
+
+        if any_fv.HasField("feature_view"):
+            fv = FeatureView.from_proto(any_fv.feature_view)
+        elif any_fv.HasField("on_demand_feature_view"):
+            fv = OnDemandFeatureView.from_proto(any_fv.on_demand_feature_view)
+        elif any_fv.HasField("stream_feature_view"):
+            fv = StreamFeatureView.from_proto(any_fv.stream_feature_view)
+        else:
+            return JSONResponse(
+                status_code=404,
+                content={"error": f"Feature view '{name}' not found."},
+            )
+
+        fv.enabled = True
+        apply_req = RegistryServer_pb2.ApplyFeatureViewRequest(
+            project=project, commit=True
+        )
+        if isinstance(fv, StreamFeatureView):
+            apply_req.stream_feature_view.CopyFrom(fv.to_proto())
+        elif isinstance(fv, OnDemandFeatureView):
+            apply_req.on_demand_feature_view.CopyFrom(fv.to_proto())
+        else:
+            apply_req.feature_view.CopyFrom(fv.to_proto())
+        grpc_call(grpc_handler.ApplyFeatureView, apply_req)
+
+        return {"name": name, "project": project, "enabled": True}
+
+    @router.put("/feature_views/{name}/disable")
+    def disable_feature_view(
+        name: str,
+        project: str = Query(...),
+    ):
+        from feast.feature_view import FeatureView
+        from feast.on_demand_feature_view import OnDemandFeatureView
+        from feast.stream_feature_view import StreamFeatureView
+
+        req = RegistryServer_pb2.GetAnyFeatureViewRequest(
+            name=name,
+            project=project,
+        )
+        resp = grpc_call(grpc_handler.GetAnyFeatureView, req)
+        any_fv = resp.any_feature_view
+
+        if any_fv.HasField("feature_view"):
+            fv = FeatureView.from_proto(any_fv.feature_view)
+        elif any_fv.HasField("on_demand_feature_view"):
+            fv = OnDemandFeatureView.from_proto(any_fv.on_demand_feature_view)
+        elif any_fv.HasField("stream_feature_view"):
+            fv = StreamFeatureView.from_proto(any_fv.stream_feature_view)
+        else:
+            return JSONResponse(
+                status_code=404,
+                content={"error": f"Feature view '{name}' not found."},
+            )
+
+        fv.enabled = False
+        apply_req = RegistryServer_pb2.ApplyFeatureViewRequest(
+            project=project, commit=True
+        )
+        if isinstance(fv, StreamFeatureView):
+            apply_req.stream_feature_view.CopyFrom(fv.to_proto())
+        elif isinstance(fv, OnDemandFeatureView):
+            apply_req.on_demand_feature_view.CopyFrom(fv.to_proto())
+        else:
+            apply_req.feature_view.CopyFrom(fv.to_proto())
+        grpc_call(grpc_handler.ApplyFeatureView, apply_req)
+
+        return {"name": name, "project": project, "enabled": False}
+
+    @router.put("/feature_views/{name}/set-state")
+    def set_feature_view_state(
+        name: str,
+        state: str = Query(...),
+        project: str = Query(...),
+    ):
+        from feast.feature_view import (
+            _VALID_STATE_TRANSITIONS,
+            FeatureView,
+            FeatureViewState,
+        )
+        from feast.on_demand_feature_view import OnDemandFeatureView
+        from feast.stream_feature_view import StreamFeatureView
+
+        try:
+            new_state = FeatureViewState[state.upper()]
+        except KeyError:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": f"Invalid state '{state}'. "
+                    f"Valid states: CREATED, GENERATED, MATERIALIZING, AVAILABLE_ONLINE."
+                },
+            )
+
+        req = RegistryServer_pb2.GetAnyFeatureViewRequest(
+            name=name,
+            project=project,
+        )
+        resp = grpc_call(grpc_handler.GetAnyFeatureView, req)
+        any_fv = resp.any_feature_view
+
+        if any_fv.HasField("feature_view"):
+            fv = FeatureView.from_proto(any_fv.feature_view)
+        elif any_fv.HasField("on_demand_feature_view"):
+            fv = OnDemandFeatureView.from_proto(any_fv.on_demand_feature_view)
+        elif any_fv.HasField("stream_feature_view"):
+            fv = StreamFeatureView.from_proto(any_fv.stream_feature_view)
+        else:
+            return JSONResponse(
+                status_code=404,
+                content={"error": f"Feature view '{name}' not found."},
+            )
+
+        if not fv.state.can_transition_to(new_state):
+            current = fv.state.name
+            allowed = _VALID_STATE_TRANSITIONS.get(fv.state, set())
+            allowed_names = ", ".join(sorted(s.name for s in allowed)) or "none"
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": f"Invalid state transition: {current} -> {new_state.name}. "
+                    f"Allowed transitions from {current}: {allowed_names}."
+                },
+            )
+
+        fv.state = new_state
+        apply_req = RegistryServer_pb2.ApplyFeatureViewRequest(
+            project=project, commit=True
+        )
+        if isinstance(fv, StreamFeatureView):
+            apply_req.stream_feature_view.CopyFrom(fv.to_proto())
+        elif isinstance(fv, OnDemandFeatureView):
+            apply_req.on_demand_feature_view.CopyFrom(fv.to_proto())
+        else:
+            apply_req.feature_view.CopyFrom(fv.to_proto())
+        grpc_call(grpc_handler.ApplyFeatureView, apply_req)
+
+        return {"name": name, "project": project, "state": new_state.name}
+
     @router.delete("/feature_views/{name}")
     def delete_feature_view(
         name: str,

--- a/sdk/python/feast/api/registry/rest/feature_views.py
+++ b/sdk/python/feast/api/registry/rest/feature_views.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
@@ -363,14 +363,32 @@ def get_feature_view_router(grpc_handler) -> APIRouter:
             project=project,
         )
         resp = grpc_call(grpc_handler.GetAnyFeatureView, req)
-        any_fv = resp.any_feature_view
+        any_fv = resp.get("anyFeatureView", {})
 
-        if any_fv.HasField("feature_view"):
-            fv = FeatureView.from_proto(any_fv.feature_view)
-        elif any_fv.HasField("on_demand_feature_view"):
-            fv = OnDemandFeatureView.from_proto(any_fv.on_demand_feature_view)
-        elif any_fv.HasField("stream_feature_view"):
-            fv = StreamFeatureView.from_proto(any_fv.stream_feature_view)
+        from google.protobuf.json_format import ParseDict
+
+        fv: Any = None
+        proto: Any = None
+        if "featureView" in any_fv and any_fv["featureView"]:
+            proto = FeatureViewProto()
+            ParseDict(any_fv["featureView"], proto)
+            fv = FeatureView.from_proto(proto)
+        elif "onDemandFeatureView" in any_fv and any_fv["onDemandFeatureView"]:
+            from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
+                OnDemandFeatureView as OnDemandFeatureViewProto,
+            )
+
+            proto = OnDemandFeatureViewProto()
+            ParseDict(any_fv["onDemandFeatureView"], proto)
+            fv = OnDemandFeatureView.from_proto(proto)
+        elif "streamFeatureView" in any_fv and any_fv["streamFeatureView"]:
+            from feast.protos.feast.core.StreamFeatureView_pb2 import (
+                StreamFeatureView as StreamFeatureViewProto,
+            )
+
+            proto = StreamFeatureViewProto()
+            ParseDict(any_fv["streamFeatureView"], proto)
+            fv = StreamFeatureView.from_proto(proto)
         else:
             return JSONResponse(
                 status_code=404,
@@ -405,14 +423,32 @@ def get_feature_view_router(grpc_handler) -> APIRouter:
             project=project,
         )
         resp = grpc_call(grpc_handler.GetAnyFeatureView, req)
-        any_fv = resp.any_feature_view
+        any_fv = resp.get("anyFeatureView", {})
 
-        if any_fv.HasField("feature_view"):
-            fv = FeatureView.from_proto(any_fv.feature_view)
-        elif any_fv.HasField("on_demand_feature_view"):
-            fv = OnDemandFeatureView.from_proto(any_fv.on_demand_feature_view)
-        elif any_fv.HasField("stream_feature_view"):
-            fv = StreamFeatureView.from_proto(any_fv.stream_feature_view)
+        from google.protobuf.json_format import ParseDict
+
+        fv: Any = None
+        proto: Any = None
+        if "featureView" in any_fv and any_fv["featureView"]:
+            proto = FeatureViewProto()
+            ParseDict(any_fv["featureView"], proto)
+            fv = FeatureView.from_proto(proto)
+        elif "onDemandFeatureView" in any_fv and any_fv["onDemandFeatureView"]:
+            from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
+                OnDemandFeatureView as OnDemandFeatureViewProto,
+            )
+
+            proto = OnDemandFeatureViewProto()
+            ParseDict(any_fv["onDemandFeatureView"], proto)
+            fv = OnDemandFeatureView.from_proto(proto)
+        elif "streamFeatureView" in any_fv and any_fv["streamFeatureView"]:
+            from feast.protos.feast.core.StreamFeatureView_pb2 import (
+                StreamFeatureView as StreamFeatureViewProto,
+            )
+
+            proto = StreamFeatureViewProto()
+            ParseDict(any_fv["streamFeatureView"], proto)
+            fv = StreamFeatureView.from_proto(proto)
         else:
             return JSONResponse(
                 status_code=404,
@@ -463,14 +499,32 @@ def get_feature_view_router(grpc_handler) -> APIRouter:
             project=project,
         )
         resp = grpc_call(grpc_handler.GetAnyFeatureView, req)
-        any_fv = resp.any_feature_view
+        any_fv = resp.get("anyFeatureView", {})
 
-        if any_fv.HasField("feature_view"):
-            fv = FeatureView.from_proto(any_fv.feature_view)
-        elif any_fv.HasField("on_demand_feature_view"):
-            fv = OnDemandFeatureView.from_proto(any_fv.on_demand_feature_view)
-        elif any_fv.HasField("stream_feature_view"):
-            fv = StreamFeatureView.from_proto(any_fv.stream_feature_view)
+        from google.protobuf.json_format import ParseDict
+
+        fv: Any = None
+        proto: Any = None
+        if "featureView" in any_fv and any_fv["featureView"]:
+            proto = FeatureViewProto()
+            ParseDict(any_fv["featureView"], proto)
+            fv = FeatureView.from_proto(proto)
+        elif "onDemandFeatureView" in any_fv and any_fv["onDemandFeatureView"]:
+            from feast.protos.feast.core.OnDemandFeatureView_pb2 import (
+                OnDemandFeatureView as OnDemandFeatureViewProto,
+            )
+
+            proto = OnDemandFeatureViewProto()
+            ParseDict(any_fv["onDemandFeatureView"], proto)
+            fv = OnDemandFeatureView.from_proto(proto)
+        elif "streamFeatureView" in any_fv and any_fv["streamFeatureView"]:
+            from feast.protos.feast.core.StreamFeatureView_pb2 import (
+                StreamFeatureView as StreamFeatureViewProto,
+            )
+
+            proto = StreamFeatureViewProto()
+            ParseDict(any_fv["streamFeatureView"], proto)
+            fv = StreamFeatureView.from_proto(proto)
         else:
             return JSONResponse(
                 status_code=404,

--- a/sdk/python/feast/cli/on_demand_feature_views.py
+++ b/sdk/python/feast/cli/on_demand_feature_views.py
@@ -1,9 +1,12 @@
+import sys
+
 import click
 import yaml
 
 from feast import utils
 from feast.cli.cli_options import tagsOption
 from feast.errors import FeastObjectNotFoundException
+from feast.feature_view import _VALID_STATE_TRANSITIONS, FeatureViewState
 from feast.repo_operations import create_feature_store
 
 
@@ -30,13 +33,12 @@ def on_demand_feature_view_describe(ctx: click.Context, name: str):
         print(e)
         exit(1)
 
-    print(
-        yaml.dump(
-            yaml.safe_load(str(on_demand_feature_view)),
-            default_flow_style=False,
-            sort_keys=False,
-        )
-    )
+    data = yaml.safe_load(str(on_demand_feature_view))
+    if hasattr(on_demand_feature_view, "enabled"):
+        data["enabled"] = on_demand_feature_view.enabled
+    if hasattr(on_demand_feature_view, "state"):
+        data["state"] = on_demand_feature_view.state.name
+    print(yaml.dump(data, default_flow_style=False, sort_keys=False))
 
 
 @on_demand_feature_views_cmd.command(name="list")
@@ -55,3 +57,90 @@ def on_demand_feature_view_list(ctx: click.Context, tags: list[str]):
     from tabulate import tabulate
 
     print(tabulate(table, headers=["NAME"], tablefmt="plain"))
+
+
+@on_demand_feature_views_cmd.command("enable")
+@click.argument("name", type=click.STRING)
+@click.pass_context
+def on_demand_feature_view_enable(ctx: click.Context, name: str):
+    """
+    Enable an on demand feature view.
+    """
+    store = create_feature_store(ctx)
+    try:
+        fv = store.get_on_demand_feature_view(name)
+    except FeastObjectNotFoundException as e:
+        print(e)
+        sys.exit(1)
+
+    if fv.enabled:
+        print(f"On demand feature view '{name}' is already enabled.")
+        return
+
+    fv.enabled = True
+    store.registry.apply_feature_view(fv, store.project)
+    print(f"On demand feature view '{name}' has been enabled.")
+
+
+@on_demand_feature_views_cmd.command("disable")
+@click.argument("name", type=click.STRING)
+@click.pass_context
+def on_demand_feature_view_disable(ctx: click.Context, name: str):
+    """
+    Disable an on demand feature view.
+    """
+    store = create_feature_store(ctx)
+    try:
+        fv = store.get_on_demand_feature_view(name)
+    except FeastObjectNotFoundException as e:
+        print(e)
+        sys.exit(1)
+
+    if not fv.enabled:
+        print(f"On demand feature view '{name}' is already disabled.")
+        return
+
+    fv.enabled = False
+    store.registry.apply_feature_view(fv, store.project)
+    print(f"On demand feature view '{name}' has been disabled.")
+
+
+@on_demand_feature_views_cmd.command("set-state")
+@click.argument("name", type=click.STRING)
+@click.argument(
+    "state",
+    type=click.Choice(
+        ["CREATED", "GENERATED", "MATERIALIZING", "AVAILABLE_ONLINE"],
+        case_sensitive=False,
+    ),
+)
+@click.pass_context
+def on_demand_feature_view_set_state(ctx: click.Context, name: str, state: str):
+    """
+    Set the lifecycle state of an on demand feature view.
+    """
+    store = create_feature_store(ctx)
+    try:
+        fv = store.get_on_demand_feature_view(name)
+    except FeastObjectNotFoundException as e:
+        print(e)
+        sys.exit(1)
+
+    new_state = FeatureViewState[state.upper()]
+    if fv.state == new_state:
+        print(f"On demand feature view '{name}' is already in state {new_state.name}.")
+        return
+
+    if not fv.state.can_transition_to(new_state):
+        current = fv.state.name
+        allowed = _VALID_STATE_TRANSITIONS.get(fv.state, set())
+        allowed_names = ", ".join(sorted(s.name for s in allowed)) or "none"
+        print(
+            f"Invalid state transition: {current} -> {new_state.name}. "
+            f"Allowed transitions from {current}: {allowed_names}."
+        )
+        return
+
+    fv.state = new_state
+    store.registry.apply_feature_view(fv, store.project)
+    print(f"On demand feature view '{name}' state set to {new_state.name}.")

--- a/sdk/python/feast/cli/stream_feature_views.py
+++ b/sdk/python/feast/cli/stream_feature_views.py
@@ -1,9 +1,12 @@
+import sys
+
 import click
 import yaml
 
 from feast import utils
 from feast.cli.cli_options import tagsOption
 from feast.errors import FeastObjectNotFoundException
+from feast.feature_view import _VALID_STATE_TRANSITIONS, FeatureViewState
 from feast.repo_operations import create_feature_store
 
 
@@ -30,13 +33,12 @@ def stream_feature_views_describe(ctx: click.Context, name: str):
         print(e)
         exit(1)
 
-    print(
-        yaml.dump(
-            yaml.safe_load(str(stream_feature_view)),
-            default_flow_style=False,
-            sort_keys=False,
-        )
-    )
+    data = yaml.safe_load(str(stream_feature_view))
+    if hasattr(stream_feature_view, "enabled"):
+        data["enabled"] = stream_feature_view.enabled
+    if hasattr(stream_feature_view, "state"):
+        data["state"] = stream_feature_view.state.name
+    print(yaml.dump(data, default_flow_style=False, sort_keys=False))
 
 
 @stream_feature_views_cmd.command(name="list")
@@ -55,3 +57,90 @@ def stream_feature_views_list(ctx: click.Context, tags: list[str]):
     from tabulate import tabulate
 
     print(tabulate(table, headers=["NAME"], tablefmt="plain"))
+
+
+@stream_feature_views_cmd.command("enable")
+@click.argument("name", type=click.STRING)
+@click.pass_context
+def stream_feature_view_enable(ctx: click.Context, name: str):
+    """
+    Enable a stream feature view.
+    """
+    store = create_feature_store(ctx)
+    try:
+        fv = store.get_stream_feature_view(name)
+    except FeastObjectNotFoundException as e:
+        print(e)
+        sys.exit(1)
+
+    if fv.enabled:
+        print(f"Stream feature view '{name}' is already enabled.")
+        return
+
+    fv.enabled = True
+    store.registry.apply_feature_view(fv, store.project)
+    print(f"Stream feature view '{name}' has been enabled.")
+
+
+@stream_feature_views_cmd.command("disable")
+@click.argument("name", type=click.STRING)
+@click.pass_context
+def stream_feature_view_disable(ctx: click.Context, name: str):
+    """
+    Disable a stream feature view.
+    """
+    store = create_feature_store(ctx)
+    try:
+        fv = store.get_stream_feature_view(name)
+    except FeastObjectNotFoundException as e:
+        print(e)
+        sys.exit(1)
+
+    if not fv.enabled:
+        print(f"Stream feature view '{name}' is already disabled.")
+        return
+
+    fv.enabled = False
+    store.registry.apply_feature_view(fv, store.project)
+    print(f"Stream feature view '{name}' has been disabled.")
+
+
+@stream_feature_views_cmd.command("set-state")
+@click.argument("name", type=click.STRING)
+@click.argument(
+    "state",
+    type=click.Choice(
+        ["CREATED", "GENERATED", "MATERIALIZING", "AVAILABLE_ONLINE"],
+        case_sensitive=False,
+    ),
+)
+@click.pass_context
+def stream_feature_view_set_state(ctx: click.Context, name: str, state: str):
+    """
+    Set the lifecycle state of a stream feature view.
+    """
+    store = create_feature_store(ctx)
+    try:
+        fv = store.get_stream_feature_view(name)
+    except FeastObjectNotFoundException as e:
+        print(e)
+        sys.exit(1)
+
+    new_state = FeatureViewState[state.upper()]
+    if fv.state == new_state:
+        print(f"Stream feature view '{name}' is already in state {new_state.name}.")
+        return
+
+    if not fv.state.can_transition_to(new_state):
+        current = fv.state.name
+        allowed = _VALID_STATE_TRANSITIONS.get(fv.state, set())
+        allowed_names = ", ".join(sorted(s.name for s in allowed)) or "none"
+        print(
+            f"Invalid state transition: {current} -> {new_state.name}. "
+            f"Allowed transitions from {current}: {allowed_names}."
+        )
+        return
+
+    fv.state = new_state
+    store.registry.apply_feature_view(fv, store.project)
+    print(f"Stream feature view '{name}' state set to {new_state.name}.")

--- a/sdk/python/tests/unit/api/test_api_rest_registry.py
+++ b/sdk/python/tests/unit/api/test_api_rest_registry.py
@@ -2137,3 +2137,59 @@ def test_metrics_resource_counts_nonexistent_project(fastapi_test_app):
     assert data["featureServices"] == []
     assert data["featureViews"] == []
     assert "registryLastUpdated" in data
+
+
+def test_enable_feature_view_via_rest(fastapi_test_app):
+    response = fastapi_test_app.put(
+        "/feature_views/user_profile/enable?project=demo_project"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "user_profile"
+    assert data["enabled"] is True
+
+
+def test_disable_feature_view_via_rest(fastapi_test_app):
+    response = fastapi_test_app.put(
+        "/feature_views/user_profile/disable?project=demo_project"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "user_profile"
+    assert data["enabled"] is False
+
+
+def test_set_feature_view_state_via_rest(fastapi_test_app):
+    # First set to CREATED, then to GENERATED (valid transition)
+    response = fastapi_test_app.put(
+        "/feature_views/user_profile/set-state?state=CREATED&project=demo_project"
+    )
+    assert response.status_code == 200
+    assert response.json()["state"] == "CREATED"
+
+    response = fastapi_test_app.put(
+        "/feature_views/user_profile/set-state?state=GENERATED&project=demo_project"
+    )
+    assert response.status_code == 200
+    assert response.json()["state"] == "GENERATED"
+
+
+def test_set_feature_view_state_invalid_transition_via_rest(fastapi_test_app):
+    # Set to CREATED first
+    fastapi_test_app.put(
+        "/feature_views/user_profile/set-state?state=CREATED&project=demo_project"
+    )
+    # CREATED -> AVAILABLE_ONLINE is not a valid transition
+    response = fastapi_test_app.put(
+        "/feature_views/user_profile/set-state?state=AVAILABLE_ONLINE&project=demo_project"
+    )
+    assert response.status_code == 400
+    assert "Invalid state transition" in response.json()["error"]
+
+
+def test_set_feature_view_state_invalid_state_via_rest(fastapi_test_app):
+    response = fastapi_test_app.put(
+        "/feature_views/user_profile/set-state?state=INVALID&project=demo_project"
+    )
+    assert response.status_code == 400
+    assert "Invalid state" in response.json()["error"]

--- a/sdk/python/tests/unit/test_feature_view_state.py
+++ b/sdk/python/tests/unit/test_feature_view_state.py
@@ -406,6 +406,52 @@ class TestRegistryEnabledState:
 # ---------------------------------------------------------------------------
 
 
+class TestFeatureStoreMethods:
+    """Tests for store.enable_feature_view / disable_feature_view / set_feature_view_state."""
+
+    def test_enable_feature_view(self, local_feature_store):
+        store = local_feature_store
+        fv = _simple_feature_view(enabled=False)
+        store.apply([fv])
+        store.enable_feature_view("test_fv")
+        retrieved = store.get_feature_view("test_fv")
+        assert retrieved.enabled is True
+        store.teardown()
+
+    def test_disable_feature_view(self, local_feature_store):
+        store = local_feature_store
+        fv = _simple_feature_view(enabled=True)
+        store.apply([fv])
+        store.disable_feature_view("test_fv")
+        retrieved = store.get_feature_view("test_fv")
+        assert retrieved.enabled is False
+        store.teardown()
+
+    def test_set_feature_view_state(self, local_feature_store):
+        store = local_feature_store
+        fv = _simple_feature_view()
+        fv.state = FeatureViewState.CREATED
+        store.apply([fv])
+        store.set_feature_view_state("test_fv", FeatureViewState.GENERATED)
+        retrieved = store.get_feature_view("test_fv")
+        assert retrieved.state == FeatureViewState.GENERATED
+        store.teardown()
+
+    def test_set_feature_view_state_invalid_transition(self, local_feature_store):
+        store = local_feature_store
+        fv = _simple_feature_view()
+        fv.state = FeatureViewState.CREATED
+        store.apply([fv])
+        with pytest.raises(ValueError, match="Invalid state transition"):
+            store.set_feature_view_state("test_fv", FeatureViewState.AVAILABLE_ONLINE)
+        store.teardown()
+
+
+# ---------------------------------------------------------------------------
+# Materialization blocks disabled feature views
+# ---------------------------------------------------------------------------
+
+
 class TestMaterializationDisabledBlocking:
     def test_materialize_disabled_fv_by_name_raises(self, local_feature_store):
         store = local_feature_store


### PR DESCRIPTION
# What this PR does / why we need it:

Extends the feature view state management (introduced in #6401) to all feature view types and adds REST API support:

- Adds `enable`, `disable`, `set-state` CLI commands under `on-demand-feature-views` and `stream-feature-views`
- Updates `describe` for on-demand and stream feature views to show `enabled` and `state`
- Adds REST API endpoints: `PUT /feature_views/{name}/enable`, `/disable`, `/set-state`
- Adds `type: ignore` annotations for mypy since `BaseFeatureView` lacks `enabled`/`state` attributes

# Which issue(s) this PR fixes:

Fixes #6429

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Testing is not required for this change

# Misc

Follow-up from PR #6401. Parent issue: #6331.