### PR TITLE
feat: Add Feature Service Create/delete REST apis and UI

### DIFF
--- a/sdk/python/feast/api/registry/rest/feature_services.py
+++ b/sdk/python/feast/api/registry/rest/feature_services.py
@@ -1,6 +1,8 @@
-from typing import Dict
+from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 from feast.api.registry.rest.codegen_utils import render_feature_service_code
 from feast.api.registry.rest.rest_utils import (
@@ -14,7 +16,37 @@ from feast.api.registry.rest.rest_utils import (
     grpc_call,
     parse_tags,
 )
+from feast.feature_service import FeatureService
 from feast.protos.feast.registry import RegistryServer_pb2
+
+
+class FeatureViewRefModel(BaseModel):
+    feature_view_name: str
+    feature_names: Optional[List[str]] = []
+
+
+class ApplyFeatureServiceRequestBody(BaseModel):
+    name: str
+    project: str
+    features: List[FeatureViewRefModel]
+    description: Optional[str] = ""
+    tags: Optional[Dict[str, str]] = {}
+    owner: Optional[str] = ""
+
+
+def _projection_view_name(projection: dict) -> Optional[str]:
+    return (
+        projection.get("featureViewName")
+        or projection.get("feature_view_name")
+        or projection.get("name")
+    )
+
+
+def _projection_feature_columns(projection: dict) -> list:
+    columns = projection.get("featureColumns")
+    if columns is None:
+        columns = projection.get("feature_columns")
+    return columns if isinstance(columns, list) else []
 
 
 def get_feature_service_router(grpc_handler) -> APIRouter:
@@ -97,9 +129,7 @@ def get_feature_service_router(grpc_handler) -> APIRouter:
             project=project,
             allow_cache=allow_cache,
         )
