### PR TITLE
fix: Fix monitoring UI to show correct status when not enabled and fix data visibility after compute

### DIFF
--- a/.cursor/rules/feast-ui.mdc
+++ b/.cursor/rules/feast-ui.mdc
@@ -1,0 +1,19 @@
+---
+description: Formatting and lint rules for the Feast UI (React/TypeScript)
+globs: ui/src/**
+alwaysApply: false
+---
+
+## After editing any file under `ui/src/`
+
+1. **Run Prettier** before considering the task complete:
+   ```bash
+   cd ui && yarn prettier --write <changed-files>
+   ```
+2. **Verify** formatting passes:
+   ```bash
+   cd ui && yarn format:check
+   ```
+   CI runs `yarn format:check` and will reject PRs with style violations.
+
+3. Prettier config lives in `ui/package.json` (no separate `.prettierrc`). Do not override it.

--- a/sdk/python/feast/api/registry/rest/monitoring.py
+++ b/sdk/python/feast/api/registry/rest/monitoring.py
@@ -64,6 +64,12 @@ def get_monitoring_router(grpc_handler, store=None):
                     status_code=503,
                     detail="Monitoring service is not available: no FeatureStore configured",
                 )
+            dqm_config = getattr(store.config, "data_quality_monitoring_config", None)
+            if dqm_config is None:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Monitoring is not enabled: add data_quality_monitoring section to feature_store.yaml",
+                )
             from feast.monitoring.monitoring_service import MonitoringService
 
             _monitoring_service = MonitoringService(store)

--- a/sdk/python/feast/monitoring/monitoring_service.py
+++ b/sdk/python/feast/monitoring/monitoring_service.py
@@ -92,7 +92,11 @@ class MonitoringService:
         project: Optional[str] = None,
         feature_view_name: Optional[str] = None,
     ) -> Dict[str, Any]:
-        """Detect date ranges from source data and compute all granularities."""
+        """Detect date ranges from source data and compute all granularities.
+
+        Also computes baseline for any features that don't have one yet
+        (idempotent -- features with existing baselines are skipped).
+        """
         start_time = time.time()
         self._ensure_monitoring_tables()
         if project is None:
@@ -101,6 +105,7 @@ class MonitoringService:
         feature_views = self._resolve_feature_views(project, feature_view_name)
         total_features = 0
         total_views = 0
+        baseline_features = 0
         granularities_computed = set()
 
         for fv in feature_views:
@@ -117,6 +122,32 @@ class MonitoringService:
                     continue
 
                 now = datetime.now(timezone.utc)
+
+                # Compute baseline for features that don't have one yet
+                fields_needing_baseline = self._get_features_without_baseline(
+                    project, fv
+                )
+                if fields_needing_baseline:
+                    bl_fields = self._classify_fields(
+                        fv, fields=fields_needing_baseline
+                    )
+                    if bl_fields:
+                        bl_metrics = self._compute_feature_metrics(
+                            fv,
+                            bl_fields,
+                            _EPOCH,
+                            _FAR_FUTURE,
+                        )
+                        self._save_computed_metrics(
+                            project=project,
+                            feature_view=fv,
+                            metrics_list=bl_metrics,
+                            metric_date=date.today(),
+                            granularity="baseline",
+                            set_baseline=True,
+                            now=now,
+                        )
+                        baseline_features += len(bl_metrics)
 
                 for granularity, window in GRANULARITY_WINDOWS.items():
                     window_start = max_ts - window
@@ -155,6 +186,7 @@ class MonitoringService:
             "status": "completed",
             "computed_feature_views": total_views,
             "computed_features": total_features,
+            "baseline_features": baseline_features,
             "granularities": sorted(granularities_computed),
             "duration_ms": duration_ms,
         }

--- a/ui/src/pages/monitoring/Index.tsx
+++ b/ui/src/pages/monitoring/Index.tsx
@@ -14,6 +14,7 @@ import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import useLoadRegistry from "../../queries/useLoadRegistry";
 import RegistryPathContext from "../../contexts/RegistryPathContext";
 import {
+  isServiceUnavailable,
   useFeatureMetrics,
   useFeatureViewMetrics,
   useFeatureServiceMetrics,
@@ -33,7 +34,7 @@ const MonitoringIndex = () => {
   const { data: registryData } = useLoadRegistry(registryUrl, projectName);
 
   const [selectedFV, setSelectedFV] = useState("");
-  const [granularity, setGranularity] = useState("baseline");
+  const [granularity, setGranularity] = useState("daily");
   const [dataSourceType, setDataSourceType] = useState("");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
@@ -112,7 +113,13 @@ const MonitoringIndex = () => {
     });
   };
 
-  const hasError = featureQuery.isError && fvQuery.isError && fsQuery.isError;
+  const allFailed = featureQuery.isError && fvQuery.isError && fsQuery.isError;
+  const monitoringNotEnabled =
+    allFailed &&
+    isServiceUnavailable(featureQuery.error) &&
+    isServiceUnavailable(fvQuery.error) &&
+    isServiceUnavailable(fsQuery.error);
+  const hasError = allFailed && !monitoringNotEnabled;
   const hasData =
     (featureQuery.data && featureQuery.data.length > 0) ||
     (fvQuery.data && fvQuery.data.length > 0);
@@ -161,6 +168,43 @@ const MonitoringIndex = () => {
       ),
     },
   ];
+
+  if (monitoringNotEnabled) {
+    return (
+      <EuiPageTemplate panelled>
+        <EuiPageTemplate.Header
+          restrictWidth
+          iconType="monitoringApp"
+          pageTitle="Monitoring"
+          description="Feature quality and data health metrics for your feature store."
+        />
+        <EuiPageTemplate.Section>
+          <EuiEmptyPrompt
+            iconType="alert"
+            color="subdued"
+            title={<h2>Monitoring Is Not Enabled</h2>}
+            body={
+              <>
+                <p>
+                  Data quality monitoring is not configured for this Feast
+                  deployment.
+                </p>
+                <p>
+                  To enable monitoring, add the following to your{" "}
+                  <code>feature_store.yaml</code>:
+                </p>
+                <pre style={{ textAlign: "left", display: "inline-block" }}>
+                  {`data_quality_monitoring:
+  auto_baseline: true`}
+                </pre>
+                <p>Then restart the Feast registry server.</p>
+              </>
+            }
+          />
+        </EuiPageTemplate.Section>
+      </EuiPageTemplate>
+    );
+  }
 
   return (
     <EuiPageTemplate panelled>

--- a/ui/src/queries/useMonitoringApi.ts
+++ b/ui/src/queries/useMonitoringApi.ts
@@ -108,6 +108,14 @@ const buildQueryString = (params: Record<string, string | undefined>) => {
   );
 };
 
+class MonitoringApiError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
 const fetchMonitoring = async <T>(
   baseUrl: string,
   path: string,
@@ -124,7 +132,10 @@ const fetchMonitoring = async <T>(
     credentials: fetchOptions?.credentials,
   });
   if (!res.ok) {
-    throw new Error(`Failed to fetch ${path}: ${res.status} ${res.statusText}`);
+    throw new MonitoringApiError(
+      res.status,
+      `Failed to fetch ${path}: ${res.status} ${res.statusText}`,
+    );
   }
   const text = await res.text();
   const sanitized = text
@@ -133,6 +144,9 @@ const fetchMonitoring = async <T>(
     .replace(/:\s*-Infinity/g, ": null");
   return JSON.parse(sanitized);
 };
+
+const isServiceUnavailable = (error: unknown): boolean =>
+  error instanceof MonitoringApiError && error.status === 503;
 
 const STALE_TIME = 30_000;
 
@@ -287,6 +301,7 @@ const useComputeMetrics = () => {
 };
 
 export {
+  isServiceUnavailable,
   useFeatureMetrics,
   useFeatureViewMetrics,
   useFeatureServiceMetrics,


### PR DESCRIPTION

# What this PR does / why we need it:

- Show "Monitoring Is Not Enabled" instead of misleading "No Metrics Yet" when data_quality_monitoring is not configured in feature_store.yaml. Previously the UI showed an empty state with a "Compute Metrics" button that silently did nothing, giving no indication that monitoring was disabled.
- Fix default granularity from "baseline" to "daily" so computed metrics are visible immediately after clicking "Compute Metrics". Previously auto_compute produced daily/weekly/monthly data but the UI defaulted to querying the baseline endpoint, which had nothing.
- Include baseline computation in auto_compute so clicking "Compute Metrics" also generates baseline reference data for features that don't have one yet (idempotent - existing baselines are skipped).

cc @jyejare 

<img width="1489" height="784" alt="Screenshot 2026-06-27 at 11 47 07 AM" src="https://github.com/user-attachments/assets/dda29e13-a5ce-44e6-a04c-63a85136f981" />
