### PR TITLE
fix(snowflake): Stop double-quoting connection identifiers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1426,7 +1426,7 @@
         "filename": "sdk/python/tests/unit/infra/utils/snowflake/test_snowflake_utils.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 15
       }
     ],
     "sdk/python/tests/unit/local_feast_tests/test_init.py": [

--- a/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
+++ b/sdk/python/feast/infra/utils/snowflake/snowflake_utils.py
@@ -76,10 +76,6 @@ class GetSnowflakeConnection:
 
             kwargs.update((k, v) for k, v in config_dict.items() if v is not None)
 
-            for k, v in kwargs.items():
-                if k in ["role", "warehouse", "database", "schema_"]:
-                    kwargs[k] = f'"{v}"'
-
             kwargs["schema"] = kwargs.pop("schema_")
 
             # https://docs.snowflake.com/en/user-guide/python-connector-example.html#using-key-pair-authentication-key-pair-rotation

--- a/sdk/python/tests/unit/infra/utils/snowflake/test_snowflake_utils.py
+++ b/sdk/python/tests/unit/infra/utils/snowflake/test_snowflake_utils.py
@@ -1,12 +1,13 @@
 import tempfile
 from typing import Optional
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from feast.infra.utils.snowflake.snowflake_utils import (
+    GetSnowflakeConnection,
     execute_snowflake_statement,
     parse_private_key_path,
 )
@@ -73,6 +74,64 @@ def test_parse_private_key_path_key_path_encrypted(encrypted_private_key):
             f.name,
             None,
         )
+
+
+class _AttrDict(dict):
+    __getattr__ = dict.__getitem__
+
+
+def _make_config(**overrides):
+    defaults = {
+        "type": "snowflake.offline",
+        "account": "test_account",
+        "user": "test_user",
+        "password": "test_password",  # pragma: allowlist secret
+        "role": "test_role",
+        "warehouse": "test_wh",
+        "database": "test_db",
+        "schema_": "test_schema",
+        "config_path": "",
+    }
+    defaults.update(overrides)
+    return _AttrDict(defaults)
+
+
+@patch("feast.infra.utils.snowflake.snowflake_utils.snowflake.connector")
+class TestGetSnowflakeConnectionIdentifierQuoting:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        with patch("feast.infra.utils.snowflake.snowflake_utils._cache", {}):
+            yield
+
+    @pytest.mark.parametrize(
+        "config_key,connect_key,value",
+        [
+            ("warehouse", "warehouse", "MY_WH"),
+            ("role", "role", "ANALYST"),
+            ("database", "database", "PROD_DB"),
+            ("schema_", "schema", "PUBLIC"),
+        ],
+    )
+    def test_identifier_passed_without_quoting(
+        self, mock_connector, config_key, connect_key, value
+    ):
+        mock_connector.connect.return_value = MagicMock()
+
+        with GetSnowflakeConnection(_make_config(**{config_key: value})):
+            pass
+
+        kwargs = mock_connector.connect.call_args[1]
+        assert kwargs[connect_key] == value
+
+    def test_schema_key_renamed_from_schema_underscore(self, mock_connector):
+        mock_connector.connect.return_value = MagicMock()
+
+        with GetSnowflakeConnection(_make_config(schema_="analytics")):
+            pass
+
+        kwargs = mock_connector.connect.call_args[1]
+        assert "schema" in kwargs
+        assert "schema_" not in kwargs
 
 
 class TestExecuteSnowflakeStatement:


### PR DESCRIPTION
# What this PR does / why we need it:

`GetSnowflakeConnection` was wrapping `role`, `warehouse`, `database`, and `schema_` in literal double quotes before passing them to `snowflake.connector.connect(...)`:

```python
for k, v in kwargs.items():
    if k in ["role", "warehouse", "database", "schema_"]:
        kwargs[k] = f'"{v}"'
```

That code was based on a misunderstanding of how the connector handles these kwargs. Tracing the connector source confirms they never reach a SQL `USE WAREHOUSE` statement - they go through a different path entirely:

- `snowflake/connector/auth/_auth.py:244-254` packs them into URL query parameters (`databaseName`, `schemaName`, `warehouse`, `roleName`) for the login REST endpoint, via `urlencode(...)`.
- `snowflake/connector/connection.py:1684` stores them verbatim on the connection object.
- `connection.py:1940-1946` reads the server-resolved `finalWarehouseName / finalDatabaseName / ...` back from the login response.

There is no client-side SQL parsing or identifier folding. So feast's `f'"{v}"'` wrapping caused the connector to send a percent-encoded `%22MY_WH%22` to the login endpoint, where the server tried to match a warehouse literally named `"MY_WH"` (with quote characters) and failed. The official [Python connector docs](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api) accordingly show all four parameters as plain unquoted strings.

Removing the wrapping lets the documented contract hold: users put the warehouse/role/database/schema name in their `feature_store.yaml` exactly as Snowflake stores it, and the connector forwards it unmodified.

# Which issue(s) this PR fixes:

Re-fixes the bug originally reported in #2595 ("Snowflake has connection issues") and previously attempted in #2601 ("fix: Remove extra quoting in snowflake python connection"). PR #2601 was closed in 2022 because the author couldn't reproduce after resetting their environment, and the maintainer's defense at the time - that Snowflake uses [quoted-identifier syntax](https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html) - was conflating SQL identifier rules with REST login-parameter handling. The connector source above shows those are entirely separate paths.

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows conventional commits format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change