### PR TITLE
ci: Fix release helm-docs install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,10 @@ jobs:
       - name: Remove previous Helm
         run: sudo rm -rf $(which helm)
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
       - name: Setup Helm-docs
+        env:
+          HOMEBREW_NO_SANDBOX_LINUX: 1
         run: |
           brew install norwoodj/tap/helm-docs
       - name: Generate helm chart READMEs
@@ -137,8 +139,10 @@ jobs:
           node-version-file: './ui/.nvmrc'
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
       - name: Setup Helm-docs
+        env:
+          HOMEBREW_NO_SANDBOX_LINUX: 1
         run: |
           brew install norwoodj/tap/helm-docs
       - name: Install Go


### PR DESCRIPTION
## Summary
- disable the Homebrew Linux sandbox for helm-docs installs in the release workflow
- switch Homebrew setup action references from deprecated `@master` to `@main`

## Context
The latest release run failed in `validate_version_bumps` while installing `norwoodj/tap/helm-docs` via Homebrew:

```
Bubblewrap is required to use the Linux sandbox but was not found.
```

Homebrew suggested `HOMEBREW_NO_SANDBOX_LINUX=1` as the workaround. This applies that env var to both release workflow helm-docs install steps, since the real release job uses the same install path after validation.

Failed job: https://github.com/feast-dev/feast/actions/runs/27455652218/job/81159643119

## Validation
- `python - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`