### PR TITLE
feat: Add Compute & Jobs API and UI page for engine visibility and materialization Jobs

### DIFF
--- a/sdk/python/feast/api/registry/rest/__init__.py
+++ b/sdk/python/feast/api/registry/rest/__init__.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 
 from fastapi import FastAPI
 
+from feast.api.registry.rest.compute_engines import get_compute_engine_router
 from feast.api.registry.rest.data_sources import get_data_source_router
 from feast.api.registry.rest.entities import get_entity_router
 from feast.api.registry.rest.feature_services import get_feature_service_router
@@ -41,6 +42,7 @@ def register_all_routes(app: FastAPI, grpc_handler, server=None, store=None):
         server.store if server and hasattr(server, "store") else None
     )
     app.include_router(get_monitoring_router(grpc_handler, store=resolved_store))
+    app.include_router(get_compute_engine_router(grpc_handler, store=resolved_store))
 
     _register_openlineage_consumer(app, resolved_store)
 

--- a/sdk/python/feast/api/registry/rest/compute_engines.py
+++ b/sdk/python/feast/api/registry/rest/compute_engines.py
@@ -1,0 +1,256 @@
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from feast.api.registry.rest.rest_utils import (
+    get_pagination_params,
+    get_sorting_params,
+    grpc_call,
+)
+from feast.protos.feast.registry import RegistryServer_pb2
+from feast.repo_config import BATCH_ENGINE_CLASS_FOR_TYPE
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_engine_info(store) -> Dict[str, Any]:
+    """Extract compute engine configuration from the FeatureStore."""
+    config = getattr(store, "config", None)
+    if config is None:
+        return {
+            "engineType": "local",
+            "engineClass": "LocalComputeEngine",
+            "config": {"type": "local"},
+        }
+
+    batch_engine = getattr(config, "batch_engine", None)
+    if batch_engine is None:
+        return {
+            "engineType": "local",
+            "engineClass": "LocalComputeEngine",
+            "config": {"type": "local"},
+        }
+
+    if isinstance(batch_engine, dict):
+        engine_type = batch_engine.get("type", "local")
+        engine_config = {k: v for k, v in batch_engine.items() if v is not None}
+    elif hasattr(batch_engine, "type"):
+        engine_type = str(batch_engine.type)
+        dump = getattr(batch_engine, "model_dump", None) or getattr(
+            batch_engine, "dict", None
+        )
+        if dump:
+            engine_config = {k: v for k, v in dump().items() if v is not None}
+        else:
+            engine_config = {"type": engine_type}
+    else:
+        engine_type = str(batch_engine)
+        engine_config = {"type": engine_type}
+
+    engine_class_path = BATCH_ENGINE_CLASS_FOR_TYPE.get(engine_type, engine_type)
+    engine_class = (
+        engine_class_path.rsplit(".", 1)[-1]
+        if "." in engine_class_path
+        else engine_class_path
+    )
+
+    return {
+        "engineType": engine_type,
+        "engineClass": engine_class,
+        "config": engine_config,
+    }
+
+
+def _extract_materialization_jobs(
+    grpc_handler, project: str, allow_cache: bool = True
+) -> List[Dict[str, Any]]:
+    """Extract materialization job info from feature view metadata."""
+    req = RegistryServer_pb2.ListFeatureViewsRequest(
+        project=project,
+        allow_cache=allow_cache,
+    )
+    response = grpc_call(grpc_handler.ListFeatureViews, req)
+    feature_views = response.get("featureViews", [])
+
+    jobs: List[Dict[str, Any]] = []
+    for fv in feature_views:
+        spec = fv.get("spec", fv)
+        meta = fv.get("meta", {})
+        fv_name = spec.get("name", "unknown")
+        intervals = meta.get("materializationIntervals", [])
+
+        for idx, interval in enumerate(intervals):
+            start_time = interval.get("startTime", interval.get("start_time"))
+            end_time = interval.get("endTime", interval.get("end_time"))
+
+            jobs.append(
+                {
+                    "id": f"{fv_name}-{idx}",
+                    "featureView": fv_name,
+                    "status": "SUCCEEDED",
+                    "startTime": start_time,
+                    "endTime": end_time,
+                }
+            )
+
+    jobs.sort(key=lambda j: j.get("startTime", ""), reverse=True)
+    return jobs
+
+
+def get_compute_engine_router(grpc_handler, store=None) -> APIRouter:
+    router = APIRouter()
+
+    def _fv_to_info(fv: dict, fv_type: str) -> Dict[str, Any]:
+        spec = fv.get("spec", fv)
+        meta = fv.get("meta", {})
+        intervals = meta.get("materializationIntervals", [])
+        batch_engine = spec.get("batchEngine")
+
+        last_materialized = None
+        if intervals:
+            last_interval = intervals[-1]
+            last_materialized = last_interval.get(
+                "endTime", last_interval.get("end_time")
+            )
+
+        return {
+            "name": spec.get("name"),
+            "type": fv_type,
+            "online": spec.get("online", True),
+            "lastMaterialized": last_materialized,
+            "hasOverride": batch_engine is not None,
+            "overrides": batch_engine,
+            "materializationIntervals": intervals,
+        }
+
+    @router.get("/compute_engines")
+    def get_compute_engine(
+        project: str = Query(...),
+        allow_cache: bool = Query(default=True),
+    ):
+        engine_info = (
+            _extract_engine_info(store)
+            if store
+            else {
+                "engineType": "local",
+                "engineClass": "LocalComputeEngine",
+                "config": {"type": "local"},
+            }
+        )
+
+        fv_infos: List[Dict[str, Any]] = []
+
+        batch_resp = grpc_call(
+            grpc_handler.ListFeatureViews,
+            RegistryServer_pb2.ListFeatureViewsRequest(
+                project=project, allow_cache=allow_cache
+            ),
+        )
+        for fv in batch_resp.get("featureViews", []):
+            fv_infos.append(_fv_to_info(fv, "Batch"))
+
+        stream_resp = grpc_call(
+            grpc_handler.ListStreamFeatureViews,
+            RegistryServer_pb2.ListStreamFeatureViewsRequest(
+                project=project, allow_cache=allow_cache
+            ),
+        )
+        for sfv in stream_resp.get("streamFeatureViews", []):
+            fv_infos.append(_fv_to_info(sfv, "Stream"))
+
+        engine_info["featureViewCount"] = len(fv_infos)
+        engine_info["project"] = project
+
+        return {
+            "engine": engine_info,
+            "featureViews": fv_infos,
+        }
+
+    @router.get("/compute_engines/all")
+    def list_all_compute_engines(
+        allow_cache: bool = Query(default=True),
+        page: int = Query(1, ge=1),
+        limit: int = Query(50, ge=1, le=100),
+    ):
+        req = RegistryServer_pb2.ListProjectsRequest(allow_cache=allow_cache)
+        projects_resp = grpc_call(grpc_handler.ListProjects, req)
+        projects = projects_resp.get("projects", [])
+
+        engines = []
+        for proj in projects:
+            proj_name = proj.get("spec", {}).get("name") or proj.get("name", "")
+            if not proj_name:
+                continue
+
+            engine_info = (
+                _extract_engine_info(store)
+                if store
+                else {
+                    "engineType": "local",
+                    "engineClass": "LocalComputeEngine",
+                    "config": {"type": "local"},
+                    "mode": "standalone",
+                    "configSource": "feature_store.yaml",
+                }
+            )
+
+            fv_req = RegistryServer_pb2.ListFeatureViewsRequest(
+                project=proj_name,
+                allow_cache=allow_cache,
+            )
+            fv_resp = grpc_call(grpc_handler.ListFeatureViews, fv_req)
+            fv_count = len(fv_resp.get("featureViews", []))
+
+            engine_info["project"] = proj_name
+            engine_info["featureViewCount"] = fv_count
+            engines.append(engine_info)
+
+        start = (page - 1) * limit
+        end = start + limit
+        paginated = engines[start:end]
+
+        return {
+            "engines": paginated,
+            "pagination": {
+                "page": page,
+                "limit": limit,
+                "total": len(engines),
+            },
+        }
+
+    @router.get("/materialization_jobs")
+    def list_materialization_jobs(
+        project: str = Query(...),
+        allow_cache: bool = Query(default=True),
+        status: Optional[str] = Query(None, description="Filter by status"),
+        feature_view: Optional[str] = Query(
+            None, alias="feature_view", description="Filter by feature view name"
+        ),
+        pagination_params: dict = Depends(get_pagination_params),
+        sorting_params: dict = Depends(get_sorting_params),
+    ):
+        jobs = _extract_materialization_jobs(grpc_handler, project, allow_cache)
+
+        if status:
+            jobs = [j for j in jobs if j.get("status") == status.upper()]
+        if feature_view:
+            jobs = [j for j in jobs if j.get("featureView") == feature_view]
+
+        page = pagination_params.get("page", 1)
+        limit = pagination_params.get("limit", 50)
+        start = (page - 1) * limit
+        end = start + limit
+        total = len(jobs)
+        paginated = jobs[start:end]
+
+        return {
+            "jobs": paginated,
+            "pagination": {
+                "page": page,
+                "limit": limit,
+                "total": total,
+            },
+        }
+
+    return router

