### PR TITLE
fix(go): Skip registry refresh when cache_ttl_seconds <= 0 and avoid NewTicker panic

### DIFF
--- a/go/internal/feast/registry/registry.go
+++ b/go/internal/feast/registry/registry.go
@@ -81,6 +81,10 @@ func (r *Registry) InitializeRegistry() error {
 }
 
 func (r *Registry) RefreshRegistryOnInterval() {
+	if r.cachedRegistryProtoTtl <= 0 {
+		log.Info().Msg("Registry cache TTL is non-positive; skipping periodic refresh")
+		return
+	}
 	ticker := time.NewTicker(r.cachedRegistryProtoTtl)
 	for ; true; <-ticker.C {
 		err := r.refresh()

--- a/go/internal/feast/registry/registry_test.go
+++ b/go/internal/feast/registry/registry_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCloudRegistryStores(t *testing.T) {
@@ -95,6 +96,24 @@ func TestCloudRegistryStores(t *testing.T) {
 					t.Errorf("Error initializing registry. msg: %s. registry path=%q", err.Error(), registryPath)
 				}
 			}
+		})
+	}
+}
+
+func TestRefreshRegistryOnIntervalNonPositiveTTL(t *testing.T) {
+	tests := []struct {
+		name string
+		ttl  time.Duration
+	}{
+		{name: "zero ttl", ttl: 0},
+		{name: "negative ttl", ttl: -1 * time.Second},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := &Registry{cachedRegistryProtoTtl: test.ttl}
+			assert.NotPanics(t, func() {
+				r.RefreshRegistryOnInterval()
+			})
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:

The Go feature server panics on startup when `cache_ttl_seconds <= 0` is set in `feature_store.yaml`:

```
panic: non-positive interval for NewTicker

goroutine 84 [running]:
time.NewTicker(...)
github.com/feast-dev/feast/go/internal/feast/registry.(*Registry).RefreshRegistryOnInterval
    go/internal/feast/registry/registry.go:83
```

Because the ticker is created in a goroutine started during `InitializeRegistry`, an unrecovered panic there terminates the entire Go process — the feature server pod enters `CrashLoopBackOff` and serves no traffic.

Python Feast treats `cache_ttl_seconds <= 0` as "do not refresh the cache", and the Go side's `getRegistryProto` already guards on `cachedRegistryProtoTtl > 0` for expiration checks. However, `RefreshRegistryOnInterval` passed the value directly to `time.NewTicker`, which panics for non-positive durations.

This PR skips the refresh loop when TTL is non-positive, preventing the `time.NewTicker` panic and aligning Go behavior with Python.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Testing is not required for this change

Added `TestRefreshRegistryOnIntervalNonPositiveTTL` covering `ttl = 0` and `ttl = -1s` via `assert.NotPanics`. Verified the test fails with the original panic message when the fix is reverted.

Also verified on a live Go feature server pod running with `cache_ttl_seconds: 0`: the pod starts cleanly and serves traffic without crashing.

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->