### PR TITLE
feat: Add RBAC permissions management UI with OIDC authentication

### DIFF
--- a/sdk/python/feast/api/registry/rest/permissions.py
+++ b/sdk/python/feast/api/registry/rest/permissions.py
@@ -1,4 +1,8 @@
+from typing import Dict, List, Optional
+
 from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 
 from feast.api.registry.rest.rest_utils import (
     create_grpc_pagination_params,
@@ -9,7 +13,107 @@ from feast.api.registry.rest.rest_utils import (
     get_sorting_params,
     grpc_call,
 )
-from feast.registry_server import RegistryServer_pb2
+from feast.protos.feast.core.Permission_pb2 import Permission as PermissionProto
+from feast.protos.feast.core.Permission_pb2 import PermissionSpec as PermissionSpecProto
+from feast.protos.feast.core.Policy_pb2 import (
+    CombinedGroupNamespacePolicy as CombinedGroupNamespacePolicyProto,
+)
+from feast.protos.feast.core.Policy_pb2 import GroupBasedPolicy as GroupBasedPolicyProto
+from feast.protos.feast.core.Policy_pb2 import (
+    NamespaceBasedPolicy as NamespaceBasedPolicyProto,
+)
+from feast.protos.feast.core.Policy_pb2 import Policy as PolicyProto
+from feast.protos.feast.core.Policy_pb2 import RoleBasedPolicy as RoleBasedPolicyProto
+from feast.protos.feast.registry import RegistryServer_pb2
+
+
+class RoleBasedPolicyModel(BaseModel):
+    roles: List[str]
+
+
+class GroupBasedPolicyModel(BaseModel):
+    groups: List[str]
+
+
+class NamespaceBasedPolicyModel(BaseModel):
+    namespaces: List[str]
+
+
+class CombinedGroupNamespacePolicyModel(BaseModel):
+    groups: List[str]
+    namespaces: List[str]
+
+
+class PolicyModel(BaseModel):
+    role_based_policy: Optional[RoleBasedPolicyModel] = None
+    group_based_policy: Optional[GroupBasedPolicyModel] = None
+    namespace_based_policy: Optional[NamespaceBasedPolicyModel] = None
+    combined_group_namespace_policy: Optional[CombinedGroupNamespacePolicyModel] = None
+
+
+class ApplyPermissionRequestBody(BaseModel):
+    name: str
+    project: str
+    types: List[str] = []
+    name_patterns: List[str] = []
+    actions: List[str] = []
+    policy: PolicyModel
+    tags: Optional[Dict[str, str]] = {}
+    required_tags: Optional[Dict[str, str]] = {}
+
+
+def _build_policy_proto(policy: PolicyModel) -> PolicyProto:
+    if policy.role_based_policy:
+        return PolicyProto(
+            role_based_policy=RoleBasedPolicyProto(roles=policy.role_based_policy.roles)
+        )
+    elif policy.group_based_policy:
+        return PolicyProto(
+            group_based_policy=GroupBasedPolicyProto(
+                groups=policy.group_based_policy.groups
+            )
+        )
+    elif policy.namespace_based_policy:
+        return PolicyProto(
+            namespace_based_policy=NamespaceBasedPolicyProto(
+                namespaces=policy.namespace_based_policy.namespaces
+            )
+        )
+    elif policy.combined_group_namespace_policy:
+        return PolicyProto(
+            combined_group_namespace_policy=CombinedGroupNamespacePolicyProto(
+                groups=policy.combined_group_namespace_policy.groups,
+                namespaces=policy.combined_group_namespace_policy.namespaces,
+            )
+        )
+    return PolicyProto()
+
+
+_TYPE_NAME_TO_ENUM = {
+    "FEATURE_VIEW": PermissionSpecProto.Type.FEATURE_VIEW,
+    "ON_DEMAND_FEATURE_VIEW": PermissionSpecProto.Type.ON_DEMAND_FEATURE_VIEW,
+    "BATCH_FEATURE_VIEW": PermissionSpecProto.Type.BATCH_FEATURE_VIEW,
+    "STREAM_FEATURE_VIEW": PermissionSpecProto.Type.STREAM_FEATURE_VIEW,
+    "ENTITY": PermissionSpecProto.Type.ENTITY,
+    "FEATURE_SERVICE": PermissionSpecProto.Type.FEATURE_SERVICE,
+    "DATA_SOURCE": PermissionSpecProto.Type.DATA_SOURCE,
+    "VALIDATION_REFERENCE": PermissionSpecProto.Type.VALIDATION_REFERENCE,
+    "SAVED_DATASET": PermissionSpecProto.Type.SAVED_DATASET,
+    "PERMISSION": PermissionSpecProto.Type.PERMISSION,
+    "PROJECT": PermissionSpecProto.Type.PROJECT,
+    "LABEL_VIEW": PermissionSpecProto.Type.LABEL_VIEW,
+}
+
+_ACTION_NAME_TO_ENUM = {
+    "CREATE": PermissionSpecProto.AuthzedAction.CREATE,
+    "DESCRIBE": PermissionSpecProto.AuthzedAction.DESCRIBE,
+    "UPDATE": PermissionSpecProto.AuthzedAction.UPDATE,
+    "DELETE": PermissionSpecProto.AuthzedAction.DELETE,
+    "READ_ONLINE": PermissionSpecProto.AuthzedAction.READ_ONLINE,
+    "READ_OFFLINE": PermissionSpecProto.AuthzedAction.READ_OFFLINE,
+    "WRITE_ONLINE": PermissionSpecProto.AuthzedAction.WRITE_ONLINE,
+    "WRITE_OFFLINE": PermissionSpecProto.AuthzedAction.WRITE_OFFLINE,
+}
 
 
 def get_permission_router(grpc_handler) -> APIRouter:
@@ -33,8 +137,6 @@ def get_permission_router(grpc_handler) -> APIRouter:
 
         result = permission
 
-        # Note: permissions may not have relationships in the traditional sense
-        # but we include the functionality for consistency
         if include_relationships:
             relationships = get_object_relationships(
                 grpc_handler, "permission", name, project, allow_cache
@@ -74,5 +176,54 @@ def get_permission_router(grpc_handler) -> APIRouter:
             result["relationships"] = relationships
 
         return result
+
+    @router.post("/permissions", status_code=201)
+    def apply_permission(body: ApplyPermissionRequestBody):
+        types = [_TYPE_NAME_TO_ENUM[t] for t in body.types if t in _TYPE_NAME_TO_ENUM]
+        actions = [
+            _ACTION_NAME_TO_ENUM[a] for a in body.actions if a in _ACTION_NAME_TO_ENUM
+        ]
+        policy_proto = _build_policy_proto(body.policy)
+
+        permission_spec = PermissionSpecProto(
+            name=body.name,
+            types=types,
+            name_patterns=body.name_patterns,
+            actions=actions,
+            policy=policy_proto,
+            tags=body.tags or {},
+            required_tags=body.required_tags or {},
+        )
+        permission_proto = PermissionProto(spec=permission_spec)
+
+        req = RegistryServer_pb2.ApplyPermissionRequest(
+            permission=permission_proto,
+            project=body.project,
+            commit=True,
+        )
+        grpc_call(grpc_handler.ApplyPermission, req)
+
+        return JSONResponse(
+            status_code=201,
+            content={
+                "name": body.name,
+                "project": body.project,
+                "status": "applied",
+            },
+        )
+
+    @router.delete("/permissions/{name}")
+    def delete_permission(
+        name: str,
+        project: str = Query(...),
+    ):
+        req = RegistryServer_pb2.DeletePermissionRequest(
+            name=name,
+            project=project,
+            commit=True,
+        )
+        grpc_call(grpc_handler.DeletePermission, req)
+
+        return {"name": name, "project": project, "status": "deleted"}
 
     return router

--- a/sdk/python/feast/permissions/auth_model.py
+++ b/sdk/python/feast/permissions/auth_model.py
@@ -37,6 +37,7 @@ class AuthConfig(FeastConfigBaseModel):
 class OidcAuthConfig(AuthConfig):
     auth_discovery_url: str
     client_id: Optional[str] = None
+    ui_client_id: Optional[str] = None
     verify_ssl: bool = True
     ca_cert_path: str = ""
 

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -28,6 +28,30 @@ def _safe_error_response(
     )
 
 
+def _build_auth_config_json(store: "feast.FeatureStore") -> str:
+    """Build a JSON string with auth config from feature_store.yaml for the UI."""
+    from feast.permissions.auth_model import AuthConfig, OidcAuthConfig
+
+    auth_cfg = getattr(store.config, "auth_config", None)
+    if not isinstance(auth_cfg, AuthConfig):
+        return json.dumps({"auth_type": "no_auth"})
+
+    auth_type = auth_cfg.type if auth_cfg else "no_auth"
+
+    config: Dict[str, str] = {"auth_type": auth_type}
+    if auth_type == "oidc" and isinstance(auth_cfg, OidcAuthConfig):
+        discovery_url = auth_cfg.auth_discovery_url
+        if "/realms/" in discovery_url:
+            base = discovery_url.split("/realms/")[0]
+            realm = discovery_url.split("/realms/")[1].split("/")[0]
+            config["url"] = base
+            config["realm"] = realm
+        config["auth_discovery_url"] = discovery_url
+        config["client_id"] = auth_cfg.ui_client_id or auth_cfg.client_id or ""
+
+    return json.dumps(config)
+
+
 def _build_projects_list(
     store: "feast.FeatureStore",
     project_id: str,
@@ -75,12 +99,63 @@ def _build_projects_list(
 
 def _setup_rest_mode(app: FastAPI, store: "feast.FeatureStore"):
     """Mount the REST registry API routes on the UI server under /api/v1."""
+    from fastapi import Depends, Request
+    from fastapi.responses import JSONResponse
+
     from feast.api.registry.rest import register_all_routes
+    from feast.errors import FeastObjectNotFoundException, FeastPermissionError
+    from feast.permissions.server.utils import (
+        ServerType,
+        init_auth_manager,
+        init_security_manager,
+        str_to_auth_manager_type,
+    )
     from feast.registry_server import RegistryServer
 
     grpc_handler = RegistryServer(store.registry, store=store)
 
-    rest_app = FastAPI(root_path="/api/v1")
+    auth_cfg = store.config.auth_config
+    dependencies = []
+    if auth_cfg and auth_cfg.type != "no_auth":
+        from feast.permissions.server.rest import inject_user_details
+
+        auth_type = str_to_auth_manager_type(auth_cfg.type)
+        init_security_manager(auth_type=auth_type, fs=store)
+        init_auth_manager(
+            auth_type=auth_type,
+            server_type=ServerType.REST,
+            auth_config=auth_cfg,
+        )
+        dependencies.append(Depends(inject_user_details))
+
+    rest_app = FastAPI(root_path="/api/v1", dependencies=dependencies)
+
+    @rest_app.exception_handler(FeastPermissionError)
+    async def feast_permission_error_handler(
+        request: Request, exc: FeastPermissionError
+    ):
+        return JSONResponse(
+            status_code=403,
+            content={
+                "status_code": 403,
+                "detail": str(exc),
+                "error_type": "FeastPermissionError",
+            },
+        )
+
+    @rest_app.exception_handler(FeastObjectNotFoundException)
+    async def feast_object_not_found_handler(
+        request: Request, exc: FeastObjectNotFoundException
+    ):
+        return JSONResponse(
+            status_code=404,
+            content={
+                "status_code": 404,
+                "detail": str(exc),
+                "error_type": "FeastObjectNotFoundException",
+            },
+        )
+
     register_all_routes(rest_app, grpc_handler, store=store)
 
     class PushRequest(BaseModel):
@@ -1086,13 +1161,24 @@ def get_app(
                 "error": "Failed to fetch model data",
             }
 
-    # For all other paths (such as paths that would otherwise be handled by react router), pass to React
-    @app.api_route("/p/{path_name:path}", methods=["GET"])
-    def catch_all():
+    auth_config_json = _build_auth_config_json(store)
+
+    def _serve_index():
         filename = ui_dir.joinpath("index.html")
         with open(filename) as f:
             content = f.read()
+        if auth_config_json:
+            tag = f'<script id="feast-auth-config" type="application/json">{auth_config_json}</script>'
+            content = content.replace("</head>", f"{tag}\n</head>", 1)
         return Response(content, media_type="text/html")
+
+    @app.get("/")
+    def serve_root():
+        return _serve_index()
+
+    @app.api_route("/p/{path_name:path}", methods=["GET"])
+    def catch_all():
+        return _serve_index()
 
     app.mount(
         "/",

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -4,6 +4,7 @@ const transformNodeModules = [
   "msw",
   "until-async",
   "chroma-js",
+  "keycloak-js",
 ];
 
 module.exports = {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,6 +18,7 @@
         "@types/styled-components": "^5.1.34",
         "dagre": "^0.8.5",
         "inter-ui": "^3.19.3",
+        "keycloak-js": "^26.2.4",
         "long": "^5.2.3",
         "moment": "^2.29.1",
         "protobufjs": "^7.1.1",
@@ -15137,6 +15138,15 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/keycloak-js": {
+      "version": "26.2.4",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.4.tgz",
+      "integrity": "sha512-PnXpR3ubETGOt0B/Qt2lxmPbkZr5bc3vlQsOqDoTPPQsZRp7JjhTKxlJ187uWh8qJhvBab6Gsjb06a8ayOPfuw==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "test"
+      ]
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,6 +32,7 @@
     "@types/styled-components": "^5.1.34",
     "dagre": "^0.8.5",
     "inter-ui": "^3.19.3",
+    "keycloak-js": "^26.2.4",
     "long": "^5.2.3",
     "moment": "^2.29.1",
     "protobufjs": "^7.1.1",

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -47,6 +47,7 @@ import {
 } from "./contexts/ProjectListContext";
 import DataModeContext from "./contexts/DataModeContext";
 import type { DataModeConfig, FetchOptions } from "./contexts/DataModeContext";
+import { AuthProvider, useAuth } from "./contexts/AuthContext";
 
 interface FeastUIConfigs {
   tabsRegistry?: FeastTabsRegistryInterface;
@@ -86,11 +87,13 @@ const FeastUISansProviders = ({
 
   return (
     <ThemeProvider>
-      <FeastUISansProvidersInner
-        basename={basename}
-        projectListContext={projectListContext}
-        feastUIConfigs={feastUIConfigs}
-      />
+      <AuthProvider>
+        <FeastUISansProvidersInner
+          basename={basename}
+          projectListContext={projectListContext}
+          feastUIConfigs={feastUIConfigs}
+        />
+      </AuthProvider>
     </ThemeProvider>
   );
 };
@@ -105,6 +108,7 @@ const FeastUISansProvidersInner = ({
   feastUIConfigs?: FeastUIConfigs;
 }) => {
   const { colorMode } = useTheme();
+  const { isInitializing } = useAuth();
 
   const dataModeConfig: DataModeConfig = {
     fetchOptions: feastUIConfigs?.fetchOptions,
@@ -115,6 +119,26 @@ const FeastUISansProvidersInner = ({
       apiBaseUrl: "/api/v1",
       enabled: true,
     };
+
+  if (isInitializing) {
+    return (
+      <EuiProvider colorMode={colorMode}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            height: "100vh",
+            flexDirection: "column",
+            gap: 16,
+          }}
+        >
+          <div className="euiLoadingSpinner euiLoadingSpinner--large" />
+          <p style={{ color: "#69707D" }}>Connecting to identity provider...</p>
+        </div>
+      </EuiProvider>
+    );
+  }
 
   return (
     <EuiProvider colorMode={colorMode}>

--- a/ui/src/components/ExplorePanel.tsx
+++ b/ui/src/components/ExplorePanel.tsx
@@ -15,9 +15,12 @@ import { useNavigate } from "react-router-dom";
 import useFCOExploreSuggestions from "../hooks/useFCOExploreSuggestions";
 
 const ExplorePanel = () => {
-  const { isLoading, isSuccess, data } = useFCOExploreSuggestions();
+  const { isLoading, isSuccess, isPermissionDenied, data } =
+    useFCOExploreSuggestions();
 
   const navigate = useNavigate();
+
+  if (isPermissionDenied) return null;
 
   return (
     <EuiPanel>

--- a/ui/src/components/ObjectsCountStats.tsx
+++ b/ui/src/components/ObjectsCountStats.tsx
@@ -4,7 +4,6 @@ import {
   EuiFlexItem,
   EuiStat,
   EuiHorizontalRule,
-  EuiTitle,
   EuiSpacer,
 } from "@elastic/eui";
 import { useNavigate, useParams } from "react-router-dom";
@@ -26,124 +25,104 @@ const ObjectsCountStats = () => {
   const { projectName } = useParams();
   const navigate = useNavigate();
 
-  const { data: featureServices, isSuccess: fsOk } = useResourceQuery<any[]>({
+  const fsQuery = useResourceQuery<any[]>({
     resourceType: "stats-fs",
     project: projectName,
     restPath: featureServiceListPath(projectName),
     restSelect: (d) => d.featureServices,
   });
 
-  const { data: featureViews, isSuccess: fvOk } = useResourceQuery<
-    genericFVType[]
-  >({
+  const fvQuery = useResourceQuery<genericFVType[]>({
     resourceType: "stats-fvs",
     project: projectName,
     restPath: featureViewListPath(projectName),
     restSelect: restFeatureViewsToMergedList,
   });
 
-  const { data: entities, isSuccess: entOk } = useResourceQuery<any[]>({
+  const entQuery = useResourceQuery<any[]>({
     resourceType: "stats-ent",
     project: projectName,
     restPath: entityListPath(projectName),
     restSelect: (d) => d.entities,
   });
 
-  const { data: dataSources, isSuccess: dsOk } = useResourceQuery<any[]>({
+  const dsQuery = useResourceQuery<any[]>({
     resourceType: "stats-ds",
     project: projectName,
     restPath: dataSourceListPath(projectName),
     restSelect: (d) => d.dataSources,
   });
 
-  const { data: features, isSuccess: featOk } = useResourceQuery<any[]>({
+  const featQuery = useResourceQuery<any[]>({
     resourceType: "stats-feat",
     project: projectName,
     restPath: featuresListPath(projectName),
     restSelect: (d) => d.features || [],
   });
 
-  const { data: labelViews, isSuccess: lvOk } = useResourceQuery<any[]>({
+  const lvQuery = useResourceQuery<any[]>({
     resourceType: "stats-lv",
     project: projectName,
     restPath: labelViewListPath(projectName),
     restSelect: restLabelViewsFromResponse,
   });
 
-  const allOk = fsOk && fvOk && entOk && dsOk && featOk && lvOk;
-  const hasLabelViews = (labelViews?.length || 0) > 0;
+  const settled = (q: { isSuccess: boolean; isError: boolean }) =>
+    q.isSuccess || q.isError;
+  const allSettled =
+    settled(fsQuery) &&
+    settled(fvQuery) &&
+    settled(entQuery) &&
+    settled(dsQuery) &&
+    settled(featQuery) &&
+    settled(lvQuery);
+
+  const stat = (
+    q: { data?: any[]; isPermissionDenied: boolean },
+    label: string,
+    path: string,
+  ) => {
+    if (q.isPermissionDenied) return null;
+    return (
+      <EuiFlexItem>
+        <EuiStat
+          style={statStyle}
+          onClick={() => navigate(`/p/${projectName}/${path}`)}
+          description={`${label}→`}
+          title={q.data?.length || 0}
+          reverse
+        />
+      </EuiFlexItem>
+    );
+  };
+
+  const hasLabelViews =
+    !lvQuery.isPermissionDenied && (lvQuery.data?.length || 0) > 0;
+
+  const queries = [fsQuery, fvQuery, featQuery, entQuery, dsQuery, lvQuery];
+  const hasAnyAccessible = queries.some((q) => !q.isPermissionDenied);
+
+  if (allSettled && !hasAnyAccessible) return null;
 
   return (
     <React.Fragment>
       <EuiSpacer size="l" />
       <EuiHorizontalRule margin="xs" />
-      {!allOk && <p>Loading</p>}
-      {allOk && (
+      {!allSettled && <p>Loading</p>}
+      {allSettled && (
         <React.Fragment>
-          <EuiTitle size="xs">
-            <h3>Registered in this Feast project are &hellip;</h3>
-          </EuiTitle>
-          <EuiSpacer size="s" />
           <EuiFlexGroup>
-            <EuiFlexItem>
-              <EuiStat
-                style={statStyle}
-                onClick={() => navigate(`/p/${projectName}/feature-service`)}
-                description="Feature Services→"
-                title={featureServices?.length || 0}
-                reverse
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiStat
-                style={statStyle}
-                description="Feature Views→"
-                onClick={() => navigate(`/p/${projectName}/feature-view`)}
-                title={featureViews?.length || 0}
-                reverse
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiStat
-                style={statStyle}
-                description="Features→"
-                onClick={() => navigate(`/p/${projectName}/features`)}
-                title={features?.length || 0}
-                reverse
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiStat
-                style={statStyle}
-                description="Entities→"
-                onClick={() => navigate(`/p/${projectName}/entity`)}
-                title={entities?.length || 0}
-                reverse
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiStat
-                style={statStyle}
-                description="Data Sources→"
-                onClick={() => navigate(`/p/${projectName}/data-source`)}
-                title={dataSources?.length || 0}
-                reverse
-              />
-            </EuiFlexItem>
+            {stat(fsQuery, "Feature Services", "feature-service")}
+            {stat(fvQuery, "Feature Views", "feature-view")}
+            {stat(featQuery, "Features", "features")}
+            {stat(entQuery, "Entities", "entity")}
+            {stat(dsQuery, "Data Sources", "data-source")}
           </EuiFlexGroup>
           {hasLabelViews && (
             <React.Fragment>
               <EuiSpacer size="m" />
               <EuiFlexGroup>
-                <EuiFlexItem>
-                  <EuiStat
-                    style={statStyle}
-                    onClick={() => navigate(`/p/${projectName}/label-view`)}
-                    description="Label Views→"
-                    title={labelViews?.length || 0}
-                    reverse
-                  />
-                </EuiFlexItem>
+                {stat(lvQuery, "Label Views", "label-view")}
                 <EuiFlexItem />
                 <EuiFlexItem />
                 <EuiFlexItem />

--- a/ui/src/components/PermissionFormModal.tsx
+++ b/ui/src/components/PermissionFormModal.tsx
@@ -1,0 +1,581 @@
+import React, { useState } from "react";
+import {
+  EuiFormRow,
+  EuiFieldText,
+  EuiSpacer,
+  EuiCallOut,
+  EuiCheckboxGroup,
+  EuiRadioGroup,
+  EuiTitle,
+  EuiHorizontalRule,
+  EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonEmpty,
+  EuiFieldText as EuiField,
+  EuiButtonIcon,
+  EuiToolTip,
+  EuiPanel,
+} from "@elastic/eui";
+import FormModal from "./forms/FormModal";
+import TagsEditor, { TagEntry } from "./forms/TagsEditor";
+
+const RESOURCE_TYPES = [
+  { id: "FEATURE_VIEW", label: "Feature View" },
+  { id: "ON_DEMAND_FEATURE_VIEW", label: "On-Demand Feature View" },
+  { id: "BATCH_FEATURE_VIEW", label: "Batch Feature View" },
+  { id: "STREAM_FEATURE_VIEW", label: "Stream Feature View" },
+  { id: "ENTITY", label: "Entity" },
+  { id: "FEATURE_SERVICE", label: "Feature Service" },
+  { id: "DATA_SOURCE", label: "Data Source" },
+  { id: "VALIDATION_REFERENCE", label: "Validation Reference" },
+  { id: "SAVED_DATASET", label: "Saved Dataset" },
+  { id: "PERMISSION", label: "Permission" },
+  { id: "PROJECT", label: "Project" },
+  { id: "LABEL_VIEW", label: "Label View" },
+];
+
+const ACTIONS = [
+  { id: "CREATE", label: "Create" },
+  { id: "DESCRIBE", label: "Describe" },
+  { id: "UPDATE", label: "Update" },
+  { id: "DELETE", label: "Delete" },
+  { id: "READ_ONLINE", label: "Read Online" },
+  { id: "READ_OFFLINE", label: "Read Offline" },
+  { id: "WRITE_ONLINE", label: "Write Online" },
+  { id: "WRITE_OFFLINE", label: "Write Offline" },
+];
+
+const ACTION_PRESETS = [
+  {
+    id: "all",
+    label: "All Actions",
+    actions: ACTIONS.map((a) => a.id),
+  },
+  {
+    id: "crud",
+    label: "CRUD Only",
+    actions: ["CREATE", "DESCRIBE", "UPDATE", "DELETE"],
+  },
+  {
+    id: "read",
+    label: "Read Only",
+    actions: ["DESCRIBE", "READ_ONLINE", "READ_OFFLINE"],
+  },
+  {
+    id: "write",
+    label: "Write Only",
+    actions: ["WRITE_ONLINE", "WRITE_OFFLINE"],
+  },
+];
+
+type PolicyType = "role_based" | "group_based" | "namespace_based" | "combined";
+
+const POLICY_TYPE_OPTIONS = [
+  { id: "role_based", label: "Role-based" },
+  { id: "group_based", label: "Group-based" },
+  { id: "namespace_based", label: "Namespace-based" },
+  { id: "combined", label: "Combined (Groups + Namespaces)" },
+];
+
+interface PermissionFormData {
+  name: string;
+  types: string[];
+  namePatterns: string[];
+  actions: string[];
+  policyType: PolicyType;
+  roles: string[];
+  groups: string[];
+  namespaces: string[];
+  tags: TagEntry[];
+  requiredTags: TagEntry[];
+}
+
+interface PermissionFormModalProps {
+  onClose: () => void;
+  onSubmit: (data: PermissionFormData) => void;
+  initialData?: PermissionFormData;
+  isEdit?: boolean;
+  isSubmitting?: boolean;
+  submitError?: string | null;
+}
+
+const EMPTY_FORM: PermissionFormData = {
+  name: "",
+  types: [],
+  namePatterns: [],
+  actions: [],
+  policyType: "role_based",
+  roles: [],
+  groups: [],
+  namespaces: [],
+  tags: [],
+  requiredTags: [],
+};
+
+const StringListEditor: React.FC<{
+  items: string[];
+  onChange: (items: string[]) => void;
+  placeholder: string;
+  addLabel: string;
+}> = ({ items, onChange, placeholder, addLabel }) => {
+  return (
+    <>
+      {items.map((item, index) => (
+        <EuiFlexGroup
+          key={index}
+          gutterSize="s"
+          alignItems="center"
+          style={{ marginTop: 4 }}
+        >
+          <EuiFlexItem>
+            <EuiField
+              placeholder={placeholder}
+              value={item}
+              onChange={(e) => {
+                const updated = [...items];
+                updated[index] = e.target.value;
+                onChange(updated);
+              }}
+              compressed
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon
+              iconType="trash"
+              color="danger"
+              aria-label={`Remove ${placeholder.toLowerCase()}`}
+              onClick={() => onChange(items.filter((_, i) => i !== index))}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ))}
+      <EuiSpacer size="xs" />
+      <EuiButtonEmpty
+        size="s"
+        iconType="plus"
+        onClick={() => onChange([...items, ""])}
+        flush="left"
+      >
+        {addLabel}
+      </EuiButtonEmpty>
+    </>
+  );
+};
+
+const PermissionFormModal: React.FC<PermissionFormModalProps> = ({
+  onClose,
+  onSubmit,
+  initialData,
+  isEdit = false,
+  isSubmitting = false,
+  submitError,
+}) => {
+  const [formData, setFormData] = useState<PermissionFormData>(
+    initialData || EMPTY_FORM,
+  );
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    if (!formData.name.trim()) {
+      newErrors.name = "Permission name is required.";
+    } else if (!/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(formData.name)) {
+      newErrors.name =
+        "Must start with a letter or underscore, and contain only letters, numbers, underscores, and hyphens.";
+    }
+
+    if (formData.types.length === 0) {
+      newErrors.types = "Select at least one resource type.";
+    }
+
+    if (formData.actions.length === 0) {
+      newErrors.actions = "Select at least one action.";
+    }
+
+    if (formData.policyType === "role_based") {
+      const nonEmpty = formData.roles.filter((r) => r.trim());
+      if (nonEmpty.length === 0) {
+        newErrors.policy = "Add at least one role.";
+      }
+    } else if (formData.policyType === "group_based") {
+      const nonEmpty = formData.groups.filter((g) => g.trim());
+      if (nonEmpty.length === 0) {
+        newErrors.policy = "Add at least one group.";
+      }
+    } else if (formData.policyType === "namespace_based") {
+      const nonEmpty = formData.namespaces.filter((n) => n.trim());
+      if (nonEmpty.length === 0) {
+        newErrors.policy = "Add at least one namespace.";
+      }
+    } else if (formData.policyType === "combined") {
+      const hasGroups = formData.groups.filter((g) => g.trim()).length > 0;
+      const hasNamespaces =
+        formData.namespaces.filter((n) => n.trim()).length > 0;
+      if (!hasGroups && !hasNamespaces) {
+        newErrors.policy = "Add at least one group or namespace.";
+      }
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = () => {
+    if (validate()) {
+      onSubmit(formData);
+    }
+  };
+
+  const selectedTypesMap: Record<string, boolean> = {};
+  formData.types.forEach((t) => {
+    selectedTypesMap[t] = true;
+  });
+
+  const selectedActionsMap: Record<string, boolean> = {};
+  formData.actions.forEach((a) => {
+    selectedActionsMap[a] = true;
+  });
+
+  const handleTypeToggle = (id: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      types: prev.types.includes(id)
+        ? prev.types.filter((t) => t !== id)
+        : [...prev.types, id],
+    }));
+  };
+
+  const handleActionToggle = (id: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      actions: prev.actions.includes(id)
+        ? prev.actions.filter((a) => a !== id)
+        : [...prev.actions, id],
+    }));
+  };
+
+  const applyActionPreset = (presetActions: string[]) => {
+    setFormData((prev) => ({ ...prev, actions: [...presetActions] }));
+  };
+
+  const selectAllTypes = () => {
+    setFormData((prev) => ({
+      ...prev,
+      types: RESOURCE_TYPES.map((t) => t.id),
+    }));
+  };
+
+  const clearAllTypes = () => {
+    setFormData((prev) => ({ ...prev, types: [] }));
+  };
+
+  return (
+    <FormModal
+      title={isEdit ? "Edit Permission" : "Create Permission"}
+      submitLabel={isEdit ? "Update" : "Create Permission"}
+      onClose={onClose}
+      onSubmit={handleSubmit}
+      isSubmitting={isSubmitting}
+      width={700}
+    >
+      {submitError && (
+        <>
+          <EuiCallOut title={submitError} color="danger" size="s" />
+          <EuiSpacer size="m" />
+        </>
+      )}
+
+      {/* Section 1: Identity */}
+      <EuiTitle size="xxs">
+        <h3>Identity</h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+
+      <EuiFormRow
+        label="Permission Name"
+        isInvalid={!!errors.name}
+        error={errors.name}
+        helpText="A unique name to identify this permission rule."
+      >
+        <EuiFieldText
+          value={formData.name}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, name: e.target.value }))
+          }
+          isInvalid={!!errors.name}
+          disabled={isEdit}
+          placeholder="e.g. data-team-read-access"
+        />
+      </EuiFormRow>
+
+      <EuiHorizontalRule margin="m" />
+
+      {/* Section 2: Resource Scope */}
+      <EuiTitle size="xxs">
+        <h3>Resource Scope</h3>
+      </EuiTitle>
+      <EuiText size="xs" color="subdued">
+        <p>Define which resources this permission applies to.</p>
+      </EuiText>
+      <EuiSpacer size="s" />
+
+      <EuiFormRow
+        label="Resource Types"
+        isInvalid={!!errors.types}
+        error={errors.types}
+      >
+        <>
+          <EuiFlexGroup gutterSize="s" style={{ marginBottom: 8 }}>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty size="xs" onClick={selectAllTypes}>
+                Select All
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty size="xs" onClick={clearAllTypes}>
+                Clear All
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+          <EuiPanel paddingSize="s" hasBorder>
+            <EuiCheckboxGroup
+              options={RESOURCE_TYPES}
+              idToSelectedMap={selectedTypesMap}
+              onChange={handleTypeToggle}
+              compressed
+            />
+          </EuiPanel>
+        </>
+      </EuiFormRow>
+
+      <EuiSpacer size="m" />
+
+      <EuiFormRow
+        label={
+          <EuiToolTip content="Regex patterns to match specific resource names. Leave empty to match all resources of the selected types.">
+            <span>
+              Name Patterns{" "}
+              <EuiText size="xs" color="subdued" component="span">
+                (optional)
+              </EuiText>
+            </span>
+          </EuiToolTip>
+        }
+      >
+        <StringListEditor
+          items={formData.namePatterns}
+          onChange={(namePatterns) =>
+            setFormData((prev) => ({ ...prev, namePatterns }))
+          }
+          placeholder="e.g. driver_.*"
+          addLabel="Add name pattern"
+        />
+      </EuiFormRow>
+
+      <EuiSpacer size="s" />
+      <EuiFormRow
+        label={
+          <EuiToolTip content="Tags that a resource must have for this permission to apply.">
+            <span>
+              Required Tags{" "}
+              <EuiText size="xs" color="subdued" component="span">
+                (optional)
+              </EuiText>
+            </span>
+          </EuiToolTip>
+        }
+      >
+        <TagsEditor
+          tags={formData.requiredTags}
+          onChange={(requiredTags) =>
+            setFormData((prev) => ({ ...prev, requiredTags }))
+          }
+        />
+      </EuiFormRow>
+
+      <EuiHorizontalRule margin="m" />
+
+      {/* Section 3: Actions */}
+      <EuiTitle size="xxs">
+        <h3>Allowed Actions</h3>
+      </EuiTitle>
+      <EuiText size="xs" color="subdued">
+        <p>Which operations are permitted on matching resources.</p>
+      </EuiText>
+      <EuiSpacer size="s" />
+
+      <EuiFormRow isInvalid={!!errors.actions} error={errors.actions}>
+        <>
+          <EuiFlexGroup gutterSize="s" style={{ marginBottom: 8 }} wrap>
+            {ACTION_PRESETS.map((preset) => (
+              <EuiFlexItem grow={false} key={preset.id}>
+                <EuiButtonEmpty
+                  size="xs"
+                  onClick={() => applyActionPreset(preset.actions)}
+                  color={
+                    JSON.stringify([...formData.actions].sort()) ===
+                    JSON.stringify([...preset.actions].sort())
+                      ? "primary"
+                      : "text"
+                  }
+                >
+                  {preset.label}
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+          <EuiPanel paddingSize="s" hasBorder>
+            <EuiCheckboxGroup
+              options={ACTIONS}
+              idToSelectedMap={selectedActionsMap}
+              onChange={handleActionToggle}
+              compressed
+            />
+          </EuiPanel>
+        </>
+      </EuiFormRow>
+
+      <EuiHorizontalRule margin="m" />
+
+      {/* Section 4: Policy */}
+      <EuiTitle size="xxs">
+        <h3>Access Policy</h3>
+      </EuiTitle>
+      <EuiText size="xs" color="subdued">
+        <p>
+          Define who is authorized. A user must match at least one entry in the
+          policy to be granted access.
+        </p>
+      </EuiText>
+      <EuiSpacer size="s" />
+
+      <EuiFormRow label="Policy Type">
+        <EuiRadioGroup
+          options={POLICY_TYPE_OPTIONS}
+          idSelected={formData.policyType}
+          onChange={(id) =>
+            setFormData((prev) => ({
+              ...prev,
+              policyType: id as PolicyType,
+            }))
+          }
+          compressed
+        />
+      </EuiFormRow>
+
+      <EuiSpacer size="s" />
+
+      {errors.policy && (
+        <>
+          <EuiCallOut title={errors.policy} color="danger" size="s" />
+          <EuiSpacer size="s" />
+        </>
+      )}
+
+      {(formData.policyType === "role_based" ||
+        formData.policyType === "combined") && (
+        <EuiFormRow
+          label={formData.policyType === "combined" ? "Groups" : undefined}
+        >
+          <>
+            {formData.policyType === "role_based" && (
+              <EuiText size="xs" color="subdued">
+                <p>User must have at least one of these roles.</p>
+              </EuiText>
+            )}
+            {formData.policyType === "role_based" && (
+              <StringListEditor
+                items={formData.roles}
+                onChange={(roles) =>
+                  setFormData((prev) => ({ ...prev, roles }))
+                }
+                placeholder="e.g. admin, data-engineer"
+                addLabel="Add role"
+              />
+            )}
+          </>
+        </EuiFormRow>
+      )}
+
+      {(formData.policyType === "group_based" ||
+        formData.policyType === "combined") && (
+        <EuiFormRow
+          label={formData.policyType === "combined" ? "Groups" : undefined}
+        >
+          <>
+            {formData.policyType === "group_based" && (
+              <EuiText size="xs" color="subdued">
+                <p>User must belong to at least one of these groups.</p>
+              </EuiText>
+            )}
+            <StringListEditor
+              items={formData.groups}
+              onChange={(groups) =>
+                setFormData((prev) => ({ ...prev, groups }))
+              }
+              placeholder="e.g. ml-team, platform-team"
+              addLabel="Add group"
+            />
+          </>
+        </EuiFormRow>
+      )}
+
+      {(formData.policyType === "namespace_based" ||
+        formData.policyType === "combined") && (
+        <EuiFormRow
+          label={formData.policyType === "combined" ? "Namespaces" : undefined}
+        >
+          <>
+            {formData.policyType === "namespace_based" && (
+              <EuiText size="xs" color="subdued">
+                <p>User must be in at least one of these namespaces.</p>
+              </EuiText>
+            )}
+            <StringListEditor
+              items={formData.namespaces}
+              onChange={(namespaces) =>
+                setFormData((prev) => ({ ...prev, namespaces }))
+              }
+              placeholder="e.g. production, staging"
+              addLabel="Add namespace"
+            />
+          </>
+        </EuiFormRow>
+      )}
+
+      {formData.policyType === "combined" && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiText size="xs" color="subdued">
+            <p>
+              User must match at least one group <strong>or</strong> one
+              namespace.
+            </p>
+          </EuiText>
+        </>
+      )}
+
+      <EuiHorizontalRule margin="m" />
+
+      {/* Section 5: Tags */}
+      <EuiTitle size="xxs">
+        <h3>
+          Metadata Tags{" "}
+          <EuiText size="xs" color="subdued" component="span">
+            (optional)
+          </EuiText>
+        </h3>
+      </EuiTitle>
+      <EuiSpacer size="s" />
+      <TagsEditor
+        tags={formData.tags}
+        onChange={(tags) => setFormData((prev) => ({ ...prev, tags }))}
+      />
+    </FormModal>
+  );
+};
+
+export default PermissionFormModal;
+export type { PermissionFormData };

--- a/ui/src/components/PermissionsDisplay.tsx
+++ b/ui/src/components/PermissionsDisplay.tsx
@@ -5,11 +5,63 @@ import {
   EuiFlexItem,
   EuiText,
   EuiToolTip,
+  EuiPanel,
+  EuiSpacer,
+  EuiHorizontalRule,
 } from "@elastic/eui";
 
 interface PermissionsDisplayProps {
   permissions: any[] | undefined;
 }
+
+const ACTION_NAMES = [
+  "CREATE",
+  "DESCRIBE",
+  "UPDATE",
+  "DELETE",
+  "READ_ONLINE",
+  "READ_OFFLINE",
+  "WRITE_ONLINE",
+  "WRITE_OFFLINE",
+];
+
+const getActionColor = (action: string) => {
+  if (action.startsWith("READ")) return "success";
+  if (action.startsWith("WRITE")) return "warning";
+  if (action === "CREATE") return "primary";
+  if (action === "UPDATE") return "accent";
+  if (action === "DELETE") return "danger";
+  if (action === "DESCRIBE") return "hollow";
+  return "default";
+};
+
+const getPolicyLabel = (policy: any): string => {
+  if (!policy) return "Allow All";
+  if (policy.roleBasedPolicy?.roles) {
+    return `Roles: ${policy.roleBasedPolicy.roles.join(", ")}`;
+  }
+  if (policy.groupBasedPolicy?.groups) {
+    return `Groups: ${policy.groupBasedPolicy.groups.join(", ")}`;
+  }
+  if (policy.namespaceBasedPolicy?.namespaces) {
+    return `Namespaces: ${policy.namespaceBasedPolicy.namespaces.join(", ")}`;
+  }
+  if (policy.combinedGroupNamespacePolicy) {
+    const parts = [];
+    if (policy.combinedGroupNamespacePolicy.groups?.length) {
+      parts.push(
+        `Groups: ${policy.combinedGroupNamespacePolicy.groups.join(", ")}`,
+      );
+    }
+    if (policy.combinedGroupNamespacePolicy.namespaces?.length) {
+      parts.push(
+        `Namespaces: ${policy.combinedGroupNamespacePolicy.namespaces.join(", ")}`,
+      );
+    }
+    return parts.join(" | ") || "Allow All";
+  }
+  return "Allow All";
+};
 
 const PermissionsDisplay: React.FC<PermissionsDisplayProps> = ({
   permissions,
@@ -22,78 +74,65 @@ const PermissionsDisplay: React.FC<PermissionsDisplayProps> = ({
     );
   }
 
-  const getActionColor = (action: string) => {
-    if (action.startsWith("READ")) return "success";
-    if (action.startsWith("WRITE")) return "warning";
-    if (action === "CREATE") return "primary";
-    if (action === "UPDATE") return "accent";
-    if (action === "DELETE") return "danger";
-    return "default";
-  };
-
   return (
     <React.Fragment>
       {permissions.map((permission, index) => {
-        const actions = permission.spec?.actions?.map((a: number) => {
-          const actionNames = [
-            "CREATE",
-            "DESCRIBE",
-            "UPDATE",
-            "DELETE",
-            "READ_ONLINE",
-            "READ_OFFLINE",
-            "WRITE_ONLINE",
-            "WRITE_OFFLINE",
-          ];
-          return actionNames[a] || `Unknown (${a})`;
-        });
+        const actions = (permission.spec?.actions || []).map(
+          (a: number) => ACTION_NAMES[a] || `Unknown (${a})`,
+        );
+        const policy = permission.spec?.policy;
+        const policyLabel = getPolicyLabel(policy);
+        const namePatterns =
+          permission.spec?.namePatterns || permission.spec?.name_patterns || [];
+        const requiredTags =
+          permission.spec?.requiredTags || permission.spec?.required_tags || {};
 
         return (
-          <div key={index} style={{ marginBottom: "8px" }}>
-            <EuiToolTip
-              position="top"
-              content={
-                <div>
-                  <p>
-                    <strong>Name:</strong> {permission.spec?.name}
-                  </p>
-                  <p>
-                    <strong>Policy:</strong>{" "}
-                    {permission.spec?.policy?.roles
-                      ? `Roles: ${permission.spec.policy.roles.join(", ")}`
-                      : "No policy defined"}
-                  </p>
-                  {permission.spec?.name_patterns && (
-                    <p>
-                      <strong>Name Patterns:</strong>{" "}
-                      {Array.isArray(permission.spec.name_patterns)
-                        ? permission.spec.name_patterns.join(", ")
-                        : permission.spec.name_patterns}
-                    </p>
-                  )}
-                  {permission.spec?.required_tags && (
-                    <p>
-                      <strong>Required Tags:</strong>{" "}
-                      {Object.entries(permission.spec.required_tags)
-                        .map(([key, value]) => `${key}: ${value}`)
-                        .join(", ")}
-                    </p>
-                  )}
-                </div>
-              }
-            >
+          <React.Fragment key={index}>
+            {index > 0 && <EuiHorizontalRule margin="s" />}
+            <EuiPanel paddingSize="s" hasBorder={false} hasShadow={false}>
               <EuiText>
                 <h4>{permission.spec?.name}</h4>
               </EuiText>
-            </EuiToolTip>
-            <EuiFlexGroup wrap responsive={false} gutterSize="xs">
-              {actions.map((action: string, actionIndex: number) => (
-                <EuiFlexItem grow={false} key={actionIndex}>
-                  <EuiBadge color={getActionColor(action)}>{action}</EuiBadge>
-                </EuiFlexItem>
-              ))}
-            </EuiFlexGroup>
-          </div>
+              <EuiSpacer size="xs" />
+              <EuiFlexGroup wrap responsive={false} gutterSize="xs">
+                {actions.map((action: string, actionIndex: number) => (
+                  <EuiFlexItem grow={false} key={actionIndex}>
+                    <EuiBadge color={getActionColor(action)}>{action}</EuiBadge>
+                  </EuiFlexItem>
+                ))}
+              </EuiFlexGroup>
+              <EuiSpacer size="xs" />
+              <EuiToolTip
+                position="bottom"
+                content={
+                  <div>
+                    <p>
+                      <strong>Policy:</strong> {policyLabel}
+                    </p>
+                    {namePatterns.length > 0 && (
+                      <p>
+                        <strong>Name Patterns:</strong>{" "}
+                        {namePatterns.join(", ")}
+                      </p>
+                    )}
+                    {Object.keys(requiredTags).length > 0 && (
+                      <p>
+                        <strong>Required Tags:</strong>{" "}
+                        {Object.entries(requiredTags)
+                          .map(([key, value]) => `${key}: ${value}`)
+                          .join(", ")}
+                      </p>
+                    )}
+                  </div>
+                }
+              >
+                <EuiText size="xs" color="subdued">
+                  {policyLabel}
+                </EuiText>
+              </EuiToolTip>
+            </EuiPanel>
+          </React.Fragment>
         );
       })}
     </React.Fragment>

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -1,0 +1,245 @@
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
+// @ts-ignore -- keycloak-js types use "exports" field; bundler resolves the JS fine
+import Keycloak from "keycloak-js";
+
+interface AuthUser {
+  username: string;
+  roles: string[];
+  groups: string[];
+  email?: string;
+}
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  isAuthEnabled: boolean;
+  isInitializing: boolean;
+  logout: () => void;
+  keycloak: Keycloak | null;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  isAuthenticated: false,
+  isAuthEnabled: false,
+  isInitializing: true,
+  logout: () => {},
+  keycloak: null,
+});
+
+interface ServerAuthConfig {
+  auth_type: string;
+  url?: string;
+  realm?: string;
+  client_id?: string;
+  auth_discovery_url?: string;
+}
+
+function readServerAuthConfig(): ServerAuthConfig | null {
+  // Injected by the Feast UI server (feast ui) into index.html from feature_store.yaml
+  const el = document.getElementById("feast-auth-config");
+  if (el) {
+    try {
+      return JSON.parse(el.textContent || "{}");
+    } catch {
+      /* fall through */
+    }
+  }
+
+  // Dev mode fallback: fetch from /api/auth-config (served by setupProxy or REST server)
+  return null;
+}
+
+function extractUser(kc: Keycloak): AuthUser {
+  const parsed = kc.tokenParsed as any;
+  const clientRoles: string[] =
+    parsed?.resource_access?.[kc.clientId!]?.roles || [];
+  const realmRoles: string[] = parsed?.realm_access?.roles || [];
+  const combined = [...clientRoles, ...realmRoles];
+
+  return {
+    username: parsed?.preferred_username || "unknown",
+    roles: combined.filter((v, i) => combined.indexOf(v) === i),
+    groups: parsed?.groups || [],
+    email: parsed?.email,
+  };
+}
+
+const TOKEN_REFRESH_INTERVAL = 30_000;
+const MIN_VALIDITY_SECS = 60;
+
+const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [kc, setKc] = useState<Keycloak | null>(null);
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isInitializing, setIsInitializing] = useState(true);
+  const [isAuthEnabled, setIsAuthEnabled] = useState(false);
+  const initStarted = useRef(false);
+
+  const syncUser = useCallback((keycloak: Keycloak) => {
+    if (keycloak.authenticated) {
+      setUser(extractUser(keycloak));
+    }
+  }, []);
+
+  const doRefresh = useCallback(
+    (keycloak: Keycloak) => {
+      keycloak
+        .updateToken(MIN_VALIDITY_SECS)
+        .then((refreshed: boolean) => {
+          if (refreshed) {
+            syncUser(keycloak);
+          }
+        })
+        .catch(() => {
+          console.warn("Token refresh failed — redirecting to login");
+          keycloak.login();
+        });
+    },
+    [syncUser],
+  );
+
+  useEffect(() => {
+    if (initStarted.current) return;
+    initStarted.current = true;
+
+    const initAuth = async () => {
+      const config = readServerAuthConfig();
+
+      if (!config || config.auth_type !== "oidc") {
+        // Auth is disabled — skip Keycloak, render the app immediately
+        setIsAuthEnabled(false);
+        setIsInitializing(false);
+        return;
+      }
+
+      setIsAuthEnabled(true);
+
+      const keycloak = new Keycloak({
+        url: config.url || "http://localhost:8080",
+        realm: config.realm || "feast",
+        clientId: config.client_id || "feast-ui",
+      });
+
+      keycloak.onTokenExpired = () => {
+        console.info("Access token expired — attempting refresh");
+        doRefresh(keycloak);
+      };
+
+      keycloak.onAuthRefreshSuccess = () => {
+        syncUser(keycloak);
+      };
+
+      keycloak.onAuthRefreshError = () => {
+        console.warn("Auth refresh error — redirecting to login");
+        keycloak.login();
+      };
+
+      try {
+        const authenticated = await keycloak.init({
+          onLoad: "login-required",
+          checkLoginIframe: false,
+          pkceMethod: "S256",
+        });
+
+        setKc(keycloak);
+        if (authenticated) {
+          syncUser(keycloak);
+        }
+      } catch (err) {
+        console.error("Keycloak init failed:", err);
+      }
+
+      setIsInitializing(false);
+    };
+
+    initAuth();
+  }, [doRefresh, syncUser]);
+
+  // Proactive token refresh
+  useEffect(() => {
+    if (!kc?.authenticated) return;
+    const id = setInterval(() => doRefresh(kc), TOKEN_REFRESH_INTERVAL);
+    return () => clearInterval(id);
+  }, [kc, doRefresh]);
+
+  // Global fetch interceptor: inject auth header on /api/ calls, handle 401
+  useEffect(() => {
+    if (!kc) return;
+
+    const originalFetch = window.fetch;
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof Request
+            ? input.url
+            : input.toString();
+
+      const isApiCall = url.includes("/api/");
+
+      if (isApiCall && kc.authenticated && kc.token) {
+        const mergedHeaders = new Headers(init?.headers);
+        if (!mergedHeaders.has("Authorization")) {
+          mergedHeaders.set("Authorization", `Bearer ${kc.token}`);
+        }
+        init = { ...init, headers: mergedHeaders };
+      }
+
+      let response = await originalFetch(input, init);
+
+      if (response.status === 401 && isApiCall) {
+        console.warn("API returned 401 — attempting token refresh and retry");
+        try {
+          await kc.updateToken(5);
+          syncUser(kc);
+          const retryHeaders = new Headers(init?.headers);
+          retryHeaders.set("Authorization", `Bearer ${kc.token}`);
+          response = await originalFetch(input, {
+            ...init,
+            headers: retryHeaders,
+          });
+        } catch {
+          kc.login();
+        }
+      }
+
+      return response;
+    };
+
+    return () => {
+      window.fetch = originalFetch;
+    };
+  }, [kc, syncUser]);
+
+  const logout = useCallback(() => {
+    if (kc) {
+      kc.logout({ redirectUri: window.location.origin });
+    }
+  }, [kc]);
+
+  const value: AuthContextValue = {
+    user,
+    isAuthenticated: !!kc?.authenticated,
+    isAuthEnabled,
+    isInitializing,
+    logout,
+    keycloak: kc,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+const useAuth = () => useContext(AuthContext);
+
+export default AuthContext;
+export { AuthProvider, useAuth };
+export type { AuthUser };

--- a/ui/src/pages/Layout.tsx
+++ b/ui/src/pages/Layout.tsx
@@ -9,6 +9,13 @@ import {
   EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiAvatar,
+  EuiText,
+  EuiBadge,
+  EuiToolTip,
+  EuiPopover,
+  EuiButtonEmpty,
+  EuiIcon,
 } from "@elastic/eui";
 import { Outlet } from "react-router-dom";
 
@@ -26,14 +33,14 @@ import RegistrySearch, {
 } from "../components/RegistrySearch";
 import GlobalSearchShortcut from "../components/GlobalSearchShortcut";
 import CommandPalette from "../components/CommandPalette";
+import { useAuth } from "../contexts/AuthContext";
 
 const Layout = () => {
-  // Registry Path Context has to be inside Layout
-  // because it has to be under routes
-  // in order to use useParams
   let { projectName } = useParams();
   const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const searchRef = useRef<RegistrySearchRef>(null);
+  const { user, logout, isAuthEnabled } = useAuth();
 
   const { data: projectsData } = useLoadProjectsList();
 
@@ -204,33 +211,167 @@ const Layout = () => {
                 height: "100vh",
               }}
             >
-              {data && (
-                <div
-                  style={{
-                    position: "sticky",
-                    top: 0,
-                    zIndex: 100,
-                    backgroundColor: "var(--euiPageBackgroundColor)",
-                    borderBottom: "1px solid #D3DAE6",
-                    boxShadow: "0px 1px 5px rgba(0, 0, 0, 0.05)",
-                    padding: "16px",
-                    width: "100%",
-                  }}
-                >
-                  <EuiFlexGroup justifyContent="center" alignItems="center">
-                    <EuiFlexItem
-                      grow={false}
-                      style={{ width: "600px", maxWidth: "90%" }}
-                    >
-                      <RegistrySearch
-                        ref={searchRef}
-                        categories={globalCategories}
-                      />
+              <div
+                style={{
+                  position: "sticky",
+                  top: 0,
+                  zIndex: 100,
+                  backgroundColor: "var(--euiPageBackgroundColor)",
+                  borderBottom: "1px solid #D3DAE6",
+                  boxShadow: "0px 1px 5px rgba(0, 0, 0, 0.05)",
+                  padding: "12px 16px",
+                  width: "100%",
+                }}
+              >
+                <EuiFlexGroup alignItems="center" gutterSize="m">
+                  {data && (
+                    <EuiFlexItem>
+                      <div
+                        style={{
+                          maxWidth: 600,
+                          margin: "0 auto",
+                          width: "100%",
+                        }}
+                      >
+                        <RegistrySearch
+                          ref={searchRef}
+                          categories={globalCategories}
+                        />
+                      </div>
                     </EuiFlexItem>
-                    <EuiFlexItem grow={false}></EuiFlexItem>
-                  </EuiFlexGroup>
-                </div>
-              )}
+                  )}
+                  {!data && <EuiFlexItem />}
+
+                  {isAuthEnabled && user && (
+                    <EuiFlexItem grow={false}>
+                      <EuiPopover
+                        button={
+                          <button
+                            onClick={() => setIsUserMenuOpen((v) => !v)}
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              gap: 8,
+                              background: "none",
+                              border: "none",
+                              cursor: "pointer",
+                              padding: "4px 8px",
+                              borderRadius: 6,
+                            }}
+                            aria-label="User menu"
+                          >
+                            <EuiAvatar
+                              name={user.username}
+                              size="s"
+                              color="#0061a6"
+                            />
+                            <EuiText size="xs">
+                              <strong>{user.username}</strong>
+                            </EuiText>
+                            <EuiIcon type="arrowDown" size="s" />
+                          </button>
+                        }
+                        isOpen={isUserMenuOpen}
+                        closePopover={() => setIsUserMenuOpen(false)}
+                        anchorPosition="downRight"
+                        panelPaddingSize="m"
+                      >
+                        <div style={{ minWidth: 220 }}>
+                          <EuiFlexGroup
+                            gutterSize="s"
+                            alignItems="center"
+                            responsive={false}
+                          >
+                            <EuiFlexItem grow={false}>
+                              <EuiAvatar
+                                name={user.username}
+                                size="m"
+                                color="#0061a6"
+                              />
+                            </EuiFlexItem>
+                            <EuiFlexItem>
+                              <EuiText size="s">
+                                <strong>{user.username}</strong>
+                              </EuiText>
+                              {user.email && (
+                                <EuiText size="xs" color="subdued">
+                                  {user.email}
+                                </EuiText>
+                              )}
+                            </EuiFlexItem>
+                          </EuiFlexGroup>
+
+                          {user.roles.length > 0 && (
+                            <>
+                              <EuiHorizontalRule margin="s" />
+                              <EuiText size="xs" color="subdued">
+                                <strong>Roles</strong>
+                              </EuiText>
+                              <EuiSpacer size="xs" />
+                              <div
+                                style={{
+                                  display: "flex",
+                                  flexWrap: "wrap",
+                                  gap: 4,
+                                }}
+                              >
+                                {user.roles
+                                  .filter(
+                                    (r) =>
+                                      ![
+                                        "default-roles-feast",
+                                        "offline_access",
+                                        "uma_authorization",
+                                      ].includes(r),
+                                  )
+                                  .map((role) => (
+                                    <EuiToolTip content={role} key={role}>
+                                      <EuiBadge color="hollow">{role}</EuiBadge>
+                                    </EuiToolTip>
+                                  ))}
+                              </div>
+                            </>
+                          )}
+
+                          {user.groups.length > 0 && (
+                            <>
+                              <EuiSpacer size="s" />
+                              <EuiText size="xs" color="subdued">
+                                <strong>Groups</strong>
+                              </EuiText>
+                              <EuiSpacer size="xs" />
+                              <div
+                                style={{
+                                  display: "flex",
+                                  flexWrap: "wrap",
+                                  gap: 4,
+                                }}
+                              >
+                                {user.groups.map((group) => (
+                                  <EuiBadge color="default" key={group}>
+                                    {group}
+                                  </EuiBadge>
+                                ))}
+                              </div>
+                            </>
+                          )}
+
+                          <EuiHorizontalRule margin="s" />
+                          <EuiButtonEmpty
+                            size="s"
+                            iconType="exit"
+                            onClick={logout}
+                            color="danger"
+                            flush="left"
+                          >
+                            Sign out
+                          </EuiButtonEmpty>
+                        </div>
+                      </EuiPopover>
+                    </EuiFlexItem>
+                  )}
+                </EuiFlexGroup>
+              </div>
               <div
                 style={{
                   flexGrow: 1,

--- a/ui/src/pages/ProjectOverviewPage.tsx
+++ b/ui/src/pages/ProjectOverviewPage.tsx
@@ -31,56 +31,70 @@ const AllProjectsDashboard = () => {
   const navigate = useNavigate();
   const { data: projectsData } = useLoadProjectsList();
 
-  const { data: allFVs } = useResourceQuery<genericFVType[]>({
+  const fvQuery = useResourceQuery<genericFVType[]>({
     resourceType: "all-proj-fvs",
     restPath: "/feature_views/all?limit=100&include_relationships=true",
     restSelect: restFeatureViewsToMergedList,
   });
 
-  const { data: allEntities } = useResourceQuery<any[]>({
+  const entQuery = useResourceQuery<any[]>({
     resourceType: "all-proj-entities",
     restPath: "/entities/all?limit=100",
     restSelect: (d) => d.entities,
   });
 
-  const { data: allDS } = useResourceQuery<any[]>({
+  const dsQuery = useResourceQuery<any[]>({
     resourceType: "all-proj-ds",
     restPath: "/data_sources/all?limit=100",
     restSelect: (d) => d.dataSources,
   });
 
-  const { data: allFS } = useResourceQuery<any[]>({
+  const fsQuery = useResourceQuery<any[]>({
     resourceType: "all-proj-fs",
     restPath: "/feature_services/all?limit=100",
     restSelect: (d) => d.featureServices,
   });
 
-  const { data: allFeatures } = useResourceQuery<any[]>({
+  const featQuery = useResourceQuery<any[]>({
     resourceType: "all-proj-features",
     restPath: "/features/all?limit=100",
     restSelect: (d) => d.features,
   });
 
-  const { data: allLabelViews } = useResourceQuery<any[]>({
+  const lvQuery = useResourceQuery<any[]>({
     resourceType: "all-proj-lvs",
     restPath: "/label_views/all?limit=100&include_relationships=true",
     restSelect: restLabelViewsFromResponse,
   });
 
-  const loaded =
-    allFVs && allEntities && allDS && allFS && allFeatures && allLabelViews;
+  const settled = (q: { isSuccess: boolean; isError: boolean }) =>
+    q.isSuccess || q.isError;
+  const allSettled =
+    settled(fvQuery) &&
+    settled(entQuery) &&
+    settled(dsQuery) &&
+    settled(fsQuery) &&
+    settled(featQuery) &&
+    settled(lvQuery);
 
-  if (!loaded) {
+  if (!allSettled) {
     return <EuiSkeletonText lines={10} />;
   }
 
+  const allFVs = fvQuery.data || [];
+  const allEntities = entQuery.data || [];
+  const allDS = dsQuery.data || [];
+  const allFS = fsQuery.data || [];
+  const allFeatures = featQuery.data || [];
+  const allLabelViews = lvQuery.data || [];
+
   const totalCounts = {
-    featureViews: allFVs.length,
-    entities: allEntities.length,
-    dataSources: allDS.length,
-    featureServices: allFS.length,
-    features: allFeatures.length,
-    labelViews: allLabelViews?.length || 0,
+    featureViews: fvQuery.isPermissionDenied ? null : allFVs.length,
+    entities: entQuery.isPermissionDenied ? null : allEntities.length,
+    dataSources: dsQuery.isPermissionDenied ? null : allDS.length,
+    featureServices: fsQuery.isPermissionDenied ? null : allFS.length,
+    features: featQuery.isPermissionDenied ? null : allFeatures.length,
+    labelViews: lvQuery.isPermissionDenied ? null : allLabelViews.length,
   };
 
   const projects = projectsData?.projects.filter((p) => p.id !== "all") || [];
@@ -90,11 +104,18 @@ const AllProjectsDashboard = () => {
     return {
       ...project,
       counts: {
-        featureViews: allFVs.filter((fv) => matchesProject(fv.object || fv))
-          .length,
-        entities: allEntities.filter(matchesProject).length,
-        features: allFeatures.filter(matchesProject).length,
-        labelViews: (allLabelViews || []).filter(matchesProject).length,
+        featureViews: fvQuery.isPermissionDenied
+          ? null
+          : allFVs.filter((fv: any) => matchesProject(fv.object || fv)).length,
+        entities: entQuery.isPermissionDenied
+          ? null
+          : allEntities.filter(matchesProject).length,
+        features: featQuery.isPermissionDenied
+          ? null
+          : allFeatures.filter(matchesProject).length,
+        labelViews: lvQuery.isPermissionDenied
+          ? null
+          : allLabelViews.filter(matchesProject).length,
       },
     };
   });
@@ -122,48 +143,58 @@ const AllProjectsDashboard = () => {
           </EuiTitle>
           <EuiSpacer size="m" />
           <EuiFlexGroup>
-            <EuiFlexItem>
-              <EuiStat
-                title={totalCounts.featureViews.toString()}
-                description="Feature Views"
-                titleSize="m"
-                textAlign="center"
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiStat
-                title={totalCounts.entities.toString()}
-                description="Entities"
-                titleSize="m"
-                textAlign="center"
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiStat
-                title={totalCounts.features.toString()}
-                description="Features"
-                titleSize="m"
-                textAlign="center"
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiStat
-                title={totalCounts.featureServices.toString()}
-                description="Feature Services"
-                titleSize="m"
-                textAlign="center"
-              />
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <EuiStat
-                title={totalCounts.dataSources.toString()}
-                description="Data Sources"
-                titleSize="m"
-                textAlign="center"
-              />
-            </EuiFlexItem>
+            {totalCounts.featureViews != null && (
+              <EuiFlexItem>
+                <EuiStat
+                  title={totalCounts.featureViews.toString()}
+                  description="Feature Views"
+                  titleSize="m"
+                  textAlign="center"
+                />
+              </EuiFlexItem>
+            )}
+            {totalCounts.entities != null && (
+              <EuiFlexItem>
+                <EuiStat
+                  title={totalCounts.entities.toString()}
+                  description="Entities"
+                  titleSize="m"
+                  textAlign="center"
+                />
+              </EuiFlexItem>
+            )}
+            {totalCounts.features != null && (
+              <EuiFlexItem>
+                <EuiStat
+                  title={totalCounts.features.toString()}
+                  description="Features"
+                  titleSize="m"
+                  textAlign="center"
+                />
+              </EuiFlexItem>
+            )}
+            {totalCounts.featureServices != null && (
+              <EuiFlexItem>
+                <EuiStat
+                  title={totalCounts.featureServices.toString()}
+                  description="Feature Services"
+                  titleSize="m"
+                  textAlign="center"
+                />
+              </EuiFlexItem>
+            )}
+            {totalCounts.dataSources != null && (
+              <EuiFlexItem>
+                <EuiStat
+                  title={totalCounts.dataSources.toString()}
+                  description="Data Sources"
+                  titleSize="m"
+                  textAlign="center"
+                />
+              </EuiFlexItem>
+            )}
           </EuiFlexGroup>
-          {totalCounts.labelViews > 0 && (
+          {totalCounts.labelViews != null && totalCounts.labelViews > 0 && (
             <React.Fragment>
               <EuiSpacer size="m" />
               <EuiFlexGroup>
@@ -205,44 +236,53 @@ const AllProjectsDashboard = () => {
               >
                 <EuiSpacer size="s" />
                 <EuiFlexGroup justifyContent="spaceAround" gutterSize="s">
-                  <EuiFlexItem grow={false}>
-                    <EuiText size="s" textAlign="center">
-                      <strong>{project.counts.featureViews}</strong>
-                      <br />
-                      <span style={{ fontSize: "0.85em", color: "#69707D" }}>
-                        Feature Views
-                      </span>
-                    </EuiText>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiText size="s" textAlign="center">
-                      <strong>{project.counts.entities}</strong>
-                      <br />
-                      <span style={{ fontSize: "0.85em", color: "#69707D" }}>
-                        Entities
-                      </span>
-                    </EuiText>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiText size="s" textAlign="center">
-                      <strong>{project.counts.features}</strong>
-                      <br />
-                      <span style={{ fontSize: "0.85em", color: "#69707D" }}>
-                        Features
-                      </span>
-                    </EuiText>
-                  </EuiFlexItem>
-                  {project.counts.labelViews > 0 && (
+                  {project.counts.featureViews != null && (
                     <EuiFlexItem grow={false}>
                       <EuiText size="s" textAlign="center">
-                        <strong>{project.counts.labelViews}</strong>
+                        <strong>{project.counts.featureViews}</strong>
                         <br />
                         <span style={{ fontSize: "0.85em", color: "#69707D" }}>
-                          Label Views
+                          Feature Views
                         </span>
                       </EuiText>
                     </EuiFlexItem>
                   )}
+                  {project.counts.entities != null && (
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="s" textAlign="center">
+                        <strong>{project.counts.entities}</strong>
+                        <br />
+                        <span style={{ fontSize: "0.85em", color: "#69707D" }}>
+                          Entities
+                        </span>
+                      </EuiText>
+                    </EuiFlexItem>
+                  )}
+                  {project.counts.features != null && (
+                    <EuiFlexItem grow={false}>
+                      <EuiText size="s" textAlign="center">
+                        <strong>{project.counts.features}</strong>
+                        <br />
+                        <span style={{ fontSize: "0.85em", color: "#69707D" }}>
+                          Features
+                        </span>
+                      </EuiText>
+                    </EuiFlexItem>
+                  )}
+                  {project.counts.labelViews != null &&
+                    project.counts.labelViews > 0 && (
+                      <EuiFlexItem grow={false}>
+                        <EuiText size="s" textAlign="center">
+                          <strong>{project.counts.labelViews}</strong>
+                          <br />
+                          <span
+                            style={{ fontSize: "0.85em", color: "#69707D" }}
+                          >
+                            Label Views
+                          </span>
+                        </EuiText>
+                      </EuiFlexItem>
+                    )}
                 </EuiFlexGroup>
               </EuiCard>
             </EuiFlexItem>

--- a/ui/src/pages/compute-engines/Index.tsx
+++ b/ui/src/pages/compute-engines/Index.tsx
@@ -20,6 +20,7 @@ import {
   EuiHealth,
   EuiFilterGroup,
   EuiFilterButton,
+  EuiCallOut,
 } from "@elastic/eui";
 
 import { ComputeEngineIcon } from "../../graphics/ComputeEngineIcon";
@@ -466,8 +467,14 @@ const Index = () => {
   const { projectName } = useParams();
   const navigate = useNavigate();
 
-  const { isLoading, isSuccess, isError, engineInfo, featureViewInfos } =
-    useLoadComputeEngine(projectName);
+  const {
+    isLoading,
+    isSuccess,
+    isError,
+    isPermissionDenied,
+    engineInfo,
+    featureViewInfos,
+  } = useLoadComputeEngine(projectName);
 
   useDocumentTitle(`Compute & Jobs | Feast`);
 
@@ -501,7 +508,14 @@ const Index = () => {
             <EuiLoadingSpinner size="m" /> Loading
           </p>
         )}
-        {isError && <p>We encountered an error while loading.</p>}
+        {isPermissionDenied && (
+          <EuiCallOut title="Permission denied" color="warning" iconType="lock">
+            <p>You do not have permission to view compute engines.</p>
+          </EuiCallOut>
+        )}
+        {isError && !isPermissionDenied && (
+          <p>We encountered an error while loading.</p>
+        )}
         {isSuccess && (
           <Routes>
             <Route

--- a/ui/src/pages/data-sources/Index.tsx
+++ b/ui/src/pages/data-sources/Index.tsx
@@ -124,7 +124,8 @@ const formDataToPayload = (formData: DataSourceFormData, project: string) => {
 
 const Index = () => {
   const { projectName } = useParams();
-  const { isLoading, isSuccess, isError, data } = useLoadDatasources();
+  const { isLoading, isSuccess, isError, isPermissionDenied, data } =
+    useLoadDatasources();
   const isAllProjects = projectName === "all";
 
   const [showCatalog, setShowCatalog] = useState(false);
@@ -306,7 +307,18 @@ const Index = () => {
                 <EuiLoadingSpinner size="m" /> Loading
               </p>
             )}
-            {isError && <p>We encountered an error while loading.</p>}
+            {isPermissionDenied && (
+              <EuiCallOut
+                title="Permission denied"
+                color="warning"
+                iconType="lock"
+              >
+                <p>You do not have permission to view data sources.</p>
+              </EuiCallOut>
+            )}
+            {isError && !isPermissionDenied && (
+              <p>We encountered an error while loading.</p>
+            )}
             {isEmpty && !isAllProjects && (
               <>
                 <EuiTitle size="s">

--- a/ui/src/pages/entities/Index.tsx
+++ b/ui/src/pages/entities/Index.tsx
@@ -47,7 +47,8 @@ const formDataToPayload = (formData: EntityFormData, project: string) => ({
 
 const Index = () => {
   const { projectName } = useParams();
-  const { isLoading, isSuccess, isError, data } = useLoadEntities();
+  const { isLoading, isSuccess, isError, isPermissionDenied, data } =
+    useLoadEntities();
   const isAllProjects = projectName === "all";
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -121,7 +122,14 @@ const Index = () => {
             <EuiLoadingSpinner size="m" /> Loading
           </p>
         )}
-        {isError && <p>We encountered an error while loading.</p>}
+        {isPermissionDenied && (
+          <EuiCallOut title="Permission denied" color="warning" iconType="lock">
+            <p>You do not have permission to view entities.</p>
+          </EuiCallOut>
+        )}
+        {isError && !isPermissionDenied && (
+          <p>We encountered an error while loading.</p>
+        )}
         {isSuccess && !data && <EntityIndexEmptyState />}
         {isSuccess && data && <EntitiesListingTable entities={data} />}
       </EuiPageTemplate.Section>

--- a/ui/src/pages/feature-services/Index.tsx
+++ b/ui/src/pages/feature-services/Index.tsx
@@ -9,6 +9,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFieldSearch,
+  EuiCallOut,
 } from "@elastic/eui";
 
 import { FeatureServiceIcon } from "../../graphics/FeatureServiceIcon";
@@ -84,7 +85,8 @@ const filterFn = (
 };
 
 const Index = () => {
-  const { isLoading, isSuccess, isError, data } = useLoadFeatureServices();
+  const { isLoading, isSuccess, isError, isPermissionDenied, data } =
+    useLoadFeatureServices();
   const tagAggregationQuery = useFeatureServiceTagsAggregation();
 
   useDocumentTitle(`Feature Services | Feast`);
@@ -127,7 +129,14 @@ const Index = () => {
             <EuiLoadingSpinner size="m" /> Loading
           </p>
         )}
-        {isError && <p>We encountered an error while loading.</p>}
+        {isPermissionDenied && (
+          <EuiCallOut title="Permission denied" color="warning" iconType="lock">
+            <p>You do not have permission to view feature services.</p>
+          </EuiCallOut>
+        )}
+        {isError && !isPermissionDenied && (
+          <p>We encountered an error while loading.</p>
+        )}
         {isSuccess && !data && <FeatureServiceIndexEmptyState />}
         {isSuccess && filterResult && (
           <React.Fragment>

--- a/ui/src/pages/feature-views/Index.tsx
+++ b/ui/src/pages/feature-views/Index.tsx
@@ -121,7 +121,8 @@ const formDataToPayload = (formData: FeatureViewFormData, project: string) => ({
 
 const Index = () => {
   const { projectName } = useParams();
-  const { isLoading, isSuccess, isError, data } = useLoadFeatureViews();
+  const { isLoading, isSuccess, isError, isPermissionDenied, data } =
+    useLoadFeatureViews();
   const isAllProjects = projectName === "all";
 
   const entitiesQuery = useResourceQuery<any[]>({
@@ -269,7 +270,14 @@ const Index = () => {
             <EuiLoadingSpinner size="m" /> Loading
           </p>
         )}
-        {isError && <p>We encountered an error while loading.</p>}
+        {isPermissionDenied && (
+          <EuiCallOut title="Permission denied" color="warning" iconType="lock">
+            <p>You do not have permission to view feature views.</p>
+          </EuiCallOut>
+        )}
+        {isError && !isPermissionDenied && (
+          <p>We encountered an error while loading.</p>
+        )}
         {isSuccess && data?.length === 0 && <FeatureViewIndexEmptyState />}
         {isSuccess && data && data.length > 0 && filterResult && (
           <React.Fragment>

--- a/ui/src/pages/features/FeatureListPage.tsx
+++ b/ui/src/pages/features/FeatureListPage.tsx
@@ -16,6 +16,7 @@ import {
   EuiFlexItem,
   EuiFormRow,
   EuiBadge,
+  EuiCallOut,
 } from "@elastic/eui";
 import EuiCustomLink from "../../components/EuiCustomLink";
 import ExportButton from "../../components/ExportButton";
@@ -53,6 +54,7 @@ const FeatureListPage = () => {
     data: features,
     isLoading,
     isError,
+    isPermissionDenied,
   } = useResourceQuery<any[]>({
     resourceType: "features-list",
     project: projectName,
@@ -257,6 +259,10 @@ const FeatureListPage = () => {
       <EuiPageTemplate.Section>
         {isLoading ? (
           <p>Loading...</p>
+        ) : isPermissionDenied ? (
+          <EuiCallOut title="Permission denied" color="warning" iconType="lock">
+            <p>You do not have permission to view features.</p>
+          </EuiCallOut>
         ) : isError ? (
           <p>We encountered an error while loading.</p>
         ) : (

--- a/ui/src/pages/label-views/Index.tsx
+++ b/ui/src/pages/label-views/Index.tsx
@@ -10,6 +10,7 @@ import {
   EuiEmptyPrompt,
   EuiTitle,
   EuiLink,
+  EuiCallOut,
 } from "@elastic/eui";
 
 import { LabelViewIcon } from "../../graphics/LabelViewIcon";
@@ -167,7 +168,8 @@ const LabelViewIndexEmptyState = () => (
 );
 
 const Index = () => {
-  const { isLoading, isSuccess, isError, data } = useLoadLabelViews();
+  const { isLoading, isSuccess, isError, isPermissionDenied, data } =
+    useLoadLabelViews();
 
   useDocumentTitle(`Label Views | Feast`);
 
@@ -184,7 +186,14 @@ const Index = () => {
             <EuiLoadingSpinner size="m" /> Loading
           </p>
         )}
-        {isError && <p>We encountered an error while loading.</p>}
+        {isPermissionDenied && (
+          <EuiCallOut title="Permission denied" color="warning" iconType="lock">
+            <p>You do not have permission to view label views.</p>
+          </EuiCallOut>
+        )}
+        {isError && !isPermissionDenied && (
+          <p>We encountered an error while loading.</p>
+        )}
         {isSuccess && (!data || data.length === 0) && (
           <LabelViewIndexEmptyState />
         )}

--- a/ui/src/pages/permissions/Index.tsx
+++ b/ui/src/pages/permissions/Index.tsx
@@ -1,96 +1,561 @@
-import React from "react";
+import React, { useState, useMemo } from "react";
 import {
   EuiPageTemplate,
-  EuiTitle,
   EuiSpacer,
-  EuiPanel,
+  EuiLoadingSpinner,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiButton,
+  EuiCallOut,
+  EuiFieldSearch,
+  EuiTitle,
+  EuiBasicTable,
+  EuiBadge,
+  EuiButtonIcon,
+  EuiConfirmModal,
   EuiText,
-  EuiLoadingSpinner,
-  EuiHorizontalRule,
+  EuiToolTip,
   EuiSelect,
   EuiFormRow,
+  EuiEmptyPrompt,
 } from "@elastic/eui";
-import { useContext, useState } from "react";
 import { useParams } from "react-router-dom";
-import RegistryPathContext from "../../contexts/RegistryPathContext";
-import useLoadRegistry from "../../queries/useLoadRegistry";
-import PermissionsDisplay from "../../components/PermissionsDisplay";
-import { filterPermissionsByAction } from "../../utils/permissionUtils";
+import { PermissionsIcon } from "../../graphics/PermissionsIcon";
+import PermissionFormModal, {
+  PermissionFormData,
+} from "../../components/PermissionFormModal";
+import {
+  useApplyPermission,
+  useDeletePermission,
+  ApplyPermissionPayload,
+} from "../../queries/mutations/usePermissionMutations";
+import useResourceQuery, {
+  permissionListPath,
+} from "../../queries/useResourceQuery";
+
+const ACTION_NAMES = [
+  "CREATE",
+  "DESCRIBE",
+  "UPDATE",
+  "DELETE",
+  "READ_ONLINE",
+  "READ_OFFLINE",
+  "WRITE_ONLINE",
+  "WRITE_OFFLINE",
+];
+
+const TYPE_DISPLAY_NAMES: Record<string, string> = {
+  FEATURE_VIEW: "Feature View",
+  ON_DEMAND_FEATURE_VIEW: "On-Demand Feature View",
+  BATCH_FEATURE_VIEW: "Batch Feature View",
+  STREAM_FEATURE_VIEW: "Stream Feature View",
+  ENTITY: "Entity",
+  FEATURE_SERVICE: "Feature Service",
+  DATA_SOURCE: "Data Source",
+  VALIDATION_REFERENCE: "Validation Reference",
+  SAVED_DATASET: "Saved Dataset",
+  PERMISSION: "Permission",
+  PROJECT: "Project",
+  LABEL_VIEW: "Label View",
+};
+
+const resolveType = (t: string | number): string => {
+  if (typeof t === "string") return t;
+  const numericMap: Record<number, string> = {
+    0: "FEATURE_VIEW",
+    1: "ON_DEMAND_FEATURE_VIEW",
+    2: "BATCH_FEATURE_VIEW",
+    3: "STREAM_FEATURE_VIEW",
+    4: "ENTITY",
+    5: "FEATURE_SERVICE",
+    6: "DATA_SOURCE",
+    7: "VALIDATION_REFERENCE",
+    8: "SAVED_DATASET",
+    9: "PERMISSION",
+    10: "PROJECT",
+    11: "LABEL_VIEW",
+  };
+  return numericMap[t] || `Type ${t}`;
+};
+
+const resolveAction = (a: string | number): string => {
+  if (typeof a === "string") return a;
+  return ACTION_NAMES[a] || `Action ${a}`;
+};
+
+const getActionColor = (action: string) => {
+  if (action.startsWith("READ")) return "success";
+  if (action.startsWith("WRITE")) return "warning";
+  if (action === "CREATE") return "primary";
+  if (action === "UPDATE") return "accent";
+  if (action === "DELETE") return "danger";
+  if (action === "DESCRIBE") return "hollow";
+  return "default";
+};
+
+const getPolicyDescription = (policy: any): string => {
+  if (!policy) return "Allow All";
+  if (policy.roleBasedPolicy?.roles) {
+    return `Roles: ${policy.roleBasedPolicy.roles.join(", ")}`;
+  }
+  if (policy.groupBasedPolicy?.groups) {
+    return `Groups: ${policy.groupBasedPolicy.groups.join(", ")}`;
+  }
+  if (policy.namespaceBasedPolicy?.namespaces) {
+    return `Namespaces: ${policy.namespaceBasedPolicy.namespaces.join(", ")}`;
+  }
+  if (policy.combinedGroupNamespacePolicy) {
+    const parts = [];
+    if (policy.combinedGroupNamespacePolicy.groups?.length) {
+      parts.push(
+        `Groups: ${policy.combinedGroupNamespacePolicy.groups.join(", ")}`,
+      );
+    }
+    if (policy.combinedGroupNamespacePolicy.namespaces?.length) {
+      parts.push(
+        `Namespaces: ${policy.combinedGroupNamespacePolicy.namespaces.join(", ")}`,
+      );
+    }
+    return parts.join(" | ");
+  }
+  return "Allow All";
+};
+
+const getPolicyType = (
+  policy: any,
+): "role_based" | "group_based" | "namespace_based" | "combined" => {
+  if (!policy) return "role_based";
+  if (policy.roleBasedPolicy) return "role_based";
+  if (policy.groupBasedPolicy) return "group_based";
+  if (policy.namespaceBasedPolicy) return "namespace_based";
+  if (policy.combinedGroupNamespacePolicy) return "combined";
+  return "role_based";
+};
+
+const permissionToFormData = (permission: any): PermissionFormData => {
+  const spec = permission.spec || permission;
+  const policy = spec.policy;
+
+  const rawTypes: string[] = (spec.types || []).map(resolveType);
+  const rawActions: string[] = (spec.actions || []).map(resolveAction);
+
+  return {
+    name: spec.name || "",
+    types: Array.from(new Set(rawTypes)),
+    namePatterns: spec.namePatterns || spec.name_patterns || [],
+    actions: Array.from(new Set(rawActions)),
+    policyType: getPolicyType(policy),
+    roles: policy?.roleBasedPolicy?.roles || [],
+    groups:
+      policy?.groupBasedPolicy?.groups ||
+      policy?.combinedGroupNamespacePolicy?.groups ||
+      [],
+    namespaces:
+      policy?.namespaceBasedPolicy?.namespaces ||
+      policy?.combinedGroupNamespacePolicy?.namespaces ||
+      [],
+    tags: Object.entries(spec.tags || {}).map(([key, value]) => ({
+      key,
+      value: value as string,
+    })),
+    requiredTags: Object.entries(
+      spec.requiredTags || spec.required_tags || {},
+    ).map(([key, value]) => ({
+      key,
+      value: value as string,
+    })),
+  };
+};
+
+const formDataToPayload = (
+  formData: PermissionFormData,
+  project: string,
+): ApplyPermissionPayload => {
+  const policy: ApplyPermissionPayload["policy"] = {};
+
+  if (formData.policyType === "role_based") {
+    policy.role_based_policy = {
+      roles: formData.roles.filter((r) => r.trim()),
+    };
+  } else if (formData.policyType === "group_based") {
+    policy.group_based_policy = {
+      groups: formData.groups.filter((g) => g.trim()),
+    };
+  } else if (formData.policyType === "namespace_based") {
+    policy.namespace_based_policy = {
+      namespaces: formData.namespaces.filter((n) => n.trim()),
+    };
+  } else if (formData.policyType === "combined") {
+    policy.combined_group_namespace_policy = {
+      groups: formData.groups.filter((g) => g.trim()),
+      namespaces: formData.namespaces.filter((n) => n.trim()),
+    };
+  }
+
+  return {
+    name: formData.name,
+    project,
+    types: formData.types,
+    name_patterns: formData.namePatterns.filter((p) => p.trim()),
+    actions: formData.actions,
+    policy,
+    tags: Object.fromEntries(
+      formData.tags.filter((t) => t.key.trim()).map((t) => [t.key, t.value]),
+    ),
+    required_tags: Object.fromEntries(
+      formData.requiredTags
+        .filter((t) => t.key.trim())
+        .map((t) => [t.key, t.value]),
+    ),
+  };
+};
+
+const useLoadPermissions = () => {
+  const { projectName } = useParams();
+  return useResourceQuery<any[]>({
+    resourceType: "permissions-list",
+    project: projectName,
+    restPath: permissionListPath(projectName),
+    restSelect: (d) => d.permissions,
+  });
+};
 
 const PermissionsIndex = () => {
-  const registryUrl = useContext(RegistryPathContext);
   const { projectName } = useParams();
-  const { isLoading, isSuccess, isError, data } = useLoadRegistry(
-    registryUrl,
-    projectName,
-  );
-  const [selectedPermissionAction, setSelectedPermissionAction] = useState("");
+  const { isLoading, isSuccess, isError, isPermissionDenied, data } =
+    useLoadPermissions();
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingPermission, setEditingPermission] = useState<any | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<any | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [searchString, setSearchString] = useState("");
+  const [actionFilter, setActionFilter] = useState("");
+
+  const applyPermission = useApplyPermission();
+  const deletePermissionMutation = useDeletePermission();
+
+  const permissions = useMemo(() => {
+    if (!data) return [];
+    let filtered = data;
+
+    if (searchString.trim()) {
+      const lower = searchString.toLowerCase();
+      filtered = filtered.filter((p) =>
+        (p.spec?.name || "").toLowerCase().includes(lower),
+      );
+    }
+
+    if (actionFilter) {
+      filtered = filtered.filter((p) => {
+        const actions = (p.spec?.actions || []).map(resolveAction);
+        return actions.includes(actionFilter);
+      });
+    }
+
+    return filtered;
+  }, [data, searchString, actionFilter]);
+
+  const handleCreate = () => {
+    setEditingPermission(null);
+    setIsModalOpen(true);
+  };
+
+  const handleEdit = (permission: any) => {
+    setEditingPermission(permission);
+    setIsModalOpen(true);
+  };
+
+  const handleDelete = (permission: any) => {
+    setDeleteTarget(permission);
+  };
+
+  const confirmDelete = () => {
+    if (!deleteTarget) return;
+    const name = deleteTarget.spec?.name || deleteTarget.name;
+    deletePermissionMutation.mutate(
+      { name, project: projectName || "" },
+      {
+        onSuccess: () => {
+          setDeleteTarget(null);
+          setErrorMessage(null);
+          setSuccessMessage(`Permission "${name}" deleted successfully.`);
+          setTimeout(() => setSuccessMessage(null), 5000);
+        },
+        onError: (err: unknown) => {
+          setDeleteTarget(null);
+          const message =
+            err instanceof Error
+              ? err.message
+              : "An unexpected error occurred.";
+          setErrorMessage(message);
+          setTimeout(() => setErrorMessage(null), 5000);
+        },
+      },
+    );
+  };
+
+  const handleFormSubmit = (formData: PermissionFormData) => {
+    const payload = formDataToPayload(formData, projectName || "");
+    applyPermission.mutate(payload, {
+      onSuccess: () => {
+        setIsModalOpen(false);
+        setEditingPermission(null);
+        setErrorMessage(null);
+        const verb = editingPermission ? "updated" : "created";
+        setSuccessMessage(
+          `Permission "${formData.name}" ${verb} successfully.`,
+        );
+        setTimeout(() => setSuccessMessage(null), 5000);
+      },
+      onError: (err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : "An unexpected error occurred.";
+        setErrorMessage(message);
+      },
+    });
+  };
+
+  const columns = [
+    {
+      field: "spec.name",
+      name: "Name",
+      sortable: true,
+      render: (_: string, item: any) => (
+        <strong>{item.spec?.name || "—"}</strong>
+      ),
+    },
+    {
+      field: "spec.types",
+      name: "Resource Types",
+      render: (_: any, item: any) => {
+        const rawTypes: string[] = (item.spec?.types || []).map(resolveType);
+        const types = Array.from(new Set(rawTypes));
+        if (types.length === 0) return <EuiText size="xs">All</EuiText>;
+        const display = (t: string) => TYPE_DISPLAY_NAMES[t] || t;
+        if (types.length > 3) {
+          return (
+            <EuiToolTip content={types.map(display).join(", ")}>
+              <EuiText size="xs">
+                {types.slice(0, 3).map(display).join(", ")} +{types.length - 3}{" "}
+                more
+              </EuiText>
+            </EuiToolTip>
+          );
+        }
+        return <EuiText size="xs">{types.map(display).join(", ")}</EuiText>;
+      },
+    },
+    {
+      field: "spec.actions",
+      name: "Actions",
+      render: (_: any, item: any) => {
+        const rawActions: string[] = (item.spec?.actions || []).map(
+          resolveAction,
+        );
+        const actions = Array.from(new Set(rawActions));
+        return (
+          <EuiFlexGroup wrap responsive={false} gutterSize="xs">
+            {actions.map((action: string, i: number) => (
+              <EuiFlexItem grow={false} key={i}>
+                <EuiBadge color={getActionColor(action)}>{action}</EuiBadge>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+        );
+      },
+    },
+    {
+      field: "spec.policy",
+      name: "Policy",
+      render: (_: any, item: any) => {
+        const desc = getPolicyDescription(item.spec?.policy);
+        return (
+          <EuiToolTip content={desc}>
+            <EuiText size="xs">
+              {desc.length > 40 ? desc.substring(0, 40) + "..." : desc}
+            </EuiText>
+          </EuiToolTip>
+        );
+      },
+    },
+    {
+      name: "Actions",
+      width: "100px",
+      render: (item: any) => (
+        <EuiFlexGroup gutterSize="xs" responsive={false}>
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content="Edit">
+              <EuiButtonIcon
+                iconType="pencil"
+                aria-label="Edit permission"
+                onClick={() => handleEdit(item)}
+                color="primary"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiToolTip content="Delete">
+              <EuiButtonIcon
+                iconType="trash"
+                aria-label="Delete permission"
+                onClick={() => handleDelete(item)}
+                color="danger"
+              />
+            </EuiToolTip>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      ),
+    },
+  ];
+
+  const hasPermissions = isSuccess && data && data.length > 0;
+  const isEmpty = isSuccess && (!data || data.length === 0);
 
   return (
-    <EuiPageTemplate restrictWidth>
+    <EuiPageTemplate panelled>
       <EuiPageTemplate.Header
+        restrictWidth
+        iconType={PermissionsIcon}
         pageTitle="Permissions"
-        description="View and manage permissions for Feast resources"
+        description="Create and manage access control rules for Feast resources"
+        rightSideItems={[
+          <EuiButton fill iconType="plus" onClick={handleCreate} key="create">
+            Create Permission
+          </EuiButton>,
+        ]}
       />
       <EuiPageTemplate.Section>
-        {isLoading && (
-          <React.Fragment>
-            <EuiLoadingSpinner size="m" /> Loading
-          </React.Fragment>
+        {successMessage && (
+          <>
+            <EuiCallOut
+              title={successMessage}
+              color="success"
+              iconType="check"
+              size="s"
+            />
+            <EuiSpacer size="m" />
+          </>
         )}
-        {isError && <p>Error loading permissions</p>}
-        {isSuccess && data && (
-          <React.Fragment>
-            <EuiFlexGroup>
-              <EuiFlexItem grow={false} style={{ width: 300 }}>
+        {errorMessage && !isModalOpen && (
+          <>
+            <EuiCallOut
+              title={errorMessage}
+              color="danger"
+              iconType="alert"
+              size="s"
+            />
+            <EuiSpacer size="m" />
+          </>
+        )}
+
+        {isLoading && (
+          <p>
+            <EuiLoadingSpinner size="m" /> Loading
+          </p>
+        )}
+        {isPermissionDenied && (
+          <EuiCallOut title="Permission denied" color="warning" iconType="lock">
+            <p>You do not have permission to view permissions.</p>
+          </EuiCallOut>
+        )}
+        {isError && !isPermissionDenied && <p>Error loading permissions.</p>}
+
+        {isEmpty && (
+          <EuiEmptyPrompt
+            iconType="lock"
+            title={<h2>No permissions yet</h2>}
+            body={
+              <p>
+                Permissions let you control who can perform specific actions on
+                your Feast resources. Create your first permission to get
+                started.
+              </p>
+            }
+            actions={
+              <EuiButton fill iconType="plus" onClick={handleCreate}>
+                Create Permission
+              </EuiButton>
+            }
+          />
+        )}
+
+        {hasPermissions && (
+          <>
+            <EuiFlexGroup gutterSize="m">
+              <EuiFlexItem grow={3}>
+                <EuiTitle size="xs">
+                  <h2>Search</h2>
+                </EuiTitle>
+                <EuiFieldSearch
+                  value={searchString}
+                  fullWidth
+                  placeholder="Filter by name..."
+                  onChange={(e) => setSearchString(e.target.value)}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={1}>
                 <EuiFormRow label="Filter by action">
                   <EuiSelect
                     options={[
-                      { value: "", text: "All" },
-                      { value: "CREATE", text: "CREATE" },
-                      { value: "DESCRIBE", text: "DESCRIBE" },
-                      { value: "UPDATE", text: "UPDATE" },
-                      { value: "DELETE", text: "DELETE" },
-                      { value: "READ_ONLINE", text: "READ_ONLINE" },
-                      { value: "READ_OFFLINE", text: "READ_OFFLINE" },
-                      { value: "WRITE_ONLINE", text: "WRITE_ONLINE" },
-                      { value: "WRITE_OFFLINE", text: "WRITE_OFFLINE" },
+                      { value: "", text: "All Actions" },
+                      ...ACTION_NAMES.map((a) => ({ value: a, text: a })),
                     ]}
-                    value={selectedPermissionAction}
-                    onChange={(e) =>
-                      setSelectedPermissionAction(e.target.value)
-                    }
-                    aria-label="Filter by action"
+                    value={actionFilter}
+                    onChange={(e) => setActionFilter(e.target.value)}
                   />
                 </EuiFormRow>
               </EuiFlexItem>
             </EuiFlexGroup>
             <EuiSpacer size="m" />
-            <EuiPanel hasBorder={true}>
-              <EuiTitle size="s">
-                <h2>Permissions</h2>
-              </EuiTitle>
-              <EuiHorizontalRule margin="xs" />
-              {data.permissions && data.permissions.length > 0 ? (
-                <PermissionsDisplay
-                  permissions={
-                    selectedPermissionAction
-                      ? filterPermissionsByAction(
-                          data.permissions,
-                          selectedPermissionAction,
-                        )
-                      : data.permissions
-                  }
-                />
-              ) : (
-                <EuiText>No permissions defined in this project.</EuiText>
-              )}
-            </EuiPanel>
-          </React.Fragment>
+            <EuiBasicTable
+              items={permissions}
+              columns={columns}
+              rowHeader="spec.name"
+            />
+          </>
         )}
       </EuiPageTemplate.Section>
+
+      {isModalOpen && (
+        <PermissionFormModal
+          onClose={() => {
+            setIsModalOpen(false);
+            setEditingPermission(null);
+            setErrorMessage(null);
+          }}
+          onSubmit={handleFormSubmit}
+          isEdit={!!editingPermission}
+          initialData={
+            editingPermission
+              ? permissionToFormData(editingPermission)
+              : undefined
+          }
+          isSubmitting={applyPermission.isLoading}
+          submitError={errorMessage}
+        />
+      )}
+
+      {deleteTarget && (
+        <EuiConfirmModal
+          title="Delete permission"
+          onCancel={() => setDeleteTarget(null)}
+          onConfirm={confirmDelete}
+          cancelButtonText="Cancel"
+          confirmButtonText="Delete"
+          buttonColor="danger"
+          isLoading={deletePermissionMutation.isLoading}
+        >
+          <p>
+            Are you sure you want to delete the permission{" "}
+            <strong>
+              &quot;{deleteTarget.spec?.name || deleteTarget.name}&quot;
+            </strong>
+            ? This action cannot be undone.
+          </p>
+        </EuiConfirmModal>
+      )}
     </EuiPageTemplate>
   );
 };

--- a/ui/src/pages/saved-data-sets/Index.tsx
+++ b/ui/src/pages/saved-data-sets/Index.tsx
@@ -78,7 +78,8 @@ function getDatasetSortValue(dataset: any, key: string): any {
 
 const Index = () => {
   const { projectName } = useParams();
-  const { isLoading, isSuccess, isError, data } = useLoadSavedDataSets();
+  const { isLoading, isSuccess, isError, isPermissionDenied, data } =
+    useLoadSavedDataSets();
   const [showRegisterModal, setShowRegisterModal] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -413,7 +414,12 @@ const Index = () => {
           </EuiFlexGroup>
         )}
 
-        {isError && (
+        {isPermissionDenied && (
+          <EuiCallOut title="Permission denied" color="warning" iconType="lock">
+            <p>You do not have permission to view saved datasets.</p>
+          </EuiCallOut>
+        )}
+        {isError && !isPermissionDenied && (
           <EuiCallOut
             title="Failed to load datasets"
             color="danger"

--- a/ui/src/queries/mutations/usePermissionMutations.ts
+++ b/ui/src/queries/mutations/usePermissionMutations.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQueryClient } from "react-query";
+import { restPost, restDelete } from "../restApiClient";
+
+interface PolicyPayload {
+  role_based_policy?: { roles: string[] };
+  group_based_policy?: { groups: string[] };
+  namespace_based_policy?: { namespaces: string[] };
+  combined_group_namespace_policy?: {
+    groups: string[];
+    namespaces: string[];
+  };
+}
+
+interface ApplyPermissionPayload {
+  name: string;
+  project: string;
+  types: string[];
+  name_patterns: string[];
+  actions: string[];
+  policy: PolicyPayload;
+  tags?: Record<string, string>;
+  required_tags?: Record<string, string>;
+}
+
+interface DeletePermissionPayload {
+  name: string;
+  project: string;
+}
+
+interface MutationResult {
+  name: string;
+  project: string;
+  status: string;
+}
+
+const API_BASE = "/api/v1";
+
+const useApplyPermission = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    (payload: ApplyPermissionPayload) =>
+      restPost<MutationResult>(API_BASE, "/permissions", payload),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["rest"]);
+        queryClient.invalidateQueries(["permissions-rest"]);
+        queryClient.invalidateQueries(["registry-rest-bulk"]);
+      },
+    },
+  );
+};
+
+const useDeletePermission = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    (payload: DeletePermissionPayload) =>
+      restDelete<MutationResult>(
+        API_BASE,
+        `/permissions/${encodeURIComponent(payload.name)}?project=${encodeURIComponent(payload.project)}`,
+      ),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["rest"]);
+        queryClient.invalidateQueries(["permissions-rest"]);
+        queryClient.invalidateQueries(["registry-rest-bulk"]);
+      },
+    },
+  );
+};
+
+export { useApplyPermission, useDeletePermission };
+export type { ApplyPermissionPayload, DeletePermissionPayload, PolicyPayload };

--- a/ui/src/queries/useLoadComputeEngine.ts
+++ b/ui/src/queries/useLoadComputeEngine.ts
@@ -2,7 +2,7 @@ import { useContext } from "react";
 import { useQuery } from "react-query";
 import RegistryPathContext from "../contexts/RegistryPathContext";
 import { useDataMode } from "../contexts/DataModeContext";
-import restFetch from "./restApiClient";
+import restFetch, { RestApiError } from "./restApiClient";
 
 export interface ComputeEngineConfig {
   type: string;
@@ -68,8 +68,17 @@ export function useLoadComputeEngine(projectName?: string) {
     {
       enabled: !!registryUrl,
       staleTime: 30_000,
+      retry: (failureCount, error) => {
+        if (error instanceof RestApiError && error.status === 403) return false;
+        return failureCount < 3;
+      },
     },
   );
+
+  const isPermissionDenied =
+    engineQuery.isError &&
+    engineQuery.error instanceof RestApiError &&
+    engineQuery.error.status === 403;
 
   let engineInfo: ComputeEngineInfo | null = null;
   let featureViewInfos: FeatureViewEngineInfo[] = [];
@@ -105,6 +114,7 @@ export function useLoadComputeEngine(projectName?: string) {
     isLoading: engineQuery.isLoading,
     isSuccess: engineQuery.isSuccess,
     isError: engineQuery.isError,
+    isPermissionDenied,
     engineInfo,
     featureViewInfos,
   };

--- a/ui/src/queries/useLoadRegistry.ts
+++ b/ui/src/queries/useLoadRegistry.ts
@@ -100,6 +100,22 @@ const assembleFeatureStoreData = (
 // REST fetch strategy
 // ---------------------------------------------------------------------------
 
+const permissionSafeFetch = async <T>(
+  apiBaseUrl: string,
+  path: string,
+  fallback: T,
+  fetchOptions?: FetchOptions,
+): Promise<T> => {
+  try {
+    return await restFetch<T>(apiBaseUrl, path, fetchOptions);
+  } catch (err: any) {
+    if (err?.status === 403 || err?.status === 401) {
+      return fallback;
+    }
+    throw err;
+  }
+};
+
 const fetchREST = async (
   apiBaseUrl: string,
   projectName?: string,
@@ -111,6 +127,8 @@ const fetchREST = async (
       : "";
   const useAllEndpoint = !projectParam;
 
+  const emptyList = (key: string) => ({ [key]: [] });
+
   const [
     entitiesResp,
     featureViewsResp,
@@ -120,49 +138,60 @@ const fetchREST = async (
     savedDatasetsResp,
     projectsResp,
   ] = await Promise.all([
-    restFetch<any>(
+    permissionSafeFetch<any>(
       apiBaseUrl,
       useAllEndpoint
         ? "/entities/all?include_relationships=true"
         : `/entities${projectParam}&include_relationships=true`,
+      emptyList("entities"),
       fetchOptions,
     ),
-    restFetch<any>(
+    permissionSafeFetch<any>(
       apiBaseUrl,
       useAllEndpoint
         ? "/feature_views/all?include_relationships=true"
         : `/feature_views${projectParam}&include_relationships=true`,
+      emptyList("featureViews"),
       fetchOptions,
     ),
-    restFetch<any>(
+    permissionSafeFetch<any>(
       apiBaseUrl,
       useAllEndpoint
         ? "/label_views/all?include_relationships=true"
         : `/label_views${projectParam}&include_relationships=true`,
+      emptyList("featureViews"),
       fetchOptions,
     ),
-    restFetch<any>(
+    permissionSafeFetch<any>(
       apiBaseUrl,
       useAllEndpoint
         ? "/feature_services/all?include_relationships=true"
         : `/feature_services${projectParam}&include_relationships=true`,
+      emptyList("featureServices"),
       fetchOptions,
     ),
-    restFetch<any>(
+    permissionSafeFetch<any>(
       apiBaseUrl,
       useAllEndpoint
         ? "/data_sources/all?include_relationships=true"
         : `/data_sources${projectParam}&include_relationships=true`,
+      emptyList("dataSources"),
       fetchOptions,
     ),
-    restFetch<any>(
+    permissionSafeFetch<any>(
       apiBaseUrl,
       useAllEndpoint
         ? "/saved_datasets/all?include_relationships=true"
         : `/saved_datasets${projectParam}&include_relationships=true`,
+      emptyList("savedDatasets"),
       fetchOptions,
     ),
-    restFetch<any>(apiBaseUrl, "/projects", fetchOptions),
+    permissionSafeFetch<any>(
+      apiBaseUrl,
+      "/projects",
+      emptyList("projects"),
+      fetchOptions,
+    ),
   ]);
 
   const entities = entitiesResp.entities || [];

--- a/ui/src/queries/useResourceQuery.ts
+++ b/ui/src/queries/useResourceQuery.ts
@@ -1,8 +1,9 @@
 import { useContext } from "react";
-import { useQuery, UseQueryResult } from "react-query";
+import { useQuery } from "react-query";
 import RegistryPathContext from "../contexts/RegistryPathContext";
 import { useDataMode } from "../contexts/DataModeContext";
 import restFetch from "./restApiClient";
+import { RestApiError } from "./restApiClient";
 import { FEAST_FV_TYPES, genericFVType } from "../parsers/mergedFVTypes";
 
 interface ResourceQueryOptions<T> {
@@ -25,19 +26,30 @@ function useResourceQuery<T>({
   restPath,
   restSelect,
   enabled = true,
-}: ResourceQueryOptions<T>): UseQueryResult<T | undefined> {
+}: ResourceQueryOptions<T>) {
   const registryUrl = useContext(RegistryPathContext);
   const { fetchOptions } = useDataMode();
 
-  return useQuery<any, Error, T | undefined>(
+  const query = useQuery<any, Error, T | undefined>(
     ["rest", resourceType, registryUrl, project || "all"],
     () => restFetch<any>(registryUrl, restPath, fetchOptions),
     {
       enabled: !!registryUrl && enabled,
       staleTime: 30_000,
       select: restSelect,
+      retry: (failureCount, error) => {
+        if (error instanceof RestApiError && error.status === 403) return false;
+        return failureCount < 3;
+      },
     },
   );
+
+  const isPermissionDenied =
+    query.isError &&
+    query.error instanceof RestApiError &&
+    query.error.status === 403;
+
+  return { ...query, isPermissionDenied };
 }
 
 // ---------------------------------------------------------------------------
@@ -108,6 +120,13 @@ function labelViewListPath(project?: string): string {
 
 function labelViewDetailPath(name: string, project: string): string {
   return `/label_views/${encodeURIComponent(name)}?project=${encodeURIComponent(project)}&include_relationships=true`;
+}
+
+function permissionListPath(project?: string): string {
+  if (project && project !== "all") {
+    return `/permissions?project=${encodeURIComponent(project)}`;
+  }
+  return `/permissions?project=default`;
 }
 
 function featuresListPath(project?: string): string {
@@ -214,6 +233,7 @@ export {
   savedDatasetDetailPath,
   labelViewListPath,
   labelViewDetailPath,
+  permissionListPath,
   featuresListPath,
   featureDetailPath,
   restFeatureViewsToMergedList,

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7562,6 +7562,11 @@ jsonpointer@^5.0.0:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+keycloak-js@^26.2.4:
+  version "26.2.4"
+  resolved "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.4.tgz"
+  integrity sha512-PnXpR3ubETGOt0B/Qt2lxmPbkZr5bc3vlQsOqDoTPPQsZRp7JjhTKxlJ187uWh8qJhvBab6Gsjb06a8ayOPfuw==
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz"


### PR DESCRIPTION

# What this PR does / why we need it:

- Add full CRUD UI for managing Feast RBAC permissions (create, edit, delete) with an intuitive form supporting role-based, group-based, namespace-based, and combined policies
- Integrate Keycloak OIDC authentication into the Feast UI using keycloak-js with PKCE flow, including automatic token injection, refresh, and user profile display
- Handle permission-denied (403) responses gracefully across all pages - showing contextual "Permission denied" 
- Add FeastPermissionError exception handler to the feast ui REST API so RBAC denials return proper 403 responses instead of 500 errors
- Add ui_client_id config option in feature_store.yaml to support separate public OIDC client for browser-based auth


https://github.com/user-attachments/assets/c860497c-875e-41cb-a0e0-08b1cdacc397

