### PR TITLE
fix: Preserve event-time ordering within Redis online_write_batch

### DIFF
--- a/sdk/python/feast/infra/online_stores/redis.py
+++ b/sdk/python/feast/infra/online_stores/redis.py
@@ -370,6 +370,13 @@ class RedisOnlineStore(OnlineStore):
             # flattening the list of lists. `hmget` does the lookup assuming a list of keys in the key bin
             prev_event_timestamps = [i[0] for i in prev_event_timestamps]
 
+            # Latest event timestamp queued so far in this batch, per entity key. The
+            # reads above all happened before any write, so without this rows sharing
+            # an entity key would each compare against the same pre-batch value, all
+            # pass the staleness check, and the last one queued would win regardless
+            # of its event time.
+            batch_latest_nanos: Dict[bytes, int] = {}
+
             for redis_key_bin, prev_event_time, (_, values, timestamp, _) in zip(
                 keys, prev_event_timestamps, data
             ):
@@ -381,15 +388,21 @@ class RedisOnlineStore(OnlineStore):
                 # New timestamp in nanoseconds
                 new_total_nanos = ts.seconds * 1_000_000_000 + ts.nanos
                 # Compare against existing timestamp (nanosecond precision)
+                prev_total_nanos = 0
                 if prev_event_time:
                     prev_ts = Timestamp()
                     prev_ts.ParseFromString(prev_event_time)
                     prev_total_nanos = prev_ts.seconds * 1_000_000_000 + prev_ts.nanos
-                    # Skip only if older OR exact same instant
-                    if prev_total_nanos and new_total_nanos <= prev_total_nanos:
-                        if progress:
-                            progress(1)
-                        continue
+                # Whichever is newer: the stored value or an earlier row of this batch
+                latest_seen_nanos = max(
+                    prev_total_nanos, batch_latest_nanos.get(redis_key_bin, 0)
+                )
+                # Skip only if older OR exact same instant
+                if latest_seen_nanos and new_total_nanos <= latest_seen_nanos:
+                    if progress:
+                        progress(1)
+                    continue
+                batch_latest_nanos[redis_key_bin] = new_total_nanos
                 # Store full timestamp (seconds + nanos)
                 entity_hset = {ts_key: ts.SerializeToString()}
 
@@ -466,6 +479,10 @@ class RedisOnlineStore(OnlineStore):
 
         prev_event_timestamps = [i[0] for i in prev_event_timestamps]
 
