### PR TITLE
docs: Clarify FeatureView TTL behavior

### DIFF
--- a/docs/getting-started/concepts/feature-view.md
+++ b/docs/getting-started/concepts/feature-view.md
@@ -25,7 +25,7 @@ Feature views consist of:
 * (optional, but recommended) metadata (for example, description, or other free-form metadata via `tags`)
 * (optional) `owner`: the email of the primary maintainer
 * (optional) `org`: the organizational unit that owns the feature view (e.g. `"ads"`, `"search"`); useful for grouping feature views by team or product area
-* (optional) a TTL, which limits how far back Feast will look when generating historical datasets
+* (optional) a TTL, which limits how far back Feast will look when generating historical datasets. This does not by itself configure database-level expiration for feature values in online stores.
 * (optional) `enable_validation=True`, which enables schema validation during materialization (see [Schema Validation](#schema-validation) below)
 
 Feature views allow Feast to model your existing feature data in a consistent way in both an offline (training) and online (serving) environment. Feature views generally contain features that are properties of a specific object, in which case that object is defined as an entity and included in the feature view.

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -115,9 +115,10 @@ class FeatureView(BaseFeatureView):
     Attributes:
         name: The unique name of the feature view.
         entities: The list of names of entities that this feature view is associated with.
-        ttl: The amount of time this group of features lives. A ttl of 0 indicates that
-            this group of features lives forever. Note that large ttl's or a ttl of 0
-            can result in extremely computationally intensive queries.
+        ttl: The time window Feast uses when looking back for historical feature
+            values. A ttl of 0 disables this lookback limit. Note that large ttl
+            values or a ttl of 0 can result in extremely computationally
+            intensive queries.
         batch_source: Optional batch source of data where this group of features
             is stored. If no source is provided, this will be None.
         stream_source: The stream source of data where this group of features is stored.
@@ -193,9 +194,10 @@ class FeatureView(BaseFeatureView):
                 and entity columns.
             # TODO: clarify that schema is only useful here...
             entities (optional): The list of entities with which this group of features is associated.
-            ttl (optional): The amount of time this group of features lives. A ttl of 0 indicates that
-                this group of features lives forever. Note that large ttl's or a ttl of 0
-                can result in extremely computationally intensive queries.
+            ttl (optional): The time window Feast uses when looking back for historical
+                feature values. A ttl of 0 disables this lookback limit. Note that
+                large ttl values or a ttl of 0 can result in extremely computationally
+                intensive queries.
             online (optional): A boolean indicating whether online retrieval is enabled for
                 this feature view.
             offline (optional): A boolean indicating whether write to offline store is enabled for


### PR DESCRIPTION
# What this PR does / why we need it:

Clarifies the `FeatureView.ttl` docs so the Python API docstring describes TTL as the historical feature lookup window instead of saying the feature group "lives" for that amount of time.

It also adds a short note to the feature view concept docs that `FeatureView.ttl` does not by itself configure database-level expiration for feature values in online stores.

# Which issue(s) this PR fixes:

Refs #4133

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [x] Testing is not required for this change

Manual check:
- `python -m py_compile sdk/python/feast/feature_view.py`
- `git diff --check`

# Misc

This is intended as a docs-only clarification of current behavior, not a runtime change or a resolution of the broader online-store TTL design discussion in #4133.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->