### PR TITLE
feat: Set Feast user-agent on S3 and S3-compatible clients

### DIFF
--- a/sdk/python/feast/infra/compute_engines/spark/utils.py
+++ b/sdk/python/feast/infra/compute_engines/spark/utils.py
@@ -9,7 +9,11 @@ from pyspark import SparkConf
 from pyspark.sql import SparkSession
 
 from feast.infra.common.serde import SerializedArtifacts
-from feast.utils import _convert_arrow_to_proto, _run_pyarrow_field_mapping
+from feast.utils import (
+    _convert_arrow_to_proto,
+    _run_pyarrow_field_mapping,
+    get_user_agent,
+)
 
 try:
     import boto3
@@ -88,6 +92,7 @@ def _ensure_s3a_event_log_dir(spark_config: Dict[str, str]) -> None:
             config=BotoConfig(
                 signature_version="s3v4",
                 s3={"addressing_style": addressing_style},
+                user_agent_extra=get_user_agent(),
             ),
         )
         resp = s3.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=1)

--- a/sdk/python/feast/infra/offline_stores/ibis.py
+++ b/sdk/python/feast/infra/offline_stores/ibis.py
@@ -477,8 +477,15 @@ def point_in_time_join(
 
 def list_s3_files(path: str, endpoint_url: str) -> List[str]:
     import boto3
+    from botocore.config import Config
 
-    s3 = boto3.client("s3", endpoint_url=endpoint_url)
+    from feast.utils import get_user_agent
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=endpoint_url,
+        config=Config(user_agent_extra=get_user_agent()),
+    )
     if path.startswith("s3://"):
         path = path[len("s3://") :]
     bucket, prefix = path.split("/", 1)

--- a/sdk/python/feast/infra/registry/s3.py
+++ b/sdk/python/feast/infra/registry/s3.py
@@ -10,10 +10,11 @@ from feast.errors import S3RegistryBucketForbiddenAccess, S3RegistryBucketNotExi
 from feast.infra.registry.registry_store import RegistryStore
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.repo_config import RegistryConfig
-from feast.utils import _utc_now
+from feast.utils import _utc_now, get_user_agent
 
 try:
     import boto3
+    from botocore.config import Config
 except ImportError as e:
     from feast.errors import FeastExtrasDependencyImportError
 
@@ -28,8 +29,11 @@ class S3RegistryStore(RegistryStore):
         self._key = self._uri.path.lstrip("/")
         self._boto_extra_args = registry_config.s3_additional_kwargs or {}
 
+        # FEAST_S3_ENDPOINT_URL may point at Amazon S3 or an S3-compatible endpoint.
         self.s3_client = boto3.resource(
-            "s3", endpoint_url=os.environ.get("FEAST_S3_ENDPOINT_URL")
+            "s3",
+            endpoint_url=os.environ.get("FEAST_S3_ENDPOINT_URL"),
+            config=Config(user_agent_extra=get_user_agent()),
         )
 
     def get_registry_proto(self):

--- a/sdk/python/feast/infra/utils/aws_utils.py
+++ b/sdk/python/feast/infra/utils/aws_utils.py
@@ -53,7 +53,10 @@ def get_s3_resource(aws_region: str):
     """
     Get the S3 resource for the given AWS region.
     """
-    return boto3.resource("s3", config=Config(region_name=aws_region))
+    return boto3.resource(
+        "s3",
+        config=Config(region_name=aws_region, user_agent_extra=get_user_agent()),
+    )
 
 
 def get_bucket_and_key(s3_path: str) -> Tuple[str, str]:
@@ -716,7 +719,10 @@ def get_account_id() -> str:
 
 
 def list_s3_files(aws_region: str, path: str) -> List[str]:
-    s3 = boto3.client("s3", config=Config(region_name=aws_region))
+    s3 = boto3.client(
+        "s3",
+        config=Config(region_name=aws_region, user_agent_extra=get_user_agent()),
+    )
     if path.startswith("s3://"):
         path = path[len("s3://") :]
     bucket, prefix = path.split("/", 1)


### PR DESCRIPTION

# What this PR does / why we need it:

## Summary

Feast talks to object storage through boto3 in several places (the S3 registry store, the AWS utils helpers, the ibis offline store lister, and the Spark event-log check). Most of these clients were created without a user-agent, so requests reached the storage service as generic boto3 traffic with no indication that Feast was the caller.

This PR threads Feast's existing user-agent (`feast-dev/feast/<version>`, already defined as `USER_AGENT` in `sdk/python/feast/utils.py`) onto those clients via `botocore` `Config(user_agent_extra=get_user_agent())`. It is a small, additive change: no new dependencies, no new configuration, and no behavior change beyond an added `User-Agent` suffix on outbound requests.

Because these clients honor a custom `endpoint_url` (for example `FEAST_S3_ENDPOINT_URL`), the same instrumentation applies whether Feast is pointed at Amazon S3 or at any S3-compatible object store (for example Backblaze B2, Cloudflare R2, or MinIO). This makes it easier for operators and storage providers to attribute traffic to Feast when debugging or reviewing usage.

## Changes

- `sdk/python/feast/infra/registry/s3.py`: pass `Config(user_agent_extra=get_user_agent())` when constructing the S3 registry resource. Added a one-line note that `FEAST_S3_ENDPOINT_URL` may point at an S3-compatible endpoint.
- `sdk/python/feast/infra/utils/aws_utils.py`: add `user_agent_extra` to the existing `Config` in `get_s3_resource` and `list_s3_files` (alongside the region already set there).
- `sdk/python/feast/infra/offline_stores/ibis.py`: pass a `Config` with `user_agent_extra` to the boto3 client used by `list_s3_files`.
- `sdk/python/feast/infra/compute_engines/spark/utils.py`: add `user_agent_extra` to the boto3 `Config` used for the S3A event-log directory check.

The value comes from the pre-existing `get_user_agent()` helper; this PR only wires it into clients that previously omitted it.

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [x] Testing is not required for this change

The change is internal instrumentation: it only appends a `User-Agent` suffix to boto3 clients and does not alter request semantics, return values, or public APIs. It reuses the existing `get_user_agent()` helper (the same value Feast already advertises elsewhere), so no new test surface is introduced. Existing unit tests were run and pass, and `ruff` is clean on the four changed files.

# Misc

Scope is intentionally minimal and additive: no new dependencies, no config changes, no user-facing API changes. Happy to add a `kind/*` label and adjust the title or wording if maintainers prefer a different convention.
