### PR TITLE
fix: Preserve all join keys in remote online store read requests

### DIFF
--- a/sdk/python/feast/infra/online_stores/remote.py
+++ b/sdk/python/feast/infra/online_stores/remote.py
@@ -598,17 +598,21 @@ class RemoteOnlineStore(OnlineStore):
             for requested_feature in requested_features:
                 api_requested_features.append(f"{table.name}:{requested_feature}")
 
-        entity_values = []
-        entity_key = ""
+        entity_columns: Dict[str, List[Any]] = {}
         for row in entity_keys:
-            entity_key = row.join_keys[0]
-            entity_values.append(
-                getattr(row.entity_values[0], row.entity_values[0].WhichOneof("val"))  # type: ignore[arg-type]
-            )
+            if len(row.join_keys) != len(row.entity_values):
+                raise ValueError(
+                    f"Entity key has {len(row.join_keys)} join keys but "
+                    f"{len(row.entity_values)} values; these must be the same length."
+                )
+            for join_key, value in zip(row.join_keys, row.entity_values):
+                entity_columns.setdefault(join_key, []).append(
+                    getattr(value, value.WhichOneof("val"))  # type: ignore[arg-type]
+                )
 
         return {
             "features": api_requested_features,
-            "entities": {entity_key: entity_values},
+            "entities": entity_columns,
         }
 
     def _construct_online_documents_api_json_request(


### PR DESCRIPTION
# What this PR does / why we need it:

`RemoteOnlineStore._construct_online_read_api_json_request` built the request body from `row.join_keys[0]` and `row.entity_values[0]` only. For a feature view with a composite entity key, every join key after the first was dropped before the request left the client. The feature server then joined on a partial key, matched a row, and returned it with status `PRESENT`. No exception was raised anywhere in the path, so callers silently received features belonging to the wrong entity.

Reproduced on 0.64.0 with a two-entity feature view keyed on `(driver_id, customer_id)`. The request that reached the server was:

```
{'features': ['driver_customer_stats:conv_rate'],
 'entities': {'driver_id': [1001, 1002]}}
```

`customer_id` is not null or truncated. It is absent.

Two notes for reviewers:

1. The issue title attributes this to `get_online_features`, but that method already builds a correct columnar request across all keys. The defect is one layer down, in the `online_read` path taken when a local `FeatureStore` is configured with an online store of `type: remote`.

2. `get_online_features` is covered by `test_columnar_entity_rows`. The `online_read` request builder had no test coverage at all, which is why the divergence between the two went unnoticed.

This PR builds the request from every `(join_key, entity_value)` pair, keyed on join key name rather than position, and raises on a length mismatch between `join_keys` and `entity_values` rather than silently truncating.

# Which issue(s) this PR fixes:

Fixes #6488

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
