### PR TITLE
docs: fix parameter name mismatches in docstrings

### DIFF
--- a/sdk/python/feast/infra/registry/base_registry.py
+++ b/sdk/python/feast/infra/registry/base_registry.py
@@ -937,7 +937,7 @@ class BaseRegistry(ABC):
         Deletes a project or raises an ProjectNotFoundException exception if not found.
 
         Args:
-            project: Feast project name that needs to be deleted
+            name: Feast project name that needs to be deleted
             commit: Whether the change should be persisted immediately
         """
         raise NotImplementedError

--- a/sdk/python/feast/permissions/server/utils.py
+++ b/sdk/python/feast/permissions/server/utils.py
@@ -70,7 +70,7 @@ def init_security_manager(auth_type: AuthManagerType, fs: "feast.FeatureStore"):
 
     Args:
         auth_type: The authorization manager type.
-        registry: The feature store registry.
+        fs: The feature store instance.
     """
     if auth_type == AuthManagerType.NONE:
         no_security_manager()


### PR DESCRIPTION
## What this PR does / why we need it

Fixes two docstrings where the documented parameter name does not match the actual function signature:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `sdk/python/feast/infra/registry/base_registry.py` | `delete_project` | `project` | `name` |
| `sdk/python/feast/permissions/server/utils.py` | `init_security_manager` | `registry` | `fs` |

Doc-only change; no behavior modified.

## Which issue(s) this PR fixes

N/A - trivial documentation fix found while reading the source.