### PR TITLE
fix: Add async_supported property to RedisOnlineStore

### DIFF
--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -42,6 +42,7 @@ from feast.infra.online_stores.helpers import (
 )
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.infra.registry.base_registry import BaseRegistry
+from feast.infra.supported_async_methods import SupportedAsyncMethods
 from feast.online_response import OnlineResponse
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import RepeatedValue
@@ -117,6 +118,10 @@ class RedisOnlineStore(OnlineStore):
     _client_async: Optional[Union[redis_asyncio.Redis, redis_asyncio.RedisCluster]] = (
         None
     )
+
+    @property
+    def async_supported(self) -> SupportedAsyncMethods:
+        return SupportedAsyncMethods(read=True, write=True)
 
     def delete_entity_values(self, config: RepoConfig, join_keys: List[str]):
         client = self._get_client(config.online_store)


### PR DESCRIPTION


# What this PR does / why we need it:

RedisOnlineStore implements full async support (`online_read_async`,
`online_write_batch_async`, `_get_client_async` using `redis.asyncio`), but
does not override the `async_supported` property from the base `OnlineStore`
class. The default returns `SupportedAsyncMethods(read=False, write=False)`,
so the feature server never uses the async path — falling back to
`run_in_threadpool(sync)` on every request.

# Which issue(s) this PR fixes:
Fixes https://github.com/feast-dev/feast/issues/6437 
