### PR TITLE
docs: Fix minor wording issues

### DIFF
--- a/docs/getting-started/architecture/model-inference.md
+++ b/docs/getting-started/architecture/model-inference.md
@@ -17,7 +17,7 @@ of model inference):
 
 *Note: online features can be sourced from batch, streaming, or request data sources.*
 
-These three approaches have different tradeoffs but, in general, have significant implementation differences. 
+These four approaches have different tradeoffs but, in general, have significant implementation differences.
 
 ## 1. Online Model Inference with Online Features
 Online model inference with online features is a powerful approach to serving data-driven machine learning applications.
@@ -78,7 +78,7 @@ if features.to_dict().get('user_data:model_predictions') is None:
     model_predictions = model_server.predict(features)
     store.write_to_online_store(feature_view_name="user_data", df=pd.DataFrame(model_predictions))
 ```
-Note that in this case a seperate call to `write_to_online_store` is required when the underlying data changes and 
+Note that in this case a separate call to `write_to_online_store` is required when the underlying data changes and
 predictions change along with it.
 
 ```python

--- a/docs/getting-started/components/compute-engine.md
+++ b/docs/getting-started/components/compute-engine.md
@@ -8,7 +8,7 @@ functions (UDFs).
 
 A materialization task abstracts over specific technologies or frameworks that are used to materialize data. It allows
 users to use a pure local serialized approach (which is the default LocalComputeEngine), or delegates the
-materialization to seperate components (e.g. AWS Lambda, as implemented by the the LambdaComputeEngine).
+materialization to separate components (e.g. AWS Lambda, as implemented by the LambdaComputeEngine).
 
 If the built-in engines are not sufficient, you can create your own custom materialization engine. Please
 see [this guide](../../how-to-guides/customizing-feast/creating-a-custom-compute-engine.md) for more details.

--- a/docs/getting-started/concepts/feature-view.md
+++ b/docs/getting-started/concepts/feature-view.md
@@ -91,7 +91,7 @@ If the `schema` parameter is not specified in the creation of the feature view, 
 
 "Entity aliases" can be specified to join `entity_dataframe` columns that do not match the column names in the source table of a FeatureView.
 
-This could be used if a user has no control over these column names or if there are multiple entities are a subclass of a more general entity. For example, "spammer" and "reporter" could be aliases of a "user" entity, and "origin" and "destination" could be aliases of a "location" entity as shown below.
+This could be used if a user has no control over these column names or if multiple entities are subclasses of a more general entity. For example, "spammer" and "reporter" could be aliases of a "user" entity, and "origin" and "destination" could be aliases of a "location" entity as shown below.
 
 It is suggested that you dynamically specify the new FeatureView name using `.with_name` and `join_key_map` override using `.with_join_key_map` instead of needing to register each new copy.
 
@@ -322,4 +322,4 @@ def driver_hourly_stats_stream(df: DataFrame):
     )
 ```
 
-See [here](https://github.com/feast-dev/streaming-tutorial) for a example of how to use stream feature views to register your own streaming data pipelines in Feast.
+See [here](https://github.com/feast-dev/streaming-tutorial) for an example of how to use stream feature views to register your own streaming data pipelines in Feast.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -4,7 +4,7 @@
 
 Feast (Feature Store) is an open-source feature store designed to facilitate the management and serving of machine learning features in a way that supports both batch and real-time applications.
 
-* *For Data Scientists*: Feast is a a tool where you can easily define, store, and retrieve your features for both model development and model deployment. By using Feast, you can focus on what you do best: build features that power your AI/ML models and maximize the value of your data.
+* *For Data Scientists*: Feast is a tool where you can easily define, store, and retrieve your features for both model development and model deployment. By using Feast, you can focus on what you do best: build features that power your AI/ML models and maximize the value of your data.
 	
 * *For MLOps Engineers*: Feast is a library that allows you to connect your existing infrastructure (e.g., online database, application server, microservice, analytical database, and orchestration tooling) that enables your Data Scientists to ship features for their models to production using a friendly SDK without having to be concerned with software engineering challenges that occur from serving real-time production systems. By using Feast, you can focus on maintaining a resilient system, instead of implementing features for Data Scientists.
 	

--- a/docs/reference/data-sources/kafka.md
+++ b/docs/reference/data-sources/kafka.md
@@ -72,4 +72,4 @@ def driver_hourly_stats_stream(df: DataFrame):
 ```
 
 ### Ingesting data
-See [here](https://github.com/feast-dev/streaming-tutorial) for a example of how to ingest data from a Kafka source into Feast.
+See [here](https://github.com/feast-dev/streaming-tutorial) for an example of how to ingest data from a Kafka source into Feast.

--- a/docs/reference/data-sources/kinesis.md
+++ b/docs/reference/data-sources/kinesis.md
@@ -71,4 +71,4 @@ def driver_hourly_stats_stream(df: DataFrame):
 ```
 
 ### Ingesting data
-See [here](https://github.com/feast-dev/streaming-tutorial) for a example of how to ingest data from a Kafka source into Feast. The approach used in the tutorial can be easily adapted to work for Kinesis as well.
+See [here](https://github.com/feast-dev/streaming-tutorial) for an example of how to ingest data from a Kafka source into Feast. The approach used in the tutorial can be easily adapted to work for Kinesis as well.

--- a/docs/reference/online-stores/dynamodb.md
+++ b/docs/reference/online-stores/dynamodb.md
@@ -24,7 +24,7 @@ The full set of configuration options is available in [DynamoDBOnlineStoreConfig
 
 ## Configuration
 
-Below is a example with performance tuning options:
+Below is an example with performance tuning options:
 
 {% code title="feature_store.yaml" %}
 ```yaml

--- a/docs/tutorials/validating-historical-features.md
+++ b/docs/tutorials/validating-historical-features.md
@@ -661,7 +661,7 @@ _ = job.to_df(validation_reference=validation_reference)
     02/02/2022 02:43:53 PM INFO: Validating data_asset_name None with expectation_suite_name default
 
 
-Validation successfully passed as no exception were raised.
+Validation successfully passed as no exceptions were raised.
 
 
 ### 5. Validating new historical retrieval


### PR DESCRIPTION
# What this PR does / why we need it:

Fixes a handful of small wording issues in the docs, including duplicated words, article usage, spelling of "separate", and one sentence that referenced three approaches after listing four.

# Which issue(s) this PR fixes:

N/A

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [x] Testing is not required for this change

Manual checks:
- `git diff --check`
- `rg -n "a a tool|seperate|by the the|a example|no exception were|These three approaches|multiple entities are a subclass" docs/getting-started docs/reference docs/tutorials`

# Misc

Docs-only cleanup; no behavior changes.