### PR TITLE
feat: Add ConnectionRef to DataSource for pluggable external credential resolution

### DIFF
--- a/docs/reference/data-sources/overview.md
+++ b/docs/reference/data-sources/overview.md
@@ -10,6 +10,79 @@ However, not every batch data source supports all of these types.
 
 For more details on the Feast type system, see [here](../type-system.md).
 
+## Per-DataSource Credentials (ConnectionRef)
+
+By default, every data source inherits connection credentials from the global `feature_store.yaml` offline store configuration. The `ConnectionRef` feature allows each data source to declare its own external credential reference, enabling:
+
+- **Multi-tenant deployments** where different feature views access different accounts or databases.
+- **Credential isolation** where secrets are resolved at runtime from external providers (Kubernetes Secrets, HashiCorp Vault, environment variables) rather than stored in configuration files.
+- **Hybrid offline store** routing where a single Feast deployment connects to multiple backends, each with independent credentials.
+
+### ConnectionRef structure
+
+A `ConnectionRef` is attached to any data source via the `connection_ref` parameter:
+
+```python
+from feast.credentials import ConnectionRef
+from feast.infra.offline_stores.snowflake_source import SnowflakeSource
+
+source = SnowflakeSource(
+    table="USER_FEATURES",
+    connection_ref=ConnectionRef(
+        provider="kubernetes",
+        name="snowflake-creds",
+        namespace="ml-team",
+        connection_type="snowflake.offline",
+        auth_type="secret",
+        params={"account": "xy12345", "warehouse": "COMPUTE_WH"},
+    ),
+)
+```
+
+| Field | Description | Required |
+|-------|-------------|----------|
+| `provider` | Credential backend — `"kubernetes"`, `"vault"`, `"env"`, `"aws-secrets-manager"`, `"gcp-secret-manager"`, `"azure-key-vault"` | Yes |
+| `name` | Provider-specific identifier — K8s Secret name, Vault path, env-var prefix, etc. | Yes |
+| `namespace` | Scope qualifier — K8s namespace, Vault mount, AWS region, etc. | No |
+| `connection_type` | Offline store type (e.g., `"snowflake.offline"`, `"bigquery"`, `"spark"`) | No |
+| `auth_type` | Authentication mechanism — `"secret"` (default), `"oauth2"`, `"basic"`, `"sigv4"` | No |
+| `params` | Non-sensitive connection parameters (account, database, warehouse, endpoint) | No |
+
+### Credential providers
+
+Feast ships with built-in providers that can be registered at startup:
+
+| Provider | Resolves from | `name` is | `namespace` is |
+|----------|---------------|-----------|----------------|
+| `env` | Environment variables | Variable prefix | — |
+| `kubernetes` | Kubernetes Secrets | Secret name | K8s namespace |
+| `vault` | HashiCorp Vault | Secret path | Vault mount |
+
+Custom providers can be registered via:
+
+```python
+from feast.credentials import register_credential_provider, CredentialProvider, ConnectionRef
+
+class MyProvider(CredentialProvider):
+    def provider_type(self) -> str:
+        return "my-provider"
+
+    def resolve(self, ref: ConnectionRef) -> dict:
+        # Return key-value credential pairs
+        return {"username": "...", "password": "..."}
+
+register_credential_provider(MyProvider())
+```
+
+### How it works
+
+1. When an offline store needs to connect, it checks whether the data source has a `connection_ref`.
+2. If present, credentials are resolved from the external provider at runtime.
+3. Resolved credentials (and any `params` from the `ConnectionRef`) are merged and used to override the global offline store configuration for that specific operation.
+4. If no `connection_ref` is set, the data source uses the global `feature_store.yaml` configuration as before.
+
+For usage with the Hybrid Offline Store, see [Hybrid Offline Store](../offline-stores/hybrid.md).
+
 ## Functionality Matrix
 
 There are currently four core batch data source implementations: `FileSource`, `BigQuerySource`, `SnowflakeSource`, and `RedshiftSource`.