--- a/sdk/python/tests/unit/api/test_api_rest_registry_server.py
+++ b/sdk/python/tests/unit/api/test_api_rest_registry_server.py
@@ -62,4 +62,4 @@ def test_routes_registered_in_app():
     server = MagicMock()
     register_all_routes(app, grpc_handler, server)
 
-    assert app.include_router.call_count == 13
+    assert app.include_router.call_count == 14

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -29,6 +29,7 @@ import LineageIndex from "./pages/lineage/Index";
 import NoProjectGuard from "./components/NoProjectGuard";
 import MonitoringIndex from "./pages/monitoring/Index";
 import FeatureMetricsDetail from "./pages/monitoring/FeatureMetricsDetail";
+import ComputeEngineIndex from "./pages/compute-engines/Index";
 
 import TabsRegistryContext, {
   FeastTabsRegistryInterface,
@@ -223,6 +224,10 @@ const FeastUISansProvidersInner = ({
                         <Route
                           path="monitoring/feature/:featureViewName/:featureName"
                           element={<FeatureMetricsDetail />}
+                        />
+                        <Route
+                          path="compute-engine/*"
+                          element={<ComputeEngineIndex />}
                         />
                       </Route>
                     </Route>

--- a/ui/src/graphics/ComputeEngineIcon.tsx
+++ b/ui/src/graphics/ComputeEngineIcon.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+const ComputeEngineIcon = (props: React.SVGProps<SVGSVGElement>) => {
+  return (
+    <svg {...props} viewBox="0 0 32 32" fill="none">
+      <path
+        d="M4 8C4 6.89543 4.89543 6 6 6H26C27.1046 6 28 6.89543 28 8V12C28 13.1046 27.1046 14 26 14H6C4.89543 14 4 13.1046 4 12V8Z"
+        fill="#0569EA"
+      />
+      <circle cx="8" cy="10" r="1.5" fill="white" />
+      <circle cx="12" cy="10" r="1.5" fill="white" />
+      <rect
+        x="16"
+        y="9"
+        width="8"
+        height="2"
+        rx="1"
+        fill="white"
+        opacity="0.6"
+      />
+      <path
+        d="M4 20C4 18.8954 4.89543 18 6 18H26C27.1046 18 28 18.8954 28 20V24C28 25.1046 27.1046 26 26 26H6C4.89543 26 4 25.1046 4 24V20Z"
+        fill="#0569EA"
+        opacity="0.6"
+      />
+      <circle cx="8" cy="22" r="1.5" fill="white" />
+      <circle cx="12" cy="22" r="1.5" fill="white" />
+      <rect
+        x="16"
+        y="21"
+        width="8"
+        height="2"
+        rx="1"
+        fill="white"
+        opacity="0.6"
+      />
+    </svg>
+  );
+};
+
+export { ComputeEngineIcon };

--- a/ui/src/graphics/JobsIcon.tsx
+++ b/ui/src/graphics/JobsIcon.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const JobsIcon = (props: React.SVGProps<SVGSVGElement>) => {
+  return (
+    <svg {...props} viewBox="0 0 32 32" fill="none">
+      <path
+        d="M16 4C9.37258 4 4 9.37258 4 16C4 22.6274 9.37258 28 16 28C22.6274 28 28 22.6274 28 16C28 9.37258 22.6274 4 16 4ZM16 6.5C21.2467 6.5 25.5 10.7533 25.5 16C25.5 21.2467 21.2467 25.5 16 25.5C10.7533 25.5 6.5 21.2467 6.5 16C6.5 10.7533 10.7533 6.5 16 6.5Z"
+        fill="#0569EA"
+      />
+      <path
+        d="M15 10V16.414L19.293 20.707L20.707 19.293L17 15.586V10H15Z"
+        fill="#0569EA"
+      />
+    </svg>
+  );
+};
+
+export { JobsIcon };

--- a/ui/src/pages/Sidebar.tsx
+++ b/ui/src/pages/Sidebar.tsx
@@ -24,6 +24,7 @@ import { FeatureIcon } from "../graphics/FeatureIcon";
 import { HomeIcon } from "../graphics/HomeIcon";
 import { PermissionsIcon } from "../graphics/PermissionsIcon";
 import { LabelViewIcon } from "../graphics/LabelViewIcon";
+import { ComputeEngineIcon } from "../graphics/ComputeEngineIcon";
 import type { genericFVType } from "../parsers/mergedFVTypes";
 
 const SideNav = () => {
@@ -194,6 +195,15 @@ const SideNav = () => {
             <Link {...props} to={`${baseUrl}/monitoring`} />
           ),
           isSelected: monitoringSelected,
+        },
+        {
+          name: "Compute & Jobs",
+          id: htmlIdGenerator("computeEngine")(),
+          icon: <EuiIcon type={ComputeEngineIcon} />,
+          renderItem: (props: any) => (
+            <Link {...props} to={`${baseUrl}/compute-engine`} />
+          ),
+          isSelected: useMatchSubpath(`${baseUrl}/compute-engine`),
         },
       ],
     },

--- a/ui/src/pages/compute-engines/Index.tsx
+++ b/ui/src/pages/compute-engines/Index.tsx
@@ -1,0 +1,534 @@
+import React, { useMemo, useState } from "react";
+import { Route, Routes, useNavigate, useParams } from "react-router-dom";
+
+import {
+  EuiPageTemplate,
+  EuiLoadingSpinner,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiStat,
+  EuiSpacer,
+  EuiPanel,
+  EuiHorizontalRule,
+  EuiTitle,
+  EuiText,
+  EuiBadge,
+  EuiBasicTable,
+  EuiDescriptionList,
+  EuiDescriptionListTitle,
+  EuiDescriptionListDescription,
+  EuiHealth,
+  EuiFilterGroup,
+  EuiFilterButton,
+} from "@elastic/eui";
+
+import { ComputeEngineIcon } from "../../graphics/ComputeEngineIcon";
+import { useMatchExact, useMatchSubpath } from "../../hooks/useMatchSubpath";
+import { useDocumentTitle } from "../../hooks/useDocumentTitle";
+import {
+  useLoadComputeEngine,
+  FeatureViewEngineInfo,
+} from "../../queries/useLoadComputeEngine";
+import EuiCustomLink from "../../components/EuiCustomLink";
+
+interface MaterializationJobRow {
+  id: string;
+  featureView: string;
+  status: "SUCCEEDED" | "RUNNING" | "ERROR" | "WAITING";
+  rangeStart: string;
+  rangeEnd: string;
+  sortKey: number;
+}
+
+function formatRange(iso: string | undefined): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+function buildJobsFromFeatureViews(
+  featureViewInfos: FeatureViewEngineInfo[],
+): MaterializationJobRow[] {
+  const jobs: MaterializationJobRow[] = [];
+
+  featureViewInfos.forEach((fv) => {
+    if (fv.materializationIntervals && fv.materializationIntervals.length > 0) {
+      fv.materializationIntervals.forEach((interval, idx) => {
+        const startTime =
+          (interval as any).startTime || (interval as any).start_time;
+        const endTime = (interval as any).endTime || (interval as any).end_time;
+
+        const sortMs = endTime
+          ? new Date(endTime).getTime()
+          : startTime
+            ? new Date(startTime).getTime()
+            : 0;
+
+        jobs.push({
+          id: `${fv.name}-${idx}`,
+          featureView: fv.name,
+          status: "SUCCEEDED",
+          rangeStart: formatRange(startTime),
+          rangeEnd: formatRange(endTime),
+          sortKey: sortMs,
+        });
+      });
+    }
+  });
+
+  return jobs.sort((a, b) => {
+    try {
+      return b.sortKey - a.sortKey;
+    } catch {
+      return 0;
+    }
+  });
+}
+
+const statusColorMap: Record<string, string> = {
+  SUCCEEDED: "success",
+  RUNNING: "primary",
+  ERROR: "danger",
+  WAITING: "subdued",
+};
+
+const OverviewTab = ({
+  engineInfo,
+  featureViewInfos,
+  projectName,
+}: {
+  engineInfo: any;
+  featureViewInfos: FeatureViewEngineInfo[];
+  projectName: string | undefined;
+}) => {
+  const materializedCount = featureViewInfos.filter(
+    (fv) => fv.lastMaterialized,
+  ).length;
+  const overrideCount = featureViewInfos.filter((fv) => fv.hasOverride).length;
+
+  const fvColumns = [
+    {
+      name: "Feature View",
+      field: "name",
+      sortable: true,
+      render: (name: string) => (
+        <EuiCustomLink to={`/p/${projectName}/feature-view/${name}`}>
+          {name}
+        </EuiCustomLink>
+      ),
+    },
+    {
+      name: "Type",
+      field: "type",
+      sortable: true,
+      render: (type: string) => <EuiBadge color="hollow">{type}</EuiBadge>,
+    },
+    {
+      name: "Online",
+      field: "online",
+      render: (online: boolean) => (
+        <EuiHealth color={online ? "success" : "subdued"}>
+          {online ? "Yes" : "No"}
+        </EuiHealth>
+      ),
+    },
+    {
+      name: "Last Materialized",
+      field: "lastMaterialized",
+      render: (val: string | undefined) => {
+        if (!val)
+          return (
+            <EuiText size="s" color="subdued">
+              Never
+            </EuiText>
+          );
+        try {
+          return new Date(val).toLocaleString();
+        } catch {
+          return val;
+        }
+      },
+    },
+    {
+      name: "Engine Override",
+      field: "hasOverride",
+      render: (hasOverride: boolean, item: any) => {
+        if (!hasOverride) {
+          return (
+            <EuiText size="s" color="subdued">
+              None
+            </EuiText>
+          );
+        }
+        const keys = item.overrides ? Object.keys(item.overrides) : [];
+        return (
+          <EuiBadge color="primary">
+            {keys.length > 0 ? keys.join(", ") : "Custom"}
+          </EuiBadge>
+        );
+      },
+    },
+  ];
+
+  return (
+    <React.Fragment>
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <EuiStat
+            title={engineInfo?.engineType || "local"}
+            description="Engine Type"
+            titleSize="s"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={String(featureViewInfos.length)}
+            description="Feature Views"
+            titleSize="s"
+            titleColor="primary"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={String(materializedCount)}
+            description="Materialized"
+            titleSize="s"
+            titleColor="success"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={String(overrideCount)}
+            description="With Overrides"
+            titleSize="s"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="l" />
+
+      <EuiPanel hasBorder={true} hasShadow={false}>
+        <EuiTitle size="xs">
+          <h3>Engine Configuration</h3>
+        </EuiTitle>
+        <EuiHorizontalRule margin="xs" />
+        <EuiDescriptionList>
+          <EuiDescriptionListTitle>Type</EuiDescriptionListTitle>
+          <EuiDescriptionListDescription>
+            <EuiBadge color="primary">
+              {engineInfo?.engineType || "local"}
+            </EuiBadge>
+          </EuiDescriptionListDescription>
+
+          <EuiDescriptionListTitle>Class</EuiDescriptionListTitle>
+          <EuiDescriptionListDescription>
+            {engineInfo?.engineClass || "LocalComputeEngine"}
+          </EuiDescriptionListDescription>
+        </EuiDescriptionList>
+
+        {engineInfo?.config &&
+          Object.entries(engineInfo.config).filter(
+            ([key, value]) => key !== "type" && value != null && value !== "",
+          ).length > 0 && (
+            <>
+              <EuiSpacer size="m" />
+              <EuiTitle size="xxs">
+                <h4>Parameters</h4>
+              </EuiTitle>
+              <EuiHorizontalRule margin="xs" />
+              <EuiDescriptionList>
+                {Object.entries(engineInfo.config)
+                  .filter(
+                    ([key, value]) =>
+                      key !== "type" && value != null && value !== "",
+                  )
+                  .map(([key, value]) => (
+                    <React.Fragment key={key}>
+                      <EuiDescriptionListTitle>{key}</EuiDescriptionListTitle>
+                      <EuiDescriptionListDescription>
+                        {typeof value === "object"
+                          ? JSON.stringify(value, null, 2)
+                          : String(value)}
+                      </EuiDescriptionListDescription>
+                    </React.Fragment>
+                  ))}
+              </EuiDescriptionList>
+            </>
+          )}
+      </EuiPanel>
+
+      <EuiSpacer size="l" />
+
+      <EuiTitle size="xs">
+        <h3>Feature Views Using This Engine</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      {featureViewInfos.length > 0 ? (
+        <EuiBasicTable
+          columns={fvColumns}
+          items={featureViewInfos}
+          rowProps={(item: any) => ({
+            "data-test-subj": `row-${item.name}`,
+          })}
+        />
+      ) : (
+        <EuiText size="s" color="subdued">
+          No feature views found in this project.
+        </EuiText>
+      )}
+    </React.Fragment>
+  );
+};
+
+const JobsTab = ({
+  engineInfo,
+  featureViewInfos,
+  projectName,
+}: {
+  engineInfo: any;
+  featureViewInfos: FeatureViewEngineInfo[];
+  projectName: string | undefined;
+}) => {
+  const [statusFilter, setStatusFilter] = useState<string | null>(null);
+
+  const jobs = useMemo(
+    () => buildJobsFromFeatureViews(featureViewInfos),
+    [featureViewInfos],
+  );
+
+  const filteredJobs = statusFilter
+    ? jobs.filter((j) => j.status === statusFilter)
+    : jobs;
+
+  const succeededCount = jobs.filter((j) => j.status === "SUCCEEDED").length;
+  const failedCount = jobs.filter((j) => j.status === "ERROR").length;
+  const runningCount = jobs.filter((j) => j.status === "RUNNING").length;
+
+  const columns = [
+    {
+      name: "Job ID",
+      field: "id",
+      sortable: true,
+      render: (id: string) => (
+        <EuiText size="xs">
+          <code>{id}</code>
+        </EuiText>
+      ),
+    },
+    {
+      name: "Feature View",
+      field: "featureView",
+      sortable: true,
+      render: (name: string) => (
+        <EuiCustomLink to={`/p/${projectName}/feature-view/${name}`}>
+          {name}
+        </EuiCustomLink>
+      ),
+    },
+    {
+      name: "Engine",
+      field: "id",
+      render: () => (
+        <EuiBadge color="hollow">{engineInfo?.engineType || "local"}</EuiBadge>
+      ),
+    },
+    {
+      name: "Status",
+      field: "status",
+      sortable: true,
+      render: (status: string) => (
+        <EuiHealth color={statusColorMap[status] || "subdued"}>
+          {status}
+        </EuiHealth>
+      ),
+    },
+    {
+      name: "Range Start",
+      field: "rangeStart",
+      sortable: true,
+    },
+    {
+      name: "Range End",
+      field: "rangeEnd",
+    },
+  ];
+
+  return (
+    <React.Fragment>
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <EuiStat
+            title={String(jobs.length)}
+            description="Total Jobs"
+            titleSize="s"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={String(succeededCount)}
+            description="Succeeded"
+            titleSize="s"
+            titleColor="success"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={String(runningCount)}
+            description="Running"
+            titleSize="s"
+            titleColor="primary"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiStat
+            title={String(failedCount)}
+            description="Failed"
+            titleSize="s"
+            titleColor="danger"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="l" />
+
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiTitle size="xxs">
+            <h4>Filter by Status</h4>
+          </EuiTitle>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiFilterGroup>
+            <EuiFilterButton
+              hasActiveFilters={statusFilter === null}
+              onClick={() => setStatusFilter(null)}
+            >
+              All
+            </EuiFilterButton>
+            <EuiFilterButton
+              hasActiveFilters={statusFilter === "SUCCEEDED"}
+              onClick={() =>
+                setStatusFilter(
+                  statusFilter === "SUCCEEDED" ? null : "SUCCEEDED",
+                )
+              }
+              numFilters={succeededCount}
+            >
+              Succeeded
+            </EuiFilterButton>
+            <EuiFilterButton
+              hasActiveFilters={statusFilter === "RUNNING"}
+              onClick={() =>
+                setStatusFilter(statusFilter === "RUNNING" ? null : "RUNNING")
+              }
+              numFilters={runningCount}
+            >
+              Running
+            </EuiFilterButton>
+            <EuiFilterButton
+              hasActiveFilters={statusFilter === "ERROR"}
+              onClick={() =>
+                setStatusFilter(statusFilter === "ERROR" ? null : "ERROR")
+              }
+              numFilters={failedCount}
+            >
+              Failed
+            </EuiFilterButton>
+          </EuiFilterGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="m" />
+
+      {filteredJobs.length > 0 ? (
+        <EuiBasicTable
+          columns={columns}
+          items={filteredJobs}
+          rowProps={(item: MaterializationJobRow) => ({
+            "data-test-subj": `row-${item.id}`,
+          })}
+        />
+      ) : (
+        <EuiText size="s" color="subdued">
+          {jobs.length === 0
+            ? "No materialization jobs found. Run 'feast materialize' to create jobs."
+            : "No jobs match the selected filter."}
+        </EuiText>
+      )}
+    </React.Fragment>
+  );
+};
+
+const Index = () => {
+  const { projectName } = useParams();
+  const navigate = useNavigate();
+
+  const { isLoading, isSuccess, isError, engineInfo, featureViewInfos } =
+    useLoadComputeEngine(projectName);
+
+  useDocumentTitle(`Compute & Jobs | Feast`);
+
+  return (
+    <EuiPageTemplate panelled>
+      <EuiPageTemplate.Header
+        restrictWidth
+        iconType={ComputeEngineIcon}
+        pageTitle="Compute & Jobs"
+        description={
+          projectName !== "all"
+            ? "Compute engine configuration and jobs history"
+            : "Compute engines and jobs across all projects"
+        }
+        tabs={[
+          {
+            label: "Overview",
+            isSelected: useMatchExact(""),
+            onClick: () => navigate(""),
+          },
+          {
+            label: "Jobs",
+            isSelected: useMatchSubpath("jobs"),
+            onClick: () => navigate("jobs"),
+          },
+        ]}
+      />
+      <EuiPageTemplate.Section>
+        {isLoading && (
+          <p>
+            <EuiLoadingSpinner size="m" /> Loading
+          </p>
+        )}
+        {isError && <p>We encountered an error while loading.</p>}
+        {isSuccess && (
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <OverviewTab
+                  engineInfo={engineInfo}
+                  featureViewInfos={featureViewInfos}
+                  projectName={projectName}
+                />
+              }
+            />
+            <Route
+              path="jobs"
+              element={
+                <JobsTab
+                  engineInfo={engineInfo}
+                  featureViewInfos={featureViewInfos}
+                  projectName={projectName}
+                />
+              }
+            />
+          </Routes>
+        )}
+      </EuiPageTemplate.Section>
+    </EuiPageTemplate>
+  );
+};
+
+export default Index;

