### PR TITLE
fix: Support Entra ID (Azure AD) token claims in OIDC auth

### DIFF
--- a/docs/getting-started/components/authz_manager.md
+++ b/docs/getting-started/components/authz_manager.md
@@ -47,7 +47,7 @@ Some assumptions are made in the OIDC server configuration:
 * The roles are exposed in the access token under `resource_access.<client_id>.roles` (Keycloak) or in the top-level `roles` claim (Entra ID app roles). Roles found in both are merged.
 * The JWT token is expected to have a verified signature and not be expired. The Feast OIDC token parser logic validates for `verify_signature` and `verify_exp` so make sure that the given OIDC provider is configured to meet these requirements.
 * The username is read from the first of `preferred_username`, `upn`, `azp`, `appid`, `sub` present in the token. Entra ID client-credentials (app-only) tokens carry no user claim, so they authenticate as the calling application.
-* For `GroupBasedPolicy` support, the `groups` claim should be present in the access token (requires a "Group Membership" protocol mapper in Keycloak).
+* For `GroupBasedPolicy` support, the `groups` claim should be present in the access token (requires a "Group Membership" protocol mapper in Keycloak). Entra ID emits group object IDs (GUIDs) in this claim rather than names, and omits it once a principal exceeds Entra's group overage limit, so on Entra a `GroupBasedPolicy` must reference those IDs and cannot rely on the claim for very large group memberships.
 
 (*) Please note that **the role match is case-sensitive**, e.g. the name of the role in the OIDC server and in the `Permission` configuration
 must be exactly the same.
