### PR TITLE
ci: Add nightly Python SDK dev release

### DIFF
--- a/.github/actions/get-semantic-release-version/action.yml
+++ b/.github/actions/get-semantic-release-version/action.yml
@@ -2,7 +2,7 @@ name: Get semantic release version
 description: ""
 inputs:
   custom_version: # Optional input for a custom version
-    description: "Custom version to publish (e.g., v1.2.3) -- only edit if you know what you are doing"
+    description: "Custom version to publish (e.g., v1.2.3 or v1.2.3.dev4) -- only edit if you know what you are doing"
     required: false
   token:
     description: "Personal Access Token"
@@ -10,10 +10,10 @@ inputs:
     default: ""
 outputs:
   release_version:
-    description: "The release version to use (e.g., v1.2.3)"
+    description: "The release version to use (e.g., v1.2.3 or v1.2.3.dev4)"
     value: ${{ steps.get_release_version.outputs.release_version }}
   version_without_prefix:
-    description: "The release version to use without 'v' (e.g., 1.2.3)"
+    description: "The release version to use without 'v' (e.g., 1.2.3 or 1.2.3.dev4)"
     value: ${{ steps.get_release_version_without_prefix.outputs.version_without_prefix }}
   highest_semver_tag:
     description: "The highest semantic version tag without the 'v' prefix (e.g., 1.2.3)"
@@ -32,10 +32,10 @@ runs:
         GIT_COMMITTER_EMAIL: feast-ci-bot@willem.co
       run: |
         if [[ -n "${{ inputs.custom_version }}" ]]; then
-          VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+$"
+          VERSION_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+)?$"
           echo "Using custom version: ${{ inputs.custom_version }}"
           if [[ ! "${{ inputs.custom_version }}" =~ $VERSION_REGEX ]]; then
-            echo "Error: custom_version must match semantic versioning (e.g., v1.2.3)."
+            echo "Error: custom_version must match semantic versioning (e.g., v1.2.3 or v1.2.3.dev4)."
             exit 1
           fi
           echo "::set-output name=release_version::${{ inputs.custom_version }}"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -7,9 +7,18 @@ on:
   workflow_dispatch: # Allows manual trigger of the workflow
     inputs:
       custom_version: # Optional input for a custom version
-        description: 'Custom version to publish (e.g., v1.2.3) -- only edit if you know what you are doing'
+        description: 'Custom version to publish (e.g., v1.2.3 or v1.2.3.dev4) -- only edit if you know what you are doing'
         required: false
         type: string
+      checkout_ref:
+        description: 'Git ref to checkout before building wheels. Defaults to the release version.'
+        required: false
+        type: string
+      build_docker_images:
+        description: 'Build Docker images as part of release verification.'
+        required: true
+        default: true
+        type: boolean
       token:
         description: 'Personal Access Token'
         required: true
@@ -18,9 +27,18 @@ on:
   workflow_call:
     inputs:
       custom_version: # Optional input for a custom version
-        description: 'Custom version to publish (e.g., v1.2.3) -- only edit if you know what you are doing'
+        description: 'Custom version to publish (e.g., v1.2.3 or v1.2.3.dev4) -- only edit if you know what you are doing'
         required: false
         type: string
+      checkout_ref:
+        description: 'Git ref to checkout before building wheels. Defaults to the release version.'
+        required: false
+        type: string
+      build_docker_images:
+        description: 'Build Docker images as part of release verification.'
+        required: false
+        default: true
+        type: boolean
       token:
         description: 'Personal Access Token'
         required: true
@@ -48,17 +66,20 @@ jobs:
       - id: get-version
         uses: ./.github/actions/get-semantic-release-version
         with:
-          custom_version: ${{ github.event.inputs.custom_version }}
-          token: ${{ github.event.inputs.token }}
+          custom_version: ${{ inputs.custom_version }}
+          token: ${{ inputs.token }}
       - name: Checkout version and install dependencies
         env:
           VERSION: ${{ steps.get-version.outputs.release_version }}
+          CHECKOUT_REF: ${{ inputs.checkout_ref }}
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           git fetch --tags
-          git checkout ${VERSION}
+          git checkout "${CHECKOUT_REF:-$VERSION}"
           python -m pip install build
       - name: Build feast
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.get-version.outputs.version_without_prefix }}
         run: python -m build
       - uses: actions/upload-artifact@v4
         with:
@@ -68,6 +89,7 @@ jobs:
   # We add this step so the docker images can be built as part of the pre-release verification steps.
   build-docker-images:
     name: Build Docker images
