### PR TITLE
fix: use POSIX paths in feast init template bootstraps

### DIFF
--- a/sdk/python/feast/templates/cassandra/bootstrap.py
+++ b/sdk/python/feast/templates/cassandra/bootstrap.py
@@ -276,7 +276,7 @@ def bootstrap():
     # feature_definitions.py
     example_py_file = repo_path / "feature_definitions.py"
     replace_str_in_file(
-        example_py_file, "%PARQUET_PATH%", str(driver_stats_path.relative_to(repo_path))
+        example_py_file, "%PARQUET_PATH%", driver_stats_path.relative_to(repo_path).as_posix()
     )
 
     # store config yaml, interact with user and then customize file:

--- a/sdk/python/feast/templates/hazelcast/bootstrap.py
+++ b/sdk/python/feast/templates/hazelcast/bootstrap.py
@@ -166,7 +166,7 @@ def bootstrap():
     # feature_definitions.py
     example_py_file = repo_path / "feature_definitions.py"
     replace_str_in_file(
-        example_py_file, "%PARQUET_PATH%", str(driver_stats_path.relative_to(repo_path))
+        example_py_file, "%PARQUET_PATH%", driver_stats_path.relative_to(repo_path).as_posix()
     )
 
     # store config yaml, interact with user and then customize file:

--- a/sdk/python/feast/templates/hbase/bootstrap.py
+++ b/sdk/python/feast/templates/hbase/bootstrap.py
@@ -24,7 +24,7 @@ def bootstrap():
 
     example_py_file = repo_path / "feature_definitions.py"
     replace_str_in_file(
-        example_py_file, "%PARQUET_PATH%", str(driver_stats_path.relative_to(repo_path))
+        example_py_file, "%PARQUET_PATH%", driver_stats_path.relative_to(repo_path).as_posix()
     )
 
 

--- a/sdk/python/feast/templates/local/README.md
+++ b/sdk/python/feast/templates/local/README.md
@@ -9,6 +9,10 @@ uses this repo. A quick view of what's in this repository's `feature_repo/` dire
 
 You can run the overall workflow with `python test_workflow.py`.
 
+### Windows notes
+- Activate the virtualenv with `venv\Scripts\activate` (cmd) or `.\venv\Scripts\Activate.ps1` (PowerShell) or `source venv/Scripts/activate` (Git Bash).
+- Generated `FileSource` paths use forward slashes so they are valid in Python string literals on Windows.
+
 ## To move from this into a more production ready workflow:
 > See more details in [Running Feast in production](https://docs.feast.dev/how-to-guides/running-feast-in-production)
 

--- a/sdk/python/feast/templates/local/bootstrap.py
+++ b/sdk/python/feast/templates/local/bootstrap.py
@@ -48,15 +48,15 @@ def bootstrap():
     example_py_file = repo_path / "feature_definitions.py"
     replace_str_in_file(example_py_file, "%PROJECT_NAME%", str(project_name))
     replace_str_in_file(
-        example_py_file, "%PARQUET_PATH%", str(driver_stats_path.relative_to(repo_path))
+        example_py_file, "%PARQUET_PATH%", driver_stats_path.relative_to(repo_path).as_posix()
     )
     replace_str_in_file(
-        example_py_file, "%LOGGING_PATH%", str(data_path.relative_to(repo_path))
+        example_py_file, "%LOGGING_PATH%", data_path.relative_to(repo_path).as_posix()
     )
     replace_str_in_file(
         example_py_file,
         "%LABEL_DATA_PATH%",
-        str(label_data_path.relative_to(repo_path)),
+        label_data_path.relative_to(repo_path).as_posix(),
     )
 
 

--- a/sdk/python/feast/templates/milvus/bootstrap.py
+++ b/sdk/python/feast/templates/milvus/bootstrap.py
@@ -26,10 +26,10 @@ def bootstrap():
     example_py_file = repo_path / "feature_definitions.py"
     replace_str_in_file(example_py_file, "%PROJECT_NAME%", str(project_name))
     replace_str_in_file(
-        example_py_file, "%PARQUET_PATH%", str(driver_stats_path.relative_to(repo_path))
+        example_py_file, "%PARQUET_PATH%", driver_stats_path.relative_to(repo_path).as_posix()
     )
     replace_str_in_file(
-        example_py_file, "%LOGGING_PATH%", str(data_path.relative_to(repo_path))
+        example_py_file, "%LOGGING_PATH%", data_path.relative_to(repo_path).as_posix()
     )
 
 

--- a/sdk/python/feast/templates/ray/bootstrap.py
+++ b/sdk/python/feast/templates/ray/bootstrap.py
@@ -73,10 +73,10 @@ def bootstrap():
     example_py_file = repo_path / "feature_definitions.py"
     replace_str_in_file(example_py_file, "%PROJECT_NAME%", str(project_name))
     replace_str_in_file(
-        example_py_file, "%PARQUET_PATH%", str(driver_stats_path.relative_to(repo_path))
+        example_py_file, "%PARQUET_PATH%", driver_stats_path.relative_to(repo_path).as_posix()
     )
     replace_str_in_file(
-        example_py_file, "%LOGGING_PATH%", str(data_path.relative_to(repo_path))
+        example_py_file, "%LOGGING_PATH%", data_path.relative_to(repo_path).as_posix()
     )
 
     print("Ray template initialized with sample data:")


### PR DESCRIPTION
## Summary
- On Windows, `feast init` bootstrap used `str(Path.relative_to(...))`, which embeds backslashes into `feature_definitions.py` string literals and triggers `SyntaxWarning: invalid escape sequence`.
- Replace with `Path.as_posix()` in local/ray/milvus/hazelcast/hbase/cassandra template bootstraps.
- Add short Windows notes to the local template README.

Fixes #6625

## Test plan
- [ ] On Windows: `pip install -e sdk/python` (or equivalent), `feast init repro`, import `feature_definitions` with `python -W default` — no `SyntaxWarning` for `\d`
- [ ] Generated paths look like `data/driver_stats.parquet` (forward slashes)
- [ ] On Linux/macOS: `feast init` still works (POSIX paths unchanged in practice)


Made with [Cursor](https://cursor.com)