### PR TITLE
fix: resolve operator namespace dynamically (#5823)

### DIFF
--- a/infra/feast-operator/internal/controller/services/namespace_registry.go
+++ b/infra/feast-operator/internal/controller/services/namespace_registry.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -38,13 +39,7 @@ type NamespaceRegistryData struct {
 
 // deployNamespaceRegistry creates and manages the namespace registry ConfigMap
 func (feast *FeastServices) deployNamespaceRegistry() error {
-	// Check if we can determine the target namespace before creating any resources
-	targetNamespace, err := feast.getNamespaceRegistryNamespace()
-	if err != nil {
-		logger := log.FromContext(feast.Handler.Context)
-		logger.V(1).Info("Skipping namespace registry deployment: unable to determine target namespace", "error", err)
-		return nil // Return nil to avoid failing the entire deployment
-	}
+	targetNamespace := feast.getNamespaceRegistryNamespace()
 
 	logger := log.FromContext(feast.Handler.Context)
 	logger.V(1).Info("Deploying namespace registry", "targetNamespace", targetNamespace)
@@ -209,37 +204,42 @@ func (feast *FeastServices) setNamespaceRegistryRoleBinding(rb *rbacv1.RoleBindi
 }
 
 // getNamespaceRegistryNamespace determines the target namespace for the namespace registry ConfigMap
-func (feast *FeastServices) getNamespaceRegistryNamespace() (string, error) {
-	// Check if we're running on OpenShift
+func (feast *FeastServices) getNamespaceRegistryNamespace() string {
 	logger := log.FromContext(feast.Handler.Context)
-	if isOpenShift {
-		// TODO: Add support for reading DSCi configuration
-		if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
-			if ns := string(data); len(ns) > 0 {
-				logger.V(1).Info("Using OpenShift namespace", "namespace", ns)
-				return ns, nil
-			}
-		}
-		// This is what notebook controller team is doing, we are following them
-		// They are not defaulting to redhat-ods-applications namespace
-		return "", fmt.Errorf("unable to determine the namespace")
+
+	// 1) Explicit override via environment variable (useful in tests or custom setups)
+	if envNs := os.Getenv("FEAST_OPERATOR_NAMESPACE"); envNs != "" {
+		logger.V(1).Info("Using operator namespace from FEAST_OPERATOR_NAMESPACE env var", "namespace", envNs)
+		return envNs
 	}
 
-	return DefaultKubernetesNamespace, nil
+	// 2) Namespace from ServiceAccount token file (standard in Kubernetes/OpenShift)
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); ns != "" {
+			logger.V(1).Info("Using operator namespace from serviceaccount namespace file", "namespace", ns)
+			return ns
+		}
+	}
+
+	// 3) Common Downward API env var, if configured
+	if podNs := os.Getenv("POD_NAMESPACE"); podNs != "" {
+		logger.V(1).Info("Using operator namespace from POD_NAMESPACE env var", "namespace", podNs)
+		return podNs
+	}
+
+	// 4) Fallback for environments without SA mounting (e.g., unit tests)
+	logger.V(1).Info("Falling back to DefaultKubernetesNamespace", "namespace", DefaultKubernetesNamespace)
+	return DefaultKubernetesNamespace
 }
 
 // AddToNamespaceRegistry adds a feature store instance to the namespace registry
 func (feast *FeastServices) AddToNamespaceRegistry() error {
 	logger := log.FromContext(feast.Handler.Context)
-	targetNamespace, err := feast.getNamespaceRegistryNamespace()
-	if err != nil {
-		logger.V(1).Info("Skipping namespace registry addition: unable to determine target namespace", "error", err)
-		return nil // Return nil to avoid failing the entire operation
-	}
+	targetNamespace := feast.getNamespaceRegistryNamespace()
 
 	// Get the existing ConfigMap
 	cm := &corev1.ConfigMap{}
-	err = feast.Handler.Client.Get(feast.Handler.Context, types.NamespacedName{
+	err := feast.Handler.Client.Get(feast.Handler.Context, types.NamespacedName{
 		Name:      NamespaceRegistryConfigMapName,
 		Namespace: targetNamespace,
 	}, cm)
@@ -319,15 +319,11 @@ func (feast *FeastServices) RemoveFromNamespaceRegistry() error {
 	logger := log.FromContext(feast.Handler.Context)
 
 	// Determine the target namespace based on platform
-	targetNamespace, err := feast.getNamespaceRegistryNamespace()
-	if err != nil {
-		logger.V(1).Info("Skipping namespace registry removal: unable to determine target namespace", "error", err)
-		return nil // Return nil to avoid failing the entire operation
-	}
+	targetNamespace := feast.getNamespaceRegistryNamespace()
 
 	// Get the existing ConfigMap
 	cm := &corev1.ConfigMap{}
-	err = feast.Handler.Client.Get(feast.Handler.Context, client.ObjectKey{
+	err := feast.Handler.Client.Get(feast.Handler.Context, client.ObjectKey{
 		Name:      NamespaceRegistryConfigMapName,
 		Namespace: targetNamespace,
 	}, cm)

--- a/infra/feast-operator/internal/controller/services/namespace_registry_test.go
+++ b/infra/feast-operator/internal/controller/services/namespace_registry_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 Feast Community.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"context"
+	"os"
+
+	feastdevv1 "github.com/feast-dev/feast/infra/feast-operator/api/v1"
+	"github.com/feast-dev/feast/infra/feast-operator/internal/controller/handler"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("getNamespaceRegistryNamespace", func() {
+	var feast *FeastServices
+
+	BeforeEach(func() {
+		feast = &FeastServices{
+			Handler: handler.FeastHandler{
+				Context: context.Background(),
+				FeatureStore: &feastdevv1.FeatureStore{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-fs",
+						Namespace: "default",
+					},
+				},
+			},
+		}
+		os.Unsetenv("FEAST_OPERATOR_NAMESPACE")
+		os.Unsetenv("POD_NAMESPACE")
+	})
+
+	AfterEach(func() {
+		os.Unsetenv("FEAST_OPERATOR_NAMESPACE")
+		os.Unsetenv("POD_NAMESPACE")
+	})
+
+	It("should return FEAST_OPERATOR_NAMESPACE when set", func() {
+		os.Setenv("FEAST_OPERATOR_NAMESPACE", "custom-ns")
+		Expect(feast.getNamespaceRegistryNamespace()).To(Equal("custom-ns"))
+	})
+
+	It("should prefer FEAST_OPERATOR_NAMESPACE over POD_NAMESPACE", func() {
+		os.Setenv("FEAST_OPERATOR_NAMESPACE", "feast-ns")
+		os.Setenv("POD_NAMESPACE", "pod-ns")
+		Expect(feast.getNamespaceRegistryNamespace()).To(Equal("feast-ns"))
+	})
+
+	It("should return POD_NAMESPACE when FEAST_OPERATOR_NAMESPACE is not set and SA file is missing", func() {
+		os.Setenv("POD_NAMESPACE", "my-pod-ns")
+		Expect(feast.getNamespaceRegistryNamespace()).To(Equal("my-pod-ns"))
+	})
+
+	It("should fall back to DefaultKubernetesNamespace when no env vars are set and SA file is missing", func() {
+		Expect(feast.getNamespaceRegistryNamespace()).To(Equal(DefaultKubernetesNamespace))
+	})
+
+	It("should ignore empty FEAST_OPERATOR_NAMESPACE", func() {
+		os.Setenv("FEAST_OPERATOR_NAMESPACE", "")
+		os.Setenv("POD_NAMESPACE", "pod-ns")
+		Expect(feast.getNamespaceRegistryNamespace()).To(Equal("pod-ns"))
+	})
+
+	It("should ignore empty POD_NAMESPACE and fall back to default", func() {
+		os.Setenv("POD_NAMESPACE", "")
+		Expect(feast.getNamespaceRegistryNamespace()).To(Equal(DefaultKubernetesNamespace))
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
When the Feast Operator is deployed to a custom namespace (not `feast-operator-system`), it fails to reconcile FeatureStore CRs because [getNamespaceRegistryNamespace()] returned a hardcoded `feast-operator-system` on non-OpenShift clusters.

This PR fixes the namespace resolution logic to dynamically determine the operator's actual namespace using a priority chain:
1. `FEAST_OPERATOR_NAMESPACE` env var (explicit override)
2. ServiceAccount namespace file `/var/run/secrets/kubernetes.io/serviceaccount/namespace` (works on both K8s and OpenShift)
3. `POD_NAMESPACE` env var (Downward API)
4. Fallback to `feast-operator-system` (unit tests only)
 
The `isOpenShift` guard was removed from the SA file check since this file is available on both Kubernetes and OpenShift. The function signature was simplified from `(string, error)` to `string` so it now always returns a usable namespace.



<!--
Outline what you're doing and why.
-->

# Which issue(s) this PR fixes:
Fixes #5823

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
Added 6 unit tests in namespace_registry_test.go covering the env var priority chain and fallback behavior.

P.S.
My first contribution to open-source, sorry if I do something wrong.

<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
