### PR TITLE
docs: Added blog post for Iceberg Data Source support

### DIFF
--- a/infra/website/docs/blog/feast-unity-catalog-integration.md
+++ b/infra/website/docs/blog/feast-unity-catalog-integration.md
@@ -1,0 +1,342 @@
+---
+title: "Feast Gets Native Apache Iceberg Support"
+description: "Feast now reads features from any Iceberg catalog — REST, SQL, Hive, Glue, DynamoDB. Connect to Unity Catalog, Apache Polaris, Nessie, or your own PyIceberg catalog. Full support for get_historical_features, materialize, and online serving."
+date: 2026-07-18
+authors: ["Nikhil Kathole"]
+---
+
+# Feast Gets Native Apache Iceberg Support
+
+Apache Iceberg has become the open table format. Your data lake is probably already on it — whether through Databricks, Snowflake, AWS, or self-managed infrastructure. But until now, connecting Feast to Iceberg tables meant either going through Spark (heavyweight, slow to start) or copying data into Feast-managed Parquet files (data duplication, governance gap).
+
+Feast now ships a native `IcebergSource` that reads directly from any Iceberg catalog. No data copies. Your feature tables live where they already live — in your Iceberg catalog — and Feast reads from them via PyIceberg. With the DuckDB offline store, you don't even need a Spark cluster — reads happen entirely in-process.
+
+## Why This Matters
+
+Before this, the path from "data in Iceberg" to "features in Feast" looked like this:
+
+1. Data engineers build Iceberg tables in their catalog (UC, Glue, Hive)
+2. ML engineers copy data to Feast-managed Parquet files, or configure a SparkSource that couples them to a specific compute engine
+3. Two copies of the data. Two metadata systems. No connection between them.
+
+Now the path is:
+
+1. Data engineers build Iceberg tables in their catalog
+2. ML engineers point `IcebergSource` at the table
+3. Done. Feast reads directly from the catalog via PyIceberg. One copy. One source of truth. Choose DuckDB for lightweight local reads or Spark when you need distributed compute — the data source definition stays the same either way.
+
+## What You Get
+
+### Any Iceberg Catalog
+
+`IcebergSource` supports every catalog backend that PyIceberg supports:
+
+| `catalog_type` | Backend | Example Use Case |
+|---|---|---|
+| `"rest"` | Iceberg REST Catalog | Databricks Unity Catalog, Apache Polaris, Project Nessie, Snowflake Open Catalog |
+| `"sql"` | SQL-backed catalog | Local dev with SQLite, CI/CD, PostgreSQL-backed catalogs |
+| `"hive"` | Hive Metastore | On-premise Hadoop, EMR |
+| `"glue"` | AWS Glue Data Catalog | AWS-native lakehouse |
+| `"dynamodb"` | DynamoDB catalog | Serverless AWS |
+
+### Both Offline Stores
+
+| Operation | DuckDB | Spark |
+|---|---|---|
+| `feast apply` | Yes | Yes |
+| `get_historical_features` | Yes | Yes |
+| `materialize` / `materialize-incremental` | Yes | Yes |
+| `get_online_features` | Yes | Yes |
+
+Both offline stores use PyIceberg for the actual Iceberg table scan — the difference is what happens after. DuckDB processes the Arrow table in-process (no JVM, no cluster), making it ideal for local development and moderate-scale workloads. Spark is there when you need distributed compute over large datasets. The same `IcebergSource` definition works with either offline store — just change `offline_store.type` in your YAML.
+
+### Full Iceberg Semantics
+
+Every read goes through PyIceberg's `table.scan().to_arrow()`. This means you get proper Iceberg semantics: schema evolution, partition pruning, and snapshot isolation — not just raw Parquet file reads.
+
+## Quick Start
+
+### Install
+
+```bash
+pip install "feast[iceberg]"
+```
+
+### Define a Source
+
+```python
+from feast.infra.data_sources.contrib.iceberg_catalog import IcebergSource
+
+driver_stats = IcebergSource(
+    warehouse="my_catalog",
+    namespace="ml_features",
+    table="driver_hourly_stats",
+    catalog_type="rest",
+    endpoint="https://my-iceberg-catalog.example.com",
+    token_env_var="CATALOG_TOKEN",
+    timestamp_field="event_timestamp",
+)
+```
+
+### Use It
+
+```python
+from datetime import timedelta
+from feast import Entity, FeatureView, Field
+from feast.types import Float64, Int64
+
+driver = Entity(name="driver", join_keys=["driver_id"])
+
+driver_stats_fv = FeatureView(
+    name="driver_hourly_stats",
+    entities=[driver],
+    ttl=timedelta(days=365),
+    schema=[
+        Field(name="driver_id", dtype=Int64),
+        Field(name="conv_rate", dtype=Float64),
+        Field(name="acc_rate", dtype=Float64),
+        Field(name="avg_daily_trips", dtype=Int64),
+    ],
+    source=driver_stats,
+    online=True,
+)
+```
+
+```yaml
+# feature_store.yaml
+project: my_project
+registry: data/registry.db
+provider: local
+online_store:
+  type: sqlite
+  path: data/online_store.db
+offline_store:
+  type: duckdb
+```
+
+```bash
+feast apply
+```
+
+Then use it like any other Feast source:
+
+```python
+from feast import FeatureStore
+import pandas as pd
+from datetime import datetime, timezone
+
+store = FeatureStore(repo_path=".")
+
+# Training data
+training_df = store.get_historical_features(
+    entity_df=pd.DataFrame({
+        "driver_id": [1001, 1002, 1003],
+        "event_timestamp": [datetime(2026, 7, 1, tzinfo=timezone.utc)] * 3,
+    }),
+    features=["driver_hourly_stats:conv_rate", "driver_hourly_stats:acc_rate"],
+).to_df()
+
+# Materialize to online store
+store.materialize_incremental(end_date=datetime.now(tz=timezone.utc))
+
+# Online serving
+online = store.get_online_features(
+    features=["driver_hourly_stats:conv_rate", "driver_hourly_stats:acc_rate"],
+    entity_rows=[{"driver_id": 1001}],
+).to_dict()
+```
+
+## Catalog Examples
+
+### AWS Glue
+
+```python
+glue_source = IcebergSource(
+    warehouse="my_glue_database",
+    namespace="ml_features",
+    table="driver_stats",
+    catalog_type="glue",
+    catalog_properties={"region_name": "us-east-1"},
+    timestamp_field="event_timestamp",
+)
+```
+
+### Hive Metastore
+
+```python
+hive_source = IcebergSource(
+    endpoint="thrift://hive-metastore:9083",
+    warehouse="warehouse",
+    namespace="features",
+    table="driver_stats",
+    catalog_type="hive",
+    timestamp_field="event_timestamp",
+)
+```
+
+### Apache Polaris / Nessie
+
+```python
+polaris_source = IcebergSource(
+    endpoint="https://polaris.example.com",
+    warehouse="my_catalog",
+    namespace="ml",
+    table="features",
+    catalog_type="rest",
+    token_env_var="POLARIS_TOKEN",
+    timestamp_field="event_timestamp",
+)
+```
+
+### Local Development (SQLite-backed)
+
+For development and CI/CD, use a local PyIceberg SQL catalog — no external service required:
+
+```python
+local_source = IcebergSource(
+    warehouse="dev_warehouse",
+    namespace="default",
+    table="driver_stats",
+    catalog_type="sql",
+    catalog_name="dev_catalog",
+    catalog_properties={
+        "uri": "sqlite:////tmp/iceberg_catalog.db",
+        "warehouse": "file:///tmp/iceberg_warehouse",
+    },
+    timestamp_field="event_timestamp",
+)
+```
+
+## Use Case: Unity Catalog Integration
+
+Unity Catalog users get everything above with simpler configuration. `UnityCatalogSource` extends `IcebergSource` with UC-specific defaults:
+
+- Default connection via `DATABRICKS_HOST` and `DATABRICKS_TOKEN` environment variables — no manual endpoint or token setup
+- Three-level naming (`warehouse.namespace.table`) maps directly to UC's catalog/schema/table hierarchy
+
+### Databricks Setup
+
+```bash
+export DATABRICKS_HOST="https://your-workspace.cloud.databricks.com"
+export DATABRICKS_TOKEN="dapi_your_token_here"
+```
+
+```python
+from feast.infra.data_sources.contrib.iceberg_catalog import UnityCatalogSource
+
+driver_stats_source = UnityCatalogSource(
+    warehouse="ml_catalog",
+    namespace="driver_features",
+    table="driver_hourly_stats",
+    timestamp_field="event_timestamp",
+    created_timestamp_column="created",
+    description="Hourly aggregated driver statistics",
+)
+```
+
+That's it. No endpoint or token parameters needed — they come from the environment variables.
+
+### Optional: Governance Metadata Sync
+
+If you want `feast apply` to annotate your UC tables with `feast.*` properties (project name, feature view, primary keys, owner), you can use the `UnityCatalogProvider`:
+
+```yaml
+# feature_store.yaml
+provider: unity_catalog
+```
+
+This is optional. For most users, `provider: local` is sufficient. Reads, materialization, and online serving work the same regardless of which provider you use.
+
+### OSS Unity Catalog
+
+The integration also works with the open-source Unity Catalog, with some differences:
+
+| Capability | Databricks UC | OSS UC |
+|---|---|---|
+| Read via Iceberg REST | Built-in | Requires `uniform_iceberg_metadata_location` in H2 DB |
+| Read via SQL catalog | Yes | Yes |
+| Credential vending | Yes | Not available |
+
+For OSS UC, set `credential_vending=False` and `token_env_var=None`:
+
+```python
+source = UnityCatalogSource(
+    warehouse="unity",
+    namespace="default",
+    table="driver_hourly_stats",
+    endpoint="http://localhost:8080/api/2.1/unity-catalog/iceberg",
+    token_env_var=None,
+    credential_vending=False,
+    catalog_type="sql",    # recommended for OSS UC
+    catalog_name="my_catalog",
+    catalog_properties={
+        "uri": "sqlite:////tmp/pyiceberg_catalog.db",
+        "warehouse": "file:///tmp/warehouse",
+    },
+    timestamp_field="event_timestamp",
+    register_as_feature_table=False,
+)
+```
+
+## How It Works
+
+### Read Path
+
+All data reads go through PyIceberg, regardless of catalog type:
+
+```
+IcebergSource.get_catalog_client()
+    → PyIceberg catalog (REST / SQL / Hive / Glue / DynamoDB)
+    → table.scan().to_arrow()
+    → Arrow table
+    → DuckDB ibis memtable or Spark DataFrame
+```
+
+If the catalog is misconfigured, you get a clear error — consistent with how every other Feast data source works.
+
+### Catalog Name Isolation
+
+Each source has a `catalog_name` parameter (default: `"feast_iceberg"`). This is the instance name PyIceberg uses when loading the catalog. If you have multiple sources pointing at different catalogs, use different names to avoid collisions:
+
+```python
+production = IcebergSource(catalog_name="prod_catalog", ...)
+staging = IcebergSource(catalog_name="staging_catalog", ...)
+```
+
+## What's Not Supported
+
+- **Write-back to Iceberg/UC tables.** Feast reads from existing tables; it doesn't write feature data back. The `write_to_offline_store` API only supports `FileSource` (DuckDB) and `SparkSource` (Spark). Your data engineering pipelines create and populate the tables.
+- **Table creation.** Tables must exist before Feast can read from them. `feast apply` registers the feature view in Feast's registry, not the table in the catalog.
+
+## Configuration Reference
+
+### IcebergSource
+
+| Parameter | Default | Description |
+|---|---|---|
+| `warehouse` | *required* | Catalog or warehouse name |
+| `namespace` | *required* | Schema or namespace |
+| `table` | *required* | Table name |
+| `catalog_type` | `"rest"` | Backend: `"rest"`, `"sql"`, `"hive"`, `"glue"`, `"dynamodb"` |
+| `catalog_name` | `"feast_iceberg"` | PyIceberg instance name (unique per catalog to avoid collisions) |
+| `endpoint` | `None` | Catalog endpoint URL |
+| `catalog_properties` | `{}` | Additional catalog config (e.g., `{"uri": "sqlite:///..."}`) |
+| `token_env_var` | `None` | Env var containing auth token |
+| `credential_vending` | `True` | Request scoped storage credentials |
+| `timestamp_field` | `None` | Event timestamp column |
+| `created_timestamp_column` | `None` | Creation timestamp for deduplication |
+
+### UnityCatalogSource (extends IcebergSource)
+
+All `IcebergSource` parameters plus:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `endpoint` | From `DATABRICKS_HOST` | Defaults to `{DATABRICKS_HOST}/api/2.1/unity-catalog/iceberg` |
+| `token_env_var` | `"DATABRICKS_TOKEN"` | Defaults to Databricks token env var |
+| `register_as_feature_table` | `True` | Sync `feast.*` properties to UC on `feast apply` |
+| `sync_lineage` | `True` | Record lineage in UC (Databricks only) |
+
+---
+
+*Native Iceberg support is available in Feast 0.64+. Install with `pip install "feast[iceberg]"` and check the [Iceberg data source documentation](/reference/data-sources/iceberg) for the full API reference.*

