### PR TITLE
ci: Fix nightly release fallback version

### DIFF
--- a/.github/workflows/nightly_python_sdk_release.yml
+++ b/.github/workflows/nightly_python_sdk_release.yml
@@ -55,11 +55,14 @@ jobs:
             set -e
             echo "$SEMANTIC_OUTPUT"
 
-            BASE_VERSION=$(echo "$SEMANTIC_OUTPUT" | grep 'The next release version is' | sed -E 's/.* ([[:digit:].]+)$/\1/' | tail -n 1)
+            BASE_VERSION=$(printf '%s\n' "$SEMANTIC_OUTPUT" | sed -nE 's/.*The next release version is ([[:digit:].]+)$/\1/p' | tail -n 1)
             if [[ -z "$BASE_VERSION" ]]; then
               echo "Could not determine a semantic-release next version (exit code: ${SEMANTIC_STATUS}); falling back to next patch after latest stable tag."
-              source infra/scripts/setup-common-functions.sh
-              LATEST_TAG=$(get_tag_release -s)
+              LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | sed -nE '/^v[0-9]+\.[0-9]+\.[0-9]+$/{p;q;}')
+              if [[ -z "$LATEST_TAG" ]]; then
+                echo "Could not determine latest stable tag."
+                exit 1
+              fi
               LATEST_VERSION="${LATEST_TAG#v}"
               IFS=. read -r MAJOR MINOR PATCH <<< "$LATEST_VERSION"
               BASE_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"


### PR DESCRIPTION
## Summary
- make nightly semantic-release version parsing safe under `set -euo pipefail`
- keep the existing fallback path working when semantic-release reports no release-worthy commits
- compute the fallback from the latest stable `vX.Y.Z` git tag directly, with an explicit empty-tag guard

## Context
The latest scheduled nightly run failed in `get-nightly-version` before it reached publishing:

https://github.com/feast-dev/feast/actions/runs/27550581747/job/81435450528

The log showed semantic-release completed successfully but found no release-worthy commits:

```
There are no relevant changes, so no new version is released.
```

The workflow already intended to fall back to the next patch after the latest stable tag, but the `grep 'The next release version is'` pipeline returned no match under `set -euo pipefail`, so the shell exited before the fallback block could run.

## Validation
- parsed `.github/workflows/nightly_python_sdk_release.yml` with PyYAML
- ran a `bash -euo pipefail` simulation of the no-release semantic-release output; it now computes `0.64.1` from latest stable tag `v0.64.0`
- `git diff --check`