### PR TITLE
docs: Add end-to-end registry deletion lifecycle example and unit test (#5360)

### DIFF
--- a/docs/getting-started/components/registry.md
+++ b/docs/getting-started/components/registry.md
@@ -69,6 +69,30 @@ store._registry.delete_validation_reference("my_validation_reference", project=s
 When using `feast apply` via the CLI, you can also use the `objects_to_delete` parameter with `partial=False` to delete objects as part of the apply operation. However, this is less common and typically used in automated deployment scenarios.
 {% endhint %}
 
+### End-to-end example
+
+The following snippet shows the full lifecycle of deleting a feature view from the registry:
+
+```python
+from feast import FeatureStore
+
+store = FeatureStore(repo_path=".")
+
+# 1. Verify the object exists before deletion
+print(store.list_batch_feature_views())  # shows my_feature_view
+
+# 2. Delete the feature view
+store.delete_feature_view("my_feature_view")
+
+# 3. Confirm it's gone
+print(store.list_batch_feature_views())  # my_feature_view no longer listed
+
+# Trying to fetch it now raises FeatureViewNotFoundException
+# store.get_feature_view("my_feature_view")
+```
+
+The same pattern works for other registry objects: list/verify the object, call the corresponding `delete_*` method, then list again to confirm the deletion.
+
 ## Accessing the registry from clients
 
 Users can specify the registry through a `feature_store.yaml` config file, or programmatically. We often see teams

--- a/sdk/python/tests/unit/local_feast_tests/test_local_feature_store.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_local_feature_store.py
@@ -11,7 +11,7 @@ from feast.aggregation import Aggregation
 from feast.data_format import AvroFormat, ParquetFormat
 from feast.data_source import KafkaSource
 from feast.entity import Entity
-from feast.errors import ConflictingFeatureViewNames
+from feast.errors import ConflictingFeatureViewNames, FeatureViewNotFoundException
 from feast.feast_object import ALL_RESOURCE_TYPES
 from feast.feature_store import FeatureStore
 from feast.feature_view import DUMMY_ENTITY_ID, DUMMY_ENTITY_NAME, FeatureView
@@ -437,6 +437,64 @@ def test_apply_permissions(test_feature_store):
 
     permissions = test_feature_store.list_permissions()
     assert len(permissions) == 0
+
+    test_feature_store.teardown()
+
+
+@pytest.mark.parametrize(
+    "test_feature_store",
+    [lazy_fixture("feature_store_with_local_registry")],
+)
+def test_apply_delete_feature_view(test_feature_store):
+    """Test that a feature view can be deleted using objects_to_delete with partial=False."""
+    assert isinstance(test_feature_store, FeatureStore)
+
+    now = pd.Timestamp.utcnow().round("ms")
+    dataframe_source = pd.DataFrame(
+        {
+            "test_key": [1, 2, 1, 3, 3],
+            "feature_value": [0.1, 0.2, 0.3, 4.0, 5.0],
+            "ts_1": [
+                now,
+                now - pd.Timedelta(hours=4),
+                now - pd.Timedelta(hours=3),
+                now - pd.Timedelta(hours=2),
+                now - pd.Timedelta(hours=1),
+            ],
+        }
+    )
+
+    with prep_file_source(df=dataframe_source, timestamp_field="ts_1") as file_source:
+        entity = Entity(
+            name="driver_entity", join_keys=["test_key"], value_type=ValueType.INT64
+        )
+        driver_fv = FeatureView(
+            name="driver_fv_to_delete",
+            entities=[entity],
+            schema=[Field(name="test_key", dtype=Int64)],
+            source=file_source,
+        )
+
+        # Register entity and feature view
+        test_feature_store.apply([entity, driver_fv])
+
+        # Verify feature view exists
+        fvs = test_feature_store.list_batch_feature_views()
+        assert len(fvs) == 1
+        assert fvs[0].name == driver_fv.name
+
+        # Delete the feature view using objects_to_delete
+        test_feature_store.apply(
+            objects=[], objects_to_delete=[driver_fv], partial=False
+        )
+
+        # Verify feature view is deleted
+        fvs = test_feature_store.list_batch_feature_views()
+        assert len(fvs) == 0
+
+        # Verify get_feature_view raises FeatureViewNotFoundException
+        with pytest.raises(FeatureViewNotFoundException):
+            test_feature_store.get_feature_view(driver_fv.name)
 
     test_feature_store.teardown()
 

--- a/sdk/python/tests/unit/local_feast_tests/test_local_feature_store.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_local_feature_store.py
@@ -11,7 +11,7 @@ from feast.aggregation import Aggregation
 from feast.data_format import AvroFormat, ParquetFormat
 from feast.data_source import KafkaSource
 from feast.entity import Entity
-from feast.errors import ConflictingFeatureViewNames
+from feast.errors import ConflictingFeatureViewNames, FeatureViewNotFoundException
 from feast.feast_object import ALL_RESOURCE_TYPES
 from feast.feature_store import FeatureStore
 from feast.feature_view import DUMMY_ENTITY_ID, DUMMY_ENTITY_NAME, FeatureView
@@ -439,6 +439,64 @@ def test_apply_permissions(test_feature_store):
 
     permissions = test_feature_store.list_permissions()
     assert len(permissions) == 0
+
+    test_feature_store.teardown()
+
+
+@pytest.mark.parametrize(
+    "test_feature_store",
+    [lazy_fixture("feature_store_with_local_registry")],
+)
+def test_apply_delete_feature_view(test_feature_store):
+    """Test that a feature view can be deleted using objects_to_delete with partial=False."""
+    assert isinstance(test_feature_store, FeatureStore)
+
+    now = pd.Timestamp.utcnow().round("ms")
+    dataframe_source = pd.DataFrame(
+        {
+            "test_key": [1, 2, 1, 3, 3],
+            "feature_value": [0.1, 0.2, 0.3, 4.0, 5.0],
+            "ts_1": [
+                now,
+                now - pd.Timedelta(hours=4),
+                now - pd.Timedelta(hours=3),
+                now - pd.Timedelta(hours=2),
+                now - pd.Timedelta(hours=1),
+            ],
+        }
+    )
+
+    with prep_file_source(df=dataframe_source, timestamp_field="ts_1") as file_source:
+        entity = Entity(
+            name="driver_entity", join_keys=["test_key"], value_type=ValueType.INT64
+        )
+        driver_fv = FeatureView(
+            name="driver_fv_to_delete",
+            entities=[entity],
+            schema=[Field(name="test_key", dtype=Int64)],
+            source=file_source,
+        )
+
+        # Register entity and feature view
+        test_feature_store.apply([entity, driver_fv])
+
+        # Verify feature view exists
+        fvs = test_feature_store.list_batch_feature_views()
+        assert len(fvs) == 1
+        assert fvs[0].name == driver_fv.name
+
+        # Delete the feature view using objects_to_delete
+        test_feature_store.apply(
+            objects=[], objects_to_delete=[driver_fv], partial=False
+        )
+
+        # Verify feature view is deleted
+        fvs = test_feature_store.list_batch_feature_views()
+        assert len(fvs) == 0
+
+        # Verify get_feature_view raises FeatureViewNotFoundException
+        with pytest.raises(FeatureViewNotFoundException):
+            test_feature_store.get_feature_view(driver_fv.name)
 
     test_feature_store.teardown()
 

--- a/sdk/python/tests/unit/local_feast_tests/test_local_feature_store.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_local_feature_store.py
@@ -443,16 +443,30 @@ def test_apply_permissions(test_feature_store):
     test_feature_store.teardown()
 
 
-@pytest.mark.parametrize(
-    "test_feature_store",
-    [lazy_fixture("feature_store_with_local_registry")],
-)
-def test_apply_delete_feature_view(test_feature_store):
-    """Test that a feature view can be deleted using objects_to_delete with partial=False."""
-    assert isinstance(test_feature_store, FeatureStore)
+def _apply_feature_view_to_delete(test_feature_store, file_source):
+    """Register an entity and a feature view, and return the feature view."""
+    entity = Entity(
+        name="driver_entity", join_keys=["test_key"], value_type=ValueType.INT64
+    )
+    driver_fv = FeatureView(
+        name="driver_fv_to_delete",
+        entities=[entity],
+        schema=[Field(name="test_key", dtype=Int64)],
+        source=file_source,
+    )
+    test_feature_store.apply([entity, driver_fv])
 
+    fvs = test_feature_store.list_batch_feature_views()
+    assert len(fvs) == 1
+    assert fvs[0].name == driver_fv.name
+
+    return driver_fv
+
+
+def _deletion_source_dataframe():
+    """Build the small source frame both deletion tests register against."""
     now = pd.Timestamp.utcnow().round("ms")
-    dataframe_source = pd.DataFrame(
+    return pd.DataFrame(
         {
             "test_key": [1, 2, 1, 3, 3],
             "feature_value": [0.1, 0.2, 0.3, 4.0, 5.0],
@@ -466,24 +480,68 @@ def test_apply_delete_feature_view(test_feature_store):
         }
     )
 
-    with prep_file_source(df=dataframe_source, timestamp_field="ts_1") as file_source:
-        entity = Entity(
-            name="driver_entity", join_keys=["test_key"], value_type=ValueType.INT64
-        )
-        driver_fv = FeatureView(
-            name="driver_fv_to_delete",
-            entities=[entity],
-            schema=[Field(name="test_key", dtype=Int64)],
-            source=file_source,
-        )
 
-        # Register entity and feature view
-        test_feature_store.apply([entity, driver_fv])
+@pytest.mark.parametrize(
+    "test_feature_store",
+    [lazy_fixture("feature_store_with_local_registry")],
+)
+def test_delete_feature_view(test_feature_store):
+    """Test the delete_feature_view lifecycle documented in registry.md.
 
-        # Verify feature view exists
-        fvs = test_feature_store.list_batch_feature_views()
-        assert len(fvs) == 1
-        assert fvs[0].name == driver_fv.name
+    Mirrors the end-to-end snippet in docs/getting-started/components/registry.md:
+    list the object, delete it by name, list again to confirm it is gone, and
+    check that fetching it afterwards raises FeatureViewNotFoundException.
+    """
+    assert isinstance(test_feature_store, FeatureStore)
+
+    with prep_file_source(
+        df=_deletion_source_dataframe(), timestamp_field="ts_1"
+    ) as file_source:
+        driver_fv = _apply_feature_view_to_delete(test_feature_store, file_source)
+
+        # Delete the feature view by name
+        test_feature_store.delete_feature_view(driver_fv.name)
+
+        # Verify feature view is deleted
+        assert len(test_feature_store.list_batch_feature_views()) == 0
+
+        # Verify get_feature_view raises FeatureViewNotFoundException
+        with pytest.raises(FeatureViewNotFoundException):
+            test_feature_store.get_feature_view(driver_fv.name)
+
+    test_feature_store.teardown()
+
+
+@pytest.mark.parametrize(
+    "test_feature_store",
+    [lazy_fixture("feature_store_with_local_registry")],
+)
+def test_delete_feature_view_raises_when_missing(test_feature_store):
+    """Deleting a feature view that was never registered raises, as documented."""
+    assert isinstance(test_feature_store, FeatureStore)
+
+    with pytest.raises(FeatureViewNotFoundException):
+        test_feature_store.delete_feature_view("feature_view_that_does_not_exist")
+
+    test_feature_store.teardown()
+
+
+@pytest.mark.parametrize(
+    "test_feature_store",
+    [lazy_fixture("feature_store_with_local_registry")],
+)
+def test_apply_delete_feature_view(test_feature_store):
+    """Test that a feature view can be deleted using objects_to_delete with partial=False.
+
+    This is the `feast apply` path called out in the hint block in registry.md,
+    and is distinct from the delete_feature_view path covered above.
+    """
+    assert isinstance(test_feature_store, FeatureStore)
+
+    with prep_file_source(
+        df=_deletion_source_dataframe(), timestamp_field="ts_1"
+    ) as file_source:
+        driver_fv = _apply_feature_view_to_delete(test_feature_store, file_source)
 
         # Delete the feature view using objects_to_delete
         test_feature_store.apply(
@@ -491,8 +549,7 @@ def test_apply_delete_feature_view(test_feature_store):
         )
 
         # Verify feature view is deleted
-        fvs = test_feature_store.list_batch_feature_views()
-        assert len(fvs) == 0
+        assert len(test_feature_store.list_batch_feature_views()) == 0
 
         # Verify get_feature_view raises FeatureViewNotFoundException
         with pytest.raises(FeatureViewNotFoundException):


### PR DESCRIPTION
## What this PR does

Closes #5360.

The existing registry docs already cover the `feast apply` deletion warning, the CLI command, the individual Python SDK `delete_*` methods, and the `partial=False` note. The one remaining gap, as agreed in the issue discussion, is that there is no single, self-contained example showing the complete deletion lifecycle in one place.

This PR addresses that gap with a minimal, copy-pasteable addition.

## Changes

- **`docs/getting-started/components/registry.md`**: Adds an "End-to-end example" section demonstrating the full feature view deletion lifecycle — list/verify the object exists, delete it, then list again to confirm removal — and notes that the same pattern applies to other registry objects via their corresponding `delete_*` methods.
- **`sdk/python/tests/unit/local_feast_tests/test_local_feature_store.py`**: Adds `test_apply_delete_feature_view`, which registers an entity and feature view, deletes it using `apply(objects_to_delete=[...], partial=False)`, and asserts the feature view is gone and that `get_feature_view` raises `FeatureViewNotFoundException`.

## Notes

This keeps the change intentionally small and documentation-focused, per the consensus reached in the issue thread between the maintainer and contributors. Thanks to @Henildiyora for the original snippet draft and review, and to @jyejare for the guidance.