### PR TITLE
fix: Add checks for registry and feature server handlers

### DIFF
--- a/sdk/python/feast/api/registry/rest/metrics.py
+++ b/sdk/python/feast/api/registry/rest/metrics.py
@@ -11,6 +11,9 @@ from feast.api.registry.rest.rest_utils import (
     grpc_call,
     paginate_and_sort,
 )
+from feast.errors import FeastObjectNotFoundException
+from feast.permissions.action import AuthzedAction
+from feast.permissions.security_manager import assert_permissions
 from feast.protos.feast.registry import RegistryServer_pb2
 
 
@@ -433,15 +436,21 @@ def get_metrics_router(grpc_handler, server=None) -> APIRouter:
         key = f"recently_visited_{user}"
         visits = []
         if project:
-            try:
-                visits_json = (
-                    server.registry.get_project_metadata(project, key)
-                    if server
-                    else None
-                )
-                visits = json.loads(visits_json) if visits_json else []
-            except Exception:
-                visits = []
+            if server:
+                try:
+                    project_obj = server.registry.get_project(
+                        name=project, allow_cache=True
+                    )
+                    assert_permissions(
+                        resource=project_obj, actions=[AuthzedAction.DESCRIBE]
+                    )
+                except FeastObjectNotFoundException:
+                    pass
+                try:
+                    visits_json = server.registry.get_project_metadata(project, key)
+                    visits = json.loads(visits_json) if visits_json else []
+                except Exception:
+                    visits = []
         else:
             try:
                 if server:

--- a/sdk/python/feast/api/registry/rest/rest_registry_server.py
+++ b/sdk/python/feast/api/registry/rest/rest_registry_server.py
@@ -235,28 +235,35 @@ class RestRegistryServer:
                     else:
                         object_type = None
                         object_name = None
-                    visit = {
-                        "path": path,
-                        "timestamp": _utc_now().isoformat(),
-                        "project": project,
-                        "user": user,
-                        "object": object_type,
-                        "object_name": object_name,
-                        "method": method,
-                    }
-                    try:
-                        visits_json = self.registry.get_project_metadata(project, key)
-                        visits = json.loads(visits_json) if visits_json else []
-                    except Exception:
-                        visits = []
-                    visits.append(visit)
-                    visits = visits[-self.recent_visits_limit :]
-                    try:
-                        self.registry.set_project_metadata(
-                            project, key, json.dumps(visits)
-                        )
-                    except Exception as e:
-                        logger.warning(f"Failed to persist recent visits: {e}")
+
+                    response = await call_next(request)
+
+                    if response.status_code < 400:
+                        visit = {
+                            "path": path,
+                            "timestamp": _utc_now().isoformat(),
+                            "project": project,
+                            "user": user,
+                            "object": object_type,
+                            "object_name": object_name,
+                            "method": method,
+                        }
+                        try:
+                            visits_json = self.registry.get_project_metadata(
+                                project, key
+                            )
+                            visits = json.loads(visits_json) if visits_json else []
+                        except Exception:
+                            visits = []
+                        visits.append(visit)
+                        visits = visits[-self.recent_visits_limit :]
+                        try:
+                            self.registry.set_project_metadata(
+                                project, key, json.dumps(visits)
+                            )
+                        except Exception as e:
+                            logger.warning(f"Failed to persist recent visits: {e}")
+                    return response
                 response = await call_next(request)
                 return response
 

