### PR TITLE
ci: Use uv torch backend for CPU installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ install-python-dependencies-ci: ## Install Python CI dependencies using uv pip s
 	# Install CPU-only torch first to prevent CUDA dependency issues (Linux only)
 	@if [ "$$(uname -s)" = "Linux" ]; then \
 		echo "Installing dependencies with torch CPU index for Linux..."; \
-		uv pip sync --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match sdk/python/requirements/py$(PYTHON_VERSION)-ci-requirements.txt; \
+		uv pip sync --torch-backend cpu sdk/python/requirements/py$(PYTHON_VERSION)-ci-requirements.txt; \
 	else \
 		echo "Installing dependencies from PyPI for macOS..."; \
 		uv pip sync sdk/python/requirements/py$(PYTHON_VERSION)-ci-requirements.txt; \


### PR DESCRIPTION
## Summary

- replace the Linux CI PyTorch CPU extra index install with uv's targeted `--torch-backend cpu` option
- keep dependency resolution on PyPI for unrelated packages like `databricks-sdk`

## Root cause

The failing `unit-test-python (3.10, ubuntu-latest)` leg on `master` died before pytest during `make install-python-dependencies-ci`. The old command used `--extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match`, which caused uv to query the PyTorch CPU index for unrelated packages. In the failing run, that made CI fetch `https://download.pytorch.org/whl/cpu/databricks-sdk/`, which returned HTTP 503.

## Validation

- `git diff --check`
- `PYTHON_VERSION=3.10 uv pip sync --dry-run --torch-backend cpu sdk/python/requirements/py3.10-ci-requirements.txt`
