### PR TITLE
fix: Return False from __eq__ on cross-type comparison

### DIFF
--- a/sdk/python/feast/aggregation/__init__.py
+++ b/sdk/python/feast/aggregation/__init__.py
@@ -90,7 +90,7 @@ class Aggregation:
 
     def __eq__(self, other):
         if not isinstance(other, Aggregation):
-            raise TypeError("Comparisons should only involve Aggregations.")
+            return False
 
         if (
             self.column != other.column

--- a/sdk/python/feast/base_feature_view.py
+++ b/sdk/python/feast/base_feature_view.py
@@ -172,9 +172,7 @@ class BaseFeatureView(ABC):
 
     def __eq__(self, other):
         if not isinstance(other, BaseFeatureView):
-            raise TypeError(
-                "Comparisons should only involve BaseFeatureView class objects."
-            )
+            return False
 
         if (
             self.name != other.name

--- a/sdk/python/feast/data_format.py
+++ b/sdk/python/feast/data_format.py
@@ -33,6 +33,8 @@ class FileFormat(ABC):
         pass
 
     def __eq__(self, other):
+        if not isinstance(other, FileFormat):
+            return False
         return self.to_proto() == other.to_proto()
 
     @classmethod
@@ -95,6 +97,8 @@ class StreamFormat(ABC):
         pass
 
     def __eq__(self, other):
+        if not isinstance(other, StreamFormat):
+            return False
         return self.to_proto() == other.to_proto()
 
     @classmethod

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -279,7 +279,7 @@ class DataSource(ABC):
             return False
 
         if not isinstance(other, DataSource):
-            raise TypeError("Comparisons should only involve DataSource class objects.")
+            return False
 
         if (
             self.name != other.name
@@ -499,9 +499,7 @@ class KafkaSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, KafkaSource):
-            raise TypeError(
-                "Comparisons should only involve KafkaSource class objects."
-            )
+            return False
 
         if not super().__eq__(other):
             return False
@@ -639,9 +637,7 @@ class RequestSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, RequestSource):
-            raise TypeError(
-                "Comparisons should only involve RequestSource class objects."
-            )
+            return False
 
         if not super().__eq__(other):
             return False
@@ -801,9 +797,7 @@ class KinesisSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, KinesisSource):
-            raise TypeError(
-                "Comparisons should only involve KinesisSource class objects."
-            )
+            return False
 
         if not super().__eq__(other):
             return False

--- a/sdk/python/feast/entity.py
+++ b/sdk/python/feast/entity.py
@@ -126,7 +126,7 @@ class Entity:
 
     def __eq__(self, other):
         if not isinstance(other, Entity):