--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -584,12 +584,22 @@ def get_app(
     @app.post("/materialize", dependencies=[Depends(inject_user_details)])
     async def materialize(request: MaterializeRequest) -> None:
         with feast_metrics.track_request_latency("/materialize"):
-            for feature_view in request.feature_views or []:
-                resource = await _get_feast_object(feature_view, True)
-                assert_permissions(
-                    resource=resource,
-                    actions=[AuthzedAction.WRITE_ONLINE],
+            if request.feature_views:
+                for feature_view in request.feature_views:
+                    resource = await _get_feast_object(feature_view, True)
+                    assert_permissions(
+                        resource=resource,
+                        actions=[AuthzedAction.WRITE_ONLINE],
+                    )
+            else:
+                feature_views_to_materialize = store._get_feature_views_to_materialize(
+                    None
                 )
+                for fv in feature_views_to_materialize:
+                    assert_permissions(
+                        resource=fv,
+                        actions=[AuthzedAction.WRITE_ONLINE],
+                    )
 
             if request.disable_event_timestamp:
                 now = datetime.now()
@@ -615,12 +625,22 @@ def get_app(
     @app.post("/materialize-incremental", dependencies=[Depends(inject_user_details)])
     async def materialize_incremental(request: MaterializeIncrementalRequest) -> None:
         with feast_metrics.track_request_latency("/materialize-incremental"):
-            for feature_view in request.feature_views or []:
-                resource = await _get_feast_object(feature_view, True)
-                assert_permissions(
-                    resource=resource,
-                    actions=[AuthzedAction.WRITE_ONLINE],
+            if request.feature_views:
+                for feature_view in request.feature_views:
+                    resource = await _get_feast_object(feature_view, True)
+                    assert_permissions(
+                        resource=resource,
+                        actions=[AuthzedAction.WRITE_ONLINE],
+                    )
+            else:
+                feature_views_to_materialize = store._get_feature_views_to_materialize(
+                    None
                 )
+                for fv in feature_views_to_materialize:
+                    assert_permissions(
+                        resource=fv,
+                        actions=[AuthzedAction.WRITE_ONLINE],
+                    )
             await run_in_threadpool(
                 store.materialize_incremental,
                 utils.make_tzaware(parser.parse(request.end_ts)),

--- a/sdk/python/feast/registry_server.py
+++ b/sdk/python/feast/registry_server.py
@@ -891,6 +891,13 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
     def ListProjectMetadata(
         self, request: RegistryServer_pb2.ListProjectMetadataRequest, context
     ):
+        try:
+            project = self.proxied_registry.get_project(
+                name=request.project, allow_cache=True
+            )
+            assert_permissions(resource=project, actions=[AuthzedAction.DESCRIBE])
+        except FeastObjectNotFoundException:
+            pass
         return RegistryServer_pb2.ListProjectMetadataResponse(
             project_metadata=[
                 project_metadata.to_proto()
@@ -923,6 +930,10 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
         return Empty()
 
     def UpdateInfra(self, request: RegistryServer_pb2.UpdateInfraRequest, context):
+        project = self.proxied_registry.get_project(
+            name=request.project, allow_cache=True
+        )
+        assert_permissions(resource=project, actions=[AuthzedAction.UPDATE])
         self.proxied_registry.update_infra(
             infra=Infra.from_proto(request.infra),
             project=request.project,
@@ -931,6 +942,10 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
         return Empty()
 
     def GetInfra(self, request: RegistryServer_pb2.GetInfraRequest, context):
+        project = self.proxied_registry.get_project(
+            name=request.project, allow_cache=True
+        )
+        assert_permissions(resource=project, actions=[AuthzedAction.DESCRIBE])
         return self.proxied_registry.get_infra(
             project=request.project, allow_cache=request.allow_cache
         ).to_proto()
@@ -1063,6 +1078,13 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
     def GetRegistryLineage(
         self, request: RegistryServer_pb2.GetRegistryLineageRequest, context
     ):
+        try:
+            project = self.proxied_registry.get_project(
+                name=request.project, allow_cache=True
+            )
+            assert_permissions(resource=project, actions=[AuthzedAction.DESCRIBE])
+        except FeastObjectNotFoundException:
+            pass
         direct_relationships, indirect_relationships = (
             self.proxied_registry.get_registry_lineage(
                 project=request.project,
@@ -1101,6 +1123,13 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
         self, request: RegistryServer_pb2.GetObjectRelationshipsRequest, context
     ):
         """Get relationships for a specific object."""
+        try:
+            project = self.proxied_registry.get_project(
+                name=request.project, allow_cache=True
+            )
+            assert_permissions(resource=project, actions=[AuthzedAction.DESCRIBE])
+        except FeastObjectNotFoundException:
+            pass
         relationships = self.proxied_registry.get_object_relationships(
             project=request.project,
             object_type=request.object_type,


### PR DESCRIPTION

# What this PR does / why we need it:

For consistency across all registry and feature server endpoints, added missing inline auth checks that their sibling handlers already enforce. 


FeastObjectNotFoundException -> Yes → pass -> return empty list

FeastPermissionError -> No → propagates → 403 