+        # See online_write_batch: guards against rows in this batch that share an
+        # entity key overwriting each other out of event-time order.
+        batch_latest_nanos: Dict[bytes, int] = {}
+
         async with client.pipeline(transaction=False) as pipe:
             for redis_key_bin, prev_event_time, (_, values, timestamp, _) in zip(
                 keys, prev_event_timestamps, data
@@ -475,14 +492,19 @@ class RedisOnlineStore(OnlineStore):
                 ts.FromDatetime(aware_ts)
                 new_total_nanos = ts.seconds * 1_000_000_000 + ts.nanos
 
+                prev_total_nanos = 0
                 if prev_event_time:
                     prev_ts = Timestamp()
                     prev_ts.ParseFromString(prev_event_time)
                     prev_total_nanos = prev_ts.seconds * 1_000_000_000 + prev_ts.nanos
-                    if prev_total_nanos and new_total_nanos <= prev_total_nanos:
-                        if progress:
-                            progress(1)
-                        continue
+                latest_seen_nanos = max(
+                    prev_total_nanos, batch_latest_nanos.get(redis_key_bin, 0)
+                )
+                if latest_seen_nanos and new_total_nanos <= latest_seen_nanos:
+                    if progress:
+                        progress(1)
+                    continue
+                batch_latest_nanos[redis_key_bin] = new_total_nanos
 
                 entity_hset = {ts_key: ts.SerializeToString()}
                 for feature_name, val in values.items():

--- a/sdk/python/tests/unit/infra/online_store/test_redis.py
+++ b/sdk/python/tests/unit/infra/online_store/test_redis.py
@@ -1,11 +1,12 @@
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from feast import Entity, FeatureView, Field, FileSource, RepoConfig
+from feast.infra.online_stores.helpers import _mmh3
 from feast.infra.online_stores.redis import RedisOnlineStore, RedisOnlineStoreConfig
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
@@ -424,6 +425,145 @@ def test_online_write_batch_with_dedup_uses_two_pipelines(
     assert mock_client.pipeline.call_count == 1
     # hmget was issued for the timestamp check
     pipe.hmget.assert_called_once()
+
+
+def _dedup_config():
+    return RepoConfig(
+        provider="local",
+        project="test",
+        entity_key_serialization_version=3,
+        registry="dummy_registry.db",
+        online_store=RedisOnlineStoreConfig(),  # default: skip_dedup=False
+    )
+
+
+def _single_entity_batch(timestamps_and_values):
+    """Build a write batch for one entity key, one row per (timestamp, value) pair."""
+    entity_key = EntityKeyProto(
+        join_keys=["entity"], entity_values=[ValueProto(int32_val=1)]
+    )
+    return [
+        (entity_key, {"feature_10": ValueProto(int32_val=value)}, timestamp, None)
+        for timestamp, value in timestamps_and_values
+    ]
+
+
+def _written_feature_values(hset_calls, feature_view_name, feature_name):
+    """Extract the serialized feature value from each queued hset call."""
+    f_key = _mmh3(f"{feature_view_name}:{feature_name}")
+    return [call.kwargs["mapping"][f_key] for call in hset_calls]
+
+
+@pytest.mark.parametrize(
+    "order",
+    ["descending", "ascending", "unordered"],
+    ids=["descending", "ascending", "unordered"],
+)
+def test_online_write_batch_keeps_latest_event_time_within_batch(
+    redis_online_store: RedisOnlineStore, feature_view, order
+):
+    """A batch containing several rows for one entity key must leave the value
+    belonging to the latest event timestamp in the store, whatever order the rows
+    arrive in.
+
+    Regression test for #5163: previous timestamps were read once up front, so rows
+    sharing an entity key all compared against the same pre-batch snapshot and could
+    not see each other. Every row passed the staleness guard and the last row queued
+    won, so a reverse-chronological batch stored the *oldest* value.
+    """
+    t1 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t2 = t1 + timedelta(seconds=5)
+    t3 = t2 + timedelta(seconds=5)
+
+    rows = {
+        "descending": [(t3, 30), (t2, 20), (t1, 10)],
+        "ascending": [(t1, 10), (t2, 20), (t3, 30)],
+        "unordered": [(t2, 20), (t3, 30), (t1, 10)],
+    }[order]
+    data = _single_entity_batch(rows)
+
+    mock_client = MagicMock()
+    pipe = MagicMock()
+    pipe.__enter__ = MagicMock(return_value=pipe)
+    pipe.__exit__ = MagicMock(return_value=False)
+    # No pre-existing value: one hmget result per row, each holding None.
+    pipe.execute.side_effect = [[[None]] * len(data), []]
+    mock_client.pipeline.return_value = pipe
+
+    with patch.object(redis_online_store, "_get_client", return_value=mock_client):
+        redis_online_store.online_write_batch(
+            _dedup_config(), feature_view, data, progress=None
+        )
+
+    written = _written_feature_values(
+        pipe.hset.call_args_list, feature_view.name, "feature_10"
+    )
+    assert written, "no write was queued for the batch"
+    # Redis applies queued commands in order, so the surviving value is the last one.
+    assert written[-1] == ValueProto(int32_val=30).SerializeToString()
+
+
+def test_online_write_batch_async_keeps_latest_event_time_within_batch(
+    redis_online_store: RedisOnlineStore, feature_view
+):
+    """online_write_batch_async must honour the same intra-batch ordering guarantee
+    as the sync path (#5163)."""
+    t1 = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t2 = t1 + timedelta(seconds=5)
+    t3 = t2 + timedelta(seconds=5)
+    data = _single_entity_batch([(t3, 30), (t2, 20), (t1, 10)])
+
+    async_pipe = AsyncMock()
+    async_pipe.__aenter__ = AsyncMock(return_value=async_pipe)
+    async_pipe.__aexit__ = AsyncMock(return_value=False)
+    async_pipe.execute = AsyncMock(side_effect=[[[None]] * len(data), []])
+    async_pipe.hset = MagicMock()
+
+    mock_async_client = AsyncMock()
+    mock_async_client.pipeline = MagicMock(return_value=async_pipe)
+
+    async def _run():
+        with patch.object(
+            redis_online_store,
+            "_get_client_async",
+            AsyncMock(return_value=mock_async_client),
+        ):
+            await redis_online_store.online_write_batch_async(
+                _dedup_config(), feature_view, data, progress=None
+            )
+
+    asyncio.run(_run())
+
+    written = _written_feature_values(
+        async_pipe.hset.call_args_list, feature_view.name, "feature_10"
+    )
+    assert written, "no write was queued for the batch"
+    assert written[-1] == ValueProto(int32_val=30).SerializeToString()
+
+
+def test_online_write_batch_still_skips_rows_older_than_stored_value(
+    redis_online_store: RedisOnlineStore, feature_view
+):
+    """The pre-existing staleness guard must keep working: a row older than the value
+    already in Redis is dropped rather than written."""
+    stored_ts = Timestamp()
+    stored_ts.FromDatetime(datetime(2024, 1, 1, 12, 0, 10, tzinfo=timezone.utc))
+    older = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    data = _single_entity_batch([(older, 10)])
+
+    mock_client = MagicMock()
+    pipe = MagicMock()
+    pipe.__enter__ = MagicMock(return_value=pipe)
+    pipe.__exit__ = MagicMock(return_value=False)
+    pipe.execute.side_effect = [[[stored_ts.SerializeToString()]], []]
+    mock_client.pipeline.return_value = pipe
+
+    with patch.object(redis_online_store, "_get_client", return_value=mock_client):
+        redis_online_store.online_write_batch(
+            _dedup_config(), feature_view, data, progress=None
+        )
+
+    pipe.hset.assert_not_called()
 
 
 def test_online_write_batch_async_skip_dedup_single_pipeline(


### PR DESCRIPTION
# What this PR does / why we need it:

`online_write_batch` performs its staleness check against a snapshot that is read
*before* any write is queued:

1. **Read phase** — `hmget` the stored event timestamp for every row's entity key, then
   `pipe.execute()` once.
2. **Write phase** — loop the rows, skip any row whose timestamp is `<=` the stored one,
   otherwise queue an `hset`.

Because the read phase completes before the first write is queued, rows in the same batch
that share an entity key all compare against the same pre-batch value. None of them can
see the others. When nothing is stored yet, `prev_event_time` is `None` for all of them,
the guard is skipped entirely, and every row gets an `hset` queued. Redis applies
pipelined commands in order, so the **last row in list order wins** — regardless of its
event time.

Pushing one entity key with timestamps in descending order therefore leaves the *oldest*
value in the store:

```python
test_data = pd.DataFrame({
    "customer_id": [1] * 3,
    "total_purchases": [30, 20, 10],
    "event_timestamp": [t3, t2, t1],   # latest first
})
store.push_features(fg_name, test_data, mode="online")
# get_online_features returns 10, the value belonging to t1
```

No error and no warning — just a silently incorrect feature value.

### The fix

Track the latest event timestamp queued so far **per entity key** within the batch, and
compare each row against whichever is newer: the stored timestamp, or an earlier row of
the same batch.

```python
latest_seen_nanos = max(prev_total_nanos, batch_latest_nanos.get(redis_key_bin, 0))
if latest_seen_nanos and new_total_nanos <= latest_seen_nanos:
    if progress:
        progress(1)
    continue
batch_latest_nanos[redis_key_bin] = new_total_nanos
```

`redis_key_bin` is already computed in the read phase and uniquely identifies
`(project, entity_key)`, so it was free to reuse as the dedup key. The guard had to move
out of the `if prev_event_time:` block, with `prev_total_nanos` initialised to `0` so the
`max()` works when nothing is stored yet — that's the structural part of the diff.

`online_write_batch_async` had the identical defect and gets the same fix; fixing only the
sync path would have left half the bug in place.

The `skip_dedup` fast path is deliberately untouched. Its own comment says it is "suitable
for initial loads or append-only pipelines where out-of-order writes are not a concern," so
losing ordering there is the documented tradeoff of enabling it.

### One design note worth your input

The issue suggests sorting the batch by timestamp, or reducing to one row per key. Either
would work, but both change behaviour for batches that are *already* correct — they alter
how many writes get queued in the ascending case and shift the `progress()` accounting.
I went with the running-max approach because it repairs only the broken case and leaves
every already-working case byte-identical. Happy to switch to sort-or-reduce if you'd
rather have the write-amplification reduction too; it's a small change from here.

Behaviour that is intentionally preserved:

- Rows older than the value already stored are still skipped.
- Ties within a batch keep the first row, matching the existing `<=` "older or same
  instant" semantics.
- A stored timestamp of epoch 0 still doesn't trigger a skip — the original required a
  truthy `prev_total_nanos`, and `max(0, ...)` preserves that.

### Note on the labels

The `wontfix` label on #5163 was applied by `stale[bot]` as its configured `staleLabel`,
not by a maintainer declining the report — the timeline shows the bot's comment as the only
activity on the issue. Flagging it so it doesn't read as a prior decision. `kind/bug` and
`priority/p2` are the defaults from `bug_report.md`. If this is out of scope for other
reasons, I'm glad to hear it.

# Which issue(s) this PR fixes:

Fixes #5163

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc

Five tests added to `sdk/python/tests/unit/infra/online_store/test_redis.py`, reusing the
existing `MagicMock` pipeline idiom, so no Redis server or Docker is needed:

| Test | Before fix | After fix |
|---|---|---|
| `keeps_latest_event_time_within_batch[descending]` | **fails** | passes |
| `keeps_latest_event_time_within_batch[unordered]` | **fails** | passes |
| `keeps_latest_event_time_within_batch[ascending]` | passes | passes |
| `async_keeps_latest_event_time_within_batch` | **fails** | passes |
| `still_skips_rows_older_than_stored_value` | passes | passes |

The two that pass *before* the fix are the load-bearing ones — they're there to show the
change repairs the broken orderings without disturbing the ascending case or the existing
staleness guard.

The pre-fix failure is `assert b'\x18\n' == b'\x18\x1e'`, i.e. `int32_val=10` where 30 was
expected — the reporter's "returns 10 instead of 30", reproduced deterministically.

`test_redis.py` goes 18 → 23 passing. `ruff check`, `ruff format --check` and
`mypy feast/infra/online_stores/redis.py` are all clean.

I ran unit tests only, not the integration suite — it needs cloud credentials I don't have.
Happy to add an integration test if you'd like one for this path.

One small correction to the issue for the record: it describes the code as skipping
"records with timestamps older than what's already been processed in the current batch."
Nothing intra-batch is tracked today, which is exactly why the bug exists — but the symptom
as reported is accurate.
