### PR TITLE
ci: Allow nightly release version check to push

### DIFF
--- a/.github/workflows/nightly_python_sdk_release.yml
+++ b/.github/workflows/nightly_python_sdk_release.yml
@@ -15,7 +15,7 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: nightly-python-sdk-release


### PR DESCRIPTION
## What changed

- Grants the nightly Python SDK release workflow `contents: write` permission.

## Why

The scheduled run on June 12 failed in `get-nightly-version` before publishing. `semantic-release --dry-run` performs a Git push permission check, and the workflow token only had read-only contents permission:

```text
EGITNOPERMISSION Cannot push to the Git repository
Permission to feast-dev/feast.git denied to github-actions[bot]
```

Run: https://github.com/feast-dev/feast/actions/runs/27413013933

## Validation

- Parsed `.github/workflows/nightly_python_sdk_release.yml` with PyYAML.
- Ran `git diff --check` on the touched workflow file.
- Commit hook passed, including `Detect secrets`.