### PR TITLE
ci: Reduce redundant workflow runs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,16 @@
 name: linter
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'community/**'
+      - 'examples/**'
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'community/**'
+      - 'examples/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -72,6 +72,7 @@ jobs:
           SNOWFLAKE_CI_WAREHOUSE: ${{ secrets.SNOWFLAKE_CI_WAREHOUSE }}
         run: make test-python-integration
       - name: Benchmark python
+        if: matrix.python-version == '3.11'
         env:
           SNOWFLAKE_CI_DEPLOYMENT: ${{ secrets.SNOWFLAKE_CI_DEPLOYMENT }}
           SNOWFLAKE_CI_USER: ${{ secrets.SNOWFLAKE_CI_USER }}
@@ -80,6 +81,7 @@ jobs:
           SNOWFLAKE_CI_WAREHOUSE: ${{ secrets.SNOWFLAKE_CI_WAREHOUSE }}
         run: uv run pytest --verbose --color=yes sdk/python/tests --integration --benchmark --benchmark-autosave --benchmark-save-data --durations=5
       - name: Upload Benchmark Artifact to S3
+        if: matrix.python-version == '3.11'
         run: aws s3 cp --recursive .benchmarks s3://feast-ci-pytest-benchmark
       - name: Minimize uv cache
         run: uv cache prune --ci

--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -2,6 +2,10 @@ name: smoke-tests
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'community/**'
+      - 'examples/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -13,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11"]
         os: [ ubuntu-latest ]
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,9 +2,17 @@ name: unit-tests
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'community/**'
+      - 'examples/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - 'docs/**'
+      - 'community/**'
+      - 'examples/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## What changed

Part of #6502.

This makes the first low-risk CI cleanup pass:

- Skips `unit-tests`, `linter`, and `smoke-tests` for PRs/pushes that only touch `docs/**`, `community/**`, or `examples/**`.
- Collapses the CLI import smoke workflow from Python 3.10/3.11/3.12 to Python 3.11, since full unit CI already exercises the broader Python matrix.
- Limits master benchmark collection and S3 upload to the Python 3.11 integration leg instead of running it once per Python version.

## Why

These changes reduce duplicate CI work without changing the underlying test commands or moving any tests between suites. The broader CI/test-suite restructuring remains tracked in #6502.

## Validation

- Parsed the touched workflow YAML files with PyYAML.
- Ran `git diff --check` on the touched workflow files.
- Commit hook ran successfully, including `Detect secrets`.