### PR TITLE
fix: Build embedded UI from local source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -813,12 +813,11 @@ build-helm-docs: ## Build helm docs
 # Note: these require node and yarn to be installed
 
 build-ui: ## Build Feast UI
-	cd $(ROOT_DIR)/sdk/python/feast/ui && yarn upgrade @feast-dev/feast-ui --latest && yarn install && npm run build --omit=dev
-
-build-ui-local: ## Build Feast UI locally
 	cd $(ROOT_DIR)/ui && yarn install && npm run build --omit=dev
 	rm -rf $(ROOT_DIR)/sdk/python/feast/ui/build
 	cp -r $(ROOT_DIR)/ui/build $(ROOT_DIR)/sdk/python/feast/ui/
+
+build-ui-local: build-ui ## Build Feast UI locally
 
 format-ui: ## Format Feast UI
 	cd $(ROOT_DIR)/ui && NPM_TOKEN= yarn install && NPM_TOKEN= yarn format


### PR DESCRIPTION
## What changed

- Update `make build-ui` to build the checked-out `ui/` source and copy the generated build into `sdk/python/feast/ui/build`.
- Keep `build-ui-local` as an alias for the same build path.

## Why

`feast ui` packages the embedded React app from `sdk/python/feast/ui/build`. The previous release build target pulled `@feast-dev/feast-ui --latest` from npm, but npm's latest published package is still `0.57.0`. That stale UI treats `registryPath` as a monolithic registry blob URL, so with the newer Python server generating `/api/v1`, it requests `GET /api/v1` and receives a 404.

Building the embedded UI from the repo-local `ui/` source keeps the frontend bundle aligned with the REST-backed Python UI server.

Fixes #6519.

## Validation

- `make -n build-ui`

I could not run the full UI build locally because `yarn` is not installed in this shell.