--- a/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/iceberg_source.py
+++ b/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/iceberg_source.py
@@ -42,6 +42,7 @@ class IcebergSource(DataSource):
         namespace: str,
         table: str,
         catalog_type: str = "rest",
+        catalog_name: str = "feast_iceberg",
         endpoint: Optional[str] = None,
         catalog_properties: Optional[Dict[str, str]] = None,
         name: Optional[str] = None,
@@ -65,6 +66,7 @@ class IcebergSource(DataSource):
             owner=owner,
         )
         self.catalog_type = catalog_type
+        self.catalog_name = catalog_name
         self.endpoint = endpoint or ""
         self.warehouse = warehouse
         self.namespace = namespace
@@ -121,7 +123,7 @@ class IcebergSource(DataSource):
             token = os.environ.get(self.token_env_var, "")
             if token:
                 config.setdefault("token", token)
-        return load_catalog("feast_iceberg", **config)
+        return load_catalog(self.catalog_name, **config)
 
     def source_type(self) -> DataSourceProto.SourceType.ValueType:
         return DataSourceProto.BATCH_ICEBERG
@@ -142,6 +144,7 @@ class IcebergSource(DataSource):
         return IcebergSource(
             name=data_source.name,
             catalog_type=custom_options.get("catalog_type", "rest"),
+            catalog_name=custom_options.get("catalog_name", "feast_iceberg"),
             endpoint=custom_options.get("endpoint", ""),
             warehouse=custom_options["warehouse"],
             namespace=custom_options["namespace"],
@@ -161,6 +164,7 @@ class IcebergSource(DataSource):
         config_json = json.dumps(
             {
                 "catalog_type": self.catalog_type,
+                "catalog_name": self.catalog_name,
                 "endpoint": self.endpoint,
                 "warehouse": self.warehouse,
                 "namespace": self.namespace,
@@ -258,6 +262,7 @@ class IcebergSource(DataSource):
             return False
         return (
             self.catalog_type == other.catalog_type
+            and self.catalog_name == other.catalog_name
             and self.endpoint == other.endpoint
             and self.warehouse == other.warehouse
             and self.namespace == other.namespace

--- a/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/tests/test_iceberg_duckdb.py
+++ b/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/tests/test_iceberg_duckdb.py
@@ -1,12 +1,8 @@
 """Unit tests for DuckDB offline store reading from IcebergSource."""
 
-import os
-import tempfile
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
 import pyarrow as pa
-import pyarrow.parquet as pq
 import pytest
 
 from feast.infra.data_sources.contrib.iceberg_catalog.iceberg_source import (
@@ -14,99 +10,46 @@ from feast.infra.data_sources.contrib.iceberg_catalog.iceberg_source import (
 )
 from feast.infra.offline_stores.duckdb import (
     _read_iceberg_catalog_source,
-    _read_parquet_location,
 )
 
 
-class TestReadParquetLocation:
-    def test_read_single_parquet_file(self):
-        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
-            df = pd.DataFrame({"id": [1, 2, 3], "value": [10.0, 20.0, 30.0]})
-            df.to_parquet(f.name, index=False)
-            try:
-                result = _read_parquet_location(f"file:{f.name}")
-                result_df = result.execute()
-                assert len(result_df) == 3
-                assert "id" in result_df.columns
-                assert "value" in result_df.columns
-            finally:
-                os.unlink(f.name)
-
-    def test_read_parquet_directory(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
-            pq.write_table(
-                pa.Table.from_pandas(df),
-                os.path.join(tmpdir, "part-00000.parquet"),
-            )
-            result = _read_parquet_location(f"file:{tmpdir}")
-            result_df = result.execute()
-            assert len(result_df) == 2
-
-    def test_read_nonexistent_location(self):
-        with pytest.raises(FileNotFoundError):
-            _read_parquet_location("file:///nonexistent/path/nowhere")
-
-
 class TestReadIcebergCatalogSource:
-    def test_local_file_mode(self):
-        """Verify file:// endpoint reads from repo_path/data/{table}."""
-        with tempfile.TemporaryDirectory() as repo_path:
-            data_dir = os.path.join(repo_path, "data", "my_table")
-            os.makedirs(data_dir)
-            df = pd.DataFrame({"id": [1, 2], "val": [10.0, 20.0]})
-            pq.write_table(
-                pa.Table.from_pandas(df),
-                os.path.join(data_dir, "data.parquet"),
-            )
-
-            source = IcebergSource(
-                endpoint="file://local",
-                warehouse="w",
-                namespace="ns",
-                table="my_table",
-                credential_vending=False,
-            )
-            result = _read_iceberg_catalog_source(source, repo_path)
-            result_df = result.execute()
-            assert len(result_df) == 2
-            assert result_df["val"].iloc[0] == 10.0
-
     @patch(
-        "feast.infra.data_sources.contrib.iceberg_catalog.iceberg_source.IcebergSource.get_catalog_client"
+        "feast.infra.data_sources.contrib.iceberg_catalog"
+        ".iceberg_source.IcebergSource.get_catalog_client"
     )
-    def test_catalog_metadata_resolution(self, mock_get_client):
-        """Verify the source resolves metadata via catalog before reading."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            df = pd.DataFrame({"id": [1], "val": [42.0]})
-            pq.write_table(
-                pa.Table.from_pandas(df),
-                os.path.join(tmpdir, "data.parquet"),
-            )
+    def test_pyiceberg_scan(self, mock_get_client):
+        """Verify data is loaded via PyIceberg scan -> Arrow -> ibis."""
+        arrow_tbl = pa.table({"id": [1, 2], "val": [10.0, 20.0]})
 
-            mock_client = MagicMock()
-            mock_client.load_table.return_value = MagicMock(location=f"file:{tmpdir}")
-            mock_get_client.return_value = mock_client
+        mock_iceberg_table = MagicMock()
+        mock_iceberg_table.scan.return_value.to_arrow.return_value = arrow_tbl
 
-            source = IcebergSource(
-                endpoint="http://host/iceberg",
-                warehouse="w",
-                namespace="ns",
-                table="t",
-                credential_vending=False,
-            )
-            result = _read_iceberg_catalog_source(source, repo_path=".")
-            result_df = result.execute()
-            assert len(result_df) == 1
-            assert result_df["val"].iloc[0] == 42.0
-
-    @patch(
-        "feast.infra.data_sources.contrib.iceberg_catalog.iceberg_source.IcebergSource.get_catalog_client"
-    )
-    def test_catalog_resolution_failure(self, mock_get_client):
-        """Verify error when table cannot be loaded from catalog."""
         mock_client = MagicMock()
-        mock_client.load_table.return_value = None
+        mock_client.load_table.return_value = mock_iceberg_table
+        mock_get_client.return_value = mock_client
+
+        source = IcebergSource(
+            endpoint="http://host/iceberg",
+            warehouse="w",
+            namespace="ns",
+            table="my_table",
+            credential_vending=False,
+        )
+        result = _read_iceberg_catalog_source(source, repo_path=".")
+        result_df = result.execute()
+        assert len(result_df) == 2
+        assert list(result_df["val"]) == [10.0, 20.0]
+        mock_client.load_table.assert_called_once_with("ns.my_table")
+
+    @patch(
+        "feast.infra.data_sources.contrib.iceberg_catalog"
+        ".iceberg_source.IcebergSource.get_catalog_client"
+    )
+    def test_catalog_load_failure_propagates(self, mock_get_client):
+        """Verify errors propagate instead of being silently swallowed."""
+        mock_client = MagicMock()
+        mock_client.load_table.side_effect = Exception("table not found")
         mock_get_client.return_value = mock_client
 
         source = IcebergSource(
@@ -115,5 +58,32 @@ class TestReadIcebergCatalogSource:
             namespace="ns",
             table="t",
         )
-        with pytest.raises(ValueError, match="Cannot load table"):
+        with pytest.raises(Exception, match="table not found"):
             _read_iceberg_catalog_source(source, repo_path=".")
+
+    @patch("pyiceberg.catalog.load_catalog")
+    def test_rest_catalog_path(self, mock_load_catalog):
+        """Verify REST catalog type uses load_catalog with correct config."""
+        arrow_tbl = pa.table({"id": [1], "val": [42.0]})
+
+        mock_iceberg_table = MagicMock()
+        mock_iceberg_table.scan.return_value.to_arrow.return_value = arrow_tbl
+
+        mock_catalog = MagicMock()
+        mock_catalog.load_table.return_value = mock_iceberg_table
+        mock_load_catalog.return_value = mock_catalog
+
+        source = IcebergSource(
+            endpoint="http://host/iceberg",
+            warehouse="w",
+            namespace="ns",
+            table="t",
+            catalog_type="rest",
+            credential_vending=False,
+        )
+        result = _read_iceberg_catalog_source(source, repo_path=".")
+        result_df = result.execute()
+        assert len(result_df) == 1
+        assert result_df["val"].iloc[0] == 42.0
+        mock_load_catalog.assert_called_once()
+        mock_catalog.load_table.assert_called_once_with("ns.t")

--- a/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/tests/test_iceberg_spark.py
+++ b/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/tests/test_iceberg_spark.py
@@ -1,13 +1,9 @@
 """Unit tests for Spark offline store reading from IcebergSource."""
 
-import os
-import tempfile
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
 import pyarrow as pa
-import pyarrow.parquet as pq
 import pytest
 
 from feast.infra.data_sources.contrib.iceberg_catalog.iceberg_source import (
@@ -19,7 +15,6 @@ pyspark = pytest.importorskip("pyspark")
 from feast.infra.offline_stores.contrib.spark_offline_store.spark import (  # noqa: E402
     _pull_from_iceberg_source,
     _register_iceberg_source_as_temp_view,
-    _resolve_uc_storage_location,
 )
 
 
@@ -39,107 +34,50 @@ def spark_session():
 
 
 class TestRegisterIcebergSourceAsTempView:
-    def test_local_file_mode(self, spark_session):
-        """file:// endpoint resolves to repo_path/data/{table}."""
-        with tempfile.TemporaryDirectory() as repo_path:
-            data_dir = os.path.join(repo_path, "data", "my_table")
-            os.makedirs(data_dir)
-            df = pd.DataFrame({"id": [1, 2, 3], "value": [10.0, 20.0, 30.0]})
-            pq.write_table(
-                pa.Table.from_pandas(df),
-                os.path.join(data_dir, "data.parquet"),
-            )
+    @patch(
+        "feast.infra.offline_stores.contrib.spark_offline_store"
+        ".spark._load_pyiceberg_table"
+    )
+    def test_pyiceberg_scan(self, mock_load, spark_session):
+        """Verify data is loaded via PyIceberg scan -> Arrow -> Spark DataFrame."""
+        arrow_tbl = pa.table({"id": [1, 2, 3], "value": [10.0, 20.0, 30.0]})
 
-            source = IcebergSource(
-                endpoint="file://local",
-                warehouse="w",
-                namespace="ns",
-                table="my_table",
-            )
-            config = MagicMock()
-            config.repo_path = repo_path
+        mock_iceberg_table = MagicMock()
+        mock_iceberg_table.scan.return_value.to_arrow.return_value = arrow_tbl
+        mock_load.return_value = mock_iceberg_table
 
-            _register_iceberg_source_as_temp_view(spark_session, source, config)
+        source = IcebergSource(
+            endpoint="http://host:8080/iceberg",
+            warehouse="w",
+            namespace="ns",
+            table="my_table",
+        )
+        config = MagicMock()
 
-            result = spark_session.sql("SELECT * FROM iceberg_tmp_my_table")
-            assert result.count() == 3
+        _register_iceberg_source_as_temp_view(spark_session, source, config)
+
+        result = spark_session.sql("SELECT * FROM iceberg_tmp_my_table")
+        assert result.count() == 3
+        mock_load.assert_called_once_with(source)
 
     @patch(
-        "feast.infra.data_sources.contrib.iceberg_catalog"
-        ".iceberg_source.IcebergSource.get_catalog_client"
+        "feast.infra.offline_stores.contrib.spark_offline_store"
+        ".spark._load_pyiceberg_table"
     )
-    def test_catalog_resolution(self, mock_get_client, spark_session):
-        """Non-file endpoint resolves location via catalog client."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            df = pd.DataFrame({"id": [1], "val": [42.0]})
-            pq.write_table(
-                pa.Table.from_pandas(df),
-                os.path.join(tmpdir, "data.parquet"),
-            )
+    def test_catalog_load_failure_propagates(self, mock_load, spark_session):
+        """Verify errors propagate instead of being silently swallowed."""
+        mock_load.side_effect = Exception("table not found")
 
-            mock_client = MagicMock()
-            mock_client.load_table.return_value = MagicMock(location=f"file://{tmpdir}")
-            mock_get_client.return_value = mock_client
+        source = IcebergSource(
+            endpoint="http://host:8080/iceberg",
+            warehouse="w",
+            namespace="ns",
+            table="bad_table",
+        )
+        config = MagicMock()
 
-            source = IcebergSource(
-                endpoint="http://host:8080/iceberg",
-                warehouse="w",
-                namespace="ns",
-                table="catalog_tbl",
-            )
-            config = MagicMock()
-            config.repo_path = "."
-
+        with pytest.raises(Exception, match="table not found"):
             _register_iceberg_source_as_temp_view(spark_session, source, config)
-
-            result = spark_session.sql("SELECT * FROM iceberg_tmp_catalog_tbl")
-            assert result.count() == 1
-            assert result.collect()[0]["val"] == 42.0
-
-
-class TestResolveUcStorageLocation:
-    @patch("requests.get")
-    def test_successful_resolution(self, mock_get):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"storage_location": "file:///data/table1"}
-        mock_get.return_value = mock_resp
-
-        source = IcebergSource(
-            endpoint="http://localhost:8080",
-            warehouse="unity",
-            namespace="default",
-            table="table1",
-        )
-
-        with patch(
-            "feast.infra.offline_stores.contrib.spark_offline_store.spark.requests",
-            wraps=None,
-        ):
-            result = _resolve_uc_storage_location(source)
-
-        assert result == "file:///data/table1"
-
-    @patch("requests.get")
-    def test_failed_resolution(self, mock_get):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 404
-        mock_get.return_value = mock_resp
-
-        source = IcebergSource(
-            endpoint="http://localhost:8080",
-            warehouse="unity",
-            namespace="default",
-            table="missing_table",
-        )
-
-        with patch(
-            "feast.infra.offline_stores.contrib.spark_offline_store.spark.requests",
-            wraps=None,
-        ):
-            result = _resolve_uc_storage_location(source)
-
-        assert result is None
 
 
 class TestPullFromIcebergSource:

--- a/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/unity_catalog_source.py
+++ b/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/unity_catalog_source.py
@@ -49,6 +49,9 @@ class UnityCatalogSource(IcebergSource):
         endpoint: Optional[str] = None,
         token_env_var: Optional[str] = None,
         credential_vending: bool = True,
+        catalog_type: str = "rest",
+        catalog_name: str = "feast_iceberg",
+        catalog_properties: Optional[Dict[str, str]] = None,
         register_as_feature_table: bool = True,
         sync_lineage: bool = True,
     ):
@@ -64,6 +67,9 @@ class UnityCatalogSource(IcebergSource):
             warehouse=warehouse,
             namespace=namespace,
             table=table,
+            catalog_type=catalog_type,
+            catalog_name=catalog_name,
+            catalog_properties=catalog_properties,
             name=name,
             timestamp_field=timestamp_field,
             created_timestamp_column=created_timestamp_column,
@@ -110,6 +116,9 @@ class UnityCatalogSource(IcebergSource):
             table=custom_options["table"],
             token_env_var=custom_options.get("token_env_var"),
             credential_vending=custom_options.get("credential_vending", True),
+            catalog_type=custom_options.get("catalog_type", "rest"),
+            catalog_name=custom_options.get("catalog_name", "feast_iceberg"),
+            catalog_properties=custom_options.get("catalog_properties"),
             register_as_feature_table=custom_options.get(
                 "register_as_feature_table", True
             ),
@@ -131,6 +140,9 @@ class UnityCatalogSource(IcebergSource):
                 "table": self.iceberg_table,
                 "token_env_var": self.token_env_var,
                 "credential_vending": self.credential_vending,
+                "catalog_type": self.catalog_type,
+                "catalog_name": self.catalog_name,
+                "catalog_properties": self.catalog_properties,
                 "register_as_feature_table": self.register_as_feature_table,
                 "sync_lineage": self.sync_lineage,
             }

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -1208,103 +1208,50 @@ def _register_iceberg_source_as_temp_view(
     data_source: "DataSource",
     config: "RepoConfig",
 ) -> None:
-    """Register an IcebergSource as a Spark temp view for SQL queries."""
+    """Register an IcebergSource as a Spark temp view for SQL queries.
+
+    Loads the table through PyIceberg (which handles all catalog types and
+    storage backends), scans it to Arrow, and creates a temp view.
+    """
     from feast.infra.data_sources.contrib.iceberg_catalog.iceberg_source import (
         IcebergSource,
     )
 
     assert isinstance(data_source, IcebergSource)
-    # Temp views require single-part names
     view_name = f"iceberg_tmp_{data_source.iceberg_table}"
 
-    if not data_source.endpoint.startswith("file://"):
-        # Try Iceberg REST catalog protocol first
-        try:
-            client = data_source.get_catalog_client()
-            metadata = client.load_table(
-                data_source.namespace, data_source.iceberg_table
-            )
-            if metadata and metadata.location:
-                location = metadata.location
-                if location.startswith("file://"):
-                    location = location[7:]
-                elif location.startswith("file:"):
-                    location = location[5:]
-                df = spark_session.read.parquet(location)
-                df.createOrReplaceTempView(view_name)
-                return
-        except Exception:
-            pass
-
-        # Fallback: query UC REST API for storage_location
-        storage_location = _resolve_uc_storage_location(data_source)
-        if storage_location:
-            if storage_location.startswith("file://"):
-                storage_location = storage_location[7:]
-            elif storage_location.startswith("file:"):
-                storage_location = storage_location[5:]
-            df = spark_session.read.parquet(storage_location)
-            df.createOrReplaceTempView(view_name)
-            return
-
-        # Last resort: configure Spark Iceberg catalog (uses multi-part names natively)
-        catalog_name = f"iceberg_{data_source.warehouse}"
-        spark_session.conf.set(
-            f"spark.sql.catalog.{catalog_name}", "org.apache.iceberg.spark.SparkCatalog"
-        )
-        spark_session.conf.set(f"spark.sql.catalog.{catalog_name}.type", "rest")
-        spark_session.conf.set(
-            f"spark.sql.catalog.{catalog_name}.uri", data_source.endpoint
-        )
-        spark_session.conf.set(
-            f"spark.sql.catalog.{catalog_name}.warehouse", data_source.warehouse
-        )
-        return
-
-    # Local file mode: resolve location and read as parquet
-    repo_path = getattr(config, "repo_path", ".") or "."
-    local_path = os.path.join(repo_path, "data", data_source.iceberg_table)
-    if os.path.exists(local_path):
-        df = spark_session.read.parquet(local_path)
-        df.createOrReplaceTempView(view_name)
-        return
-
-    # Try catalog client
-    try:
-        client = data_source.get_catalog_client()
-        metadata = client.load_table(data_source.namespace, data_source.iceberg_table)
-        if metadata and metadata.location:
-            location = metadata.location
-            if location.startswith("file://"):
-                location = location[7:]
-            elif location.startswith("file:"):
-                location = location[5:]
-            df = spark_session.read.parquet(location)
-            df.createOrReplaceTempView(view_name)
-    except Exception:
-        pass
+    iceberg_table = _load_pyiceberg_table(data_source)
+    arrow_table = iceberg_table.scan().to_arrow()
+    df = spark_session.createDataFrame(arrow_table.to_pandas())
+    df.createOrReplaceTempView(view_name)
 
 
-def _resolve_uc_storage_location(data_source: "DataSource") -> Optional[str]:
-    """Query Unity Catalog REST API for a table's storage_location."""
-    import requests as _requests
-
+def _load_pyiceberg_table(data_source: "DataSource"):
+    """Load an Iceberg table via PyIceberg, respecting the source's catalog_type."""
     from feast.infra.data_sources.contrib.iceberg_catalog.iceberg_source import (
         IcebergSource,
     )
 
     assert isinstance(data_source, IcebergSource)
-    uc_url = (
-        f"{data_source.endpoint}/api/2.1/unity-catalog/tables/"
-        f"{data_source.warehouse}.{data_source.namespace}.{data_source.iceberg_table}"
-    )
-    try:
-        resp = _requests.get(uc_url, timeout=10)
-        if resp.status_code == 200:
-            return resp.json().get("storage_location")
-    except _requests.exceptions.RequestException:
-        pass
-    return None
+    fqn = f"{data_source.namespace}.{data_source.iceberg_table}"
+
+    if data_source.catalog_type != "rest":
+        catalog_client = data_source.get_catalog_client()
+        return catalog_client.load_table(fqn)
+
+    from pyiceberg.catalog import load_catalog
+
+    catalog_config: Dict[str, str] = {
+        "type": "rest",
+        "uri": data_source.endpoint,
+        "warehouse": data_source.warehouse,
+    }
+    if data_source.token_env_var:
+        token = os.environ.get(data_source.token_env_var)
+        if token:
+            catalog_config["token"] = token
+    catalog = load_catalog(data_source.catalog_name, **catalog_config)
+    return catalog.load_table(fqn)
 
 
 def _pull_from_iceberg_source(
@@ -1320,8 +1267,7 @@ def _pull_from_iceberg_source(
 ) -> "SparkRetrievalJob":
     """Read from an IcebergSource using Spark.
 
-    Resolves table storage location via Iceberg REST or UC API,
-    reads as Parquet into a temp view, then queries with time filter.
+    Loads the table via PyIceberg into a temp view, then queries with time filter.
     """
     from feast.infra.data_sources.contrib.iceberg_catalog.iceberg_source import (
         IcebergSource,

--- a/sdk/python/feast/infra/offline_stores/duckdb.py
+++ b/sdk/python/feast/infra/offline_stores/duckdb.py
@@ -72,96 +72,32 @@ def _read_data_source(data_source: DataSource, repo_path: str) -> Table:
 
 
 def _read_iceberg_catalog_source(data_source: "IcebergSource", repo_path: str) -> Table:
-    """Read from an IcebergSource by resolving via the catalog."""
-    import logging
+    """Read from an IcebergSource via PyIceberg.
 
-    logger = logging.getLogger(__name__)
+    Loads the table through the configured catalog (REST, SQL, Hive, etc.)
+    and scans it to Arrow.
+    """
+    fqn = f"{data_source.namespace}.{data_source.iceberg_table}"
 
-    # Local file mode for dev/testing
-    if data_source.endpoint.startswith("file://"):
-        local_path = os.path.join(repo_path, "data", data_source.iceberg_table)
-        if os.path.exists(local_path):
-            return _read_parquet_location(local_path)
-
-    # Resolve via Iceberg REST Catalog
-    client = data_source.get_catalog_client()
-    metadata = client.load_table(data_source.namespace, data_source.iceberg_table)
-
-    if metadata is not None:
-        # Try PyIceberg first (full Iceberg protocol)
-        try:
-            from pyiceberg.catalog import load_catalog
-
-            catalog_config = {
-                "type": "rest",
-                "uri": data_source.endpoint,
-                "warehouse": data_source.warehouse,
-            }
-            if data_source.token_env_var:
-                token = os.environ.get(data_source.token_env_var)
-                if token:
-                    catalog_config["token"] = token
-
-            catalog = load_catalog("feast_iceberg", **catalog_config)
-            table = catalog.load_table(
-                f"{data_source.namespace}.{data_source.iceberg_table}"
-            )
-            arrow_table = table.scan().to_arrow()
-            return ibis.memtable(arrow_table)
-        except Exception as e:
-            logger.debug(f"PyIceberg read failed, falling back to Parquet: {e}")
-
-        # Fallback: read Parquet from resolved location
-        return _read_parquet_location(metadata.location)
-
-    # Fallback: try Unity Catalog REST API for storage_location
-    import requests as _requests
-
-    uc_url = (
-        f"{data_source.endpoint}/api/2.1/unity-catalog/tables/"
-        f"{data_source.warehouse}.{data_source.namespace}.{data_source.iceberg_table}"
-    )
-    try:
-        resp = _requests.get(uc_url, timeout=10)
-        if resp.status_code == 200:
-            storage_location = resp.json().get("storage_location")
-            if storage_location:
-                return _read_parquet_location(storage_location)
-    except _requests.exceptions.RequestException:
-        pass
-
-    raise ValueError(
-        f"Cannot load table '{data_source.fqn}' from catalog "
-        f"at '{data_source.endpoint}'"
-    )
-
-
-def _read_parquet_location(location: str) -> Table:
-    """Read Parquet files from a storage location (file:// or local path)."""
-    import glob
-
-    if location.startswith("file:"):
-        location = location.replace("file:", "").lstrip("/")
-        location = "/" + location
-
-    if os.path.isdir(location):
-        parquet_files = glob.glob(
-            os.path.join(location, "**/*.parquet"), recursive=True
-        )
-        if not parquet_files:
-            parquet_files = glob.glob(
-                os.path.join(location, "**/*.snappy.parquet"), recursive=True
-            )
-        if parquet_files:
-            import pyarrow as pa
-
-            tables = [pq.read_table(f) for f in parquet_files]
-            return ibis.memtable(pa.concat_tables(tables))
-        raise FileNotFoundError(f"No Parquet files found in {location}")
-    elif os.path.isfile(location):
-        return ibis.read_parquet(location)
+    if data_source.catalog_type != "rest":
+        catalog_client = data_source.get_catalog_client()
+        table = catalog_client.load_table(fqn)
     else:
-        raise FileNotFoundError(f"Cannot access table location: {location}")
+        from pyiceberg.catalog import load_catalog
+
+        catalog_config: dict = {
+            "type": "rest",
+            "uri": data_source.endpoint,
+            "warehouse": data_source.warehouse,
+        }
+        if data_source.token_env_var:
+            token = os.environ.get(data_source.token_env_var)
+            if token:
+                catalog_config["token"] = token
+        catalog = load_catalog(data_source.catalog_name, **catalog_config)
+        table = catalog.load_table(fqn)
+
+    return ibis.memtable(table.scan().to_arrow())
 
 
 def _write_data_source(


### PR DESCRIPTION

# What this PR does / why we need it:

Added blog post documenting Iceberg data source support, catalog backend options, and UC integration. Also, Added configurable catalog_name parameter to IcebergSource and UnityCatalogSource to avoid catalog instance collisions.