### PR TITLE
feat: Multi-arch publish for feast operator image

### DIFF
--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -102,8 +102,8 @@ jobs:
             push_mode: all_tags
           - component: feast-operator
             target: feast-operator
-            build_args: ""
-            push_mode: all_tags
+            build_args: DOCKER_PUSH=true DOCKER_PLATFORMS=linux/amd64,linux/arm64
+            push_mode: imagetools
     env:
       REGISTRY: quay.io/feastdev-ci
     steps:
@@ -135,7 +135,7 @@ jobs:
       - name: Push image
         run: |
           if [[ "${{ matrix.push_mode }}" == "imagetools" ]]; then
-            docker buildx imagetools create -t ${REGISTRY}/feature-server:develop ${REGISTRY}/feature-server:${GITHUB_SHA}
+            docker buildx imagetools create -t ${REGISTRY}/${{ matrix.target }}:develop ${REGISTRY}/${{ matrix.target }}:${GITHUB_SHA}
           else
             docker tag ${REGISTRY}/${{ matrix.target }}:${GITHUB_SHA} ${REGISTRY}/${{ matrix.target }}:develop && docker push ${REGISTRY}/${{ matrix.target }} --all-tags
           fi

--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           VERSION_WITHOUT_PREFIX: ${{ steps.get-version.outputs.version_without_prefix }}
         run: |
-          if [ "${{ matrix.component }}" = "feature-server" ]; then
+          if [[ "${{ matrix.component }}" == "feature-server" || "${{ matrix.component }}" == "feast-operator" ]]; then
             make build-${{ matrix.component }}-docker REGISTRY=${REGISTRY} VERSION=${VERSION_WITHOUT_PREFIX} DOCKER_PUSH=true DOCKER_PLATFORMS=linux/amd64,linux/arm64
           else
             make build-${{ matrix.component }}-docker REGISTRY=${REGISTRY} VERSION=${VERSION_WITHOUT_PREFIX}
@@ -84,8 +84,8 @@ jobs:
           VERSION_WITHOUT_PREFIX: ${{ steps.get-version.outputs.version_without_prefix }}
           HIGHEST_SEMVER_TAG: ${{ steps.get-version.outputs.highest_semver_tag }}
         run: |
-          if [ "${{ matrix.component }}" = "feature-server" ]; then
-            echo "feature-server image pushed via buildx during build step"
+          if [[ "${{ matrix.component }}" == "feature-server" || "${{ matrix.component }}" == "feast-operator" ]]; then
+            echo "${{ matrix.component }} image pushed via buildx during build step"
           else
             make push-${{ matrix.component }}-docker REGISTRY=${REGISTRY} VERSION=${VERSION_WITHOUT_PREFIX}
           fi
@@ -93,8 +93,8 @@ jobs:
           echo "Only push to latest tag if tag is the highest semver version $HIGHEST_SEMVER_TAG"
           if [ "${VERSION_WITHOUT_PREFIX}" = "${HIGHEST_SEMVER_TAG:1}" ]
           then
-            if [ "${{ matrix.component }}" = "feature-server" ]; then
-              docker buildx imagetools create -t ${REGISTRY}/feature-server:latest ${REGISTRY}/feature-server:${VERSION_WITHOUT_PREFIX}
+            if [[ "${{ matrix.component }}" == "feature-server" || "${{ matrix.component }}" == "feast-operator" ]]; then
+              docker buildx imagetools create -t ${REGISTRY}/${{ matrix.component }}:latest ${REGISTRY}/${{ matrix.component }}:${VERSION_WITHOUT_PREFIX}
             else
               docker tag ${REGISTRY}/${{ matrix.component }}:${VERSION_WITHOUT_PREFIX} ${REGISTRY}/${{ matrix.component }}:latest
               docker push ${REGISTRY}/${{ matrix.component }}:latest

--- a/Makefile
+++ b/Makefile
@@ -730,10 +730,16 @@ push-feast-operator-docker: ## Push Feast Operator Docker image
 	$(MAKE) docker-push
 
 build-feast-operator-docker: ## Build Feast Operator Docker image
-	cd infra/feast-operator && \
-	IMAGE_TAG_BASE=$(REGISTRY)/feast-operator \
-	VERSION=$(VERSION) \
-	$(MAKE) docker-build
+	@if [ -n "$(DOCKER_PLATFORMS)" ]; then \
+		cd infra/feast-operator && \
+		docker buildx build --push --platform=$(DOCKER_PLATFORMS) \
+			--tag $(REGISTRY)/feast-operator:$(VERSION) -f Dockerfile .; \
+	else \
+		cd infra/feast-operator && \
+		IMAGE_TAG_BASE=$(REGISTRY)/feast-operator \
+		VERSION=$(VERSION) \
+		$(MAKE) docker-build; \
+	fi
 
 build-feast-operator-docker-on-mac: ## Build Feast Operator Docker image on Mac
 	cd infra/feast-operator && \


### PR DESCRIPTION

# What this PR does / why we need it:

After the next release, `quay.io/feastdev/feast-operator:<version>` will be a multi-arch manifest supporting both linux/amd64 and linux/arm64, eliminating the `exec /manager: exec format error` on ARM nodes without requiring any nodeSelector, or other workarounds.

# Which issue(s) this PR fixes:

https://feastopensource.slack.com/archives/C01MSKCMB37/p1784926783048189 