### PR TITLE
perf: Optimize feature serving latency with batched async Redis, cached checks fix

### DIFF
--- a/sdk/python/feast/feature_server.py
+++ b/sdk/python/feast/feature_server.py
@@ -54,7 +54,11 @@ from feast.feast_object import FeastObject
 from feast.feature_server_utils import convert_response_to_dict
 from feast.feature_view_utils import get_feature_view_from_feature_store
 from feast.permissions.action import WRITE, AuthzedAction
-from feast.permissions.security_manager import assert_permissions
+from feast.permissions.security_manager import (
+    assert_permissions,
+    get_security_manager,
+    is_auth_necessary,
+)
 from feast.permissions.server.rest import inject_user_details
 from feast.permissions.server.utils import (
     ServerType,
@@ -184,7 +188,7 @@ async def _get_features(
             resource=feature_service, actions=[AuthzedAction.READ_ONLINE]
         )
         features = feature_service  # type: ignore
-    else:
+    elif is_auth_necessary(get_security_manager()):
         all_feature_views, all_on_demand_feature_views = await run_in_threadpool(
             utils._get_feature_views_to_use,
             store.registry,
@@ -201,6 +205,8 @@ async def _get_features(
             assert_permissions(
                 resource=od_feature_view, actions=[AuthzedAction.READ_ONLINE]
             )
+        features = request.features  # type: ignore
+    else:
         features = request.features  # type: ignore
     return features
 

--- a/sdk/python/feast/infra/online_stores/online_store.py
+++ b/sdk/python/feast/infra/online_stores/online_store.py
@@ -253,55 +253,14 @@ class OnlineStore(ABC):
         )
         return OnlineResponse(online_features_response, feature_types=feature_types)
 
+    _versioned_read_supported: Optional[bool] = None
+
     def _check_versioned_read_support(self, grouped_refs):
         """Raise an error if versioned reads are attempted on unsupported stores."""
-        from feast.infra.online_stores.sqlite import SqliteOnlineStore
+        if self._versioned_read_supported is None:
+            self._versioned_read_supported = self._is_versioned_read_supported()
 
-        supported_types: list[type] = [SqliteOnlineStore]
-        try:
-            from feast.infra.online_stores.mysql_online_store.mysql import (
-                MySQLOnlineStore,
-            )
-
-            supported_types.append(MySQLOnlineStore)
-        except ImportError:
-            pass
-        try:
-            from feast.infra.online_stores.postgres_online_store.postgres import (
-                PostgreSQLOnlineStore,
-            )
-
-            supported_types.append(PostgreSQLOnlineStore)
-        except ImportError:
-            pass
-        try:
-            from feast.infra.online_stores.faiss_online_store import FaissOnlineStore
-
-            supported_types.append(FaissOnlineStore)
-        except ImportError:
-            pass
-        try:
-            from feast.infra.online_stores.redis import RedisOnlineStore
-
-            supported_types.append(RedisOnlineStore)
-        except Exception:
-            pass
-        try:
-            from feast.infra.online_stores.dynamodb import DynamoDBOnlineStore
-
-            supported_types.append(DynamoDBOnlineStore)
-        except Exception:
-            pass
-        try:
-            from feast.infra.online_stores.milvus_online_store.milvus import (
-                MilvusOnlineStore,
-            )
-
-            supported_types.append(MilvusOnlineStore)
-        except ImportError:
-            pass
-
-        if isinstance(self, tuple(supported_types)):
+        if self._versioned_read_supported:
             return
         for table, _ in grouped_refs:
             version_tag = getattr(table.projection, "version_tag", None)
@@ -309,6 +268,34 @@ class OnlineStore(ABC):
                 raise VersionedOnlineReadNotSupported(
                     self.__class__.__name__, version_tag
                 )
+
+    def _is_versioned_read_supported(self) -> bool:
+        """Check if this store type supports versioned reads (resolved once, cached)."""
+        from feast.infra.online_stores.sqlite import SqliteOnlineStore
+
+        supported_types: list[type] = [SqliteOnlineStore]
+        for module, cls_name in (
+            ("feast.infra.online_stores.mysql_online_store.mysql", "MySQLOnlineStore"),
+            (
+                "feast.infra.online_stores.postgres_online_store.postgres",
+                "PostgreSQLOnlineStore",
+            ),
+            ("feast.infra.online_stores.faiss_online_store", "FaissOnlineStore"),
+            ("feast.infra.online_stores.redis", "RedisOnlineStore"),
+            ("feast.infra.online_stores.dynamodb", "DynamoDBOnlineStore"),
+            (
+                "feast.infra.online_stores.milvus_online_store.milvus",
+                "MilvusOnlineStore",
+            ),
+        ):
+            try:
+                import importlib
+
+                mod = importlib.import_module(module)
+                supported_types.append(getattr(mod, cls_name))
+            except Exception:
+                pass
+        return isinstance(self, tuple(supported_types))
 
     async def get_online_features_async(
         self,

--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -34,6 +34,7 @@ from pydantic import StrictStr
 
 from feast import Entity, FeatureView, RepoConfig, utils
 from feast.feature_service import FeatureService
+from feast.infra.key_encoding_utils import serialize_entity_key
 from feast.infra.online_stores.helpers import (
     _mmh3,
     _redis_key,
@@ -506,15 +507,14 @@ class RedisOnlineStore(OnlineStore):
     def _generate_redis_keys_for_entities(
         self, config: RepoConfig, entity_keys: List[EntityKeyProto]
     ) -> List[bytes]:
-        keys = []
-        for entity_key in entity_keys:
-            redis_key_bin = _redis_key(
-                config.project,
-                entity_key,
-                entity_key_serialization_version=config.entity_key_serialization_version,
-            )
-            keys.append(redis_key_bin)
-        return keys
+        project = config.project
+        version = config.entity_key_serialization_version
+        project_bytes = project.encode("utf-8")
+        return [
+            serialize_entity_key(ek, entity_key_serialization_version=version)
+            + project_bytes
+            for ek in entity_keys
+        ]
 
     def _generate_hset_keys_for_features(
         self,
@@ -700,6 +700,146 @@ class RedisOnlineStore(OnlineStore):
                     for redis_key in redis_keys:
                         pipe.hmget(redis_key, hset_keys)
                 all_results = pipe.execute()
+
+            offset = 0
+            for (
+                table,
+                req_features,
+                fv_name,
+                _,
+                redis_keys,
+                idxs,
+                output_len,
+            ) in work_items:
+                n = len(redis_keys)
+                redis_values = all_results[offset : offset + n]
+                offset += n
+
+                read_rows = self._convert_redis_values_to_protobuf(
+                    redis_values, fv_name, req_features
+                )
+
+                utils._populate_response_from_feature_data(
+                    req_features,
+                    read_rows,
+                    idxs,
+                    online_features_response,
+                    full_feature_names,
+                    table,
+                    output_len,
+                    include_feature_view_version_metadata,
+                )
+
+        if _track_read:
+            from feast.metrics import track_online_store_read
+
+            track_online_store_read(_time.monotonic() - _read_start)
+
+        feature_types = self._build_feature_types(grouped_refs)
+
+        if requested_on_demand_feature_views:
+            utils._augment_response_with_on_demand_transforms(
+                online_features_response,
+                feature_refs,
+                requested_on_demand_feature_views,
+                full_feature_names,
+                feature_types=feature_types,
+            )
+
+        utils._drop_unneeded_columns(
+            online_features_response, requested_result_row_names
+        )
+        return OnlineResponse(online_features_response, feature_types=feature_types)
+
+    async def get_online_features_async(
+        self,
+        config: RepoConfig,
+        features: Union[List[str], FeatureService],
+        entity_rows: Union[
+            List[Dict[str, Any]],
+            Mapping[str, Union[Sequence[Any], Sequence[ValueProto], RepeatedValue]],
+        ],
+        registry: BaseRegistry,
+        project: str,
+        full_feature_names: bool = False,
+        include_feature_view_version_metadata: bool = False,
+    ) -> OnlineResponse:
+        """
+        Async version of get_online_features using a single batched Redis pipeline.
+
+        Mirrors the sync override: all HMGET commands across all feature views are
+        issued in one async pipeline execution (O(1) round trips).
+        """
+        if isinstance(entity_rows, list):
+            columnar: Dict[str, List[Any]] = {k: [] for k in entity_rows[0].keys()}
+            for entity_row in entity_rows:
+                for key, value in entity_row.items():
+                    try:
+                        columnar[key].append(value)
+                    except KeyError as e:
+                        raise ValueError(
+                            "All entity_rows must have the same keys."
+                        ) from e
+            entity_rows = columnar
+
+        (
+            join_key_values,
+            grouped_refs,
+            entity_name_to_join_key_map,
+            requested_on_demand_feature_views,
+            feature_refs,
+            requested_result_row_names,
+            online_features_response,
+        ) = utils._prepare_entities_to_read_from_online_store(
+            registry=registry,
+            project=project,
+            features=features,
+            entity_values=entity_rows,
+            full_feature_names=full_feature_names,
+            native_entity_values=True,
+        )
+
+        self._check_versioned_read_support(grouped_refs)
+
+        _track_read = False
+        try:
+            from feast.metrics import _config as _metrics_config
+
+            _track_read = _metrics_config.online_features
+        except Exception:
+            pass
+
+        if _track_read:
+            import time as _time
+
+            _read_start = _time.monotonic()
+
+        work_items = []
+        for table, requested_features in grouped_refs:
+            table_entity_values, idxs, output_len = utils._get_unique_entities(
+                table,
+                join_key_values,
+                entity_name_to_join_key_map,
+            )
+            entity_key_protos = utils._get_entity_key_protos(table_entity_values)
+            fv_name = _versioned_fv_name(table, config)
+            redis_keys = self._generate_redis_keys_for_entities(
+                config, entity_key_protos
+            )
+            req_features, hset_keys = self._generate_hset_keys_for_features(
+                table, requested_features, fv_name_override=fv_name
+            )
+            work_items.append(
+                (table, req_features, fv_name, hset_keys, redis_keys, idxs, output_len)
+            )
+
+        if work_items:
+            client = await self._get_client_async(config.online_store)
+            async with client.pipeline(transaction=False) as pipe:
+                for _, _, _, hset_keys, redis_keys, _, _ in work_items:
+                    for redis_key in redis_keys:
+                        pipe.hmget(redis_key, hset_keys)
+                all_results = await pipe.execute()
 
             offset = 0
             for (

--- a/sdk/python/feast/rest_error_handler.py
+++ b/sdk/python/feast/rest_error_handler.py
@@ -39,7 +39,6 @@ def rest_error_handling_decorator(func):
     def wrapper(config: RepoConfig, *args, **kwargs):
         assert isinstance(config, RepoConfig)
 
-        # Extract connection pool configuration from online_store if available
         pool_maxsize = None
         max_idle_seconds = None
         max_retries = None
@@ -58,7 +57,6 @@ def rest_error_handling_decorator(func):
             max_idle_seconds = conn_config["max_idle_seconds"]
             max_retries = conn_config["max_retries"]
 
-        # Get a cached session with connection pooling
         session = get_http_auth_requests_session(
             config.auth_config,
             pool_maxsize=pool_maxsize,
@@ -66,39 +64,46 @@ def rest_error_handling_decorator(func):
             max_retries=max_retries,
         )
 
-        # Define a wrapper for session methods to add logging and error handling
-        def method_wrapper(method_name):
-            original_method = getattr(session, method_name)
+        _wrap_session_methods(session)
 
-            @wraps(original_method)
-            def wrapped_method(*args, **kwargs):
-                logger.debug(
-                    f"Calling {method_name} with args: {args}, kwargs: {kwargs}"
-                )
-                response = original_method(*args, **kwargs)
-                logger.debug(
-                    f"{method_name} response status code: {response.status_code}"
-                )
-
-                try:
-                    response.raise_for_status()
-                except requests.RequestException:
-                    logger.debug(f"response.json() = {response.json()}")
-                    mapped_error = FeastError.from_error_detail(response.json())
-                    logger.debug(f"mapped_error = {str(mapped_error)}")
-                    if mapped_error is not None:
-                        raise mapped_error
-                return response
-
-            return wrapped_method
-
-        # Enhance session methods with logging and error handling
-        session.get = method_wrapper("get")  # type: ignore[method-assign]
-        session.post = method_wrapper("post")  # type: ignore[method-assign]
-        session.put = method_wrapper("put")  # type: ignore[method-assign]
-        session.delete = method_wrapper("delete")  # type: ignore[method-assign]
-
-        # Pass the enhanced session object to the decorated function
         return func(session, config, *args, **kwargs)
 
     return wrapper
+
+
+_ATTR_WRAPPED = "_feast_methods_wrapped"
+
+
+def _wrap_session_methods(session: requests.Session) -> None:
+    """
+    Wrap session HTTP methods with logging and Feast error mapping.
+
+    Wraps each method exactly once. Subsequent calls are no-ops, preventing
+    the unbounded nesting that leads to ``RecursionError`` when a cached
+    session is reused across many requests.
+    """
+    if getattr(session, _ATTR_WRAPPED, False):
+        return
+
+    for method_name in ("get", "post", "put", "delete"):
+        original_method = getattr(session, method_name)
+
+        @wraps(original_method)
+        def wrapped_method(*args, _orig=original_method, _name=method_name, **kwargs):
+            logger.debug(f"Calling {_name} with args: {args}, kwargs: {kwargs}")
+            response = _orig(*args, **kwargs)
+            logger.debug(f"{_name} response status code: {response.status_code}")
+
+            try:
+                response.raise_for_status()
+            except requests.RequestException:
+                logger.debug(f"response.json() = {response.json()}")
+                mapped_error = FeastError.from_error_detail(response.json())
+                logger.debug(f"mapped_error = {str(mapped_error)}")
+                if mapped_error is not None:
+                    raise mapped_error
+            return response
+
+        setattr(session, method_name, wrapped_method)
+
+    object.__setattr__(session, _ATTR_WRAPPED, True)


### PR DESCRIPTION

# What this PR does / why we need it:

The online feature server has per-request overheads that compound to push p99 latency above 10ms:

- The base class `get_online_features_async` issues O(N_feature_views) round trips to Redis instead of batching, making async 5-entity requests 2-3x slower than sync.
- `_check_versioned_read_support` performs up to 7 lazy module imports on every request, adding ~0.5-1ms overhead.
- `_get_features` resolves feature views via threadpool solely to check permissions that are no-ops when auth is no_auth, duplicating work already done inside get_online_features.
- `_generate_redis_keys_for_entities` re-encodes project bytes and goes through an extra function layer per entity.
- `rest_error_handling_decorator` re-wraps cached session methods on every call, causing progressive performance degradation and eventual RecursionError after ~1000 requests.