-        feature_service = grpc_call(grpc_handler.GetFeatureService, req)
-
-        result = feature_service
+        result = grpc_call(grpc_handler.GetFeatureService, req)
 
         if include_relationships:
             relationships = get_object_relationships(
@@ -109,25 +139,33 @@ def get_feature_service_router(grpc_handler) -> APIRouter:
 
         if result:
             spec = result.get("spec", result)
-            name = spec.get("name") or result.get("name") or "default_feature_service"
+            service_name = (
+                spec.get("name") or result.get("name") or "default_feature_service"
+            )
             projections = spec.get("features", [])
             if not isinstance(projections, list):
                 projections = []
 
             features_exprs = []
             for proj in projections:
-                if isinstance(proj, dict):
-                    view_name = proj.get("name")
-                    feature_names = proj.get("features", [])
-                else:
-                    view_name = str(proj)
-                    feature_names = []
+                if not isinstance(proj, dict):
+                    continue
 
+                view_name = _projection_view_name(proj)
                 if not view_name:
                     continue
 
+                feature_columns = _projection_feature_columns(proj)
+                feature_names = [
+                    column.get("name")
+                    for column in feature_columns
+                    if isinstance(column, dict) and column.get("name")
+                ]
+
                 if feature_names:
-                    feature_list = ", ".join([repr(f) for f in feature_names])
+                    feature_list = ", ".join(
+                        [repr(feature_name) for feature_name in feature_names]
+                    )
                     features_exprs.append(f"{view_name}[[{feature_list}]]")
                 else:
                     features_exprs.append(view_name)
@@ -135,7 +173,7 @@ def get_feature_service_router(grpc_handler) -> APIRouter:
             features_str = ", ".join(features_exprs)
 
             context = {
-                "name": name,
+                "name": service_name,
                 "features": features_str,
                 "tags": spec.get("tags", {}),
                 "description": spec.get("description", ""),
@@ -144,5 +182,40 @@ def get_feature_service_router(grpc_handler) -> APIRouter:
 
             result["featureDefinition"] = render_feature_service_code(context)
         return result
+
+    @router.post("/feature_services", status_code=201)
+    def apply_feature_service(body: ApplyFeatureServiceRequestBody):
+        req = FeatureService.build_apply_request(
+            name=body.name,
+            project=body.project,
+            feature_view_refs=[
+                (feature.feature_view_name, feature.feature_names or None)
+                for feature in body.features
+            ],
+            description=body.description or "",
+            tags=body.tags or {},
+            owner=body.owner or "",
+            commit=True,
+        )
+        grpc_call(grpc_handler.ApplyFeatureService, req)
+
+        return JSONResponse(
+            status_code=201,
+            content={"name": body.name, "project": body.project, "status": "applied"},
+        )
+
+    @router.delete("/feature_services/{name}")
+    def delete_feature_service(
+        name: str,
+        project: str = Query(...),
+    ):
+        req = RegistryServer_pb2.DeleteFeatureServiceRequest(
+            name=name,
+            project=project,
+            commit=True,
+        )
+        grpc_call(grpc_handler.DeleteFeatureService, req)
+
+        return {"name": name, "project": project, "status": "deleted"}
 
     return router

--- a/sdk/python/feast/feature_service.py
+++ b/sdk/python/feast/feature_service.py
@@ -1,14 +1,18 @@
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from google.protobuf.json_format import MessageToJson
 from typeguard import typechecked
 
 from feast.base_feature_view import BaseFeatureView
-from feast.errors import FeatureViewMissingDuringFeatureServiceInference
+from feast.errors import (
+    FeastObjectNotFoundException,
+    FeatureViewMissingDuringFeatureServiceInference,
+)
 from feast.feature_logging import LoggingConfig
 from feast.feature_view import FeatureView
 from feast.feature_view_projection import FeatureViewProjection
+from feast.field import Field
 from feast.labeling.label_view import LabelView
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.protos.feast.core.FeatureService_pb2 import (
@@ -20,6 +24,9 @@ from feast.protos.feast.core.FeatureService_pb2 import (
 from feast.protos.feast.core.FeatureService_pb2 import (
     FeatureServiceSpec as FeatureServiceSpecProto,
 )
+
+if TYPE_CHECKING:
+    from feast.infra.registry.base_registry import BaseRegistry
 
 
 @typechecked
@@ -161,6 +168,119 @@ class FeatureService:
                     f'{type(feature_grouping)} as part of the "features" argument.)'
                 )
 
+    def prepare_for_apply(
+        self,
+        registry: "BaseRegistry",
+        project: str,
+        allow_cache: bool = False,
+    ) -> "FeatureService":
+        """
+        Materialize feature view projections before registry apply.
+
+        Uses the same FeatureService construction and ``infer_features`` path as
+        ``FeatureStore.apply`` for SDK-defined services.
+
+        When the service is already fully resolved (SDK path where _features is
+        set and projections already have features populated via infer_features,
+        OR the proto deserialization path where projections carry full dtype
+        info), this is a no-op.
+        """
+        from feast.types import Invalid
+
+        if self._features and all(p.features for p in self.feature_view_projections):
+            return self
+
+        if (
+            not self._features
+            and self.feature_view_projections
+            and all(
+                p.features and all(f.dtype != Invalid for f in p.features)
+                for p in self.feature_view_projections
+            )
+        ):
+            return self
+
+        fvs_to_update: Dict[str, Union[FeatureView, BaseFeatureView]] = {}
+
+        if self._features:
+            for feature_grouping in self._features:
+                if isinstance(feature_grouping, BaseFeatureView):
+                    fvs_to_update[feature_grouping.name] = (
+                        registry.get_any_feature_view(
+                            feature_grouping.name, project, allow_cache=allow_cache
+                        )
+                    )
+            self.infer_features(fvs_to_update=fvs_to_update)
+            return self
+
+        resolved_features: List[Union[FeatureView, OnDemandFeatureView, LabelView]] = []
+        for projection in self.feature_view_projections:
+            try:
+                feature_view = registry.get_any_feature_view(
+                    projection.name, project, allow_cache=allow_cache
+                )
+            except FeastObjectNotFoundException as exc:
+                raise FeastObjectNotFoundException(
+                    f"Feature view '{projection.name}' not found in project '{project}'"
+                ) from exc
+
+            if not isinstance(
+                feature_view, (FeatureView, OnDemandFeatureView, LabelView)
+            ):
+                raise ValueError(
+                    f"Cannot resolve projection for feature view '{projection.name}'"
+                )
+
+            fvs_to_update[feature_view.name] = feature_view
+            features_by_name = {
+                feature.name: feature for feature in feature_view.features
+            }
+
+            if self._projection_matches_registry_features(projection, features_by_name):
+                resolved_features.append(feature_view.with_projection(projection))
+            elif projection.desired_features:
+                resolved_features.append(
+                    feature_view[list(projection.desired_features)]
+                )
+            elif not projection.features:
+                resolved_features.append(feature_view)
+            else:
+                resolved_features.append(
+                    feature_view[[feature.name for feature in projection.features]]
+                )
+
+        prepared = FeatureService(
+            name=self.name,
+            features=resolved_features,
+            tags=self.tags,
+            description=self.description,
+            owner=self.owner,
+            logging_config=self.logging_config,
+            precompute_online=self.precompute_online,
+        )
+        prepared.created_timestamp = self.created_timestamp
+        prepared.last_updated_timestamp = self.last_updated_timestamp
+        prepared.infer_features(fvs_to_update=fvs_to_update)
+
+        self._features = prepared._features
+        self.feature_view_projections = prepared.feature_view_projections
+        return self
+
+    @staticmethod
+    def _projection_matches_registry_features(
+        projection: FeatureViewProjection,
+        features_by_name: Dict[str, Field],
+    ) -> bool:
+        if not projection.features:
+            return False
+
+        for feature in projection.features:
+            if feature.name not in features_by_name:
+                return False
+            if feature != features_by_name[feature.name]:
+                return False
+        return True
+
     def __repr__(self):
         items = (f"{k} = {v}" for k, v in self.__dict__.items())
         return f"<{self.__class__.__name__}({', '.join(items)})>"
@@ -258,6 +378,48 @@ class FeatureService:
         )
 
         return FeatureServiceProto(spec=spec, meta=meta)
+
+    @classmethod
+    def build_apply_request(
+        cls,
+        *,
+        name: str,
+        project: str,
+        feature_view_refs: List[tuple[str, Optional[List[str]]]],
+        description: str = "",
+        tags: Optional[Dict[str, str]] = None,
+        owner: str = "",
+        commit: bool = True,
+    ):
+        """Build an unresolved ApplyFeatureServiceRequest from feature view refs."""
+        from feast.protos.feast.core.Feature_pb2 import FeatureSpecV2
+        from feast.protos.feast.core.FeatureViewProjection_pb2 import (
+            FeatureViewProjection as FeatureViewProjectionProto,
+        )
+        from feast.protos.feast.registry import RegistryServer_pb2
+
+        projections = []
+        for feature_view_name, feature_names in feature_view_refs:
+            projection = FeatureViewProjectionProto(
+                feature_view_name=feature_view_name,
+            )
+            if feature_names:
+                for feature_name in feature_names:
+                    projection.feature_columns.append(FeatureSpecV2(name=feature_name))
+            projections.append(projection)
+
+        spec = FeatureServiceSpecProto(
+            name=name,
+            features=projections,
+            tags=tags or {},
+            description=description,
+            owner=owner,
+        )
+        return RegistryServer_pb2.ApplyFeatureServiceRequest(
+            feature_service=FeatureServiceProto(spec=spec),
+            project=project,
+            commit=commit,
+        )
 
     def validate(self):
         if not self.precompute_online:

--- a/sdk/python/feast/infra/registry/registry.py
+++ b/sdk/python/feast/infra/registry/registry.py
@@ -453,6 +453,7 @@ class Registry(BaseRegistry):
     def apply_feature_service(
         self, feature_service: FeatureService, project: str, commit: bool = True
     ):
+        feature_service.prepare_for_apply(self, project, allow_cache=True)
         now = _utc_now()
         if not feature_service.created_timestamp:
             feature_service.created_timestamp = now

--- a/sdk/python/feast/infra/registry/snowflake.py
+++ b/sdk/python/feast/infra/registry/snowflake.py
@@ -264,6 +264,7 @@ class SnowflakeRegistry(BaseRegistry):
     def apply_feature_service(
         self, feature_service: FeatureService, project: str, commit: bool = True
     ):
+        feature_service.prepare_for_apply(self, project, allow_cache=True)
         return self._apply_object(
             "FEATURE_SERVICES",
             project,

--- a/sdk/python/feast/infra/registry/sql.py
+++ b/sdk/python/feast/infra/registry/sql.py
@@ -1031,6 +1031,7 @@ class SqlRegistry(CachingRegistry):
     def apply_feature_service(
         self, feature_service: FeatureService, project: str, commit: bool = True
     ):
+        feature_service.prepare_for_apply(self, project, allow_cache=True)
         return self._apply_object(
             feature_services,
             project,

--- a/sdk/python/tests/unit/api/test_api_rest_registry.py
+++ b/sdk/python/tests/unit/api/test_api_rest_registry.py
@@ -2162,6 +2162,116 @@ def test_apply_and_delete_feature_view_via_rest(fastapi_test_app):
     assert response.status_code == 404
 
 
+def test_apply_and_delete_feature_service_via_rest(fastapi_test_app):
+    """Test POST /feature_services and DELETE /feature_services/{name} endpoints."""
+    response = fastapi_test_app.post(
+        "/feature_views",
+        json={
+            "name": "driver_stats_for_service",
+            "project": "demo_project",
+            "entities": ["user_id"],
+            "features": [
+                {
+                    "name": "trip_count",
+                    "value_type": 2,
+                    "description": "Number of completed trips",
+                },
+            ],
+            "ttl_seconds": 86400,
+            "online": True,
+            "description": "Driver statistics feature view",
+        },
+    )
+    assert response.status_code == 201
+
+    response = fastapi_test_app.post(
+        "/feature_services",
+        json={
+            "name": "driver_activity_v1",
+            "project": "demo_project",
+            "features": [
+                {
+                    "feature_view_name": "driver_stats_for_service",
+                    "feature_names": ["trip_count"],
+                }
+            ],
+            "description": "Driver activity feature service",
+            "owner": "ml-team",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "driver_activity_v1"
+    assert data["status"] == "applied"
+
+    response = fastapi_test_app.get(
+        "/feature_services/driver_activity_v1?project=demo_project"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["spec"]["name"] == "driver_activity_v1"
+    projections = data["spec"]["features"]
+    assert len(projections) == 1
+    assert projections[0]["featureViewName"] == "driver_stats_for_service"
+    assert len(projections[0]["featureColumns"]) == 1
+    assert projections[0]["featureColumns"][0]["name"] == "trip_count"
+
+    response = fastapi_test_app.get("/feature_services?project=demo_project")
+    assert response.status_code == 200
+    listed = next(
+        fs
+        for fs in response.json()["featureServices"]
+        if fs["spec"]["name"] == "driver_activity_v1"
+    )
+    listed_projection = listed["spec"]["features"][0]
+    assert listed_projection["featureColumns"][0]["name"] == "trip_count"
+
+    response = fastapi_test_app.post(
+        "/feature_services",
+        json={
+            "name": "driver_activity_all",
+            "project": "demo_project",
+            "features": [
+                {"feature_view_name": "driver_stats_for_service"},
+            ],
+            "description": "All features from the feature view",
+        },
+    )
+    assert response.status_code == 201
+
+    response = fastapi_test_app.get(
+        "/feature_services/driver_activity_all?project=demo_project"
+    )
+    assert response.status_code == 200
+    all_features_projection = response.json()["spec"]["features"][0]
+    assert all_features_projection["featureViewName"] == "driver_stats_for_service"
+    assert len(all_features_projection["featureColumns"]) == 1
+    assert all_features_projection["featureColumns"][0]["name"] == "trip_count"
+
+    response = fastapi_test_app.delete(
+        "/feature_services/driver_activity_all?project=demo_project"
+    )
+    assert response.status_code == 200
+
+    response = fastapi_test_app.delete(
+        "/feature_services/driver_activity_v1?project=demo_project"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "driver_activity_v1"
+    assert data["status"] == "deleted"
+
+    response = fastapi_test_app.get(
+        "/feature_services/driver_activity_v1?project=demo_project"
+    )
+    assert response.status_code == 404
+
+    response = fastapi_test_app.delete(
+        "/feature_views/driver_stats_for_service?project=demo_project"
+    )
+    assert response.status_code == 200
+
+
 def test_metrics_resource_counts_nonexistent_project(fastapi_test_app):
     """Test /metrics/resource_counts with a non-existent project returns empty data."""
     response = fastapi_test_app.get(

--- a/sdk/python/tests/unit/test_feature_service.py
+++ b/sdk/python/tests/unit/test_feature_service.py
@@ -1,9 +1,150 @@
+from feast.errors import FeastObjectNotFoundException
 from feast.feature_service import FeatureService
 from feast.feature_view import FeatureView
+from feast.feature_view_projection import FeatureViewProjection
 from feast.field import Field
 from feast.infra.offline_stores.file_source import FileSource
-from feast.types import Float32
+from feast.protos.feast.core.Feature_pb2 import FeatureSpecV2
+from feast.protos.feast.core.FeatureViewProjection_pb2 import (
+    FeatureViewProjection as FeatureViewProjectionProto,
+)
+from feast.types import Float32, String
 from tests.utils.test_wrappers import no_warnings
+
+
+class _MockRegistry:
+    def __init__(self, feature_view: FeatureView):
+        self._feature_view = feature_view
+
+    def get_any_feature_view(self, name, project, allow_cache=False):
+        if name != self._feature_view.name:
+            raise FeastObjectNotFoundException(name)
+        return self._feature_view
+
+
+def _build_feature_view():
+    file_source = FileSource(name="my-file-source", path="test.parquet")
+    return FeatureView(
+        name="my-feature-view",
+        entities=[],
+        schema=[
+            Field(name="feature1", dtype=Float32),
+            Field(name="feature2", dtype=String),
+        ],
+        source=file_source,
+    )
+
+
+def test_prepare_for_apply_whole_view():
+    feature_view = _build_feature_view()
+    feature_service = FeatureService.from_proto(
+        FeatureService(
+            name="my-feature-service",
+            features=[],
+        ).to_proto()
+    )
+    feature_service.feature_view_projections = [
+        FeatureViewProjection(
+            name=feature_view.name,
+            name_alias=None,
+            desired_features=[],
+            features=[],
+        )
+    ]
+
+    feature_service.prepare_for_apply(_MockRegistry(feature_view), "test_project")
+
+    assert len(feature_service.feature_view_projections) == 1
+    resolved = feature_service.feature_view_projections[0]
+    assert [feature.name for feature in resolved.features] == [
+        "feature1",
+        "feature2",
+    ]
+    assert resolved.features[0].dtype == Float32
+    assert resolved.features[1].dtype == String
+
+
+def test_prepare_for_apply_feature_subset():
+    feature_view = _build_feature_view()
+    feature_service = FeatureService(
+        name="my-feature-service",
+        features=[],
+    )
+    feature_service.feature_view_projections = [
+        FeatureViewProjection(
+            name=feature_view.name,
+            name_alias=None,
+            desired_features=["feature2"],
+            features=[],
+        )
+    ]
+
+    feature_service.prepare_for_apply(_MockRegistry(feature_view), "test_project")
+
+    resolved = feature_service.feature_view_projections[0]
+    assert len(resolved.features) == 1
+    assert resolved.features[0].name == "feature2"
+    assert resolved.features[0].dtype == String
+
+
+def test_prepare_for_apply_name_only_columns():
+    feature_view = _build_feature_view()
+    projection_proto = FeatureViewProjectionProto(
+        feature_view_name=feature_view.name,
+    )
+    projection_proto.feature_columns.append(FeatureSpecV2(name="feature2"))
+    feature_service = FeatureService.from_proto(
+        FeatureService(name="my-feature-service", features=[]).to_proto()
+    )
+    feature_service.feature_view_projections = [
+        FeatureViewProjection.from_proto(projection_proto)
+    ]
+
+    feature_service.prepare_for_apply(_MockRegistry(feature_view), "test_project")
+
+    resolved = feature_service.feature_view_projections[0]
+    assert len(resolved.features) == 1
+    assert resolved.features[0].name == "feature2"
+    assert resolved.features[0].dtype == String
+
+
+def test_prepare_for_apply_keeps_complete_projection():
+    feature_view = _build_feature_view()
+    feature_service = FeatureService(
+        name="my-feature-service",
+        features=[feature_view[["feature1"]]],
+    )
+    original_projection = feature_service.feature_view_projections[0]
+
+    feature_service.prepare_for_apply(_MockRegistry(feature_view), "test_project")
+
+    assert feature_service.feature_view_projections[0] == original_projection
+
+
+def test_build_apply_request():
+    request = FeatureService.build_apply_request(
+        name="my-feature-service",
+        project="test_project",
+        feature_view_refs=[
+            ("feature_view_a", None),
+            ("feature_view_b", ["feature1"]),
+        ],
+        description="test service",
+        tags={"team": "ml"},
+        owner="owner@example.com",
+    )
+
+    spec = request.feature_service.spec
+    assert spec.name == "my-feature-service"
+    assert spec.description == "test service"
+    assert spec.owner == "owner@example.com"
+    assert dict(spec.tags) == {"team": "ml"}
+    assert request.project == "test_project"
+    assert len(spec.features) == 2
+    assert spec.features[0].feature_view_name == "feature_view_a"
+    assert len(spec.features[0].feature_columns) == 0
+    assert spec.features[1].feature_view_name == "feature_view_b"
+    assert [column.name for column in spec.features[1].feature_columns] == ["feature1"]
 
 
 def test_feature_service_with_description():

--- a/ui/src/components/FeatureServiceFormModal.tsx
+++ b/ui/src/components/FeatureServiceFormModal.tsx
@@ -1,0 +1,380 @@
+import React, { useState, useEffect, useMemo } from "react";
+import {
+  EuiSpacer,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiHorizontalRule,
+  EuiCallOut,
+  EuiButtonEmpty,
+  EuiButtonIcon,
+  EuiFormRow,
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+} from "@elastic/eui";
+import { useParams } from "react-router-dom";
+import FormModal from "./forms/FormModal";
+import TagsEditor, { TagEntry } from "./forms/TagsEditor";
+import NameDescriptionOwnerFields from "./forms/NameDescriptionOwnerFields";
+import useResourceQuery, {
+  featureViewListPath,
+  restFeatureViewsToMergedList,
+} from "../queries/useResourceQuery";
+
+interface FeatureViewProjectionEntry {
+  featureViewName: string;
+  featureNames: string[];
+}
+
+interface FeatureServiceFormData {
+  name: string;
+  description: string;
+  owner: string;
+  projections: FeatureViewProjectionEntry[];
+  tags: TagEntry[];
+}
+
+interface FeatureServiceFormModalProps {
+  onClose: () => void;
+  onSubmit: (data: FeatureServiceFormData) => void;
+  initialData?: FeatureServiceFormData;
+  isEdit?: boolean;
+  isSubmitting?: boolean;
+  submitError?: string | null;
+}
+
+const EMPTY_PROJECTION: FeatureViewProjectionEntry = {
+  featureViewName: "",
+  featureNames: [],
+};
+
+const EMPTY_FORM: FeatureServiceFormData = {
+  name: "",
+  description: "",
+  owner: "",
+  projections: [{ ...EMPTY_PROJECTION }],
+  tags: [],
+};
+
+const FeatureServiceFormModal: React.FC<FeatureServiceFormModalProps> = ({
+  onClose,
+  onSubmit,
+  initialData,
+  isEdit = false,
+  isSubmitting = false,
+  submitError,
+}) => {
+  const [formData, setFormData] = useState<FeatureServiceFormData>(
+    initialData || EMPTY_FORM,
+  );
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitted, setSubmitted] = useState(false);
+
+  const { projectName } = useParams();
+
+  const featureViewsQuery = useResourceQuery<any[]>({
+    resourceType: "feature-views-list-fs-form",
+    project: projectName,
+    restPath: featureViewListPath(projectName),
+    restSelect: restFeatureViewsToMergedList,
+  });
+
+  const featureViews = useMemo(
+    () => featureViewsQuery.data || [],
+    [featureViewsQuery.data],
+  );
+
+  const featureViewOptions: EuiComboBoxOptionOption<string>[] = useMemo(
+    () =>
+      featureViews.map((fv) => ({
+        label: fv.name,
+        value: fv.name,
+      })),
+    [featureViews],
+  );
+
+  const featureNamesByView = useMemo(() => {
+    const map: Record<string, string[]> = {};
+    featureViews.forEach((fv) => {
+      const features = fv.object?.spec?.features || [];
+      map[fv.name] = features
+        .map((feature: any) => feature?.name || "")
+        .filter(Boolean);
+    });
+    return map;
+  }, [featureViews]);
+
+  useEffect(() => {
+    if (initialData) {
+      setFormData(initialData);
+    }
+  }, [initialData]);
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    if (!formData.name.trim()) {
+      newErrors.name = "Feature service name is required.";
+    } else if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(formData.name)) {
+      newErrors.name =
+        "Must start with a letter or underscore, and contain only letters, numbers, and underscores.";
+    }
+
+    const validProjections = formData.projections.filter((projection) =>
+      projection.featureViewName.trim(),
+    );
+    if (validProjections.length === 0) {
+      newErrors.projections = "Select at least one feature view.";
+    }
+
+    const viewNames = validProjections.map(
+      (projection) => projection.featureViewName,
+    );
+    if (new Set(viewNames).size !== viewNames.length) {
+      newErrors.projections = "Each feature view can only be selected once.";
+    }
+
+    const tagKeys = formData.tags
+      .map((tag) => tag.key)
+      .filter((key) => key.trim());
+    if (new Set(tagKeys).size !== tagKeys.length) {
+      newErrors.tags = "Tag keys must be unique.";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = () => {
+    setSubmitted(true);
+    if (validate()) {
+      onSubmit({
+        ...formData,
+        projections: formData.projections.filter((projection) =>
+          projection.featureViewName.trim(),
+        ),
+        tags: formData.tags.filter((tag) => tag.key.trim()),
+      });
+    }
+  };
+
+  const updateField = <K extends keyof FeatureServiceFormData>(
+    field: K,
+    value: FeatureServiceFormData[K],
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (submitted) {
+      setErrors((prev) => {
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      });
+    }
+  };
+
+  const addProjection = () => {
+    updateField("projections", [
+      ...formData.projections,
+      { ...EMPTY_PROJECTION },
+    ]);
+  };
+
+  const removeProjection = (index: number) => {
+    if (formData.projections.length <= 1) {
+      return;
+    }
+    updateField(
+      "projections",
+      formData.projections.filter(
+        (_, projectionIndex) => projectionIndex !== index,
+      ),
+    );
+  };
+
+  const updateProjection = (
+    index: number,
+    field: keyof FeatureViewProjectionEntry,
+    value: string | string[],
+  ) => {
+    const updated = [...formData.projections];
+    updated[index] = {
+      ...updated[index],
+      [field]: value,
+      ...(field === "featureViewName" ? { featureNames: [] } : {}),
+    };
+    updateField("projections", updated);
+  };
+
+  return (
+    <FormModal
+      title={isEdit ? "Edit Feature Service" : "Create Feature Service"}
+      submitLabel={isEdit ? "Update Feature Service" : "Create Feature Service"}
+      onClose={onClose}
+      onSubmit={handleSubmit}
+      isSubmitting={isSubmitting}
+    >
+      {submitError && (
+        <>
+          <EuiCallOut
+            title={
+              isEdit
+                ? "Unable to update feature service"
+                : "Unable to create feature service"
+            }
+            color="danger"
+            iconType="alert"
+            size="s"
+          >
+            <p>{submitError}</p>
+          </EuiCallOut>
+          <EuiSpacer size="m" />
+        </>
+      )}
+
+      <NameDescriptionOwnerFields
+        name={formData.name}
+        description={formData.description}
+        owner={formData.owner}
+        onChangeName={(value) => updateField("name", value)}
+        onChangeDescription={(value) => updateField("description", value)}
+        onChangeOwner={(value) => updateField("owner", value)}
+        nameDisabled={isEdit}
+        nameError={errors.name}
+        nameHelpText="A unique identifier for this feature service."
+        namePlaceholder="e.g. customer_activity_v1"
+        descriptionPlaceholder="Describe what this feature service is used for..."
+      />
+
+      <EuiSpacer size="m" />
+      <EuiHorizontalRule margin="s" />
+
+      <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+        <EuiFlexItem grow={false}>
+          <EuiText size="s">
+            <h4>Feature views</h4>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty
+            size="s"
+            iconType="plus"
+            onClick={addProjection}
+            flush="right"
+          >
+            Add feature view
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiText size="xs" color="subdued">
+        Select one or more feature views to include in this service. Leave
+        feature selection empty to include all features from a view.
+      </EuiText>
+
+      {errors.projections && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiCallOut title={errors.projections} color="danger" size="s" />
+        </>
+      )}
+
+      {formData.projections.map((projection, index) => {
+        const availableFeatures =
+          featureNamesByView[projection.featureViewName] || [];
+        const selectedFeatureOptions = projection.featureNames.map(
+          (featureName) => ({
+            label: featureName,
+            value: featureName,
+          }),
+        );
+        const featureOptions = availableFeatures.map((featureName) => ({
+          label: featureName,
+          value: featureName,
+        }));
+
+        return (
+          <React.Fragment key={`projection-${index}`}>
+            <EuiSpacer size="m" />
+            <EuiFlexGroup alignItems="flexStart" gutterSize="s">
+              <EuiFlexItem>
+                <EuiFormRow label="Feature view">
+                  <EuiComboBox
+                    singleSelection={{ asPlainText: true }}
+                    options={featureViewOptions}
+                    selectedOptions={
+                      projection.featureViewName
+                        ? [
+                            {
+                              label: projection.featureViewName,
+                              value: projection.featureViewName,
+                            },
+                          ]
+                        : []
+                    }
+                    onChange={(selected) =>
+                      updateProjection(
+                        index,
+                        "featureViewName",
+                        selected.length > 0 ? selected[0].value || "" : "",
+                      )
+                    }
+                    placeholder="Select a feature view"
+                    isLoading={featureViewsQuery.isLoading}
+                    compressed
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiFormRow
+                  label="Features (optional)"
+                  helpText="Leave empty to include all features from the view."
+                >
+                  <EuiComboBox
+                    options={featureOptions}
+                    selectedOptions={selectedFeatureOptions}
+                    onChange={(selected) =>
+                      updateProjection(
+                        index,
+                        "featureNames",
+                        selected.map((option) => option.value || option.label),
+                      )
+                    }
+                    placeholder={
+                      projection.featureViewName
+                        ? "All features"
+                        : "Select a feature view first"
+                    }
+                    isDisabled={!projection.featureViewName}
+                    compressed
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiFormRow hasEmptyLabelSpace>
+                  <EuiButtonIcon
+                    iconType="trash"
+                    color="danger"
+                    aria-label="Remove feature view"
+                    onClick={() => removeProjection(index)}
+                    disabled={formData.projections.length <= 1}
+                  />
+                </EuiFormRow>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </React.Fragment>
+        );
+      })}
+
+      <EuiSpacer size="m" />
+
+      <TagsEditor
+        tags={formData.tags}
+        onChange={(tags) => updateField("tags", tags)}
+        error={errors.tags}
+      />
+    </FormModal>
+  );
+};
+
+export default FeatureServiceFormModal;
+export type { FeatureServiceFormData, FeatureViewProjectionEntry };

--- a/ui/src/pages/data-sources/DataSourceInstance.tsx
+++ b/ui/src/pages/data-sources/DataSourceInstance.tsx
@@ -1,21 +1,343 @@
-import React from "react";
+import React, { useState } from "react";
 import { Route, Routes, useNavigate, useParams } from "react-router-dom";
-import { EuiPageTemplate } from "@elastic/eui";
+import {
+  EuiPageTemplate,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiConfirmModal,
+} from "@elastic/eui";
 
 import { DataSourceIcon } from "../../graphics/DataSourceIcon";
 import { useMatchExact } from "../../hooks/useMatchSubpath";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import DataSourceRawData from "./DataSourceRawData";
 import DataSourceOverviewTab from "./DataSourceOverviewTab";
+import DataSourceFormModal, {
+  DataSourceFormData,
+} from "../../components/DataSourceFormModal";
+import {
+  useApplyDataSource,
+  useDeleteDataSource,
+} from "../../queries/mutations/useDataSourceMutations";
+import useLoadDataSource from "./useLoadDataSource";
+import { feast } from "../../protos";
 
 import {
   useDataSourceCustomTabs,
   useDataSourceCustomTabRoutes,
 } from "../../custom-tabs/TabsRegistryContext";
 
+const buildEditFormData = (ds: any): DataSourceFormData => {
+  const spec = ds.spec || ds;
+  const tags = spec.tags
+    ? Object.entries(spec.tags).map(([key, value]) => ({
+        key,
+        value: value as string,
+      }))
+    : [];
+
+  return {
+    name: spec.name || ds.name || "",
+    description: spec.description || ds.description || "",
+    owner: spec.owner || ds.owner || "",
+    sourceType: String(spec.type ?? ds.type ?? 0),
+    timestampField: spec.timestampField || ds.timestampField || "",
+    createdTimestampColumn:
+      spec.createdTimestampColumn || ds.createdTimestampColumn || "",
+    tags,
+    // File
+    fileUri: spec.fileOptions?.uri || ds.fileOptions?.uri || "",
+    fileFormat:
+      spec.fileOptions?.fileFormat || ds.fileOptions?.fileFormat || "parquet",
+    fileS3EndpointOverride:
+      spec.fileOptions?.s3EndpointOverride ||
+      ds.fileOptions?.s3EndpointOverride ||
+      "",
+    // BigQuery
+    bigqueryTable:
+      spec.bigqueryOptions?.table || ds.bigqueryOptions?.table || "",
+    bigqueryQuery:
+      spec.bigqueryOptions?.query || ds.bigqueryOptions?.query || "",
+    bigqueryDatePartitionColumn:
+      spec.datePartitionColumn || ds.datePartitionColumn || "",
+    // Snowflake
+    snowflakeTable:
+      spec.snowflakeOptions?.table || ds.snowflakeOptions?.table || "",
+    snowflakeDatabase:
+      spec.snowflakeOptions?.database || ds.snowflakeOptions?.database || "",
+    snowflakeSchema:
+      spec.snowflakeOptions?.schema || ds.snowflakeOptions?.schema || "",
+    snowflakeQuery:
+      spec.snowflakeOptions?.query || ds.snowflakeOptions?.query || "",
+    snowflakeWarehouse:
+      spec.snowflakeOptions?.warehouse || ds.snowflakeOptions?.warehouse || "",
+    // Redshift
+    redshiftTable:
+      spec.redshiftOptions?.table || ds.redshiftOptions?.table || "",
+    redshiftDatabase:
+      spec.redshiftOptions?.database || ds.redshiftOptions?.database || "",
+    redshiftSchema:
+      spec.redshiftOptions?.schema || ds.redshiftOptions?.schema || "",
+    redshiftQuery:
+      spec.redshiftOptions?.query || ds.redshiftOptions?.query || "",
+    // Kafka
+    kafkaBootstrapServers:
+      spec.kafkaOptions?.kafkaBootstrapServers ||
+      ds.kafkaOptions?.kafkaBootstrapServers ||
+      "",
+    kafkaTopic: spec.kafkaOptions?.topic || ds.kafkaOptions?.topic || "",
+    kafkaMessageFormat:
+      spec.kafkaOptions?.messageFormat ||
+      ds.kafkaOptions?.messageFormat ||
+      "json",
+    kafkaWatermarkDelay:
+      spec.kafkaOptions?.watermarkDelayThreshold ||
+      ds.kafkaOptions?.watermarkDelayThreshold ||
+      "",
+    // Spark
+    sparkTable: spec.sparkOptions?.table || ds.sparkOptions?.table || "",
+    sparkPath: spec.sparkOptions?.path || ds.sparkOptions?.path || "",
+    sparkQuery: spec.sparkOptions?.query || ds.sparkOptions?.query || "",
+    sparkFileFormat:
+      spec.sparkOptions?.fileFormat || ds.sparkOptions?.fileFormat || "",
+    sparkTableFormat:
+      spec.sparkOptions?.tableFormat?.formatType ||
+      ds.sparkOptions?.tableFormat?.formatType ||
+      "",
+    sparkTableFormatCatalog:
+      spec.sparkOptions?.tableFormat?.catalog ||
+      ds.sparkOptions?.tableFormat?.catalog ||
+      "",
+    sparkTableFormatNamespace:
+      spec.sparkOptions?.tableFormat?.namespace ||
+      ds.sparkOptions?.tableFormat?.namespace ||
+      "",
+    sparkTableFormatProperties: (() => {
+      const props =
+        spec.sparkOptions?.tableFormat?.properties ||
+        ds.sparkOptions?.tableFormat?.properties;
+      return props ? JSON.stringify(props) : "";
+    })(),
+    sparkDatePartitionColumn:
+      spec.sparkOptions?.datePartitionColumn ||
+      ds.sparkOptions?.datePartitionColumn ||
+      spec.datePartitionColumn ||
+      ds.datePartitionColumn ||
+      "",
+    sparkDatePartitionFormat:
+      spec.sparkOptions?.datePartitionColumnFormat ||
+      ds.sparkOptions?.datePartitionColumnFormat ||
+      "%Y-%m-%d",
+    // Kinesis
+    kinesisRegion:
+      spec.kinesisOptions?.region || ds.kinesisOptions?.region || "",
+    kinesisStreamName:
+      spec.kinesisOptions?.streamName || ds.kinesisOptions?.streamName || "",
+    kinesisRecordFormat:
+      spec.kinesisOptions?.recordFormat ||
+      ds.kinesisOptions?.recordFormat ||
+      "json",
+    // Trino
+    trinoTable: spec.trinoOptions?.table || ds.trinoOptions?.table || "",
+    trinoQuery: spec.trinoOptions?.query || ds.trinoOptions?.query || "",
+    // Athena
+    athenaTable: spec.athenaOptions?.table || ds.athenaOptions?.table || "",
+    athenaQuery: spec.athenaOptions?.query || ds.athenaOptions?.query || "",
+    athenaDatabase:
+      spec.athenaOptions?.database || ds.athenaOptions?.database || "",
+    athenaDataSource:
+      spec.athenaOptions?.dataSource || ds.athenaOptions?.dataSource || "",
+    athenaDatePartitionColumn:
+      spec.datePartitionColumn || ds.datePartitionColumn || "",
+    // Custom
+    customSourceClassName:
+      spec.customOptions?.className || ds.customOptions?.className || "",
+    customSourceConfig:
+      spec.customOptions?.config || ds.customOptions?.config || "",
+    // Iceberg
+    ...(() => {
+      const configStr =
+        spec.customOptions?.configuration ||
+        ds.customOptions?.configuration ||
+        "";
+      if (
+        String(spec.type ?? ds.type ?? 0) ===
+          String(feast.core.DataSource.SourceType.BATCH_ICEBERG) &&
+        configStr
+      ) {
+        try {
+          const cfg = JSON.parse(configStr);
+          return {
+            icebergCatalogType: cfg.catalog_type || "rest",
+            icebergEndpoint: cfg.endpoint || "",
+            icebergWarehouse: cfg.warehouse || "",
+            icebergNamespace: cfg.namespace || "",
+            icebergTable: cfg.table || "",
+            icebergTokenEnvVar: cfg.token_env_var || "",
+            icebergCredentialVending: String(cfg.credential_vending ?? true),
+            icebergCatalogProperties: cfg.catalog_properties
+              ? JSON.stringify(cfg.catalog_properties)
+              : "",
+          };
+        } catch {
+          /* ignore parse errors */
+        }
+      }
+      return {
+        icebergCatalogType: "rest",
+        icebergEndpoint: "",
+        icebergWarehouse: "",
+        icebergNamespace: "",
+        icebergTable: "",
+        icebergTokenEnvVar: "",
+        icebergCredentialVending: "true",
+        icebergCatalogProperties: "",
+      };
+    })(),
+    // Ray
+    rayReaderType: "",
+    rayPath: "",
+    rayReaderOptions: "",
+    // Postgres
+    postgresTable: "",
+    postgresQuery: "",
+    // MongoDB
+    mongodbCollection: "",
+    // ClickHouse
+    clickhouseTable: "",
+    clickhouseQuery: "",
+    // MSSQL
+    mssqlTable: "",
+    mssqlConnectionStr: "",
+    mssqlDatePartitionColumn: "",
+    // Oracle
+    oracleTable: "",
+    oracleConnectionStr: "",
+    oracleDatePartitionColumn: "",
+    // Couchbase
+    couchbaseDatabase: "",
+    couchbaseScope: "",
+    couchbaseCollection: "",
+    couchbaseQuery: "",
+  };
+};
+
+const formDataToPayload = (formData: DataSourceFormData, project: string) => {
+  const payload: Record<string, any> = {
+    name: formData.name,
+    project,
+    type: parseInt(formData.sourceType, 10),
+    timestamp_field: formData.timestampField,
+    created_timestamp_column: formData.createdTimestampColumn,
+    description: formData.description,
+    owner: formData.owner,
+    tags: Object.fromEntries(
+      formData.tags.filter((t) => t.key.trim()).map((t) => [t.key, t.value]),
+    ),
+  };
+
+  const st = formData.sourceType;
+  if (st === String(feast.core.DataSource.SourceType.BATCH_FILE)) {
+    payload.file_options = {
+      uri: formData.fileUri,
+      file_format: formData.fileFormat || "parquet",
+      s3_endpoint_override: formData.fileS3EndpointOverride || "",
+    };
+  } else if (st === String(feast.core.DataSource.SourceType.BATCH_BIGQUERY)) {
+    payload.bigquery_options = {
+      table: formData.bigqueryTable,
+      query: formData.bigqueryQuery,
+    };
+    if (formData.bigqueryDatePartitionColumn) {
+      payload.date_partition_column = formData.bigqueryDatePartitionColumn;
+    }
+  } else if (st === String(feast.core.DataSource.SourceType.BATCH_SNOWFLAKE)) {
+    payload.snowflake_options = {
+      table: formData.snowflakeTable,
+      database: formData.snowflakeDatabase,
+      schema_: formData.snowflakeSchema,
+      query: formData.snowflakeQuery || "",
+      warehouse: formData.snowflakeWarehouse || "",
+    };
+  } else if (st === String(feast.core.DataSource.SourceType.BATCH_REDSHIFT)) {
+    payload.redshift_options = {
+      table: formData.redshiftTable,
+      database: formData.redshiftDatabase,
+      schema_: formData.redshiftSchema,
+      query: formData.redshiftQuery || "",
+    };
+  } else if (st === String(feast.core.DataSource.SourceType.STREAM_KAFKA)) {
+    payload.kafka_options = {
+      kafka_bootstrap_servers: formData.kafkaBootstrapServers,
+      topic: formData.kafkaTopic,
+      message_format: formData.kafkaMessageFormat || "json",
+      watermark_delay_threshold: formData.kafkaWatermarkDelay || "",
+    };
+  } else if (st === String(feast.core.DataSource.SourceType.BATCH_SPARK)) {
+    payload.spark_options = {
+      table: formData.sparkTable,
+      path: formData.sparkPath,
+      query: formData.sparkQuery || "",
+      file_format: formData.sparkFileFormat || "",
+      table_format: formData.sparkTableFormat || "",
+      table_format_catalog: formData.sparkTableFormatCatalog || "",
+      table_format_namespace: formData.sparkTableFormatNamespace || "",
+      table_format_properties: formData.sparkTableFormatProperties || "",
+      date_partition_column: formData.sparkDatePartitionColumn || "",
+      date_partition_column_format: formData.sparkDatePartitionFormat || "",
+    };
+  } else if (st === String(feast.core.DataSource.SourceType.BATCH_TRINO)) {
+    payload.trino_options = {
+      table: formData.trinoTable,
+      query: formData.trinoQuery,
+    };
+  } else if (st === String(feast.core.DataSource.SourceType.BATCH_ATHENA)) {
+    payload.athena_options = {
+      table: formData.athenaTable,
+      query: formData.athenaQuery,
+      database: formData.athenaDatabase,
+      data_source: formData.athenaDataSource,
+    };
+    if (formData.athenaDatePartitionColumn) {
+      payload.date_partition_column = formData.athenaDatePartitionColumn;
+    }
+  } else if (st === String(feast.core.DataSource.SourceType.BATCH_ICEBERG)) {
+    const catalogProps = formData.icebergCatalogProperties.trim()
+      ? JSON.parse(formData.icebergCatalogProperties)
+      : {};
+    payload.custom_options = {
+      configuration: JSON.stringify({
+        catalog_type: formData.icebergCatalogType || "rest",
+        endpoint: formData.icebergEndpoint,
+        warehouse: formData.icebergWarehouse,
+        namespace: formData.icebergNamespace,
+        table: formData.icebergTable,
+        token_env_var: formData.icebergTokenEnvVar || null,
+        credential_vending: formData.icebergCredentialVending !== "false",
+        catalog_properties: catalogProps,
+      }),
+    };
+    payload.data_source_class_type =
+      "feast.infra.data_sources.contrib.iceberg_catalog.iceberg_source.IcebergSource";
+  } else if (st === String(feast.core.DataSource.SourceType.STREAM_KINESIS)) {
+    payload.kinesis_options = {
+      region: formData.kinesisRegion,
+      stream_name: formData.kinesisStreamName,
+      record_format: formData.kinesisRecordFormat || "json",
+    };
+  } else if (st === String(feast.core.DataSource.SourceType.CUSTOM_SOURCE)) {
+    payload.custom_options = {
+      class_name: formData.customSourceClassName,
+      config: formData.customSourceConfig,
+    };
+  }
+
+  return payload;
+};
+
 const DataSourceInstance = () => {
   const navigate = useNavigate();
-  let { dataSourceName } = useParams();
+  let { dataSourceName, projectName } = useParams();
 
   useDocumentTitle(`${dataSourceName} | Data Source | Feast`);
 
@@ -34,12 +356,66 @@ const DataSourceInstance = () => {
 
   const CustomTabRoutes = useDataSourceCustomTabRoutes();
 
+  const { data } = useLoadDataSource(dataSourceName || "");
+  const applyDataSource = useApplyDataSource();
+  const deleteDataSource = useDeleteDataSource();
+
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const handleDelete = () => {
+    deleteDataSource.mutate(
+      { name: dataSourceName || "", project: projectName || "" },
+      {
+        onSuccess: () => {
+          navigate(`/p/${projectName}/data-source`);
+        },
+      },
+    );
+  };
+
+  const handleEditSubmit = (formData: DataSourceFormData) => {
+    const payload = formDataToPayload(formData, projectName || "");
+    applyDataSource.mutate(payload as any, {
+      onSuccess: () => {
+        setIsEditModalOpen(false);
+        setEditError(null);
+      },
+      onError: (err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "An unexpected error occurred.";
+        setEditError(message);
+      },
+    });
+  };
+
   return (
     <EuiPageTemplate panelled>
       <EuiPageTemplate.Header
         restrictWidth
         iconType={DataSourceIcon}
         pageTitle={`Data Source: ${dataSourceName}`}
+        rightSideItems={[
+          <EuiButton
+            key="edit"
+            iconType="pencil"
+            onClick={() => {
+              setEditError(null);
+              setIsEditModalOpen(true);
+            }}
+          >
+            Edit
+          </EuiButton>,
+          <EuiButtonEmpty
+            key="delete"
+            color="danger"
+            iconType="trash"
+            onClick={() => setShowDeleteConfirm(true)}
+          >
+            Delete
+          </EuiButtonEmpty>,
+        ]}
         tabs={tabs}
       />
       <EuiPageTemplate.Section>
@@ -49,6 +425,37 @@ const DataSourceInstance = () => {
           {CustomTabRoutes}
         </Routes>
       </EuiPageTemplate.Section>
+
+      {showDeleteConfirm && (
+        <EuiConfirmModal
+          title={`Delete "${dataSourceName}"?`}
+          onCancel={() => setShowDeleteConfirm(false)}
+          onConfirm={handleDelete}
+          cancelButtonText="Cancel"
+          confirmButtonText="Delete"
+          buttonColor="danger"
+          isLoading={deleteDataSource.isLoading}
+        >
+          <p>
+            This will permanently remove the data source. This action cannot be
+            undone.
+          </p>
+        </EuiConfirmModal>
+      )}
+
+      {isEditModalOpen && data && (
+        <DataSourceFormModal
+          onClose={() => {
+            setIsEditModalOpen(false);
+            setEditError(null);
+          }}
+          onSubmit={handleEditSubmit}
+          initialData={buildEditFormData(data)}
+          isEdit
+          isSubmitting={applyDataSource.isLoading}
+          submitError={editError}
+        />
+      )}
     </EuiPageTemplate>
   );
 };

--- a/ui/src/pages/data-sources/DataSourceOverviewTab.tsx
+++ b/ui/src/pages/data-sources/DataSourceOverviewTab.tsx
@@ -4,8 +4,6 @@ import {
   EuiLoadingSpinner,
   EuiText,
   EuiTitle,
-  EuiButtonEmpty,
-  EuiCallOut,
 } from "@elastic/eui";
 import {
   EuiPanel,
@@ -15,328 +13,16 @@ import {
   EuiDescriptionListDescription,
   EuiSpacer,
 } from "@elastic/eui";
-import React, { useState } from "react";
+import React from "react";
 import { useParams } from "react-router-dom";
-import DataSourceFormModal, {
-  DataSourceFormData,
-} from "../../components/DataSourceFormModal";
-import { feast } from "../../protos";
-import { useApplyDataSource } from "../../queries/mutations/useDataSourceMutations";
 import BatchSourcePropertiesView from "./BatchSourcePropertiesView";
 import FeatureViewEdgesList from "../entities/FeatureViewEdgesList";
 import RequestDataSourceSchemaTable from "./RequestDataSourceSchemaTable";
 import useLoadDataSource from "./useLoadDataSource";
-
-const buildEditFormData = (ds: any): DataSourceFormData => {
-  const spec = ds.spec || ds;
-  const tags = spec.tags
-    ? Object.entries(spec.tags).map(([key, value]) => ({
-        key,
-        value: value as string,
-      }))
-    : [];
-
-  return {
-    name: spec.name || ds.name || "",
-    description: spec.description || ds.description || "",
-    owner: spec.owner || ds.owner || "",
-    sourceType: String(spec.type ?? ds.type ?? 0),
-    timestampField: spec.timestampField || ds.timestampField || "",
-    createdTimestampColumn:
-      spec.createdTimestampColumn || ds.createdTimestampColumn || "",
-    tags,
-    // File
-    fileUri: spec.fileOptions?.uri || ds.fileOptions?.uri || "",
-    fileFormat:
-      spec.fileOptions?.fileFormat || ds.fileOptions?.fileFormat || "parquet",
-    fileS3EndpointOverride:
-      spec.fileOptions?.s3EndpointOverride ||
-      ds.fileOptions?.s3EndpointOverride ||
-      "",
-    // BigQuery
-    bigqueryTable:
-      spec.bigqueryOptions?.table || ds.bigqueryOptions?.table || "",
-    bigqueryQuery:
-      spec.bigqueryOptions?.query || ds.bigqueryOptions?.query || "",
-    bigqueryDatePartitionColumn:
-      spec.datePartitionColumn || ds.datePartitionColumn || "",
-    // Snowflake
-    snowflakeTable:
-      spec.snowflakeOptions?.table || ds.snowflakeOptions?.table || "",
-    snowflakeDatabase:
-      spec.snowflakeOptions?.database || ds.snowflakeOptions?.database || "",
-    snowflakeSchema:
-      spec.snowflakeOptions?.schema || ds.snowflakeOptions?.schema || "",
-    snowflakeQuery:
-      spec.snowflakeOptions?.query || ds.snowflakeOptions?.query || "",
-    snowflakeWarehouse:
-      spec.snowflakeOptions?.warehouse || ds.snowflakeOptions?.warehouse || "",
-    // Redshift
-    redshiftTable:
-      spec.redshiftOptions?.table || ds.redshiftOptions?.table || "",
-    redshiftDatabase:
-      spec.redshiftOptions?.database || ds.redshiftOptions?.database || "",
-    redshiftSchema:
-      spec.redshiftOptions?.schema || ds.redshiftOptions?.schema || "",
-    redshiftQuery:
-      spec.redshiftOptions?.query || ds.redshiftOptions?.query || "",
-    // Kafka
-    kafkaBootstrapServers:
-      spec.kafkaOptions?.kafkaBootstrapServers ||
-      ds.kafkaOptions?.kafkaBootstrapServers ||
-      "",
-    kafkaTopic: spec.kafkaOptions?.topic || ds.kafkaOptions?.topic || "",
-    kafkaMessageFormat:
-      spec.kafkaOptions?.messageFormat ||
-      ds.kafkaOptions?.messageFormat ||
-      "json",
-    kafkaWatermarkDelay:
-      spec.kafkaOptions?.watermarkDelayThreshold ||
-      ds.kafkaOptions?.watermarkDelayThreshold ||
-      "",
-    // Spark
-    sparkTable: spec.sparkOptions?.table || ds.sparkOptions?.table || "",
-    sparkPath: spec.sparkOptions?.path || ds.sparkOptions?.path || "",
-    sparkQuery: spec.sparkOptions?.query || ds.sparkOptions?.query || "",
-    sparkFileFormat:
-      spec.sparkOptions?.fileFormat || ds.sparkOptions?.fileFormat || "",
-    sparkTableFormat:
-      spec.sparkOptions?.tableFormat?.formatType ||
-      ds.sparkOptions?.tableFormat?.formatType ||
-      "",
-    sparkTableFormatCatalog:
-      spec.sparkOptions?.tableFormat?.catalog ||
-      ds.sparkOptions?.tableFormat?.catalog ||
-      "",
-    sparkTableFormatNamespace:
-      spec.sparkOptions?.tableFormat?.namespace ||
-      ds.sparkOptions?.tableFormat?.namespace ||
-      "",
-    sparkTableFormatProperties: (() => {
-      const props =
-        spec.sparkOptions?.tableFormat?.properties ||
-        ds.sparkOptions?.tableFormat?.properties;
-      return props ? JSON.stringify(props) : "";
-    })(),
-    sparkDatePartitionColumn:
-      spec.sparkOptions?.datePartitionColumn ||
-      ds.sparkOptions?.datePartitionColumn ||
-      spec.datePartitionColumn ||
-      ds.datePartitionColumn ||
-      "",
-    sparkDatePartitionFormat:
-      spec.sparkOptions?.datePartitionColumnFormat ||
-      ds.sparkOptions?.datePartitionColumnFormat ||
-      "%Y-%m-%d",
-    // Kinesis
-    kinesisRegion:
-      spec.kinesisOptions?.region || ds.kinesisOptions?.region || "",
-    kinesisStreamName:
-      spec.kinesisOptions?.streamName || ds.kinesisOptions?.streamName || "",
-    kinesisRecordFormat:
-      spec.kinesisOptions?.recordFormat ||
-      ds.kinesisOptions?.recordFormat ||
-      "json",
-    // Trino
-    trinoTable: spec.trinoOptions?.table || ds.trinoOptions?.table || "",
-    trinoQuery: spec.trinoOptions?.query || ds.trinoOptions?.query || "",
-    // Athena
-    athenaTable: spec.athenaOptions?.table || ds.athenaOptions?.table || "",
-    athenaQuery: spec.athenaOptions?.query || ds.athenaOptions?.query || "",
-    athenaDatabase:
-      spec.athenaOptions?.database || ds.athenaOptions?.database || "",
-    athenaDataSource:
-      spec.athenaOptions?.dataSource || ds.athenaOptions?.dataSource || "",
-    athenaDatePartitionColumn:
-      spec.datePartitionColumn || ds.datePartitionColumn || "",
-    // Custom
-    customSourceClassName:
-      spec.customOptions?.className || ds.customOptions?.className || "",
-    customSourceConfig:
-      spec.customOptions?.config || ds.customOptions?.config || "",
-    // Iceberg
-    ...(() => {
-      const configStr =
-        spec.customOptions?.configuration ||
-        ds.customOptions?.configuration ||
-        "";
-      if (
-        String(spec.type ?? ds.type ?? 0) ===
-          String(feast.core.DataSource.SourceType.BATCH_ICEBERG) &&
-        configStr
-      ) {
-        try {
-          const cfg = JSON.parse(configStr);
-          return {
-            icebergCatalogType: cfg.catalog_type || "rest",
-            icebergEndpoint: cfg.endpoint || "",
-            icebergWarehouse: cfg.warehouse || "",
-            icebergNamespace: cfg.namespace || "",
-            icebergTable: cfg.table || "",
-            icebergTokenEnvVar: cfg.token_env_var || "",
-            icebergCredentialVending: String(cfg.credential_vending ?? true),
-            icebergCatalogProperties: cfg.catalog_properties
-              ? JSON.stringify(cfg.catalog_properties)
-              : "",
-          };
-        } catch {
-          /* ignore parse errors */
-        }
-      }
-      return {
-        icebergCatalogType: "rest",
-        icebergEndpoint: "",
-        icebergWarehouse: "",
-        icebergNamespace: "",
-        icebergTable: "",
-        icebergTokenEnvVar: "",
-        icebergCredentialVending: "true",
-        icebergCatalogProperties: "",
-      };
-    })(),
-    // Ray
-    rayReaderType: "",
-    rayPath: "",
-    rayReaderOptions: "",
-    // Postgres
-    postgresTable: "",
-    postgresQuery: "",
-    // MongoDB
-    mongodbCollection: "",
-    // ClickHouse
-    clickhouseTable: "",
-    clickhouseQuery: "",
-    // MSSQL
-    mssqlTable: "",
-    mssqlConnectionStr: "",
-    mssqlDatePartitionColumn: "",
-    // Oracle
-    oracleTable: "",
-    oracleConnectionStr: "",
-    oracleDatePartitionColumn: "",
-    // Couchbase
-    couchbaseDatabase: "",
-    couchbaseScope: "",
-    couchbaseCollection: "",
-    couchbaseQuery: "",
-  };
-};
-
-const formDataToPayload = (formData: DataSourceFormData, project: string) => {
-  const payload: Record<string, any> = {
-    name: formData.name,
-    project,
-    type: parseInt(formData.sourceType, 10),
-    timestamp_field: formData.timestampField,
-    created_timestamp_column: formData.createdTimestampColumn,
-    description: formData.description,
-    owner: formData.owner,
-    tags: Object.fromEntries(
-      formData.tags.filter((t) => t.key.trim()).map((t) => [t.key, t.value]),
-    ),
-  };
-
-  const st = formData.sourceType;
-  if (st === String(feast.core.DataSource.SourceType.BATCH_FILE)) {
-    payload.file_options = {
-      uri: formData.fileUri,
-      file_format: formData.fileFormat || "parquet",
-      s3_endpoint_override: formData.fileS3EndpointOverride || "",
-    };
-  } else if (st === String(feast.core.DataSource.SourceType.BATCH_BIGQUERY)) {
-    payload.bigquery_options = {
-      table: formData.bigqueryTable,
-      query: formData.bigqueryQuery,
-    };
-    if (formData.bigqueryDatePartitionColumn) {
-      payload.date_partition_column = formData.bigqueryDatePartitionColumn;
-    }
-  } else if (st === String(feast.core.DataSource.SourceType.BATCH_SNOWFLAKE)) {
-    payload.snowflake_options = {
-      table: formData.snowflakeTable,
-      database: formData.snowflakeDatabase,
-      schema_: formData.snowflakeSchema,
-      query: formData.snowflakeQuery || "",
-      warehouse: formData.snowflakeWarehouse || "",
-    };
-  } else if (st === String(feast.core.DataSource.SourceType.BATCH_REDSHIFT)) {
-    payload.redshift_options = {
-      table: formData.redshiftTable,
-      database: formData.redshiftDatabase,
-      schema_: formData.redshiftSchema,
-      query: formData.redshiftQuery || "",
-    };
-  } else if (st === String(feast.core.DataSource.SourceType.STREAM_KAFKA)) {
-    payload.kafka_options = {
-      kafka_bootstrap_servers: formData.kafkaBootstrapServers,
-      topic: formData.kafkaTopic,
-      message_format: formData.kafkaMessageFormat || "json",
-      watermark_delay_threshold: formData.kafkaWatermarkDelay || "",
-    };
-  } else if (st === String(feast.core.DataSource.SourceType.BATCH_SPARK)) {
-    payload.spark_options = {
-      table: formData.sparkTable,
-      path: formData.sparkPath,
-      query: formData.sparkQuery || "",
-      file_format: formData.sparkFileFormat || "",
-      table_format: formData.sparkTableFormat || "",
-      table_format_catalog: formData.sparkTableFormatCatalog || "",
-      table_format_namespace: formData.sparkTableFormatNamespace || "",
-      table_format_properties: formData.sparkTableFormatProperties || "",
-      date_partition_column: formData.sparkDatePartitionColumn || "",
-      date_partition_column_format: formData.sparkDatePartitionFormat || "",
-    };
-  } else if (st === String(feast.core.DataSource.SourceType.BATCH_TRINO)) {
-    payload.trino_options = {
-      table: formData.trinoTable,
-      query: formData.trinoQuery,
-    };
-  } else if (st === String(feast.core.DataSource.SourceType.BATCH_ATHENA)) {
-    payload.athena_options = {
-      table: formData.athenaTable,
-      query: formData.athenaQuery,
-      database: formData.athenaDatabase,
-      data_source: formData.athenaDataSource,
-    };
-    if (formData.athenaDatePartitionColumn) {
-      payload.date_partition_column = formData.athenaDatePartitionColumn;
-    }
-  } else if (st === String(feast.core.DataSource.SourceType.BATCH_ICEBERG)) {
-    const catalogProps = formData.icebergCatalogProperties.trim()
-      ? JSON.parse(formData.icebergCatalogProperties)
-      : {};
-    payload.custom_options = {
-      configuration: JSON.stringify({
-        catalog_type: formData.icebergCatalogType || "rest",
-        endpoint: formData.icebergEndpoint,
-        warehouse: formData.icebergWarehouse,
-        namespace: formData.icebergNamespace,
-        table: formData.icebergTable,
-        token_env_var: formData.icebergTokenEnvVar || null,
-        credential_vending: formData.icebergCredentialVending !== "false",
-        catalog_properties: catalogProps,
-      }),
-    };
-    payload.data_source_class_type =
-      "feast.infra.data_sources.contrib.iceberg_catalog.iceberg_source.IcebergSource";
-  } else if (st === String(feast.core.DataSource.SourceType.STREAM_KINESIS)) {
-    payload.kinesis_options = {
-      region: formData.kinesisRegion,
-      stream_name: formData.kinesisStreamName,
-      record_format: formData.kinesisRecordFormat || "json",
-    };
-  } else if (st === String(feast.core.DataSource.SourceType.CUSTOM_SOURCE)) {
-    payload.custom_options = {
-      class_name: formData.customSourceClassName,
-      config: formData.customSourceConfig,
-    };
-  }
-
-  return payload;
-};
+import { feast } from "../../protos";
 
 const DataSourceOverviewTab = () => {
-  const { dataSourceName, projectName } = useParams();
+  const { dataSourceName } = useParams();
 
   const dsName = dataSourceName === undefined ? "" : dataSourceName;
   const { isLoading, isSuccess, isError, data, consumingFeatureViews } =
@@ -352,31 +38,6 @@ const DataSourceOverviewTab = () => {
         }, {})
       : undefined;
 
-  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const applyDataSource = useApplyDataSource();
-
-  const handleEditSubmit = (formData: DataSourceFormData) => {
-    const payload = formDataToPayload(formData, projectName || "");
-    applyDataSource.mutate(payload as any, {
-      onSuccess: () => {
-        setIsEditModalOpen(false);
-        setErrorMessage(null);
-        setSuccessMessage(
-          `Data source "${formData.name}" updated successfully.`,
-        );
-        setTimeout(() => setSuccessMessage(null), 5000);
-      },
-      onError: (err: unknown) => {
-        // Error shown inside the modal via submitError prop
-        const message =
-          err instanceof Error ? err.message : "An unexpected error occurred.";
-        setErrorMessage(message);
-      },
-    });
-  };
-
   const spec = data?.spec || data;
   const sourceType = spec?.type;
 
@@ -391,39 +52,6 @@ const DataSourceOverviewTab = () => {
       {isError && <p>Error loading data source: {dataSourceName}</p>}
       {isSuccess && data && (
         <React.Fragment>
-          {successMessage && (
-            <>
-              <EuiCallOut
-                title={successMessage}
-                color="success"
-                iconType="check"
-                size="s"
-              />
-              <EuiSpacer size="m" />
-            </>
-          )}
-          {errorMessage && (
-            <>
-              <EuiCallOut
-                title={errorMessage}
-                color="danger"
-                iconType="alert"
-                size="s"
-              />
-              <EuiSpacer size="m" />
-            </>
-          )}
-          <EuiFlexGroup justifyContent="flexEnd">
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                iconType="pencil"
-                onClick={() => setIsEditModalOpen(true)}
-              >
-                Edit Data Source
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size="s" />
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiFlexGroup>
@@ -564,20 +192,6 @@ const DataSourceOverviewTab = () => {
             </EuiFlexItem>
           </EuiFlexGroup>
         </React.Fragment>
-      )}
-
-      {isEditModalOpen && data && (
-        <DataSourceFormModal
-          onClose={() => {
-            setIsEditModalOpen(false);
-            setErrorMessage(null);
-          }}
-          onSubmit={handleEditSubmit}
-          initialData={buildEditFormData(data)}
-          isEdit
-          isSubmitting={applyDataSource.isLoading}
-          submitError={errorMessage}
-        />
       )}
     </React.Fragment>
   );

--- a/ui/src/pages/entities/EntityInstance.tsx
+++ b/ui/src/pages/entities/EntityInstance.tsx
@@ -1,24 +1,101 @@
-import React from "react";
+import React, { useState } from "react";
 import { Route, Routes, useNavigate, useParams } from "react-router-dom";
-import { EuiPageTemplate } from "@elastic/eui";
+import {
+  EuiPageTemplate,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiConfirmModal,
+} from "@elastic/eui";
 
 import { EntityIcon } from "../../graphics/EntityIcon";
 import { useMatchExact } from "../../hooks/useMatchSubpath";
 import EntityOverviewTab from "./EntityOverviewTab";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
+import EntityFormModal, {
+  EntityFormData,
+} from "../../components/EntityFormModal";
+import {
+  useApplyEntity,
+  useDeleteEntity,
+} from "../../queries/mutations/useEntityMutations";
+import useLoadEntity from "./useLoadEntity";
 import {
   useEntityCustomTabs,
   useEntityCustomTabRoutes,
 } from "../../custom-tabs/TabsRegistryContext";
+import { feast } from "../../protos";
+
+const buildEditFormData = (entity: feast.core.IEntity): EntityFormData => {
+  const tags = entity.spec?.tags
+    ? Object.entries(entity.spec.tags).map(([key, value]) => ({
+        key,
+        value: String(value),
+      }))
+    : [];
+
+  const joinKeys = entity.spec?.joinKey ? [entity.spec.joinKey] : [""];
+
+  return {
+    name: entity.spec?.name || "",
+    description: entity.spec?.description || "",
+    joinKeys,
+    valueType: String(entity.spec?.valueType ?? 0),
+    tags,
+  };
+};
 
 const EntityInstance = () => {
   const navigate = useNavigate();
-  let { entityName } = useParams();
+  let { entityName, projectName } = useParams();
 
   const { customNavigationTabs } = useEntityCustomTabs(navigate);
   const CustomTabRoutes = useEntityCustomTabRoutes();
 
   useDocumentTitle(`${entityName} | Entity | Feast`);
+
+  const { data } = useLoadEntity(entityName || "");
+  const applyEntity = useApplyEntity();
+  const deleteEntity = useDeleteEntity();
+
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const handleDelete = () => {
+    deleteEntity.mutate(
+      { name: entityName || "", project: projectName || "" },
+      {
+        onSuccess: () => {
+          navigate(`/p/${projectName}/entity`);
+        },
+      },
+    );
+  };
+
+  const handleEditSubmit = (formData: EntityFormData) => {
+    const payload = {
+      name: formData.name,
+      project: projectName || "",
+      join_key: formData.joinKeys[0] || formData.name,
+      value_type: parseInt(formData.valueType, 10),
+      description: formData.description,
+      tags: Object.fromEntries(
+        formData.tags.filter((t) => t.key.trim()).map((t) => [t.key, t.value]),
+      ),
+      owner: "",
+    };
+    applyEntity.mutate(payload, {
+      onSuccess: () => {
+        setIsEditModalOpen(false);
+        setEditError(null);
+      },
+      onError: (err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "An unexpected error occurred.";
+        setEditError(message);
+      },
+    });
+  };
 
   return (
     <EuiPageTemplate panelled>
@@ -26,6 +103,26 @@ const EntityInstance = () => {
         restrictWidth
         iconType={EntityIcon}
         pageTitle={`Entity: ${entityName}`}
+        rightSideItems={[
+          <EuiButton
+            key="edit"
+            iconType="pencil"
+            onClick={() => {
+              setEditError(null);
+              setIsEditModalOpen(true);
+            }}
+          >
+            Edit
+          </EuiButton>,
+          <EuiButtonEmpty
+            key="delete"
+            color="danger"
+            iconType="trash"
+            onClick={() => setShowDeleteConfirm(true)}
+          >
+            Delete
+          </EuiButtonEmpty>,
+        ]}
         tabs={[
           {
             label: "Overview",
@@ -43,6 +140,37 @@ const EntityInstance = () => {
           {CustomTabRoutes}
         </Routes>
       </EuiPageTemplate.Section>
+
+      {showDeleteConfirm && (
+        <EuiConfirmModal
+          title={`Delete "${entityName}"?`}
+          onCancel={() => setShowDeleteConfirm(false)}
+          onConfirm={handleDelete}
+          cancelButtonText="Cancel"
+          confirmButtonText="Delete"
+          buttonColor="danger"
+          isLoading={deleteEntity.isLoading}
+        >
+          <p>
+            This will permanently remove the entity. This action cannot be
+            undone.
+          </p>
+        </EuiConfirmModal>
+      )}
+
+      {isEditModalOpen && data && (
+        <EntityFormModal
+          onClose={() => {
+            setIsEditModalOpen(false);
+            setEditError(null);
+          }}
+          onSubmit={handleEditSubmit}
+          initialData={buildEditFormData(data)}
+          isEdit
+          isSubmitting={applyEntity.isLoading}
+          submitError={editError}
+        />
+      )}
     </EuiPageTemplate>
   );
 };

--- a/ui/src/pages/entities/EntityOverviewTab.tsx
+++ b/ui/src/pages/entities/EntityOverviewTab.tsx
@@ -3,8 +3,6 @@ import {
   EuiHorizontalRule,
   EuiLoadingSpinner,
   EuiTitle,
-  EuiButtonEmpty,
-  EuiCallOut,
 } from "@elastic/eui";
 import {
   EuiPanel,
@@ -15,12 +13,9 @@ import {
   EuiDescriptionListTitle,
   EuiDescriptionListDescription,
 } from "@elastic/eui";
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { useParams } from "react-router-dom";
 import PermissionsDisplay from "../../components/PermissionsDisplay";
-import EntityFormModal, {
-  EntityFormData,
-} from "../../components/EntityFormModal";
 import TagsDisplay from "../../components/TagsDisplay";
 import RegistryPathContext from "../../contexts/RegistryPathContext";
 import { FEAST_FCO_TYPES } from "../../parsers/types";
@@ -28,30 +23,9 @@ import { FEAST_FCO_TYPES } from "../../parsers/types";
 import useLoadRegistry from "../../queries/useLoadRegistry";
 import { getEntityPermissions } from "../../utils/permissionUtils";
 import { toDate } from "../../utils/timestamp";
-import { feast } from "../../protos";
 import FeatureViewEdgesList from "./FeatureViewEdgesList";
 import useFeatureViewEdgesByEntity from "./useFeatureViewEdgesByEntity";
 import useLoadEntity from "./useLoadEntity";
-import { useApplyEntity } from "../../queries/mutations/useEntityMutations";
-
-const buildEditFormData = (entity: feast.core.IEntity): EntityFormData => {
-  const tags = entity.spec?.tags
-    ? Object.entries(entity.spec.tags).map(([key, value]) => ({
-        key,
-        value: String(value),
-      }))
-    : [];
-
-  const joinKeys = entity.spec?.joinKey ? [entity.spec.joinKey] : [""];
-
-  return {
-    name: entity.spec?.name || "",
-    description: entity.spec?.description || "",
-    joinKeys,
-    valueType: String(entity.spec?.valueType ?? 0),
-    tags,
-  };
-};
 
 const EntityOverviewTab = () => {
   let { entityName, projectName } = useParams();
@@ -75,39 +49,6 @@ const EntityOverviewTab = () => {
         }, {})
       : undefined;
 
-  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const applyEntity = useApplyEntity();
-
-  const handleEditSubmit = (formData: EntityFormData) => {
-    const payload = {
-      name: formData.name,
-      project: projectName || "",
-      join_key: formData.joinKeys[0] || formData.name,
-      value_type: parseInt(formData.valueType, 10),
-      description: formData.description,
-      tags: Object.fromEntries(
-        formData.tags.filter((t) => t.key.trim()).map((t) => [t.key, t.value]),
-      ),
-      owner: "",
-    };
-    applyEntity.mutate(payload, {
-      onSuccess: () => {
-        setIsEditModalOpen(false);
-        setErrorMessage(null);
-        setSuccessMessage(`Entity "${formData.name}" updated successfully.`);
-        setTimeout(() => setSuccessMessage(null), 5000);
-      },
-      onError: (err: unknown) => {
-        // Error shown inside the modal via submitError prop
-        const message =
-          err instanceof Error ? err.message : "An unexpected error occurred.";
-        setErrorMessage(message);
-      },
-    });
-  };
-
   return (
     <React.Fragment>
       {isLoading && (
@@ -119,39 +60,6 @@ const EntityOverviewTab = () => {
       {isError && <p>Error loading entity: {entityName}</p>}
       {isSuccess && data && (
         <React.Fragment>
-          {successMessage && (
-            <>
-              <EuiCallOut
-                title={successMessage}
-                color="success"
-                iconType="check"
-                size="s"
-              />
-              <EuiSpacer size="m" />
-            </>
-          )}
-          {errorMessage && (
-            <>
-              <EuiCallOut
-                title={errorMessage}
-                color="danger"
-                iconType="alert"
-                size="s"
-              />
-              <EuiSpacer size="m" />
-            </>
-          )}
-          <EuiFlexGroup justifyContent="flexEnd">
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
-                iconType="pencil"
-                onClick={() => setIsEditModalOpen(true)}
-              >
-                Edit Entity
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          <EuiSpacer size="s" />
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiPanel hasBorder={true}>
@@ -271,20 +179,6 @@ const EntityOverviewTab = () => {
             </EuiFlexItem>
           </EuiFlexGroup>
         </React.Fragment>
-      )}
-
-      {isEditModalOpen && data && (
-        <EntityFormModal
-          onClose={() => {
-            setIsEditModalOpen(false);
-            setErrorMessage(null);
-          }}
-          onSubmit={handleEditSubmit}
-          initialData={buildEditFormData(data)}
-          isEdit
-          isSubmitting={applyEntity.isLoading}
-          submitError={errorMessage}
-        />
       )}
     </React.Fragment>
   );

--- a/ui/src/pages/feature-services/FeatureServiceIndexEmptyState.tsx
+++ b/ui/src/pages/feature-services/FeatureServiceIndexEmptyState.tsx
@@ -2,28 +2,41 @@ import React from "react";
 import { EuiEmptyPrompt, EuiTitle, EuiLink, EuiButton } from "@elastic/eui";
 import FeastIconBlue from "../../graphics/FeastIconBlue";
 
-const FeatureServiceIndexEmptyState = () => {
+interface FeatureServiceIndexEmptyStateProps {
+  onCreate?: () => void;
+}
+
+const FeatureServiceIndexEmptyState: React.FC<
+  FeatureServiceIndexEmptyStateProps
+> = ({ onCreate }) => {
   return (
     <EuiEmptyPrompt
       iconType={FeastIconBlue}
       title={<h2>There are no feature services</h2>}
       body={
         <p>
-          This project does not have any Feature Services. Learn more about
-          creating Feature Services in Feast Docs.
+          Feature services group related features from one or more feature views
+          for training or online serving. Create your first feature service to
+          get started.
         </p>
       }
       actions={
-        <EuiButton
-          onClick={() => {
-            window.open(
-              "https://docs.feast.dev/getting-started/concepts/feature-retrieval#feature-services",
-              "_blank",
-            );
-          }}
-        >
-          Open Feature Services Docs
-        </EuiButton>
+        onCreate ? (
+          <EuiButton fill iconType="plus" onClick={onCreate}>
+            Create Feature Service
+          </EuiButton>
+        ) : (
+          <EuiButton
+            onClick={() => {
+              window.open(
+                "https://docs.feast.dev/getting-started/concepts/feature-retrieval#feature-services",
+                "_blank",
+              );
+            }}
+          >
+            Open Feature Services Docs
+          </EuiButton>
+        )
       }
       footer={
         <>

--- a/ui/src/pages/feature-services/FeatureServiceInstance.tsx
+++ b/ui/src/pages/feature-services/FeatureServiceInstance.tsx
@@ -1,11 +1,24 @@
-import React from "react";
+import React, { useState } from "react";
 import { Route, Routes, useNavigate, useParams } from "react-router-dom";
-import { EuiPageTemplate } from "@elastic/eui";
+import {
+  EuiPageTemplate,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiConfirmModal,
+} from "@elastic/eui";
 
 import { FeatureServiceIcon } from "../../graphics/FeatureServiceIcon";
 import { useMatchExact } from "../../hooks/useMatchSubpath";
 import FeatureServiceOverviewTab from "./FeatureServiceOverviewTab";
 import { useDocumentTitle } from "../../hooks/useDocumentTitle";
+import FeatureServiceFormModal, {
+  FeatureServiceFormData,
+} from "../../components/FeatureServiceFormModal";
+import {
+  useApplyFeatureService,
+  useDeleteFeatureService,
+} from "../../queries/mutations/useFeatureServiceMutations";
+import useLoadFeatureService from "./useLoadFeatureService";
 
 import {
   useFeatureServiceCustomTabs,
@@ -14,12 +27,80 @@ import {
 
 const FeatureServiceInstance = () => {
   const navigate = useNavigate();
-  let { featureServiceName } = useParams();
+  let { featureServiceName, projectName } = useParams();
 
   useDocumentTitle(`${featureServiceName} | Feature Service | Feast`);
 
   const { customNavigationTabs } = useFeatureServiceCustomTabs(navigate);
   const CustomTabRoutes = useFeatureServiceCustomTabRoutes();
+
+  const { data } = useLoadFeatureService(featureServiceName || "");
+  const deleteFeatureService = useDeleteFeatureService();
+  const applyFeatureService = useApplyFeatureService();
+
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const handleDelete = () => {
+    deleteFeatureService.mutate(
+      { name: featureServiceName || "", project: projectName || "" },
+      {
+        onSuccess: () => {
+          navigate(`/p/${projectName}/feature-service`);
+        },
+      },
+    );
+  };
+
+  const buildInitialEditData = (): FeatureServiceFormData | undefined => {
+    if (!data?.spec) return undefined;
+    const spec = data.spec;
+    return {
+      name: spec.name || featureServiceName || "",
+      description: spec.description || "",
+      owner: spec.owner || "",
+      projections: (spec.features || []).map((proj: any) => ({
+        featureViewName: proj.featureViewName || "",
+        featureNames: (proj.featureColumns || [])
+          .map((col: any) => col.name)
+          .filter(Boolean),
+      })),
+      tags: Object.entries(spec.tags || {}).map(([key, value]) => ({
+        key,
+        value: value as string,
+      })),
+    };
+  };
+
+  const handleEditSubmit = (formData: FeatureServiceFormData) => {
+    const payload = {
+      name: formData.name,
+      project: projectName || "",
+      features: formData.projections.map((projection) => ({
+        feature_view_name: projection.featureViewName,
+        feature_names: projection.featureNames,
+      })),
+      description: formData.description,
+      owner: formData.owner,
+      tags: Object.fromEntries(
+        formData.tags
+          .filter((tag) => tag.key.trim())
+          .map((tag) => [tag.key, tag.value]),
+      ),
+    };
+    applyFeatureService.mutate(payload, {
+      onSuccess: () => {
+        setIsEditModalOpen(false);
+        setEditError(null);
+      },
+      onError: (err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "An unexpected error occurred.";
+        setEditError(message);
+      },
+    });
+  };
 
   return (
     <EuiPageTemplate panelled>
@@ -27,6 +108,26 @@ const FeatureServiceInstance = () => {
         restrictWidth
         iconType={FeatureServiceIcon}
         pageTitle={`Feature Service: ${featureServiceName}`}
+        rightSideItems={[
+          <EuiButton
+            key="edit"
+            iconType="pencil"
+            onClick={() => {
+              setEditError(null);
+              setIsEditModalOpen(true);
+            }}
+          >
+            Edit
+          </EuiButton>,
+          <EuiButtonEmpty
+            key="delete"
+            color="danger"
+            iconType="trash"
+            onClick={() => setShowDeleteConfirm(true)}
+          >
+            Delete
+          </EuiButtonEmpty>,
+        ]}
         tabs={[
           {
             label: "Overview",
@@ -44,6 +145,37 @@ const FeatureServiceInstance = () => {
           {CustomTabRoutes}
         </Routes>
       </EuiPageTemplate.Section>
+
+      {showDeleteConfirm && (
+        <EuiConfirmModal
+          title={`Delete "${featureServiceName}"?`}
+          onCancel={() => setShowDeleteConfirm(false)}
+          onConfirm={handleDelete}
+          cancelButtonText="Cancel"
+          confirmButtonText="Delete"
+          buttonColor="danger"
+          isLoading={deleteFeatureService.isLoading}
+        >
+          <p>
+            This will permanently remove the feature service. This action cannot
+            be undone.
+          </p>
+        </EuiConfirmModal>
+      )}
+
+      {isEditModalOpen && (
+        <FeatureServiceFormModal
+          onClose={() => {
+            setIsEditModalOpen(false);
+            setEditError(null);
+          }}
+          onSubmit={handleEditSubmit}
+          initialData={buildInitialEditData()}
+          isEdit={true}
+          isSubmitting={applyFeatureService.isLoading}
+          submitError={editError}
+        />
+      )}
     </EuiPageTemplate>
   );
 };

--- a/ui/src/pages/feature-services/FeatureServiceListingTable.tsx
+++ b/ui/src/pages/feature-services/FeatureServiceListingTable.tsx
@@ -29,7 +29,6 @@ const FeatureServiceListingTable = ({
       name: "Name",
       field: "spec.name",
       render: (name: string, item: feast.core.IFeatureService) => {
-        // For "All Projects" view, link to the specific project
         const itemProject =
           item?.spec?.project || (item as any)?.project || projectName;
         return (
@@ -42,10 +41,12 @@ const FeatureServiceListingTable = ({
     {
       name: "# of Features",
       field: "spec.features",
-      render: (featureViews: feast.core.IFeatureViewProjection[]) => {
-        var numFeatures = 0;
-        featureViews.forEach((featureView) => {
-          numFeatures += featureView.featureColumns!.length;
+      render: (
+        featureViews: feast.core.IFeatureViewProjection[] | undefined,
+      ) => {
+        let numFeatures = 0;
+        (featureViews || []).forEach((featureView) => {
+          numFeatures += (featureView.featureColumns || []).length;
         });
         return numFeatures;
       },
@@ -59,7 +60,6 @@ const FeatureServiceListingTable = ({
     },
   ];
 
-  // Add Project column when viewing all projects
   if (projectName === "all") {
     columns.splice(1, 0, {
       name: "Project",

--- a/ui/src/pages/feature-services/FeatureServiceOverviewTab.tsx
+++ b/ui/src/pages/feature-services/FeatureServiceOverviewTab.tsx
@@ -39,11 +39,12 @@ const FeatureServiceOverviewTab = () => {
   const labelProjections: any[] = [];
   if (data) {
     data?.spec?.features?.forEach((featureView: any) => {
+      const columnCount = (featureView?.featureColumns || []).length;
       if (featureView.viewType === "labelView") {
-        numLabels += featureView?.featureColumns!.length;
+        numLabels += columnCount;
         labelProjections.push(featureView);
       } else {
-        numFeatures += featureView?.featureColumns!.length;
+        numFeatures += columnCount;
         featureProjections.push(featureView);
       }
     });

--- a/ui/src/pages/feature-services/Index.tsx
+++ b/ui/src/pages/feature-services/Index.tsx
@@ -1,14 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 
 import {
   EuiPageTemplate,
   EuiLoadingSpinner,
-  EuiTitle,
   EuiSpacer,
+  EuiTitle,
+  EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFieldSearch,
+  EuiButton,
   EuiCallOut,
 } from "@elastic/eui";
 
@@ -25,10 +26,16 @@ import { useDocumentTitle } from "../../hooks/useDocumentTitle";
 import FeatureServiceIndexEmptyState from "./FeatureServiceIndexEmptyState";
 import TagSearch from "../../components/TagSearch";
 import ExportButton from "../../components/ExportButton";
+import FeatureServiceFormModal, {
+  FeatureServiceFormData,
+} from "../../components/FeatureServiceFormModal";
+import { useApplyFeatureService } from "../../queries/mutations/useFeatureServiceMutations";
 import { useFeatureServiceTagsAggregation } from "../../hooks/useTagsAggregation";
 import { feast } from "../../protos";
 import useResourceQuery, {
   featureServiceListPath,
+  featureViewListPath,
+  restFeatureViewsToMergedList,
 } from "../../queries/useResourceQuery";
 
 const useLoadFeatureServices = () => {
@@ -50,7 +57,7 @@ const shouldIncludeFSsGivenTokenGroups = (
 
     if (entryTagValue) {
       return values.every((value) => {
-        return value.length > 0 ? entryTagValue.indexOf(value) >= 0 : true; // Don't filter if the string is empty
+        return value.length > 0 ? entryTagValue.indexOf(value) >= 0 : true;
       });
     } else {
       return false;
@@ -84,10 +91,45 @@ const filterFn = (
   return filteredByTags;
 };
 
+const formDataToPayload = (
+  formData: FeatureServiceFormData,
+  project: string,
+) => ({
+  name: formData.name,
+  project,
+  features: formData.projections.map((projection) => ({
+    feature_view_name: projection.featureViewName,
+    feature_names: projection.featureNames,
+  })),
+  description: formData.description,
+  owner: formData.owner,
+  tags: Object.fromEntries(
+    formData.tags
+      .filter((tag) => tag.key.trim())
+      .map((tag) => [tag.key, tag.value]),
+  ),
+});
+
 const Index = () => {
+  const { projectName } = useParams();
   const { isLoading, isSuccess, isError, isPermissionDenied, data } =
     useLoadFeatureServices();
+  const isAllProjects = projectName === "all";
   const tagAggregationQuery = useFeatureServiceTagsAggregation();
+
+  const featureViewsQuery = useResourceQuery<any[]>({
+    resourceType: "feature-views-list-fs-prereq",
+    project: projectName,
+    restPath: featureViewListPath(projectName),
+    restSelect: restFeatureViewsToMergedList,
+    enabled: !isAllProjects,
+  });
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [prereqWarning, setPrereqWarning] = useState<string | null>(null);
+  const applyFeatureService = useApplyFeatureService();
 
   useDocumentTitle(`Feature Services | Feast`);
 
@@ -109,6 +151,40 @@ const Index = () => {
     ? filterFn(data, { tagTokenGroups, searchTokens })
     : data;
 
+  const handleCreateClick = () => {
+    const featureViews = featureViewsQuery.data || [];
+    if (featureViews.length === 0) {
+      setPrereqWarning(
+        "Feature services require at least one feature view. Create a feature view first, or proceed and add views later.",
+      );
+    } else {
+      setPrereqWarning(null);
+    }
+    setIsModalOpen(true);
+  };
+
+  const handleCreateSubmit = (formData: FeatureServiceFormData) => {
+    const payload = formDataToPayload(formData, projectName || "");
+    applyFeatureService.mutate(payload, {
+      onSuccess: () => {
+        setIsModalOpen(false);
+        setErrorMessage(null);
+        setPrereqWarning(null);
+        setSuccessMessage(
+          `Feature service "${formData.name}" created successfully.`,
+        );
+        setTimeout(() => setSuccessMessage(null), 5000);
+      },
+      onError: (err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "An unexpected error occurred.";
+        setErrorMessage(message);
+      },
+    });
+  };
+
+  const showEmptyState = isSuccess && (!data || data.length === 0);
+
   return (
     <EuiPageTemplate panelled>
       <EuiPageTemplate.Header
@@ -116,14 +192,49 @@ const Index = () => {
         iconType={FeatureServiceIcon}
         pageTitle="Feature Services"
         rightSideItems={[
+          ...(isAllProjects
+            ? []
+            : [
+                <EuiButton
+                  fill
+                  iconType="plus"
+                  onClick={handleCreateClick}
+                  key="create"
+                >
+                  Create Feature Service
+                </EuiButton>,
+              ]),
           <ExportButton
             data={filterResult ?? []}
             fileName="feature_services"
             formats={["json"]}
+            key="export"
           />,
         ]}
       />
       <EuiPageTemplate.Section>
+        {successMessage && (
+          <>
+            <EuiCallOut
+              title={successMessage}
+              color="success"
+              iconType="check"
+              size="s"
+            />
+            <EuiSpacer size="m" />
+          </>
+        )}
+        {prereqWarning && !isModalOpen && (
+          <>
+            <EuiCallOut
+              title={prereqWarning}
+              color="warning"
+              iconType="alert"
+              size="s"
+            />
+            <EuiSpacer size="m" />
+          </>
+        )}
         {isLoading && (
           <p>
             <EuiLoadingSpinner size="m" /> Loading
@@ -137,8 +248,12 @@ const Index = () => {
         {isError && !isPermissionDenied && (
           <p>We encountered an error while loading.</p>
         )}
-        {isSuccess && !data && <FeatureServiceIndexEmptyState />}
-        {isSuccess && filterResult && (
+        {showEmptyState && (
+          <FeatureServiceIndexEmptyState
+            onCreate={isAllProjects ? undefined : handleCreateClick}
+          />
+        )}
+        {isSuccess && filterResult && filterResult.length > 0 && (
           <React.Fragment>
             <EuiFlexGroup>
               <EuiFlexItem grow={2}>
@@ -173,6 +288,18 @@ const Index = () => {
           </React.Fragment>
         )}
       </EuiPageTemplate.Section>
+
+      {isModalOpen && (
+        <FeatureServiceFormModal
+          onClose={() => {
+            setIsModalOpen(false);
+            setErrorMessage(null);
+          }}
+          onSubmit={handleCreateSubmit}
+          isSubmitting={applyFeatureService.isLoading}
+          submitError={errorMessage}
+        />
+      )}
     </EuiPageTemplate>
   );
 };

--- a/ui/src/pages/feature-views/RegularFeatureViewInstance.tsx
+++ b/ui/src/pages/feature-views/RegularFeatureViewInstance.tsx
@@ -1,6 +1,12 @@
-import React, { useContext } from "react";
-import { Route, Routes, useNavigate } from "react-router-dom";
-import { EuiBadge, EuiPageTemplate } from "@elastic/eui";
+import React, { useContext, useState } from "react";
+import { Route, Routes, useNavigate, useParams } from "react-router-dom";
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiConfirmModal,
+  EuiPageTemplate,
+} from "@elastic/eui";
 
 import { FeatureViewIcon } from "../../graphics/FeatureViewIcon";
 
@@ -8,6 +14,13 @@ import { useMatchExact, useMatchSubpath } from "../../hooks/useMatchSubpath";
 import RegularFeatureViewOverviewTab from "./RegularFeatureViewOverviewTab";
 import FeatureViewLineageTab from "./FeatureViewLineageTab";
 import FeatureViewVersionsTab from "./FeatureViewVersionsTab";
+import FeatureViewFormModal, {
+  FeatureViewFormData,
+} from "../../components/FeatureViewFormModal";
+import {
+  useApplyFeatureView,
+  useDeleteFeatureView,
+} from "../../queries/mutations/useFeatureViewMutations";
 
 import {
   useRegularFeatureViewCustomTabs,
@@ -21,12 +34,69 @@ interface RegularFeatureInstanceProps {
   permissions?: any[];
 }
 
+const buildEditFormData = (
+  fv: feast.core.IFeatureView,
+): FeatureViewFormData => {
+  const tags = fv.spec?.tags
+    ? Object.entries(fv.spec.tags).map(([key, value]) => ({ key, value }))
+    : [];
+
+  const features = (fv.spec?.features || []).map((f) => ({
+    name: f.name || "",
+    valueType: String(f.valueType ?? 0),
+    description: f.description || "",
+  }));
+
+  let ttlValue = 0;
+  let ttlUnit = "seconds";
+  if (fv.spec?.ttl?.seconds) {
+    const secs =
+      typeof fv.spec.ttl.seconds === "number"
+        ? fv.spec.ttl.seconds
+        : ((fv.spec.ttl.seconds as any).toNumber?.() ?? 0);
+    if (secs > 0 && secs % 86400 === 0) {
+      ttlValue = secs / 86400;
+      ttlUnit = "days";
+    } else if (secs > 0 && secs % 3600 === 0) {
+      ttlValue = secs / 3600;
+      ttlUnit = "hours";
+    } else if (secs > 0 && secs % 60 === 0) {
+      ttlValue = secs / 60;
+      ttlUnit = "minutes";
+    } else {
+      ttlValue = secs;
+      ttlUnit = "seconds";
+    }
+  }
+
+  return {
+    name: fv.spec?.name || "",
+    description: fv.spec?.description || "",
+    owner: fv.spec?.owner || "",
+    entities: fv.spec?.entities || [],
+    features,
+    batchSource: fv.spec?.batchSource?.name || "",
+    ttlValue,
+    ttlUnit,
+    online: fv.spec?.online ?? true,
+    tags,
+  };
+};
+
+const TTL_UNITS: Record<string, number> = {
+  days: 86400,
+  hours: 3600,
+  minutes: 60,
+  seconds: 1,
+};
+
 const RegularFeatureInstance = ({
   data,
   permissions,
 }: RegularFeatureInstanceProps) => {
   const { enabledFeatureStatistics } = useContext(FeatureFlagsContext);
   const navigate = useNavigate();
+  const { projectName } = useParams();
 
   const { customNavigationTabs } = useRegularFeatureViewCustomTabs(navigate);
   let tabs = [
@@ -70,6 +140,56 @@ const RegularFeatureInstance = ({
 
   const TabRoutes = useRegularFeatureViewCustomTabRoutes();
 
+  const applyFeatureView = useApplyFeatureView();
+  const deleteFeatureView = useDeleteFeatureView();
+
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const handleDelete = () => {
+    deleteFeatureView.mutate(
+      { name: data?.spec?.name || "", project: projectName || "" },
+      {
+        onSuccess: () => {
+          navigate(`/p/${projectName}/feature-view`);
+        },
+      },
+    );
+  };
+
+  const handleEditSubmit = (formData: FeatureViewFormData) => {
+    const payload = {
+      name: formData.name,
+      project: projectName || "",
+      entities: formData.entities,
+      features: formData.features.map((f) => ({
+        name: f.name,
+        value_type: parseInt(f.valueType, 10),
+        description: f.description,
+      })),
+      batch_source: formData.batchSource,
+      ttl_seconds: formData.ttlValue * (TTL_UNITS[formData.ttlUnit] || 1),
+      online: formData.online,
+      description: formData.description,
+      owner: formData.owner,
+      tags: Object.fromEntries(
+        formData.tags.filter((t) => t.key.trim()).map((t) => [t.key, t.value]),
+      ),
+    };
+    applyFeatureView.mutate(payload, {
+      onSuccess: () => {
+        setIsEditModalOpen(false);
+        setEditError(null);
+      },
+      onError: (err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "An unexpected error occurred.";
+        setEditError(message);
+      },
+    });
+  };
+
   return (
     <EuiPageTemplate panelled>
       <EuiPageTemplate.Header
@@ -86,6 +206,26 @@ const RegularFeatureInstance = ({
               )}
           </>
         }
+        rightSideItems={[
+          <EuiButton
+            key="edit"
+            iconType="pencil"
+            onClick={() => {
+              setEditError(null);
+              setIsEditModalOpen(true);
+            }}
+          >
+            Edit
+          </EuiButton>,
+          <EuiButtonEmpty
+            key="delete"
+            color="danger"
+            iconType="trash"
+            onClick={() => setShowDeleteConfirm(true)}
+          >
+            Delete
+          </EuiButtonEmpty>,
+        ]}
         tabs={tabs}
       />
       <EuiPageTemplate.Section>
@@ -112,6 +252,37 @@ const RegularFeatureInstance = ({
           {TabRoutes}
         </Routes>
       </EuiPageTemplate.Section>
+
+      {showDeleteConfirm && (
+        <EuiConfirmModal
+          title={`Delete "${data?.spec?.name}"?`}
+          onCancel={() => setShowDeleteConfirm(false)}
+          onConfirm={handleDelete}
+          cancelButtonText="Cancel"
+          confirmButtonText="Delete"
+          buttonColor="danger"
+          isLoading={deleteFeatureView.isLoading}
+        >
+          <p>
+            This will permanently remove the feature view. This action cannot be
+            undone.
+          </p>
+        </EuiConfirmModal>
+      )}
+
+      {isEditModalOpen && data && (
+        <FeatureViewFormModal
+          onClose={() => {
+            setIsEditModalOpen(false);
+            setEditError(null);
+          }}
+          onSubmit={handleEditSubmit}
+          initialData={buildEditFormData(data)}
+          isEdit
+          isSubmitting={applyFeatureView.isLoading}
+          submitError={editError}
+        />
+      )}
     </EuiPageTemplate>
   );
 };

--- a/ui/src/pages/feature-views/RegularFeatureViewOverviewTab.tsx
+++ b/ui/src/pages/feature-views/RegularFeatureViewOverviewTab.tsx
@@ -1,7 +1,5 @@
 import {
   EuiBadge,
-  EuiButtonEmpty,
-  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -12,13 +10,10 @@ import {
   EuiTitle,
   EuiToolTip,
 } from "@elastic/eui";
-import React, { useState } from "react";
+import React from "react";
 
 import { useNavigate, useParams } from "react-router-dom";
 import FeaturesListDisplay from "../../components/FeaturesListDisplay";
-import FeatureViewFormModal, {
-  FeatureViewFormData,
-} from "../../components/FeatureViewFormModal";
 import PermissionsDisplay from "../../components/PermissionsDisplay";
 import TagsDisplay from "../../components/TagsDisplay";
 import { encodeSearchQueryString } from "../../hooks/encodeSearchQueryString";
@@ -26,7 +21,6 @@ import { EntityRelation } from "../../parsers/parseEntityRelationships";
 import { FEAST_FCO_TYPES } from "../../parsers/types";
 import useLoadRelationshipData from "../../queries/useLoadRelationshipsData";
 import useLoadFeatureUsage from "../../queries/useLoadFeatureUsage";
-import { useApplyFeatureView } from "../../queries/mutations/useFeatureViewMutations";
 import { getEntityPermissions } from "../../utils/permissionUtils";
 import BatchSourcePropertiesView from "../data-sources/BatchSourcePropertiesView";
 import ConsumingFeatureServicesList from "./ConsumingFeatureServicesList";
@@ -47,55 +41,6 @@ interface RegularFeatureViewOverviewTabProps {
   data: feast.core.IFeatureView;
   permissions?: any[];
 }
-
-const buildEditFormData = (
-  fv: feast.core.IFeatureView,
-): FeatureViewFormData => {
-  const tags = fv.spec?.tags
-    ? Object.entries(fv.spec.tags).map(([key, value]) => ({ key, value }))
-    : [];
-
-  const features = (fv.spec?.features || []).map((f) => ({
-    name: f.name || "",
-    valueType: String(f.valueType ?? 0),
-    description: f.description || "",
-  }));
-
-  let ttlValue = 0;
-  let ttlUnit = "seconds";
-  if (fv.spec?.ttl?.seconds) {
-    const secs =
-      typeof fv.spec.ttl.seconds === "number"
-        ? fv.spec.ttl.seconds
-        : ((fv.spec.ttl.seconds as any).toNumber?.() ?? 0);
-    if (secs > 0 && secs % 86400 === 0) {
-      ttlValue = secs / 86400;
-      ttlUnit = "days";
-    } else if (secs > 0 && secs % 3600 === 0) {
-      ttlValue = secs / 3600;
-      ttlUnit = "hours";
-    } else if (secs > 0 && secs % 60 === 0) {
-      ttlValue = secs / 60;
-      ttlUnit = "minutes";
-    } else {
-      ttlValue = secs;
-      ttlUnit = "seconds";
-    }
-  }
-
-  return {
-    name: fv.spec?.name || "",
-    description: fv.spec?.description || "",
-    owner: fv.spec?.owner || "",
-    entities: fv.spec?.entities || [],
-    features,
-    batchSource: fv.spec?.batchSource?.name || "",
-    ttlValue,
-    ttlUnit,
-    online: fv.spec?.online ?? true,
-    tags,
-  };
-};
 
 const RegularFeatureViewOverviewTab = ({
   data,
@@ -118,55 +63,6 @@ const RegularFeatureViewOverviewTab = ({
     : [];
   const numOfFs = fsNames.length;
 
-  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const applyFeatureView = useApplyFeatureView();
-
-  const TTL_UNITS: Record<string, number> = {
-    days: 86400,
-    hours: 3600,
-    minutes: 60,
-    seconds: 1,
-  };
-
-  const handleEditSubmit = (formData: FeatureViewFormData) => {
-    const payload = {
-      name: formData.name,
-      project: projectName || "",
-      entities: formData.entities,
-      features: formData.features.map((f) => ({
-        name: f.name,
-        value_type: parseInt(f.valueType, 10),
-        description: f.description,
-      })),
-      batch_source: formData.batchSource,
-      ttl_seconds: formData.ttlValue * (TTL_UNITS[formData.ttlUnit] || 1),
-      online: formData.online,
-      description: formData.description,
-      owner: formData.owner,
-      tags: Object.fromEntries(
-        formData.tags.filter((t) => t.key.trim()).map((t) => [t.key, t.value]),
-      ),
-    };
-    applyFeatureView.mutate(payload, {
-      onSuccess: () => {
-        setIsEditModalOpen(false);
-        setErrorMessage(null);
-        setSuccessMessage(
-          `Feature view "${formData.name}" updated successfully.`,
-        );
-        setTimeout(() => setSuccessMessage(null), 5000);
-      },
-      onError: (err: unknown) => {
-        // Error shown inside the modal via submitError prop
-        const message =
-          err instanceof Error ? err.message : "An unexpected error occurred.";
-        setErrorMessage(message);
-      },
-    });
-  };
-
   const fvUsage = usageData?.feature_usage?.[fvName];
   const runCount = fvUsage?.run_count ?? 0;
   const lastUsed = fvUsage?.last_used ?? null;
@@ -175,39 +71,6 @@ const RegularFeatureViewOverviewTab = ({
 
   return (
     <React.Fragment>
-      {successMessage && (
-        <>
-          <EuiCallOut
-            title={successMessage}
-            color="success"
-            iconType="check"
-            size="s"
-          />
-          <EuiSpacer size="m" />
-        </>
-      )}
-      {errorMessage && (
-        <>
-          <EuiCallOut
-            title={errorMessage}
-            color="danger"
-            iconType="alert"
-            size="s"
-          />
-          <EuiSpacer size="m" />
-        </>
-      )}
-      <EuiFlexGroup justifyContent="flexEnd">
-        <EuiFlexItem grow={false}>
-          <EuiButtonEmpty
-            iconType="pencil"
-            onClick={() => setIsEditModalOpen(true)}
-          >
-            Edit Feature View
-          </EuiButtonEmpty>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size="s" />
       <EuiFlexGroup>
         <EuiFlexItem>
           <EuiStat title={`${numOfFs}`} description="Consuming Services" />
@@ -373,20 +236,6 @@ const RegularFeatureViewOverviewTab = ({
           })}
         </React.Fragment>
       </EuiPanel>
-
-      {isEditModalOpen && data && (
-        <FeatureViewFormModal
-          onClose={() => {
-            setIsEditModalOpen(false);
-            setErrorMessage(null);
-          }}
-          onSubmit={handleEditSubmit}
-          initialData={buildEditFormData(data)}
-          isEdit
-          isSubmitting={applyFeatureView.isLoading}
-          submitError={errorMessage}
-        />
-      )}
     </React.Fragment>
   );
 };

--- a/ui/src/pages/feature-views/components/FeatureViewProjectionDisplayPanel.tsx
+++ b/ui/src/pages/feature-views/components/FeatureViewProjectionDisplayPanel.tsx
@@ -51,7 +51,7 @@ const FeatureViewProjectionDisplayPanel = (
       <EuiSpacer size="s" />
       <EuiBasicTable
         columns={columns}
-        items={featureViewProjection?.featureColumns!}
+        items={featureViewProjection?.featureColumns || []}
       />
     </EuiPanel>
   );

--- a/ui/src/pages/saved-data-sets/DatasetInstance.tsx
+++ b/ui/src/pages/saved-data-sets/DatasetInstance.tsx
@@ -95,7 +95,6 @@ const DatasetInstance = () => {
           <EuiButton
             key="edit"
             iconType="pencil"
-            size="s"
             onClick={() => {
               setEditError(null);
               setShowEditModal(true);
@@ -106,7 +105,6 @@ const DatasetInstance = () => {
           <EuiButtonEmpty
             key="delete"
             iconType="trash"
-            size="s"
             color="danger"
             onClick={() => setShowDeleteConfirm(true)}
           >

--- a/ui/src/queries/mutations/useFeatureServiceMutations.ts
+++ b/ui/src/queries/mutations/useFeatureServiceMutations.ts
@@ -1,0 +1,100 @@
+import { useMutation, useQueryClient } from "react-query";
+
+interface FeatureViewProjectionPayload {
+  feature_view_name: string;
+  feature_names?: string[];
+}
+
+interface ApplyFeatureServicePayload {
+  name: string;
+  project: string;
+  features: FeatureViewProjectionPayload[];
+  description?: string;
+  tags?: Record<string, string>;
+  owner?: string;
+}
+
+interface DeleteFeatureServicePayload {
+  name: string;
+  project: string;
+}
+
+interface MutationResult {
+  name: string;
+  project: string;
+  status: string;
+}
+
+const API_BASE = "/api/v1";
+
+const applyFeatureService = async (
+  payload: ApplyFeatureServicePayload,
+): Promise<MutationResult> => {
+  const response = await fetch(`${API_BASE}/feature_services`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = await response
+      .json()
+      .catch(() => ({ detail: response.statusText }));
+    throw new Error(
+      error.detail || `Failed to apply feature service: ${response.status}`,
+    );
+  }
+
+  return response.json();
+};
+
+const deleteFeatureService = async (
+  payload: DeleteFeatureServicePayload,
+): Promise<MutationResult> => {
+  const response = await fetch(
+    `${API_BASE}/feature_services/${encodeURIComponent(payload.name)}?project=${encodeURIComponent(payload.project)}`,
+    { method: "DELETE" },
+  );
+
+  if (!response.ok) {
+    const error = await response
+      .json()
+      .catch(() => ({ detail: response.statusText }));
+    throw new Error(
+      error.detail || `Failed to delete feature service: ${response.status}`,
+    );
+  }
+
+  return response.json();
+};
+
+const useApplyFeatureService = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(applyFeatureService, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(["rest"]);
+      queryClient.invalidateQueries(["feature-services-rest"]);
+      queryClient.invalidateQueries(["feature-service-rest"]);
+    },
+  });
+};
+
+const useDeleteFeatureService = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(deleteFeatureService, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(["rest"]);
+      queryClient.invalidateQueries(["feature-services-rest"]);
+      queryClient.invalidateQueries(["feature-service-rest"]);
+    },
+  });
+};
+
+export { useApplyFeatureService, useDeleteFeatureService };
+export type {
+  ApplyFeatureServicePayload,
+  DeleteFeatureServicePayload,
+  FeatureViewProjectionPayload,
+};

--- a/ui/src/utils/permissionUtils.ts
+++ b/ui/src/utils/permissionUtils.ts
@@ -1,6 +1,17 @@
 import { FEAST_FCO_TYPES } from "../parsers/types";
 
 /**
+ * Test if a regex pattern is potentially vulnerable to catastrophic backtracking.
+ * Rejects patterns with nested quantifiers like (a+)+ or (a*)*
+ */
+const isSafePattern = (pattern: string): boolean => {
+  if (pattern.length > 1000) return false;
+  // Reject nested quantifiers: a quantifier applied to a group containing a quantifier
+  if (/(\([^)]*[+*][^)]*\))[+*{]/.test(pattern)) return false;
+  return true;
+};
+
+/**
  * Get permissions for a specific entity
  * @param permissions List of all permissions
  * @param entityType Type of the entity
@@ -42,6 +53,9 @@ export const getEntityPermissions = (
       matchesName = true; // If no name patterns, matches all names
     } else {
       matchesName = permission.spec?.name_patterns?.some((pattern: string) => {
+        if (!pattern || !isSafePattern(pattern)) {
+          return pattern === entityName;
+        }
         try {
           const regex = new RegExp(pattern);
           return regex.test(entityName);


### PR DESCRIPTION


# What this PR does / why we need it:

This PR adds REST create/delete for feature services and a matching Feast UI create flow. Incomplete projections (view name only, or optional feature subset) are resolved in core via FeatureService.prepare_for_apply() using the same constructor + infer_features path as FeatureStore.apply, so REST/gRPC stay thin and GET returns fully populated featureColumns.

Also, added delete functionality on entity, data sources and feature view. 

https://github.com/user-attachments/assets/f945ade9-c42f-4f4d-8479-6fe1b1274ba7