--- a/ui/src/queries/useLoadComputeEngine.ts
+++ b/ui/src/queries/useLoadComputeEngine.ts
@@ -1,0 +1,111 @@
+import { useContext } from "react";
+import { useQuery } from "react-query";
+import RegistryPathContext from "../contexts/RegistryPathContext";
+import { useDataMode } from "../contexts/DataModeContext";
+import restFetch from "./restApiClient";
+
+export interface ComputeEngineConfig {
+  type: string;
+  [key: string]: any;
+}
+
+export interface ComputeEngineInfo {
+  engineType: string;
+  engineClass: string;
+  config: ComputeEngineConfig;
+  featureViewCount: number;
+}
+
+export interface FeatureViewEngineInfo {
+  name: string;
+  type: string;
+  online: boolean;
+  lastMaterialized?: string;
+  hasOverride: boolean;
+  overrides?: Record<string, any>;
+  materializationIntervals: Array<{
+    startTime?: string;
+    endTime?: string;
+    start_time?: string;
+    end_time?: string;
+  }>;
+}
+
+const ENGINE_TYPE_TO_CLASS: Record<string, string> = {
+  local: "LocalComputeEngine",
+  "spark.engine": "SparkComputeEngine",
+  "ray.engine": "RayComputeEngine",
+  "flink.engine": "FlinkComputeEngine",
+  "snowflake.engine": "SnowflakeComputeEngine",
+  lambda: "LambdaComputeEngine",
+  k8s: "KubernetesComputeEngine",
+};
+
+function extractFeatureViewInfos(featureViews: any[]): FeatureViewEngineInfo[] {
+  return featureViews.map((fv: any) => ({
+    name: fv.name,
+    type: fv.type || "Batch",
+    online: fv.online ?? true,
+    lastMaterialized: fv.lastMaterialized,
+    hasOverride: fv.hasOverride ?? false,
+    overrides: fv.overrides,
+    materializationIntervals: fv.materializationIntervals || [],
+  }));
+}
+
+export function useLoadComputeEngine(projectName?: string) {
+  const registryUrl = useContext(RegistryPathContext);
+  const { fetchOptions } = useDataMode();
+
+  const enginePath =
+    projectName && projectName !== "all"
+      ? `/compute_engines?project=${encodeURIComponent(projectName)}`
+      : "/compute_engines/all?limit=100";
+
+  const engineQuery = useQuery<any, Error>(
+    ["rest", "compute-engine", registryUrl, projectName || "all"],
+    () => restFetch<any>(registryUrl, enginePath, fetchOptions),
+    {
+      enabled: !!registryUrl,
+      staleTime: 30_000,
+    },
+  );
+
+  let engineInfo: ComputeEngineInfo | null = null;
+  let featureViewInfos: FeatureViewEngineInfo[] = [];
+
+  if (engineQuery.isSuccess && engineQuery.data) {
+    const engine = engineQuery.data.engine || engineQuery.data.engines?.[0];
+    if (engine) {
+      engineInfo = {
+        engineType: engine.engineType || "local",
+        engineClass:
+          engine.engineClass ||
+          ENGINE_TYPE_TO_CLASS[engine.engineType] ||
+          "LocalComputeEngine",
+        config: engine.config || { type: engine.engineType || "local" },
+        featureViewCount: engine.featureViewCount || 0,
+      };
+    }
+
+    const rawFvs = engineQuery.data.featureViews || [];
+    featureViewInfos = extractFeatureViewInfos(rawFvs);
+  }
+
+  if (!engineInfo) {
+    engineInfo = {
+      engineType: "local",
+      engineClass: "LocalComputeEngine",
+      config: { type: "local" },
+      featureViewCount: featureViewInfos.length,
+    };
+  }
+
+  return {
+    isLoading: engineQuery.isLoading,
+    isSuccess: engineQuery.isSuccess,
+    isError: engineQuery.isError,
+    engineInfo,
+    featureViewInfos,
+  };
+}


### PR DESCRIPTION

# What this PR does / why we need it:

Adds a new "Compute & Jobs" page to the Feast UI that gives users visibility into
their project's batch compute engine configuration and centralized materialization job history.

<img width="1489" height="784" alt="Screenshot 2026-06-27 at 10 47 42 AM" src="https://github.com/user-attachments/assets/d7fcce69-b89d-4944-8602-25754c5530c1" />


<img width="1489" height="784" alt="Screenshot 2026-06-27 at 10 49 22 AM" src="https://github.com/user-attachments/assets/61e6cc28-d84a-4ba5-b3f9-d3c2f1a97b39" />
