### PR TITLE
fix: Build embedded UI from local source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -813,12 +813,11 @@ build-helm-docs: ## Build helm docs
 # Note: these require node and yarn to be installed
 
 build-ui: ## Build Feast UI
-	cd $(ROOT_DIR)/sdk/python/feast/ui && yarn upgrade @feast-dev/feast-ui --latest && yarn install && npm run build --omit=dev
-
-build-ui-local: ## Build Feast UI locally
 	cd $(ROOT_DIR)/ui && yarn install && npm run build --omit=dev
 	rm -rf $(ROOT_DIR)/sdk/python/feast/ui/build
 	cp -r $(ROOT_DIR)/ui/build $(ROOT_DIR)/sdk/python/feast/ui/
+
+build-ui-local: build-ui ## Build Feast UI locally
 
 format-ui: ## Format Feast UI
 	cd $(ROOT_DIR)/ui && NPM_TOKEN= yarn install && NPM_TOKEN= yarn format

--- a/infra/feast-operator/bundle/manifests/openlineage-secret_v1_secret.yaml
+++ b/infra/feast-operator/bundle/manifests/openlineage-secret_v1_secret.yaml
@@ -3,4 +3,4 @@ kind: Secret
 metadata:
   name: openlineage-secret
 stringData:
-  api_key: your-marquez-api-key
+  api_key: your-marquez-api-key # pragma: allowlist secret

--- a/sdk/python/feast/api/registry/rest/rest_registry_server.py
+++ b/sdk/python/feast/api/registry/rest/rest_registry_server.py
@@ -78,7 +78,7 @@ class RestRegistryServer:
 
         registry_cfg = getattr(store.config, "registry", None)
         mcp_cfg = getattr(registry_cfg, "mcp", None)
-        if mcp_cfg and getattr(mcp_cfg, "enabled", False):
+        if mcp_cfg and getattr(mcp_cfg, "enabled", False) is True:
             try:
                 from fastapi_mcp import FastApiMCP
 

--- a/sdk/python/tests/unit/api/test_api_rest_registry_server.py
+++ b/sdk/python/tests/unit/api/test_api_rest_registry_server.py
@@ -54,33 +54,12 @@ def test_rest_registry_server_initializes_correctly(
     assert {"BearerAuth": []} in openapi_schema["security"]
 
 
-def test_routes_registered_in_app(mock_store_and_registry):
-    from fastapi.routing import APIRoute
+def test_routes_registered_in_app():
+    from feast.api.registry.rest import register_all_routes
 
-    store, _ = mock_store_and_registry
+    app = MagicMock()
+    grpc_handler = MagicMock()
+    server = MagicMock()
+    register_all_routes(app, grpc_handler, server)
 
-    server = RestRegistryServer(store)
-    route_paths = [
-        route.path for route in server.app.routes if isinstance(route, APIRoute)
-    ]
-    assert "/feature_services" in route_paths
-    assert "/entities" in route_paths
-    assert "/projects" in route_paths
-    assert "/data_sources" in route_paths
-    assert "/saved_datasets" in route_paths
-    assert "/permissions" in route_paths
-    assert "/lineage/registry" in route_paths
-    assert "/lineage/objects/{object_type}/{object_name}" in route_paths
-    assert "/lineage/complete" in route_paths
-    assert "/entities/all" in route_paths
-    assert "/feature_views/all" in route_paths
-    assert "/data_sources/all" in route_paths
-    assert "/feature_services/all" in route_paths
-    assert "/saved_datasets/all" in route_paths
-    assert "/lineage/registry/all" in route_paths
-    assert "/lineage/complete/all" in route_paths
-    assert "/features" in route_paths
-    assert "/features/all" in route_paths
-    assert "/features/{feature_view}/{name}" in route_paths
-    assert "/metrics/resource_counts" in route_paths
-    assert "/metrics/recently_visited" in route_paths
+    assert app.include_router.call_count == 13


### PR DESCRIPTION
## What changed

- Backport #6525 to `v0.64-branch`.
- Update `make build-ui` to build the checked-out `ui/` source and copy the generated build into `sdk/python/feast/ui/build`.
- Keep `build-ui-local` as an alias for the same build path.
- Backport the explicit MCP enablement guard from `master` so mocked config does not accidentally mount MCP routes in unit tests.
- Backport the `master` REST route registration test simplification so the test verifies router inclusion directly instead of depending on mocked `RestRegistryServer` construction side effects.
- Backport the `master` allowlist comment for the OpenLineage placeholder API key so `detect-secrets --all-files` passes on the release branch.

## Why

`feast ui` packages the embedded React app from `sdk/python/feast/ui/build`. The previous release build target pulled `@feast-dev/feast-ui --latest` from npm, but npm's latest published package is still `0.57.0`. That stale UI treats `registryPath` as a monolithic registry blob URL, so with the newer Python server generating `/api/v1`, it requests `GET /api/v1` and receives a 404.

Building the embedded UI from the repo-local `ui/` source keeps the frontend bundle aligned with the REST-backed Python UI server for the 0.64 release branch.

The test-only backports are included because `v0.64-branch` unit tests use a `MagicMock` config. Without requiring `mcp.enabled is True`, the mock is truthy and the server mounts MCP routes. After that guard, the route-path assertion still depends on mocked server construction, so this PR also matches `master` by verifying `register_all_routes` directly.

The OpenLineage manifest change matches `master`; it is a placeholder value, not a real secret.

Fixes #6519.

## Validation

- `make -n build-ui`
- `python3 -m py_compile sdk/python/tests/unit/api/test_api_rest_registry_server.py sdk/python/feast/api/registry/rest/rest_registry_server.py`

I could not run the full UI build locally because `yarn` is not installed in this shell. I also could not run the targeted Python test locally because `uv` is not installed in this shell, and I could not run `pre-commit` locally because `pre-commit` is not installed in this shell.