### PR TITLE
ci: Strip color from release version check

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -195,6 +195,7 @@ jobs:
             echo "Error: Failed to get Feast version."
             exit 1
           fi
+          VERSION_OUTPUT=$(printf '%s\n' "$VERSION_OUTPUT" | python -c 'import re, sys; print(re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", sys.stdin.read()).strip())')
           VERSION_REGEX='[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+)?'
           OUTPUT_REGEX="^Feast SDK Version: \"${VERSION_REGEX}\"$"
           VERSION=$(echo "$VERSION_OUTPUT" | grep -oE "$VERSION_REGEX")


### PR DESCRIPTION
## What changed

- Strips ANSI color escape sequences from `feast version` output before release wheel validation checks the version string.

## Why

The June 13 nightly Python SDK release got past version computation and built the wheel, but failed in the wheel verification matrix before publishing:

```text
Feast SDK Version: "0.64.0.dev2"
Process completed with exit code 1
```

The actual log output includes ANSI color codes from the CLI, so the installed version is correct but the strict `^Feast SDK Version: ...$` regex does not match.

Run: https://github.com/feast-dev/feast/actions/runs/27463977756
Failed job: https://github.com/feast-dev/feast/actions/runs/27463977756/job/81183044422

## Validation

- Parsed `.github/workflows/build_wheels.yml` with PyYAML.
- Ran `git diff --check` on the touched workflow file.
- Replayed the validation shell fragment against a colored `feast version` sample and confirmed it passes.
- Commit hook passed, including `Detect secrets`.