### PR TITLE
fix: Detect duplicate feature view/data source names early in parse_repo to fix flaky test (#6417)

### DIFF
--- a/sdk/python/feast/cli/cli.py
+++ b/sdk/python/feast/cli/cli.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import sys
 import logging
+import sys
 from datetime import datetime
 from importlib.metadata import version as importlib_version
 from pathlib import Path

--- a/sdk/python/feast/cli/cli.py
+++ b/sdk/python/feast/cli/cli.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import sys
 import logging
 from datetime import datetime
 from importlib.metadata import version as importlib_version
@@ -49,7 +50,7 @@ from feast.cli.stream_feature_views import stream_feature_views_cmd
 from feast.cli.ui import ui
 from feast.cli.validation_references import validation_references_cmd
 from feast.constants import FEAST_FS_YAML_FILE_PATH_ENV_NAME
-from feast.errors import FeastProviderLoginError
+from feast.errors import FeastError, FeastProviderLoginError
 from feast.repo_config import load_repo_config
 from feast.repo_operations import (
     apply_total,
@@ -258,6 +259,9 @@ def plan_command(
         plan(repo_config, repo, skip_source_validation, skip_feature_view_validation)
     except FeastProviderLoginError as e:
         print(str(e))
+    except FeastError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 @cli.command("apply", cls=NoOptionDefaultFormat)
@@ -316,6 +320,9 @@ def apply_total_command(
         )
     except FeastProviderLoginError as e:
         print(str(e))
+    except FeastError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 @cli.command("teardown", cls=NoOptionDefaultFormat)

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -21,6 +21,7 @@ from feast.constants import FEATURE_STORE_YAML_ENV_NAME
 from feast.data_source import DataSource, KafkaSource, KinesisSource
 from feast.diff.registry_diff import extract_objects_for_keep_delete_update_add
 from feast.entity import Entity
+from feast.errors import ConflictingFeatureViewNames, DataSourceRepeatNamesException
 from feast.feature_service import FeatureService
 from feast.feature_store import FeatureStore
 from feast.feature_view import DUMMY_ENTITY, FeatureView
@@ -28,7 +29,6 @@ from feast.file_utils import replace_str_in_file
 from feast.infra.registry.base_registry import BaseRegistry
 from feast.infra.registry.registry import FEAST_OBJECT_TYPES, FeastObjectType, Registry
 from feast.names import adjectives, animals
-from feast.errors import ConflictingFeatureViewNames, DataSourceRepeatNamesException
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.permissions.permission import Permission
 from feast.project import Project

--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -28,6 +28,7 @@ from feast.file_utils import replace_str_in_file
 from feast.infra.registry.base_registry import BaseRegistry
 from feast.infra.registry.registry import FEAST_OBJECT_TYPES, FeastObjectType, Registry
 from feast.names import adjectives, animals
+from feast.errors import ConflictingFeatureViewNames, DataSourceRepeatNamesException
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.permissions.permission import Permission
 from feast.project import Project
@@ -218,6 +219,33 @@ def parse_repo(repo_root: Path) -> RepoContents:
                 res.permissions.append(obj)
             elif isinstance(obj, Project) and not any((obj is p) for p in res.projects):
                 res.projects.append(obj)
+
+    # Early duplicate detection: validate feature view names are case-insensitively unique
+    # This runs before FeatureStore initialization to avoid slow cleanup on error
+    fv_names_seen = {}
+    all_feature_views = (
+        res.feature_views + res.stream_feature_views + res.on_demand_feature_views
+    )
+    for fv in all_feature_views:
+        lower_name = fv.name.lower()
+        if lower_name in fv_names_seen:
+            existing_fv = fv_names_seen[lower_name]
+            raise ConflictingFeatureViewNames(
+                fv.name,
+                existing_type=type(existing_fv).__name__,
+                new_type=type(fv).__name__,
+            )
+        fv_names_seen[lower_name] = fv
+
+    # Early duplicate detection: validate data source names are case-insensitively unique
+    ds_names_seen = {}
+    for ds in res.data_sources:
+        if ds.name is None:
+            continue
+        lower_name = ds.name.lower()
+        if lower_name in ds_names_seen:
+            raise DataSourceRepeatNamesException(ds.name)
+        ds_names_seen[lower_name] = ds
 
     res.entities.append(DUMMY_ENTITY)
     return res


### PR DESCRIPTION
## What this PR does / why we need it

Fixes the flaky test `test_cli_apply_duplicated_featureview_names` (and similar tests) that intermittently fails in CI with empty output due to subprocess timeout.

**Root cause:** Duplicate feature view name detection happened too late in the pipeline — inside `store.plan()` / `store.apply()` via `_validate_feature_views()`, after `FeatureStore` and heavy dependencies (Dask, registry, provider) had already been initialized. When the validation error was raised, slow `atexit` handlers (Dask thread pool) could block process exit indefinitely, causing the 60s timeout to trigger and the output to be lost.

## Changes

### `sdk/python/feast/repo_operations.py`
- Added `ConflictingFeatureViewNames` and `DataSourceRepeatNamesException` imports from `feast.errors`
- - Added **early duplicate detection** in `parse_repo()` before any `FeatureStore` initialization:
-   - Validates that all feature view names (across `FeatureView`, `StreamFeatureView`, `OnDemandFeatureView`) are case-insensitively unique → raises `ConflictingFeatureViewNames` immediately if collision found
-   - Validates that all data source names are case-insensitively unique → raises `DataSourceRepeatNamesException` immediately if collision found
### `sdk/python/feast/cli/cli.py`
- Added `import sys`
- - Added `FeastError` to the import from `feast.errors`
- - Added `except FeastError` handler (after existing `FeastProviderLoginError`) in both `plan_command` and `apply_total_command` — prints a clean error message and exits with code 1 instead of letting validation errors propagate as unhandled tracebacks
## How has this been tested

- The existing integration tests in `sdk/python/tests/integration/cli/test_cli_apply_duplicates.py` cover the fix:
-   - `test_cli_apply_duplicated_featureview_names`
-   - `test_cli_apply_duplicate_data_source_names`
-   - `test_cli_apply_duplicated_featureview_names_multiple_py_files`
These tests assert `rc != 0` and the expected error message in the output, which is now guaranteed since the error is raised before any heavy initialization.

## Closes

Closes #6417