### PR TITLE
test: Retry CliRunner apply subprocess on timeout to reduce flakiness

### DIFF
--- a/sdk/python/tests/utils/cli_repo_creator.py
+++ b/sdk/python/tests/utils/cli_repo_creator.py
@@ -63,26 +63,43 @@ class CliRunner:
         env["PYTHONPATH"] = os.pathsep.join(parent_paths)
         return env
 
-    def run(self, args: List[str], cwd: Path) -> subprocess.CompletedProcess:
+    def run(
+        self, args: List[str], cwd: Path, attempts: int = 2
+    ) -> subprocess.CompletedProcess:
         # Apply a conservative timeout to prevent CI hangs from Dask atexit-handler
         # stalls or other subprocess blockages.
         timeout = 120
 
-        try:
-            return subprocess.run(
-                [sys.executable, cli.__file__] + args,
-                cwd=cwd,
-                capture_output=True,
-                timeout=timeout,
-                env=self._subprocess_env(),
-            )
-        except subprocess.TimeoutExpired:
-            return subprocess.CompletedProcess(
-                args=[sys.executable, cli.__file__] + args,
-                returncode=-1,
-                stdout=b"",
-                stderr=f"Command timed out after {timeout}s: {args}".encode(),
-            )
+        # Commands routed through here (e.g. `apply`) do not materialize, so they
+        # cannot trigger the Dask atexit hang described in the module docstring. A
+        # timeout is therefore almost always transient slowness — a cold child
+        # interpreter importing Feast (pandas/pyarrow/...) on a loaded CI runner,
+        # which has been observed to exceed the timeout on the slower macOS
+        # runners. Retry once so a single slow cold start does not flake the test:
+        # the retry runs with warm OS/page caches and typically finishes quickly,
+        # while a genuine repeated stall still fails once attempts are exhausted.
+        full_args = [sys.executable, cli.__file__] + args
+        result = None
+        for attempt in range(1, attempts + 1):
+            try:
+                return subprocess.run(
+                    full_args,
+                    cwd=cwd,
+                    capture_output=True,
+                    timeout=timeout,
+                    env=self._subprocess_env(),
+                )
+            except subprocess.TimeoutExpired:
+                result = subprocess.CompletedProcess(
+                    args=full_args,
+                    returncode=-1,
+                    stdout=b"",
+                    stderr=(
+                        f"Command timed out after {timeout}s "
+                        f"(attempt {attempt}/{attempts}): {args}"
+                    ).encode(),
+                )
+        return result
 
     def run_with_output(self, args: List[str], cwd: Path) -> Tuple[int, bytes]:
         is_teardown = "teardown" in args


### PR DESCRIPTION
## What changed
`CliRunner.run()` (the helper that runs `feast apply` in a fresh child interpreter for unit tests) now retries once on `subprocess.TimeoutExpired` instead of treating the first timeout as terminal. The per-attempt timeout is unchanged (120s); the timeout message now includes the attempt counter.

## Why
The unit-test workflow flaked on `unit-test-python (3.11, macos-14)` while setting up `test_feature_server.py::test_push_and_get`:

```text
ERROR sdk/python/tests/unit/test_feature_server.py::test_push_and_get
  AssertionError: stdout: b''
  stderr: b"Command timed out after 120s: [\x27apply\x27]"
2259 passed, 47 skipped, 1 error
```

`run()` spawns a **new** Python interpreter (`sys.executable feast.cli apply`) — deliberately, for feature-repo import isolation — which has to import Feast (pandas/pyarrow/protobuf/...) from cold. On a loaded macOS runner that cold start can occasionally exceed the 120s guard. The same commit passed on `macos-14 / 3.12` and on all three Ubuntu legs, which is the signature of an environmental cold-start stall rather than a code fault.

Crucially, commands routed through `run()` (e.g. `apply`) do **not** materialize, so they cannot trigger the Dask atexit hang that `run_with_output()` and the module docstring describe. A timeout here is therefore almost always transient slowness, not a deadlock — so a single retry with warm OS/page caches clears it, while a genuine repeated stall still fails once the attempts are exhausted. Retries are intentionally **not** added to `run_with_output()`, whose commands can legitimately hang and whose existing machinery recovers partial output rather than retrying.

This builds directly on the CliRunner subprocess stabilization in #6560.

## Validation
- `uv run ruff check sdk/python/tests/utils/cli_repo_creator.py` — passed
- `uv run ruff format --check sdk/python/tests/utils/cli_repo_creator.py` — already formatted
- Retry logic verified by monkeypatching `subprocess.run`:
  - transient timeout on attempt 1 → recovered on attempt 2 (`returncode == 0`)
  - always timing out → `returncode == -1`, message `... (attempt 2/2): [...]`, no exception raised
  - success on first attempt → exactly one subprocess call (no behavior change for the passing path)

Note: the full unit suite could not be collected on my machine (local venv lacks the `google.cloud` test extra pulled by `conftest.py`); the change is confined to the retry loop, which is covered by the targeted verification above.

Separate from #6591 (which surfaced this flake).