### PR TITLE
fix: Avoid importing feast.feature_store at mcp_server import time

### DIFF
--- a/sdk/python/feast/infra/mcp_servers/mcp_server.py
+++ b/sdk/python/feast/infra/mcp_servers/mcp_server.py
@@ -6,9 +6,10 @@ to expose Feast functionality through the Model Context Protocol.
 """
 
 import logging
-from typing import Any, Dict, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, Optional, Set
 
-from feast.feature_store import FeatureStore
+if TYPE_CHECKING:
+    from feast.feature_store import FeatureStore
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +98,9 @@ def _patch_fastapi_mcp_schema_resolver() -> None:
         pass
 
 
-def add_mcp_support_to_app(app, store: FeatureStore, config) -> Optional["FastApiMCP"]:
+def add_mcp_support_to_app(
+    app, store: "FeatureStore", config
+) -> Optional["FastApiMCP"]:
     """Add MCP support to the FastAPI app if enabled in configuration."""
     if not MCP_AVAILABLE:
         logger.warning("MCP support requested but fastapi_mcp is not available")


### PR DESCRIPTION
# What this PR does / why we need it:

`feast/infra/mcp_servers/mcp_server.py` imported `feast.feature_store.FeatureStore` at module load, but used it only for a type annotation on `add_mcp_support_to_app`. Because the `feast.infra.mcp_servers` package `__init__` eagerly imports `mcp_server`, importing the package pulled the entire `feature_store` import graph in as a side effect.

Under parallel unit-test collection (`pytest -n`), that heavy import intermittently raced with an in-progress `feature_store` import and failed collection of `tests/unit/infra/feature_servers/test_mcp_server.py` with `KeyError: 'feast.infra.mcp_servers.mcp_server'`. The tests pass in isolation, so it shows up as a flaky `unit-test-python` failure.

Moving the import under `TYPE_CHECKING` with a forward-reference annotation removes `feature_store` from `mcp_server`'s module-load path, so importing `mcp_server` no longer triggers that graph. Public API and the annotation are unchanged.

# Which issue(s) this PR fixes:

Fixes #6633

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

`test_mcp_server.py` passes (23), and `feast.infra.mcp_servers` still exposes `add_mcp_support_to_app` and `McpFeatureServerConfig`. ruff and mypy clean.

# Misc

Release note: NONE.

As an outside contributor I can't apply labels, so a maintainer will need to add `kind/bug` and run `ok-to-test`.