+    if: ${{ inputs.build_docker_images }}
     runs-on: ubuntu-latest
     needs: [ build-python-wheel ]
     strategy:
@@ -96,8 +118,8 @@ jobs:
       - id: get-version
         uses: ./.github/actions/get-semantic-release-version
         with:
-          custom_version: ${{ github.event.inputs.custom_version }}
-          token: ${{ github.event.inputs.token }}
+          custom_version: ${{ inputs.custom_version }}
+          token: ${{ inputs.token }}
       - name: Build image
         env:
           VERSION_WITHOUT_PREFIX: ${{ steps.get-version.outputs.version_without_prefix }}
@@ -162,8 +184,8 @@ jobs:
       - id: get-version
         uses: ./.github/actions/get-semantic-release-version
         with:
-          custom_version: ${{ github.event.inputs.custom_version }}
-          token: ${{ github.event.inputs.token }}
+          custom_version: ${{ inputs.custom_version }}
+          token: ${{ inputs.token }}
       - name: Validate Feast Version
         env:
           VERSION_WITHOUT_PREFIX: ${{ steps.get-version.outputs.version_without_prefix }}
@@ -173,10 +195,10 @@ jobs:
             echo "Error: Failed to get Feast version."
             exit 1
           fi
-          VERSION_REGEX='[0-9]+\.[0-9]+\.[0-9]+'
-          OUTPUT_REGEX='^Feast SDK Version: "$VERSION_REGEX"$'
-          VERSION=$(echo $VERSION_OUTPUT | grep -oE "$VERSION_REGEX")
-          OUTPUT=$(echo $VERSION_OUTPUT | grep -E "$REGEX")
+          VERSION_REGEX='[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+)?'
+          OUTPUT_REGEX="^Feast SDK Version: \"${VERSION_REGEX}\"$"
+          VERSION=$(echo "$VERSION_OUTPUT" | grep -oE "$VERSION_REGEX")
+          OUTPUT=$(echo "$VERSION_OUTPUT" | grep -E "$OUTPUT_REGEX")
           echo "Installed Feast Version: $VERSION and using Feast Version: $VERSION_WITHOUT_PREFIX"
           if  [ -n "$OUTPUT" ] && [ "$VERSION" = "$VERSION_WITHOUT_PREFIX" ]; then
             echo "Correct Feast Version Installed"

