### PR TITLE
fix: Merge shared ODFV source projections in feature resolution

### DIFF
--- a/sdk/python/feast/utils.py
+++ b/sdk/python/feast/utils.py
@@ -55,6 +55,7 @@ if typing.TYPE_CHECKING:
     from feast.base_feature_view import BaseFeatureView
     from feast.feature_service import FeatureService
     from feast.feature_view import FeatureView
+    from feast.feature_view_projection import FeatureViewProjection
     from feast.infra.registry.base_registry import BaseRegistry
     from feast.on_demand_feature_view import OnDemandFeatureView
 
@@ -1193,6 +1194,19 @@ def _list_feature_views(
     return feature_views
 
 
+def _merge_projection_features(
+    target: "FeatureViewProjection",
+    other: "FeatureViewProjection",
+) -> None:
+    existing_names = {feature.name for feature in target.features}
+    merged = list(target.features)
+    for feature in other.features:
+        if feature.name not in existing_names:
+            existing_names.add(feature.name)
+            merged.append(feature)
+    target.features = merged
+
+
 def _get_feature_views_to_use(
     registry: "BaseRegistry",
     project,
@@ -1223,6 +1237,25 @@ def _get_feature_views_to_use(
         feature_views = parsed  # type: ignore[assignment]
 
     fvs_to_use, od_fvs_to_use = [], []
+    fvs_by_projection_key: Dict[str, "FeatureView"] = {}
+
+    def _append_or_merge_source_fv(fv_with_projection: "FeatureView") -> None:
+        # Index every (source) feature view by its effective projection key so
+        # that a regular FeatureView and an ODFV source projection resolving to
+        # the same key are merged into a single entry instead of duplicated.
+        # Without this, requesting ["src_fv:a", "odfv_b:b_out"] where odfv_b
+        # sources src_fv appends two src_fv entries and later raises
+        # "KeyError: Feature a not found in projection src_fv".
+        projection_key = fv_with_projection.projection.name_to_use()
+        existing = fvs_by_projection_key.get(projection_key)
+        if existing is None:
+            fvs_by_projection_key[projection_key] = fv_with_projection
+            fvs_to_use.append(fv_with_projection)
+        else:
+            _merge_projection_features(
+                existing.projection, fv_with_projection.projection
+            )
+
     for name, version_num, projection in feature_views:
         if version_num is not None:
             if not getattr(registry, "enable_online_versioning", False):
@@ -1286,10 +1319,8 @@ def _get_feature_views_to_use(
                     source_fv.entities = []  # type: ignore[attr-defined]
                     source_fv.entity_columns = []  # type: ignore[attr-defined]
 
-                if source_fv not in fvs_to_use:
-                    fvs_to_use.append(
-                        source_fv.with_projection(copy.copy(source_projection))
-                    )
+                new_source_fv = source_fv.with_projection(copy.copy(source_projection))
+                _append_or_merge_source_fv(new_source_fv)
         else:
             if (
                 hide_dummy_entity
@@ -1302,7 +1333,7 @@ def _get_feature_views_to_use(
                 fv = fv.with_projection(copy.copy(projection))
                 if version_num is not None:
                     fv.projection.version_tag = version_num
-            fvs_to_use.append(fv)
+            _append_or_merge_source_fv(fv)  # type: ignore[arg-type]
 
     return (fvs_to_use, od_fvs_to_use)
 

--- a/sdk/python/tests/unit/test_utils.py
+++ b/sdk/python/tests/unit/test_utils.py
@@ -266,3 +266,177 @@ class TestPopulateResponseFromFeatureData:
                 assert ts.seconds == expected_ts
             for status in fv.statuses:
                 assert status == FieldStatus.PRESENT
+
+
+class TestGetFeatureViewsToUseSharedSource:
+    def _build_store(self, data_dir):
+        import os
+        from datetime import timedelta
+
+        import pandas as pd
+
+        from feast import Entity, FeatureStore, FeatureView, Field, FileSource
+        from feast.infra.online_stores.sqlite import SqliteOnlineStoreConfig
+        from feast.on_demand_feature_view import on_demand_feature_view
+        from feast.repo_config import RepoConfig
+        from feast.types import Float64
+
+        driver = Entity(name="driver", join_keys=["driver_id"])
+
+        df = pd.DataFrame(
+            {
+                "driver_id": [1001, 1002],
+                "event_timestamp": [
+                    datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+                    datetime(2024, 1, 1, 11, 0, 0, tzinfo=timezone.utc),
+                ],
+                "created": [
+                    datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+                    datetime(2024, 1, 1, 11, 0, 0, tzinfo=timezone.utc),
+                ],
+                "a": [1.0, 2.0],
+                "b": [10.0, 20.0],
+            }
+        )
+        src_path = os.path.join(data_dir, "src.parquet")
+        df.to_parquet(path=src_path, allow_truncated_timestamps=True)
+
+        src = FileSource(
+            name="src_source",
+            path=src_path,
+            timestamp_field="event_timestamp",
+            created_timestamp_column="created",
+        )
+
+        src_fv = FeatureView(
+            name="src_fv",
+            entities=[driver],
+            ttl=timedelta(days=0),
+            schema=[
+                Field(name="a", dtype=Float64),
+                Field(name="b", dtype=Float64),
+            ],
+            online=True,
+            source=src,
+        )
+
+        @on_demand_feature_view(
+            sources=[src_fv[["a"]]],
+            schema=[Field(name="a_out", dtype=Float64)],
+            mode="pandas",
+        )
+        def odfv_a(inputs):
+            return pd.DataFrame({"a_out": inputs["a"] + 1})
+
+        @on_demand_feature_view(
+            sources=[src_fv[["b"]]],
+            schema=[Field(name="b_out", dtype=Float64)],
+            mode="pandas",
+        )
+        def odfv_b(inputs):
+            return pd.DataFrame({"b_out": inputs["b"] + 100})
+
+        store = FeatureStore(
+            config=RepoConfig(
+                project="test_shared_source",
+                registry=os.path.join(data_dir, "registry.db"),
+                provider="local",
+                entity_key_serialization_version=3,
+                online_store=SqliteOnlineStoreConfig(
+                    path=os.path.join(data_dir, "online.db")
+                ),
+            )
+        )
+        store.apply([driver, src, src_fv, odfv_a, odfv_b])
+        return store
+
+    def test_shared_source_projections_are_merged(self):
+        import tempfile
+
+        from feast.utils import _get_feature_views_to_use
+
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as data_dir:
+            store = self._build_store(data_dir)
+
+            fvs, odfvs = _get_feature_views_to_use(
+                store.registry,
+                store.project,
+                ["odfv_a:a_out", "odfv_b:b_out"],
+            )
+
+            src_entries = [fv for fv in fvs if fv.projection.name_to_use() == "src_fv"]
+            assert len(src_entries) == 1
+            projected = sorted(
+                feature.name for feature in src_entries[0].projection.features
+            )
+            assert projected == ["a", "b"]
+            assert {odfv.name for odfv in odfvs} == {"odfv_a", "odfv_b"}
+
+    def test_regular_fv_and_odfv_source_are_merged(self):
+        # Regression: a regular FeatureView requested alongside an ODFV that
+        # sources it must resolve to a single, merged src_fv entry. Previously
+        # the regular FV was appended but not indexed in fvs_by_projection_key,
+        # so the ODFV source appended a second partial src_fv projection and a
+        # later lookup raised "KeyError: Feature a not found in projection
+        # src_fv".
+        import tempfile
+
+        from feast.utils import _get_feature_views_to_use
+
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as data_dir:
+            store = self._build_store(data_dir)
+
+            fvs, odfvs = _get_feature_views_to_use(
+                store.registry,
+                store.project,
+                ["src_fv:a", "odfv_b:b_out"],
+            )
+
+            src_entries = [fv for fv in fvs if fv.projection.name_to_use() == "src_fv"]
+            assert len(src_entries) == 1
+            projected = sorted(
+                feature.name for feature in src_entries[0].projection.features
+            )
+            assert projected == ["a", "b"]
+            assert {odfv.name for odfv in odfvs} == {"odfv_b"}
+
+    def test_regular_fv_and_odfv_source_merge_order_independent(self):
+        import tempfile
+
+        from feast.utils import _get_feature_views_to_use
+
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as data_dir:
+            store = self._build_store(data_dir)
+
+            fvs, _ = _get_feature_views_to_use(
+                store.registry,
+                store.project,
+                ["odfv_b:b_out", "src_fv:a"],
+            )
+
+            src_entries = [fv for fv in fvs if fv.projection.name_to_use() == "src_fv"]
+            assert len(src_entries) == 1
+            projected = sorted(
+                feature.name for feature in src_entries[0].projection.features
+            )
+            assert projected == ["a", "b"]
+
+    def test_shared_source_ref_order_independent(self):
+        import tempfile
+
+        from feast.utils import _get_feature_views_to_use
+
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as data_dir:
+            store = self._build_store(data_dir)
+
+            fvs, _ = _get_feature_views_to_use(
+                store.registry,
+                store.project,
+                ["odfv_b:b_out", "odfv_a:a_out"],
+            )
+            src_entries = [fv for fv in fvs if fv.projection.name_to_use() == "src_fv"]
+            assert len(src_entries) == 1
+            projected = sorted(
+                feature.name for feature in src_entries[0].projection.features
+            )
+            assert projected == ["a", "b"]


### PR DESCRIPTION
What this does
Fixes #6621.

When several on demand feature views share a source feature view but select different input columns, _get_feature_views_to_use appended the shared source view once per ODFV, each copy carrying only that ODFV's projection. The membership guard if source_fv not in fvs_to_use never matched, because BaseFeatureView.__eq__ compares projections and the freshly-fetched full-projection view never equals an already-stored narrowed copy.

Downstream, _group_feature_refs keys its view index by projection.name_to_use(), so the duplicate entries collide and the last one wins, the other ODFVs' source projections are silently dropped. During get_historical_features this means the losing ODFV's input columns are never fetched, so transforms receive missing inputs (NaN in pandas mode).

The offline retrieval path is masked on 0.62+ by the ref-injection loop from #6140, but the resolution helper still returns duplicate entries with conflicting projections to its other callers (_get_online_request_context, retrieve_online_documents, retrieve_online_documents_v2).

The fix
In _get_feature_views_to_use, index accumulated source views by projection.name_to_use() and, on a repeat hit, merge the projections (union of features, deduped by name) instead of appending a duplicate. A shared source view now resolves to a single entry carrying the union of the required input columns.

The merge helper reassigns projection.features to a fresh list rather than mutating in place, because the projections in play are shallow copies (copy.copy) that share their features list with the registry object.

Tests
Added TestGetFeatureViewsToUseSharedSource in tests/unit/test_utils.py:

- test_shared_source_projections_are_merged two ODFVs (odfv_a on src_fv[["a"]], odfv_b on src_fv[["b"]]) resolve to a single src_fv entry with projection ["a", "b"].
- test_shared_source_ref_order_independent result is the same regardless of ODFV request order.

Both fail on master (assert 2 == 1 the duplicate entries) and pass with this change. ruff check and ruff format are clean.

Related
#6099, #6140
