### PR TITLE
ci: Preserve OpenLineage placeholder allowlist

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1015,6 +1015,15 @@
         "line_number": 1108
       }
     ],
+    "infra/feast-operator/bundle/manifests/openlineage-secret_v1_secret.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "infra/feast-operator/bundle/manifests/openlineage-secret_v1_secret.yaml",
+        "hashed_secret": "598319ac6aa4a94e72a9d8a8d405cc7bc9e048ee",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
     "infra/feast-operator/config/samples/v1_featurestore_db_persistence.yaml": [
       {
         "type": "Secret Keyword",


### PR DESCRIPTION
## What changed

- add the generated OpenLineage API-key placeholder to `.secrets.baseline`
- keep secret scanning enabled for the rest of the generated manifest

## Why

The 0.65.0 release regenerated `infra/feast-operator/bundle/manifests/openlineage-secret_v1_secret.yaml` and removed its inline `pragma: allowlist secret` comment. The `detect-secrets` pre-commit hook then failed on `master` before Ruff and mypy could run.

A baseline entry is durable across future operator bundle regeneration because it records the known placeholder by file and hash instead of relying on a comment that the generator strips.

## Validation

- reproduced the original `detect-secrets` failure on `origin/master`
- targeted `detect-secrets-hook` passes with the baseline entry
- full-repository `detect-secrets` hook passes
- `make lint-python` passes with the CI Python 3.11 environment (Ruff, formatting, and mypy)
