### PR TITLE
fix: tear down demo FeatureStore in-process (Windows WinError 32)

### DIFF
--- a/sdk/python/feast/templates/aws/feature_repo/test_workflow.py
+++ b/sdk/python/feast/templates/aws/feature_repo/test_workflow.py
@@ -65,7 +65,7 @@ def run_demo():
     fetch_online_features(store, source="push")
 
     print("\n--- Run feast teardown ---")
-    subprocess.run(["feast", "teardown"])
+    store.teardown()
 
 
 def fetch_historical_features_entity_sql(store: FeatureStore, for_batch_scoring):

--- a/sdk/python/feast/templates/cassandra/feature_repo/test_workflow.py
+++ b/sdk/python/feast/templates/cassandra/feature_repo/test_workflow.py
@@ -54,7 +54,7 @@ def run_demo():
     fetch_online_features(store, source="push")
 
     print("\n--- Run feast teardown ---")
-    subprocess.run(["feast", "teardown"])
+    store.teardown()
 
 
 def fetch_historical_features_entity_df(store: FeatureStore, for_batch_scoring: bool):

--- a/sdk/python/feast/templates/couchbase/feature_repo/test_workflow.py
+++ b/sdk/python/feast/templates/couchbase/feature_repo/test_workflow.py
@@ -36,7 +36,7 @@ def run_demo():
     fetch_online_features(store, source="push")
 
     print("\n--- Run feast teardown ---")
-    subprocess.run(["feast", "--chdir", os.path.dirname(__file__), "teardown"])
+    store.teardown()
 
 
 def fetch_historical_features_entity_df(store: FeatureStore, for_batch_scoring: bool):

--- a/sdk/python/feast/templates/gcp/feature_repo/test_workflow.py
+++ b/sdk/python/feast/templates/gcp/feature_repo/test_workflow.py
@@ -67,7 +67,7 @@ def run_demo():
     fetch_online_features(store, source="push")
 
     print("\n--- Run feast teardown ---")
-    subprocess.run(["feast", "teardown"])
+    store.teardown()
 
 
 def fetch_historical_features_entity_sql(store: FeatureStore, for_batch_scoring):

--- a/sdk/python/feast/templates/hazelcast/feature_repo/test_workflow.py
+++ b/sdk/python/feast/templates/hazelcast/feature_repo/test_workflow.py
@@ -54,7 +54,7 @@ def run_demo():
     fetch_online_features(store, source="push")
 
     print("\n--- Run feast teardown ---")
-    subprocess.run(["feast", "teardown"])
+    store.teardown()
 
 
 def fetch_historical_features_entity_df(store: FeatureStore, for_batch_scoring: bool):

--- a/sdk/python/feast/templates/hbase/feature_repo/test_workflow.py
+++ b/sdk/python/feast/templates/hbase/feature_repo/test_workflow.py
@@ -54,7 +54,7 @@ def run_demo():
     fetch_online_features(store, source="push")
 
     print("\n--- Run feast teardown ---")
-    subprocess.run(["feast", "teardown"])
+    store.teardown()
 
 
 def fetch_historical_features_entity_df(store: FeatureStore, for_batch_scoring: bool):

--- a/sdk/python/feast/templates/local/feature_repo/test_workflow.py
+++ b/sdk/python/feast/templates/local/feature_repo/test_workflow.py
@@ -60,7 +60,7 @@ def run_demo():
     fetch_online_features(store, source="push")
 
     print("\n--- Run feast teardown ---")
-    subprocess.run(["feast", "teardown"])
+    store.teardown()
 
 
 def fetch_historical_features_entity_df(store: FeatureStore, for_batch_scoring: bool):

--- a/sdk/python/feast/templates/milvus/feature_repo/test_workflow.py
+++ b/sdk/python/feast/templates/milvus/feature_repo/test_workflow.py
@@ -54,7 +54,7 @@ def run_demo():
     fetch_online_features(store, source="push")
 
     print("\n--- Run feast teardown ---")
-    subprocess.run(["feast", "teardown"])
+    store.teardown()
 
 
 def fetch_historical_features_entity_df(store: FeatureStore, for_batch_scoring: bool):

--- a/sdk/python/feast/templates/postgres/feature_repo/test_workflow.py
+++ b/sdk/python/feast/templates/postgres/feature_repo/test_workflow.py
@@ -55,7 +55,7 @@ def run_demo():
     fetch_online_features(store, source="push")
 
     print("\n--- Run feast teardown ---")
-    subprocess.run(["feast", "--chdir", os.path.dirname(__file__), "teardown"])
+    store.teardown()
 
 
 def fetch_historical_features_entity_df(store: FeatureStore, for_batch_scoring: bool):

--- a/sdk/python/feast/templates/spark/feature_repo/test_workflow.py
+++ b/sdk/python/feast/templates/spark/feature_repo/test_workflow.py
@@ -49,7 +49,7 @@ def run_demo():
     fetch_online_features(store, use_feature_service=True)
 
     print("\n--- Run feast teardown ---")
-    subprocess.run(["feast", "teardown"])
+    store.teardown()
 
 
 def fetch_historical_features_entity_df(store: FeatureStore, for_batch_scoring: bool):


### PR DESCRIPTION
## Summary
- Generated `test_workflow.py` demos called `subprocess.run([\"feast\", \"teardown\"])` while the parent still held an open SQLite connection via `FeatureStore`.
- On Windows this causes `PermissionError: WinError 32` when deleting `online_store.db`.
- Switch templates to `store.teardown()` so the same process closes the connection before unlinking.

Fixes #6626

## Test plan
- [ ] On Windows: `feast init repro && cd repro/feature_repo && python test_workflow.py` completes without WinError 32 at teardown
- [ ] Demo steps before teardown still succeed (apply, historical, materialize, online, push)


Made with [Cursor](https://cursor.com)