--- a/.github/workflows/nightly_python_sdk_release.yml
+++ b/.github/workflows/nightly_python_sdk_release.yml
@@ -1,0 +1,92 @@
+name: nightly python sdk release
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      base_version:
+        description: "Optional base version without the .dev suffix (e.g., 1.2.3). Defaults to the next semantic-release version."
+        required: false
+        type: string
+      dev_number:
+        description: "Optional dev release number. Defaults to the workflow run number."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-python-sdk-release
+  cancel-in-progress: false
+
+jobs:
+  get-nightly-version:
+    if: github.repository == 'feast-dev/feast'
+    runs-on: ubuntu-latest
+    outputs:
+      nightly_version: ${{ steps.version.outputs.nightly_version }}
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      INPUT_BASE_VERSION: ${{ inputs.base_version }}
+      INPUT_DEV_NUMBER: ${{ inputs.dev_number }}
+      DEFAULT_DEV_NUMBER: ${{ github.run_number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - name: Get nightly version
+        id: version
+        run: |
+          set -euo pipefail
+
+          if [[ -n "$INPUT_BASE_VERSION" ]]; then
+            BASE_VERSION="${INPUT_BASE_VERSION#v}"
+          else
+            set +e
+            SEMANTIC_OUTPUT=$(npx -p @semantic-release/changelog -p @semantic-release/git -p @semantic-release/exec -p semantic-release semantic-release --dry-run 2>&1)
+            SEMANTIC_STATUS=$?
+            set -e
+            echo "$SEMANTIC_OUTPUT"
+
+            BASE_VERSION=$(echo "$SEMANTIC_OUTPUT" | grep 'The next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/' | tail -n 1)
+            if [[ -z "$BASE_VERSION" ]]; then
+              echo "Could not determine a semantic-release next version (exit code: ${SEMANTIC_STATUS}); falling back to next patch after latest stable tag."
+              source infra/scripts/setup-common-functions.sh
+              LATEST_TAG=$(get_tag_release -s)
+              LATEST_VERSION="${LATEST_TAG#v}"
+              IFS=. read -r MAJOR MINOR PATCH <<< "$LATEST_VERSION"
+              BASE_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+            fi
+          fi
+
+          if [[ ! "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Base version must match X.Y.Z, got: ${BASE_VERSION}"
+            exit 1
+          fi
+
+          DEV_NUMBER="${INPUT_DEV_NUMBER:-$DEFAULT_DEV_NUMBER}"
+          if [[ ! "$DEV_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Dev number must be numeric, got: ${DEV_NUMBER}"
+            exit 1
+          fi
+
+          NIGHTLY_VERSION="v${BASE_VERSION}.dev${DEV_NUMBER}"
+          echo "Nightly version is ${NIGHTLY_VERSION}"
+          echo "nightly_version=${NIGHTLY_VERSION}" >> "$GITHUB_OUTPUT"
+
+  publish-nightly-python-sdk:
+    needs: get-nightly-version
+    uses: ./.github/workflows/publish_python_sdk.yml
+    secrets: inherit # pragma: allowlist secret
+    with:
+      custom_version: ${{ needs.get-nightly-version.outputs.nightly_version }}
+      checkout_ref: ${{ github.sha }}
+      build_docker_images: false
+      token: ${{ github.token }}

--- a/.github/workflows/publish_python_sdk.yml
+++ b/.github/workflows/publish_python_sdk.yml
@@ -4,9 +4,18 @@ on:
   workflow_dispatch: # Allows manual trigger of the workflow
     inputs:
       custom_version: # Optional input for a custom version
-        description: 'Custom version to publish (e.g., v1.2.3) -- only edit if you know what you are doing'
+        description: 'Custom version to publish (e.g., v1.2.3 or v1.2.3.dev4) -- only edit if you know what you are doing'
         required: false
         type: string
+      checkout_ref:
+        description: 'Git ref to checkout before building wheels. Defaults to the release version.'
+        required: false
+        type: string
+      build_docker_images:
+        description: 'Build Docker images as part of release verification.'
+        required: true
+        default: true
+        type: boolean
       token:
         description: 'Personal Access Token'
         required: true
@@ -16,9 +25,18 @@ on:
   workflow_call: # Allows trigger of the workflow from another workflow
     inputs:
       custom_version: # Optional input for a custom version
-        description: 'Custom version to publish (e.g., v1.2.3) -- only edit if you know what you are doing'
+        description: 'Custom version to publish (e.g., v1.2.3 or v1.2.3.dev4) -- only edit if you know what you are doing'
         required: false
         type: string
+      checkout_ref:
+        description: 'Git ref to checkout before building wheels. Defaults to the release version.'
+        required: false
+        type: string
+      build_docker_images:
+        description: 'Build Docker images as part of release verification.'
+        required: false
+        default: true
+        type: boolean
       token:
         description: 'Personal Access Token'
         required: true
@@ -30,8 +48,10 @@ jobs:
     uses: ./.github/workflows/build_wheels.yml
     secrets: inherit
     with:
-      custom_version: ${{ github.event.inputs.custom_version }}
-      token: ${{ github.event.inputs.token }}
+      custom_version: ${{ inputs.custom_version }}
+      checkout_ref: ${{ inputs.checkout_ref }}
+      build_docker_images: ${{ inputs.build_docker_images }}
+      token: ${{ inputs.token }}
 
   publish-python-sdk:
     if: github.repository == 'feast-dev/feast'

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,7 +151,7 @@
         "filename": ".github/workflows/publish_python_sdk.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 49
       }
     ],
     ".prow.yaml": [
@@ -1555,5 +1555,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-09T15:21:51Z"
+  "generated_at": "2026-06-11T15:45:28Z"
 }


### PR DESCRIPTION
## What changed

Adds a scheduled nightly Python SDK release workflow that publishes dev builds like `x.y.z.devN` through the existing Python SDK publish path.

The change also updates the reusable wheel/publish workflow so custom dev versions can be built from a specified ref using `SETUPTOOLS_SCM_PRETEND_VERSION`, and lets nightly runs skip Docker image verification while preserving the default behavior for normal release builds.

## Validation

- Parsed all touched GitHub Actions YAML files with PyYAML.
- Verified the dev-version regex accepts `v1.2.3.dev4` and rejects invalid variants.
- Built a local wheel with `SETUPTOOLS_SCM_PRETEND_VERSION=1.2.3.dev4`; it produced `feast-1.2.3.dev4-py3-none-any.whl`.
- Pre-commit hooks passed during commit, including `detect-secrets`.