### PR TITLE
docs: Add Feast + Ray LLM post-training blog and example

### DIFF
--- a/examples/ray-llm-posttrain/.gitignore
+++ b/examples/ray-llm-posttrain/.gitignore
@@ -1,0 +1,13 @@
+# Feast / Ray local artifacts
+data/
+.feast/
+ray_storage/
+/tmp/ray/
+ray_results/
+.ray/
+
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+.env

--- a/examples/ray-llm-posttrain/README.md
+++ b/examples/ray-llm-posttrain/README.md
@@ -2,7 +2,7 @@
 
 | Name | Type | Fields |
 |---|---|---|
-| `web_documents` | FeatureView | `human`, `bot`, `human_repeat_ratio`, `bot_repeat_ratio`, `part_of_speech` |
+| `web_documents` | FeatureView | `human`, `bot`, `human_repeat_ratio`, `bot_repeat_ratio` |
 | `train_example` | OnDemandFeatureView | `cleaned_human`, `cleaned_bot`, `char_count`, `is_trainable`, `sft_text` |
 | `llm_posttrain` | FeatureService | `web_documents` + `train_example` |
 
@@ -14,8 +14,6 @@ Source data is **prepared parquet** (`document_id` + `event_timestamp` already p
 |---|---|
 | (default) | `to_ray_dataset()` + preprocess `sft_text` (ODFV does **not** run) |
 | `--via-df` | `to_df()` so ODFV `train_example` runs |
-| `--create-saved-dataset NAME` | `create_saved_dataset`, then Ray on storage |
-| `--saved-dataset NAME` | Ray reads an existing SavedDataset |
 
 ## Setup
 

--- a/examples/ray-llm-posttrain/README.md
+++ b/examples/ray-llm-posttrain/README.md
@@ -1,0 +1,37 @@
+# How to Use Feast for SLM/LLM Post-Training (with Ray)
+
+| Name | Type | Fields |
+|---|---|---|
+| `web_documents` | FeatureView | `human`, `bot`, `human_repeat_ratio`, `bot_repeat_ratio`, `part_of_speech` |
+| `train_example` | OnDemandFeatureView | `cleaned_human`, `cleaned_bot`, `char_count`, `is_trainable`, `sft_text` |
+| `llm_posttrain` | FeatureService | `web_documents` + `train_example` |
+
+Source data is **prepared parquet** (`document_id` + `event_timestamp` already present). No Feast core patches.
+
+## Paths
+
+| Flag | What happens |
+|---|---|
+| (default) | `to_ray_dataset()` + preprocess `sft_text` (ODFV does **not** run) |
+| `--via-df` | `to_df()` so ODFV `train_example` runs |
+| `--create-saved-dataset NAME` | `create_saved_dataset`, then Ray on storage |
+| `--saved-dataset NAME` | Ray reads an existing SavedDataset |
+
+## Setup
+
+```bash
+uv pip install -e "../../sdk/python[ray]" -r requirements.txt
+PYTHONPATH=../../sdk/python python scripts/prepare_data.py
+cd feature_repo && feast apply && cd ..
+```
+
+## Run (data load only)
+
+```bash
+PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run
+PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run --via-df
+```
+
+## Blog
+
+[How to Use Feast for SLM/LLM Post-Training with Ray](/blog/feast-ray-llm-posttrain)

--- a/examples/ray-llm-posttrain/feature_repo/feature_definitions.py
+++ b/examples/ray-llm-posttrain/feature_repo/feature_definitions.py
@@ -1,0 +1,106 @@
+"""Feast feature definitions for Ray + ODFV LLM post-training.
+
+Pipeline (supported Feast APIs only):
+  scripts/prepare_data.py  → parquet with document_id + event_timestamp
+    → RaySource (parquet)
+    → FeatureView web_documents
+    → OnDemandFeatureView train_example
+    → FeatureService llm_posttrain
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+from feast import Entity, FeatureService, FeatureView, Field, ValueType
+from feast.infra.offline_stores.contrib.ray_offline_store.ray_source import RaySource
+from feast.on_demand_feature_view import on_demand_feature_view
+from feast.types import Bool, Float64, Int64, String
+
+_REPO_DIR = Path(__file__).resolve().parent
+_PARQUET = str(_REPO_DIR / "data" / "tiny_webtext.parquet")
+
+document = Entity(
+    name="document",
+    join_keys=["document_id"],
+    value_type=ValueType.STRING,
+    description="Document id (added by scripts/prepare_data.py)",
+)
+
+# Parquet already has document_id + event_timestamp (see prepare_data.py).
+# Do not rely on BatchFeatureView UDFs to invent timestamps during entity-less
+# retrieval — that path is not supported without Feast core changes.
+tiny_web = RaySource(
+    name="tiny_webtext",
+    reader_type="parquet",
+    path=_PARQUET,
+    timestamp_field="event_timestamp",
+)
+
+web_documents = FeatureView(
+    name="web_documents",
+    entities=[document],
+    ttl=timedelta(days=365),
+    schema=[
+        Field(name="human", dtype=String),
+        Field(name="bot", dtype=String),
+        Field(name="human_repeat_ratio", dtype=Float64),
+        Field(name="bot_repeat_ratio", dtype=Float64),
+        Field(name="part_of_speech", dtype=String),
+    ],
+    source=tiny_web,
+    online=False,
+    description="Conversation columns from prepared parquet",
+    tags={"use_case": "llm_posttrain", "source": "parquet"},
+)
+
+
+@on_demand_feature_view(
+    sources=[web_documents],
+    schema=[
+        Field(name="cleaned_human", dtype=String),
+        Field(name="cleaned_bot", dtype=String),
+        Field(name="char_count", dtype=Int64),
+        Field(name="is_trainable", dtype=Bool),
+        Field(name="sft_text", dtype=String),
+    ],
+    mode="pandas",
+)
+def train_example(inputs):
+    """Quality gate + human→bot SFT formatting."""
+    import pandas as pd
+
+    min_chars = 64
+    max_repeat_ratio = 0.65
+
+    cleaned_human = inputs["human"].fillna("").astype(str).str.strip()
+    cleaned_bot = inputs["bot"].fillna("").astype(str).str.strip()
+    char_count = cleaned_bot.str.len().astype("int64")
+
+    human_ratio = inputs["human_repeat_ratio"].fillna(1.0).astype(float)
+    bot_ratio = inputs["bot_repeat_ratio"].fillna(1.0).astype(float)
+    is_trainable = (
+        (char_count >= min_chars)
+        & (human_ratio <= max_repeat_ratio)
+        & (bot_ratio <= max_repeat_ratio)
+    )
+
+    sft_text = "### Human\n" + cleaned_human + "\n### Assistant\n" + cleaned_bot
+
+    return pd.DataFrame(
+        {
+            "cleaned_human": cleaned_human,
+            "cleaned_bot": cleaned_bot,
+            "char_count": char_count,
+            "is_trainable": is_trainable,
+            "sft_text": sft_text,
+        }
+    )
+
+
+llm_posttrain = FeatureService(
+    name="llm_posttrain",
+    features=[web_documents, train_example],
+    tags={"use_case": "llm_posttrain", "model": "gpt2"},
+)

--- a/examples/ray-llm-posttrain/feature_repo/feature_definitions.py
+++ b/examples/ray-llm-posttrain/feature_repo/feature_definitions.py
@@ -47,7 +47,6 @@ web_documents = FeatureView(
         Field(name="bot", dtype=String),
         Field(name="human_repeat_ratio", dtype=Float64),
         Field(name="bot_repeat_ratio", dtype=Float64),
-        Field(name="part_of_speech", dtype=String),
     ],
     source=tiny_web,
     online=False,
@@ -86,7 +85,10 @@ def train_example(inputs):
         & (bot_ratio <= max_repeat_ratio)
     )
 
-    sft_text = "### Human\n" + cleaned_human + "\n### Assistant\n" + cleaned_bot
+    sft_text = (
+        "<|im_start|>user\n" + cleaned_human + "<|im_end|>\n"
+        "<|im_start|>assistant\n" + cleaned_bot + "<|im_end|>"
+    )
 
     return pd.DataFrame(
         {

--- a/examples/ray-llm-posttrain/feature_repo/feature_store.yaml
+++ b/examples/ray-llm-posttrain/feature_repo/feature_store.yaml
@@ -1,0 +1,25 @@
+project: ray_llm_posttrain
+registry: data/registry.db
+provider: local
+
+# Laptop-friendly Ray offline store (no KubeRay)
+offline_store:
+  type: ray
+  storage_path: data/ray_storage
+  enable_ray_logging: false
+  ray_conf:
+    num_cpus: 2
+    object_store_memory: 104857600
+    _memory: 524288000
+
+batch_engine:
+  type: ray.engine
+  max_workers: 2
+
+online_store:
+  type: sqlite
+  path: data/online_store.db
+
+entity_key_serialization_version: 3
+auth:
+  type: no_auth

--- a/examples/ray-llm-posttrain/requirements.txt
+++ b/examples/ray-llm-posttrain/requirements.txt
@@ -1,0 +1,8 @@
+# Feast + Ray offline store / compute engine
+feast[ray]>=0.50.0
+datasets>=2.19.0
+
+# Short GPT-2 SFT
+transformers>=4.40.0
+torch>=2.1.0
+accelerate>=0.30.0

--- a/examples/ray-llm-posttrain/scripts/prepare_data.py
+++ b/examples/ray-llm-posttrain/scripts/prepare_data.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Prepare a small local parquet seed for the example.
+
+Hugging Face tiny-webtext has no document_id / event_timestamp. Feast entity-less
+retrieval needs those columns on the *source* data. We synthesize them here
+(outside Feast) and write parquet — no Feast core changes required.
+
+    PYTHONPATH=../../sdk/python python scripts/prepare_data.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUT_PATH = REPO_ROOT / "feature_repo" / "data" / "tiny_webtext.parquet"
+SPLIT = "train[:2000]"
+DATASET = "nampdn-ai/tiny-webtext"
+
+
+def main() -> int:
+    from datasets import load_dataset
+
+    print(f"Loading {DATASET} split={SPLIT!r}...")
+    ds = load_dataset(DATASET, split=SPLIT)
+    df = ds.to_pandas()
+
+    demo_base_ts = pd.Timestamp("2024-06-01", tz="UTC")
+    demo_window_seconds = 30 * 24 * 3600
+
+    humans = df["human"].fillna("").astype(str)
+    bots = df["bot"].fillna("").astype(str)
+    doc_ids: list[str] = []
+    timestamps: list[pd.Timestamp] = []
+    for human, bot in zip(humans, bots, strict=True):
+        digest = hashlib.sha256(f"{human}\n{bot}".encode()).hexdigest()
+        doc_ids.append(digest[:16])
+        offset = int(digest[:8], 16) % demo_window_seconds
+        timestamps.append(demo_base_ts + pd.Timedelta(seconds=offset))
+
+    df = df.copy()
+    df["document_id"] = doc_ids
+    df["event_timestamp"] = timestamps
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(OUT_PATH, index=False)
+    print(f"Wrote {len(df)} rows → {OUT_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/ray-llm-posttrain/scripts/train_sft.py
+++ b/examples/ray-llm-posttrain/scripts/train_sft.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Feast conversation features → training rows (paths match the blog).
+
+Paths:
+  A) Default: get_historical_features → to_ray_dataset() → preprocess sft_text
+     (ODFVs do NOT run on to_ray_dataset)
+  B) --via-df: get_historical_features → to_df() (ODFV train_example runs)
+  C) --create-saved-dataset NAME: materialize with to_df() (ODFVs run),
+     then create SavedDataset and stream with Ray
+     --saved-dataset NAME: stream an existing SavedDataset with Ray
+
+    PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run
+    PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run --via-df
+    PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run \\
+        --create-saved-dataset sft_support_q2
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FEATURE_REPO = REPO_ROOT / "feature_repo"
+DATA_DIR = REPO_ROOT / "data"
+
+# Matches the blog Option A snippet (length gate)
+_MIN_CHARS = 64
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-steps", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--max-length", type=int, default=256)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DATA_DIR / "gpt2-sft",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print a few training rows; skip the optional GPT-2 smoke",
+    )
+    parser.add_argument(
+        "--via-df",
+        action="store_true",
+        help="Use to_df() so OnDemandFeatureView train_example runs",
+    )
+    parser.add_argument(
+        "--create-saved-dataset",
+        type=str,
+        default=None,
+        metavar="NAME",
+        help="Create a SavedDataset (ODFV via persist), then stream it with Ray",
+    )
+    parser.add_argument(
+        "--saved-dataset",
+        type=str,
+        default=None,
+        metavar="NAME",
+        help="Stream an existing SavedDataset from its storage path with Ray",
+    )
+    return parser.parse_args()
+
+
+def _date_window() -> tuple[datetime, datetime]:
+    return (
+        datetime(2024, 6, 1, tzinfo=timezone.utc),
+        datetime(2024, 7, 1, tzinfo=timezone.utc),
+    )
+
+
+def _preprocess_sft_batch(batch):
+    """Build sft_text from FeatureView columns (blog Option A)."""
+    import pandas as pd
+
+    if not isinstance(batch, pd.DataFrame):
+        batch = pd.DataFrame(batch)
+
+    human = batch["human"].fillna("").astype(str).str.strip()
+    bot = batch["bot"].fillna("").astype(str).str.strip()
+    ok = bot.str.len() >= _MIN_CHARS
+    sft_text = "### Human\n" + human + "\n### Assistant\n" + bot
+    return pd.DataFrame({"sft_text": sft_text}).loc[ok].reset_index(drop=True)
+
+
+def retrieve_via_ray_stream():
+    """Option A: to_ray_dataset() + preprocess (ODFV does not run)."""
+    from feast import FeatureStore
+
+    store = FeatureStore(repo_path=str(FEATURE_REPO))
+    start_date, end_date = _date_window()
+
+    print("get_historical_features → to_ray_dataset() (preprocess sft_text on Ray)")
+    job = store.get_historical_features(
+        features=[
+            "web_documents:human",
+            "web_documents:bot",
+            "web_documents:human_repeat_ratio",
+            "web_documents:bot_repeat_ratio",
+        ],
+        start_date=start_date,
+        end_date=end_date,
+    )
+    ds = job.to_ray_dataset()
+    return ds.map_batches(_preprocess_sft_batch, batch_format="pandas")
+
+
+def retrieve_via_df():
+    """Option B: to_df() so ODFV train_example runs, then Ray from pandas."""
+    import ray
+    from feast import FeatureStore
+
+    store = FeatureStore(repo_path=str(FEATURE_REPO))
+    start_date, end_date = _date_window()
+
+    print("get_historical_features → to_df() (ODFV train_example runs)")
+    df = store.get_historical_features(
+        features=store.get_feature_service("llm_posttrain"),
+        start_date=start_date,
+        end_date=end_date,
+    ).to_df()
+
+    if "is_trainable" not in df.columns or "sft_text" not in df.columns:
+        raise RuntimeError("Expected ODFV columns is_trainable / sft_text from to_df()")
+
+    mask = df["is_trainable"].fillna(False).astype(bool)
+    mask &= df["sft_text"].fillna("").astype(str).str.len() > 0
+    slim = df.loc[mask, ["sft_text"]].reset_index(drop=True)
+    return ray.data.from_pandas(slim)
+
+
+def create_and_stream_saved_dataset(name: str):
+    """Option C: create SavedDataset (as in the blog), then Ray-read storage."""
+    from feast import FeatureStore
+    from feast.infra.offline_stores.file_source import SavedDatasetFileStorage
+
+    store = FeatureStore(repo_path=str(FEATURE_REPO))
+    start_date, end_date = _date_window()
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    storage_path = DATA_DIR / f"{name}.parquet"
+
+    print(
+        "get_historical_features → to_df() (ODFVs run) → create_saved_dataset "
+        f"({name!r})"
+    )
+    job = store.get_historical_features(
+        features=store.get_feature_service("llm_posttrain"),
+        start_date=start_date,
+        end_date=end_date,
+    )
+    job.to_df()
+    store.create_saved_dataset(
+        from_=job,
+        name=name,
+        storage=SavedDatasetFileStorage(path=str(storage_path)),
+    )
+    print(f"  wrote {storage_path}")
+    return stream_saved_dataset(name)
+
+
+def stream_saved_dataset(name: str):
+    """Ray reads a SavedDataset that was already materialized."""
+    import ray
+    from feast import FeatureStore
+
+    store = FeatureStore(repo_path=str(FEATURE_REPO))
+    print(f"get_saved_dataset({name!r}) → Ray read of storage path")
+    saved = store.get_saved_dataset(name)
+    path = saved.storage.to_data_source().path
+    print(f"  storage path: {path}")
+    ds = ray.data.read_parquet(path)
+    ds = ds.filter(lambda row: row.get("is_trainable", True))
+    return ds
+
+
+def train_gpt2_optional(
+    ray_ds, *, max_steps: int, batch_size: int, max_length: int, output_dir: Path
+) -> None:
+    import torch
+    from transformers import (
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        DataCollatorForLanguageModeling,
+        Trainer,
+        TrainingArguments,
+    )
+
+    rows = ray_ds.take(min(500, max(50, max_steps * batch_size * 4)))
+    texts = [r["sft_text"] for r in rows if r.get("sft_text")]
+    if not texts:
+        raise RuntimeError("No trainable SFT rows")
+
+    print(f"[optional] GPT-2 smoke on {len(texts)} rows, {max_steps} steps...")
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = AutoModelForCausalLM.from_pretrained("gpt2")
+    encodings = tokenizer(
+        texts,
+        truncation=True,
+        max_length=max_length,
+        padding="max_length",
+        return_tensors="pt",
+    )
+
+    class _TextDataset(torch.utils.data.Dataset):
+        def __len__(self) -> int:
+            return encodings["input_ids"].shape[0]
+
+        def __getitem__(self, idx: int) -> dict:
+            return {
+                "input_ids": encodings["input_ids"][idx],
+                "attention_mask": encodings["attention_mask"][idx],
+                "labels": encodings["input_ids"][idx].clone(),
+            }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    args = TrainingArguments(
+        output_dir=str(output_dir),
+        per_device_train_batch_size=batch_size,
+        max_steps=max_steps,
+        logging_steps=max(1, max_steps // 5),
+        save_steps=max_steps,
+        learning_rate=5e-5,
+        report_to=[],
+        remove_unused_columns=False,
+    )
+    trainer = Trainer(
+        model=model,
+        args=args,
+        train_dataset=_TextDataset(),
+        data_collator=DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False),
+    )
+    trainer.train()
+    trainer.save_model(str(output_dir))
+    tokenizer.save_pretrained(str(output_dir))
+    print(f"Saved optional checkpoint to {output_dir}")
+
+
+def main() -> int:
+    args = _parse_args()
+    if not (FEATURE_REPO / "feature_store.yaml").exists():
+        print(f"Missing feature repo at {FEATURE_REPO}", file=sys.stderr)
+        return 1
+
+    if args.create_saved_dataset and args.saved_dataset:
+        print(
+            "Use only one of --create-saved-dataset or --saved-dataset",
+            file=sys.stderr,
+        )
+        return 1
+    if args.via_df and (args.create_saved_dataset or args.saved_dataset):
+        print("--via-df cannot be combined with SavedDataset flags", file=sys.stderr)
+        return 1
+
+    if args.create_saved_dataset:
+        ds = create_and_stream_saved_dataset(args.create_saved_dataset)
+    elif args.saved_dataset:
+        ds = stream_saved_dataset(args.saved_dataset)
+    elif args.via_df:
+        ds = retrieve_via_df()
+    else:
+        ds = retrieve_via_ray_stream()
+
+    sample = ds.take(3)
+    print(f"Sample training rows: {len(sample)}")
+    for i, row in enumerate(sample):
+        preview = str(row.get("sft_text", row))[:160].replace("\n", "\\n")
+        print(f"  [{i}] {preview}...")
+
+    if args.dry_run:
+        print("Done (trainer skipped).")
+        return 0
+
+    train_gpt2_optional(
+        ds,
+        max_steps=args.max_steps,
+        batch_size=args.batch_size,
+        max_length=args.max_length,
+        output_dir=args.output_dir,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/ray-llm-posttrain/scripts/train_sft.py
+++ b/examples/ray-llm-posttrain/scripts/train_sft.py
@@ -5,14 +5,9 @@ Paths:
   A) Default: get_historical_features → to_ray_dataset() → preprocess sft_text
      (ODFVs do NOT run on to_ray_dataset)
   B) --via-df: get_historical_features → to_df() (ODFV train_example runs)
-  C) --create-saved-dataset NAME: materialize with to_df() (ODFVs run),
-     then create SavedDataset and stream with Ray
-     --saved-dataset NAME: stream an existing SavedDataset with Ray
 
     PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run
     PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run --via-df
-    PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run \\
-        --create-saved-dataset sft_support_q2
 """
 
 from __future__ import annotations
@@ -50,20 +45,6 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Use to_df() so OnDemandFeatureView train_example runs",
     )
