### PR TITLE
ci: Fix checkout failure in pull_request_target workflows

### DIFF
--- a/.github/workflows/pr_integration_tests.yml
+++ b/.github/workflows/pr_integration_tests.yml
@@ -49,6 +49,7 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           submodules: recursive
           persist-credentials: false
+          allow-unsafe-pr-checkout: true  # Security: gated by label check above
       - name: Setup Python
         uses: actions/setup-python@v5
         id: setup-python
@@ -108,6 +109,7 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           submodules: recursive
           persist-credentials: false
+          allow-unsafe-pr-checkout: true  # Security: gated by label check above
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pr_registration_integration_tests.yml
+++ b/.github/workflows/pr_registration_integration_tests.yml
@@ -27,6 +27,7 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           submodules: recursive
           persist-credentials: false
+          allow-unsafe-pr-checkout: true  # Security: gated by label check above
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
@@ -58,6 +59,7 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           submodules: recursive
           persist-credentials: false
+          allow-unsafe-pr-checkout: true  # Security: gated by label check above
       - name: Authenticate to Google Cloud
         uses: 'google-github-actions/auth@v2'
         with:


### PR DESCRIPTION


# What this PR does / why we need it:

## Problem

`actions/checkout` [v4.4.0](https://github.com/actions/checkout/releases/tag/v4.4.0)
(released 2026-07-20) backported a security check from v7 that blocks checking out
fork PR code in `pull_request_target` workflows by default. This broke **all fork PRs**
that trigger:

- `pr-integration-tests`
- `pr-registration-integration-tests`

Error:
> Refusing to check out fork pull request code from a 'pull_request_target' workflow.
> This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch
> cache scope, and runner access.

See: https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/

## Fix

Add `allow-unsafe-pr-checkout: true` to the 4 affected checkout steps across 2 workflow files.

## Why this is safe

Both workflows already implement the recommended mitigations:

- ✅ **Label gating** — jobs only run when a maintainer adds `ok-to-test`, `approved`, or `lgtm`
- ✅ **`persist-credentials: false`** — PR code cannot steal the GITHUB_TOKEN
- ✅ **Repository check** — `github.repository == 'feast-dev/feast'` prevents forks from self-triggering
