### PR TITLE
feat: Add retrieve_online_documents_v2 support to Qdrant online store

### DIFF
--- a/docs/reference/alpha-vector-database.md
+++ b/docs/reference/alpha-vector-database.md
@@ -14,8 +14,8 @@ Below are supported vector databases and implemented features:
 | Milvus          | [x]       | [x]      | [x]         | [x]         |
 | Faiss           | [ ]       | [ ]      | []          | []          |
 | SQLite          | [x]       | [ ]      | [x]         | [x]         |
-| Qdrant          | [x]       | [x]      | []          | []          |
 | ScyllaDB        | [x]       | [x]      | [x]         | [x]         |
+| Qdrant          | [x]       | [x]      | [x]         | [x]         |
 
 *Note: V2 Support means the SDK supports retrieval of features along with vector embeddings from vector similarity search.
 
@@ -31,7 +31,7 @@ Beyond that, we will then have `retrieve_online_documents` and `retrieve_online_
 backwards compatibility and the adopt industry standard naming conventions.
 {% endhint %}
 
-**Note**: Milvus, SQLite, and ScyllaDB implement the v2 `retrieve_online_documents_v2` method in the SDK. This will be the longer-term solution so that Data Scientists can easily enable vector similarity search by just flipping a flag.
+**Note**: Milvus, SQLite, PostgreSQL, Elasticsearch, MongoDB, ScyllaDB and Qdrant implement the v2 `retrieve_online_documents_v2` method in the SDK. This will be the longer-term solution so that Data Scientists can easily enable vector similarity search by just flipping a flag.
 
 ## Examples
 

--- a/docs/reference/online-stores/qdrant.md
+++ b/docs/reference/online-stores/qdrant.md
@@ -47,10 +47,67 @@ The full set of configuration options is available in [QdrantOnlineStoreConfig](
 | collocated by feature view                                | yes      |
 | collocated by feature service                             | no       |
 | collocated by entity key                                  | no       |
+| retrieve_online_documents_v2 (vector search)              | yes      |
+| hybrid text search (`query_string`)                       | yes (opt-in) |
 
 To compare this set of functionality against other online stores, please see the full [functionality matrix](overview.md#functionality-matrix).
 
-## Retrieving online document vectors
+## Vector search with retrieve_online_documents_v2
+
+Qdrant stores one point per feature. `retrieve_online_documents_v2` runs dense vector search on the embedding feature, then joins sibling feature points by `entity_key` so the response includes every requested feature in a single `Dict[str, ValueProto]`.
+
+{% code title="python" %}
+
+```python
+from feast import FeatureStore
+
+store = FeatureStore(repo_path="feature_store.yaml")
+
+results = store.retrieve_online_documents_v2(
+    features=["documents:embedding", "documents:text_field"],
+    query=[0.1, 0.2, 0.3],  # embedding vector
+    top_k=5,
+)
+```
+
+{% endcode %}
+
+## Opt-in hybrid search
+
+Hybrid keyword + vector search is **disabled by default**. Enable it in `feature_store.yaml`, recreate the collection (`feast teardown` + `feast apply`), and install `fastembed` so the Qdrant client can encode sparse vectors at upload time (via `models.Document`):
+
+{% code title="feature_store.yaml" %}
+
+```yaml
+online_store:
+    type: qdrant
+    host: localhost
+    port: 6333
+    vector_enabled: true
+    text_search_enabled: true
+    sparse_vector_name: sparse
+    sparse_embedding_model: Qdrant/bm25
+    text_feature: text_field  # optional; defaults to first STRING feature
+```
+
+{% endcode %}
+
+{% code title="python" %}
+
+```python
+results = store.retrieve_online_documents_v2(
+    features=["documents:embedding", "documents:text_field"],
+    query=[0.1, 0.2, 0.3],
+    query_string="searchable keywords",
+    top_k=5,
+)
+```
+
+{% endcode %}
+
+Hybrid queries use Qdrant's Query API with reciprocal rank fusion (RRF) over dense and sparse vectors.
+
+## Retrieving online document vectors (v1)
 
 The Qdrant online store supports retrieving document vectors for a given list of entity keys. The document vectors are returned as a dictionary where the key is the entity key and the value is the document vector. The document vector is a dense vector of floats.
 

--- a/sdk/python/feast/infra/online_stores/qdrant_online_store/qdrant.py
+++ b/sdk/python/feast/infra/online_stores/qdrant_online_store/qdrant.py
@@ -11,6 +11,7 @@ from qdrant_client import QdrantClient, models
 
 from feast import Entity, FeatureView, RepoConfig
 from feast.infra.key_encoding_utils import (
+    deserialize_entity_key,
     get_list_val_str,
     serialize_entity_key,
 )
@@ -19,11 +20,13 @@ from feast.infra.online_stores.vector_store import VectorStoreConfig
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
 from feast.repo_config import FeastConfigBaseModel
+from feast.types import PrimitiveFeastType
 from feast.utils import (
     _build_retrieve_online_document_record,
     _get_feature_view_vector_field_metadata,
     to_naive_utc,
 )
+from feast.value_type import ValueType
 
 SCROLL_SIZE = 1000
 
@@ -33,6 +36,8 @@ DISTANCE_MAPPING = {
     "dot": models.Distance.DOT,
     "l1": models.Distance.MANHATTAN,
 }
+
+logger = logging.getLogger(__name__)
 
 
 class QdrantOnlineStoreConfig(FeastConfigBaseModel, VectorStoreConfig):
@@ -64,6 +69,78 @@ class QdrantOnlineStoreConfig(FeastConfigBaseModel, VectorStoreConfig):
     # If `true`, each request will explicitly wait for the confirmation of completion. Might be slower.
     # If `false`, each reequest will return immediately after receiving an acknowledgement.
     upload_wait: bool = True
+    vector_enabled: Optional[bool] = True
+    # Opt-in hybrid keyword search via Qdrant sparse vectors + RRF fusion.
+    text_search_enabled: Optional[bool] = False
+    sparse_vector_name: str = "sparse"
+    sparse_embedding_model: str = "Qdrant/bm25"
+    # STRING feature to index for sparse/hybrid search. Defaults to the first string feature.
+    text_feature: Optional[str] = None
+
+
+def _dense_vector_using(config: QdrantOnlineStoreConfig) -> Optional[str]:
+    return config.vector_name or None
+
+
+def _entity_key_bytes_from_payload(raw: Any) -> Optional[bytes]:
+    if raw is None:
+        return None
+    if isinstance(raw, bytes):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return base64.b64decode(raw, validate=True)
+        except Exception:
+            return raw.encode("utf-8")
+    return None
+
+
+def _parse_timestamp(raw: Any) -> Optional[datetime]:
+    if raw is None:
+        return None
+    if isinstance(raw, datetime):
+        return raw
+    if isinstance(raw, str):
+        for fmt in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
+            try:
+                return datetime.strptime(raw, fmt)
+            except ValueError:
+                continue
+        raise ValueError(f"Unsupported timestamp format: {raw!r}")
+    return None
+
+
+def _decode_feature_value(encoded_value: Any) -> ValueProto:
+    value_proto = ValueProto()
+    if isinstance(encoded_value, str):
+        value_proto.ParseFromString(base64.b64decode(encoded_value))
+    elif isinstance(encoded_value, bytes):
+        value_proto.ParseFromString(encoded_value)
+    return value_proto
+
+
+def _string_from_value_proto(value: ValueProto) -> Optional[str]:
+    if value.HasField("string_val"):
+        return value.string_val
+    return None
+
+
+def _get_string_feature_names(table: FeatureView) -> List[str]:
+    return [
+        field.name
+        for field in table.features
+        if isinstance(field.dtype, PrimitiveFeastType)
+        and field.dtype.to_value_type() == ValueType.STRING
+    ]
+
+
+def _resolve_text_feature(
+    table: FeatureView, config: QdrantOnlineStoreConfig
+) -> Optional[str]:
+    if config.text_feature:
+        return config.text_feature
+    string_fields = _get_string_feature_names(table)
+    return string_fields[0] if string_fields else None
 
 
 class QdrantOnlineStore(OnlineStore):
@@ -105,12 +182,18 @@ class QdrantOnlineStore(OnlineStore):
         ],
         progress: Optional[Callable[[int], Any]],
     ) -> None:
-        points = []
+        online_store_config = config.online_store
+        assert isinstance(online_store_config, QdrantOnlineStoreConfig)
+
+        text_feature: Optional[str] = None
+        points: List[models.PointStruct] = []
+
         for entity_key, values, timestamp, created_ts in data:
             entity_key_bin = serialize_entity_key(
                 entity_key,
                 entity_key_serialization_version=config.entity_key_serialization_version,
             )
+            entity_key_payload = base64.b64encode(entity_key_bin).decode("ascii")
 
             timestamp = to_naive_utc(timestamp)
             if created_ts is not None:
@@ -120,15 +203,28 @@ class QdrantOnlineStore(OnlineStore):
                     "utf-8"
                 )
                 vector_val = get_list_val_str(value)
+                vector: Dict[str, Any] = {}
                 if vector_val:
-                    vector = {config.online_store.vector_name: json.loads(vector_val)}
-                else:
-                    vector = {}
+                    dense_name = online_store_config.vector_name
+                    vector[dense_name] = json.loads(vector_val)
+                if online_store_config.text_search_enabled:
+                    if text_feature is None:
+                        text_feature = _resolve_text_feature(table, online_store_config)
+                    if text_feature and feature_name == text_feature:
+                        text_content = _string_from_value_proto(value)
+                        if text_content:
+                            vector[online_store_config.sparse_vector_name] = (
+                                models.Document(
+                                    text=text_content,
+                                    model=online_store_config.sparse_embedding_model,
+                                )
+                            )
+
                 points.append(
                     models.PointStruct(
                         id=uuid.uuid4().hex,
                         payload={
-                            "entity_key": entity_key_bin,
+                            "entity_key": entity_key_payload,
                             "feature_name": feature_name,
                             "feature_value": encoded_value,
                             "timestamp": timestamp,
@@ -140,9 +236,9 @@ class QdrantOnlineStore(OnlineStore):
 
         self._get_client(config).upload_points(
             collection_name=table.name,
-            batch_size=config.online_store.write_batch_size,
+            batch_size=online_store_config.write_batch_size or 64,
             points=points,
-            wait=True,
+            wait=online_store_config.upload_wait,
         )
 
     def online_read(
@@ -201,22 +297,33 @@ class QdrantOnlineStore(OnlineStore):
             config: Feast repo configuration object.
             table: FeatureView table for which the index needs to be created.
         """
+        online_store_config = config.online_store
+        assert isinstance(online_store_config, QdrantOnlineStoreConfig)
 
         vector_field_length = getattr(
             _get_feature_view_vector_field_metadata(table), "vector_length", 512
         )
+        similarity = online_store_config.similarity or "cosine"
 
         client: QdrantClient = self._get_client(config)
 
-        client.create_collection(
-            collection_name=table.name,
-            vectors_config={
-                config.online_store.vector_name: models.VectorParams(
+        create_kwargs: Dict[str, Any] = {
+            "collection_name": table.name,
+            "vectors_config": {
+                online_store_config.vector_name: models.VectorParams(
                     size=vector_field_length,
-                    distance=DISTANCE_MAPPING[config.online_store.similarity.lower()],
+                    distance=DISTANCE_MAPPING[similarity.lower()],
                 )
             },
-        )
+        }
+        if online_store_config.text_search_enabled:
+            create_kwargs["sparse_vectors_config"] = {
+                online_store_config.sparse_vector_name: models.SparseVectorParams(
+                    modifier=models.Modifier.IDF
+                )
+            }
+
+        client.create_collection(**create_kwargs)
         client.create_payload_index(
             collection_name=table.name,
             field_name="entity_key",
@@ -255,6 +362,271 @@ class QdrantOnlineStore(OnlineStore):
         except Exception as e:
             logging.exception(f"Error deleting collection in project {project}: {e}")
             raise
+
+    def _vector_field_name(self, table: FeatureView) -> str:
+        vector_metadata = _get_feature_view_vector_field_metadata(table)
+        if vector_metadata is None:
+            raise ValueError(
+                f"Feature view '{table.name}' has no fields with vector_index=True."
+            )
+        return vector_metadata.name
+
+    def _fetch_features_by_entity_keys(
+        self,
+        client: QdrantClient,
+        collection_name: str,
+        entity_keys: List[bytes],
+        requested_features: List[str],
+    ) -> Dict[bytes, Dict[str, ValueProto]]:
+        if not entity_keys or not requested_features:
+            return {}
+
+        features_by_entity: Dict[bytes, Dict[str, ValueProto]] = {}
+        next_offset = None
+        stop_scrolling = False
+        entity_key_filters = [
+            base64.b64encode(entity_key).decode("ascii") for entity_key in entity_keys
+        ]
+        scroll_filter = models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="entity_key",
+                    match=models.MatchAny(any=entity_key_filters),
+                ),
+                models.FieldCondition(
+                    key="feature_name",
+                    match=models.MatchAny(any=requested_features),
+                ),
+            ]
+        )
+        while not stop_scrolling:
+            records, next_offset = client.scroll(
+                collection_name=collection_name,
+                limit=SCROLL_SIZE,
+                offset=next_offset,
+                with_payload=True,
+                scroll_filter=scroll_filter,
+            )
+            stop_scrolling = next_offset is None
+            for point in records:
+                payload = point.payload or {}
+                entity_key_bin = _entity_key_bytes_from_payload(
+                    payload.get("entity_key")
+                )
+                feature_name = payload.get("feature_name")
+                feature_value = payload.get("feature_value")
+                if (
+                    entity_key_bin is None
+                    or not isinstance(feature_name, str)
+                    or feature_value is None
+                ):
+                    continue
+                features_by_entity.setdefault(entity_key_bin, {})[feature_name] = (
+                    _decode_feature_value(feature_value)
+                )
+        return features_by_entity
+
+    def _build_v2_result(
+        self,
+        entity_key_bin: bytes,
+        payload: Dict[str, Any],
+        requested_features: List[str],
+        features_by_entity: Dict[bytes, Dict[str, ValueProto]],
+        distance: Optional[float],
+        text_rank: Optional[float],
+        entity_key_serialization_version: int,
+    ) -> Tuple[
+        Optional[datetime],
+        Optional[EntityKeyProto],
+        Optional[Dict[str, ValueProto]],
+    ]:
+        entity_key_proto = deserialize_entity_key(
+            entity_key_bin,
+            entity_key_serialization_version=entity_key_serialization_version,
+        )
+        timestamp = _parse_timestamp(payload.get("timestamp"))
+        feature_dict = dict(features_by_entity.get(entity_key_bin, {}))
+        for feature_name in requested_features:
+            feature_dict.setdefault(feature_name, ValueProto())
+        if distance is not None:
+            feature_dict["distance"] = ValueProto(float_val=float(distance))
+        if text_rank is not None:
+            feature_dict["text_rank"] = ValueProto(float_val=float(text_rank))
+        return timestamp, entity_key_proto, feature_dict
+
+    def retrieve_online_documents_v2(
+        self,
+        config: RepoConfig,
+        table: FeatureView,
+        requested_features: List[str],
+        embedding: Optional[List[float]],
+        top_k: int,
+        distance_metric: Optional[str] = None,
+        query_string: Optional[str] = None,
+        include_feature_view_version_metadata: bool = False,
+    ) -> List[
+        Tuple[
+            Optional[datetime],
+            Optional[EntityKeyProto],
+            Optional[Dict[str, ValueProto]],
+        ]
+    ]:
+        online_store_config = config.online_store
+        assert isinstance(online_store_config, QdrantOnlineStoreConfig)
+
+        if embedding is None and query_string is None:
+            raise ValueError("Either embedding or query_string must be provided")
+
+        if embedding is not None and not online_store_config.vector_enabled:
+            raise ValueError("Vector search is not enabled in the online store config")
+
+        if query_string is not None and not online_store_config.text_search_enabled:
+            raise ValueError(
+                "Text search requires text_search_enabled: true in the Qdrant "
+                "online store config. Recreate the collection with feast apply after "
+                "enabling it."
+            )
+
+        metric = (distance_metric or online_store_config.similarity or "cosine").lower()
+        if metric not in DISTANCE_MAPPING:
+            raise ValueError(f"Unsupported distance metric: {metric}")
+
+        client = self._get_client(config)
+        collection_name = table.name
+        vector_field_name = self._vector_field_name(table)
+        dense_using = _dense_vector_using(online_store_config)
+        vector_feature_filter = models.Filter(
+            must=[
+                models.FieldCondition(
+                    key="feature_name",
+                    match=models.MatchValue(value=vector_field_name),
+                )
+            ]
+        )
+
+        sparse_score_by_entity: Dict[bytes, float] = {}
+        dense_score_by_entity: Dict[bytes, float] = {}
+        hit_order: List[bytes] = []
+        hit_payload_by_entity: Dict[bytes, Dict[str, Any]] = {}
+
+        if embedding is not None and query_string is not None:
+            prefetches = [
+                models.Prefetch(
+                    query=embedding,
+                    using=dense_using,
+                    filter=vector_feature_filter,
+                    limit=top_k,
+                ),
+                models.Prefetch(
+                    query=models.Document(
+                        text=query_string,
+                        model=online_store_config.sparse_embedding_model,
+                    ),
+                    using=online_store_config.sparse_vector_name,
+                    limit=top_k,
+                ),
+            ]
+            # One Qdrant point per feature: the same entity may appear twice in
+            # fused results (embedding + text_field). Request extra points so we
+            # can dedupe to top_k unique entities.
+            response = client.query_points(
+                collection_name=collection_name,
+                prefetch=prefetches,
+                query=models.FusionQuery(fusion=models.Fusion.RRF),
+                limit=top_k * 2,
+                with_payload=True,
+            )
+            points = response.points
+        elif embedding is not None:
+            response = client.query_points(
+                collection_name=collection_name,
+                query=embedding,
+                query_filter=vector_feature_filter,
+                limit=top_k,
+                with_payload=True,
+                using=dense_using,
+            )
+            points = response.points
+        else:
+            assert query_string is not None
+            response = client.query_points(
+                collection_name=collection_name,
+                query=models.Document(
+                    text=query_string,
+                    model=online_store_config.sparse_embedding_model,
+                ),
+                using=online_store_config.sparse_vector_name,
+                limit=top_k,
+                with_payload=True,
+            )
+            points = response.points
+
+        is_hybrid = embedding is not None and query_string is not None
+        text_feature_name = (
+            _resolve_text_feature(table, online_store_config) if is_hybrid else None
+        )
+
+        for point in points:
+            payload = point.payload or {}
+            entity_key_bin = _entity_key_bytes_from_payload(payload.get("entity_key"))
+            if entity_key_bin is None:
+                continue
+            if entity_key_bin not in hit_order:
+                hit_order.append(entity_key_bin)
+            hit_payload_by_entity.setdefault(entity_key_bin, payload)
+            if point.score is not None:
+                score = float(point.score)
+                feature_name = payload.get("feature_name")
+                if is_hybrid:
+                    if feature_name == vector_field_name:
+                        dense_score_by_entity.setdefault(entity_key_bin, score)
+                    elif feature_name == text_feature_name:
+                        sparse_score_by_entity.setdefault(entity_key_bin, score)
+                else:
+                    if embedding is not None:
+                        dense_score_by_entity.setdefault(entity_key_bin, score)
+                    if query_string is not None:
+                        sparse_score_by_entity.setdefault(entity_key_bin, score)
+
+        hit_order = hit_order[:top_k]
+
+        if not hit_order:
+            return []
+
+        features_by_entity = self._fetch_features_by_entity_keys(
+            client,
+            collection_name,
+            hit_order,
+            requested_features,
+        )
+
+        results: List[
+            Tuple[
+                Optional[datetime],
+                Optional[EntityKeyProto],
+                Optional[Dict[str, ValueProto]],
+            ]
+        ] = []
+        for entity_key_bin in hit_order:
+            payload = hit_payload_by_entity[entity_key_bin]
+            distance = dense_score_by_entity.get(entity_key_bin)
+            text_rank = (
+                sparse_score_by_entity.get(entity_key_bin)
+                if query_string is not None
+                else None
+            )
+            results.append(
+                self._build_v2_result(
+                    entity_key_bin,
+                    payload,
+                    requested_features,
+                    features_by_entity,
+                    distance,
+                    text_rank,
+                    config.entity_key_serialization_version,
+                )
+            )
+        return results
 
     def retrieve_online_documents(
         self,
@@ -299,10 +671,13 @@ class QdrantOnlineStore(OnlineStore):
         )
         for point in points:
             payload = point.payload or {}
-            entity_key = str(payload.get("entity_key"))
+            entity_key_bin = _entity_key_bytes_from_payload(payload.get("entity_key"))
+            if entity_key_bin is None:
+                continue
             feature_value = str(payload.get("feature_value"))
-            timestamp_str = str(payload.get("timestamp"))
-            timestamp = datetime.strptime(timestamp_str, "%Y-%m-%dT%H:%M:%S.%f")
+            timestamp = _parse_timestamp(payload.get("timestamp"))
+            if timestamp is None:
+                continue
             distance = point.score
             vector_value = str(
                 point.vector[config.online_store.vector_name]
@@ -312,7 +687,7 @@ class QdrantOnlineStore(OnlineStore):
 
             result.append(
                 _build_retrieve_online_document_record(
-                    entity_key,
+                    entity_key_bin,
                     base64.b64decode(feature_value),
                     vector_value,
                     distance,

--- a/sdk/python/feast/infra/online_stores/qdrant_online_store/qdrant.py
+++ b/sdk/python/feast/infra/online_stores/qdrant_online_store/qdrant.py
@@ -471,6 +471,44 @@ class QdrantOnlineStore(OnlineStore):
             Optional[Dict[str, ValueProto]],
         ]
     ]:
+        """Retrieve documents from Qdrant with all requested features per entity.
+
+        Qdrant stores one point per feature, so this method searches on the
+        vector (and/or sparse) field and then joins the remaining features via
+        a scroll query keyed on entity_key.
+
+        Three search modes are supported:
+
+        * **Dense only** (``embedding`` provided, no ``query_string``): standard
+          nearest-neighbour search on the named dense vector.
+        * **Sparse / text only** (``query_string`` provided, no ``embedding``):
+          BM25 keyword search on the sparse vector field.
+        * **Hybrid** (both ``embedding`` *and* ``query_string``): two prefetch
+          queries (dense + sparse) fused via Reciprocal Rank Fusion (RRF).
+          The returned ``distance`` value is the **fused RRF rank score**, not a
+          raw cosine similarity or BM25 relevance.  ``text_rank`` is not
+          populated in hybrid mode because individual sub-scores are unavailable
+          after fusion.
+
+        Args:
+            config: Feast repo configuration.
+            table: The FeatureView whose collection to search.
+            requested_features: Feature names to return for each hit entity.
+            embedding: Dense query vector (required unless ``query_string`` given).
+            top_k: Maximum number of unique entities to return.
+            distance_metric: Optional metric name for validation.  The actual
+                metric used is always the one configured on the collection at
+                creation time (``online_store.similarity``).
+            query_string: Text query for sparse / hybrid search (requires
+                ``text_search_enabled: true`` in the online store config).
+            include_feature_view_version_metadata: Reserved for future use.
+
+        Returns:
+            A list of ``(timestamp, entity_key_proto, feature_dict)`` tuples
+            ordered by descending relevance.  ``feature_dict`` includes a
+            ``distance`` entry (float) and, for text-only search, a
+            ``text_rank`` entry.
+        """
         online_store_config = config.online_store
         assert isinstance(online_store_config, QdrantOnlineStoreConfig)
 
@@ -490,6 +528,16 @@ class QdrantOnlineStore(OnlineStore):
         metric = (distance_metric or online_store_config.similarity or "cosine").lower()
         if metric not in DISTANCE_MAPPING:
             raise ValueError(f"Unsupported distance metric: {metric}")
+        configured = (online_store_config.similarity or "cosine").lower()
+        if distance_metric is not None and metric != configured:
+            logger.warning(
+                "distance_metric=%r differs from the collection's configured "
+                "similarity=%r. Qdrant always uses the metric set at collection "
+                "creation time; the distance_metric parameter has no effect on "
+                "the query.",
+                distance_metric,
+                configured,
+            )
 
         client = self._get_client(config)
         collection_name = table.name
@@ -506,6 +554,7 @@ class QdrantOnlineStore(OnlineStore):
 
         sparse_score_by_entity: Dict[bytes, float] = {}
         dense_score_by_entity: Dict[bytes, float] = {}
+        fused_score_by_entity: Dict[bytes, float] = {}
         hit_order: List[bytes] = []
         hit_payload_by_entity: Dict[bytes, Dict[str, Any]] = {}
 
@@ -526,9 +575,12 @@ class QdrantOnlineStore(OnlineStore):
                     limit=top_k,
                 ),
             ]
-            # One Qdrant point per feature: the same entity may appear twice in
-            # fused results (embedding + text_field). Request extra points so we
-            # can dedupe to top_k unique entities.
+            # Qdrant stores one point per feature. In RRF fusion the same
+            # entity can appear twice — once from the embedding point and once
+            # from the text_field point. We request top_k * 2 points so that
+            # after deduplication we still have up to top_k unique entities.
+            # This factor assumes exactly 2 point types participate in fusion
+            # (the dense embedding and the sparse text_field).
             response = client.query_points(
                 collection_name=collection_name,
                 prefetch=prefetches,
@@ -562,9 +614,6 @@ class QdrantOnlineStore(OnlineStore):
             points = response.points
 
         is_hybrid = embedding is not None and query_string is not None
-        text_feature_name = (
-            _resolve_text_feature(table, online_store_config) if is_hybrid else None
-        )
 
         for point in points:
             payload = point.payload or {}
@@ -576,12 +625,11 @@ class QdrantOnlineStore(OnlineStore):
             hit_payload_by_entity.setdefault(entity_key_bin, payload)
             if point.score is not None:
                 score = float(point.score)
-                feature_name = payload.get("feature_name")
                 if is_hybrid:
-                    if feature_name == vector_field_name:
-                        dense_score_by_entity.setdefault(entity_key_bin, score)
-                    elif feature_name == text_feature_name:
-                        sparse_score_by_entity.setdefault(entity_key_bin, score)
+                    # RRF fusion produces a single fused rank score per point,
+                    # not the original cosine/BM25 sub-scores. Keep the first
+                    # (highest) fused score per entity.
+                    fused_score_by_entity.setdefault(entity_key_bin, score)
                 else:
                     if embedding is not None:
                         dense_score_by_entity.setdefault(entity_key_bin, score)
@@ -609,12 +657,16 @@ class QdrantOnlineStore(OnlineStore):
         ] = []
         for entity_key_bin in hit_order:
             payload = hit_payload_by_entity[entity_key_bin]
-            distance = dense_score_by_entity.get(entity_key_bin)
-            text_rank = (
-                sparse_score_by_entity.get(entity_key_bin)
-                if query_string is not None
-                else None
-            )
+            if is_hybrid:
+                distance = fused_score_by_entity.get(entity_key_bin)
+                text_rank = None
+            else:
+                distance = dense_score_by_entity.get(entity_key_bin)
+                text_rank = (
+                    sparse_score_by_entity.get(entity_key_bin)
+                    if query_string is not None
+                    else None
+                )
             results.append(
                 self._build_v2_result(
                     entity_key_bin,

--- a/sdk/python/tests/integration/online_store/manual_qdrant_v2.py
+++ b/sdk/python/tests/integration/online_store/manual_qdrant_v2.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Manual smoke test for Qdrant retrieve_online_documents_v2.
+
+Run from repo root:
+  uv run python sdk/python/tests/integration/online_store/manual_qdrant_v2.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+try:
+    import qdrant_client  # noqa: F401
+except ImportError:
+    print("Install qdrant: pip install 'feast[qdrant]'")
+    sys.exit(1)
+
+from feast import Entity, FeatureStore, FeatureView, Field, FileSource
+from feast.types import Array, Float32, Int64, String
+from feast.value_type import ValueType
+
+
+def main() -> None:
+    repo_dir = Path(tempfile.mkdtemp(prefix="feast_qdrant_manual_"))
+    print(f"Repo dir: {repo_dir}")
+
+    vector_dim = 3
+    n_rows = 5
+    rng = np.random.default_rng(0)
+
+    parquet_path = repo_dir / "docs.parquet"
+    df = pd.DataFrame(
+        {
+            "doc_id": list(range(n_rows)),
+            "embedding": [rng.random(vector_dim).tolist() for _ in range(n_rows)],
+            "text_field": [f"manual test document {i}" for i in range(n_rows)],
+            "event_timestamp": [datetime.now(UTC) for _ in range(n_rows)],
+        }
+    )
+    df.to_parquet(parquet_path)
+
+    (repo_dir / "feature_store.yaml").write_text(
+        f"""
+project: manual_qdrant
+registry: {repo_dir / "registry.db"}
+provider: local
+entity_key_serialization_version: 3
+online_store:
+  type: qdrant
+  path: {repo_dir / "qdrant_data"}
+  similarity: cosine
+  vector_enabled: true
+  text_search_enabled: false
+""".strip()
+        + "\n"
+    )
+
+    try:
+        item = Entity(name="doc_id", join_keys=["doc_id"], value_type=ValueType.INT64)
+        fv = FeatureView(
+            name="documents",
+            entities=[item],
+            schema=[
+                Field(
+                    name="embedding",
+                    dtype=Array(Float32),
+                    vector_index=True,
+                    vector_length=vector_dim,
+                ),
+                Field(name="text_field", dtype=String),
+                Field(name="doc_id", dtype=Int64),
+            ],
+            source=FileSource(
+                path=str(parquet_path), timestamp_field="event_timestamp"
+            ),
+        )
+
+        store = FeatureStore(repo_path=str(repo_dir))
+        print("Applying feature view...")
+        store.apply([item, fv])
+
+        print("Writing to online store...")
+        store.write_to_online_store("documents", df)
+
+        query = rng.random(vector_dim).tolist()
+        print(f"Query embedding: {[round(x, 4) for x in query]}")
+
+        print("retrieve_online_documents_v2 (top_k=3)...")
+        response = store.retrieve_online_documents_v2(
+            features=[
+                "documents:embedding",
+                "documents:text_field",
+                "documents:doc_id",
+            ],
+            query=query,
+            top_k=3,
+            distance_metric="cosine",
+        )
+        result = response.to_dict()
+
+        print("\n--- Results ---")
+        for i in range(len(result["doc_id"])):
+            print(
+                f"  [{i}] doc_id={result['doc_id'][i]} "
+                f"distance={result['distance'][i]:.4f} "
+                f"text={result['text_field'][i]!r}"
+            )
+
+        assert len(result["doc_id"]) == 3
+        assert all(isinstance(x, str) for x in result["text_field"])
+        print("\nManual Qdrant v2 smoke test PASSED")
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+        print(f"Cleaned up {repo_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/tests/integration/online_store/test_qdrant_retrieve_online_documents_v2.py
+++ b/sdk/python/tests/integration/online_store/test_qdrant_retrieve_online_documents_v2.py
@@ -1,0 +1,166 @@
+"""Integration tests for Qdrant retrieve_online_documents_v2 (local path store)."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("qdrant_client")
+
+from feast import Entity, FeatureStore, FeatureView, Field, FileSource
+from feast.types import Array, Float32, Int64, String
+from feast.value_type import ValueType
+
+
+@pytest.mark.integration
+def test_qdrant_retrieve_online_documents_v2_dense() -> None:
+    """End-to-end: materialize to Qdrant and run dense v2 retrieval."""
+    repo_dir = Path(tempfile.mkdtemp(prefix="feast_qdrant_v2_"))
+    qdrant_path = repo_dir / "qdrant_data"
+    parquet_path = repo_dir / "docs.parquet"
+    registry_path = repo_dir / "registry.db"
+
+    vector_dim = 3
+    n_rows = 10
+    rng = np.random.default_rng(42)
+
+    df = pd.DataFrame(
+        {
+            "doc_id": list(range(n_rows)),
+            "embedding": [rng.random(vector_dim).tolist() for _ in range(n_rows)],
+            "text_field": [f"document {i} feast qdrant test" for i in range(n_rows)],
+            "category": [f"cat-{i % 3}" for i in range(n_rows)],
+            "event_timestamp": [datetime.now(UTC) for _ in range(n_rows)],
+        }
+    )
+    df.to_parquet(parquet_path)
+
+    feature_store_yaml = f"""
+project: qdrant_v2_test
+registry: {registry_path}
+provider: local
+entity_key_serialization_version: 3
+online_store:
+  type: qdrant
+  path: {qdrant_path}
+  similarity: cosine
+  vector_enabled: true
+  text_search_enabled: false
+"""
+    (repo_dir / "feature_store.yaml").write_text(feature_store_yaml.strip() + "\n")
+
+    try:
+        item = Entity(name="doc_id", join_keys=["doc_id"], value_type=ValueType.INT64)
+        documents_fv = FeatureView(
+            name="documents",
+            entities=[item],
+            schema=[
+                Field(
+                    name="embedding",
+                    dtype=Array(Float32),
+                    vector_index=True,
+                    vector_length=vector_dim,
+                ),
+                Field(name="text_field", dtype=String),
+                Field(name="category", dtype=String),
+                Field(name="doc_id", dtype=Int64),
+            ],
+            source=FileSource(
+                path=str(parquet_path),
+                timestamp_field="event_timestamp",
+            ),
+        )
+
+        store = FeatureStore(repo_path=str(repo_dir))
+        store.apply([item, documents_fv])
+        store.write_to_online_store("documents", df)
+
+        query_embedding = rng.random(vector_dim).tolist()
+        response = store.retrieve_online_documents_v2(
+            features=[
+                "documents:embedding",
+                "documents:text_field",
+                "documents:category",
+                "documents:doc_id",
+            ],
+            query=query_embedding,
+            top_k=3,
+            distance_metric="cosine",
+        )
+        result = response.to_dict()
+
+        assert len(result["embedding"]) == 3
+        assert len(result["distance"]) == 3
+        assert len(result["text_field"]) == 3
+        assert len(result["category"]) == 3
+        assert len(result["doc_id"]) == 3
+        assert all(isinstance(d, float) for d in result["distance"])
+        assert all(
+            isinstance(t, str) and t.startswith("document")
+            for t in result["text_field"]
+        )
+        assert all(
+            isinstance(c, str) and c.startswith("cat-") for c in result["category"]
+        )
+        assert all(isinstance(i, int) for i in result["doc_id"])
+        assert all(
+            isinstance(e, list) and len(e) == vector_dim for e in result["embedding"]
+        )
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+@pytest.mark.integration
+def test_qdrant_retrieve_online_documents_v2_query_string_requires_flag() -> None:
+    """query_string without text_search_enabled should fail clearly."""
+    repo_dir = Path(tempfile.mkdtemp(prefix="feast_qdrant_v2_flag_"))
+    qdrant_path = repo_dir / "qdrant_data"
+    registry_path = repo_dir / "registry.db"
+
+    feature_store_yaml = f"""
+project: qdrant_v2_flag_test
+registry: {registry_path}
+provider: local
+entity_key_serialization_version: 3
+online_store:
+  type: qdrant
+  path: {qdrant_path}
+  similarity: cosine
+  vector_enabled: true
+  text_search_enabled: false
+"""
+    (repo_dir / "feature_store.yaml").write_text(feature_store_yaml.strip() + "\n")
+
+    try:
+        item = Entity(name="doc_id", join_keys=["doc_id"], value_type=ValueType.INT64)
+        documents_fv = FeatureView(
+            name="documents",
+            entities=[item],
+            schema=[
+                Field(
+                    name="embedding",
+                    dtype=Array(Float32),
+                    vector_index=True,
+                    vector_length=3,
+                ),
+                Field(name="text_field", dtype=String),
+            ],
+            source=FileSource(path="dummy.parquet", timestamp_field="event_timestamp"),
+        )
+        store = FeatureStore(repo_path=str(repo_dir))
+        store.apply([item, documents_fv])
+
+        with pytest.raises(ValueError, match="text_search_enabled"):
+            store.retrieve_online_documents_v2(
+                features=["documents:text_field"],
+                query_string="feast",
+                top_k=1,
+            )
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)

--- a/sdk/python/tests/integration/online_store/test_qdrant_retrieve_online_documents_v2.py
+++ b/sdk/python/tests/integration/online_store/test_qdrant_retrieve_online_documents_v2.py
@@ -117,6 +117,98 @@ online_store:
 
 
 @pytest.mark.integration
+def test_qdrant_retrieve_online_documents_v2_hybrid() -> None:
+    """End-to-end: materialize to Qdrant and run hybrid (dense + sparse) retrieval."""
+    pytest.importorskip("fastembed")
+
+    repo_dir = Path(tempfile.mkdtemp(prefix="feast_qdrant_v2_hybrid_"))
+    qdrant_path = repo_dir / "qdrant_data"
+    parquet_path = repo_dir / "docs.parquet"
+    registry_path = repo_dir / "registry.db"
+
+    vector_dim = 3
+    n_rows = 10
+    rng = np.random.default_rng(42)
+
+    df = pd.DataFrame(
+        {
+            "doc_id": list(range(n_rows)),
+            "embedding": [rng.random(vector_dim).tolist() for _ in range(n_rows)],
+            "text_field": [
+                f"document {i} feast qdrant hybrid test" for i in range(n_rows)
+            ],
+            "category": [f"cat-{i % 3}" for i in range(n_rows)],
+            "event_timestamp": [datetime.now(UTC) for _ in range(n_rows)],
+        }
+    )
+    df.to_parquet(parquet_path)
+
+    feature_store_yaml = f"""
+project: qdrant_v2_hybrid_test
+registry: {registry_path}
+provider: local
+entity_key_serialization_version: 3
+online_store:
+  type: qdrant
+  path: {qdrant_path}
+  similarity: cosine
+  vector_enabled: true
+  text_search_enabled: true
+  sparse_embedding_model: "Qdrant/bm25"
+"""
+    (repo_dir / "feature_store.yaml").write_text(feature_store_yaml.strip() + "\n")
+
+    try:
+        item = Entity(name="doc_id", join_keys=["doc_id"], value_type=ValueType.INT64)
+        documents_fv = FeatureView(
+            name="documents",
+            entities=[item],
+            schema=[
+                Field(
+                    name="embedding",
+                    dtype=Array(Float32),
+                    vector_index=True,
+                    vector_length=vector_dim,
+                ),
+                Field(name="text_field", dtype=String),
+                Field(name="category", dtype=String),
+                Field(name="doc_id", dtype=Int64),
+            ],
+            source=FileSource(
+                path=str(parquet_path),
+                timestamp_field="event_timestamp",
+            ),
+        )
+
+        store = FeatureStore(repo_path=str(repo_dir))
+        store.apply([item, documents_fv])
+        store.write_to_online_store("documents", df)
+
+        query_embedding = rng.random(vector_dim).tolist()
+        response = store.retrieve_online_documents_v2(
+            features=[
+                "documents:embedding",
+                "documents:text_field",
+                "documents:category",
+                "documents:doc_id",
+            ],
+            query=query_embedding,
+            query_string="feast hybrid",
+            top_k=3,
+        )
+        result = response.to_dict()
+
+        assert len(result["embedding"]) == 3
+        assert len(result["distance"]) == 3
+        assert all(isinstance(d, float) for d in result["distance"])
+        assert len(result["text_field"]) == 3
+        assert len(result["category"]) == 3
+        assert len(result["doc_id"]) == 3
+    finally:
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+
+@pytest.mark.integration
 def test_qdrant_retrieve_online_documents_v2_query_string_requires_flag() -> None:
     """query_string without text_search_enabled should fail clearly."""
     repo_dir = Path(tempfile.mkdtemp(prefix="feast_qdrant_v2_flag_"))

--- a/sdk/python/tests/unit/infra/online_store/test_qdrant_online_retrieval.py
+++ b/sdk/python/tests/unit/infra/online_store/test_qdrant_online_retrieval.py
@@ -329,8 +329,10 @@ def test_retrieve_online_documents_v2_hybrid_dedupes_entities_and_keeps_best_sco
     assert entity_b.entity_values[0].int64_val == 2
     assert features_a is not None
     assert features_b is not None
+    # In hybrid mode, distance holds the fused RRF score (first/best per entity).
+    # text_rank is not populated because RRF doesn't preserve individual sub-scores.
     assert features_a["distance"].float_val == pytest.approx(0.9)
-    assert features_a["text_rank"].float_val == pytest.approx(0.7)
+    assert "text_rank" not in features_a
     assert features_b["distance"].float_val == pytest.approx(0.8)
 
 

--- a/sdk/python/tests/unit/infra/online_store/test_qdrant_online_retrieval.py
+++ b/sdk/python/tests/unit/infra/online_store/test_qdrant_online_retrieval.py
@@ -1,0 +1,401 @@
+"""Unit tests for Qdrant retrieve_online_documents_v2."""
+
+# ruff: noqa: E402
+
+import base64
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("qdrant_client")
+
+from feast import Entity, FeatureView, Field, FileSource, RepoConfig  # noqa: E402
+from feast.infra.key_encoding_utils import serialize_entity_key
+from feast.infra.online_stores.qdrant_online_store.qdrant import (  # noqa: E402
+    QdrantOnlineStore,
+    QdrantOnlineStoreConfig,
+    _decode_feature_value,
+    _entity_key_bytes_from_payload,
+    _parse_timestamp,
+)
+from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+from feast.protos.feast.types.Value_pb2 import FloatList as FloatListProto
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+from feast.types import Array, Float32, Int64, String
+from feast.value_type import ValueType
+
+
+def _make_repo_config(**kwargs) -> RepoConfig:
+    online_store = QdrantOnlineStoreConfig(
+        host="localhost",
+        port=6333,
+        similarity="cosine",
+        **kwargs,
+    )
+    return RepoConfig(
+        project="test_project",
+        registry="data/registry.db",
+        provider="local",
+        online_store=online_store,
+        entity_key_serialization_version=3,
+    )
+
+
+def _make_document_fv() -> FeatureView:
+    item = Entity(name="item_id", join_keys=["item_id"], value_type=ValueType.INT64)
+    return FeatureView(
+        name="documents",
+        entities=[item],
+        schema=[
+            Field(name="embedding", dtype=Array(Float32), vector_index=True),
+            Field(name="text_field", dtype=String),
+            Field(name="item_id", dtype=Int64),
+        ],
+        source=FileSource(path="fake.parquet", timestamp_field="event_timestamp"),
+    )
+
+
+def _entity_key(item_id: int = 1) -> EntityKeyProto:
+    return EntityKeyProto(
+        join_keys=["item_id"],
+        entity_values=[ValueProto(int64_val=item_id)],
+    )
+
+
+def test_entity_key_bytes_from_payload_handles_bytes_and_base64():
+    raw = b"\x01\x02\x03"
+    assert _entity_key_bytes_from_payload(raw) == raw
+    encoded = base64.b64encode(raw).decode("utf-8")
+    assert _entity_key_bytes_from_payload(encoded) == raw
+
+
+def test_decode_feature_value_round_trip():
+    original = ValueProto(string_val="hello")
+    encoded = base64.b64encode(original.SerializeToString()).decode("utf-8")
+    decoded = _decode_feature_value(encoded)
+    assert decoded.string_val == "hello"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("2024-01-01T12:00:00.000000", datetime(2024, 1, 1, 12, 0, 0)),
+        ("2024-01-01T12:00:00", datetime(2024, 1, 1, 12, 0, 0)),
+        (datetime(2024, 6, 1, 8, 30, 15), datetime(2024, 6, 1, 8, 30, 15)),
+    ],
+)
+def test_parse_timestamp_handles_fractional_and_whole_seconds(raw, expected):
+    assert _parse_timestamp(raw) == expected
+
+
+def test_parse_timestamp_returns_none_for_missing_value():
+    assert _parse_timestamp(None) is None
+
+
+def test_build_v2_result_includes_requested_features_and_distance():
+    entity_key = _entity_key(7)
+    entity_key_bin = serialize_entity_key(
+        entity_key, entity_key_serialization_version=3
+    )
+    title_proto = ValueProto(string_val="doc title")
+    features_by_entity = {entity_key_bin: {"text_field": title_proto}}
+    payload = {"timestamp": datetime(2024, 1, 1, 12, 0, 0)}
+
+    ts, entity_proto, feature_dict = QdrantOnlineStore()._build_v2_result(
+        entity_key_bin,
+        payload,
+        requested_features=["text_field", "embedding"],
+        features_by_entity=features_by_entity,
+        distance=0.91,
+        text_rank=None,
+        entity_key_serialization_version=3,
+    )
+
+    assert ts == payload["timestamp"]
+    assert entity_proto is not None
+    assert entity_proto.entity_values[0].int64_val == 7
+    assert feature_dict is not None
+    assert feature_dict["text_field"].string_val == "doc title"
+    assert feature_dict["embedding"] == ValueProto()
+    assert feature_dict["distance"].float_val == pytest.approx(0.91)
+
+
+def test_retrieve_online_documents_v1_decodes_base64_entity_key():
+    config = _make_repo_config()
+    table = _make_document_fv()
+    store = QdrantOnlineStore()
+    entity_key = _entity_key(42)
+    entity_key_bin = serialize_entity_key(
+        entity_key, entity_key_serialization_version=3
+    )
+
+    text_proto = ValueProto(string_val="doc body")
+    encoded_text = base64.b64encode(text_proto.SerializeToString()).decode("utf-8")
+    hit_point = MagicMock()
+    hit_point.payload = {
+        "entity_key": base64.b64encode(entity_key_bin).decode("ascii"),
+        "feature_value": encoded_text,
+        "timestamp": "2024-01-01T12:00:00",
+    }
+    hit_point.score = 0.95
+    hit_point.vector = {"": [0.1, 0.2, 0.3]}
+
+    mock_client = MagicMock()
+    mock_client.query_points.return_value = MagicMock(points=[hit_point])
+
+    with patch.object(store, "_get_client", return_value=mock_client):
+        results = store.retrieve_online_documents(
+            config=config,
+            table=table,
+            requested_features=["text_field"],
+            embedding=[0.1, 0.2, 0.3],
+            top_k=1,
+        )
+
+    assert len(results) == 1
+    ts, entity_proto, feature_proto, vector_proto, distance_proto = results[0]
+    assert entity_proto is not None
+    assert entity_proto.entity_values[0].int64_val == 42
+    assert feature_proto is not None
+    assert feature_proto.string_val == "doc body"
+    assert distance_proto is not None
+    assert distance_proto.float_val == pytest.approx(0.95)
+    assert ts == datetime(2024, 1, 1, 12, 0, 0)
+
+
+def test_retrieve_online_documents_v2_dense_search_joins_features():
+    config = _make_repo_config()
+    table = _make_document_fv()
+    store = QdrantOnlineStore()
+    entity_key = _entity_key(1)
+    entity_key_bin = serialize_entity_key(
+        entity_key, entity_key_serialization_version=3
+    )
+
+    import base64
+
+    text_proto = ValueProto(string_val="hello world")
+    encoded_text = base64.b64encode(text_proto.SerializeToString()).decode("utf-8")
+    hit_payload = {
+        "entity_key": base64.b64encode(entity_key_bin).decode("ascii"),
+        "feature_name": "embedding",
+        "feature_value": encoded_text,
+        "timestamp": "2024-01-01T12:00:00.000000",
+    }
+    hit_point = MagicMock()
+    hit_point.payload = hit_payload
+    hit_point.score = 0.88
+
+    scroll_point = MagicMock()
+    scroll_point.payload = {
+        "entity_key": base64.b64encode(entity_key_bin).decode("ascii"),
+        "feature_name": "text_field",
+        "feature_value": encoded_text,
+    }
+
+    mock_client = MagicMock()
+    mock_client.query_points.return_value = MagicMock(points=[hit_point])
+    mock_client.scroll.return_value = ([scroll_point], None)
+
+    with patch.object(store, "_get_client", return_value=mock_client):
+        results = store.retrieve_online_documents_v2(
+            config=config,
+            table=table,
+            requested_features=["text_field", "embedding"],
+            embedding=[0.1, 0.2, 0.3],
+            top_k=1,
+        )
+
+    assert len(results) == 1
+    ts, entity_proto, feature_dict = results[0]
+    assert entity_proto is not None
+    assert feature_dict is not None
+    assert feature_dict["text_field"].string_val == "hello world"
+    assert feature_dict["distance"].float_val == pytest.approx(0.88)
+    assert ts == datetime(2024, 1, 1, 12, 0, 0)
+
+    query_kwargs = mock_client.query_points.call_args.kwargs
+    assert query_kwargs["limit"] == 1
+    assert query_kwargs["query"] == [0.1, 0.2, 0.3]
+
+
+def test_retrieve_online_documents_v2_requires_text_search_for_query_string():
+    config = _make_repo_config(text_search_enabled=False)
+    table = _make_document_fv()
+    store = QdrantOnlineStore()
+
+    with pytest.raises(ValueError, match="text_search_enabled"):
+        store.retrieve_online_documents_v2(
+            config=config,
+            table=table,
+            requested_features=["text_field"],
+            embedding=None,
+            top_k=1,
+            query_string="hello",
+        )
+
+
+def test_retrieve_online_documents_v2_hybrid_uses_rrf_prefetch():
+    config = _make_repo_config(text_search_enabled=True)
+    table = _make_document_fv()
+    store = QdrantOnlineStore()
+    entity_key_bin = serialize_entity_key(
+        _entity_key(2), entity_key_serialization_version=3
+    )
+
+    hit_point = MagicMock()
+    hit_point.payload = {
+        "entity_key": base64.b64encode(entity_key_bin).decode("ascii"),
+        "feature_name": "embedding",
+        "feature_value": "",
+        "timestamp": "2024-01-01T12:00:00.000000",
+    }
+    hit_point.score = 0.75
+
+    mock_client = MagicMock()
+    mock_client.query_points.return_value = MagicMock(points=[hit_point])
+    mock_client.scroll.return_value = ([], None)
+
+    with patch.object(store, "_get_client", return_value=mock_client):
+        store.retrieve_online_documents_v2(
+            config=config,
+            table=table,
+            requested_features=["text_field"],
+            embedding=[0.1, 0.2, 0.3],
+            top_k=2,
+            query_string="hello",
+        )
+
+    from qdrant_client import models
+
+    query_kwargs = mock_client.query_points.call_args.kwargs
+    assert len(query_kwargs["prefetch"]) == 2
+    assert isinstance(query_kwargs["query"], models.FusionQuery)
+    assert query_kwargs["limit"] == 4
+
+
+def test_retrieve_online_documents_v2_hybrid_dedupes_entities_and_keeps_best_scores():
+    config = _make_repo_config(text_search_enabled=True)
+    table = _make_document_fv()
+    store = QdrantOnlineStore()
+    entity_key_a = serialize_entity_key(
+        _entity_key(1), entity_key_serialization_version=3
+    )
+    entity_key_b = serialize_entity_key(
+        _entity_key(2), entity_key_serialization_version=3
+    )
+
+    def _hit_point(entity_key_bin: bytes, feature_name: str, score: float):
+        point = MagicMock()
+        point.payload = {
+            "entity_key": base64.b64encode(entity_key_bin).decode("ascii"),
+            "feature_name": feature_name,
+            "feature_value": "",
+            "timestamp": "2024-01-01T12:00:00.000000",
+        }
+        point.score = score
+        return point
+
+    # Entity A appears twice (embedding then text_field with lower score).
+    # Entity B appears once. With limit=top_k only one unique entity might
+    # survive; with dedup + truncate we expect both up to top_k=2.
+    points = [
+        _hit_point(entity_key_a, "embedding", 0.9),
+        _hit_point(entity_key_a, "text_field", 0.7),
+        _hit_point(entity_key_b, "embedding", 0.8),
+    ]
+
+    mock_client = MagicMock()
+    mock_client.query_points.return_value = MagicMock(points=points)
+    mock_client.scroll.return_value = ([], None)
+
+    with patch.object(store, "_get_client", return_value=mock_client):
+        results = store.retrieve_online_documents_v2(
+            config=config,
+            table=table,
+            requested_features=["text_field"],
+            embedding=[0.1, 0.2, 0.3],
+            top_k=2,
+            query_string="hello",
+        )
+
+    assert len(results) == 2
+    _, entity_a, features_a = results[0]
+    _, entity_b, features_b = results[1]
+    assert entity_a is not None
+    assert entity_b is not None
+    assert entity_a.entity_values[0].int64_val == 1
+    assert entity_b.entity_values[0].int64_val == 2
+    assert features_a is not None
+    assert features_b is not None
+    assert features_a["distance"].float_val == pytest.approx(0.9)
+    assert features_a["text_rank"].float_val == pytest.approx(0.7)
+    assert features_b["distance"].float_val == pytest.approx(0.8)
+
+
+def test_online_write_batch_uses_document_for_sparse_vectors():
+    from qdrant_client import models
+
+    config = _make_repo_config(text_search_enabled=True)
+    table = _make_document_fv()
+    store = QdrantOnlineStore()
+    entity_key = _entity_key(1)
+    text_proto = ValueProto(string_val="hello world")
+    embedding_proto = ValueProto(float_list_val=FloatListProto(val=[0.1, 0.2, 0.3]))
+
+    mock_client = MagicMock()
+    with patch.object(store, "_get_client", return_value=mock_client):
+        store.online_write_batch(
+            config=config,
+            table=table,
+            data=[
+                (
+                    entity_key,
+                    {
+                        "text_field": text_proto,
+                        "embedding": embedding_proto,
+                    },
+                    datetime(2024, 1, 1, 12, 0, 0),
+                    None,
+                )
+            ],
+            progress=None,
+        )
+
+    points = mock_client.upload_points.call_args.kwargs["points"]
+    text_point = next(p for p in points if p.payload["feature_name"] == "text_field")
+    sparse_vector = text_point.vector["sparse"]
+    assert isinstance(sparse_vector, models.Document)
+    assert sparse_vector.text == "hello world"
+    assert sparse_vector.model == "Qdrant/bm25"
+
+
+def test_fetch_features_by_entity_keys_groups_points():
+    store = QdrantOnlineStore()
+    entity_key_bin = serialize_entity_key(
+        _entity_key(3), entity_key_serialization_version=3
+    )
+    import base64
+
+    text_proto = ValueProto(string_val="chunk")
+    encoded = base64.b64encode(text_proto.SerializeToString()).decode("utf-8")
+
+    point = MagicMock()
+    point.payload = {
+        "entity_key": base64.b64encode(entity_key_bin).decode("ascii"),
+        "feature_name": "text_field",
+        "feature_value": encoded,
+    }
+    mock_client = MagicMock()
+    mock_client.scroll.return_value = ([point], None)
+
+    features = store._fetch_features_by_entity_keys(
+        mock_client,
+        "documents",
+        [entity_key_bin],
+        ["text_field"],
+    )
+
+    assert entity_key_bin in features
+    assert features[entity_key_bin]["text_field"].string_val == "chunk"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing and why.
-->

This PR adds retrieve_online_documents_v2 for the Qdrant online store so vector search returns all requested features per document, not just the embedding hit. It implements dense embedding search (with a join across Qdrant’s one-point-per-feature layout), plus optional hybrid search when text_search_enabled: true. v1 is unchanged; hybrid is off by default so existing setups don’t need migration. Files touched: qdrant.py, qdrant.md, alpha-vector-database.md, test_qdrant_online_retrieval.py, test_qdrant_retrieve_online_documents_v2.py, and manual_qdrant_v2.py.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
[#6445](https://github.com/feast-dev/feast/issues/6445)

# Checks
- [ ] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [ ] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [x] Integration tests
- [x] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/feast-dev/feast/pull/6484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->