--- a/docs/reference/offline-stores/hybrid.md
+++ b/docs/reference/offline-stores/hybrid.md
@@ -82,6 +82,84 @@ store.materialize(
 )
 ```
 
+## Using ConnectionRef with Hybrid Offline Store
+
+When using the HybridOfflineStore, each data source can carry its own credentials via `ConnectionRef`. This is particularly useful when different feature views connect to different accounts or clusters — you no longer need to embed all credentials in `feature_store.yaml`.
+
+### Example: Per-DataSource Credentials
+
+{% code title="feature_store.yaml" %}
+```yaml
+project: my_feature_repo
+registry: data/registry.db
+provider: local
+offline_store:
+  type: hybrid_offline_store.HybridOfflineStore
+  offline_stores:
+    - type: snowflake.offline
+    - type: bigquery
+```
+{% endcode %}
+
+```python
+from feast import FeatureView, Entity, ValueType
+from feast.credentials import ConnectionRef
+from feast.infra.offline_stores.snowflake_source import SnowflakeSource
+from feast.infra.offline_stores.bigquery_source import BigQuerySource
+
+entity = Entity(name="user_id", value_type=ValueType.INT64, join_keys=["user_id"])
+
+# Snowflake source with credentials from a Kubernetes Secret
+feature_view1 = FeatureView(
+    name="user_features",
+    entities=["user_id"],
+    ttl=None,
+    source=SnowflakeSource(
+        table="USER_FEATURES",
+        connection_ref=ConnectionRef(
+            provider="kubernetes",
+            name="snowflake-team-a-creds",
+            namespace="ml-team",
+            connection_type="snowflake.offline",
+            params={"account": "xy12345", "warehouse": "COMPUTE_WH"},
+        ),
+    ),
+)
+
+# BigQuery source with credentials from a Kubernetes Secret
+feature_view2 = FeatureView(
+    name="user_activity",
+    entities=["user_id"],
+    ttl=None,
+    source=BigQuerySource(
+        table="my_project.dataset.user_activity",
+        connection_ref=ConnectionRef(
+            provider="kubernetes",
+            name="bigquery-team-b-creds",
+            namespace="ml-team",
+            connection_type="bigquery",
+        ),
+    ),
+)
+```
+
+In this setup:
+- No sensitive credentials are stored in `feature_store.yaml`.
+- Each data source resolves its credentials independently at runtime from the referenced Kubernetes Secret.
+- The HybridOfflineStore routes operations to the correct backend based on the source type.
+
+### How credential resolution works
+
+1. The HybridOfflineStore determines which backend to use based on the data source class (e.g., `SnowflakeSource` → Snowflake offline store).
+2. Before connecting, the offline store checks if the data source has a `connection_ref`.
+3. If present, credentials are fetched from the external provider (e.g., reading a Kubernetes Secret).
+4. Resolved credentials override the global offline store config for that operation.
+5. If no `connection_ref` is set, the global `feature_store.yaml` configuration is used as a fallback.
+
+This pattern is especially valuable in multi-tenant environments where a shared Feast deployment serves multiple teams, each with isolated credentials and backend accounts.
+
+For details on the `ConnectionRef` structure and supported providers, see [Data Sources Overview](../data-sources/overview.md#per-datasource-credentials-connectionref).
+
 ## Functionality Matrix
 | Feature/Functionality                             | Supported                  |
 |---------------------------------------------------|----------------------------|

--- a/protos/feast/core/DataSource.proto
+++ b/protos/feast/core/DataSource.proto
@@ -28,8 +28,38 @@ import "feast/core/DataFormat.proto";
 import "feast/types/Value.proto";
 import "feast/core/Feature.proto";
 
+// Connection reference for a DataSource.
+// Combines connection type, credential resolution, and non-sensitive
+// connection parameters into a single reusable reference.
+// Allows DataSources to declare their full connection identity — which
+// backend to use, how to authenticate, and where to connect — independent
+// of the global offline_store config in feature_store.yaml.
+message ConnectionRef {
+  // Credential provider type: "kubernetes", "vault", "aws-secrets-manager",
+  // "gcp-secret-manager", "azure-key-vault", "env".
+  string provider = 1;
+
+  // Provider-specific name: K8s Secret name, Vault path, env var prefix, etc.
+  string name = 2;
+
+  // Optional scope qualifier: K8s namespace, Vault mount, AWS region, etc.
+  string namespace = 3;
+
+  // Optional offline store class type (e.g., "snowflake.offline", "bigquery",
+  // "spark", "iceberg-rest"). When empty, inferred from the DataSource class.
+  string connection_type = 4;
+
+  // Optional authentication mechanism: "secret", "oauth2", "basic", "sigv4".
+  // Defaults to "secret" (raw key-value credentials from provider).
+  string auth_type = 5;
+
+  // Optional non-sensitive connection parameters (e.g., account, database,
+  // warehouse, endpoint URI). Keys and values are backend-specific.
+  map<string, string> params = 6;
+}
+
 // Defines a Data Source that can be used source Feature data
-// Next available id: 29
+// Next available id: 30
 message DataSource {
   // Field indexes should *not* be reused. Not sure if fields 6-10 were used previously or not,
   // but they are going to be reserved for backwards compatibility.
@@ -94,6 +124,13 @@ message DataSource {
 
   // Optional batch source for streaming sources for historical features and materialization.
   DataSource batch_source = 26;
+
+  // Optional connection reference for this data source.
+  // When set, OfflineStores resolve connection type and credentials at
+  // runtime via the registered CredentialProvider instead of using ambient
+  // env vars or the global offline_store config in feature_store.yaml.
+  // All fields except provider and name are optional.
+  ConnectionRef connection_ref = 29;
 
   SourceMeta meta = 50;
 

--- a/sdk/python/feast/credentials.py
+++ b/sdk/python/feast/credentials.py
@@ -1,0 +1,398 @@
+"""
+External connection and credential resolution for Feast DataSources.
+
+Provides a pluggable mechanism for DataSources to declare their full
+connection identity — which backend to use, how to authenticate, and
+where to connect — via a :class:`ConnectionRef` stored on each DataSource.
+
+Credentials are resolved at runtime from external systems (Kubernetes
+Secrets, HashiCorp Vault, cloud secret managers, environment variables)
+instead of embedding them in ``feature_store.yaml``.
+
+Usage::
+
+    from feast.credentials import ConnectionRef
+
+    # Minimal: just credentials (connection_type inferred from source class)
+    source = FileSource(
+        path="s3://bucket/features/",
+        connection_ref=ConnectionRef(
+            provider="kubernetes",
+            name="my-s3-secret",
+            namespace="ml-project",
+        ),
+    )
+
+    # Full: explicit connection type + auth + params
+    source = SnowflakeSource(
+        table="USER_FEATURES",
+        connection_ref=ConnectionRef(
+            provider="kubernetes",
+            name="snowflake-creds",
+            namespace="ml-team",
+            connection_type="snowflake.offline",
+            auth_type="secret",
+            params={"account": "xy12345", "warehouse": "COMPUTE_WH"},
+        ),
+    )
+
+Providers are registered via :func:`register_credential_provider` and
+resolved at runtime by :func:`resolve_credentials`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# ConnectionRef — the connection + credential reference stored on a DataSource
+# ---------------------------------------------------------------------------
+
+TAG_PREFIX = "feast.connection-ref."
+
+
+@dataclass(frozen=True)
+class ConnectionRef:
+    """Immutable reference to an external connection and credential store.
+
+    ``ConnectionRef`` is intended for credentials that are stored externally
+    (K8s Secrets, Vault, etc.) and need to be resolved at runtime.  Auth
+    methods that are handled natively by the cloud SDK credential chain
+    (e.g., AWS IAM roles, IRSA, EKS Pod Identity, GCP Workload Identity)
+    do **not** need a ``ConnectionRef`` — they are picked up automatically
+    by the underlying client libraries (boto3, google-auth, etc.).
+
+    Attributes:
+        provider: Credential backend type — ``"kubernetes"``, ``"vault"``,
+            ``"aws-secrets-manager"``, ``"gcp-secret-manager"``,
+            ``"azure-key-vault"``, ``"env"``.
+        name: Provider-specific identifier — K8s Secret name, Vault path,
+            env-var prefix, etc.
+        namespace: Optional scope qualifier — K8s namespace, Vault mount,
+            AWS region, etc.  Defaults to ``""``.
+        connection_type: Optional offline store class type (e.g.,
+            ``"snowflake.offline"``, ``"bigquery"``, ``"spark"``).
+            When empty, inferred from the DataSource class at runtime.
+        auth_type: Authentication mechanism — ``"secret"`` (default),
+            ``"oauth2"``, ``"basic"``, ``"sigv4"``.
+        params: Optional non-sensitive connection parameters (e.g.,
+            account, database, warehouse, endpoint URI).
+    """
+
+    provider: str
+    name: str
+    namespace: str = ""
+    connection_type: str = ""
+    auth_type: str = "secret"
+    params: Dict[str, str] = field(default_factory=dict)
+
+    # -- serialization to/from DataSource tags (backward-compatible) --------
+
+    def to_tags(self) -> Dict[str, str]:
+        """Serialize into DataSource ``tags`` dict entries."""
+        tags: Dict[str, str] = {
+            f"{TAG_PREFIX}provider": self.provider,
+            f"{TAG_PREFIX}name": self.name,
+        }
+        if self.namespace:
+            tags[f"{TAG_PREFIX}namespace"] = self.namespace
+        if self.connection_type:
+            tags[f"{TAG_PREFIX}connection-type"] = self.connection_type
+        if self.auth_type and self.auth_type != "secret":
+            tags[f"{TAG_PREFIX}auth-type"] = self.auth_type
+        for key, value in self.params.items():
+            tags[f"{TAG_PREFIX}param.{key}"] = value
+        return tags
+
+    @classmethod
+    def from_tags(cls, tags: Dict[str, str]) -> Optional["ConnectionRef"]:
+        """Deserialize from DataSource ``tags``.  Returns *None* when no
+        connection-ref tags are present."""
+        provider = tags.get(f"{TAG_PREFIX}provider")
+        name = tags.get(f"{TAG_PREFIX}name")
+        if not provider or not name:
+            return None
+
+        namespace = tags.get(f"{TAG_PREFIX}namespace", "")
+        connection_type = tags.get(f"{TAG_PREFIX}connection-type", "")
+        auth_type = tags.get(f"{TAG_PREFIX}auth-type", "secret")
+
+        params: Dict[str, str] = {}
+        param_prefix = f"{TAG_PREFIX}param."
+        for key, value in tags.items():
+            if key.startswith(param_prefix):
+                param_key = key[len(param_prefix) :]
+                params[param_key] = value
+
+        return cls(
+            provider=provider,
+            name=name,
+            namespace=namespace,
+            connection_type=connection_type,
+            auth_type=auth_type,
+            params=params,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CredentialProvider — pluggable backend abstraction
+# ---------------------------------------------------------------------------
+
+
+class CredentialProvider(ABC):
+    """Resolves a :class:`ConnectionRef` into key-value credential pairs."""
+
+    @abstractmethod
+    def provider_type(self) -> str:
+        """Return the provider identifier this implementation handles."""
+        ...
+
+    @abstractmethod
+    def resolve(self, ref: ConnectionRef) -> Dict[str, str]:
+        """Return credential key-value pairs for *ref*.
+
+        Raises:
+            CredentialResolutionError: If the credentials cannot be resolved.
+        """
+        ...
+
+
+class CredentialResolutionError(Exception):
+    """Raised when a :class:`CredentialProvider` cannot resolve credentials."""
+
+
+# ---------------------------------------------------------------------------
+# Provider registry
+# ---------------------------------------------------------------------------
+
+_PROVIDERS: Dict[str, CredentialProvider] = {}
+
+
+def register_credential_provider(provider: CredentialProvider) -> None:
+    """Register a :class:`CredentialProvider` for its declared type."""
+    _PROVIDERS[provider.provider_type()] = provider
+
+
+def get_credential_provider(provider_type: str) -> CredentialProvider:
+    """Return the registered provider for *provider_type*.
+
+    Raises:
+        CredentialResolutionError: If no provider is registered.
+    """
+    if provider_type not in _PROVIDERS:
+        raise CredentialResolutionError(
+            f"No CredentialProvider registered for type '{provider_type}'. "
+            f"Available: {list(_PROVIDERS.keys())}"
+        )
+    return _PROVIDERS[provider_type]
+
+
+def resolve_credentials(ref: ConnectionRef) -> Dict[str, str]:
+    """Convenience wrapper: look up the provider and resolve *ref*."""
+    return get_credential_provider(ref.provider).resolve(ref)
+
+
+# ---------------------------------------------------------------------------
+
+
+def get_connection_config_override(data_source) -> Optional[Dict[str, str]]:
+    """Get merged connection config from a DataSource's ``connection_ref``.
+
+    Merges resolved credentials (secrets) with non-sensitive ``params``
+    from the connection ref.  Returns ``None`` if no ``connection_ref`` is set.
+
+    Offline stores can use this to override their global config::
+
+        override = get_connection_config_override(data_source)
+        if override:
+            account = override.get("account", config.offline_store.account)
+            ...
+    """
+    ref = getattr(data_source, "connection_ref", None)
+    if ref is None:
+        return None
+    creds = resolve_credentials(ref)
+    if ref.params:
+        merged = dict(ref.params)
+        merged.update(creds)
+        return merged
+    return creds
+
+
+# ---------------------------------------------------------------------------
+# Built-in provider: Environment variables (backward-compatible default)
+# ---------------------------------------------------------------------------
+
+
+class EnvironmentProvider(CredentialProvider):
+    """Reads credentials from environment variables.
+
+    ``ref.name`` is used as a prefix filter.  For example,
+    ``ConnectionRef(provider="env", name="AWS")`` returns all env vars
+    starting with ``AWS`` (``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``,
+    ``AWS_DEFAULT_REGION``, …).
+
+    If ``ref.name`` is empty or ``"*"``, all env vars are returned (use with
+    care).
+    """
+
+    def provider_type(self) -> str:
+        return "env"
+
+    def resolve(self, ref: ConnectionRef) -> Dict[str, str]:
+        prefix = ref.name
+        if not prefix or prefix == "*":
+            logger.warning(
+                "EnvironmentProvider: resolving ALL environment variables "
+                "(name='%s'). Restrict with a prefix to avoid exposing "
+                "unrelated variables.",
+                ref.name,
+            )
+            return dict(os.environ)
+        return {k: v for k, v in os.environ.items() if k.startswith(prefix)}
+
+
+# ---------------------------------------------------------------------------
+# Built-in provider: Kubernetes Secrets
+# ---------------------------------------------------------------------------
+
+
+class KubernetesSecretProvider(CredentialProvider):
+    """Reads credentials from Kubernetes Secrets via the K8s API.
+
+    Requires the ``kubernetes`` Python package and a valid kubeconfig or
+    in-cluster service account.
+
+    ``ref.name`` is the Secret name.  ``ref.namespace`` is the K8s namespace
+    (falls back to the Pod's own namespace when empty).
+    """
+
+    def provider_type(self) -> str:
+        return "kubernetes"
+
+    def resolve(self, ref: ConnectionRef) -> Dict[str, str]:
+        try:
+            from kubernetes import client
+            from kubernetes import config as k8s_config
+        except ImportError as exc:
+            raise CredentialResolutionError(
+                "kubernetes package is required for the 'kubernetes' "
+                "credential provider.  Install it with: "
+                "pip install kubernetes"
+            ) from exc
+
+        try:
+            k8s_config.load_incluster_config()
+        except k8s_config.ConfigException:
+            try:
+                k8s_config.load_kube_config()
+            except k8s_config.ConfigException as exc:
+                raise CredentialResolutionError(
+                    "Could not load Kubernetes configuration. "
+                    "Ensure the Pod has a service account or a valid kubeconfig."
+                ) from exc
+
+        namespace = ref.namespace or self._current_namespace()
+        v1 = client.CoreV1Api()
+        try:
+            secret = v1.read_namespaced_secret(name=ref.name, namespace=namespace)
+        except client.exceptions.ApiException as exc:
+            raise CredentialResolutionError(
+                f"Failed to read Kubernetes Secret '{ref.name}' "
+                f"in namespace '{namespace}': {exc.reason} (HTTP {exc.status})"
+            ) from None
+
+        import base64
+
+        return {
+            key: base64.b64decode(value).decode("utf-8")
+            for key, value in (secret.data or {}).items()
+        }
+
+    @staticmethod
+    def _current_namespace() -> str:
+        """Return the namespace this Pod is running in."""
+        ns_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+        try:
+            with open(ns_path) as f:
+                return f.read().strip()
+        except FileNotFoundError:
+            return "default"
+
+
+# ---------------------------------------------------------------------------
+# Built-in provider: HashiCorp Vault (KV v2)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VaultProviderConfig:
+    """Configuration for the Vault credential provider."""
+
+    addr: str = field(default_factory=lambda: os.environ.get("VAULT_ADDR", ""))
+    token: str = field(default_factory=lambda: os.environ.get("VAULT_TOKEN", ""))
+    role: str = field(default_factory=lambda: os.environ.get("VAULT_ROLE", ""))
+    auth_method: str = field(
+        default_factory=lambda: os.environ.get("VAULT_AUTH_METHOD", "token")
+    )
+
+
+class VaultProvider(CredentialProvider):
+    """Reads credentials from HashiCorp Vault KV v2 secrets engine.
+
+    ``ref.name`` is the Vault secret path (e.g. ``"secret/data/feast/my-conn"``).
+    ``ref.namespace`` is the Vault mount point (defaults to ``"secret"``).
+
+    Requires the ``hvac`` Python package.
+    """
+
+    def __init__(self, config: Optional[VaultProviderConfig] = None):
+        self._config = config or VaultProviderConfig()
+
+    def provider_type(self) -> str:
+        return "vault"
+
+    def resolve(self, ref: ConnectionRef) -> Dict[str, str]:
+        try:
+            import hvac
+        except ImportError as exc:
+            raise CredentialResolutionError(
+                "hvac package is required for the 'vault' credential provider. "
+                "Install it with: pip install hvac"
+            ) from exc
+
+        vault_client = hvac.Client(url=self._config.addr, token=self._config.token)
+        if not vault_client.is_authenticated():
+            raise CredentialResolutionError(
+                "Vault client is not authenticated. "
+                "Set VAULT_ADDR and VAULT_TOKEN, or configure auth_method."
+            )
+
+        mount_point = ref.namespace or "secret"
+        try:
+            response = vault_client.secrets.kv.v2.read_secret_version(
+                path=ref.name, mount_point=mount_point
+            )
+        except Exception as exc:
+            raise CredentialResolutionError(
+                f"Failed to read Vault secret '{ref.name}' "
+                f"at mount '{mount_point}': {type(exc).__name__}: {exc}"
+            ) from None
+
+        data = response.get("data", {}).get("data", {})
+        return {k: str(v) for k, v in data.items()}
+
+
+# ---------------------------------------------------------------------------
+# Auto-register built-in providers on import
+# ---------------------------------------------------------------------------
+
+register_credential_provider(EnvironmentProvider())
+register_credential_provider(KubernetesSecretProvider())
+register_credential_provider(VaultProvider())

--- a/sdk/python/feast/credentials.py
+++ b/sdk/python/feast/credentials.py
@@ -1,0 +1,385 @@
+"""
+External connection and credential resolution for Feast DataSources.
+
+Provides a pluggable mechanism for DataSources to declare their full
+connection identity — which backend to use, how to authenticate, and
+where to connect — via a :class:`ConnectionRef` stored on each DataSource.
+
+Credentials are resolved at runtime from external systems (Kubernetes
+Secrets, HashiCorp Vault, cloud secret managers, environment variables)
+instead of embedding them in ``feature_store.yaml``.
+
+Usage::
+
+    from feast.credentials import ConnectionRef
+
+    # Minimal: just credentials (connection_type inferred from source class)
+    source = FileSource(
+        path="s3://bucket/features/",
+        connection_ref=ConnectionRef(
+            provider="kubernetes",
+            name="my-s3-secret",
+            namespace="ml-project",
+        ),
+    )
+
+    # Full: explicit connection type + auth + params
+    source = SnowflakeSource(
+        table="USER_FEATURES",
+        connection_ref=ConnectionRef(
+            provider="kubernetes",
+            name="snowflake-creds",
+            namespace="ml-team",
+            connection_type="snowflake.offline",
+            auth_type="secret",
+            params={"account": "xy12345", "warehouse": "COMPUTE_WH"},
+        ),
+    )
+
+Providers are registered via :func:`register_credential_provider` and
+resolved at runtime by :func:`resolve_credentials`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# ConnectionRef — the connection + credential reference stored on a DataSource
+# ---------------------------------------------------------------------------
+
+TAG_PREFIX = "feast.connection-ref."
+
+
+@dataclass(frozen=True)
+class ConnectionRef:
+    """Immutable reference to an external connection and credential store.
+
+    Attributes:
+        provider: Credential backend type — ``"kubernetes"``, ``"vault"``,
+            ``"aws-secrets-manager"``, ``"gcp-secret-manager"``,
+            ``"azure-key-vault"``, ``"env"``.
+        name: Provider-specific identifier — K8s Secret name, Vault path,
+            env-var prefix, etc.
+        namespace: Optional scope qualifier — K8s namespace, Vault mount,
+            AWS region, etc.  Defaults to ``""``.
+        connection_type: Optional offline store class type (e.g.,
+            ``"snowflake.offline"``, ``"bigquery"``, ``"spark"``).
+            When empty, inferred from the DataSource class at runtime.
+        auth_type: Authentication mechanism — ``"secret"`` (default),
+            ``"oauth2"``, ``"basic"``, ``"sigv4"``.
+        params: Optional non-sensitive connection parameters (e.g.,
+            account, database, warehouse, endpoint URI).
+    """
+
+    provider: str
+    name: str
+    namespace: str = ""
+    connection_type: str = ""
+    auth_type: str = "secret"
+    params: Dict[str, str] = field(default_factory=dict)
+
+    # -- serialization to/from DataSource tags (backward-compatible) --------
+
+    def to_tags(self) -> Dict[str, str]:
+        """Serialize into DataSource ``tags`` dict entries."""
+        tags: Dict[str, str] = {
+            f"{TAG_PREFIX}provider": self.provider,
+            f"{TAG_PREFIX}name": self.name,
+        }
+        if self.namespace:
+            tags[f"{TAG_PREFIX}namespace"] = self.namespace
+        if self.connection_type:
+            tags[f"{TAG_PREFIX}connection-type"] = self.connection_type
+        if self.auth_type and self.auth_type != "secret":
+            tags[f"{TAG_PREFIX}auth-type"] = self.auth_type
+        for key, value in self.params.items():
+            tags[f"{TAG_PREFIX}param.{key}"] = value
+        return tags
+
+    @classmethod
+    def from_tags(cls, tags: Dict[str, str]) -> Optional["ConnectionRef"]:
+        """Deserialize from DataSource ``tags``.  Returns *None* when no
+        connection-ref tags are present."""
+        provider = tags.get(f"{TAG_PREFIX}provider")
+        name = tags.get(f"{TAG_PREFIX}name")
+        if not provider or not name:
+            return None
+
+        namespace = tags.get(f"{TAG_PREFIX}namespace", "")
+        connection_type = tags.get(f"{TAG_PREFIX}connection-type", "")
+        auth_type = tags.get(f"{TAG_PREFIX}auth-type", "secret")
+
+        params: Dict[str, str] = {}
+        param_prefix = f"{TAG_PREFIX}param."
+        for key, value in tags.items():
+            if key.startswith(param_prefix):
+                param_key = key[len(param_prefix) :]
+                params[param_key] = value
+
+        return cls(
+            provider=provider,
+            name=name,
+            namespace=namespace,
+            connection_type=connection_type,
+            auth_type=auth_type,
+            params=params,
+        )
+
+
+# ---------------------------------------------------------------------------
+# CredentialProvider — pluggable backend abstraction
+# ---------------------------------------------------------------------------
+
+
+class CredentialProvider(ABC):
+    """Resolves a :class:`ConnectionRef` into key-value credential pairs."""
+
+    @abstractmethod
+    def provider_type(self) -> str:
+        """Return the provider identifier this implementation handles."""
+        ...
+
+    @abstractmethod
+    def resolve(self, ref: ConnectionRef) -> Dict[str, str]:
+        """Return credential key-value pairs for *ref*.
+
+        Raises:
+            CredentialResolutionError: If the credentials cannot be resolved.
+        """
+        ...
+
+
+class CredentialResolutionError(Exception):
+    """Raised when a :class:`CredentialProvider` cannot resolve credentials."""
+
+
+# ---------------------------------------------------------------------------
+# Provider registry
+# ---------------------------------------------------------------------------
+
+_PROVIDERS: Dict[str, CredentialProvider] = {}
+
+
+def register_credential_provider(provider: CredentialProvider) -> None:
+    """Register a :class:`CredentialProvider` for its declared type."""
+    _PROVIDERS[provider.provider_type()] = provider
+
+
+def get_credential_provider(provider_type: str) -> CredentialProvider:
+    """Return the registered provider for *provider_type*.
+
+    Raises:
+        CredentialResolutionError: If no provider is registered.
+    """
+    if provider_type not in _PROVIDERS:
+        raise CredentialResolutionError(
+            f"No CredentialProvider registered for type '{provider_type}'. "
+            f"Available: {list(_PROVIDERS.keys())}"
+        )
+    return _PROVIDERS[provider_type]
+
+
+def resolve_credentials(ref: ConnectionRef) -> Dict[str, str]:
+    """Convenience wrapper: look up the provider and resolve *ref*."""
+    return get_credential_provider(ref.provider).resolve(ref)
+
+
+# ---------------------------------------------------------------------------
+
+
+def get_connection_config_override(data_source) -> Optional[Dict[str, str]]:
+    """Get merged connection config from a DataSource's ``connection_ref``.
+
+    Merges resolved credentials (secrets) with non-sensitive ``params``
+    from the connection ref.  Returns ``None`` if no ``connection_ref`` is set.
+
+    Offline stores can use this to override their global config::
+
+        override = get_connection_config_override(data_source)
+        if override:
+            account = override.get("account", config.offline_store.account)
+            ...
+    """
+    ref = getattr(data_source, "connection_ref", None)
+    if ref is None:
+        return None
+    creds = resolve_credentials(ref)
+    if ref.params:
+        merged = dict(ref.params)
+        merged.update(creds)
+        return merged
+    return creds
+
+
+# ---------------------------------------------------------------------------
+# Built-in provider: Environment variables (backward-compatible default)
+# ---------------------------------------------------------------------------
+
+
+class EnvironmentProvider(CredentialProvider):
+    """Reads credentials from environment variables.
+
+    ``ref.name`` is used as a prefix filter.  For example,
+    ``ConnectionRef(provider="env", name="AWS")`` returns all env vars
+    starting with ``AWS`` (``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``,
+    ``AWS_DEFAULT_REGION``, …).
+
+    If ``ref.name`` is empty or ``"*"``, all env vars are returned (use with
+    care).
+    """
+
+    def provider_type(self) -> str:
+        return "env"
+
+    def resolve(self, ref: ConnectionRef) -> Dict[str, str]:
+        prefix = ref.name
+        if not prefix or prefix == "*":
+            return dict(os.environ)
+        return {k: v for k, v in os.environ.items() if k.startswith(prefix)}
+
+
+# ---------------------------------------------------------------------------
+# Built-in provider: Kubernetes Secrets
+# ---------------------------------------------------------------------------
+
+
+class KubernetesSecretProvider(CredentialProvider):
+    """Reads credentials from Kubernetes Secrets via the K8s API.
+
+    Requires the ``kubernetes`` Python package and a valid kubeconfig or
+    in-cluster service account.
+
+    ``ref.name`` is the Secret name.  ``ref.namespace`` is the K8s namespace
+    (falls back to the Pod's own namespace when empty).
+    """
+
+    def provider_type(self) -> str:
+        return "kubernetes"
+
+    def resolve(self, ref: ConnectionRef) -> Dict[str, str]:
+        try:
+            from kubernetes import client
+            from kubernetes import config as k8s_config
+        except ImportError as exc:
+            raise CredentialResolutionError(
+                "kubernetes package is required for the 'kubernetes' "
+                "credential provider.  Install it with: "
+                "pip install kubernetes"
+            ) from exc
+
+        try:
+            k8s_config.load_incluster_config()
+        except k8s_config.ConfigException:
+            try:
+                k8s_config.load_kube_config()
+            except k8s_config.ConfigException as exc:
+                raise CredentialResolutionError(
+                    "Could not load Kubernetes configuration. "
+                    "Ensure the Pod has a service account or a valid kubeconfig."
+                ) from exc
+
+        namespace = ref.namespace or self._current_namespace()
+        v1 = client.CoreV1Api()
+        try:
+            secret = v1.read_namespaced_secret(name=ref.name, namespace=namespace)
+        except client.exceptions.ApiException as exc:
+            raise CredentialResolutionError(
+                f"Failed to read Kubernetes Secret '{ref.name}' "
+                f"in namespace '{namespace}': {exc.reason}"
+            ) from exc
+
+        import base64
+
+        return {
+            key: base64.b64decode(value).decode("utf-8")
+            for key, value in (secret.data or {}).items()
+        }
+
+    @staticmethod
+    def _current_namespace() -> str:
+        """Return the namespace this Pod is running in."""
+        ns_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+        try:
+            with open(ns_path) as f:
+                return f.read().strip()
+        except FileNotFoundError:
+            return "default"
+
+
+# ---------------------------------------------------------------------------
+# Built-in provider: HashiCorp Vault (KV v2)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VaultProviderConfig:
+    """Configuration for the Vault credential provider."""
+
+    addr: str = field(default_factory=lambda: os.environ.get("VAULT_ADDR", ""))
+    token: str = field(default_factory=lambda: os.environ.get("VAULT_TOKEN", ""))
+    role: str = field(default_factory=lambda: os.environ.get("VAULT_ROLE", ""))
+    auth_method: str = field(
+        default_factory=lambda: os.environ.get("VAULT_AUTH_METHOD", "token")
+    )
+
+
+class VaultProvider(CredentialProvider):
+    """Reads credentials from HashiCorp Vault KV v2 secrets engine.
+
+    ``ref.name`` is the Vault secret path (e.g. ``"secret/data/feast/my-conn"``).
+    ``ref.namespace`` is the Vault mount point (defaults to ``"secret"``).
+
+    Requires the ``hvac`` Python package.
+    """
+
+    def __init__(self, config: Optional[VaultProviderConfig] = None):
+        self._config = config or VaultProviderConfig()
+
+    def provider_type(self) -> str:
+        return "vault"
+
+    def resolve(self, ref: ConnectionRef) -> Dict[str, str]:
+        try:
+            import hvac
+        except ImportError as exc:
+            raise CredentialResolutionError(
+                "hvac package is required for the 'vault' credential provider. "
+                "Install it with: pip install hvac"
+            ) from exc
+
+        vault_client = hvac.Client(url=self._config.addr, token=self._config.token)
+        if not vault_client.is_authenticated():
+            raise CredentialResolutionError(
+                "Vault client is not authenticated. "
+                "Set VAULT_ADDR and VAULT_TOKEN, or configure auth_method."
+            )
+
+        mount_point = ref.namespace or "secret"
+        try:
+            response = vault_client.secrets.kv.v2.read_secret_version(
+                path=ref.name, mount_point=mount_point
+            )
+        except Exception as exc:
+            raise CredentialResolutionError(
+                f"Failed to read Vault secret '{ref.name}' "
+                f"at mount '{mount_point}': {exc}"
+            ) from exc
+
+        data = response.get("data", {}).get("data", {})
+        return {k: str(v) for k, v in data.items()}
+
+
+# ---------------------------------------------------------------------------
+# Auto-register built-in providers on import
+# ---------------------------------------------------------------------------
+
+register_credential_provider(EnvironmentProvider())
+register_credential_provider(KubernetesSecretProvider())
+register_credential_provider(VaultProvider())

--- a/sdk/python/feast/data_source.py
+++ b/sdk/python/feast/data_source.py
@@ -22,6 +22,7 @@ from google.protobuf.json_format import MessageToJson
 from typeguard import typechecked
 
 from feast import type_map
+from feast.credentials import ConnectionRef
 from feast.data_format import StreamFormat
 from feast.field import Field
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
@@ -194,6 +195,10 @@ class DataSource(ABC):
         owner (optional): The owner of the data source, typically the email of the primary
             maintainer.
         date_partition_column (optional): Timestamp column used for partitioning. Not supported by all offline stores.
+        connection_ref (optional): Connection reference for this data source.
+            When set, OfflineStores resolve connection type and credentials at runtime
+            via the registered CredentialProvider instead of using ambient env vars or
+            the global offline_store config. All fields except provider and name are optional.
         created_timestamp: The time when the data source was created.
         last_updated_timestamp: The time when the data source was last updated.
     """
@@ -207,6 +212,7 @@ class DataSource(ABC):
     owner: str
     date_partition_column: str
     timestamp_field_type: str
+    connection_ref: Optional[ConnectionRef]
     created_timestamp: Optional[datetime]
     last_updated_timestamp: Optional[datetime]
 
@@ -222,6 +228,7 @@ class DataSource(ABC):
         owner: Optional[str] = "",
         date_partition_column: Optional[str] = None,
         timestamp_field_type: Optional[str] = None,
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """
         Creates a DataSource object.
@@ -243,6 +250,8 @@ class DataSource(ABC):
             timestamp_field_type (optional): Type of the timestamp_field column.
                 Defaults to "TIMESTAMP". Set to "DATE" when the event timestamp column
                 is a DATE type, so SQL generation uses date-only comparisons.
+            connection_ref (optional): Connection reference for this data source.
+                See :class:`~feast.credentials.ConnectionRef`.
         """
         self.name = name
         self.timestamp_field = timestamp_field or ""
@@ -264,9 +273,22 @@ class DataSource(ABC):
             date_partition_column if date_partition_column else ""
         )
         self.timestamp_field_type = timestamp_field_type if timestamp_field_type else ""
+        self.connection_ref = connection_ref
         now = _utc_now()
         self.created_timestamp = now
         self.last_updated_timestamp = now
+
+    def resolve_credentials(self) -> Optional[Dict[str, str]]:
+        """Resolve credentials from the ``connection_ref`` if set.
+
+        Returns ``None`` when no ``connection_ref`` is configured (ambient
+        credentials are used instead).
+        """
+        if self.connection_ref is None:
+            return None
+        from feast.credentials import resolve_credentials
+
+        return resolve_credentials(self.connection_ref)
 
     def __hash__(self):
         return hash((self.name, self.timestamp_field))
@@ -291,6 +313,7 @@ class DataSource(ABC):
             or self.description != other.description
             or self.tags != other.tags
             or self.owner != other.owner
+            or self.connection_ref != other.connection_ref
         ):
             return False
 
@@ -329,6 +352,9 @@ class DataSource(ABC):
             data_source_instance = cls.from_proto(data_source)
 
         data_source_instance._extract_timestamps_from_proto(data_source)
+        data_source_instance.connection_ref = ConnectionRef.from_tags(
+            dict(data_source.tags)
+        )
 
         return data_source_instance
 
@@ -338,6 +364,10 @@ class DataSource(ABC):
         """
         proto = self._to_proto_impl()
         self._set_timestamps_in_proto(proto)
+
+        if self.connection_ref is not None:
+            for key, value in self.connection_ref.to_tags().items():
+                proto.tags[key] = value
 
         return proto
 

--- a/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/iceberg_source.py
+++ b/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/iceberg_source.py
@@ -16,6 +16,7 @@ import json
 import os
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
 from feast.repo_config import RepoConfig
@@ -54,6 +55,7 @@ class IcebergSource(DataSource):
         owner: Optional[str] = "",
         token_env_var: Optional[str] = None,
         credential_vending: bool = True,
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         _name = name or f"{warehouse}.{namespace}.{table}"
         super().__init__(
@@ -64,6 +66,7 @@ class IcebergSource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
         self.catalog_type = catalog_type
         self.catalog_name = catalog_name
@@ -158,6 +161,7 @@ class IcebergSource(DataSource):
             description=data_source.description,
             tags=dict(data_source.tags),
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(dict(data_source.tags)),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/unity_catalog_source.py
+++ b/sdk/python/feast/infra/data_sources/contrib/iceberg_catalog/unity_catalog_source.py
@@ -16,6 +16,7 @@ import json
 import os
 from typing import Any, Dict, Optional
 
+from feast.credentials import ConnectionRef
 from feast.infra.data_sources.contrib.iceberg_catalog.iceberg_source import (
     IcebergSource,
 )
@@ -54,6 +55,7 @@ class UnityCatalogSource(IcebergSource):
         catalog_properties: Optional[Dict[str, str]] = None,
         register_as_feature_table: bool = True,
         sync_lineage: bool = True,
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         if endpoint is None:
             host = os.environ.get("DATABRICKS_HOST", "")
@@ -79,6 +81,7 @@ class UnityCatalogSource(IcebergSource):
             owner=owner,
             token_env_var=token_env_var,
             credential_vending=credential_vending,
+            connection_ref=connection_ref,
         )
         self.register_as_feature_table = register_as_feature_table
         self.sync_lineage = sync_lineage
@@ -129,6 +132,7 @@ class UnityCatalogSource(IcebergSource):
             description=data_source.description,
             tags=dict(data_source.tags),
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(dict(data_source.tags)),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -27,6 +27,7 @@ from pydantic import StrictStr, field_validator
 from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
 from feast import flags_helper
+from feast.credentials import get_connection_config_override
 from feast.data_source import DataSource
 from feast.errors import (
     BigQueryJobCancelled,
@@ -1586,8 +1587,28 @@ def _get_entity_df_event_timestamp_range(
 
 
 def _get_bigquery_client(
-    project: Optional[str] = None, location: Optional[str] = None
+    project: Optional[str] = None,
+    location: Optional[str] = None,
+    data_source=None,
 ) -> bigquery.Client:
+    override = get_connection_config_override(data_source) if data_source else None
+    if override and "service_account_json" in override:
+        from google.oauth2 import service_account
+
+        try:
+            sa_info = json.loads(override["service_account_json"])
+        except json.JSONDecodeError as exc:
+            raise FeastProviderLoginError(
+                "The 'service_account_json' credential resolved from "
+                f"ConnectionRef is not valid JSON: {exc}"
+            )
+        credentials = service_account.Credentials.from_service_account_info(sa_info)
+        return bigquery.Client(
+            project=override.get("project", project),
+            location=location,
+            credentials=credentials,
+            client_info=get_http_client_info(),
+        )
     try:
         client = bigquery.Client(
             project=project, location=location, client_info=get_http_client_info()

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -27,6 +27,7 @@ from pydantic import StrictStr, field_validator
 from tenacity import Retrying, retry_if_exception_type, stop_after_delay, wait_fixed
 
 from feast import flags_helper
+from feast.credentials import get_connection_config_override
 from feast.data_source import DataSource
 from feast.errors import (
     BigQueryJobCancelled,
@@ -1586,8 +1587,23 @@ def _get_entity_df_event_timestamp_range(
 
 
 def _get_bigquery_client(
-    project: Optional[str] = None, location: Optional[str] = None
+    project: Optional[str] = None,
+    location: Optional[str] = None,
+    data_source=None,
 ) -> bigquery.Client:
+    override = get_connection_config_override(data_source) if data_source else None
+    if override and "service_account_json" in override:
+        from google.oauth2 import service_account
+
+        credentials = service_account.Credentials.from_service_account_info(
+            json.loads(override["service_account_json"])
+        )
+        return bigquery.Client(
+            project=override.get("project", project),
+            location=location,
+            credentials=credentials,
+            client_info=get_http_client_info(),
+        )
     try:
         client = bigquery.Client(
             project=project, location=location, client_info=get_http_client_info()

--- a/sdk/python/feast/infra/offline_stores/bigquery_source.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery_source.py
@@ -3,6 +3,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Tuple
 from typeguard import typechecked
 
 from feast import type_map
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.errors import DataSourceNoNameException, DataSourceNotFoundException
 from feast.feature_logging import LoggingDestination
@@ -40,6 +41,7 @@ class BigQuerySource(DataSource):
         description: Optional[str] = "",
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """Create a BigQuerySource from an existing table or query.
 
@@ -64,6 +66,7 @@ class BigQuerySource(DataSource):
             tags (optional): A dictionary of key-value pairs to store arbitrary metadata.
             owner (optional): The owner of the bigquery source, typically the email of the primary
                 maintainer.
+            connection_ref (optional): Connection reference for credential resolution.
         Example:
             >>> from feast import BigQuerySource
             >>> my_bigquery_source = BigQuerySource(table="gcp_project:bq_dataset.bq_table")
@@ -89,6 +92,7 @@ class BigQuerySource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
     # Note: Python requires redefining hash in child classes that override __eq__
@@ -117,6 +121,7 @@ class BigQuerySource(DataSource):
     def from_proto(data_source: DataSourceProto):
         assert data_source.HasField("bigquery_options")
 
+        tags = dict(data_source.tags)
         return BigQuerySource(
             name=data_source.name,
             field_mapping=dict(data_source.field_mapping),
@@ -127,8 +132,9 @@ class BigQuerySource(DataSource):
             timestamp_field_type=data_source.timestamp_field_type or None,
             query=data_source.bigquery_options.query,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/athena_offline_store/athena_source.py
@@ -1,6 +1,7 @@
 from typing import Callable, Dict, Iterable, Optional, Tuple
 
 from feast import type_map
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.errors import DataSourceNoNameException, DataSourceNotFoundException
 from feast.feature_logging import LoggingDestination
@@ -35,6 +36,7 @@ class AthenaSource(DataSource):
         description: Optional[str] = "",
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """
         Creates a AthenaSource object.
@@ -82,6 +84,7 @@ class AthenaSource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
     @staticmethod
@@ -95,6 +98,7 @@ class AthenaSource(DataSource):
         Returns:
             A AthenaSource object based on the data_source protobuf.
         """
+        tags = dict(data_source.tags)
         return AthenaSource(
             name=data_source.name,
             timestamp_field=data_source.timestamp_field,
@@ -106,7 +110,8 @@ class AthenaSource(DataSource):
             date_partition_column=data_source.date_partition_column,
             query=data_source.athena_options.query,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     # Note: Python requires redefining hash in child classes that override __eq__

--- a/sdk/python/feast/infra/offline_stores/contrib/clickhouse_offline_store/clickhouse_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/clickhouse_offline_store/clickhouse_source.py
@@ -16,6 +16,7 @@ from clickhouse_connect.datatypes.string import String
 from clickhouse_connect.datatypes.temporal import DateTime, DateTime64
 
 from feast import RepoConfig, ValueType
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.errors import DataSourceNoNameException
 from feast.infra.utils.clickhouse.connection_utils import get_client
@@ -71,6 +72,7 @@ class ClickhouseSource(DataSource):
         description: Optional[str] = "",
         tags: Optional[dict[str, str]] = None,
         owner: Optional[str] = "",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         self._clickhouse_options = ClickhouseOptions(
             name=name, query=query, table=table
@@ -89,6 +91,7 @@ class ClickhouseSource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
     @staticmethod
@@ -97,6 +100,7 @@ class ClickhouseSource(DataSource):
 
         postgres_options = json.loads(data_source.custom_options.configuration)
 
+        tags = dict(data_source.tags)
         return ClickhouseSource(
             name=postgres_options["name"],
             query=postgres_options["query"],
@@ -105,8 +109,9 @@ class ClickhouseSource(DataSource):
             timestamp_field=data_source.timestamp_field,
             created_timestamp_column=data_source.created_timestamp_column,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/offline_stores/contrib/couchbase_offline_store/couchbase_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/couchbase_offline_store/couchbase_source.py
@@ -7,6 +7,7 @@ from couchbase_columnar.credential import Credential
 from couchbase_columnar.options import ClusterOptions, QueryOptions, TimeoutOptions
 from typeguard import typechecked
 
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.errors import DataSourceNoNameException, ZeroColumnQueryResult
 from feast.feature_logging import LoggingDestination
@@ -43,6 +44,7 @@ class CouchbaseColumnarSource(DataSource):
         description: Optional[str] = "",
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """Creates a CouchbaseColumnarSource object.
 
@@ -86,6 +88,7 @@ class CouchbaseColumnarSource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
     def __hash__(self):
@@ -109,6 +112,7 @@ class CouchbaseColumnarSource(DataSource):
 
         couchbase_options = json.loads(data_source.custom_options.configuration)
 
+        tags = dict(data_source.tags)
         return CouchbaseColumnarSource(
             name=couchbase_options["name"],
             query=couchbase_options["query"],
@@ -119,8 +123,9 @@ class CouchbaseColumnarSource(DataSource):
             timestamp_field=data_source.timestamp_field,
             created_timestamp_column=data_source.created_timestamp_column,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/offline_stores/contrib/mongodb_offline_store/mongodb.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/mongodb_offline_store/mongodb.py
@@ -56,6 +56,7 @@ except ImportError:
 
 from pydantic import StrictStr
 
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.errors import (
     DataSourceNoNameException,
@@ -133,6 +134,7 @@ class MongoDBSource(DataSource):
         description: Optional[str] = "",
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         if name is None:
             raise DataSourceNoNameException()
@@ -144,6 +146,7 @@ class MongoDBSource(DataSource):
             description=description,
             tags=tags or {},
             owner=owner,
+            connection_ref=connection_ref,
         )
 
     @property
@@ -159,14 +162,16 @@ class MongoDBSource(DataSource):
     @staticmethod
     def from_proto(data_source: DataSourceProto) -> "MongoDBSource":
         assert data_source.HasField("custom_options")
+        tags = dict(data_source.tags)
         return MongoDBSource(
             name=data_source.name,
             timestamp_field=data_source.timestamp_field,
             created_timestamp_column=data_source.created_timestamp_column,
             field_mapping=dict(data_source.field_mapping),
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssqlserver_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/mssql_offline_store/mssqlserver_source.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Iterable, Optional, Tuple
 from urllib import parse
 
 from feast import type_map
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
 from feast.repo_config import RepoConfig
@@ -129,6 +130,7 @@ class MsSqlServerSource(DataSource):
         description: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = None,
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """Creates a MsSqlServerSource object.
 
@@ -166,6 +168,7 @@ class MsSqlServerSource(DataSource):
             owner=owner,
             name=name,
             timestamp_field=event_timestamp_column,
+            connection_ref=connection_ref,
         )
 
     def __eq__(self, other):
@@ -212,6 +215,7 @@ class MsSqlServerSource(DataSource):
     @staticmethod
     def from_proto(data_source: DataSourceProto):
         options = json.loads(data_source.custom_options.configuration)
+        tags = dict(data_source.tags)
         return MsSqlServerSource(
             name=data_source.name,
             field_mapping=dict(data_source.field_mapping),
@@ -220,6 +224,8 @@ class MsSqlServerSource(DataSource):
             event_timestamp_column=data_source.timestamp_field,
             created_timestamp_column=data_source.created_timestamp_column,
             date_partition_column=data_source.date_partition_column,
+            tags=tags,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/offline_stores/contrib/oracle_offline_store/oracle_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/oracle_offline_store/oracle_source.py
@@ -2,6 +2,7 @@ import json
 from typing import Callable, Dict, Iterable, Optional, Tuple
 
 from feast import type_map
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
 from feast.repo_config import RepoConfig
@@ -74,6 +75,7 @@ class OracleSource(DataSource):
         description: Optional[str] = None,
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = None,
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """Creates an OracleSource object.
 
@@ -101,6 +103,7 @@ class OracleSource(DataSource):
             owner=owner,
             name=name,
             timestamp_field=event_timestamp_column,
+            connection_ref=connection_ref,
         )
 
     def __eq__(self, other):
@@ -142,6 +145,7 @@ class OracleSource(DataSource):
     @staticmethod
     def from_proto(data_source: DataSourceProto):
         options = json.loads(data_source.custom_options.configuration)
+        tags = dict(data_source.tags)
         return OracleSource(
             name=data_source.name,
             field_mapping=dict(data_source.field_mapping),
@@ -149,6 +153,8 @@ class OracleSource(DataSource):
             event_timestamp_column=data_source.timestamp_field,
             created_timestamp_column=data_source.created_timestamp_column,
             date_partition_column=data_source.date_partition_column,
+            tags=tags,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres_source.py
@@ -3,6 +3,7 @@ from typing import Callable, Dict, Iterable, Optional, Tuple
 
 from typeguard import typechecked
 
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.errors import DataSourceNoNameException, ZeroColumnQueryResult
 from feast.infra.utils.postgres.connection_utils import _get_conn
@@ -35,6 +36,7 @@ class PostgreSQLSource(DataSource):
         description: Optional[str] = "",
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """Creates a PostgreSQLSource object.
 
@@ -70,6 +72,7 @@ class PostgreSQLSource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
     def __hash__(self):
@@ -93,6 +96,7 @@ class PostgreSQLSource(DataSource):
 
         postgres_options = json.loads(data_source.custom_options.configuration)
 
+        tags = dict(data_source.tags)
         return PostgreSQLSource(
             name=postgres_options["name"],
             query=postgres_options["query"],
@@ -101,8 +105,9 @@ class PostgreSQLSource(DataSource):
             timestamp_field=data_source.timestamp_field,
             created_timestamp_column=data_source.created_timestamp_column,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/offline_stores/contrib/ray_offline_store/ray_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/ray_offline_store/ray_source.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.protos.feast.core.DataSource_pb2 import DataSource as DataSourceProto
 from feast.repo_config import RepoConfig
@@ -85,6 +86,7 @@ class RaySource(DataSource):
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
         timestamp_field: Optional[str] = None,
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """Creates a RaySource object.
 
@@ -113,6 +115,7 @@ class RaySource(DataSource):
                 maintainer.
             timestamp_field: Event timestamp field used for point-in-time joins of
                 feature values.
+            connection_ref: Connection reference for credential resolution.
         """
         if reader_type not in SUPPORTED_READER_TYPES:
             raise ValueError(
@@ -128,6 +131,7 @@ class RaySource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
         self.ray_source_options = RaySourceOptions(
@@ -163,6 +167,7 @@ class RaySource(DataSource):
         """
         assert data_source.type == DataSourceProto.CUSTOM_SOURCE
         config = json.loads(data_source.custom_options.configuration)
+        tags = dict(data_source.tags)
         return RaySource(
             name=data_source.name,
             reader_type=config["reader_type"],
@@ -172,8 +177,9 @@ class RaySource(DataSource):
             timestamp_field=data_source.timestamp_field or None,
             created_timestamp_column=data_source.created_timestamp_column or None,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark_source.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple
 
 from feast import flags_helper
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.errors import DataSourceNoNameException, DataSourceNotFoundException
 from feast.infra.offline_stores.offline_utils import get_temp_entity_table_name
@@ -51,6 +52,7 @@ class SparkSource(DataSource):
         timestamp_field: Optional[str] = None,
         date_partition_column: Optional[str] = None,
         date_partition_column_format: Optional[str] = "%Y-%m-%d",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """Creates a SparkSource object.
 
@@ -90,6 +92,7 @@ class SparkSource(DataSource):
             date_partition_column=date_partition_column,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
         if not flags_helper.is_test():
@@ -155,6 +158,7 @@ class SparkSource(DataSource):
         assert data_source.HasField("spark_options")
         spark_options = SparkOptions.from_proto(data_source.spark_options)
 
+        tags = dict(data_source.tags)
         return SparkSource(
             name=data_source.name,
             field_mapping=dict(data_source.field_mapping),
@@ -168,8 +172,9 @@ class SparkSource(DataSource):
             timestamp_field=data_source.timestamp_field,
             created_timestamp_column=data_source.created_timestamp_column,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_source.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/trino_offline_store/trino_source.py
@@ -1,6 +1,7 @@
 from typing import Callable, Dict, Iterable, Optional, Tuple
 
 from feast import ValueType
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.errors import DataSourceNoNameException
 from feast.infra.offline_stores.contrib.trino_offline_store.trino_queries import Trino
@@ -101,6 +102,7 @@ class TrinoSource(DataSource):
         description: Optional[str] = "",
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """
         Creates a TrinoSource object.
@@ -137,6 +139,7 @@ class TrinoSource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
         self._trino_options = TrinoOptions(table=table, query=query)
@@ -187,6 +190,7 @@ class TrinoSource(DataSource):
     def from_proto(data_source: DataSourceProto):
         assert data_source.HasField("trino_options")
 
+        tags = dict(data_source.tags)
         return TrinoSource(
             name=data_source.name,
             field_mapping=dict(data_source.field_mapping),
@@ -195,8 +199,9 @@ class TrinoSource(DataSource):
             timestamp_field=data_source.timestamp_field,
             created_timestamp_column=data_source.created_timestamp_column,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:

--- a/sdk/python/feast/infra/offline_stores/dask.py
+++ b/sdk/python/feast/infra/offline_stores/dask.py
@@ -657,7 +657,9 @@ class DaskOfflineStore(OfflineStore):
             uri=data_source.file_options.uri,
         )
         filesystem, path = FileSource.create_filesystem_and_path(
-            str(absolute_path), data_source.file_options.s3_endpoint_override
+            str(absolute_path),
+            data_source.file_options.s3_endpoint_override,
+            resolved_credentials=data_source.resolve_credentials(),
         )
         try:
             t = pq.read_table(path, filesystem=filesystem, columns=[timestamp_field])
@@ -778,7 +780,9 @@ def _dask_read_batch_arrow(
         uri=data_source.file_options.uri,
     )
     filesystem, path = FileSource.create_filesystem_and_path(
-        str(absolute_path), data_source.file_options.s3_endpoint_override
+        str(absolute_path),
+        data_source.file_options.s3_endpoint_override,
+        resolved_credentials=data_source.resolve_credentials(),
     )
     return pq.read_table(path, filesystem=filesystem)
 
@@ -999,15 +1003,26 @@ def _get_entity_df_event_timestamp_range(
 
 
 def _read_datasource(data_source, repo_path) -> dd.DataFrame:
-    storage_options = (
-        {
+    storage_options: Optional[dict] = None
+    resolved_creds = data_source.resolve_credentials()
+
+    if resolved_creds:
+        storage_options = {
+            "key": resolved_creds.get("AWS_ACCESS_KEY_ID", ""),
+            "secret": resolved_creds.get("AWS_SECRET_ACCESS_KEY", ""),
+        }
+        endpoint = data_source.file_options.s3_endpoint_override
+        if endpoint:
+            storage_options["client_kwargs"] = {"endpoint_url": endpoint}
+        session_token = resolved_creds.get("AWS_SESSION_TOKEN")
+        if session_token:
+            storage_options["token"] = session_token
+    elif data_source.file_options.s3_endpoint_override:
+        storage_options = {
             "client_kwargs": {
                 "endpoint_url": data_source.file_options.s3_endpoint_override
             }
         }
-        if data_source.file_options.s3_endpoint_override
-        else None
-    )
 
     path = FileSource.get_uri_for_file_path(
         repo_path=repo_path,

--- a/sdk/python/feast/infra/offline_stores/duckdb.py
+++ b/sdk/python/feast/infra/offline_stores/duckdb.py
@@ -58,15 +58,40 @@ def _read_data_source(data_source: DataSource, repo_path: str) -> Table:
 
     assert isinstance(data_source, FileSource)
 
+    resolved_creds = data_source.resolve_credentials()
+
     if isinstance(data_source.file_format, ParquetFormat) or (
         data_source.file_format is None and data_source.path.endswith(".parquet")
     ):
+        if resolved_creds and data_source.path.startswith("s3://"):
+            storage_options = {
+                "AWS_ACCESS_KEY_ID": resolved_creds.get("AWS_ACCESS_KEY_ID", ""),
+                "AWS_SECRET_ACCESS_KEY": resolved_creds.get(
+                    "AWS_SECRET_ACCESS_KEY", ""
+                ),
+            }
+            if data_source.s3_endpoint_override:
+                storage_options["AWS_ENDPOINT_URL"] = data_source.s3_endpoint_override
+            session_token = resolved_creds.get("AWS_SESSION_TOKEN")
+            if session_token:
+                storage_options["AWS_SESSION_TOKEN"] = session_token
+            return ibis.read_parquet(data_source.path, storage_options=storage_options)
         return ibis.read_parquet(data_source.path)
     elif isinstance(data_source.file_format, DeltaFormat):
+        storage_options = {}
+        if resolved_creds:
+            storage_options["AWS_ACCESS_KEY_ID"] = resolved_creds.get(
+                "AWS_ACCESS_KEY_ID", ""
+            )
+            storage_options["AWS_SECRET_ACCESS_KEY"] = resolved_creds.get(
+                "AWS_SECRET_ACCESS_KEY", ""
+            )
+            session_token = resolved_creds.get("AWS_SESSION_TOKEN")
+            if session_token:
+                storage_options["AWS_SESSION_TOKEN"] = session_token
         if data_source.s3_endpoint_override:
-            storage_options = {
-                "AWS_ENDPOINT_URL": data_source.s3_endpoint_override,
-            }
+            storage_options["AWS_ENDPOINT_URL"] = data_source.s3_endpoint_override
+        if storage_options:
             return ibis.read_delta(data_source.path, storage_options=storage_options)
         return ibis.read_delta(data_source.path)
 

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -11,6 +11,7 @@ from pyarrow.parquet import ParquetDataset
 from typeguard import typechecked
 
 from feast import type_map
+from feast.credentials import ConnectionRef
 from feast.data_format import DeltaFormat, FileFormat, ParquetFormat
 from feast.data_source import DataSource
 from feast.feature_logging import LoggingDestination
@@ -49,6 +50,7 @@ class FileSource(DataSource):
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
         timestamp_field: Optional[str] = "",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """
         Creates a FileSource object.
@@ -70,6 +72,8 @@ class FileSource(DataSource):
                 maintainer.
             timestamp_field (optional): Event timestamp field used for point in time
                 joins of feature values.
+            connection_ref (optional): Connection reference (K8s Secret, Vault path, etc.)
+                with optional connection_type, auth_type, and non-sensitive params.
 
         Examples:
             >>> from feast import FileSource
@@ -89,6 +93,7 @@ class FileSource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
     # Note: Python requires redefining hash in child classes that override __eq__
@@ -124,6 +129,7 @@ class FileSource(DataSource):
 
     @staticmethod
     def from_proto(data_source: DataSourceProto):
+        tags = dict(data_source.tags)
         return FileSource(
             name=data_source.name,
             field_mapping=dict(data_source.field_mapping),
@@ -133,8 +139,9 @@ class FileSource(DataSource):
             created_timestamp_column=data_source.created_timestamp_column,
             s3_endpoint_override=data_source.file_options.s3_endpoint_override,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:
@@ -259,12 +266,29 @@ class FileSource(DataSource):
 
     @staticmethod
     def create_filesystem_and_path(
-        path: str, s3_endpoint_override: str
+        path: str,
+        s3_endpoint_override: str,
+        resolved_credentials: Optional[Dict[str, str]] = None,
     ) -> Tuple[Optional[FileSystem], str]:
         if path.startswith("s3://"):
-            s3fs = S3FileSystem(
-                endpoint_override=s3_endpoint_override if s3_endpoint_override else None
-            )
+            kwargs: Dict[str, Optional[str]] = {}
+            if s3_endpoint_override:
+                kwargs["endpoint_override"] = s3_endpoint_override
+
+            if resolved_credentials:
+                access_key = resolved_credentials.get("AWS_ACCESS_KEY_ID", "")
+                secret_key = resolved_credentials.get("AWS_SECRET_ACCESS_KEY", "")
+                session_token = resolved_credentials.get("AWS_SESSION_TOKEN")
+                region = resolved_credentials.get("AWS_DEFAULT_REGION")
+                if access_key and secret_key:
+                    kwargs["access_key"] = access_key
+                    kwargs["secret_key"] = secret_key
+                if session_token:
+                    kwargs["session_token"] = session_token
+                if region:
+                    kwargs["region"] = region
+
+            s3fs = S3FileSystem(**kwargs)
             return s3fs, path.replace("s3://", "")
         else:
             return None, path

--- a/sdk/python/feast/infra/offline_stores/file_source.py
+++ b/sdk/python/feast/infra/offline_stores/file_source.py
@@ -11,6 +11,7 @@ from pyarrow.parquet import ParquetDataset
 from typeguard import typechecked
 
 from feast import type_map
+from feast.credentials import ConnectionRef
 from feast.data_format import DeltaFormat, FileFormat, ParquetFormat
 from feast.data_source import DataSource
 from feast.feature_logging import LoggingDestination
@@ -49,6 +50,7 @@ class FileSource(DataSource):
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
         timestamp_field: Optional[str] = "",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """
         Creates a FileSource object.
@@ -70,6 +72,8 @@ class FileSource(DataSource):
                 maintainer.
             timestamp_field (optional): Event timestamp field used for point in time
                 joins of feature values.
+            connection_ref (optional): Connection reference (K8s Secret, Vault path, etc.)
+                with optional connection_type, auth_type, and non-sensitive params.
 
         Examples:
             >>> from feast import FileSource
@@ -89,6 +93,7 @@ class FileSource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
     # Note: Python requires redefining hash in child classes that override __eq__
@@ -124,6 +129,7 @@ class FileSource(DataSource):
 
     @staticmethod
     def from_proto(data_source: DataSourceProto):
+        tags = dict(data_source.tags)
         return FileSource(
             name=data_source.name,
             field_mapping=dict(data_source.field_mapping),
@@ -133,8 +139,9 @@ class FileSource(DataSource):
             created_timestamp_column=data_source.created_timestamp_column,
             s3_endpoint_override=data_source.file_options.s3_endpoint_override,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     def _to_proto_impl(self) -> DataSourceProto:
@@ -259,12 +266,46 @@ class FileSource(DataSource):
 
     @staticmethod
     def create_filesystem_and_path(
-        path: str, s3_endpoint_override: str
+        path: str,
+        s3_endpoint_override: str,
+        resolved_credentials: Optional[Dict[str, str]] = None,
     ) -> Tuple[Optional[FileSystem], str]:
+        """Build a PyArrow filesystem for the given path.
+
+        For S3 paths, ``resolved_credentials`` (from ``ConnectionRef``) may
+        supply explicit AWS credentials.  Supported keys:
+
+        - ``AWS_ACCESS_KEY_ID`` + ``AWS_SECRET_ACCESS_KEY`` — static credentials
+        - ``AWS_SESSION_TOKEN`` — STS / assumed-role temporary credentials
+        - ``AWS_DEFAULT_REGION`` — override the default region
+
+        AWS auth methods that do **not** require ``ConnectionRef`` (they are
+        resolved automatically by the AWS SDK / boto3 credential chain):
+
+        - IAM instance profiles (EC2)
+        - IRSA / EKS Pod Identity (Kubernetes)
+        - OIDC federation
+        - Environment variables set directly on the Pod
+        """
         if path.startswith("s3://"):
-            s3fs = S3FileSystem(
-                endpoint_override=s3_endpoint_override if s3_endpoint_override else None
-            )
+            kwargs: Dict[str, Optional[str]] = {}
+            if s3_endpoint_override:
+                kwargs["endpoint_override"] = s3_endpoint_override
+
+            if resolved_credentials:
+                access_key = resolved_credentials.get("AWS_ACCESS_KEY_ID", "")
+                secret_key = resolved_credentials.get("AWS_SECRET_ACCESS_KEY", "")
+                session_token = resolved_credentials.get("AWS_SESSION_TOKEN")
+                region = resolved_credentials.get("AWS_DEFAULT_REGION")
+                if access_key and secret_key:
+                    kwargs["access_key"] = access_key
+                    kwargs["secret_key"] = secret_key
+                if session_token:
+                    kwargs["session_token"] = session_token
+                if region:
+                    kwargs["region"] = region
+
+            s3fs = S3FileSystem(**kwargs)
             return s3fs, path.replace("s3://", "")
         else:
             return None, path

--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -24,6 +24,7 @@ from dateutil import parser
 from pydantic import StrictStr, model_validator
 
 from feast import OnDemandFeatureView, RedshiftSource
+from feast.credentials import get_connection_config_override
 from feast.data_source import DataSource
 from feast.errors import InvalidEntityType
 from feast.feature_logging import LoggingConfig, LoggingSource
@@ -54,6 +55,25 @@ from feast.monitoring.monitoring_utils import (
 )
 from feast.repo_config import FeastConfigBaseModel, RepoConfig
 from feast.saved_dataset import SavedDatasetStorage
+
+
+def _get_redshift_client(config: "RepoConfig", data_source=None):
+    """Get a Redshift Data API client, optionally using credentials from data source's connection_ref."""
+    override = get_connection_config_override(data_source) if data_source else None
+    if override:
+        region = override.get("AWS_DEFAULT_REGION", config.offline_store.region)
+        import boto3
+
+        session_kwargs: Dict[str, str] = {}
+        if "AWS_ACCESS_KEY_ID" in override:
+            session_kwargs["aws_access_key_id"] = override["AWS_ACCESS_KEY_ID"]
+        if "AWS_SECRET_ACCESS_KEY" in override:
+            session_kwargs["aws_secret_access_key"] = override["AWS_SECRET_ACCESS_KEY"]
+        if "AWS_SESSION_TOKEN" in override:
+            session_kwargs["aws_session_token"] = override["AWS_SESSION_TOKEN"]
+        session = boto3.Session(region_name=region, **session_kwargs)
+        return session.client("redshift-data")
+    return aws_utils.get_redshift_data_client(config.offline_store.region)
 
 
 class RedshiftOfflineStoreConfig(FeastConfigBaseModel):

--- a/sdk/python/feast/infra/offline_stores/redshift_source.py
+++ b/sdk/python/feast/infra/offline_stores/redshift_source.py
@@ -3,6 +3,7 @@ from typing import Callable, Dict, Iterable, Optional, Tuple
 from typeguard import typechecked
 
 from feast import type_map
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.errors import (
     DataSourceNoNameException,
@@ -43,6 +44,7 @@ class RedshiftSource(DataSource):
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
         database: Optional[str] = "",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """
         Creates a RedshiftSource object.
@@ -66,6 +68,7 @@ class RedshiftSource(DataSource):
             owner (optional): The owner of the redshift source, typically the email of the primary
                 maintainer.
             database (optional): The Redshift database name.
+            connection_ref (optional): Connection reference for credential resolution.
         """
         if table is None and query is None:
             raise ValueError('No "table" or "query" argument provided.')
@@ -90,6 +93,7 @@ class RedshiftSource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
     @staticmethod
@@ -103,6 +107,7 @@ class RedshiftSource(DataSource):
         Returns:
             A RedshiftSource object based on the data_source protobuf.
         """
+        tags = dict(data_source.tags)
         return RedshiftSource(
             name=data_source.name,
             timestamp_field=data_source.timestamp_field,
@@ -112,9 +117,10 @@ class RedshiftSource(DataSource):
             field_mapping=dict(data_source.field_mapping),
             query=data_source.redshift_options.query,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
             database=data_source.redshift_options.database,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     # Note: Python requires redefining hash in child classes that override __eq__

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -28,6 +28,7 @@ import pyarrow
 from pydantic import ConfigDict, Field, StrictStr
 
 from feast import OnDemandFeatureView
+from feast.credentials import get_connection_config_override
 from feast.data_source import DataSource
 from feast.errors import EntitySQLEmptyResults, InvalidEntityType
 from feast.feature_logging import LoggingConfig, LoggingSource
@@ -87,6 +88,31 @@ if TYPE_CHECKING:
     from pyspark.sql import DataFrame, SparkSession
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+def _get_snowflake_conn(config: "RepoConfig", data_source=None):
+    """Get a Snowflake connection, optionally overriding config from data source's connection_ref."""
+    override = get_connection_config_override(data_source) if data_source else None
+    if override:
+        from feast.infra.utils.snowflake.snowflake_utils import GetSnowflakeConnection
+
+        patched_config = config.offline_store.model_copy()
+        if "account" in override:
+            patched_config.account = override["account"]
+        if "user" in override or "username" in override:
+            patched_config.user = override.get("user") or override.get("username")
+        if "password" in override:
+            patched_config.password = override["password"]
+        if "database" in override:
+            patched_config.database = override["database"]
+        if "warehouse" in override:
+            patched_config.warehouse = override["warehouse"]
+        if "role" in override:
+            patched_config.role = override["role"]
+        if "schema" in override:
+            patched_config.schema_ = override["schema"]
+        return GetSnowflakeConnection(patched_config)
+    return GetSnowflakeConnection(config.offline_store)
 
 
 class SnowflakeOfflineStoreConfig(FeastConfigBaseModel):

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -28,6 +28,7 @@ import pyarrow
 from pydantic import ConfigDict, Field, StrictStr
 
 from feast import OnDemandFeatureView
+from feast.credentials import get_connection_config_override
 from feast.data_source import DataSource
 from feast.errors import EntitySQLEmptyResults, InvalidEntityType
 from feast.feature_logging import LoggingConfig, LoggingSource
@@ -87,6 +88,37 @@ if TYPE_CHECKING:
     from pyspark.sql import DataFrame, SparkSession
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+def _get_snowflake_conn(config: "RepoConfig", data_source=None):
+    """Get a Snowflake connection, optionally overriding config from data source's connection_ref."""
+    override = get_connection_config_override(data_source) if data_source else None
+    if override:
+        from feast.infra.utils.snowflake.snowflake_utils import GetSnowflakeConnection
+
+        patched_config = config.offline_store.model_copy()
+        if "account" in override:
+            patched_config.account = override["account"]
+        if "user" in override or "username" in override:
+            patched_config.user = override.get("user") or override.get("username")
+        if "password" in override:
+            patched_config.password = override["password"]
+        if "database" in override:
+            patched_config.database = override["database"]
+        if "warehouse" in override:
+            patched_config.warehouse = override["warehouse"]
+        if "role" in override:
+            patched_config.role = override["role"]
+        if "schema" in override:
+            patched_config.schema_ = override["schema"]
+        if "authenticator" in override:
+            patched_config.authenticator = override["authenticator"]
+        if "private_key" in override:
+            patched_config.private_key = override["private_key"]
+        if "private_key_passphrase" in override:
+            patched_config.private_key_passphrase = override["private_key_passphrase"]
+        return GetSnowflakeConnection(patched_config)
+    return GetSnowflakeConnection(config.offline_store)
 
 
 class SnowflakeOfflineStoreConfig(FeastConfigBaseModel):

--- a/sdk/python/feast/infra/offline_stores/snowflake_source.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake_source.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, no_type
 from typeguard import typechecked
 
 from feast import type_map
+from feast.credentials import ConnectionRef
 from feast.data_source import DataSource
 from feast.errors import DataSourceNoNameException, DataSourceNotFoundException
 from feast.feature_logging import LoggingDestination
@@ -38,6 +39,7 @@ class SnowflakeSource(DataSource):
         description: Optional[str] = "",
         tags: Optional[Dict[str, str]] = None,
         owner: Optional[str] = "",
+        connection_ref: Optional[ConnectionRef] = None,
     ):
         """
         Creates a SnowflakeSource object.
@@ -61,6 +63,7 @@ class SnowflakeSource(DataSource):
             tags (optional): A dictionary of key-value pairs to store arbitrary metadata.
             owner (optional): The owner of the snowflake source, typically the email of the primary
                 maintainer.
+            connection_ref (optional): Connection reference for credential resolution.
         """
 
         if warehouse:
@@ -99,6 +102,7 @@ class SnowflakeSource(DataSource):
             description=description,
             tags=tags,
             owner=owner,
+            connection_ref=connection_ref,
         )
 
     @staticmethod
@@ -112,6 +116,7 @@ class SnowflakeSource(DataSource):
         Returns:
             A SnowflakeSource object based on the data_source protobuf.
         """
+        tags = dict(data_source.tags)
         return SnowflakeSource(
             name=data_source.name,
             timestamp_field=data_source.timestamp_field,
@@ -122,8 +127,9 @@ class SnowflakeSource(DataSource):
             field_mapping=dict(data_source.field_mapping),
             query=data_source.snowflake_options.query,
             description=data_source.description,
-            tags=dict(data_source.tags),
+            tags=tags,
             owner=data_source.owner,
+            connection_ref=ConnectionRef.from_tags(tags),
         )
 
     # Note: Python requires redefining hash in child classes that override __eq__

--- a/sdk/python/tests/unit/test_credentials.py
+++ b/sdk/python/tests/unit/test_credentials.py
@@ -1,0 +1,358 @@
+import base64
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from feast.credentials import (
+    ConnectionRef,
+    CredentialProvider,
+    CredentialResolutionError,
+    EnvironmentProvider,
+    KubernetesSecretProvider,
+    VaultProvider,
+    VaultProviderConfig,
+    get_credential_provider,
+    register_credential_provider,
+    resolve_credentials,
+)
+
+# ---------------------------------------------------------------------------
+# ConnectionRef serialization
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionRefTags:
+    def test_minimal_roundtrip(self):
+        ref = ConnectionRef(provider="kubernetes", name="my-secret")
+        tags = ref.to_tags()
+        restored = ConnectionRef.from_tags(tags)
+        assert restored == ref
+
+    def test_full_roundtrip(self):
+        ref = ConnectionRef(
+            provider="vault",
+            name="secret/data/feast/conn",
+            namespace="ml-team",
+            connection_type="snowflake.offline",
+            auth_type="oauth2",
+            params={"account": "xy12345", "warehouse": "COMPUTE_WH"},
+        )
+        tags = ref.to_tags()
+        restored = ConnectionRef.from_tags(tags)
+        assert restored == ref
+
+    def test_from_tags_returns_none_when_no_provider(self):
+        assert ConnectionRef.from_tags({"unrelated": "tag"}) is None
+
+    def test_from_tags_returns_none_when_no_name(self):
+        tags = {"feast.connection-ref.provider": "kubernetes"}
+        assert ConnectionRef.from_tags(tags) is None
+
+    def test_default_auth_type_not_serialized(self):
+        ref = ConnectionRef(provider="env", name="AWS", auth_type="secret")
+        tags = ref.to_tags()
+        assert "feast.connection-ref.auth-type" not in tags
+
+    def test_non_default_auth_type_serialized(self):
+        ref = ConnectionRef(provider="env", name="AWS", auth_type="oauth2")
+        tags = ref.to_tags()
+        assert tags["feast.connection-ref.auth-type"] == "oauth2"
+
+    def test_params_roundtrip(self):
+        ref = ConnectionRef(
+            provider="env",
+            name="PG",
+            params={"host": "localhost", "port": "5432"},
+        )
+        tags = ref.to_tags()
+        assert tags["feast.connection-ref.param.host"] == "localhost"
+        assert tags["feast.connection-ref.param.port"] == "5432"
+        assert ConnectionRef.from_tags(tags) == ref
+
+    def test_mixed_tags_ignored(self):
+        tags = {
+            "feast.connection-ref.provider": "env",
+            "feast.connection-ref.name": "AWS",
+            "team": "ml",
+            "version": "2",
+        }
+        ref = ConnectionRef.from_tags(tags)
+        assert ref == ConnectionRef(provider="env", name="AWS")
+
+    def test_immutable(self):
+        ref = ConnectionRef(provider="env", name="AWS")
+        with pytest.raises(AttributeError):
+            ref.provider = "vault"
+
+
+# ---------------------------------------------------------------------------
+# Provider registry
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRegistry:
+    def test_unknown_provider_raises(self):
+        with pytest.raises(CredentialResolutionError, match="No CredentialProvider"):
+            get_credential_provider("nonexistent-provider-xyz")
+
+    def test_builtin_providers_registered(self):
+        assert get_credential_provider("env") is not None
+        assert get_credential_provider("kubernetes") is not None
+        assert get_credential_provider("vault") is not None
+
+    def test_custom_provider_registration(self):
+        class DummyProvider(CredentialProvider):
+            def provider_type(self):
+                return "dummy-test"
+
+            def resolve(self, ref):
+                return {"key": "value"}
+
+        register_credential_provider(DummyProvider())
+        provider = get_credential_provider("dummy-test")
+        result = provider.resolve(ConnectionRef(provider="dummy-test", name="x"))
+        assert result == {"key": "value"}
+
+
+# ---------------------------------------------------------------------------
+# EnvironmentProvider
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentProvider:
+    def test_prefix_filter(self, monkeypatch):
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIA...")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+        monkeypatch.setenv("UNRELATED_VAR", "nope")
+
+        provider = EnvironmentProvider()
+        ref = ConnectionRef(provider="env", name="AWS")
+        result = provider.resolve(ref)
+
+        assert "AWS_ACCESS_KEY_ID" in result
+        assert "AWS_SECRET_ACCESS_KEY" in result
+        assert "UNRELATED_VAR" not in result
+
+    def test_empty_prefix_returns_all(self, monkeypatch):
+        monkeypatch.setenv("TEST_CRED_VAR", "yes")
+        provider = EnvironmentProvider()
+        ref = ConnectionRef(provider="env", name="*")
+        result = provider.resolve(ref)
+        assert "TEST_CRED_VAR" in result
+
+    def test_no_match_returns_empty(self, monkeypatch):
+        provider = EnvironmentProvider()
+        ref = ConnectionRef(provider="env", name="NONEXISTENT_PREFIX_XYZ_")
+        result = provider.resolve(ref)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# KubernetesSecretProvider
+# ---------------------------------------------------------------------------
+
+
+class TestKubernetesSecretProvider:
+    @patch(
+        "feast.credentials.KubernetesSecretProvider._current_namespace",
+        return_value="default",
+    )
+    def test_resolve_reads_and_decodes_secret(self, _mock_ns):
+        mock_secret = MagicMock()
+        mock_secret.data = {
+            "username": base64.b64encode(b"admin").decode(),
+            "password": base64.b64encode(
+                b"s3cret"
+            ).decode(),  # pragma: allowlist secret
+        }
+
+        with patch("kubernetes.config.load_incluster_config"):
+            with patch("kubernetes.client.CoreV1Api") as mock_api_cls:
+                mock_api_cls.return_value.read_namespaced_secret.return_value = (
+                    mock_secret
+                )
+
+                provider = KubernetesSecretProvider()
+                ref = ConnectionRef(
+                    provider="kubernetes", name="my-secret", namespace="test-ns"
+                )
+                result = provider.resolve(ref)
+
+        assert result == {
+            "username": "admin",
+            "password": "s3cret",  # pragma: allowlist secret
+        }
+        mock_api_cls.return_value.read_namespaced_secret.assert_called_once_with(
+            name="my-secret", namespace="test-ns"
+        )
+
+    @patch(
+        "feast.credentials.KubernetesSecretProvider._current_namespace",
+        return_value="default",
+    )
+    def test_resolve_uses_pod_namespace_when_empty(self, mock_ns):
+        mock_secret = MagicMock()
+        mock_secret.data = {"key": base64.b64encode(b"val").decode()}
+
+        with patch("kubernetes.config.load_incluster_config"):
+            with patch("kubernetes.client.CoreV1Api") as mock_api_cls:
+                mock_api_cls.return_value.read_namespaced_secret.return_value = (
+                    mock_secret
+                )
+
+                provider = KubernetesSecretProvider()
+                ref = ConnectionRef(provider="kubernetes", name="my-secret")
+                provider.resolve(ref)
+
+        mock_api_cls.return_value.read_namespaced_secret.assert_called_once_with(
+            name="my-secret", namespace="default"
+        )
+
+    @patch(
+        "feast.credentials.KubernetesSecretProvider._current_namespace",
+        return_value="default",
+    )
+    def test_resolve_raises_on_api_error(self, _mock_ns):
+        from kubernetes.client.exceptions import ApiException
+
+        with patch("kubernetes.config.load_incluster_config"):
+            with patch("kubernetes.client.CoreV1Api") as mock_api_cls:
+                mock_api_cls.return_value.read_namespaced_secret.side_effect = (
+                    ApiException(status=403, reason="Forbidden")
+                )
+
+                provider = KubernetesSecretProvider()
+                ref = ConnectionRef(
+                    provider="kubernetes", name="forbidden-secret", namespace="ns"
+                )
+                with pytest.raises(CredentialResolutionError, match="Forbidden"):
+                    provider.resolve(ref)
+
+    @patch(
+        "feast.credentials.KubernetesSecretProvider._current_namespace",
+        return_value="default",
+    )
+    def test_resolve_handles_empty_secret_data(self, _mock_ns):
+        mock_secret = MagicMock()
+        mock_secret.data = None
+
+        with patch("kubernetes.config.load_incluster_config"):
+            with patch("kubernetes.client.CoreV1Api") as mock_api_cls:
+                mock_api_cls.return_value.read_namespaced_secret.return_value = (
+                    mock_secret
+                )
+
+                provider = KubernetesSecretProvider()
+                ref = ConnectionRef(
+                    provider="kubernetes", name="empty-secret", namespace="ns"
+                )
+                result = provider.resolve(ref)
+
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# VaultProvider
+# ---------------------------------------------------------------------------
+
+
+try:
+    import hvac  # noqa: F401
+
+    _has_hvac = True
+except ImportError:
+    _has_hvac = False
+
+
+@pytest.mark.skipif(not _has_hvac, reason="hvac not installed")
+class TestVaultProvider:
+    def test_resolve_reads_kv_v2_secret(self):
+        mock_client_instance = MagicMock()
+        mock_client_instance.is_authenticated.return_value = True
+        mock_client_instance.secrets.kv.v2.read_secret_version.return_value = {
+            "data": {
+                "data": {
+                    "api_key": "abc123",  # pragma: allowlist secret
+                    "endpoint": "https://api.example.com",
+                }
+            }
+        }
+
+        with patch("hvac.Client", return_value=mock_client_instance):
+            config = VaultProviderConfig(addr="https://vault:8200", token="s.token")
+            provider = VaultProvider(config=config)
+            ref = ConnectionRef(
+                provider="vault", name="feast/my-conn", namespace="secret"
+            )
+            result = provider.resolve(ref)
+
+        assert result == {
+            "api_key": "abc123",  # pragma: allowlist secret
+            "endpoint": "https://api.example.com",
+        }
+        mock_client_instance.secrets.kv.v2.read_secret_version.assert_called_once_with(
+            path="feast/my-conn", mount_point="secret"
+        )
+
+    def test_resolve_defaults_mount_to_secret(self):
+        mock_client_instance = MagicMock()
+        mock_client_instance.is_authenticated.return_value = True
+        mock_client_instance.secrets.kv.v2.read_secret_version.return_value = {
+            "data": {"data": {"k": "v"}}
+        }
+
+        with patch("hvac.Client", return_value=mock_client_instance):
+            provider = VaultProvider(
+                config=VaultProviderConfig(addr="http://vault", token="t")
+            )
+            ref = ConnectionRef(provider="vault", name="path/to/secret")
+            provider.resolve(ref)
+
+        mock_client_instance.secrets.kv.v2.read_secret_version.assert_called_once_with(
+            path="path/to/secret", mount_point="secret"
+        )
+
+    def test_resolve_raises_when_not_authenticated(self):
+        mock_client_instance = MagicMock()
+        mock_client_instance.is_authenticated.return_value = False
+
+        with patch("hvac.Client", return_value=mock_client_instance):
+            provider = VaultProvider(
+                config=VaultProviderConfig(addr="http://vault", token="bad")
+            )
+            ref = ConnectionRef(provider="vault", name="path")
+            with pytest.raises(CredentialResolutionError, match="not authenticated"):
+                provider.resolve(ref)
+
+    def test_resolve_raises_on_vault_error(self):
+        mock_client_instance = MagicMock()
+        mock_client_instance.is_authenticated.return_value = True
+        mock_client_instance.secrets.kv.v2.read_secret_version.side_effect = Exception(
+            "permission denied"
+        )
+
+        with patch("hvac.Client", return_value=mock_client_instance):
+            provider = VaultProvider(
+                config=VaultProviderConfig(addr="http://vault", token="t")
+            )
+            ref = ConnectionRef(provider="vault", name="forbidden/path")
+            with pytest.raises(CredentialResolutionError, match="permission denied"):
+                provider.resolve(ref)
+
+
+# ---------------------------------------------------------------------------
+# resolve_credentials (end-to-end dispatch)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCredentials:
+    def test_dispatches_to_correct_provider(self, monkeypatch):
+        monkeypatch.setenv("MYAPP_KEY", "resolved-value")
+        ref = ConnectionRef(provider="env", name="MYAPP_")
+        result = resolve_credentials(ref)
+        assert result["MYAPP_KEY"] == "resolved-value"
+
+    def test_raises_for_unknown_provider(self):
+        ref = ConnectionRef(provider="does-not-exist", name="x")
+        with pytest.raises(CredentialResolutionError):
+            resolve_credentials(ref)


### PR DESCRIPTION

# What this PR does / why we need it:

Feast DataSources today have no mechanism to reference external credentials - authentication relies on ambient environment variables or a single global 
`offline_store` config in `feature_store.yaml`. 

This PR introduces `ConnectionRef` - which backend to use, how to authenticate, and where to connect - an optional reference on `DataSource` that points to an external credential store (Kubernetes Secrets, HashiCorp Vault, cloud secret managers, or environment variables). Credentials are resolved 
at runtime by a pluggable `CredentialProvider` interface. 


This enables:

- **HybridOfflineStore at runtime**: Users configure a HybridOfflineStore via CR/feature_store.yaml, then add new data sources at runtime with their own `connection_ref` specifying `connection_type`, credentials, and connection params - no server restart needed.
- **Per-source credential isolation**: Each DataSource resolves its own credentials from K8s Secrets, Vault, or other providers, removing the need for a single shared credential set.
- **Self-describing data sources**: Non-sensitive connection parameters (account, warehouse, endpoint) live on the DataSource alongside the credential reference, making the source fully portable.