-    parser.add_argument(
-        "--create-saved-dataset",
-        type=str,
-        default=None,
-        metavar="NAME",
-        help="Create a SavedDataset (ODFV via persist), then stream it with Ray",
-    )
-    parser.add_argument(
-        "--saved-dataset",
-        type=str,
-        default=None,
-        metavar="NAME",
-        help="Stream an existing SavedDataset from its storage path with Ray",
-    )
     return parser.parse_args()
 
 
@@ -84,7 +65,10 @@ def _preprocess_sft_batch(batch):
     human = batch["human"].fillna("").astype(str).str.strip()
     bot = batch["bot"].fillna("").astype(str).str.strip()
     ok = bot.str.len() >= _MIN_CHARS
-    sft_text = "### Human\n" + human + "\n### Assistant\n" + bot
+    sft_text = (
+        "<|im_start|>user\n" + human + "<|im_end|>\n"
+        "<|im_start|>assistant\n" + bot + "<|im_end|>"
+    )
     return pd.DataFrame({"sft_text": sft_text}).loc[ok].reset_index(drop=True)
 
 
@@ -132,50 +116,6 @@ def retrieve_via_df():
     mask &= df["sft_text"].fillna("").astype(str).str.len() > 0
     slim = df.loc[mask, ["sft_text"]].reset_index(drop=True)
     return ray.data.from_pandas(slim)
