### PR TITLE
fix: Replace comma with space in DynamoDB-incompatible label tag value

### DIFF
--- a/sdk/python/feast/templates/local/feature_repo/feature_definitions.py
+++ b/sdk/python/feast/templates/local/feature_repo/feature_definitions.py
@@ -199,7 +199,7 @@ driver_quality_labels = LabelView(
         "feast.io/field-role:is_reliable": "label",
         "feast.io/field-role:quality_score": "label",
         "feast.io/field-role:reviewer_notes": "metadata",
-        "feast.io/label-values:is_reliable": "1,0",
+        "feast.io/label-values:is_reliable": "1 0",
         "feast.io/label-widget:is_reliable": "binary",
         "feast.io/label-widget:quality_score": "number",
         "feast.io/label-widget:reviewer_notes": "text",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing and why.
-->
`feast apply` fails with a ValidationException from AWS DynamoDB when deploying a FeatureStore using a DynamoDB online store. The failure occurs at table creation time and blocks the entire apply operation:
botocore.exceptions.ClientError: An error occurred (ValidationException)
when calling the CreateTable operation: The Tag Value provided is invalid, Value: 1,0

The root cause is the tag **`"feast.io/label-values:is_reliable": "1,0"`** in the LabelView defined in the local project template (sdk/python/feast/templates/local/feature_repo/feature_definitions.py). [AWS DynamoDB tag value constraints](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html) explicitly prohibit commas in tag values.
This affects any user who runs feast init --template local and then feast apply against a DynamoDB online store.

**Fix**
Replace the comma separator with a space:
Diff

```
-"feast.io/label-values:is_reliable": "1,0",
+"feast.io/label-values:is_reliable": "1 0",
```
Space is permitted by AWS tag value constraints. The semantic intent — indicating the two valid label values 1 and 0 — is preserved.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [ ] I've made sure the tests are passing.
- [ ] My commits are signed off (`git commit -s`)
- [ ] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