-            raise TypeError("Comparisons should only involve Entity class objects.")
+            return False
 
         if (
             self.name != other.name

--- a/sdk/python/feast/feature.py
+++ b/sdk/python/feast/feature.py
@@ -50,6 +50,8 @@ class Feature:
             self._labels = labels
 
     def __eq__(self, other):
+        if not isinstance(other, Feature):
+            return False
         if self.name != other.name or self.dtype != other.dtype:
             return False
         return True

--- a/sdk/python/feast/feature_service.py
+++ b/sdk/python/feast/feature_service.py
@@ -293,9 +293,7 @@ class FeatureService:
 
     def __eq__(self, other):
         if not isinstance(other, FeatureService):
-            raise TypeError(
-                "Comparisons should only involve FeatureService class objects."
-            )
+            return False
 
         if (
             self.name != other.name

--- a/sdk/python/feast/feature_view.py
+++ b/sdk/python/feast/feature_view.py
@@ -395,9 +395,7 @@ class FeatureView(BaseFeatureView):
 
     def __eq__(self, other):
         if not isinstance(other, FeatureView):
-            raise TypeError(
-                "Comparisons should only involve FeatureView class objects."
-            )
+            return False
 
         if not super().__eq__(other):
             return False

--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -97,9 +97,7 @@ class BigQuerySource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, BigQuerySource):
-            raise TypeError(
-                "Comparisons should only involve BigQuerySource class objects."
-            )
+            return False
 
         return (
             super().__eq__(other)

--- a/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena_source.py
@@ -115,9 +115,7 @@ class AthenaSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, AthenaSource):
-            raise TypeError(
-                "Comparisons should only involve AthenaSource class objects."
-            )
+            return False
 
         return (
             super().__eq__(other)

--- a/sdk/python/feast/infra/offline_stores/contrib/couchbase_offline_store/couchbase_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/couchbase_offline_store/couchbase_source.py
@@ -93,9 +93,7 @@ class CouchbaseColumnarSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, CouchbaseColumnarSource):
-            raise TypeError(
-                "Comparisons should only involve CouchbaseColumnarSource class objects."
-            )
+            return False
 
         return (
             super().__eq__(other)

--- a/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssqlserver_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssqlserver_source.py
@@ -170,9 +170,7 @@ class MsSqlServerSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, MsSqlServerSource):
-            raise TypeError(
-                "Comparisons should only involve SqlServerSource class objects."
-            )
+            return False
 
         return (
             self.name == other.name

--- a/sdk/python/feast/infra/offline_stores/contrib/oracle_offline_store/oracle_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/oracle_offline_store/oracle_source.py
@@ -105,9 +105,7 @@ class OracleSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, OracleSource):
-            raise TypeError(
-                "Comparisons should only involve OracleSource class objects."
-            )
+            return False
 
         return (
             self.name == other.name

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres_source.py
@@ -77,9 +77,7 @@ class PostgreSQLSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, PostgreSQLSource):
-            raise TypeError(
-                "Comparisons should only involve PostgreSQLSource class objects."
-            )
+            return False
 
         return (
             super().__eq__(other)

--- a/sdk/python/feast/infra/offline_stores/contrib/ray_offline_store/ray_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/ray_offline_store/ray_source.py
@@ -228,7 +228,7 @@ class RaySource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, RaySource):
-            raise TypeError("Comparisons should only involve RaySource class objects.")
+            return False
         base_eq = super().__eq__(other)
         if not base_eq:
             return False

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -262,8 +262,13 @@ class SparkSource(DataSource):
         return reader.load(self.path)
 
     def __eq__(self, other):
-        base_eq = super().__eq__(other)
-        if not base_eq:
+        # Guard before the spark-specific attribute access below: the base
+        # DataSource.__eq__ accepts any DataSource subclass, so a cross-type
+        # comparison (e.g. against a FileSource with a matching name) would
+        # otherwise raise AttributeError on `other.table` (#6636).
+        if not isinstance(other, SparkSource):
+            return False
+        if not super().__eq__(other):
             return False
         return (
             self.table == other.table

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_source.py
@@ -146,9 +146,7 @@ class TrinoSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, TrinoSource):
-            raise TypeError(
-                "Comparisons should only involve TrinoSource class objects."
-            )
+            return False
 
         return (
             super().__eq__(other)

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -97,7 +97,7 @@ class FileSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, FileSource):
-            raise TypeError("Comparisons should only involve FileSource class objects.")
+            return False
 
         return (
             super().__eq__(other)

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -123,9 +123,7 @@ class RedshiftSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, RedshiftSource):
-            raise TypeError(
-                "Comparisons should only involve RedshiftSource class objects."
-            )
+            return False
 
         return (
             super().__eq__(other)

--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -132,9 +132,7 @@ class SnowflakeSource(DataSource):
 
     def __eq__(self, other):
         if not isinstance(other, SnowflakeSource):
-            raise TypeError(
-                "Comparisons should only involve SnowflakeSource class objects."
-            )
+            return False
 
         return (
             super().__eq__(other)

--- a/sdk/python/feast/labeling/label_view.py
+++ b/sdk/python/feast/labeling/label_view.py
@@ -221,7 +221,7 @@ class LabelView(BaseFeatureView):
 
     def __eq__(self, other):
         if not isinstance(other, LabelView):
-            raise TypeError("Comparisons should only involve LabelView class objects.")
+            return False
 
         if not super().__eq__(other):
             return False

--- a/sdk/python/feast/on_demand_feature_view.py
+++ b/sdk/python/feast/on_demand_feature_view.py
@@ -459,9 +459,7 @@ class OnDemandFeatureView(BaseFeatureView):
 
     def __eq__(self, other):
         if not isinstance(other, OnDemandFeatureView):
-            raise TypeError(
-                "Comparisons should only involve OnDemandFeatureView class objects."
-            )
+            return False
 
         # Note, no longer evaluating the base feature view layer as ODFVs can have
         # multiple datasources and a base_feature_view only has one source

--- a/sdk/python/feast/permissions/permission.py
+++ b/sdk/python/feast/permissions/permission.py
@@ -84,7 +84,7 @@ class Permission(ABC):
 
     def __eq__(self, other):
         if not isinstance(other, Permission):
-            raise TypeError("Comparisons should only involve Permission class objects.")
+            return False
 
         if (
             self.name != other.name

--- a/sdk/python/feast/permissions/policy.py
+++ b/sdk/python/feast/permissions/policy.py
@@ -80,9 +80,7 @@ class RoleBasedPolicy(Policy):
 
     def __eq__(self, other):
         if not isinstance(other, RoleBasedPolicy):
-            raise TypeError(
-                "Comparisons should only involve RoleBasedPolicy class objects."
-            )
+            return False
 
         if sorted(self.roles) != sorted(other.roles):
             return False
@@ -148,9 +146,7 @@ class GroupBasedPolicy(Policy):
 
     def __eq__(self, other):
         if not isinstance(other, GroupBasedPolicy):
-            raise TypeError(
-                "Comparisons should only involve GroupBasedPolicy class objects."
-            )
+            return False
 
         if sorted(self.groups) != sorted(other.groups):
             return False
@@ -206,9 +202,7 @@ class NamespaceBasedPolicy(Policy):
 
     def __eq__(self, other):
         if not isinstance(other, NamespaceBasedPolicy):
-            raise TypeError(
-                "Comparisons should only involve NamespaceBasedPolicy class objects."
-            )
+            return False
 
         if sorted(self.namespaces) != sorted(other.namespaces):
             return False
@@ -270,9 +264,7 @@ class CombinedGroupNamespacePolicy(Policy):
 
     def __eq__(self, other):
         if not isinstance(other, CombinedGroupNamespacePolicy):
-            raise TypeError(
-                "Comparisons should only involve CombinedGroupNamespacePolicy class objects."
-            )
+            return False
 
         if sorted(self.groups) != sorted(other.groups) or sorted(
             self.namespaces

--- a/sdk/python/feast/project.py
+++ b/sdk/python/feast/project.py
@@ -82,7 +82,7 @@ class Project:
 
     def __eq__(self, other):
         if not isinstance(other, Project):
-            raise TypeError("Comparisons should only involve Project class objects.")
+            return False
 
         if (
             self.name != other.name

--- a/sdk/python/feast/project_metadata.py
+++ b/sdk/python/feast/project_metadata.py
@@ -60,9 +60,7 @@ class ProjectMetadata:
 
     def __eq__(self, other):
         if not isinstance(other, ProjectMetadata):
-            raise TypeError(
-                "Comparisons should only involve ProjectMetadata class objects."
-            )
+            return False
 
         if (
             self.project_name != other.project_name

--- a/sdk/python/feast/saved_dataset.py
+++ b/sdk/python/feast/saved_dataset.py
@@ -133,9 +133,7 @@ class SavedDataset:
 
     def __eq__(self, other):
         if not isinstance(other, SavedDataset):
-            raise TypeError(
-                "Comparisons should only involve SavedDataset class objects."
-            )
+            return False
 
         if (
             self.name != other.name

--- a/sdk/python/feast/stream_feature_view.py
+++ b/sdk/python/feast/stream_feature_view.py
@@ -248,7 +248,7 @@ class StreamFeatureView(FeatureView):
 
     def __eq__(self, other):
         if not isinstance(other, StreamFeatureView):
-            raise TypeError("Comparisons should only involve StreamFeatureViews")
+            return False
 
         if not super().__eq__(other):
             return False

--- a/sdk/python/feast/transformation/pandas_transformation.py
+++ b/sdk/python/feast/transformation/pandas_transformation.py
@@ -132,9 +132,7 @@ class PandasTransformation(Transformation):
 
     def __eq__(self, other):
         if not isinstance(other, PandasTransformation):
-            raise TypeError(
-                "Comparisons should only involve PandasTransformation class objects."
-            )
+            return False
 
         if (
             self.udf_string != other.udf_string

--- a/sdk/python/feast/transformation/python_transformation.py
+++ b/sdk/python/feast/transformation/python_transformation.py
@@ -143,9 +143,7 @@ class PythonTransformation(Transformation):
 
     def __eq__(self, other):
         if not isinstance(other, PythonTransformation):
-            raise TypeError(
-                "Comparisons should only involve PythonTransformation class objects."
-            )
+            return False
 
         if (
             self.udf_string != other.udf_string

--- a/sdk/python/feast/transformation/ray_transformation.py
+++ b/sdk/python/feast/transformation/ray_transformation.py
@@ -270,9 +270,7 @@ class RayTransformation(Transformation):
 
     def __eq__(self, other):
         if not isinstance(other, RayTransformation):
-            raise TypeError(
-                "Comparisons should only involve RayTransformation class objects."
-            )
+            return False
 
         if (
             self.udf_string != other.udf_string

--- a/sdk/python/feast/transformation/substrait_transformation.py
+++ b/sdk/python/feast/transformation/substrait_transformation.py
@@ -133,9 +133,7 @@ class SubstraitTransformation(Transformation):
 
     def __eq__(self, other):
         if not isinstance(other, SubstraitTransformation):
-            raise TypeError(
-                "Comparisons should only involve SubstraitTransformation class objects."
-            )
+            return False
 
         return (
             self.substrait_plan == other.substrait_plan

--- a/sdk/python/tests/unit/permissions/test_policy.py
+++ b/sdk/python/tests/unit/permissions/test_policy.py
@@ -42,3 +42,10 @@ def test_role_based_policy(users, required_roles, username, result):
         assertpy.assert_that(explain).is_equal_to("")
     else:
         assertpy.assert_that(len(explain)).is_greater_than(0)
+
+
+def test_policy_eq_cross_type_returns_false():
+    """A policy compared to a different type returns False, not TypeError."""
+    policy = RoleBasedPolicy(roles=["reader"])
+    assert (policy == "not a policy") is False
+    assert (policy == 42) is False

--- a/sdk/python/tests/unit/test_data_sources.py
+++ b/sdk/python/tests/unit/test_data_sources.py
@@ -306,3 +306,30 @@ def test_redshift_fully_qualified_table_name(source_kwargs, expected_name):
     )
 
     assert redshift_source.redshift_options.fully_qualified_table_name == expected_name
+
+
+def test_data_source_eq_cross_type_returns_false():
+    """A DataSource compared to a different type returns ``False``, never ``TypeError``.
+
+    Regression: ``__eq__`` used to ``raise TypeError("Comparisons should only involve
+    <X> class objects.")`` on a cross-type comparison, so changing a feature view's
+    source type and re-``apply()``-ing over an existing registry crashed. Comparing
+    objects of different types must return ``False``, matching ``PushSource.__eq__``.
+    """
+    file_source = FileSource(name="src", path="/tmp/x.parquet", timestamp_field="ts")
+    snowflake_source = SnowflakeSource(
+        name="src", database="D", schema="S", table="T", timestamp_field="ts"
+    )
+
+    # Cross-type comparison is False in both directions, not a raise.
+    assert (file_source == snowflake_source) is False
+    assert (snowflake_source == file_source) is False
+
+    # Comparison against a non-DataSource operand is also False, not a raise.
+    assert (file_source == "not a data source") is False
+    assert (file_source == 42) is False
+
+    # Same-type equality still holds for two independently-built equal instances.
+    assert file_source == FileSource(
+        name="src", path="/tmp/x.parquet", timestamp_field="ts"
+    )

--- a/sdk/python/tests/unit/test_entity.py
+++ b/sdk/python/tests/unit/test_entity.py
@@ -88,3 +88,10 @@ def test_entity_with_value_type_no_warning():
         warnings.simplefilter("error")
         entity = Entity(name="my-entity", value_type=ValueType.STRING)
     assert entity.value_type == ValueType.STRING
+
+
+def test_entity_eq_cross_type_returns_false():
+    """Entity compared to a different type returns False, not TypeError."""
+    entity = Entity(name="my-entity", value_type=ValueType.STRING)
+    assert (entity == "not an entity") is False
+    assert (entity == 42) is False

--- a/sdk/python/tests/unit/test_eq_cross_type.py
+++ b/sdk/python/tests/unit/test_eq_cross_type.py
@@ -1,0 +1,94 @@
+"""Cross-type ``__eq__`` regression tests (see #6636).
+
+Comparing two Feast registry objects of different types must return ``False``
+instead of raising ``TypeError``. This exercises the shared
+``if not isinstance(other, X): return False`` guard across the importable core
+object model in one place; the per-type tests for ``DataSource``, ``Entity``,
+``LabelView``, and ``RoleBasedPolicy`` live in their own modules.
+
+The contrib offline sources (athena, couchbase, mssql, oracle, postgres, ray,
+trino) and the optional-dependency transformations are intentionally omitted:
+the unit environment does not install their drivers, so they cannot be imported
+here. Their ``__eq__`` follows the identical, mechanical pattern.
+"""
+
+from datetime import timedelta
+
+import pytest
+
+from feast import Entity, FeatureService, FeatureView, Project
+from feast.aggregation import Aggregation
+from feast.data_format import ProtoFormat
+from feast.data_source import KafkaSource, KinesisSource, RequestSource
+from feast.field import Field
+from feast.infra.offline_stores.bigquery_source import BigQuerySource
+from feast.infra.offline_stores.file_source import FileSource
+from feast.infra.offline_stores.redshift_source import RedshiftSource
+from feast.infra.offline_stores.snowflake_source import SnowflakeSource
+from feast.permissions.permission import Permission
+from feast.permissions.policy import (
+    CombinedGroupNamespacePolicy,
+    GroupBasedPolicy,
+    NamespaceBasedPolicy,
+    RoleBasedPolicy,
+)
+from feast.types import Int64
+
+
+def _instances():
+    """One instance of each importable type touched by the __eq__ sweep."""
+    return {
+        "Entity": Entity(name="e"),
+        "Project": Project(name="proj"),
+        "Aggregation": Aggregation(column="c", function="sum"),
+        "Permission": Permission(name="perm"),
+        "RoleBasedPolicy": RoleBasedPolicy(roles=["reader"]),
+        "GroupBasedPolicy": GroupBasedPolicy(groups=["g"]),
+        "NamespaceBasedPolicy": NamespaceBasedPolicy(namespaces=["n"]),
+        "CombinedGroupNamespacePolicy": CombinedGroupNamespacePolicy(
+            groups=["g"], namespaces=["n"]
+        ),
+        "FileSource": FileSource(
+            name="fs", path="/tmp/x.parquet", timestamp_field="ts"
+        ),
+        "BigQuerySource": BigQuerySource(
+            name="bq", table="p.d.t", timestamp_field="ts"
+        ),
+        "RedshiftSource": RedshiftSource(name="rs", table="t", timestamp_field="ts"),
+        "SnowflakeSource": SnowflakeSource(
+            name="sf", database="D", schema="S", table="T", timestamp_field="ts"
+        ),
+        "KafkaSource": KafkaSource(
+            name="ks",
+            kafka_bootstrap_servers="s",
+            message_format=ProtoFormat("cp"),
+            topic="t",
+            timestamp_field="ts",
+        ),
+        "KinesisSource": KinesisSource(
+            name="kn",
+            region="r",
+            record_format=ProtoFormat("cp"),
+            stream_name="s",
+            timestamp_field="ts",
+        ),
+        "RequestSource": RequestSource(
+            name="rq", schema=[Field(name="f", dtype=Int64)]
+        ),
+        "FeatureView": FeatureView(name="fv", ttl=timedelta(days=1)),
+        "FeatureService": FeatureService(name="svc", features=[]),
+    }
+
+
+_CASES = list(_instances().items())
+
+
+@pytest.mark.parametrize("name,obj", _CASES, ids=[n for n, _ in _CASES])
+def test_eq_cross_type_returns_false(name, obj):
+    # A different-typed operand must compare False, never raise (#6636).
+    assert (obj == object()) is False
+    assert (obj == "not a feast object") is False
+    # __ne__ derives from __eq__, so it must be the inverse.
+    assert (obj != object()) is True
+    # The isinstance guard must not break same-object equality.
+    assert (obj == obj) is True

--- a/sdk/python/tests/unit/test_eq_cross_type.py
+++ b/sdk/python/tests/unit/test_eq_cross_type.py
@@ -6,10 +6,13 @@ instead of raising ``TypeError``. This exercises the shared
 object model in one place; the per-type tests for ``DataSource``, ``Entity``,
 ``LabelView``, and ``RoleBasedPolicy`` live in their own modules.
 
-The contrib offline sources (athena, couchbase, mssql, oracle, postgres, ray,
+Most contrib offline sources (athena, couchbase, mssql, oracle, postgres, ray,
 trino) and the optional-dependency transformations are intentionally omitted:
 the unit environment does not install their drivers, so they cannot be imported
-here. Their ``__eq__`` follows the identical, mechanical pattern.
+here. Their ``__eq__`` follows the identical, mechanical pattern. SparkSource
+is the exception — its module imports without pyspark, and its ``__eq__``
+accesses spark-only attributes after the shared ``DataSource`` base check, so
+it gets a dedicated cross-subclass test below.
 """
 
 from datetime import timedelta
@@ -18,8 +21,9 @@ import pytest
 
 from feast import Entity, FeatureService, FeatureView, Project
 from feast.aggregation import Aggregation
-from feast.data_format import ProtoFormat
+from feast.data_format import ParquetFormat, ProtoFormat
 from feast.data_source import KafkaSource, KinesisSource, RequestSource
+from feast.feature import Feature
 from feast.field import Field
 from feast.infra.offline_stores.bigquery_source import BigQuerySource
 from feast.infra.offline_stores.file_source import FileSource
@@ -33,12 +37,16 @@ from feast.permissions.policy import (
     RoleBasedPolicy,
 )
 from feast.types import Int64
+from feast.value_type import ValueType
 
 
 def _instances():
     """One instance of each importable type touched by the __eq__ sweep."""
     return {
         "Entity": Entity(name="e"),
+        "Feature": Feature(name="f", dtype=ValueType.INT64),
+        "ParquetFormat": ParquetFormat(),
+        "ProtoFormat": ProtoFormat("com.example.Msg"),
         "Project": Project(name="proj"),
         "Aggregation": Aggregation(column="c", function="sum"),
         "Permission": Permission(name="perm"),
@@ -92,3 +100,23 @@ def test_eq_cross_type_returns_false(name, obj):
     assert (obj != object()) is True
     # The isinstance guard must not break same-object equality.
     assert (obj == obj) is True
+
+
+def test_spark_source_vs_file_source_eq():
+    # Reported on #6636: swapping a FeatureView's source from FileSource to
+    # SparkSource. The two sources share the base DataSource fields, so
+    # SparkSource.__eq__ used to pass the base check and then raise
+    # AttributeError on FileSource's missing `table`. Both directions must
+    # simply compare False.
+    spark_source = pytest.importorskip(
+        "feast.infra.offline_stores.contrib.spark_offline_store.spark_source"
+    )
+    SparkSource = spark_source.SparkSource
+
+    spark = SparkSource(name="src", table="t", timestamp_field="ts")
+    file = FileSource(name="src", path="/tmp/x.parquet", timestamp_field="ts")
+
+    assert (spark == file) is False
+    assert (file == spark) is False
+    assert (spark == object()) is False
+    assert (spark == SparkSource(name="src", table="t", timestamp_field="ts")) is True

--- a/sdk/python/tests/unit/test_label_view.py
+++ b/sdk/python/tests/unit/test_label_view.py
@@ -175,8 +175,9 @@ class TestLabelViewCopyAndEquality:
 
     def test_equality_type_check(self):
         lv = _sample_label_view()
-        with pytest.raises(TypeError):
-            lv == "not a label view"
+        # Cross-type comparison returns False, not TypeError.
+        assert (lv == "not a label view") is False
+        assert (lv == 42) is False
 
     def test_hash_by_name(self):
         lv1 = _sample_label_view()


### PR DESCRIPTION
# What this PR does / why we need it:

Every registry object's `__eq__` raised `TypeError` when compared against an object of a different type:

```python
if not isinstance(other, X):
    raise TypeError("Comparisons should only involve X class objects.")
```

Comparing objects of different types should be `False`, not an error. Because the apply/diff path compares registered objects against incoming ones, this meant changing a feature view's data source type and re-running `feast apply` over an existing registry crashed with `TypeError: Comparisons should only involve <X> class objects.`

This replaces the raise with `return False` across all 35 affected `__eq__` methods (`DataSource` and its `Kafka`/`Request`/`Kinesis` subclasses, the offline and contrib sources, `Entity`, `FeatureView`, `BaseFeatureView`, `OnDemandFeatureView`, `StreamFeatureView`, `FeatureService`, `SavedDataset`, `Project`, `ProjectMetadata`, the transformations, `Aggregation`, `LabelView`, `Permission`, and the policies). `PushSource.__eq__` already handled a cross-type comparison this way, so this makes every other `__eq__` consistent with it rather than introducing a new pattern (there is no `return NotImplemented` anywhere in the codebase).

# Which issue(s) this PR fixes:

Fixes #6636

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

Added cross-type regression tests asserting `False` (not a raise) for `DataSource`, `Entity`, and a policy object, and updated `test_label_view.py::test_equality_type_check`, which previously asserted the removed `TypeError`. Full unit suite passes locally.

# Misc

Release note: Comparing two Feast objects of different types now returns `False` instead of raising `TypeError`, so changing a feature view's data source type and re-applying no longer crashes.

Scope: this sweeps all 35 sites across the object model. Happy to narrow to just the `DataSource` hierarchy (where the crash reproduces), with a follow-up for the rest, if a smaller diff is preferred.

As an outside contributor I can't apply labels, so a maintainer will need to add a `kind/bug` label and run `ok-to-test`.