-
-
-def create_and_stream_saved_dataset(name: str):
-    """Option C: create SavedDataset (as in the blog), then Ray-read storage."""
-    from feast import FeatureStore
-    from feast.infra.offline_stores.file_source import SavedDatasetFileStorage
-
-    store = FeatureStore(repo_path=str(FEATURE_REPO))
-    start_date, end_date = _date_window()
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
-    storage_path = DATA_DIR / f"{name}.parquet"
-
-    print(
-        "get_historical_features → to_df() (ODFVs run) → create_saved_dataset "
-        f"({name!r})"
-    )
-    job = store.get_historical_features(
-        features=store.get_feature_service("llm_posttrain"),
-        start_date=start_date,
-        end_date=end_date,
-    )
-    job.to_df()
-    store.create_saved_dataset(
-        from_=job,
-        name=name,
-        storage=SavedDatasetFileStorage(path=str(storage_path)),
-    )
-    print(f"  wrote {storage_path}")
-    return stream_saved_dataset(name)
-
-
-def stream_saved_dataset(name: str):
-    """Ray reads a SavedDataset that was already materialized."""
-    import ray
-    from feast import FeatureStore
-
-    store = FeatureStore(repo_path=str(FEATURE_REPO))
-    print(f"get_saved_dataset({name!r}) → Ray read of storage path")
-    saved = store.get_saved_dataset(name)
-    path = saved.storage.to_data_source().path
-    print(f"  storage path: {path}")
-    ds = ray.data.read_parquet(path)
-    ds = ds.filter(lambda row: row.get("is_trainable", True))
-    return ds
 
 
 def train_gpt2_optional(
@@ -248,21 +188,7 @@ def main() -> int:
         print(f"Missing feature repo at {FEATURE_REPO}", file=sys.stderr)
         return 1
 
-    if args.create_saved_dataset and args.saved_dataset:
-        print(
-            "Use only one of --create-saved-dataset or --saved-dataset",
-            file=sys.stderr,
-        )
-        return 1
-    if args.via_df and (args.create_saved_dataset or args.saved_dataset):
-        print("--via-df cannot be combined with SavedDataset flags", file=sys.stderr)
-        return 1
-
-    if args.create_saved_dataset:
-        ds = create_and_stream_saved_dataset(args.create_saved_dataset)
-    elif args.saved_dataset:
-        ds = stream_saved_dataset(args.saved_dataset)
-    elif args.via_df:
+    if args.via_df:
         ds = retrieve_via_df()
     else:
         ds = retrieve_via_ray_stream()

--- a/infra/website/docs/blog/feast-ray-llm-posttrain.md
+++ b/infra/website/docs/blog/feast-ray-llm-posttrain.md
@@ -17,7 +17,7 @@ This post walks through the [ray-llm-posttrain example](https://github.com/feast
 
 1. Put conversation features in Feast  
 2. Retrieve them with `get_historical_features` (entity-less date range)  
-3. Get rows into your trainer — stream with Ray **or** materialize with `.to_df()` / a SavedDataset  
+3. Get rows into your trainer — stream with Ray **or** materialize with `.to_df()`  
 
 You bring your own trainer. GPT-2 in the script is optional smoke only.
 
@@ -25,7 +25,7 @@ You bring your own trainer. GPT-2 in the script is optional smoke only.
 
 | Name | Type | What it holds |
 |---|---|---|
-| `web_documents` | [FeatureView](https://docs.feast.dev/getting-started/concepts/feature-view) | `human`, `bot`, `human_repeat_ratio`, `bot_repeat_ratio`, `part_of_speech` |
+| `web_documents` | [FeatureView](https://docs.feast.dev/getting-started/concepts/feature-view) | `human`, `bot`, `human_repeat_ratio`, `bot_repeat_ratio` |
 | `train_example` | [OnDemandFeatureView](https://docs.feast.dev/reference/beta-on-demand-feature-view) | `cleaned_human`, `cleaned_bot`, `char_count`, `is_trainable`, `sft_text` |
 | `llm_posttrain` | FeatureService | Bundles `web_documents` + `train_example` |
 
@@ -112,7 +112,6 @@ web_documents = FeatureView(
         Field(name="bot", dtype=String),
         Field(name="human_repeat_ratio", dtype=Float64),
         Field(name="bot_repeat_ratio", dtype=Float64),
-        Field(name="part_of_speech", dtype=String),
     ],
     source=tiny_web,
     online=False,
@@ -139,7 +138,10 @@ def train_example(inputs):
     cleaned_human = inputs["human"].fillna("").astype(str).str.strip()
     cleaned_bot = inputs["bot"].fillna("").astype(str).str.strip()
     # ... length + repeat-ratio gate ...
-    sft_text = "### Human\n" + cleaned_human + "\n### Assistant\n" + cleaned_bot
+    sft_text = (
+        "<|im_start|>user\n" + cleaned_human + "<|im_end|>\n"
+        "<|im_start|>assistant\n" + cleaned_bot + "<|im_end|>"
+    )
     return pd.DataFrame({...})
 ```
 
@@ -181,13 +183,14 @@ job = store.get_historical_features(
 
 Then choose how you turn that job into training rows.
 
-## Step 3: Three ways into the trainer
+## Step 3: Two ways into the trainer
 
 | Path | ODFV runs? | When to use |
 |---|---|---|
 | `job.to_ray_dataset()` then preprocess | **No** | Stream FeatureView columns; shape `sft_text` yourself |
 | `job.to_df()` / `to_arrow()` | **Yes** | Want `train_example` outputs from Feast |
-| `to_df()` / `to_arrow()` then `create_saved_dataset`, Ray on storage | **Yes** (at materialize time) | Freeze a named training slice |
+
+Pick **Option A** when you want full control over text formatting or need custom preprocessing (e.g., multi-turn chat templates, tokenization-aware truncation). Pick **Option B** when you want Feast to enforce quality gates consistently across training and serving.
 
 ### Option A — Stream with Ray, preprocess yourself
 
@@ -204,7 +207,10 @@ def preprocess_sft(batch):
     human = batch["human"].fillna("").astype(str).str.strip()
     bot = batch["bot"].fillna("").astype(str).str.strip()
     ok = bot.str.len() >= 64
-    sft_text = "### Human\n" + human + "\n### Assistant\n" + bot
+    sft_text = (
+        "<|im_start|>user\n" + human + "<|im_end|>\n"
+        "<|im_start|>assistant\n" + bot + "<|im_end|>"
+    )
     return pd.DataFrame({"sft_text": sft_text}).loc[ok].reset_index(drop=True)
 
 train_ds = ds.map_batches(preprocess_sft, batch_format="pandas")
@@ -237,45 +243,17 @@ trainable = df[df["is_trainable"] & df["sft_text"].astype(str).str.len().gt(0)]
 PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run --via-df
 ```
 
-### Option C — Save the slice, then stream with Ray
+### The same ODFV at serving time
 
-[Saved datasets](https://docs.feast.dev/getting-started/concepts/dataset) freeze a retrieval for later training. Pattern from the [validating historical features](https://docs.feast.dev/tutorials/validating-historical-features) tutorial—adapted for Ray file storage:
+The `train_example` ODFV runs identically during online serving — the quality gate and formatting logic stay in one place:
 
 ```python
-from feast.infra.offline_stores.file_source import SavedDatasetFileStorage
-
-job = store.get_historical_features(
-    features=store.get_feature_service("llm_posttrain"),
-    start_date=...,
-    end_date=...,
-)
-# Materialize first so ODFVs run before persisting
-job.to_df()
-store.create_saved_dataset(
-    from_=job,
-    name="sft_support_q2",
-    storage=SavedDatasetFileStorage(path="data/sft_support_q2.parquet"),
-)
-
-saved = store.get_saved_dataset("sft_support_q2")
-df = saved.to_df()  # full table
-
-# Large freeze: stream with Ray instead of loading everything
-import ray
-path = saved.storage.to_data_source().path
-stream = ray.data.read_parquet(path)
-# ODFV outputs are in the parquet — filter for trainable rows
-stream = stream.filter(lambda row: row["is_trainable"])
-```
-
-```bash
-# Create + stream (writes data/sft_support_q2.parquet)
-PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run \
-  --create-saved-dataset sft_support_q2
-
-# Later: stream an existing freeze
-PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run \
-  --saved-dataset sft_support_q2
+# At inference time, the same ODFV runs on the fly
+features = store.get_online_features(
+    features=["train_example:sft_text", "train_example:is_trainable"],
+    entity_rows=[{"document_id": "doc_42"}],
+).to_dict()
+# features["sft_text"], features["is_trainable"] — same logic as training
 ```
 
 ## Try the full example
@@ -288,8 +266,6 @@ cd feature_repo && feast apply && cd ..
 
 PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run
 PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run --via-df
-PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run \
-  --create-saved-dataset sft_support_q2
 
 # optional GPT-2 smoke
 PYTHONPATH=../../sdk/python python scripts/train_sft.py --max-steps 20
@@ -301,7 +277,7 @@ Details: [ray-llm-posttrain README](https://github.com/feast-dev/feast/tree/mast
 
 1. **Keep conversation features in Feast** — this example’s `web_documents`.  
 2. **Stream with Ray** — `to_ray_dataset()`, then preprocess training text yourself.  
-3. **Want ODFVs** — `.to_df()` / `.to_arrow()` to materialize, then optionally SavedDataset + Ray on storage (filter for `is_trainable`).  
+3. **Want ODFVs** — `.to_df()` / `.to_arrow()` to materialize, then train.  
 4. **Bring your own trainer** — GPT-2 in the example is optional.  
 
 ## References
@@ -318,7 +294,6 @@ Details: [ray-llm-posttrain README](https://github.com/feast-dev/feast/tree/mast
 - [Ray data source](https://docs.feast.dev/reference/data-sources/ray)  
 - [Ray compute engine](https://docs.feast.dev/reference/compute-engine/ray)  
 - [On demand feature views](https://docs.feast.dev/reference/beta-on-demand-feature-view)  
-- [Saved dataset](https://docs.feast.dev/getting-started/concepts/dataset)  
 - [Feature retrieval](https://docs.feast.dev/getting-started/concepts/feature-retrieval)  
 - [FAQ: historical features without entity dataframe](https://docs.feast.dev/getting-started/faq#how-do-i-run-get_historical_features-without-providing-an-entity-dataframe)  
 

--- a/infra/website/docs/blog/feast-ray-llm-posttrain.md
+++ b/infra/website/docs/blog/feast-ray-llm-posttrain.md
@@ -1,0 +1,329 @@
+---
+title: "How to Use Feast for SLM/LLM Post-Training with Ray"
+description: "Keep conversation features in Feast, retrieve them for training, then stream into your trainer with Ray."
+date: 2026-07-14
+authors: ["Chaitanya Patel"]
+---
+
+# How to Use Feast for SLM/LLM Post-Training with Ray
+
+Your support bot answers a lot of tickets. It’s fine—but it sounds generic. The team wants a smaller model that talks more like *your* agents: your refund wording, your product names, your tone.
+
+So someone says: **fine-tune on our real chats.**
+
+That part sounds easy. The messy part is the data—exports, notebook cleaning, and prompt formatting scattered across training scripts.
+
+This post walks through the [ray-llm-posttrain example](https://github.com/feast-dev/feast/tree/master/examples/ray-llm-posttrain):
+
+1. Put conversation features in Feast  
+2. Retrieve them with `get_historical_features` (entity-less date range)  
+3. Get rows into your trainer — stream with Ray **or** materialize with `.to_df()` / a SavedDataset  
+
+You bring your own trainer. GPT-2 in the script is optional smoke only.
+
+## What’s in the example
+
+| Name | Type | What it holds |
+|---|---|---|
+| `web_documents` | [FeatureView](https://docs.feast.dev/getting-started/concepts/feature-view) | `human`, `bot`, `human_repeat_ratio`, `bot_repeat_ratio`, `part_of_speech` |
+| `train_example` | [OnDemandFeatureView](https://docs.feast.dev/reference/beta-on-demand-feature-view) | `cleaned_human`, `cleaned_bot`, `char_count`, `is_trainable`, `sft_text` |
+| `llm_posttrain` | FeatureService | Bundles `web_documents` + `train_example` |
+
+Full definitions live in [feature_definitions.py](https://github.com/feast-dev/feast/blob/master/examples/ray-llm-posttrain/feature_repo/feature_definitions.py). Ray is the [offline store](https://docs.feast.dev/reference/offline-stores/ray) and one way to stream rows out—not a separate feature catalog.
+
+This example stays on **supported Feast APIs only** (no core patches). Conversation rows already include `document_id` and `event_timestamp` before Feast reads them.
+
+## Step 1: Point Feast at conversation data
+
+### Ray offline store (local)
+
+From the example [feature_store.yaml](https://github.com/feast-dev/feast/blob/master/examples/ray-llm-posttrain/feature_repo/feature_store.yaml). Cap Ray resources on a laptop—see [Ray offline store: resource management](https://docs.feast.dev/reference/offline-stores/ray#important-resource-management):
+
+```yaml
+project: ray_llm_posttrain
+registry: data/registry.db
+provider: local
+
+offline_store:
+  type: ray
+  storage_path: data/ray_storage
+  enable_ray_logging: false
+  ray_conf:
+    num_cpus: 2
+    object_store_memory: 104857600
+    _memory: 524288000
+
+batch_engine:
+  type: ray.engine
+  max_workers: 2
+
+online_store:
+  type: sqlite
+  path: data/online_store.db
+
+entity_key_serialization_version: 3
+auth:
+  type: no_auth
+```
+
+You can also start from the built-in template:
+
+```bash
+feast init -t ray my_ray_project
+```
+
+See the [Ray template / offline store docs](https://docs.feast.dev/reference/offline-stores/ray#quick-start-with-ray-template) and the related blog [Scaling ML with Feast and Ray](/blog/feast-ray-distributed-processing).
+
+### Demo seed: prepare parquet, then `RaySource`
+
+[RaySource](https://docs.feast.dev/reference/data-sources/ray) tells Feast how to load data through Ray. Hugging Face is only used in a **prepare script**—not as a live Feast source that invents timestamps at retrieval time.
+
+`nampdn-ai/tiny-webtext` has no `document_id` / `event_timestamp`. Entity-less retrieval needs those columns on the source. We add them **outside Feast**, write parquet, then point Feast at that file (supported path):
+
+```bash
+PYTHONPATH=../../sdk/python python scripts/prepare_data.py
+# → feature_repo/data/tiny_webtext.parquet
+```
+
+```python
+from feast.infra.offline_stores.contrib.ray_offline_store.ray_source import RaySource
+
+tiny_web = RaySource(
+    name="tiny_webtext",
+    reader_type="parquet",
+    path="data/tiny_webtext.parquet",
+    timestamp_field="event_timestamp",
+)
+```
+
+In production you’d skip the HF prepare step and register your real conversation store (warehouse / lake / parquet) that already has join keys and timestamps.
+
+More reader types are in the [Ray data source reference](https://docs.feast.dev/reference/data-sources/ray#supported-reader_type-values).
+
+### Feature view
+
+```python
+web_documents = FeatureView(
+    name="web_documents",
+    entities=[document],
+    ttl=timedelta(days=365),
+    schema=[
+        Field(name="human", dtype=String),
+        Field(name="bot", dtype=String),
+        Field(name="human_repeat_ratio", dtype=Float64),
+        Field(name="bot_repeat_ratio", dtype=Float64),
+        Field(name="part_of_speech", dtype=String),
+    ],
+    source=tiny_web,
+    online=False,
+)
+```
+
+### Optional: OnDemandFeatureView for derived training features
+
+If you want Feast to own `sft_text` / quality gates (same idea as in the [ODFV docs](https://docs.feast.dev/reference/beta-on-demand-feature-view)):
+
+```python
+@on_demand_feature_view(
+    sources=[web_documents],
+    schema=[
+        Field(name="cleaned_human", dtype=String),
+        Field(name="cleaned_bot", dtype=String),
+        Field(name="char_count", dtype=Int64),
+        Field(name="is_trainable", dtype=Bool),
+        Field(name="sft_text", dtype=String),
+    ],
+    mode="pandas",
+)
+def train_example(inputs):
+    cleaned_human = inputs["human"].fillna("").astype(str).str.strip()
+    cleaned_bot = inputs["bot"].fillna("").astype(str).str.strip()
+    # ... length + repeat-ratio gate ...
+    sft_text = "### Human\n" + cleaned_human + "\n### Assistant\n" + cleaned_bot
+    return pd.DataFrame({...})
+```
+
+```python
+llm_posttrain = FeatureService(
+    name="llm_posttrain",
+    features=[web_documents, train_example],
+)
+```
+
+Apply:
+
+```bash
+cd examples/ray-llm-posttrain/feature_repo
+feast apply
+```
+
+## Step 2: Retrieve for training (entity-less)
+
+No `entity_df`—just a date window. That pattern is covered in [Historical Features Without Entity IDs](/blog/entity-less-historical-features-retrieval) and the [FAQ](https://docs.feast.dev/getting-started/faq#how-do-i-run-get_historical_features-without-providing-an-entity-dataframe):
+
+```python
+from datetime import datetime, timezone
+from feast import FeatureStore
+
+store = FeatureStore(repo_path="feature_repo")
+
+job = store.get_historical_features(
+    features=[
+        "web_documents:human",
+        "web_documents:bot",
+        "web_documents:human_repeat_ratio",
+        "web_documents:bot_repeat_ratio",
+    ],
+    start_date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+    end_date=datetime(2024, 7, 1, tzinfo=timezone.utc),
+)
+```
+
+Then choose how you turn that job into training rows.
+
+## Step 3: Three ways into the trainer
+
+| Path | ODFV runs? | When to use |
+|---|---|---|
+| `job.to_ray_dataset()` then preprocess | **No** | Stream FeatureView columns; shape `sft_text` yourself |
+| `job.to_df()` / `to_arrow()` | **Yes** | Want `train_example` outputs from Feast |
+| `to_df()` / `to_arrow()` then `create_saved_dataset`, Ray on storage | **Yes** (at materialize time) | Freeze a named training slice |
+
+### Option A — Stream with Ray, preprocess yourself
+
+`to_ray_dataset()` returns a Ray Dataset of retrieved FeatureView columns. It does **not** apply OnDemandFeatureViews. Build training text with Ray `map_batches` (as in [train_sft.py](https://github.com/feast-dev/feast/blob/master/examples/ray-llm-posttrain/scripts/train_sft.py)):
+
+```python
+ds = job.to_ray_dataset()
+
+def preprocess_sft(batch):
+    import pandas as pd
+
+    if not isinstance(batch, pd.DataFrame):
+        batch = pd.DataFrame(batch)
+    human = batch["human"].fillna("").astype(str).str.strip()
+    bot = batch["bot"].fillna("").astype(str).str.strip()
+    ok = bot.str.len() >= 64
+    sft_text = "### Human\n" + human + "\n### Assistant\n" + bot
+    return pd.DataFrame({"sft_text": sft_text}).loc[ok].reset_index(drop=True)
+
+train_ds = ds.map_batches(preprocess_sft, batch_format="pandas")
+# → hand train_ds to your SLM/LLM trainer
+```
+
+Run the example default path:
+
+```bash
+PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run
+```
+
+### Option B — Use the ODFV, then train
+
+Materialize with `.to_df()` so `train_example` runs (same retrieval/serving idea as in the [ODFV overview](https://docs.feast.dev/reference/beta-on-demand-feature-view#why-use-on-demand-feature-views)):
+
+```python
+df = store.get_historical_features(
+    features=store.get_feature_service("llm_posttrain"),
+    start_date=datetime(2024, 6, 1, tzinfo=timezone.utc),
+    end_date=datetime(2024, 7, 1, tzinfo=timezone.utc),
+).to_df()
+
+trainable = df[df["is_trainable"] & df["sft_text"].astype(str).str.len().gt(0)]
+# trainable["sft_text"] → your trainer
+# or: import ray; ray.data.from_pandas(trainable[["sft_text"]])
+```
+
+```bash
+PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run --via-df
+```
+
+### Option C — Save the slice, then stream with Ray
+
+[Saved datasets](https://docs.feast.dev/getting-started/concepts/dataset) freeze a retrieval for later training. Pattern from the [validating historical features](https://docs.feast.dev/tutorials/validating-historical-features) tutorial—adapted for Ray file storage:
+
+```python
+from feast.infra.offline_stores.file_source import SavedDatasetFileStorage
+
+job = store.get_historical_features(
+    features=store.get_feature_service("llm_posttrain"),
+    start_date=...,
+    end_date=...,
+)
+# Materialize first so ODFVs run before persisting
+job.to_df()
+store.create_saved_dataset(
+    from_=job,
+    name="sft_support_q2",
+    storage=SavedDatasetFileStorage(path="data/sft_support_q2.parquet"),
+)
+
+saved = store.get_saved_dataset("sft_support_q2")
+df = saved.to_df()  # full table
+
+# Large freeze: stream with Ray instead of loading everything
+import ray
+path = saved.storage.to_data_source().path
+stream = ray.data.read_parquet(path)
+# ODFV outputs are in the parquet — filter for trainable rows
+stream = stream.filter(lambda row: row["is_trainable"])
+```
+
+```bash
+# Create + stream (writes data/sft_support_q2.parquet)
+PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run \
+  --create-saved-dataset sft_support_q2
+
+# Later: stream an existing freeze
+PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run \
+  --saved-dataset sft_support_q2
+```
+
+## Try the full example
+
+```bash
+cd examples/ray-llm-posttrain
+uv pip install -e "../../sdk/python[ray]" -r requirements.txt
+PYTHONPATH=../../sdk/python python scripts/prepare_data.py
+cd feature_repo && feast apply && cd ..
+
+PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run
+PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run --via-df
+PYTHONPATH=../../sdk/python python scripts/train_sft.py --dry-run \
+  --create-saved-dataset sft_support_q2
+
+# optional GPT-2 smoke
+PYTHONPATH=../../sdk/python python scripts/train_sft.py --max-steps 20
+```
+
+Details: [ray-llm-posttrain README](https://github.com/feast-dev/feast/tree/master/examples/ray-llm-posttrain).
+
+## Takeaways
+
+1. **Keep conversation features in Feast** — this example’s `web_documents`.  
+2. **Stream with Ray** — `to_ray_dataset()`, then preprocess training text yourself.  
+3. **Want ODFVs** — `.to_df()` / `.to_arrow()` to materialize, then optionally SavedDataset + Ray on storage (filter for `is_trainable`).  
+4. **Bring your own trainer** — GPT-2 in the example is optional.  
+
+## References
+
+**This example**
+
+- [ray-llm-posttrain example](https://github.com/feast-dev/feast/tree/master/examples/ray-llm-posttrain)  
+- [feature_definitions.py](https://github.com/feast-dev/feast/blob/master/examples/ray-llm-posttrain/feature_repo/feature_definitions.py)  
+- [train_sft.py](https://github.com/feast-dev/feast/blob/master/examples/ray-llm-posttrain/scripts/train_sft.py)  
+
+**Docs**
+
+- [Ray offline store](https://docs.feast.dev/reference/offline-stores/ray)  
+- [Ray data source](https://docs.feast.dev/reference/data-sources/ray)  
+- [Ray compute engine](https://docs.feast.dev/reference/compute-engine/ray)  
+- [On demand feature views](https://docs.feast.dev/reference/beta-on-demand-feature-view)  
+- [Saved dataset](https://docs.feast.dev/getting-started/concepts/dataset)  
+- [Feature retrieval](https://docs.feast.dev/getting-started/concepts/feature-retrieval)  
+- [FAQ: historical features without entity dataframe](https://docs.feast.dev/getting-started/faq#how-do-i-run-get_historical_features-without-providing-an-entity-dataframe)  
+
+**Related blogs & tutorials**
+
+- [Historical Features Without Entity IDs](/blog/entity-less-historical-features-retrieval)  
+- [Scaling ML with Feast and Ray](/blog/feast-ray-distributed-processing)  
+- [Validating historical features](https://docs.feast.dev/tutorials/validating-historical-features)  


### PR DESCRIPTION
## Summary
- Add a blog post on keeping conversation / SFT features in Feast and retrieving them for SLM/LLM post-training with Ray
- Add `examples/ray-llm-posttrain/` with prepare→parquet, FeatureView + ODFV, and `train_sft.py` paths (`to_ray_dataset`, `to_df`, SavedDataset)
- Uses supported Feast APIs only (no core SDK patches); HF is a prepare-script seed, not a live RaySource inventing timestamps
