### PR TITLE
feat: Enhance DataSource and FeatureView modals with error handling a…

### DIFF
--- a/ui/src/components/DataSourceFormModal.tsx
+++ b/ui/src/components/DataSourceFormModal.tsx
@@ -6,6 +6,7 @@ import {
   EuiSpacer,
   EuiHorizontalRule,
   EuiText,
+  EuiCallOut,
 } from "@elastic/eui";
 import { feast } from "../protos";
 import FormModal from "./forms/FormModal";
@@ -75,6 +76,8 @@ interface DataSourceFormModalProps {
   onSubmit: (data: DataSourceFormData) => void;
   initialData?: DataSourceFormData;
   isEdit?: boolean;
+  isSubmitting?: boolean;
+  submitError?: string | null;
 }
 
 const EMPTY_FORM: DataSourceFormData = {
@@ -100,11 +103,21 @@ const EMPTY_FORM: DataSourceFormData = {
   sparkPath: "",
 };
 
+const BATCH_SOURCE_TYPES = new Set([
+  String(feast.core.DataSource.SourceType.BATCH_FILE),
+  String(feast.core.DataSource.SourceType.BATCH_BIGQUERY),
+  String(feast.core.DataSource.SourceType.BATCH_SNOWFLAKE),
+  String(feast.core.DataSource.SourceType.BATCH_REDSHIFT),
+  String(feast.core.DataSource.SourceType.BATCH_SPARK),
+]);
+
 const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
   onClose,
   onSubmit,
   initialData,
   isEdit = false,
+  isSubmitting = false,
+  submitError,
 }) => {
   const [formData, setFormData] = useState<DataSourceFormData>(
     initialData || EMPTY_FORM,
@@ -118,8 +131,11 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
     }
   }, [initialData]);
 
