### PR TITLE
fix: Fix helm-docs failure in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,12 @@ jobs:
       next_version: ${{ steps.get_versions.outputs.next_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "lts/*"
       - name: Release (Dry Run)
@@ -76,11 +76,11 @@ jobs:
       CURRENT_VERSION: ${{ needs.get_dry_release_versions.outputs.current_version }}
       NEXT_VERSION: ${{ needs.get_dry_release_versions.outputs.next_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "lts/*"
       - name: Bump file versions
@@ -101,6 +101,7 @@ jobs:
         env:
           HOMEBREW_NO_SANDBOX_LINUX: 1
         run: |
+          brew trust norwoodj/tap
           brew install norwoodj/tap/helm-docs
       - name: Generate helm chart READMEs
         run: make build-helm-docs
@@ -129,12 +130,12 @@ jobs:
       GIT_COMMITTER_EMAIL: feast-ci-bot@willem.co
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: './ui/.nvmrc'
       - name: Set up Homebrew
@@ -144,6 +145,7 @@ jobs:
         env:
           HOMEBREW_NO_SANDBOX_LINUX: 1
         run: |
+          brew trust norwoodj/tap
           brew install norwoodj/tap/helm-docs
       - name: Install Go
         uses: actions/setup-go@v5
@@ -178,7 +180,7 @@ jobs:
       GITHUB_REPOSITORY: ${{ github.repository }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
# What this PR does / why we need it:


Fix https://github.com/feast-dev/feast/actions/runs/27455652218/job/81159643119 


## Problems

- Homebrew/actions/setup-homebrew@master is deprecated - must use main

- Bubblewrap (bwrap) is missing on the runner - Homebrew's Linux sandbox requires it. Either install it or set HOMEBREW_NO_SANDBOX_LINUX=1.

- norwoodj/tap is untrusted - need to run brew trust norwoodj/tap before installing from it.

