### PR TITLE
test: Stabilize CLI runner subprocess path

### DIFF
--- a/sdk/python/tests/utils/cli_repo_creator.py
+++ b/sdk/python/tests/utils/cli_repo_creator.py
@@ -19,6 +19,7 @@ overhead and avoids atexit-handler (Dask thread pool, PySpark JVM) hang risks
 that can push the cumulative test time past the pytest global timeout budget.
 """
 
+import os
 import random
 import string
 import subprocess
@@ -53,6 +54,15 @@ class CliRunner:
     modules from the feature repo, and it is hard to clean up that state otherwise.
     """
 
+    def _subprocess_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        parent_paths = [path for path in sys.path if path]
+        existing_pythonpath = env.get("PYTHONPATH")
+        if existing_pythonpath:
+            parent_paths.append(existing_pythonpath)
+        env["PYTHONPATH"] = os.pathsep.join(parent_paths)
+        return env
+
     def run(self, args: List[str], cwd: Path) -> subprocess.CompletedProcess:
         # Apply a conservative timeout to prevent CI hangs from Dask atexit-handler
         # stalls or other subprocess blockages.
@@ -64,6 +74,7 @@ class CliRunner:
                 cwd=cwd,
                 capture_output=True,
                 timeout=timeout,
+                env=self._subprocess_env(),
             )
         except subprocess.TimeoutExpired:
             return subprocess.CompletedProcess(
@@ -87,6 +98,7 @@ class CliRunner:
             cwd=cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            env=self._subprocess_env(),
         )
         try:
             stdout, _ = proc.communicate(timeout=timeout)


### PR DESCRIPTION
## What changed
- Normalizes the environment used by `CliRunner` subprocesses in unit tests.
- Adds the parent pytest process `sys.path` entries to `PYTHONPATH` before invoking `feast.cli.cli` in a child Python process.
- Applies the same environment to both `subprocess.run(...)` and `subprocess.Popen(...)` helper paths.

## Why
The unit-test workflow flaked on `unit-test-python (3.12, ubuntu-latest)` while setting up `test_push_source_does_not_exist`. The parent pytest process had imported Feast successfully, but the child `feast apply` subprocess failed before the test body with:

```text
ModuleNotFoundError: No module named 'google.protobuf.timestamp_pb2'
```

That points at the subprocess import environment rather than the test assertion. Passing through the parent process import path makes the CLI subprocess use the same repo/site-packages view as pytest.

## Validation
- `uv run ruff check sdk/python/tests/utils/cli_repo_creator.py`
- `uv run python -m pytest sdk/python/tests/unit/test_feature_server.py::test_push_source_does_not_exist -q`
- subprocess smoke: `from google.protobuf.timestamp_pb2 import Timestamp` using `CliRunner._subprocess_env()`

Note: local setup required `make install-python-dependencies-ci PYTHON_VERSION=3.12` because this machine does not have a `python` shim for the Makefile's default version detection.