+  const isBatchSource = BATCH_SOURCE_TYPES.has(formData.sourceType);
+
   const validate = (): boolean => {
     const newErrors: Record<string, string> = {};
+    const st = formData.sourceType;
 
     if (!formData.name.trim()) {
       newErrors.name = "Data source name is required.";
@@ -128,14 +144,20 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
         "Must start with a letter or underscore, and contain only letters, numbers, and underscores.";
     }
 
-    const st = formData.sourceType;
+    // Source-type-specific required fields
     if (st === String(feast.core.DataSource.SourceType.BATCH_FILE)) {
       if (!formData.fileUri.trim()) {
-        newErrors.fileUri = "File URI is required for file sources.";
+        newErrors.fileUri = "File URI is required.";
+      } else if (
+        !/^(s3|gs|gcs|hdfs|abfs|file):\/\/\S+$/.test(formData.fileUri.trim())
+      ) {
+        newErrors.fileUri =
+          "Must be a valid URI (e.g. s3://bucket/path, gs://bucket/path, file:///local/path).";
       }
     } else if (st === String(feast.core.DataSource.SourceType.BATCH_BIGQUERY)) {
       if (!formData.bigqueryTable.trim() && !formData.bigqueryQuery.trim()) {
-        newErrors.bigqueryTable = "Either table or query is required.";
+        newErrors.bigqueryTable =
+          "Either a table reference or a query is required.";
       }
     } else if (
       st === String(feast.core.DataSource.SourceType.BATCH_SNOWFLAKE)
@@ -143,13 +165,47 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
       if (!formData.snowflakeTable.trim()) {
         newErrors.snowflakeTable = "Table name is required for Snowflake.";
       }
+      if (!formData.snowflakeDatabase.trim()) {
+        newErrors.snowflakeDatabase = "Database is required for Snowflake.";
+      }
+    } else if (st === String(feast.core.DataSource.SourceType.BATCH_REDSHIFT)) {
+      if (!formData.redshiftTable.trim()) {
+        newErrors.redshiftTable = "Table name is required for Redshift.";
+      }
+      if (!formData.redshiftDatabase.trim()) {
+        newErrors.redshiftDatabase = "Database is required for Redshift.";
+      }
+    } else if (st === String(feast.core.DataSource.SourceType.BATCH_SPARK)) {
+      if (!formData.sparkTable.trim() && !formData.sparkPath.trim()) {
+        newErrors.sparkTable =
+          "Either a table reference or a path is required for Spark.";
+      }
     } else if (st === String(feast.core.DataSource.SourceType.STREAM_KAFKA)) {
       if (!formData.kafkaBootstrapServers.trim()) {
         newErrors.kafkaBootstrapServers = "Bootstrap servers are required.";
+      } else if (
+        !/^[\w.-]+:\d+(,[\w.-]+:\d+)*$/.test(
+          formData.kafkaBootstrapServers.trim(),
+        )
+      ) {
+        newErrors.kafkaBootstrapServers =
+          "Must be in host:port format (e.g. localhost:9092).";
       }
       if (!formData.kafkaTopic.trim()) {
         newErrors.kafkaTopic = "Topic is required.";
       }
+    }
+
+    // Timestamp field required for batch sources (needed for point-in-time correctness)
+    if (isBatchSource && !formData.timestampField.trim()) {
+      newErrors.timestampField =
+        "Timestamp field is required for batch sources. It is used for point-in-time correct feature retrieval.";
+    } else if (
+      formData.timestampField.trim() &&
+      !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(formData.timestampField.trim())
+    ) {
+      newErrors.timestampField =
+        "Must be a valid column name (letters, numbers, underscores).";
     }
 
     const tagKeys = formData.tags.map((t) => t.key).filter((k) => k.trim());
@@ -195,7 +251,7 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
           label="File URI"
           isInvalid={!!errors.fileUri}
           error={errors.fileUri}
-          helpText="s3://path/to/file, gs://path/to/file, or file:///local/path"
+          helpText="Path to parquet or CSV file(s). Supports s3://, gs://, and file:// schemes."
         >
           <EuiFieldText
             value={formData.fileUri}
@@ -225,12 +281,12 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
           </EuiFormRow>
           <EuiFormRow
             label="Query"
-            helpText="Alternative to table: a SQL query"
+            helpText="Optional SQL query — use instead of a fixed table reference."
           >
             <EuiFieldText
               value={formData.bigqueryQuery}
               onChange={(e) => updateField("bigqueryQuery", e.target.value)}
-              placeholder="SELECT * FROM ..."
+              placeholder="SELECT * FROM `project.dataset.table`"
             />
           </EuiFormRow>
         </>
@@ -240,6 +296,25 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
     if (st === String(feast.core.DataSource.SourceType.BATCH_SNOWFLAKE)) {
       return (
         <>
+          <EuiFormRow
+            label="Database"
+            isInvalid={!!errors.snowflakeDatabase}
+            error={errors.snowflakeDatabase}
+          >
+            <EuiFieldText
+              value={formData.snowflakeDatabase}
+              onChange={(e) => updateField("snowflakeDatabase", e.target.value)}
+              isInvalid={!!errors.snowflakeDatabase}
+              placeholder="MY_DATABASE"
+            />
+          </EuiFormRow>
+          <EuiFormRow label="Schema">
+            <EuiFieldText
+              value={formData.snowflakeSchema}
+              onChange={(e) => updateField("snowflakeSchema", e.target.value)}
+              placeholder="PUBLIC"
+            />
+          </EuiFormRow>
           <EuiFormRow
             label="Table"
             isInvalid={!!errors.snowflakeTable}
@@ -252,20 +327,6 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
               placeholder="MY_TABLE"
             />
           </EuiFormRow>
-          <EuiFormRow label="Database">
-            <EuiFieldText
-              value={formData.snowflakeDatabase}
-              onChange={(e) => updateField("snowflakeDatabase", e.target.value)}
-              placeholder="MY_DATABASE"
-            />
-          </EuiFormRow>
-          <EuiFormRow label="Schema">
-            <EuiFieldText
-              value={formData.snowflakeSchema}
-              onChange={(e) => updateField("snowflakeSchema", e.target.value)}
-              placeholder="PUBLIC"
-            />
-          </EuiFormRow>
         </>
       );
     }
@@ -273,17 +334,15 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
     if (st === String(feast.core.DataSource.SourceType.BATCH_REDSHIFT)) {
       return (
         <>
-          <EuiFormRow label="Table">
-            <EuiFieldText
-              value={formData.redshiftTable}
-              onChange={(e) => updateField("redshiftTable", e.target.value)}
-              placeholder="my_table"
-            />
-          </EuiFormRow>
-          <EuiFormRow label="Database">
+          <EuiFormRow
+            label="Database"
+            isInvalid={!!errors.redshiftDatabase}
+            error={errors.redshiftDatabase}
+          >
             <EuiFieldText
               value={formData.redshiftDatabase}
               onChange={(e) => updateField("redshiftDatabase", e.target.value)}
+              isInvalid={!!errors.redshiftDatabase}
               placeholder="my_database"
             />
           </EuiFormRow>
@@ -292,6 +351,18 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
               value={formData.redshiftSchema}
               onChange={(e) => updateField("redshiftSchema", e.target.value)}
               placeholder="public"
+            />
+          </EuiFormRow>
+          <EuiFormRow
+            label="Table"
+            isInvalid={!!errors.redshiftTable}
+            error={errors.redshiftTable}
+          >
+            <EuiFieldText
+              value={formData.redshiftTable}
+              onChange={(e) => updateField("redshiftTable", e.target.value)}
+              isInvalid={!!errors.redshiftTable}
+              placeholder="my_table"
             />
           </EuiFormRow>
         </>
@@ -305,6 +376,7 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
             label="Bootstrap Servers"
             isInvalid={!!errors.kafkaBootstrapServers}
             error={errors.kafkaBootstrapServers}
+            helpText="Comma-separated list of broker host:port pairs."
           >
             <EuiFieldText
               value={formData.kafkaBootstrapServers}
@@ -312,7 +384,7 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
                 updateField("kafkaBootstrapServers", e.target.value)
               }
               isInvalid={!!errors.kafkaBootstrapServers}
-              placeholder="localhost:9092"
+              placeholder="broker1:9092,broker2:9092"
             />
           </EuiFormRow>
           <EuiFormRow
@@ -334,14 +406,23 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
     if (st === String(feast.core.DataSource.SourceType.BATCH_SPARK)) {
       return (
         <>
-          <EuiFormRow label="Table">
+          <EuiFormRow
+            label="Table"
+            isInvalid={!!errors.sparkTable}
+            error={errors.sparkTable}
+            helpText="Spark catalog table reference (catalog.database.table). Provide either table or path."
+          >
             <EuiFieldText
               value={formData.sparkTable}
               onChange={(e) => updateField("sparkTable", e.target.value)}
+              isInvalid={!!errors.sparkTable}
               placeholder="catalog.database.table"
             />
           </EuiFormRow>
-          <EuiFormRow label="Path" helpText="Alternative to table">
+          <EuiFormRow
+            label="Path"
+            helpText="Alternative to table: path to data files (s3://, gs://, hdfs://)."
+          >
             <EuiFieldText
               value={formData.sparkPath}
               onChange={(e) => updateField("sparkPath", e.target.value)}
@@ -366,14 +447,6 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
     return null;
   };
 
-  const isBatchSource =
-    formData.sourceType !==
-      String(feast.core.DataSource.SourceType.STREAM_KAFKA) &&
-    formData.sourceType !==
-      String(feast.core.DataSource.SourceType.REQUEST_SOURCE) &&
-    formData.sourceType !==
-      String(feast.core.DataSource.SourceType.PUSH_SOURCE);
-
   return (
     <FormModal
       title={isEdit ? "Edit Data Source" : "Create Data Source"}
@@ -381,7 +454,26 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
       onClose={onClose}
       onSubmit={handleSubmit}
       width={650}
+      isSubmitting={isSubmitting}
     >
+      {submitError && (
+        <>
+          <EuiCallOut
+            title={
+              isEdit
+                ? "Unable to update data source"
+                : "Unable to create data source"
+            }
+            color="danger"
+            iconType="alert"
+            size="s"
+          >
+            <p>{submitError}</p>
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+        </>
+      )}
+
       <NameDescriptionOwnerFields
         name={formData.name}
         description={formData.description}
@@ -396,11 +488,31 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
         descriptionPlaceholder="Describe this data source..."
       />
 
-      <EuiFormRow label="Source Type" helpText="Type of the data source.">
+      <EuiFormRow
+        label="Source Type"
+        helpText="The type of underlying storage system for this data source."
+      >
         <EuiSelect
           options={SOURCE_TYPE_OPTIONS}
           value={formData.sourceType}
-          onChange={(e) => updateField("sourceType", e.target.value)}
+          onChange={(e) => {
+            updateField("sourceType", e.target.value);
+            // Clear source-specific errors when type changes
+            setErrors((prev) => {
+              const next = { ...prev };
+              delete next.fileUri;
+              delete next.bigqueryTable;
+              delete next.snowflakeTable;
+              delete next.snowflakeDatabase;
+              delete next.redshiftTable;
+              delete next.redshiftDatabase;
+              delete next.kafkaBootstrapServers;
+              delete next.kafkaTopic;
+              delete next.sparkTable;
+              delete next.timestampField;
+              return next;
+            });
+          }}
           disabled={isEdit}
         />
       </EuiFormRow>
@@ -419,17 +531,20 @@ const DataSourceFormModal: React.FC<DataSourceFormModalProps> = ({
           <EuiSpacer size="m" />
           <EuiFormRow
             label="Timestamp Field"
-            helpText="Event timestamp column name."
+            isInvalid={!!errors.timestampField}
+            error={errors.timestampField}
+            helpText="Column containing the event timestamp. Required for point-in-time correct feature retrieval."
           >
             <EuiFieldText
               value={formData.timestampField}
               onChange={(e) => updateField("timestampField", e.target.value)}
+              isInvalid={!!errors.timestampField}
               placeholder="event_timestamp"
             />
           </EuiFormRow>
           <EuiFormRow
             label="Created Timestamp Column"
-            helpText="Column tracking when the row was created."
+            helpText="Optional: column tracking when the row was written (used for deduplication)."
           >
             <EuiFieldText
               value={formData.createdTimestampColumn}

--- a/ui/src/components/FeatureViewFormModal.tsx
+++ b/ui/src/components/FeatureViewFormModal.tsx
@@ -20,11 +20,13 @@ import FeatureFieldEditor, {
 } from "./forms/FeatureFieldEditor";
 import EntityFormModal, { EntityFormData } from "./EntityFormModal";
 import DataSourceFormModal, { DataSourceFormData } from "./DataSourceFormModal";
-import { useLoadEntitiesREST } from "../queries/useLoadEntitiesREST";
-import { useLoadDataSourcesREST } from "../queries/useLoadDataSourcesREST";
 import { useApplyEntity } from "../queries/mutations/useEntityMutations";
 import { useApplyDataSource } from "../queries/mutations/useDataSourceMutations";
 import { feast } from "../protos";
+import useResourceQuery, {
+  entityListPath,
+  dataSourceListPath,
+} from "../queries/useResourceQuery";
 
 const TTL_UNIT_OPTIONS = [
   { value: "seconds", text: "Seconds" },
@@ -32,6 +34,13 @@ const TTL_UNIT_OPTIONS = [
   { value: "hours", text: "Hours" },
   { value: "days", text: "Days" },
 ];
+
+const TTL_UNITS: Record<string, number> = {
+  seconds: 1,
+  minutes: 60,
+  hours: 3600,
+  days: 86400,
+};
 
 interface FeatureViewFormData {
   name: string;
@@ -51,6 +60,8 @@ interface FeatureViewFormModalProps {
   onSubmit: (data: FeatureViewFormData) => void;
   initialData?: FeatureViewFormData;
   isEdit?: boolean;
+  isSubmitting?: boolean;
+  submitError?: string | null;
 }
 
 const EMPTY_FORM: FeatureViewFormData = {
@@ -71,6 +82,8 @@ const FeatureViewFormModal: React.FC<FeatureViewFormModalProps> = ({
   onSubmit,
   initialData,
   isEdit = false,
+  isSubmitting = false,
+  submitError,
 }) => {
   const [formData, setFormData] = useState<FeatureViewFormData>(
     initialData || EMPTY_FORM,
@@ -81,24 +94,37 @@ const FeatureViewFormModal: React.FC<FeatureViewFormModalProps> = ({
   const [showDataSourceForm, setShowDataSourceForm] = useState(false);
 
   const { projectName } = useParams();
-  const entitiesQuery = useLoadEntitiesREST(projectName || "");
-  const dataSourcesQuery = useLoadDataSourcesREST(projectName || "");
+
+  const entitiesQuery = useResourceQuery<any[]>({
+    resourceType: "entities-list",
+    project: projectName,
+    restPath: entityListPath(projectName),
+    restSelect: (d) => d.entities,
+  });
+
+  const dataSourcesQuery = useResourceQuery<any[]>({
+    resourceType: "data-sources-list",
+    project: projectName,
+    restPath: dataSourceListPath(projectName),
+    restSelect: (d) => d.dataSources,
+  });
+
   const applyEntity = useApplyEntity();
   const applyDataSource = useApplyDataSource();
 
-  const entities = entitiesQuery.data?.entities || [];
-  const dataSources = dataSourcesQuery.data?.dataSources || [];
+  // REST API returns objects with spec.name; fall back to top-level name
+  const entities: any[] = entitiesQuery.data || [];
+  const dataSources: any[] = dataSourcesQuery.data || [];
 
-  const entityOptions: EuiComboBoxOptionOption<string>[] = entities.map(
-    (e: any) => ({
-      label: e?.spec?.name || e?.name || "",
-    }),
-  );
+  const entityOptions: EuiComboBoxOptionOption<string>[] = entities
+    .map((e: any) => e?.spec?.name || e?.name || "")
+    .filter(Boolean)
+    .map((name: string) => ({ label: name }));
 
-  const dataSourceOptions = dataSources.map((ds: any) => ({
-    value: ds?.name || ds?.spec?.name || "",
-    text: ds?.name || ds?.spec?.name || "",
-  }));
+  const dataSourceOptions = dataSources
+    .map((ds: any) => ds?.spec?.name || ds?.name || "")
+    .filter(Boolean)
+    .map((name: string) => ({ value: name, text: name }));
 
   const hasNoEntities = entitiesQuery.isSuccess && entities.length === 0;
   const hasNoDataSources =
@@ -126,15 +152,26 @@ const FeatureViewFormModal: React.FC<FeatureViewFormModalProps> = ({
       const hasEmptyName = formData.features.some((f) => !f.name.trim());
       if (hasEmptyName) {
         newErrors.features = "All features must have a name.";
-      }
-      const featureNames = formData.features.map((f) => f.name.trim());
-      if (new Set(featureNames).size !== featureNames.length) {
-        newErrors.features = "Feature names must be unique.";
+      } else {
+        const featureNames = formData.features.map((f) => f.name.trim());
+        if (new Set(featureNames).size !== featureNames.length) {
+          newErrors.features = "Feature names must be unique.";
+        }
+        const invalidName = featureNames.find(
+          (n) => !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(n),
+        );
+        if (invalidName) {
+          newErrors.features = `Invalid feature name "${invalidName}". Use only letters, numbers, and underscores.`;
+        }
       }
     }
 
     if (!formData.batchSource.trim()) {
       newErrors.batchSource = "A batch source is required.";
+    }
+
+    if (formData.ttlValue < 0) {
+      newErrors.ttlValue = "TTL must be 0 (never expire) or a positive number.";
     }
 
     const tagKeys = formData.tags.map((t) => t.key).filter((k) => k.trim());
@@ -258,7 +295,26 @@ const FeatureViewFormModal: React.FC<FeatureViewFormModalProps> = ({
         onClose={onClose}
         onSubmit={handleSubmit}
         width={750}
+        isSubmitting={isSubmitting}
       >
+        {submitError && (
+          <>
+            <EuiCallOut
+              title={
+                isEdit
+                  ? "Unable to update feature view"
+                  : "Unable to create feature view"
+              }
+              color="danger"
+              iconType="alert"
+              size="s"
+            >
+              <p>{submitError}</p>
+            </EuiCallOut>
+            <EuiSpacer size="m" />
+          </>
+        )}
+
         <NameDescriptionOwnerFields
           name={formData.name}
           description={formData.description}
@@ -303,7 +359,13 @@ const FeatureViewFormModal: React.FC<FeatureViewFormModalProps> = ({
           helpText="Entities that this feature view is associated with."
         >
           <EuiComboBox
-            placeholder="Select entities"
+            placeholder={
+              entitiesQuery.isLoading
+                ? "Loading entities..."
+                : entityOptions.length === 0
+                  ? "No entities available — create one above"
+                  : "Select entities"
+            }
             options={entityOptions}
             selectedOptions={selectedEntityOptions}
             onChange={(selected) =>
@@ -356,13 +418,18 @@ const FeatureViewFormModal: React.FC<FeatureViewFormModalProps> = ({
               value={formData.batchSource}
               onChange={(e) => updateField("batchSource", e.target.value)}
               isInvalid={!!errors.batchSource}
+              isLoading={dataSourcesQuery.isLoading}
             />
           ) : (
             <EuiFieldText
               value={formData.batchSource}
               onChange={(e) => updateField("batchSource", e.target.value)}
               isInvalid={!!errors.batchSource}
-              placeholder="data_source_name"
+              placeholder={
+                dataSourcesQuery.isLoading
+                  ? "Loading data sources..."
+                  : "Enter data source name"
+              }
             />
           )}
         </EuiFormRow>
@@ -379,7 +446,9 @@ const FeatureViewFormModal: React.FC<FeatureViewFormModalProps> = ({
 
         <EuiFormRow
           label="TTL (Time to Live)"
-          helpText="How long features remain valid after their event timestamp."
+          isInvalid={!!errors.ttlValue}
+          error={errors.ttlValue}
+          helpText="How long features remain valid after their event timestamp. Set to 0 for no expiry."
         >
           <div style={{ display: "flex", gap: 8 }}>
             <EuiFieldNumber
@@ -388,6 +457,7 @@ const FeatureViewFormModal: React.FC<FeatureViewFormModalProps> = ({
                 updateField("ttlValue", parseInt(e.target.value) || 0)
               }
               min={0}
+              isInvalid={!!errors.ttlValue}
               style={{ width: 120 }}
             />
             <EuiSelect
@@ -435,3 +505,4 @@ const FeatureViewFormModal: React.FC<FeatureViewFormModalProps> = ({
 
 export default FeatureViewFormModal;
 export type { FeatureViewFormData };
+export { TTL_UNITS };

--- a/ui/src/pages/data-sources/DataSourceOverviewTab.tsx
+++ b/ui/src/pages/data-sources/DataSourceOverviewTab.tsx
@@ -155,10 +155,10 @@ const DataSourceOverviewTab = () => {
         setTimeout(() => setSuccessMessage(null), 5000);
       },
       onError: (err: unknown) => {
+        // Error shown inside the modal via submitError prop
         const message =
           err instanceof Error ? err.message : "An unexpected error occurred.";
         setErrorMessage(message);
-        setTimeout(() => setErrorMessage(null), 8000);
       },
     });
   };
@@ -288,10 +288,15 @@ const DataSourceOverviewTab = () => {
 
       {isEditModalOpen && data && (
         <DataSourceFormModal
-          onClose={() => setIsEditModalOpen(false)}
+          onClose={() => {
+            setIsEditModalOpen(false);
+            setErrorMessage(null);
+          }}
           onSubmit={handleEditSubmit}
           initialData={buildEditFormData(data)}
           isEdit
+          isSubmitting={applyDataSource.isLoading}
+          submitError={errorMessage}
         />
       )}
     </React.Fragment>

--- a/ui/src/pages/data-sources/Index.tsx
+++ b/ui/src/pages/data-sources/Index.tsx
@@ -128,10 +128,10 @@ const Index = () => {
         setTimeout(() => setSuccessMessage(null), 5000);
       },
       onError: (err: unknown) => {
+        // Error shown inside the modal via submitError prop
         const message =
           err instanceof Error ? err.message : "An unexpected error occurred.";
         setErrorMessage(message);
-        setTimeout(() => setErrorMessage(null), 8000);
       },
     });
   };
@@ -217,8 +217,13 @@ const Index = () => {
 
       {isModalOpen && (
         <DataSourceFormModal
-          onClose={() => setIsModalOpen(false)}
+          onClose={() => {
+            setIsModalOpen(false);
+            setErrorMessage(null);
+          }}
           onSubmit={handleCreateSubmit}
+          isSubmitting={applyDataSource.isLoading}
+          submitError={errorMessage}
         />
       )}
     </EuiPageTemplate>

--- a/ui/src/pages/entities/EntityOverviewTab.tsx
+++ b/ui/src/pages/entities/EntityOverviewTab.tsx
@@ -100,10 +100,10 @@ const EntityOverviewTab = () => {
         setTimeout(() => setSuccessMessage(null), 5000);
       },
       onError: (err: unknown) => {
+        // Error shown inside the modal via submitError prop
         const message =
           err instanceof Error ? err.message : "An unexpected error occurred.";
         setErrorMessage(message);
-        setTimeout(() => setErrorMessage(null), 8000);
       },
     });
   };
@@ -275,10 +275,15 @@ const EntityOverviewTab = () => {
 
       {isEditModalOpen && data && (
         <EntityFormModal
-          onClose={() => setIsEditModalOpen(false)}
+          onClose={() => {
+            setIsEditModalOpen(false);
+            setErrorMessage(null);
+          }}
           onSubmit={handleEditSubmit}
           initialData={buildEditFormData(data)}
           isEdit
+          isSubmitting={applyEntity.isLoading}
+          submitError={errorMessage}
         />
       )}
     </React.Fragment>

--- a/ui/src/pages/feature-views/Index.tsx
+++ b/ui/src/pages/feature-views/Index.tsx
@@ -193,10 +193,10 @@ const Index = () => {
         setTimeout(() => setSuccessMessage(null), 5000);
       },
       onError: (err: unknown) => {
+        // Error shown inside the modal via submitError prop
         const message =
           err instanceof Error ? err.message : "An unexpected error occurred.";
         setErrorMessage(message);
-        setTimeout(() => setErrorMessage(null), 8000);
       },
     });
   };
@@ -312,8 +312,11 @@ const Index = () => {
           onClose={() => {
             setIsModalOpen(false);
             setPrereqWarning(null);
+            setErrorMessage(null);
           }}
           onSubmit={handleCreateSubmit}
+          isSubmitting={applyFeatureView.isLoading}
+          submitError={errorMessage}
         />
       )}
     </EuiPageTemplate>

--- a/ui/src/pages/feature-views/RegularFeatureViewOverviewTab.tsx
+++ b/ui/src/pages/feature-views/RegularFeatureViewOverviewTab.tsx
@@ -159,10 +159,10 @@ const RegularFeatureViewOverviewTab = ({
         setTimeout(() => setSuccessMessage(null), 5000);
       },
       onError: (err: unknown) => {
+        // Error shown inside the modal via submitError prop
         const message =
           err instanceof Error ? err.message : "An unexpected error occurred.";
         setErrorMessage(message);
-        setTimeout(() => setErrorMessage(null), 8000);
       },
     });
   };
@@ -376,10 +376,15 @@ const RegularFeatureViewOverviewTab = ({
 
       {isEditModalOpen && data && (
         <FeatureViewFormModal
-          onClose={() => setIsEditModalOpen(false)}
+          onClose={() => {
+            setIsEditModalOpen(false);
+            setErrorMessage(null);
+          }}
           onSubmit={handleEditSubmit}
           initialData={buildEditFormData(data)}
           isEdit
+          isSubmitting={applyFeatureView.isLoading}
+          submitError={errorMessage}
         />
       )}
     </React.Fragment>


### PR DESCRIPTION
# What this PR does / why we need it:

Adds client-side form validation and fixes entity/data source population in the Control Plane UI create/edit flows.

**DataSourceFormModal**
- Add missing validation for Redshift (database + table required), Spark (table or path required), and all batch sources (timestamp field required for point-in-time correctness)
- Add format validation for File URI (scheme check) and Kafka bootstrap servers (`host:port` format)
- Clear source-type-specific errors when source type changes
- Add `isSubmitting` / `submitError` props so backend errors appear inside the modal instead of a dismissing page banner

**FeatureViewFormModal**
- Fix broken imports: replace non-existent `useLoadEntitiesREST` / `useLoadDataSourcesREST` with `useResourceQuery`
- Populate Entities combo-box and Batch Source dropdown from live REST API data on open
- Fix entity/data source name resolution to use `spec.name` (REST API shape)
- Show actionable empty-state warnings with inline Create buttons when no entities or data sources exist

**Calling pages** (`data-sources/Index`, `DataSourceOverviewTab`, `feature-views/Index`, `RegularFeatureViewOverviewTab`, `entities/EntityOverviewTab`)
- Pass `isSubmitting={applyXxx.isLoading}` — Submit button shows a spinner while request is in-flight
- Pass `submitError={errorMessage}` — errors shown inside the open modal
- Clear error state on modal close to prevent stale errors on re-open

# Which issue(s) this PR fixes:
#6482 

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Testing is not required for this change