### PR TITLE
docs: Fix dead Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 
 ## Join us on Slack!
-👋👋👋 [Come say hi on Slack!](https://communityinviter.com/apps/feastopensource/feast-the-open-source-feature-store)
+👋👋👋 [Come say hi on Slack!](https://slack.feast.dev/)
 
 [Check out our DeepWiki!](https://deepwiki.com/feast-dev/feast)
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -2,7 +2,7 @@
 
 ## Links & Resources
 
-* [Come say hi on Slack!](https://communityinviter.com/apps/feastopensource/feast-the-open-source-feature-store)
+* [Come say hi on Slack!](https://slack.feast.dev/)
   * As a part of the Linux Foundation, we ask community members to adhere to the [Linux Foundation Code of Conduct](https://events.linuxfoundation.org/about/code-of-conduct/)
 * [GitHub Repository](https://github.com/feast-dev/feast/): Find the complete Feast codebase on GitHub.
   * [Community Governance Doc](https://github.com/feast-dev/feast/blob/master/community): See the governance model of Feast, including who the maintainers are and how decisions are made.

--- a/infra/templates/README.md.jinja2
+++ b/infra/templates/README.md.jinja2
@@ -17,7 +17,7 @@
 
 
 ## Join us on Slack!
-👋👋👋 [Come say hi on Slack!](https://communityinviter.com/apps/feastopensource/feast-the-open-source-feature-store)
+👋👋👋 [Come say hi on Slack!](https://slack.feast.dev/)
 
 [Check out our DeepWiki!](https://deepwiki.com/feast-dev/feast)
 


### PR DESCRIPTION
# What this PR does / why we need it:

The "Come say hi on Slack!" link points at `communityinviter.com`, which has been deprecated; the invite no longer resolves (it shows a "Community Inviter has moved" splash with no join form). This repoints it at `https://slack.feast.dev/`, the Feast-owned vanity URL that redirects to the current Slack workspace invite and stays valid as the underlying invite rotates.

Updated in both the README and `docs/community.md` (the source for the docs.feast.dev/community page).

# Which issue(s) this PR fixes:

None filed; this is a small docs fix.

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [x] Testing is not required for this change

# Misc

Release note: NONE.

As an outside contributor I can't apply labels, so a maintainer will need to add a `kind/documentation` (or `kind/housekeeping`) label and run `ok-to-test`.
