### PR TITLE
perf: Cache feature view resolution in get_online_features to reduce per-request overhead

### DIFF
--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -919,6 +919,16 @@ class BaseRegistry(ABC):
         """Refreshes the state of the registry cache by fetching the registry state from the remote registry store."""
         raise NotImplementedError
 
+    def is_cache_valid(self) -> bool:
+        """Check whether the registry's local cache is still within its TTL.
+
+        Returns True if cached data can be used without a refresh.
+        Subclasses that support caching should override this.
+        Registries without caching always return False (every read goes
+        to the backing store).
+        """
+        return False
+
     # Lineage operations
     def get_registry_lineage(
         self,

--- a/sdk/python/feast/infra/registry/caching_registry.py
+++ b/sdk/python/feast/infra/registry/caching_registry.py
@@ -442,32 +442,26 @@ class CachingRegistry(BaseRegistry):
         except Exception as e:
             logger.debug(f"Error while refreshing registry: {e}", exc_info=True)
 
+    def is_cache_valid(self) -> bool:
+        if (
+            self.cached_registry_proto is None
+            or self.cached_registry_proto == RegistryProto()
+        ):
+            return False
+        if (
+            not hasattr(self, "cached_registry_proto_created")
+            or self.cached_registry_proto_created is None
+        ):
+            return False
+        if self.cached_registry_proto_ttl.total_seconds() > 0 and _utc_now() > (
+            self.cached_registry_proto_created + self.cached_registry_proto_ttl
+        ):
+            return False
+        return True
+
     def _refresh_cached_registry_if_necessary(self):
         if self.cache_mode == "sync":
-
-            def is_cache_expired():
-                if (
-                    self.cached_registry_proto is None
-                    or self.cached_registry_proto == RegistryProto()
-                ):
-                    return True
-
-                # Cache is expired if creation time is None
-                if (
-                    not hasattr(self, "cached_registry_proto_created")
-                    or self.cached_registry_proto_created is None
-                ):
-                    return True
-
-                # Cache is expired if TTL > 0 and current time exceeds creation + TTL
-                if self.cached_registry_proto_ttl.total_seconds() > 0 and _utc_now() > (
-                    self.cached_registry_proto_created + self.cached_registry_proto_ttl
-                ):
-                    return True
-
-                return False
-
-            if is_cache_expired():
+            if not self.is_cache_valid():
                 if not self._refresh_lock.acquire(blocking=False):
                     logger.debug(
                         "Skipping refresh if lock is already held by another thread"

--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -1287,6 +1287,17 @@ class Registry(BaseRegistry):
         """Refreshes the state of the registry cache by fetching the registry state from the remote registry store."""
         self._get_registry_proto(project=project, allow_cache=False)
 
+    def is_cache_valid(self) -> bool:
+        if self.cached_registry_proto_created is None:
+            return False
+        if (
+            self.cached_registry_proto_ttl.total_seconds() > 0
+            and _utc_now()
+            > self.cached_registry_proto_created + self.cached_registry_proto_ttl
+        ):
+            return False
+        return True
+
     def teardown(self):
         """Tears down (removes) the registry."""
         self._registry_store.teardown()

--- a/sdk/python/feast/utils.py
+++ b/sdk/python/feast/utils.py
@@ -1,6 +1,8 @@
 import copy
 import itertools
+import logging
 import os
+import threading
 import typing
 import warnings
 from collections import Counter, defaultdict
@@ -1380,6 +1382,96 @@ def _get_online_request_context(
     )
 
 
+_feature_resolution_cache: Dict[tuple, tuple] = {}
+_feature_resolution_cache_lock = threading.Lock()
+_feature_resolution_registry_ts: Optional[datetime] = None
+
+_logger = logging.getLogger(__name__)
+
+
+def _get_cached_request_context(
+    registry,
+    project: str,
+    features: Union[List[str], "FeatureService"],
+    full_feature_names: bool,
+):
+    """Return the output of _get_online_request_context plus resolved ODFV
+    entity join keys, using a cache that is invalidated whenever the
+    registry refreshes or its cache TTL expires."""
+    from feast.feature_service import FeatureService as _FS
+
+    global _feature_resolution_cache, _feature_resolution_registry_ts
+
+    registry_ts = getattr(registry, "cached_registry_proto_created", None)
+
+    if isinstance(features, _FS):
+        features_key: tuple = ("__fs__", features.name)
+    else:
+        features_key = tuple(features)
+
+    cache_key = (features_key, project, full_feature_names)
+
+    is_cache_valid = getattr(registry, "is_cache_valid", None)
+    registry_cache_valid = is_cache_valid() if callable(is_cache_valid) else False
+
+    if registry_ts is not None and registry_cache_valid:
+        with _feature_resolution_cache_lock:
+            if registry_ts != _feature_resolution_registry_ts:
+                _feature_resolution_cache.clear()
+                _feature_resolution_registry_ts = registry_ts
+                _logger.debug("Feature resolution cache cleared (registry refreshed)")
+            else:
+                cached = _feature_resolution_cache.get(cache_key)
+                if cached is not None:
+                    return cached
+
+    ctx = _get_online_request_context(registry, project, features, full_feature_names)
+
+    (
+        feature_refs,
+        requested_on_demand_feature_views,
+        entity_name_to_join_key_map,
+        entity_type_map,
+        join_keys_set,
+        grouped_refs,
+        requested_result_row_names,
+        needed_request_data,
+        entityless_case,
+    ) = ctx
+
+    odfv_join_keys: set = set()
+    for on_demand_feature_view in requested_on_demand_feature_views:
+        entities_for_odfv = getattr(on_demand_feature_view, "entities", [])
+        if len(entities_for_odfv) > 0 and isinstance(entities_for_odfv[0], str):
+            entities_for_odfv = [
+                registry.get_entity(entity_name, project, allow_cache=True)
+                for entity_name in entities_for_odfv
+            ]
+        odfv_join_keys.update(entities_for_odfv)
+
+    result = (
+        feature_refs,
+        requested_on_demand_feature_views,
+        entity_name_to_join_key_map,
+        entity_type_map,
+        join_keys_set | odfv_join_keys,
+        grouped_refs,
+        frozenset(requested_result_row_names),
+        needed_request_data,
+        entityless_case,
+    )
+
+    registry_ts_after = getattr(registry, "cached_registry_proto_created", None)
+    if registry_ts_after is not None:
+        with _feature_resolution_cache_lock:
+            if registry_ts_after != _feature_resolution_registry_ts:
+                _feature_resolution_cache.clear()
+                _feature_resolution_registry_ts = registry_ts_after
+            _feature_resolution_cache[cache_key] = result
+
+    return result
+
+
 def _prepare_entities_to_read_from_online_store(
     registry,
     project,
@@ -1399,10 +1491,13 @@ def _prepare_entities_to_read_from_online_store(
         entity_type_map,
         join_keys_set,
         grouped_refs,
-        requested_result_row_names,
+        requested_result_row_names_frozen,
         needed_request_data,
         entityless_case,
-    ) = _get_online_request_context(registry, project, features, full_feature_names)
+    ) = _get_cached_request_context(registry, project, features, full_feature_names)
+
+    # Mutable copy — downstream code adds join keys to this set.
+    requested_result_row_names = set(requested_result_row_names_frozen)
 
     # Extract Sequence from RepeatedValue Protobuf.
     entity_value_lists: Dict[str, Union[List[Any], List[ValueProto]]] = {
@@ -1423,23 +1518,6 @@ def _prepare_entities_to_read_from_online_store(
         entity_proto_values = entity_value_lists
 
     num_rows = _validate_entity_values(entity_proto_values)
-
-    odfv_entities: List[Entity] = []
-    request_source_keys: List[str] = []
-    for on_demand_feature_view in requested_on_demand_feature_views:
-        entities_for_odfv = getattr(on_demand_feature_view, "entities", [])
-        if len(entities_for_odfv) > 0 and isinstance(entities_for_odfv[0], str):
-            entities_for_odfv = [
-                registry.get_entity(entity_name, project, allow_cache=True)
-                for entity_name in entities_for_odfv
-            ]
-        odfv_entities.extend(entities_for_odfv)
-        for source in on_demand_feature_view.source_request_sources:
-            source_schema = on_demand_feature_view.source_request_sources[source].schema
-            for column in source_schema:
-                request_source_keys.append(column.name)
-
-    join_keys_set.update(set(odfv_entities))
 
     join_key_values: Dict[str, List[ValueProto]] = {}
     request_data_features: Dict[str, List[ValueProto]] = {}

--- a/sdk/python/tests/unit/test_feature_resolution_cache.py
+++ b/sdk/python/tests/unit/test_feature_resolution_cache.py
@@ -1,0 +1,171 @@
+"""Tests for the feature resolution cache in feast.utils._get_cached_request_context."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import feast.utils as utils
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Reset the module-level cache before each test."""
+    with utils._feature_resolution_cache_lock:
+        utils._feature_resolution_cache.clear()
+        utils._feature_resolution_registry_ts = None
+    yield
+    with utils._feature_resolution_cache_lock:
+        utils._feature_resolution_cache.clear()
+        utils._feature_resolution_registry_ts = None
+
+
+def _make_registry(ts: datetime, ttl_seconds: int = 600, cache_valid: bool = True):
+    reg = MagicMock()
+    reg.cached_registry_proto_created = ts
+    reg.cached_registry_proto_ttl = timedelta(seconds=ttl_seconds)
+    reg.is_cache_valid.return_value = cache_valid
+    return reg
+
+
+def _make_context():
+    """Return a plausible fake context tuple matching _get_online_request_context output."""
+    return (
+        ["fv:feat1"],  # feature_refs
+        [],  # requested_on_demand_feature_views
+        {},  # entity_name_to_join_key_map
+        {},  # entity_type_map
+        {"user_id"},  # join_keys_set
+        [("fv_table", ["feat1"])],  # grouped_refs
+        {"feat1"},  # requested_result_row_names
+        set(),  # needed_request_data
+        False,  # entityless_case
+    )
+
+
+class TestFeatureResolutionCache:
+    @patch("feast.utils._get_online_request_context")
+    def test_second_call_uses_cache(self, mock_ctx):
+        """Identical feature requests within the same registry generation
+        should only call _get_online_request_context once."""
+        mock_ctx.return_value = _make_context()
+        now = datetime.now(tz=timezone.utc)
+        registry = _make_registry(now, ttl_seconds=600)
+        features = ["fv:feat1"]
+
+        utils._get_cached_request_context(registry, "proj", features, False)
+        utils._get_cached_request_context(registry, "proj", features, False)
+
+        mock_ctx.assert_called_once()
+
+    @patch("feast.utils._get_online_request_context")
+    def test_different_features_are_separate_cache_entries(self, mock_ctx):
+        """Different feature lists should be cached independently."""
+        mock_ctx.return_value = _make_context()
+        now = datetime.now(tz=timezone.utc)
+        registry = _make_registry(now, ttl_seconds=600)
+
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+        utils._get_cached_request_context(registry, "proj", ["fv:feat2"], False)
+
+        assert mock_ctx.call_count == 2
+
+    @patch("feast.utils._get_online_request_context")
+    def test_cache_cleared_on_registry_refresh(self, mock_ctx):
+        """When registry.cached_registry_proto_created changes, the cache
+        must be cleared and _get_online_request_context called again."""
+        mock_ctx.return_value = _make_context()
+        t1 = datetime.now(tz=timezone.utc)
+        t2 = t1 + timedelta(seconds=30)
+
+        registry = _make_registry(t1, ttl_seconds=600)
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+        assert mock_ctx.call_count == 1
+
+        registry.cached_registry_proto_created = t2
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+        assert mock_ctx.call_count == 2
+
+    @patch("feast.utils._get_online_request_context")
+    def test_cache_bypassed_when_registry_ttl_expired(self, mock_ctx):
+        """If the registry's own cache has expired (TTL), the feature
+        resolution cache must NOT be used even if the timestamp matches."""
+        mock_ctx.return_value = _make_context()
+        past = datetime.now(tz=timezone.utc) - timedelta(seconds=120)
+        registry = _make_registry(past, ttl_seconds=60, cache_valid=False)
+
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+
+        assert mock_ctx.call_count == 2
+
+    @patch("feast.utils._get_online_request_context")
+    def test_cache_works_with_infinite_ttl(self, mock_ctx):
+        """TTL of 0 means infinite cache — should cache normally."""
+        mock_ctx.return_value = _make_context()
+        past = datetime.now(tz=timezone.utc) - timedelta(hours=24)
+        registry = _make_registry(past, ttl_seconds=0)
+
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+
+        mock_ctx.assert_called_once()
+
+    @patch("feast.utils._get_online_request_context")
+    def test_no_cache_without_registry_timestamp(self, mock_ctx):
+        """Registries without cached_registry_proto_created should bypass
+        caching entirely."""
+        mock_ctx.return_value = _make_context()
+        registry = MagicMock(spec=[])
+
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+
+        assert mock_ctx.call_count == 2
+
+    @patch("feast.utils._get_online_request_context")
+    def test_returned_result_row_names_is_mutable_copy(self, mock_ctx):
+        """requested_result_row_names is stored as frozenset in cache;
+        each call to _prepare_entities_to_read_from_online_store should
+        get a fresh mutable copy so mutations don't leak between requests."""
+        mock_ctx.return_value = _make_context()
+        now = datetime.now(tz=timezone.utc)
+        registry = _make_registry(now, ttl_seconds=600)
+
+        r1 = utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+        r2 = utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+
+        result_row_names_1 = r1[6]
+        result_row_names_2 = r2[6]
+        assert isinstance(result_row_names_1, frozenset)
+        assert result_row_names_1 == result_row_names_2
+
+    @patch("feast.utils._get_online_request_context")
+    def test_feature_service_cached_separately(self, mock_ctx):
+        """FeatureService objects should be cached by name."""
+        mock_ctx.return_value = _make_context()
+        now = datetime.now(tz=timezone.utc)
+        registry = _make_registry(now, ttl_seconds=600)
+
+        fs = MagicMock()
+        fs.name = "credit_scoring_v1"
+
+        utils._get_cached_request_context(registry, "proj", fs, False)
+        utils._get_cached_request_context(registry, "proj", fs, False)
+
+        mock_ctx.assert_called_once()
+
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+        assert mock_ctx.call_count == 2
+
+    @patch("feast.utils._get_online_request_context")
+    def test_full_feature_names_flag_is_cache_key(self, mock_ctx):
+        """full_feature_names=True vs False should be different cache entries."""
+        mock_ctx.return_value = _make_context()
+        now = datetime.now(tz=timezone.utc)
+        registry = _make_registry(now, ttl_seconds=600)
+
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], False)
+        utils._get_cached_request_context(registry, "proj", ["fv:feat1"], True)
+
+        assert mock_ctx.call_count == 2


### PR DESCRIPTION

# What this PR does / why we need it:

Every call to `get_online_features` invokes `_prepare_entities_to_read_from_online_store()` which performs registry lookups, feature view resolution, entity grouping, and ODFV entity resolution. For repeated requests with the same feature set - the common production pattern - this computation is identical and adds ~1-1.5ms of pure Python overhead per call.

This PR caches the registry-derived outputs of `_get_online_request_context()` so that repeated requests with the same features skip the resolution entirely.

# Which issue(s) this PR fixes:
Fixes https://github.com/feast-dev/feast/issues/6438 

The cache does **not** introduce a separate TTL - it is tied entirely to the registry cache lifecycle:
- Same registry generation + within TTL → cache hit
- Registry refreshed (timestamp changed) → entire cache cleared
- Registry TTL expired → cache bypassed, forces registry refresh
Both sync (`get_online_features`) and async (`get_online_features_async`) paths benefit automatically since the cache is in the shared `_prepare_entities_to_read_from_online_store()`.