### PR TITLE
ci: Allow nightly fallback with no release

### DIFF
--- a/.github/workflows/nightly_python_sdk_release.yml
+++ b/.github/workflows/nightly_python_sdk_release.yml
@@ -55,7 +55,7 @@ jobs:
             set -e
             echo "$SEMANTIC_OUTPUT"
 
-            BASE_VERSION=$(echo "$SEMANTIC_OUTPUT" | grep 'The next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/' | tail -n 1)
+            BASE_VERSION=$(echo "$SEMANTIC_OUTPUT" | grep 'The next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/' | tail -n 1 || true)
             if [[ -z "$BASE_VERSION" ]]; then
               echo "Could not determine a semantic-release next version (exit code: ${SEMANTIC_STATUS}); falling back to next patch after latest stable tag."
               source infra/scripts/setup-common-functions.sh


### PR DESCRIPTION
## What changed

- Makes nightly version extraction tolerate the case where `semantic-release --dry-run` reports no release-worthy commits.

## Why

The June 15 nightly run failed in `get-nightly-version` before publishing. The workflow intentionally has fallback logic for this case, but the extraction pipeline exits under `set -euo pipefail` when this grep finds no match:

```bash
grep 'The next release version is'
```

So the script exits before reaching the fallback to the next patch version after the latest stable tag.

Run: https://github.com/feast-dev/feast/actions/runs/27550581747
Failed job: https://github.com/feast-dev/feast/actions/runs/27550581747/job/81435450528

## Validation

- Parsed `.github/workflows/nightly_python_sdk_release.yml` with PyYAML.
- Ran `git diff --check` on the touched workflow file.
- Replayed the `set -euo pipefail` no-release extraction case and confirmed the fallback path remains reachable.
- Commit hook passed, including `Detect secrets`.