@@ -65,6 +65,16 @@ For example, the access token for a client `app` of a user with `reader` role an
   },
   "groups": [
     "data-team"
+  ]
+}
+```
+
+A Microsoft Entra ID (Azure AD) client-credentials (app-only) token has no user claim; the application authenticates as itself, and its app roles arrive in the top-level `roles` claim:
+```json
+{
+  "azp": "11111111-2222-3333-4444-555555555555",
+  "roles": [
+    "reader"
   ]
 }
 ```

--- a/docs/getting-started/components/authz_manager.md
+++ b/docs/getting-started/components/authz_manager.md
@@ -44,9 +44,9 @@ The server, in turn, uses the same OIDC server to validate the token and extract
 
 Some assumptions are made in the OIDC server configuration:
 * The OIDC token refers to a client with roles matching the RBAC roles of the configured `Permission`s (*)
-* The roles are exposed in the access token under `resource_access.<client_id>.roles`
+* The roles are exposed in the access token under `resource_access.<client_id>.roles` (Keycloak) or in the top-level `roles` claim (Entra ID app roles). Roles found in both are merged.
 * The JWT token is expected to have a verified signature and not be expired. The Feast OIDC token parser logic validates for `verify_signature` and `verify_exp` so make sure that the given OIDC provider is configured to meet these requirements.
-* The `preferred_username` should be part of the JWT token claim.
+* The username is read from the first of `preferred_username`, `upn`, `azp`, `appid`, `sub` present in the token. Entra ID client-credentials (app-only) tokens carry no user claim, so they authenticate as the calling application.
 * For `GroupBasedPolicy` support, the `groups` claim should be present in the access token (requires a "Group Membership" protocol mapper in Keycloak).
 
 (*) Please note that **the role match is case-sensitive**, e.g. the name of the role in the OIDC server and in the `Permission` configuration

--- a/docs/getting-started/components/authz_manager.md
+++ b/docs/getting-started/components/authz_manager.md
@@ -47,7 +47,8 @@ Some assumptions are made in the OIDC server configuration:
 * The roles are exposed in the access token under `resource_access.<client_id>.roles` (Keycloak) or in the top-level `roles` claim (Entra ID app roles). Roles found in both are merged.
 * The JWT token is expected to have a verified signature and not be expired. The Feast OIDC token parser logic validates for `verify_signature` and `verify_exp` so make sure that the given OIDC provider is configured to meet these requirements.
 * The username is read from the first of `preferred_username`, `upn`, `azp`, `appid`, `sub` present in the token. Entra ID client-credentials (app-only) tokens carry no user claim, so they authenticate as the calling application.
-* For `GroupBasedPolicy` support, the `groups` claim should be present in the access token (requires a "Group Membership" protocol mapper in Keycloak). Entra ID emits group object IDs (GUIDs) in this claim rather than names, and omits it once a principal exceeds Entra's group overage limit, so on Entra a `GroupBasedPolicy` must reference those IDs and cannot rely on the claim for very large group memberships.
+* For `GroupBasedPolicy` support, the `groups` claim should be present in the access token (requires a "Group Membership" protocol mapper in Keycloak).
+* **Entra ID limitation**: Group claims use object IDs (GUIDs) instead of names, and are omitted entirely when a user exceeds the group overage threshold. GroupBasedPolicy must reference GUIDs and cannot be used for principals with large group memberships.
 
 (*) Please note that **the role match is case-sensitive**, e.g. the name of the role in the OIDC server and in the `Permission` configuration
 must be exactly the same.

--- a/sdk/python/feast/permissions/auth/oidc_token_parser.py
+++ b/sdk/python/feast/permissions/auth/oidc_token_parser.py
@@ -61,17 +61,23 @@ class OidcTokenParser(TokenParser):
 
     @staticmethod
     def _extract_username_or_raise_error(data: dict) -> str:
-        """Extract the username from the decoded JWT. Raises if missing — identity is mandatory.
+        """Extract the username from the decoded JWT, or raise if the token
+        carries none of the recognised identity claims.
 
         Human identity claims take precedence: ``preferred_username`` (Keycloak
         default), then ``upn`` (Azure AD / Entra ID). Client-credentials
         (app-only) tokens carry neither, so the calling application's own
         identity is used instead: ``azp`` (Entra ID v2 tokens), ``appid``
         (Entra ID v1 tokens), and finally ``sub``, which every issuer sets.
+        A claim present with a null or non-string value is skipped rather than
+        returned, so it never shadows a usable later claim. Because ``sub`` is a
+        mandatory string JWT claim, the raise below fires only for a malformed
+        token that provides none of the five as a string.
         """
         for claim in ("preferred_username", "upn", "azp", "appid", "sub"):
-            if claim in data:
-                return data[claim]
+            value = data.get(claim)
+            if isinstance(value, str):
+                return value
         raise AuthenticationError(
             "Missing username claim in access token: expected one of "
             "preferred_username, upn, azp, appid or sub."
@@ -199,10 +205,8 @@ class OidcTokenParser(TokenParser):
             )
             # Entra ID emits app roles in the top-level `roles` claim instead of
             # Keycloak's nested `resource_access.<client_id>.roles`. Merge both
-            # shapes, preserving order and dropping duplicates.
-            roles = roles + [
-                r for r in self._extract_claim(data, "roles") if r not in roles
-            ]
+            # shapes for every issuer, preserving order and dropping duplicates.
+            roles = list(dict.fromkeys(roles + self._extract_claim(data, "roles")))
             groups = self._extract_claim(data, "groups")
 
             logger.info(

--- a/sdk/python/feast/permissions/auth/oidc_token_parser.py
+++ b/sdk/python/feast/permissions/auth/oidc_token_parser.py
@@ -78,6 +78,9 @@ class OidcTokenParser(TokenParser):
             value = data.get(claim)
             if isinstance(value, str):
                 return value
+        logger.debug(
+            f"No usable username claim; token claims present: {list(data.keys())}"
+        )
         raise AuthenticationError(
             "Missing username claim in access token: expected one of "
             "preferred_username, upn, azp, appid or sub."

--- a/sdk/python/feast/permissions/auth/oidc_token_parser.py
+++ b/sdk/python/feast/permissions/auth/oidc_token_parser.py
@@ -63,15 +63,18 @@ class OidcTokenParser(TokenParser):
     def _extract_username_or_raise_error(data: dict) -> str:
         """Extract the username from the decoded JWT. Raises if missing — identity is mandatory.
 
-        Checks ``preferred_username`` first (Keycloak default), then falls back
-        to ``upn`` (Azure AD / Entra ID).
+        Human identity claims take precedence: ``preferred_username`` (Keycloak
+        default), then ``upn`` (Azure AD / Entra ID). Client-credentials
+        (app-only) tokens carry neither, so the calling application's own
+        identity is used instead: ``azp`` (Entra ID v2 tokens), ``appid``
+        (Entra ID v1 tokens), and finally ``sub``, which every issuer sets.
         """
-        if "preferred_username" in data:
-            return data["preferred_username"]
-        if "upn" in data:
-            return data["upn"]
+        for claim in ("preferred_username", "upn", "azp", "appid", "sub"):
+            if claim in data:
+                return data[claim]
         raise AuthenticationError(
-            "Missing preferred_username or upn field in access token."
+            "Missing username claim in access token: expected one of "
+            "preferred_username, upn, azp, appid or sub."
         )
 
     @staticmethod
@@ -194,6 +197,12 @@ class OidcTokenParser(TokenParser):
                 if self._auth_config.client_id
                 else []
             )
+            # Entra ID emits app roles in the top-level `roles` claim instead of
+            # Keycloak's nested `resource_access.<client_id>.roles`. Merge both
+            # shapes, preserving order and dropping duplicates.
+            roles = roles + [
+                r for r in self._extract_claim(data, "roles") if r not in roles
+            ]
             groups = self._extract_claim(data, "groups")
 
             logger.info(

--- a/sdk/python/tests/unit/permissions/auth/conftest.py
+++ b/sdk/python/tests/unit/permissions/auth/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 from kubernetes import client
 
@@ -60,6 +62,22 @@ def oidc_config() -> OidcAuthConfig:
         client_id=_CLIENT_ID,
         type="oidc",
     )
+
+
+@pytest.fixture
+def discovery_data() -> dict:
+    return {
+        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
+        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
+        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
+    }
+
+
+@pytest.fixture
+def signing_key() -> MagicMock:
+    key = MagicMock()
+    key.key = "a-key"
+    return key
 
 
 @pytest.fixture(

--- a/sdk/python/tests/unit/permissions/auth/conftest.py
+++ b/sdk/python/tests/unit/permissions/auth/conftest.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from unittest.mock import MagicMock
 
 import pytest
@@ -65,7 +66,7 @@ def oidc_config() -> OidcAuthConfig:
 
 
 @pytest.fixture
-def discovery_data() -> dict:
+def discovery_data() -> Dict[str, str]:
     return {
         "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
         "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",

--- a/sdk/python/tests/unit/permissions/auth/test_token_parser.py
+++ b/sdk/python/tests/unit/permissions/auth/test_token_parser.py
@@ -23,17 +23,16 @@ _CLIENT_ID = "test"
 @patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
 @patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
 def test_oidc_token_validation_success(
-    mock_discovery_data, mock_jwt, mock_signing_key, mock_oauth2, oidc_config
+    mock_discovery_data,
+    mock_jwt,
+    mock_signing_key,
+    mock_oauth2,
+    oidc_config,
+    discovery_data,
+    signing_key,
 ):
-    signing_key = MagicMock()
-    signing_key.key = "a-key"
     mock_signing_key.return_value = signing_key
-
-    mock_discovery_data.return_value = {
-        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
-        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
-        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
-    }
+    mock_discovery_data.return_value = discovery_data
 
     user_data = {
         "preferred_username": "my-name",
@@ -67,17 +66,16 @@ def test_oidc_token_validation_success(
 @patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
 @patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
 def test_oidc_token_missing_roles_key_returns_empty(
-    mock_discovery_data, mock_jwt, mock_signing_key, mock_oauth2, oidc_config
+    mock_discovery_data,
+    mock_jwt,
+    mock_signing_key,
+    mock_oauth2,
+    oidc_config,
+    discovery_data,
+    signing_key,
 ):
-    signing_key = MagicMock()
-    signing_key.key = "a-key"
     mock_signing_key.return_value = signing_key
-
-    mock_discovery_data.return_value = {
-        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
-        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
-        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
-    }
+    mock_discovery_data.return_value = discovery_data
 
     user_data = {
         "preferred_username": "my-name",
@@ -104,17 +102,16 @@ def test_oidc_token_missing_roles_key_returns_empty(
 @patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
 @patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
 def test_oidc_token_extracts_groups(
-    mock_discovery_data, mock_jwt, mock_signing_key, mock_oauth2, oidc_config
+    mock_discovery_data,
+    mock_jwt,
+    mock_signing_key,
+    mock_oauth2,
+    oidc_config,
+    discovery_data,
+    signing_key,
 ):
-    signing_key = MagicMock()
-    signing_key.key = "a-key"
     mock_signing_key.return_value = signing_key
-
-    mock_discovery_data.return_value = {
-        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
-        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
-        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
-    }
+    mock_discovery_data.return_value = discovery_data
 
     user_data = {
         "preferred_username": "my-name",
@@ -146,17 +143,16 @@ def test_oidc_token_extracts_groups(
 @patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
 @patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
 def test_oidc_token_extracts_groups_and_roles(
-    mock_discovery_data, mock_jwt, mock_signing_key, mock_oauth2, oidc_config
+    mock_discovery_data,
+    mock_jwt,
+    mock_signing_key,
+    mock_oauth2,
+    oidc_config,
+    discovery_data,
+    signing_key,
 ):
-    signing_key = MagicMock()
-    signing_key.key = "a-key"
     mock_signing_key.return_value = signing_key
-
-    mock_discovery_data.return_value = {
-        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
-        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
-        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
-    }
+    mock_discovery_data.return_value = discovery_data
 
     user_data = {
         "preferred_username": "my-name",
@@ -233,16 +229,11 @@ def test_oidc_token_username_claim_precedence(
     token_claims,
     expected_username,
     oidc_config,
+    discovery_data,
+    signing_key,
 ):
-    signing_key = MagicMock()
-    signing_key.key = "a-key"
     mock_signing_key.return_value = signing_key
-
-    mock_discovery_data.return_value = {
-        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
-        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
-        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
-    }
+    mock_discovery_data.return_value = discovery_data
 
     mock_jwt.return_value = token_claims
 
@@ -281,16 +272,11 @@ def test_oidc_token_without_usable_username_claim_fails(
     mock_oauth2,
     token_claims,
     oidc_config,
+    discovery_data,
+    signing_key,
 ):
-    signing_key = MagicMock()
-    signing_key.key = "a-key"
     mock_signing_key.return_value = signing_key
-
-    mock_discovery_data.return_value = {
-        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
-        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
-        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
-    }
+    mock_discovery_data.return_value = discovery_data
 
     mock_jwt.return_value = token_claims
 
@@ -335,16 +321,11 @@ def test_oidc_token_merges_top_level_and_resource_access_roles(
     token_claims,
     expected_roles,
     oidc_config,
+    discovery_data,
+    signing_key,
 ):
-    signing_key = MagicMock()
-    signing_key.key = "a-key"
     mock_signing_key.return_value = signing_key
-
-    mock_discovery_data.return_value = {
-        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
-        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
-        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
-    }
+    mock_discovery_data.return_value = discovery_data
 
     mock_jwt.return_value = {"preferred_username": "my-name", **token_claims}
 
@@ -366,19 +347,18 @@ def test_oidc_token_merges_top_level_and_resource_access_roles(
 @patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
 @patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
 def test_oidc_identity_and_roles_come_from_verified_decode(
-    mock_discovery_data, mock_jwt, mock_signing_key, mock_oauth2, oidc_config
+    mock_discovery_data,
+    mock_jwt,
+    mock_signing_key,
+    mock_oauth2,
+    oidc_config,
+    discovery_data,
+    signing_key,
 ):
     """Identity and roles must come from the signature-verified decode, not the
     unverified decode used only for routing."""
-    signing_key = MagicMock()
-    signing_key.key = "a-key"
     mock_signing_key.return_value = signing_key
-
-    mock_discovery_data.return_value = {
-        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
-        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
-        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
-    }
+    mock_discovery_data.return_value = discovery_data
 
     def decode(token, key=None, *args, **kwargs):
         if kwargs.get("options", {}).get("verify_signature") is False:
@@ -623,14 +603,10 @@ def test_k8s_inter_server_comm(
 @patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
 @patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
 def test_oidc_parser_handles_sa_token_via_token_review(
-    mock_discovery_data, mock_jwt_decode, oidc_config
+    mock_discovery_data, mock_jwt_decode, oidc_config, discovery_data
 ):
     """When a token contains kubernetes.io claim, _handle_sa_token is called (not the OIDC JWKS path)."""
-    mock_discovery_data.return_value = {
-        "authorization_endpoint": "https://localhost:8080/auth",
-        "token_endpoint": "https://localhost:8080/token",
-        "jwks_uri": "https://localhost:8080/certs",
-    }
+    mock_discovery_data.return_value = discovery_data
 
     mock_jwt_decode.return_value = {
         "kubernetes.io": {"namespace": "feast"},
@@ -669,18 +645,17 @@ def test_oidc_parser_handles_sa_token_via_token_review(
 @patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
 @patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
 def test_oidc_parser_routes_keycloak_token_normally(
-    mock_discovery_data, mock_jwt_decode, mock_signing_key, mock_oauth2, oidc_config
+    mock_discovery_data,
+    mock_jwt_decode,
+    mock_signing_key,
+    mock_oauth2,
+    oidc_config,
+    discovery_data,
+    signing_key,
 ):
     """When a token does NOT contain kubernetes.io claim, it should follow the OIDC path."""
-    signing_key = MagicMock()
-    signing_key.key = "a-key"
     mock_signing_key.return_value = signing_key
-
-    mock_discovery_data.return_value = {
-        "authorization_endpoint": "https://localhost:8080/auth",
-        "token_endpoint": "https://localhost:8080/token",
-        "jwks_uri": "https://localhost:8080/certs",
-    }
+    mock_discovery_data.return_value = discovery_data
 
     keycloak_payload = {
         "preferred_username": "testuser",

--- a/sdk/python/tests/unit/permissions/auth/test_token_parser.py
+++ b/sdk/python/tests/unit/permissions/auth/test_token_parser.py
@@ -357,9 +357,53 @@ def test_oidc_token_merges_top_level_and_resource_access_roles(
     assertpy.assert_that(user).is_type_of(User)
     if isinstance(user, User):
         assertpy.assert_that(user.roles).is_equal_to(expected_roles)
-        for role in expected_roles:
-            assertpy.assert_that(user.has_matching_role([role])).is_true()
-        assertpy.assert_that(user.has_matching_role(["updater"])).is_false()
+
+
+@patch(
+    "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
+)
+@patch("feast.permissions.auth.oidc_token_parser.PyJWKClient.get_signing_key_from_jwt")
+@patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
+@patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
+def test_oidc_identity_and_roles_come_from_verified_decode(
+    mock_discovery_data, mock_jwt, mock_signing_key, mock_oauth2, oidc_config
+):
+    """Identity and roles must come from the signature-verified decode, not the
+    unverified decode used only for routing."""
+    signing_key = MagicMock()
+    signing_key.key = "a-key"
+    mock_signing_key.return_value = signing_key
+
+    mock_discovery_data.return_value = {
+        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
+        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
+        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
+    }
+
+    def decode(token, key=None, *args, **kwargs):
+        if kwargs.get("options", {}).get("verify_signature") is False:
+            # Unverified decode, used only for routing; must not drive identity.
+            return {
+                "preferred_username": "spoofed-user",
+                "resource_access": {_CLIENT_ID: {"roles": ["spoofed-role"]}},
+            }
+        return {
+            "preferred_username": "verified-user",
+            "resource_access": {_CLIENT_ID: {"roles": ["reader"]}},
+        }
+
+    mock_jwt.side_effect = decode
+
+    access_token = "aaa-bbb-ccc"
+    token_parser = OidcTokenParser(auth_config=oidc_config)
+    user = asyncio.run(
+        token_parser.user_details_from_access_token(access_token=access_token)
+    )
+
+    assertpy.assert_that(user).is_type_of(User)
+    if isinstance(user, User):
+        assertpy.assert_that(user.username).is_equal_to("verified-user")
+        assertpy.assert_that(user.roles).is_equal_to(["reader"])
 
 
 @patch(

--- a/sdk/python/tests/unit/permissions/auth/test_token_parser.py
+++ b/sdk/python/tests/unit/permissions/auth/test_token_parser.py
@@ -200,6 +200,16 @@ def test_oidc_token_extracts_groups_and_roles(
             {"upn": "my-name@example.com", "azp": "my-client-app"},
             "my-name@example.com",
         ),
+        # A human claim still wins when accompanied only by application claims.
+        (
+            {
+                "preferred_username": "my-name",
+                "appid": "my-v1-client-app",
+                "sub": "my-subject",
+            },
+            "my-name",
+        ),
+        ({"upn": "my-name@example.com", "sub": "my-subject"}, "my-name@example.com"),
         # Entra ID client-credentials (app-only) tokens carry no human claim.
         (
             {"azp": "my-client-app", "appid": "my-v1-client-app", "sub": "my-subject"},
@@ -247,14 +257,30 @@ def test_oidc_token_username_claim_precedence(
         assertpy.assert_that(user.username).is_equal_to(expected_username)
 
 
+@pytest.mark.parametrize(
+    "token_claims",
+    [
+        # No identity claim at all.
+        {"resource_access": {_CLIENT_ID: {"roles": ["reader"]}}},
+        # Identity claims present but null are skipped, not accepted.
+        {"preferred_username": None, "upn": None, "azp": None, "sub": None},
+        # A non-string identity claim is skipped, not accepted.
+        {"sub": 12345},
+    ],
+)
 @patch(
     "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
 )
 @patch("feast.permissions.auth.oidc_token_parser.PyJWKClient.get_signing_key_from_jwt")
 @patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
 @patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
-def test_oidc_token_without_any_username_claim_fails(
-    mock_discovery_data, mock_jwt, mock_signing_key, mock_oauth2, oidc_config
+def test_oidc_token_without_usable_username_claim_fails(
+    mock_discovery_data,
+    mock_jwt,
+    mock_signing_key,
+    mock_oauth2,
+    token_claims,
+    oidc_config,
 ):
     signing_key = MagicMock()
     signing_key.key = "a-key"
@@ -266,7 +292,7 @@ def test_oidc_token_without_any_username_claim_fails(
         "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
     }
 
-    mock_jwt.return_value = {"resource_access": {_CLIENT_ID: {"roles": ["reader"]}}}
+    mock_jwt.return_value = token_claims
 
     access_token = "aaa-bbb-ccc"
     token_parser = OidcTokenParser(auth_config=oidc_config)
@@ -281,6 +307,8 @@ def test_oidc_token_without_any_username_claim_fails(
     [
         # Entra ID app roles arrive in the top-level `roles` claim.
         ({"roles": ["reader", "writer"]}, ["reader", "writer"]),
+        # Duplicates within the top-level claim are collapsed.
+        ({"roles": ["reader", "reader", "writer"]}, ["reader", "writer"]),
         # Keycloak's nested claim keeps working on its own.
         ({"resource_access": {_CLIENT_ID: {"roles": ["reader"]}}}, ["reader"]),
         # Both shapes present: merged, in order, without duplicates.

--- a/sdk/python/tests/unit/permissions/auth/test_token_parser.py
+++ b/sdk/python/tests/unit/permissions/auth/test_token_parser.py
@@ -184,6 +184,156 @@ def test_oidc_token_extracts_groups_and_roles(
         assertpy.assert_that(user.has_matching_group(["banking-admin"])).is_true()
 
 
+@pytest.mark.parametrize(
+    "token_claims, expected_username",
+    [
+        # Human identity claims keep precedence over the application claims.
+        (
+            {
+                "preferred_username": "my-name",
+                "upn": "my-name@example.com",
+                "azp": "my-client-app",
+            },
+            "my-name",
+        ),
+        (
+            {"upn": "my-name@example.com", "azp": "my-client-app"},
+            "my-name@example.com",
+        ),
+        # Entra ID client-credentials (app-only) tokens carry no human claim.
+        (
+            {"azp": "my-client-app", "appid": "my-v1-client-app", "sub": "my-subject"},
+            "my-client-app",
+        ),
+        ({"appid": "my-v1-client-app", "sub": "my-subject"}, "my-v1-client-app"),
+        ({"sub": "my-subject"}, "my-subject"),
+    ],
+)
+@patch(
+    "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
+)
+@patch("feast.permissions.auth.oidc_token_parser.PyJWKClient.get_signing_key_from_jwt")
+@patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
+@patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
+def test_oidc_token_username_claim_precedence(
+    mock_discovery_data,
+    mock_jwt,
+    mock_signing_key,
+    mock_oauth2,
+    token_claims,
+    expected_username,
+    oidc_config,
+):
+    signing_key = MagicMock()
+    signing_key.key = "a-key"
+    mock_signing_key.return_value = signing_key
+
+    mock_discovery_data.return_value = {
+        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
+        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
+        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
+    }
+
+    mock_jwt.return_value = token_claims
+
+    access_token = "aaa-bbb-ccc"
+    token_parser = OidcTokenParser(auth_config=oidc_config)
+    user = asyncio.run(
+        token_parser.user_details_from_access_token(access_token=access_token)
+    )
+
+    assertpy.assert_that(user).is_type_of(User)
+    if isinstance(user, User):
+        assertpy.assert_that(user.username).is_equal_to(expected_username)
+
+
+@patch(
+    "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
+)
+@patch("feast.permissions.auth.oidc_token_parser.PyJWKClient.get_signing_key_from_jwt")
+@patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
+@patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
+def test_oidc_token_without_any_username_claim_fails(
+    mock_discovery_data, mock_jwt, mock_signing_key, mock_oauth2, oidc_config
+):
+    signing_key = MagicMock()
+    signing_key.key = "a-key"
+    mock_signing_key.return_value = signing_key
+
+    mock_discovery_data.return_value = {
+        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
+        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
+        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
+    }
+
+    mock_jwt.return_value = {"resource_access": {_CLIENT_ID: {"roles": ["reader"]}}}
+
+    access_token = "aaa-bbb-ccc"
+    token_parser = OidcTokenParser(auth_config=oidc_config)
+    with pytest.raises(AuthenticationError):
+        asyncio.run(
+            token_parser.user_details_from_access_token(access_token=access_token)
+        )
+
+
+@pytest.mark.parametrize(
+    "token_claims, expected_roles",
+    [
+        # Entra ID app roles arrive in the top-level `roles` claim.
+        ({"roles": ["reader", "writer"]}, ["reader", "writer"]),
+        # Keycloak's nested claim keeps working on its own.
+        ({"resource_access": {_CLIENT_ID: {"roles": ["reader"]}}}, ["reader"]),
+        # Both shapes present: merged, in order, without duplicates.
+        (
+            {
+                "resource_access": {_CLIENT_ID: {"roles": ["reader", "writer"]}},
+                "roles": ["writer", "admin"],
+            },
+            ["reader", "writer", "admin"],
+        ),
+    ],
+)
+@patch(
+    "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
+)
+@patch("feast.permissions.auth.oidc_token_parser.PyJWKClient.get_signing_key_from_jwt")
+@patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
+@patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
+def test_oidc_token_merges_top_level_and_resource_access_roles(
+    mock_discovery_data,
+    mock_jwt,
+    mock_signing_key,
+    mock_oauth2,
+    token_claims,
+    expected_roles,
+    oidc_config,
+):
+    signing_key = MagicMock()
+    signing_key.key = "a-key"
+    mock_signing_key.return_value = signing_key
+
+    mock_discovery_data.return_value = {
+        "authorization_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/auth",
+        "token_endpoint": "https://localhost:8080/realms/master/protocol/openid-connect/token",
+        "jwks_uri": "https://localhost:8080/realms/master/protocol/openid-connect/certs",
+    }
+
+    mock_jwt.return_value = {"preferred_username": "my-name", **token_claims}
+
+    access_token = "aaa-bbb-ccc"
+    token_parser = OidcTokenParser(auth_config=oidc_config)
+    user = asyncio.run(
+        token_parser.user_details_from_access_token(access_token=access_token)
+    )
+
+    assertpy.assert_that(user).is_type_of(User)
+    if isinstance(user, User):
+        assertpy.assert_that(user.roles).is_equal_to(expected_roles)
+        for role in expected_roles:
+            assertpy.assert_that(user.has_matching_role([role])).is_true()
+        assertpy.assert_that(user.has_matching_role(["updater"])).is_false()
+
+
 @patch(
     "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
 )


### PR DESCRIPTION
# What this PR does / why we need it:

The OIDC token parser is written against Keycloak's token shape, and that breaks Microsoft Entra ID (Azure AD) in two independent places.

Username extraction accepted only `preferred_username` or `upn`. Entra client-credentials (app-only) tokens carry neither, so every machine-to-machine caller was rejected at authentication. This falls back to the calling application's own identity when no human claim is present: `azp` on v2 tokens, `appid` on v1, then `sub`, which every issuer sets. A claim that is present but null or non-string is skipped rather than returned, and a token providing none of the five claims as a string still raises `AuthenticationError`.

Roles were read only from Keycloak's nested `resource_access.<client_id>.roles`. Entra puts app roles in the top-level `roles` claim, so the extracted list was always empty and `RoleBasedPolicy` never matched. This merges the top-level claim into the existing extraction, preserving order and dropping duplicates.

Keycloak's default behavior is unchanged: the username fallbacks only fire when `preferred_username` and `upn` are both absent, the merge only adds roles, and token validation (signature and expiry) is untouched. One behavior change worth calling out for existing deployments: role resolution now also reads the top-level `roles` claim for every issuer, not only Entra. An installation whose IdP already emits a top-level `roles` claim (for example a Keycloak realm with a custom mapper) will see those roles merged into the user's Feast roles. The Keycloak `resource_access.<client_id>.roles` path itself is unchanged.

We run this exact change against an Entra tenant in production as a build-time patch on 0.64.

# Which issue(s) this PR fixes:

Fixes #6630. Supersedes #4934, which requested the roles half and was closed stale.

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

New unit tests in `sdk/python/tests/unit/permissions/auth/test_token_parser.py` cover: `preferred_username` and `upn` precedence over the application claims (including directly against `appid`/`sub`); `azp`-only, `appid`-only, and `sub`-only tokens each authenticating with that value; tokens whose only identity claims are null or non-string still raising; top-level roles extracted on their own; Keycloak `resource_access` roles still working; the de-duplicated merge when both shapes are present, including duplicates within the top-level claim; and that identity and roles are read from the signature-verified decode rather than the unverified routing decode.

# Misc

Release note: OIDC authentication now accepts Microsoft Entra ID (Azure AD) tokens. The username falls back to `azp`, `appid`, or `sub` for client-credentials (app-only) tokens, and app roles in the top-level `roles` claim are merged with Keycloak's `resource_access.<client_id>.roles`.

The PR template here does not have an auto-generated release-note field, so the note is inline above. I can't apply labels as an outside contributor, so a maintainer will need to add `kind/bug` (and `ok-to-test` for CI).

The last two `test:` commits are self-contained (a fidelity test plus a fixture extraction) and can be dropped without affecting the fix if a smaller diff is preferred.
