### PR TITLE
feat: Implemented registry refresh action feature 

### DIFF
--- a/docs/how-to-guides/online-server-performance-tuning.md
+++ b/docs/how-to-guides/online-server-performance-tuning.md
@@ -266,15 +266,6 @@ The `registryTTLSeconds` field on the Operator CR (or `--registry_ttl_sec` CLI f
 | Production (low-latency) | `thread` | 300 |
 | Production (frequent schema changes) | `thread` | 60 |
 
-### UI refresh
-
-The Feast UI caches the project list using the same registry cache. After running `feast apply` to add a new project, it may take up to `cache_ttl_seconds` before the project appears in the UI.
-
-To see new projects faster:
-
-- **Lower the TTL**: Set `cache_ttl_seconds: 10` (or similar) in your `feature_store.yaml` registry config. This makes all registry consumers — including the UI — pick up changes within 10 seconds.
-- **Refresh on demand**: The project selection page has a **Refresh** button that explicitly invalidates the server-side registry cache (`POST /api/registry/refresh`) and reloads the project list without a full page refresh.
-
 ---
 
 ## Online store selection

--- a/docs/how-to-guides/online-server-performance-tuning.md
+++ b/docs/how-to-guides/online-server-performance-tuning.md
@@ -266,6 +266,15 @@ The `registryTTLSeconds` field on the Operator CR (or `--registry_ttl_sec` CLI f
 | Production (low-latency) | `thread` | 300 |
 | Production (frequent schema changes) | `thread` | 60 |
 
+### UI refresh
+
+The Feast UI caches the project list using the same registry cache. After running `feast apply` to add a new project, it may take up to `cache_ttl_seconds` before the project appears in the UI.
+
+To see new projects faster:
+
+- **Lower the TTL**: Set `cache_ttl_seconds: 10` (or similar) in your `feature_store.yaml` registry config. This makes all registry consumers — including the UI — pick up changes within 10 seconds.
+- **Refresh on demand**: The project selection page has a **Refresh** button that explicitly invalidates the server-side registry cache (`POST /api/registry/refresh`) and reloads the project list without a full page refresh.
+
 ---
 
 ## Online store selection

--- a/docs/reference/alpha-web-ui.md
+++ b/docs/reference/alpha-web-ui.md
@@ -153,3 +153,12 @@ const tabsRegistry = {
 ```
 
 Examples of custom tabs can be found in the `ui/custom-tabs` folder.
+
+## Refreshing the project list
+
+The Feast UI caches the project list using the same registry cache. After running `feast apply` to add a new project, it may take up to `cache_ttl_seconds` before the project appears in the UI.
+
+To see new projects faster:
+
+- **Lower the TTL**: Set `cache_ttl_seconds: 10` (or similar) in your `feature_store.yaml` registry config. This makes all registry consumers — including the UI — pick up changes within 10 seconds.
+- **Refresh on demand**: The project selection page has a **Refresh** button that explicitly invalidates the server-side registry cache (`POST /api/v1/registry/refresh`) and reloads the project list without a full page refresh.

--- a/docs/reference/alpha-web-ui.md
+++ b/docs/reference/alpha-web-ui.md
@@ -154,11 +154,11 @@ const tabsRegistry = {
 
 Examples of custom tabs can be found in the `ui/custom-tabs` folder.
 
-## Refreshing the project list
+## Refreshing the registry
 
-The Feast UI caches the project list using the same registry cache. After running `feast apply` to add a new project, it may take up to `cache_ttl_seconds` before the project appears in the UI.
+The Feast UI caches registry data (projects, feature views, entities, etc.) using the registry cache. After running `feast apply` to make changes, it may take up to `cache_ttl_seconds` before the updates appear in the UI.
 
-To see new projects faster:
+To see changes faster:
 
 - **Lower the TTL**: Set `cache_ttl_seconds: 10` (or similar) in your `feature_store.yaml` registry config. This makes all registry consumers — including the UI — pick up changes within 10 seconds.
-- **Refresh on demand**: The project selection page has a **Refresh** button that explicitly invalidates the server-side registry cache (`POST /api/v1/registry/refresh`) and reloads the project list without a full page refresh.
+- **Refresh on demand**: The UI has a **Refresh** button that explicitly invalidates the server-side registry cache (`POST /api/v1/registry/refresh`) and reloads the UI without a full page refresh.

--- a/sdk/python/feast/api/registry/rest/__init__.py
+++ b/sdk/python/feast/api/registry/rest/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response, status
 
 from feast.api.registry.rest.compute_engines import get_compute_engine_router
 from feast.api.registry.rest.data_sources import get_data_source_router
@@ -43,6 +43,21 @@ def register_all_routes(app: FastAPI, grpc_handler, server=None, store=None):
     app.include_router(get_saved_dataset_router(grpc_handler))
     app.include_router(get_monitoring_router(grpc_handler, store=resolved_store))
     app.include_router(get_compute_engine_router(grpc_handler, store=resolved_store))
+
+    if resolved_store:
+
+        @app.post("/registry/refresh")
+        def refresh_registry():
+            try:
+                resolved_store.refresh_registry()
+                return Response(status_code=status.HTTP_200_OK)
+            except Exception:
+                logger.exception("Registry refresh failed")
+                return Response(
+                    content='{"detail":"Registry refresh failed. Check server logs for details."}',
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    media_type="application/json",
+                )
 
     _register_openlineage_consumer(app, resolved_store)
 

--- a/sdk/python/feast/api/registry/rest/__init__.py
+++ b/sdk/python/feast/api/registry/rest/__init__.py
@@ -49,6 +49,14 @@ def register_all_routes(app: FastAPI, grpc_handler, server=None, store=None):
         @app.post("/registry/refresh")
         def refresh_registry():
             try:
+                from feast.permissions.action import AuthzedAction
+                from feast.permissions.security_manager import assert_permissions
+
+                project = resolved_store.registry.get_project(
+                    name=resolved_store.project, allow_cache=True
+                )
+                assert_permissions(resource=project, actions=[AuthzedAction.UPDATE])
+
                 resolved_store.refresh_registry()
                 return Response(status_code=status.HTTP_200_OK)
             except Exception:

--- a/sdk/python/feast/api/registry/rest/__init__.py
+++ b/sdk/python/feast/api/registry/rest/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional
 
-from fastapi import FastAPI, Response, status
+from fastapi import FastAPI
 
 from feast.api.registry.rest.compute_engines import get_compute_engine_router
 from feast.api.registry.rest.data_sources import get_data_source_router
@@ -14,7 +14,7 @@ from feast.api.registry.rest.lineage import get_lineage_router
 from feast.api.registry.rest.metrics import get_metrics_router
 from feast.api.registry.rest.monitoring import get_monitoring_router
 from feast.api.registry.rest.permissions import get_permission_router
-from feast.api.registry.rest.projects import get_project_router
+from feast.api.registry.rest.projects import get_project_router, get_registry_router
 from feast.api.registry.rest.saved_datasets import get_saved_dataset_router
 from feast.api.registry.rest.search import get_search_router
 
@@ -45,27 +45,7 @@ def register_all_routes(app: FastAPI, grpc_handler, server=None, store=None):
     app.include_router(get_compute_engine_router(grpc_handler, store=resolved_store))
 
     if resolved_store:
-
-        @app.post("/registry/refresh")
-        def refresh_registry():
-            try:
-                from feast.permissions.action import AuthzedAction
-                from feast.permissions.security_manager import assert_permissions
-
-                project = resolved_store.registry.get_project(
-                    name=resolved_store.project, allow_cache=True
-                )
-                assert_permissions(resource=project, actions=[AuthzedAction.UPDATE])
-
-                resolved_store.refresh_registry()
-                return Response(status_code=status.HTTP_200_OK)
-            except Exception:
-                logger.exception("Registry refresh failed")
-                return Response(
-                    content='{"detail":"Registry refresh failed. Check server logs for details."}',
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    media_type="application/json",
-                )
+        app.include_router(get_registry_router(resolved_store))
 
     _register_openlineage_consumer(app, resolved_store)
 

--- a/sdk/python/feast/api/registry/rest/projects.py
+++ b/sdk/python/feast/api/registry/rest/projects.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Response, status
 
 from feast.api.registry.rest.rest_utils import (
     get_pagination_params,
@@ -48,5 +48,21 @@ def get_project_router(grpc_handler) -> APIRouter:
             "projects": projects,
             "pagination": pagination,
         }
+
+    return router
+
+
+def get_registry_router(store) -> APIRouter:
+    router = APIRouter()
+
+    @router.post("/registry/refresh")
+    def refresh_registry():
+        from feast.permissions.action import AuthzedAction
+        from feast.permissions.security_manager import assert_permissions
+
+        project = store.registry.get_project(name=store.project, allow_cache=True)
+        assert_permissions(resource=project, actions=[AuthzedAction.UPDATE])
+        store.refresh_registry()
+        return Response(status_code=status.HTTP_200_OK)
 
     return router

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -158,11 +158,6 @@ def _setup_rest_mode(app: FastAPI, store: "feast.FeatureStore"):
 
     register_all_routes(rest_app, grpc_handler, store=store)
 
-    @rest_app.post("/registry/refresh")
-    def refresh_registry():
-        store.refresh_registry()
-        return Response(status_code=status.HTTP_200_OK)
-
     class PushRequest(BaseModel):
         push_source_name: str
         df: Dict[str, List]

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -889,308 +889,310 @@ def get_app(
 
     ui_dir_ref = importlib_resources.files(__spec__.parent) / "ui/build/"  # type: ignore[name-defined, arg-type]
     with importlib_resources.as_file(ui_dir_ref) as ui_dir:
-        projects_dict = _build_projects_list(store, project_id, root_path)
-        with ui_dir.joinpath("projects-list.json").open(mode="w") as f:
-            f.write(json.dumps(projects_dict))
 
-    @app.get("/projects-list.json")
-    def get_projects_list():
-        return _build_projects_list(store, project_id, root_path)
+        @app.get("/projects-list.json")
+        def get_projects_list():
+            return _build_projects_list(store, project_id, root_path)
 
-    @app.get("/api/mlflow-runs")
-    def get_mlflow_runs(max_results: int = 50):
-        """Return MLflow runs linked to this Feast project via auto-logging."""
-        mlflow_cfg = getattr(store.config, "mlflow", None)
-        if not mlflow_cfg or not mlflow_cfg.enabled:
-            return {"runs": [], "mlflow_uri": None}
+        @app.get("/api/mlflow-runs")
+        def get_mlflow_runs(max_results: int = 50):
+            """Return MLflow runs linked to this Feast project via auto-logging."""
+            mlflow_cfg = getattr(store.config, "mlflow", None)
+            if not mlflow_cfg or not mlflow_cfg.enabled:
+                return {"runs": [], "mlflow_uri": None}
 
-        try:
-            import mlflow
-
-            tracking_uri = mlflow_cfg.get_tracking_uri()
-            mlflow_ui_base = tracking_uri or mlflow.get_tracking_uri() or ""
-            client = mlflow.MlflowClient(tracking_uri=tracking_uri)
-
-            project_name = store.config.project
-            experiment = client.get_experiment_by_name(project_name)
-            if experiment is None:
-                return {"runs": [], "mlflow_uri": mlflow_ui_base or None}
-            experiment_ids = [experiment.experiment_id]
-
-            safe_project = project_name.replace("\\", "\\\\").replace("'", "\\'")
-            filter_str = (
-                f"tags.`feast.project` = '{safe_project}' "
-                f"AND tags.`feast.retrieval_type` != ''"
-            )
-
-            max_results = min(max(max_results, 1), 200)
-            runs = client.search_runs(
-                experiment_ids=experiment_ids,
-                filter_string=filter_str,
-                max_results=max_results,
-                order_by=["start_time DESC"],
-            )
-
-            run_id_to_models: Dict[str, List[dict]] = {}
             try:
-                for rm in client.search_registered_models():
-                    for mv in rm.latest_versions or []:
-                        if mv.run_id:
-                            run_id_to_models.setdefault(mv.run_id, []).append(
-                                {
-                                    "model_name": rm.name,
-                                    "version": mv.version,
-                                    "stage": mv.current_stage,
-                                    "mlflow_url": (
-                                        f"{mlflow_ui_base}/#/models/"
-                                        f"{rm.name}/versions/{mv.version}"
-                                    ),
-                                }
-                            )
+                import mlflow
+
+                tracking_uri = mlflow_cfg.get_tracking_uri()
+                mlflow_ui_base = tracking_uri or mlflow.get_tracking_uri() or ""
+                client = mlflow.MlflowClient(tracking_uri=tracking_uri)
+
+                project_name = store.config.project
+                experiment = client.get_experiment_by_name(project_name)
+                if experiment is None:
+                    return {"runs": [], "mlflow_uri": mlflow_ui_base or None}
+                experiment_ids = [experiment.experiment_id]
+
+                safe_project = project_name.replace("\\", "\\\\").replace("'", "\\'")
+                filter_str = (
+                    f"tags.`feast.project` = '{safe_project}' "
+                    f"AND tags.`feast.retrieval_type` != ''"
+                )
+
+                max_results = min(max(max_results, 1), 200)
+                runs = client.search_runs(
+                    experiment_ids=experiment_ids,
+                    filter_string=filter_str,
+                    max_results=max_results,
+                    order_by=["start_time DESC"],
+                )
+
+                run_id_to_models: Dict[str, List[dict]] = {}
+                try:
+                    for rm in client.search_registered_models():
+                        for mv in rm.latest_versions or []:
+                            if mv.run_id:
+                                run_id_to_models.setdefault(mv.run_id, []).append(
+                                    {
+                                        "model_name": rm.name,
+                                        "version": mv.version,
+                                        "stage": mv.current_stage,
+                                        "mlflow_url": (
+                                            f"{mlflow_ui_base}/#/models/"
+                                            f"{rm.name}/versions/{mv.version}"
+                                        ),
+                                    }
+                                )
+                except Exception:
+                    pass
+
+                result = []
+                for run in runs:
+                    run_tags = run.data.tags
+                    run_params = run.data.params
+                    fv_raw = run_tags.get("feast.feature_views", "")
+                    refs_raw = run_tags.get(
+                        "feast.feature_refs",
+                        run_params.get("feast.feature_refs", ""),
+                    )
+                    result.append(
+                        {
+                            "run_id": run.info.run_id,
+                            "run_name": run.info.run_name,
+                            "status": run.info.status,
+                            "start_time": run.info.start_time,
+                            "feature_service": run_tags.get("feast.feature_service"),
+                            "feature_views": [v for v in fv_raw.split(",") if v],
+                            "feature_refs": [v for v in refs_raw.split(",") if v],
+                            "retrieval_type": run_tags.get("feast.retrieval_type"),
+                            "entity_count": run_tags.get(
+                                "feast.entity_count",
+                                run_params.get("feast.entity_count"),
+                            ),
+                            "mlflow_url": (
+                                f"{mlflow_ui_base}/#/experiments/"
+                                f"{run.info.experiment_id}/runs/{run.info.run_id}"
+                            ),
+                            "registered_models": run_id_to_models.get(
+                                run.info.run_id, []
+                            ),
+                        }
+                    )
+
+                return {"runs": result, "mlflow_uri": mlflow_ui_base or None}
+            except ImportError:
+                return {
+                    "runs": [],
+                    "mlflow_uri": None,
+                    "error": "mlflow is not installed",
+                }
             except Exception:
-                pass
+                return {
+                    "runs": [],
+                    "mlflow_uri": None,
+                    "error": "Failed to fetch MLflow runs",
+                }
 
-            result = []
-            for run in runs:
-                run_tags = run.data.tags
-                run_params = run.data.params
-                fv_raw = run_tags.get("feast.feature_views", "")
-                refs_raw = run_tags.get(
-                    "feast.feature_refs",
-                    run_params.get("feast.feature_refs", ""),
+        _feature_usage_cache: Dict = {"data": None, "timestamp": 0.0}
+        _FEATURE_USAGE_TTL_SECONDS = 300
+
+        @app.get("/api/mlflow-feature-usage")
+        def get_mlflow_feature_usage():
+            """Return per-feature-view usage stats aggregated from MLflow runs.
+
+            Caches results for 5 minutes to avoid hammering the MLflow server.
+            """
+            import time as _time
+
+            mlflow_cfg = getattr(store.config, "mlflow", None)
+            if not mlflow_cfg or not mlflow_cfg.enabled:
+                return {"feature_usage": {}, "mlflow_enabled": False}
+
+            now = _time.monotonic()
+            if (
+                _feature_usage_cache["data"] is not None
+                and (now - _feature_usage_cache["timestamp"])
+                < _FEATURE_USAGE_TTL_SECONDS
+            ):
+                return _feature_usage_cache["data"]
+
+            try:
+                import mlflow
+
+                tracking_uri = mlflow_cfg.get_tracking_uri()
+                client = mlflow.MlflowClient(tracking_uri=tracking_uri)
+                project_name = store.config.project
+
+                experiment = client.get_experiment_by_name(project_name)
+                if experiment is None:
+                    result = {"feature_usage": {}, "mlflow_enabled": True}
+                    _feature_usage_cache["data"] = result
+                    _feature_usage_cache["timestamp"] = now
+                    return result
+
+                safe_project = project_name.replace("\\", "\\\\").replace("'", "\\'")
+                filter_str = (
+                    f"tags.`feast.project` = '{safe_project}' "
+                    f"AND tags.`feast.retrieval_type` != ''"
                 )
-                result.append(
-                    {
-                        "run_id": run.info.run_id,
-                        "run_name": run.info.run_name,
-                        "status": run.info.status,
-                        "start_time": run.info.start_time,
-                        "feature_service": run_tags.get("feast.feature_service"),
-                        "feature_views": [v for v in fv_raw.split(",") if v],
-                        "feature_refs": [v for v in refs_raw.split(",") if v],
-                        "retrieval_type": run_tags.get("feast.retrieval_type"),
-                        "entity_count": run_tags.get(
-                            "feast.entity_count",
-                            run_params.get("feast.entity_count"),
-                        ),
-                        "mlflow_url": (
-                            f"{mlflow_ui_base}/#/experiments/"
-                            f"{run.info.experiment_id}/runs/{run.info.run_id}"
-                        ),
-                        "registered_models": run_id_to_models.get(run.info.run_id, []),
-                    }
+                runs = client.search_runs(
+                    experiment_ids=[experiment.experiment_id],
+                    filter_string=filter_str,
+                    max_results=200,
+                    order_by=["start_time DESC"],
                 )
 
-            return {"runs": result, "mlflow_uri": mlflow_ui_base or None}
-        except ImportError:
-            return {
-                "runs": [],
-                "mlflow_uri": None,
-                "error": "mlflow is not installed",
-            }
-        except Exception:
-            return {
-                "runs": [],
-                "mlflow_uri": None,
-                "error": "Failed to fetch MLflow runs",
-            }
+                run_id_to_models: Dict[str, List[str]] = {}
+                try:
+                    for rm in client.search_registered_models():
+                        for mv in rm.latest_versions or []:
+                            if mv.run_id:
+                                run_id_to_models.setdefault(mv.run_id, []).append(
+                                    rm.name
+                                )
+                except Exception:
+                    pass
 
-    _feature_usage_cache: Dict = {"data": None, "timestamp": 0.0}
-    _FEATURE_USAGE_TTL_SECONDS = 300
+                usage: Dict[str, dict] = {}
+                for run in runs:
+                    refs_raw = run.data.tags.get("feast.feature_refs", "")
+                    fv_names = set()
+                    for ref in refs_raw.split(","):
+                        ref = ref.strip()
+                        if ":" in ref:
+                            fv_names.add(ref.split(":")[0])
 
-    @app.get("/api/mlflow-feature-usage")
-    def get_mlflow_feature_usage():
-        """Return per-feature-view usage stats aggregated from MLflow runs.
+                    run_models = run_id_to_models.get(run.info.run_id, [])
 
-        Caches results for 5 minutes to avoid hammering the MLflow server.
-        """
-        import time as _time
+                    for fv_name in fv_names:
+                        if fv_name not in usage:
+                            usage[fv_name] = {
+                                "run_count": 0,
+                                "last_used": None,
+                                "models": [],
+                            }
+                        usage[fv_name]["run_count"] += 1
+                        run_ts = run.info.start_time
+                        if usage[fv_name]["last_used"] is None or (
+                            run_ts and run_ts > usage[fv_name]["last_used"]
+                        ):
+                            usage[fv_name]["last_used"] = run_ts
+                        for m in run_models:
+                            if m not in usage[fv_name]["models"]:
+                                usage[fv_name]["models"].append(m)
 
-        mlflow_cfg = getattr(store.config, "mlflow", None)
-        if not mlflow_cfg or not mlflow_cfg.enabled:
-            return {"feature_usage": {}, "mlflow_enabled": False}
-
-        now = _time.monotonic()
-        if (
-            _feature_usage_cache["data"] is not None
-            and (now - _feature_usage_cache["timestamp"]) < _FEATURE_USAGE_TTL_SECONDS
-        ):
-            return _feature_usage_cache["data"]
-
-        try:
-            import mlflow
-
-            tracking_uri = mlflow_cfg.get_tracking_uri()
-            client = mlflow.MlflowClient(tracking_uri=tracking_uri)
-            project_name = store.config.project
-
-            experiment = client.get_experiment_by_name(project_name)
-            if experiment is None:
-                result = {"feature_usage": {}, "mlflow_enabled": True}
+                result = {"feature_usage": usage, "mlflow_enabled": True}
                 _feature_usage_cache["data"] = result
                 _feature_usage_cache["timestamp"] = now
                 return result
+            except ImportError:
+                return {
+                    "feature_usage": {},
+                    "mlflow_enabled": False,
+                    "error": "mlflow is not installed",
+                }
+            except Exception as e:
+                logger.debug("Failed to fetch feature usage: %s", e)
+                return {
+                    "feature_usage": {},
+                    "mlflow_enabled": True,
+                    "error": "Failed to fetch usage data",
+                }
 
-            safe_project = project_name.replace("\\", "\\\\").replace("'", "\\'")
-            filter_str = (
-                f"tags.`feast.project` = '{safe_project}' "
-                f"AND tags.`feast.retrieval_type` != ''"
-            )
-            runs = client.search_runs(
-                experiment_ids=[experiment.experiment_id],
-                filter_string=filter_str,
-                max_results=200,
-                order_by=["start_time DESC"],
-            )
+        @app.get("/api/mlflow-feature-models")
+        def get_mlflow_feature_models():
+            """Return a mapping of feature_ref -> registered models that use it.
 
-            run_id_to_models: Dict[str, List[str]] = {}
+            Walks the MLflow Model Registry, inspects the training run for each
+            model's latest version(s), reads the ``feast.feature_refs`` tag, and
+            inverts it into a reverse index so the UI can show which registered
+            models depend on a given feature.
+            """
+            mlflow_cfg = getattr(store.config, "mlflow", None)
+            if not mlflow_cfg or not mlflow_cfg.enabled:
+                return {"feature_models": {}}
+
             try:
+                import mlflow
+
+                tracking_uri = mlflow_cfg.get_tracking_uri()
+                mlflow_ui_base = tracking_uri or mlflow.get_tracking_uri() or ""
+                client = mlflow.MlflowClient(tracking_uri=tracking_uri)
+                project_name = store.config.project
+
+                feature_models: Dict[str, List[dict]] = {}
+
                 for rm in client.search_registered_models():
-                    for mv in rm.latest_versions or []:
-                        if mv.run_id:
-                            run_id_to_models.setdefault(mv.run_id, []).append(rm.name)
-            except Exception:
-                pass
+                    model_name = rm.name
+                    latest_versions = rm.latest_versions or []
+                    for mv in latest_versions:
+                        if not mv.run_id:
+                            continue
+                        try:
+                            run = client.get_run(mv.run_id)
+                        except Exception:
+                            continue
 
-            usage: Dict[str, dict] = {}
-            for run in runs:
-                refs_raw = run.data.tags.get("feast.feature_refs", "")
-                fv_names = set()
-                for ref in refs_raw.split(","):
-                    ref = ref.strip()
-                    if ":" in ref:
-                        fv_names.add(ref.split(":")[0])
+                        tags = run.data.tags
+                        if tags.get("feast.project") != project_name:
+                            continue
 
-                run_models = run_id_to_models.get(run.info.run_id, [])
+                        refs_raw = tags.get("feast.feature_refs", "")
+                        feature_refs = [r for r in refs_raw.split(",") if r]
 
-                for fv_name in fv_names:
-                    if fv_name not in usage:
-                        usage[fv_name] = {
-                            "run_count": 0,
-                            "last_used": None,
-                            "models": [],
+                        model_info = {
+                            "model_name": model_name,
+                            "version": mv.version,
+                            "stage": mv.current_stage,
+                            "mlflow_url": (
+                                f"{mlflow_ui_base}/#/models/"
+                                f"{model_name}/versions/{mv.version}"
+                            ),
                         }
-                    usage[fv_name]["run_count"] += 1
-                    run_ts = run.info.start_time
-                    if usage[fv_name]["last_used"] is None or (
-                        run_ts and run_ts > usage[fv_name]["last_used"]
-                    ):
-                        usage[fv_name]["last_used"] = run_ts
-                    for m in run_models:
-                        if m not in usage[fv_name]["models"]:
-                            usage[fv_name]["models"].append(m)
 
-            result = {"feature_usage": usage, "mlflow_enabled": True}
-            _feature_usage_cache["data"] = result
-            _feature_usage_cache["timestamp"] = now
-            return result
-        except ImportError:
-            return {
-                "feature_usage": {},
-                "mlflow_enabled": False,
-                "error": "mlflow is not installed",
-            }
-        except Exception as e:
-            logger.debug("Failed to fetch feature usage: %s", e)
-            return {
-                "feature_usage": {},
-                "mlflow_enabled": True,
-                "error": "Failed to fetch usage data",
-            }
+                        for ref in feature_refs:
+                            feature_models.setdefault(ref, []).append(model_info)
 
-    @app.get("/api/mlflow-feature-models")
-    def get_mlflow_feature_models():
-        """Return a mapping of feature_ref -> registered models that use it.
+                return {"feature_models": feature_models}
+            except ImportError:
+                return {
+                    "feature_models": {},
+                    "error": "mlflow is not installed",
+                }
+            except Exception as e:
+                logger.debug("Failed to fetch MLflow feature-model mapping: %s", e)
+                return {
+                    "feature_models": {},
+                    "error": "Failed to fetch model data",
+                }
 
-        Walks the MLflow Model Registry, inspects the training run for each
-        model's latest version(s), reads the ``feast.feature_refs`` tag, and
-        inverts it into a reverse index so the UI can show which registered
-        models depend on a given feature.
-        """
-        mlflow_cfg = getattr(store.config, "mlflow", None)
-        if not mlflow_cfg or not mlflow_cfg.enabled:
-            return {"feature_models": {}}
+        auth_config_json = _build_auth_config_json(store)
 
-        try:
-            import mlflow
+        def _serve_index():
+            filename = ui_dir.joinpath("index.html")
+            with open(filename) as f:
+                content = f.read()
+            if auth_config_json:
+                tag = f'<script id="feast-auth-config" type="application/json">{auth_config_json}</script>'
+                content = content.replace("</head>", f"{tag}\n</head>", 1)
+            return Response(content, media_type="text/html")
 
-            tracking_uri = mlflow_cfg.get_tracking_uri()
-            mlflow_ui_base = tracking_uri or mlflow.get_tracking_uri() or ""
-            client = mlflow.MlflowClient(tracking_uri=tracking_uri)
-            project_name = store.config.project
+        @app.get("/")
+        def serve_root():
+            return _serve_index()
 
-            feature_models: Dict[str, List[dict]] = {}
+        @app.api_route("/p/{path_name:path}", methods=["GET"])
+        def catch_all():
+            return _serve_index()
 
-            for rm in client.search_registered_models():
-                model_name = rm.name
-                latest_versions = rm.latest_versions or []
-                for mv in latest_versions:
-                    if not mv.run_id:
-                        continue
-                    try:
-                        run = client.get_run(mv.run_id)
-                    except Exception:
-                        continue
+        app.mount(
+            "/",
+            StaticFiles(directory=ui_dir, html=True),
+            name="site",
+        )
 
-                    tags = run.data.tags
-                    if tags.get("feast.project") != project_name:
-                        continue
-
-                    refs_raw = tags.get("feast.feature_refs", "")
-                    feature_refs = [r for r in refs_raw.split(",") if r]
-
-                    model_info = {
-                        "model_name": model_name,
-                        "version": mv.version,
-                        "stage": mv.current_stage,
-                        "mlflow_url": (
-                            f"{mlflow_ui_base}/#/models/"
-                            f"{model_name}/versions/{mv.version}"
-                        ),
-                    }
-
-                    for ref in feature_refs:
-                        feature_models.setdefault(ref, []).append(model_info)
-
-            return {"feature_models": feature_models}
-        except ImportError:
-            return {
-                "feature_models": {},
-                "error": "mlflow is not installed",
-            }
-        except Exception as e:
-            logger.debug("Failed to fetch MLflow feature-model mapping: %s", e)
-            return {
-                "feature_models": {},
-                "error": "Failed to fetch model data",
-            }
-
-    auth_config_json = _build_auth_config_json(store)
-
-    def _serve_index():
-        filename = ui_dir.joinpath("index.html")
-        with open(filename) as f:
-            content = f.read()
-        if auth_config_json:
-            tag = f'<script id="feast-auth-config" type="application/json">{auth_config_json}</script>'
-            content = content.replace("</head>", f"{tag}\n</head>", 1)
-        return Response(content, media_type="text/html")
-
-    @app.get("/")
-    def serve_root():
-        return _serve_index()
-
-    @app.api_route("/p/{path_name:path}", methods=["GET"])
-    def catch_all():
-        return _serve_index()
-
-    app.mount(
-        "/",
-        StaticFiles(directory=ui_dir, html=True),
-        name="site",
-    )
-
-    return app
+        return app
 
 
 def start_server(

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -62,7 +62,7 @@ def _build_projects_list(
     registry_path_template = f"{root_path}/api/v1"
 
     try:
-        projects = store.registry.list_projects(allow_cache=True)
+        projects = store.registry.list_projects(allow_cache=False)
         for proj in projects:
             discovered_projects.append(
                 {

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -158,6 +158,11 @@ def _setup_rest_mode(app: FastAPI, store: "feast.FeatureStore"):
 
     register_all_routes(rest_app, grpc_handler, store=store)
 
+    @rest_app.post("/registry/refresh")
+    def refresh_registry():
+        store.refresh_registry()
+        return Response(status_code=status.HTTP_200_OK)
+
     class PushRequest(BaseModel):
         push_source_name: str
         df: Dict[str, List]
@@ -889,16 +894,13 @@ def get_app(
 
     ui_dir_ref = importlib_resources.files(__spec__.parent) / "ui/build/"  # type: ignore[name-defined, arg-type]
     with importlib_resources.as_file(ui_dir_ref) as ui_dir:
-        pass
+        projects_dict = _build_projects_list(store, project_id, root_path)
+        with ui_dir.joinpath("projects-list.json").open(mode="w") as f:
+            f.write(json.dumps(projects_dict))
 
     @app.get("/projects-list.json")
     def get_projects_list():
         return _build_projects_list(store, project_id, root_path)
-
-    @app.post("/api/registry/refresh")
-    def refresh_registry():
-        store.refresh_registry()
-        return Response(status_code=status.HTTP_200_OK)
 
     @app.get("/api/mlflow-runs")
     def get_mlflow_runs(max_results: int = 50):

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -62,7 +62,7 @@ def _build_projects_list(
     registry_path_template = f"{root_path}/api/v1"
 
     try:
-        projects = store.registry.list_projects(allow_cache=False)
+        projects = store.registry.list_projects(allow_cache=True)
         for proj in projects:
             discovered_projects.append(
                 {
@@ -894,6 +894,11 @@ def get_app(
     @app.get("/projects-list.json")
     def get_projects_list():
         return _build_projects_list(store, project_id, root_path)
+
+    @app.post("/api/registry/refresh")
+    def refresh_registry():
+        store.refresh_registry()
+        return Response(status_code=status.HTTP_200_OK)
 
     @app.get("/api/mlflow-runs")
     def get_mlflow_runs(max_results: int = 50):

--- a/sdk/python/feast/ui_server.py
+++ b/sdk/python/feast/ui_server.py
@@ -889,9 +889,11 @@ def get_app(
 
     ui_dir_ref = importlib_resources.files(__spec__.parent) / "ui/build/"  # type: ignore[name-defined, arg-type]
     with importlib_resources.as_file(ui_dir_ref) as ui_dir:
-        projects_dict = _build_projects_list(store, project_id, root_path)
-        with ui_dir.joinpath("projects-list.json").open(mode="w") as f:
-            f.write(json.dumps(projects_dict))
+        pass
+
+    @app.get("/projects-list.json")
+    def get_projects_list():
+        return _build_projects_list(store, project_id, root_path)
 
     @app.get("/api/mlflow-runs")
     def get_mlflow_runs(max_results: int = 50):

--- a/sdk/python/tests/unit/api/test_api_rest_registry.py
+++ b/sdk/python/tests/unit/api/test_api_rest_registry.py
@@ -2323,9 +2323,8 @@ def test_registry_refresh_via_rest_error():
     register_all_routes(app, grpc_handler, store=store)
 
     with patch.object(store, "refresh_registry", side_effect=Exception("db error")):
-        client = TestClient(app)
+        client = TestClient(app, raise_server_exceptions=False)
         response = client.post("/registry/refresh")
         assert response.status_code == 500
-        assert "Registry refresh failed" in response.json()["detail"]
 
     tmp_dir.cleanup()

--- a/sdk/python/tests/unit/api/test_api_rest_registry.py
+++ b/sdk/python/tests/unit/api/test_api_rest_registry.py
@@ -2286,3 +2286,46 @@ def test_metrics_resource_counts_nonexistent_project(fastapi_test_app):
     assert data["featureServices"] == []
     assert data["featureViews"] == []
     assert "registryLastUpdated" in data
+
+
+def test_registry_refresh_via_rest(fastapi_test_app):
+    """POST /registry/refresh invalidates the registry cache and returns 200."""
+    response = fastapi_test_app.post("/registry/refresh")
+    assert response.status_code == 200
+
+
+def test_registry_refresh_via_rest_error():
+    """POST /registry/refresh returns 500 when refresh fails."""
+    from unittest.mock import patch
+
+    from feast.api.registry.rest import register_all_routes
+    from feast.registry_server import RegistryServer
+
+    tmp_dir = tempfile.TemporaryDirectory()
+    registry_path = os.path.join(tmp_dir.name, "registry.db")
+
+    config = {
+        "registry": registry_path,
+        "project": "demo_project",
+        "provider": "local",
+        "offline_store": {"type": "file"},
+        "online_store": {"type": "sqlite", "path": ":memory:"},
+    }
+    from fastapi import FastAPI
+
+    from feast.repo_config import RepoConfig
+
+    store = FeatureStore(config=RepoConfig.model_validate(config))
+    store.apply([])
+
+    app = FastAPI()
+    grpc_handler = RegistryServer(store.registry, store=store)
+    register_all_routes(app, grpc_handler, store=store)
+
+    with patch.object(store, "refresh_registry", side_effect=Exception("db error")):
+        client = TestClient(app)
+        response = client.post("/registry/refresh")
+        assert response.status_code == 500
+        assert "Registry refresh failed" in response.json()["detail"]
+
+    tmp_dir.cleanup()

--- a/sdk/python/tests/unit/api/test_api_rest_registry_server.py
+++ b/sdk/python/tests/unit/api/test_api_rest_registry_server.py
@@ -75,4 +75,4 @@ def test_routes_registered_in_app():
     server = MagicMock()
     register_all_routes(app, grpc_handler, server)
 
-    assert app.include_router.call_count == 14
+    assert app.include_router.call_count == 15

--- a/sdk/python/tests/unit/test_ui_server.py
+++ b/sdk/python/tests/unit/test_ui_server.py
@@ -148,11 +148,12 @@ def test_catch_all_route(ui_app_with_registry):
 # ---------- projects-list.json tests ----------
 
 
-def _read_projects_list(temp_dir):
-    """Read the projects-list.json written by get_app via the mock (ui_dir = temp_dir)."""
-    projects_file = os.path.join(temp_dir, "projects-list.json")
-    with open(projects_file) as f:
-        return json.load(f)
+def _get_projects_list(app):
+    """Fetch the dynamic projects-list.json endpoint."""
+    client = TestClient(app)
+    resp = client.get("/projects-list.json")
+    assertpy.assert_that(resp.status_code).is_equal_to(EXPECTED_SUCCESS_STATUS)
+    return resp.json()
 
 
 def test_projects_list_registry_path(mock_feature_store):
@@ -165,9 +166,9 @@ def test_projects_list_registry_path(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            get_app(mock_feature_store, TEST_PROJECT_NAME)
+            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _read_projects_list(temp_dir)
+        data = _get_projects_list(app)
         assertpy.assert_that(data["projects"][0]["registryPath"]).is_equal_to("/api/v1")
 
 
@@ -181,13 +182,13 @@ def test_projects_list_with_root_path(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            get_app(
+            app = get_app(
                 mock_feature_store,
                 TEST_PROJECT_NAME,
                 root_path="/feast",
             )
 
-        data = _read_projects_list(temp_dir)
+        data = _get_projects_list(app)
         assertpy.assert_that(data["projects"][0]["registryPath"]).is_equal_to(
             "/feast/api/v1"
         )
@@ -206,9 +207,9 @@ def test_projects_list_multiple_projects(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            get_app(mock_feature_store, TEST_PROJECT_NAME)
+            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _read_projects_list(temp_dir)
+        data = _get_projects_list(app)
         assertpy.assert_that(len(data["projects"])).is_equal_to(3)
         assertpy.assert_that(data["projects"][0]["id"]).is_equal_to("all")
         assertpy.assert_that(data["projects"][1]["id"]).is_equal_to("project_alpha")
@@ -225,9 +226,9 @@ def test_projects_list_fallback_on_empty(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            get_app(mock_feature_store, TEST_PROJECT_NAME)
+            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _read_projects_list(temp_dir)
+        data = _get_projects_list(app)
         assertpy.assert_that(len(data["projects"])).is_equal_to(1)
         assertpy.assert_that(data["projects"][0]["id"]).is_equal_to(TEST_PROJECT_NAME)
 
@@ -242,8 +243,40 @@ def test_projects_list_fallback_on_exception(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            get_app(mock_feature_store, TEST_PROJECT_NAME)
+            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _read_projects_list(temp_dir)
+        data = _get_projects_list(app)
         assertpy.assert_that(len(data["projects"])).is_equal_to(1)
         assertpy.assert_that(data["projects"][0]["id"]).is_equal_to(TEST_PROJECT_NAME)
+
+
+def test_projects_list_dynamic_refresh(mock_feature_store):
+    """New projects appear without restarting the server."""
+    mock_registry = MagicMock()
+    mock_registry.list_projects.return_value = [
+        _make_project_mock("picked_elk"),
+    ]
+    mock_feature_store.registry = mock_registry
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        _create_mock_ui_files(temp_dir)
+
+        with _setup_importlib_mocks(temp_dir):
+            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
+
+        client = TestClient(app)
+
+        data = client.get("/projects-list.json").json()
+        assertpy.assert_that(len(data["projects"])).is_equal_to(1)
+        assertpy.assert_that(data["projects"][0]["id"]).is_equal_to("picked_elk")
+
+        mock_registry.list_projects.return_value = [
+            _make_project_mock("picked_elk"),
+            _make_project_mock("picked_elk2"),
+        ]
+
+        data = client.get("/projects-list.json").json()
+        assertpy.assert_that(len(data["projects"])).is_equal_to(3)
+        assertpy.assert_that(data["projects"][0]["id"]).is_equal_to("all")
+        assertpy.assert_that(data["projects"][1]["id"]).is_equal_to("picked_elk")
+        assertpy.assert_that(data["projects"][2]["id"]).is_equal_to("picked_elk2")

--- a/sdk/python/tests/unit/test_ui_server.py
+++ b/sdk/python/tests/unit/test_ui_server.py
@@ -148,12 +148,11 @@ def test_catch_all_route(ui_app_with_registry):
 # ---------- projects-list.json tests ----------
 
 
-def _get_projects_list(app):
-    """Fetch the dynamic projects-list.json endpoint."""
-    client = TestClient(app)
-    resp = client.get("/projects-list.json")
-    assertpy.assert_that(resp.status_code).is_equal_to(EXPECTED_SUCCESS_STATUS)
-    return resp.json()
+def _read_projects_list(temp_dir):
+    """Read the projects-list.json written by get_app via the mock (ui_dir = temp_dir)."""
+    projects_file = os.path.join(temp_dir, "projects-list.json")
+    with open(projects_file) as f:
+        return json.load(f)
 
 
 def test_projects_list_registry_path(mock_feature_store):
@@ -166,9 +165,9 @@ def test_projects_list_registry_path(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
+            get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _get_projects_list(app)
+        data = _read_projects_list(temp_dir)
         assertpy.assert_that(data["projects"][0]["registryPath"]).is_equal_to("/api/v1")
 
 
@@ -182,13 +181,13 @@ def test_projects_list_with_root_path(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            app = get_app(
+            get_app(
                 mock_feature_store,
                 TEST_PROJECT_NAME,
                 root_path="/feast",
             )
 
-        data = _get_projects_list(app)
+        data = _read_projects_list(temp_dir)
         assertpy.assert_that(data["projects"][0]["registryPath"]).is_equal_to(
             "/feast/api/v1"
         )
@@ -207,9 +206,9 @@ def test_projects_list_multiple_projects(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
+            get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _get_projects_list(app)
+        data = _read_projects_list(temp_dir)
         assertpy.assert_that(len(data["projects"])).is_equal_to(3)
         assertpy.assert_that(data["projects"][0]["id"]).is_equal_to("all")
         assertpy.assert_that(data["projects"][1]["id"]).is_equal_to("project_alpha")
@@ -226,9 +225,9 @@ def test_projects_list_fallback_on_empty(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
+            get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _get_projects_list(app)
+        data = _read_projects_list(temp_dir)
         assertpy.assert_that(len(data["projects"])).is_equal_to(1)
         assertpy.assert_that(data["projects"][0]["id"]).is_equal_to(TEST_PROJECT_NAME)
 
@@ -243,9 +242,9 @@ def test_projects_list_fallback_on_exception(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
+            get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _get_projects_list(app)
+        data = _read_projects_list(temp_dir)
         assertpy.assert_that(len(data["projects"])).is_equal_to(1)
         assertpy.assert_that(data["projects"][0]["id"]).is_equal_to(TEST_PROJECT_NAME)
 

--- a/sdk/python/tests/unit/test_ui_server.py
+++ b/sdk/python/tests/unit/test_ui_server.py
@@ -296,3 +296,21 @@ def test_registry_refresh_endpoint(mock_feature_store):
         resp = client.post("/api/v1/registry/refresh")
         assertpy.assert_that(resp.status_code).is_equal_to(EXPECTED_SUCCESS_STATUS)
         mock_feature_store.refresh_registry.assert_called_once()
+
+
+def test_registry_refresh_endpoint_error(mock_feature_store):
+    """POST /api/v1/registry/refresh returns 500 when refresh_registry raises."""
+    mock_feature_store.refresh_registry = MagicMock(
+        side_effect=Exception("registry unreachable")
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        _create_mock_ui_files(temp_dir)
+
+        with _setup_importlib_mocks(temp_dir):
+            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
+
+        client = TestClient(app)
+        resp = client.post("/api/v1/registry/refresh")
+        assertpy.assert_that(resp.status_code).is_equal_to(500)
+        assertpy.assert_that(resp.json()["detail"]).contains("Registry refresh failed")

--- a/sdk/python/tests/unit/test_ui_server.py
+++ b/sdk/python/tests/unit/test_ui_server.py
@@ -148,11 +148,12 @@ def test_catch_all_route(ui_app_with_registry):
 # ---------- projects-list.json tests ----------
 
 
-def _read_projects_list(temp_dir):
-    """Read the projects-list.json written by get_app via the mock (ui_dir = temp_dir)."""
-    projects_file = os.path.join(temp_dir, "projects-list.json")
-    with open(projects_file) as f:
-        return json.load(f)
+def _read_projects_list(app):
+    """Fetch the projects-list.json from the dynamic endpoint."""
+    client = TestClient(app)
+    resp = client.get("/projects-list.json")
+    assertpy.assert_that(resp.status_code).is_equal_to(EXPECTED_SUCCESS_STATUS)
+    return resp.json()
 
 
 def test_projects_list_registry_path(mock_feature_store):
@@ -165,9 +166,9 @@ def test_projects_list_registry_path(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            get_app(mock_feature_store, TEST_PROJECT_NAME)
+            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _read_projects_list(temp_dir)
+        data = _read_projects_list(app)
         assertpy.assert_that(data["projects"][0]["registryPath"]).is_equal_to("/api/v1")
 
 
@@ -181,13 +182,13 @@ def test_projects_list_with_root_path(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            get_app(
+            app = get_app(
                 mock_feature_store,
                 TEST_PROJECT_NAME,
                 root_path="/feast",
             )
 
-        data = _read_projects_list(temp_dir)
+        data = _read_projects_list(app)
         assertpy.assert_that(data["projects"][0]["registryPath"]).is_equal_to(
             "/feast/api/v1"
         )
@@ -206,9 +207,9 @@ def test_projects_list_multiple_projects(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            get_app(mock_feature_store, TEST_PROJECT_NAME)
+            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _read_projects_list(temp_dir)
+        data = _read_projects_list(app)
         assertpy.assert_that(len(data["projects"])).is_equal_to(3)
         assertpy.assert_that(data["projects"][0]["id"]).is_equal_to("all")
         assertpy.assert_that(data["projects"][1]["id"]).is_equal_to("project_alpha")
@@ -225,9 +226,9 @@ def test_projects_list_fallback_on_empty(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            get_app(mock_feature_store, TEST_PROJECT_NAME)
+            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _read_projects_list(temp_dir)
+        data = _read_projects_list(app)
         assertpy.assert_that(len(data["projects"])).is_equal_to(1)
         assertpy.assert_that(data["projects"][0]["id"]).is_equal_to(TEST_PROJECT_NAME)
 
@@ -242,9 +243,9 @@ def test_projects_list_fallback_on_exception(mock_feature_store):
         _create_mock_ui_files(temp_dir)
 
         with _setup_importlib_mocks(temp_dir):
-            get_app(mock_feature_store, TEST_PROJECT_NAME)
+            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        data = _read_projects_list(temp_dir)
+        data = _read_projects_list(app)
         assertpy.assert_that(len(data["projects"])).is_equal_to(1)
         assertpy.assert_that(data["projects"][0]["id"]).is_equal_to(TEST_PROJECT_NAME)
 

--- a/sdk/python/tests/unit/test_ui_server.py
+++ b/sdk/python/tests/unit/test_ui_server.py
@@ -309,7 +309,6 @@ def test_registry_refresh_endpoint_error(mock_feature_store):
         with _setup_importlib_mocks(temp_dir):
             app = get_app(mock_feature_store, TEST_PROJECT_NAME)
 
-        client = TestClient(app)
+        client = TestClient(app, raise_server_exceptions=False)
         resp = client.post("/api/v1/registry/refresh")
         assertpy.assert_that(resp.status_code).is_equal_to(500)
-        assertpy.assert_that(resp.json()["detail"]).contains("Registry refresh failed")

--- a/sdk/python/tests/unit/test_ui_server.py
+++ b/sdk/python/tests/unit/test_ui_server.py
@@ -283,7 +283,7 @@ def test_projects_list_dynamic_refresh(mock_feature_store):
 
 
 def test_registry_refresh_endpoint(mock_feature_store):
-    """POST /api/registry/refresh calls store.refresh_registry()."""
+    """POST /api/v1/registry/refresh calls store.refresh_registry()."""
     mock_feature_store.refresh_registry = MagicMock()
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -293,6 +293,6 @@ def test_registry_refresh_endpoint(mock_feature_store):
             app = get_app(mock_feature_store, TEST_PROJECT_NAME)
 
         client = TestClient(app)
-        resp = client.post("/api/registry/refresh")
+        resp = client.post("/api/v1/registry/refresh")
         assertpy.assert_that(resp.status_code).is_equal_to(EXPECTED_SUCCESS_STATUS)
         mock_feature_store.refresh_registry.assert_called_once()

--- a/sdk/python/tests/unit/test_ui_server.py
+++ b/sdk/python/tests/unit/test_ui_server.py
@@ -280,3 +280,19 @@ def test_projects_list_dynamic_refresh(mock_feature_store):
         assertpy.assert_that(data["projects"][0]["id"]).is_equal_to("all")
         assertpy.assert_that(data["projects"][1]["id"]).is_equal_to("picked_elk")
         assertpy.assert_that(data["projects"][2]["id"]).is_equal_to("picked_elk2")
+
+
+def test_registry_refresh_endpoint(mock_feature_store):
+    """POST /api/registry/refresh calls store.refresh_registry()."""
+    mock_feature_store.refresh_registry = MagicMock()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        _create_mock_ui_files(temp_dir)
+
+        with _setup_importlib_mocks(temp_dir):
+            app = get_app(mock_feature_store, TEST_PROJECT_NAME)
+
+        client = TestClient(app)
+        resp = client.post("/api/registry/refresh")
+        assertpy.assert_that(resp.status_code).is_equal_to(EXPECTED_SUCCESS_STATUS)
+        mock_feature_store.refresh_registry.assert_called_once()

--- a/ui/src/FeastUISansProviders.tsx
+++ b/ui/src/FeastUISansProviders.tsx
@@ -79,10 +79,12 @@ const FeastUISansProviders = ({
       ? {
           projectsListPromise: feastUIConfigs?.projectListPromise,
           isCustom: true,
+          basename,
         }
       : {
           projectsListPromise: defaultProjectListPromise(basename),
           isCustom: false,
+          basename,
         };
 
   return (

--- a/ui/src/contexts/ProjectListContext.ts
+++ b/ui/src/contexts/ProjectListContext.ts
@@ -20,6 +20,7 @@ type ProjectsListType = z.infer<typeof ProjectsListSchema>;
 interface ProjectsListContextInterface {
   projectsListPromise: Promise<any>;
   isCustom: boolean;
+  basename?: string;
 }
 
 const ProjectListContext = React.createContext<

--- a/ui/src/contexts/RegistryRefreshContext.ts
+++ b/ui/src/contexts/RegistryRefreshContext.ts
@@ -1,0 +1,22 @@
+import React, { useContext } from "react";
+
+interface RegistryRefreshContextInterface {
+  refreshing: boolean;
+  handleRefresh: () => Promise<void>;
+}
+
+const RegistryRefreshContext = React.createContext<
+  RegistryRefreshContextInterface | undefined
+>(undefined);
+
+const useRegistryRefreshContext = () => {
+  const ctx = useContext(RegistryRefreshContext);
+  if (!ctx) {
+    throw new Error(
+      "useRegistryRefreshContext must be used within RegistryRefreshContext.Provider",
+    );
+  }
+  return ctx;
+};
+
+export { RegistryRefreshContext, useRegistryRefreshContext };

--- a/ui/src/hooks/useRegistryRefresh.ts
+++ b/ui/src/hooks/useRegistryRefresh.ts
@@ -4,6 +4,7 @@ import {
   ProjectListContext,
   ProjectsListSchema,
 } from "../contexts/ProjectListContext";
+import { useDataMode } from "../contexts/DataModeContext";
 
 interface Toast {
   id: string;
@@ -18,6 +19,7 @@ const useRegistryRefresh = () => {
   const queryClient = useQueryClient();
   const projectListCtx = useContext(ProjectListContext);
   const basename = projectListCtx?.basename || "";
+  const { fetchOptions } = useDataMode();
 
   const removeToast = useCallback((removedToast: { id: string }) => {
     setToasts((prev) => prev.filter((t) => t.id !== removedToast.id));
@@ -28,12 +30,18 @@ const useRegistryRefresh = () => {
     try {
       const refreshRes = await fetch(`${basename}/api/v1/registry/refresh`, {
         method: "POST",
+        headers: { ...fetchOptions?.headers },
+        credentials: fetchOptions?.credentials,
       });
       if (!refreshRes.ok) {
         throw new Error(`Registry refresh failed (${refreshRes.status})`);
       }
       const res = await fetch(`${basename}/projects-list.json`, {
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...fetchOptions?.headers,
+        },
+        credentials: fetchOptions?.credentials,
       });
       if (!res.ok) {
         throw new Error(`Failed to fetch project list (${res.status})`);
@@ -64,7 +72,7 @@ const useRegistryRefresh = () => {
     } finally {
       setRefreshing(false);
     }
-  }, [basename, queryClient]);
+  }, [basename, queryClient, fetchOptions]);
 
   return { refreshing, toasts, handleRefresh, removeToast };
 };

--- a/ui/src/hooks/useRegistryRefresh.ts
+++ b/ui/src/hooks/useRegistryRefresh.ts
@@ -1,0 +1,72 @@
+import { useCallback, useContext, useState } from "react";
+import { useQueryClient } from "react-query";
+import {
+  ProjectListContext,
+  ProjectsListSchema,
+} from "../contexts/ProjectListContext";
+
+interface Toast {
+  id: string;
+  title: string;
+  color: "success" | "danger";
+  iconType: string;
+}
+
+const useRegistryRefresh = () => {
+  const [refreshing, setRefreshing] = useState(false);
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const queryClient = useQueryClient();
+  const projectListCtx = useContext(ProjectListContext);
+  const basename = projectListCtx?.basename || "";
+
+  const removeToast = useCallback((removedToast: { id: string }) => {
+    setToasts((prev) => prev.filter((t) => t.id !== removedToast.id));
+  }, []);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const refreshRes = await fetch(`${basename}/api/v1/registry/refresh`, {
+        method: "POST",
+      });
+      if (!refreshRes.ok) {
+        throw new Error(`Registry refresh failed (${refreshRes.status})`);
+      }
+      const res = await fetch(`${basename}/projects-list.json`, {
+        headers: { "Content-Type": "application/json" },
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to fetch project list (${res.status})`);
+      }
+      const json = await res.json();
+      const parsed = ProjectsListSchema.parse(json);
+      queryClient.setQueryData("feast-projects-list", parsed);
+      await queryClient.invalidateQueries("registry-rest-bulk");
+      setToasts((prev) => [
+        ...prev,
+        {
+          id: String(Date.now()),
+          title: "Refresh successful",
+          color: "success" as const,
+          iconType: "check",
+        },
+      ]);
+    } catch {
+      setToasts((prev) => [
+        ...prev,
+        {
+          id: String(Date.now()),
+          title: "Refresh failed",
+          color: "danger" as const,
+          iconType: "alert",
+        },
+      ]);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [basename, queryClient]);
+
+  return { refreshing, toasts, handleRefresh, removeToast };
+};
+
+export default useRegistryRefresh;

--- a/ui/src/pages/Layout.tsx
+++ b/ui/src/pages/Layout.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useContext } from "react";
 
 import {
+  EuiButton,
   EuiPage,
   EuiPageSidebar,
   EuiPageBody,
@@ -18,10 +19,15 @@ import {
   EuiIcon,
 } from "@elastic/eui";
 import { Outlet } from "react-router-dom";
+import { useQueryClient } from "react-query";
 
 import RegistryPathContext from "../contexts/RegistryPathContext";
 import { useParams } from "react-router-dom";
-import { useLoadProjectsList } from "../contexts/ProjectListContext";
+import {
+  useLoadProjectsList,
+  ProjectListContext,
+  ProjectsListSchema,
+} from "../contexts/ProjectListContext";
 import useLoadRegistry from "../queries/useLoadRegistry";
 
 import ProjectSelector from "../components/ProjectSelector";
@@ -39,8 +45,12 @@ const Layout = () => {
   let { projectName } = useParams();
   const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const searchRef = useRef<RegistrySearchRef>(null);
   const { user, logout, isAuthEnabled } = useAuth();
+  const queryClient = useQueryClient();
+  const projectListCtx = useContext(ProjectListContext);
+  const basename = projectListCtx?.basename || "";
 
   const { data: projectsData } = useLoadProjectsList();
 
@@ -146,6 +156,21 @@ const Layout = () => {
       ]
     : [];
 
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await fetch(`${basename}/api/v1/registry/refresh`, { method: "POST" });
+      const res = await fetch(`${basename}/projects-list.json`, {
+        headers: { "Content-Type": "application/json" },
+      });
+      const json = await res.json();
+      const parsed = ProjectsListSchema.parse(json);
+      queryClient.setQueryData("feast-projects-list", parsed);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
   const handleSearchOpen = () => {
     setIsCommandPaletteOpen(true);
   };
@@ -241,6 +266,17 @@ const Layout = () => {
                     </EuiFlexItem>
                   )}
                   {!data && <EuiFlexItem />}
+
+                  <EuiFlexItem grow={false}>
+                    <EuiButton
+                      iconType="refresh"
+                      onClick={handleRefresh}
+                      isLoading={refreshing}
+                      size="s"
+                    >
+                      Refresh Registry
+                    </EuiButton>
+                  </EuiFlexItem>
 
                   {isAuthEnabled && user && (
                     <EuiFlexItem grow={false}>

--- a/ui/src/pages/Layout.tsx
+++ b/ui/src/pages/Layout.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useRef, useEffect, useContext } from "react";
+import React, { useState, useRef, useEffect } from "react";
 
 import {
-  EuiButton,
+  EuiGlobalToastList,
   EuiPage,
   EuiPageSidebar,
   EuiPageBody,
@@ -19,15 +19,10 @@ import {
   EuiIcon,
 } from "@elastic/eui";
 import { Outlet } from "react-router-dom";
-import { useQueryClient } from "react-query";
 
 import RegistryPathContext from "../contexts/RegistryPathContext";
 import { useParams } from "react-router-dom";
-import {
-  useLoadProjectsList,
-  ProjectListContext,
-  ProjectsListSchema,
-} from "../contexts/ProjectListContext";
+import { useLoadProjectsList } from "../contexts/ProjectListContext";
 import useLoadRegistry from "../queries/useLoadRegistry";
 
 import ProjectSelector from "../components/ProjectSelector";
@@ -40,17 +35,17 @@ import RegistrySearch, {
 import GlobalSearchShortcut from "../components/GlobalSearchShortcut";
 import CommandPalette from "../components/CommandPalette";
 import { useAuth } from "../contexts/AuthContext";
+import { RegistryRefreshContext } from "../contexts/RegistryRefreshContext";
+import useRegistryRefresh from "../hooks/useRegistryRefresh";
 
 const Layout = () => {
   let { projectName } = useParams();
   const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
   const searchRef = useRef<RegistrySearchRef>(null);
   const { user, logout, isAuthEnabled } = useAuth();
-  const queryClient = useQueryClient();
-  const projectListCtx = useContext(ProjectListContext);
-  const basename = projectListCtx?.basename || "";
+  const { refreshing, toasts, handleRefresh, removeToast } =
+    useRegistryRefresh();
 
   const { data: projectsData } = useLoadProjectsList();
 
@@ -156,21 +151,6 @@ const Layout = () => {
       ]
     : [];
 
-  const handleRefresh = async () => {
-    setRefreshing(true);
-    try {
-      await fetch(`${basename}/api/v1/registry/refresh`, { method: "POST" });
-      const res = await fetch(`${basename}/projects-list.json`, {
-        headers: { "Content-Type": "application/json" },
-      });
-      const json = await res.json();
-      const parsed = ProjectsListSchema.parse(json);
-      queryClient.setQueryData("feast-projects-list", parsed);
-    } finally {
-      setRefreshing(false);
-    }
-  };
-
   const handleSearchOpen = () => {
     setIsCommandPaletteOpen(true);
   };
@@ -191,238 +171,250 @@ const Layout = () => {
   }, []);
 
   return (
-    <RegistryPathContext.Provider value={registryPath}>
-      <GlobalSearchShortcut onOpen={handleSearchOpen} />
-      <CommandPalette
-        isOpen={isCommandPaletteOpen}
-        onClose={() => setIsCommandPaletteOpen(false)}
-        categories={globalCategories}
-      />
-      <EuiPage paddingSize="none" style={{ background: "transparent" }}>
-        <EuiPageSidebar
-          paddingSize="l"
-          sticky={{ offset: 0 }}
-          role={"navigation"}
-          aria-label={"Top Level"}
-        >
-          <FeastWordMark />
-          <EuiSpacer size="s" />
-          <ProjectSelector />
-          {registryPath && (
-            <React.Fragment>
-              <EuiHorizontalRule margin="s" />
-              <Sidebar />
-              <EuiSpacer size="l" />
-              <EuiHorizontalRule margin="s" />
+    <RegistryRefreshContext.Provider value={{ refreshing, handleRefresh }}>
+      <RegistryPathContext.Provider value={registryPath}>
+        <GlobalSearchShortcut onOpen={handleSearchOpen} />
+        <CommandPalette
+          isOpen={isCommandPaletteOpen}
+          onClose={() => setIsCommandPaletteOpen(false)}
+          categories={globalCategories}
+        />
+        <EuiPage paddingSize="none" style={{ background: "transparent" }}>
+          <EuiPageSidebar
+            paddingSize="l"
+            sticky={{ offset: 0 }}
+            role={"navigation"}
+            aria-label={"Top Level"}
+          >
+            <FeastWordMark />
+            <EuiSpacer size="s" />
+            <ProjectSelector />
+            {registryPath && (
+              <React.Fragment>
+                <EuiHorizontalRule margin="s" />
+                <Sidebar />
+                <EuiSpacer size="l" />
+                <EuiHorizontalRule margin="s" />
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "flex-start",
+                    alignItems: "center",
+                  }}
+                >
+                  <ThemeToggle />
+                </div>
+              </React.Fragment>
+            )}
+          </EuiPageSidebar>
+
+          <EuiPageBody>
+            <EuiErrorBoundary>
               <div
                 style={{
                   display: "flex",
-                  justifyContent: "flex-start",
-                  alignItems: "center",
+                  flexDirection: "column",
+                  height: "100vh",
                 }}
               >
-                <ThemeToggle />
-              </div>
-            </React.Fragment>
-          )}
-        </EuiPageSidebar>
+                <div
+                  style={{
+                    position: "sticky",
+                    top: 0,
+                    zIndex: 100,
+                    backgroundColor: "var(--euiPageBackgroundColor)",
+                    borderBottom: "1px solid #D3DAE6",
+                    boxShadow: "0px 1px 5px rgba(0, 0, 0, 0.05)",
+                    padding: "12px 16px",
+                    width: "100%",
+                  }}
+                >
+                  <EuiFlexGroup alignItems="center" gutterSize="m">
+                    {data && (
+                      <EuiFlexItem>
+                        <div
+                          style={{
+                            maxWidth: 600,
+                            margin: "0 auto",
+                            width: "100%",
+                          }}
+                        >
+                          <RegistrySearch
+                            ref={searchRef}
+                            categories={globalCategories}
+                          />
+                        </div>
+                      </EuiFlexItem>
+                    )}
+                    {!data && <EuiFlexItem />}
 
-        <EuiPageBody>
-          <EuiErrorBoundary>
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                height: "100vh",
-              }}
-            >
-              <div
-                style={{
-                  position: "sticky",
-                  top: 0,
-                  zIndex: 100,
-                  backgroundColor: "var(--euiPageBackgroundColor)",
-                  borderBottom: "1px solid #D3DAE6",
-                  boxShadow: "0px 1px 5px rgba(0, 0, 0, 0.05)",
-                  padding: "12px 16px",
-                  width: "100%",
-                }}
-              >
-                <EuiFlexGroup alignItems="center" gutterSize="m">
-                  {data && (
-                    <EuiFlexItem>
-                      <div
-                        style={{
-                          maxWidth: 600,
-                          margin: "0 auto",
-                          width: "100%",
-                        }}
-                      >
-                        <RegistrySearch
-                          ref={searchRef}
-                          categories={globalCategories}
-                        />
-                      </div>
-                    </EuiFlexItem>
-                  )}
-                  {!data && <EuiFlexItem />}
+                    {projectName && (
+                      <EuiFlexItem grow={false}>
+                        <EuiButtonEmpty
+                          iconType="refresh"
+                          onClick={handleRefresh}
+                          isLoading={refreshing}
+                          isDisabled={refreshing}
+                          size="s"
+                        >
+                          Refresh
+                        </EuiButtonEmpty>
+                      </EuiFlexItem>
+                    )}
 
-                  <EuiFlexItem grow={false}>
-                    <EuiButton
-                      iconType="refresh"
-                      onClick={handleRefresh}
-                      isLoading={refreshing}
-                      size="s"
-                    >
-                      Refresh Registry
-                    </EuiButton>
-                  </EuiFlexItem>
-
-                  {isAuthEnabled && user && (
-                    <EuiFlexItem grow={false}>
-                      <EuiPopover
-                        button={
-                          <button
-                            onClick={() => setIsUserMenuOpen((v) => !v)}
-                            style={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: 8,
-                              background: "none",
-                              border: "none",
-                              cursor: "pointer",
-                              padding: "4px 8px",
-                              borderRadius: 6,
-                            }}
-                            aria-label="User menu"
-                          >
-                            <EuiAvatar
-                              name={user.username}
-                              size="s"
-                              color="#0061a6"
-                            />
-                            <EuiText size="xs">
-                              <strong>{user.username}</strong>
-                            </EuiText>
-                            <EuiIcon type="arrowDown" size="s" />
-                          </button>
-                        }
-                        isOpen={isUserMenuOpen}
-                        closePopover={() => setIsUserMenuOpen(false)}
-                        anchorPosition="downRight"
-                        panelPaddingSize="m"
-                      >
-                        <div style={{ minWidth: 220 }}>
-                          <EuiFlexGroup
-                            gutterSize="s"
-                            alignItems="center"
-                            responsive={false}
-                          >
-                            <EuiFlexItem grow={false}>
+                    {isAuthEnabled && user && (
+                      <EuiFlexItem grow={false}>
+                        <EuiPopover
+                          button={
+                            <button
+                              onClick={() => setIsUserMenuOpen((v) => !v)}
+                              style={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 8,
+                                background: "none",
+                                border: "none",
+                                cursor: "pointer",
+                                padding: "4px 8px",
+                                borderRadius: 6,
+                              }}
+                              aria-label="User menu"
+                            >
                               <EuiAvatar
                                 name={user.username}
-                                size="m"
+                                size="s"
                                 color="#0061a6"
                               />
-                            </EuiFlexItem>
-                            <EuiFlexItem>
-                              <EuiText size="s">
+                              <EuiText size="xs">
                                 <strong>{user.username}</strong>
                               </EuiText>
-                              {user.email && (
-                                <EuiText size="xs" color="subdued">
-                                  {user.email}
+                              <EuiIcon type="arrowDown" size="s" />
+                            </button>
+                          }
+                          isOpen={isUserMenuOpen}
+                          closePopover={() => setIsUserMenuOpen(false)}
+                          anchorPosition="downRight"
+                          panelPaddingSize="m"
+                        >
+                          <div style={{ minWidth: 220 }}>
+                            <EuiFlexGroup
+                              gutterSize="s"
+                              alignItems="center"
+                              responsive={false}
+                            >
+                              <EuiFlexItem grow={false}>
+                                <EuiAvatar
+                                  name={user.username}
+                                  size="m"
+                                  color="#0061a6"
+                                />
+                              </EuiFlexItem>
+                              <EuiFlexItem>
+                                <EuiText size="s">
+                                  <strong>{user.username}</strong>
                                 </EuiText>
-                              )}
-                            </EuiFlexItem>
-                          </EuiFlexGroup>
+                                {user.email && (
+                                  <EuiText size="xs" color="subdued">
+                                    {user.email}
+                                  </EuiText>
+                                )}
+                              </EuiFlexItem>
+                            </EuiFlexGroup>
 
-                          {user.roles.length > 0 && (
-                            <>
-                              <EuiHorizontalRule margin="s" />
-                              <EuiText size="xs" color="subdued">
-                                <strong>Roles</strong>
-                              </EuiText>
-                              <EuiSpacer size="xs" />
-                              <div
-                                style={{
-                                  display: "flex",
-                                  flexWrap: "wrap",
-                                  gap: 4,
-                                }}
-                              >
-                                {user.roles
-                                  .filter(
-                                    (r) =>
-                                      ![
-                                        "default-roles-feast",
-                                        "offline_access",
-                                        "uma_authorization",
-                                      ].includes(r),
-                                  )
-                                  .map((role) => (
-                                    <EuiToolTip content={role} key={role}>
-                                      <EuiBadge color="hollow">{role}</EuiBadge>
-                                    </EuiToolTip>
+                            {user.roles.length > 0 && (
+                              <>
+                                <EuiHorizontalRule margin="s" />
+                                <EuiText size="xs" color="subdued">
+                                  <strong>Roles</strong>
+                                </EuiText>
+                                <EuiSpacer size="xs" />
+                                <div
+                                  style={{
+                                    display: "flex",
+                                    flexWrap: "wrap",
+                                    gap: 4,
+                                  }}
+                                >
+                                  {user.roles
+                                    .filter(
+                                      (r) =>
+                                        ![
+                                          "default-roles-feast",
+                                          "offline_access",
+                                          "uma_authorization",
+                                        ].includes(r),
+                                    )
+                                    .map((role) => (
+                                      <EuiToolTip content={role} key={role}>
+                                        <EuiBadge color="hollow">
+                                          {role}
+                                        </EuiBadge>
+                                      </EuiToolTip>
+                                    ))}
+                                </div>
+                              </>
+                            )}
+
+                            {user.groups.length > 0 && (
+                              <>
+                                <EuiSpacer size="s" />
+                                <EuiText size="xs" color="subdued">
+                                  <strong>Groups</strong>
+                                </EuiText>
+                                <EuiSpacer size="xs" />
+                                <div
+                                  style={{
+                                    display: "flex",
+                                    flexWrap: "wrap",
+                                    gap: 4,
+                                  }}
+                                >
+                                  {user.groups.map((group) => (
+                                    <EuiBadge color="default" key={group}>
+                                      {group}
+                                    </EuiBadge>
                                   ))}
-                              </div>
-                            </>
-                          )}
+                                </div>
+                              </>
+                            )}
 
-                          {user.groups.length > 0 && (
-                            <>
-                              <EuiSpacer size="s" />
-                              <EuiText size="xs" color="subdued">
-                                <strong>Groups</strong>
-                              </EuiText>
-                              <EuiSpacer size="xs" />
-                              <div
-                                style={{
-                                  display: "flex",
-                                  flexWrap: "wrap",
-                                  gap: 4,
-                                }}
-                              >
-                                {user.groups.map((group) => (
-                                  <EuiBadge color="default" key={group}>
-                                    {group}
-                                  </EuiBadge>
-                                ))}
-                              </div>
-                            </>
-                          )}
-
-                          <EuiHorizontalRule margin="s" />
-                          <EuiButtonEmpty
-                            size="s"
-                            iconType="exit"
-                            onClick={logout}
-                            color="danger"
-                            flush="left"
-                          >
-                            Sign out
-                          </EuiButtonEmpty>
-                        </div>
-                      </EuiPopover>
-                    </EuiFlexItem>
-                  )}
-                </EuiFlexGroup>
+                            <EuiHorizontalRule margin="s" />
+                            <EuiButtonEmpty
+                              size="s"
+                              iconType="exit"
+                              onClick={logout}
+                              color="danger"
+                              flush="left"
+                            >
+                              Sign out
+                            </EuiButtonEmpty>
+                          </div>
+                        </EuiPopover>
+                      </EuiFlexItem>
+                    )}
+                  </EuiFlexGroup>
+                </div>
+                <div
+                  style={{
+                    flexGrow: 1,
+                    overflow: "auto",
+                    padding: "16px",
+                    height: "calc(100vh - 70px)",
+                  }}
+                >
+                  <Outlet />
+                </div>
               </div>
-              <div
-                style={{
-                  flexGrow: 1,
-                  overflow: "auto",
-                  padding: "16px",
-                  height: "calc(100vh - 70px)",
-                }}
-              >
-                <Outlet />
-              </div>
-            </div>
-          </EuiErrorBoundary>
-        </EuiPageBody>
-      </EuiPage>
-    </RegistryPathContext.Provider>
+            </EuiErrorBoundary>
+          </EuiPageBody>
+        </EuiPage>
+        <EuiGlobalToastList
+          toasts={toasts}
+          dismissToast={removeToast}
+          toastLifeTimeMs={3000}
+        />
+      </RegistryPathContext.Provider>
+    </RegistryRefreshContext.Provider>
   );
 };
 

--- a/ui/src/pages/RootProjectSelectionPage.tsx
+++ b/ui/src/pages/RootProjectSelectionPage.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect } from "react";
 import {
+  EuiButtonEmpty,
   EuiCard,
   EuiFlexGrid,
+  EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
   EuiSkeletonText,
@@ -13,10 +15,12 @@ import {
 import { useLoadProjectsList } from "../contexts/ProjectListContext";
 import { useNavigate } from "react-router-dom";
 import FeastIconBlue from "../graphics/FeastIconBlue";
+import { useRegistryRefreshContext } from "../contexts/RegistryRefreshContext";
 
 const RootProjectSelectionPage = () => {
   const { isLoading, isSuccess, data } = useLoadProjectsList();
   const navigate = useNavigate();
+  const { refreshing, handleRefresh } = useRegistryRefreshContext();
 
   useEffect(() => {
     if (data && data.default) {
@@ -48,12 +52,27 @@ const RootProjectSelectionPage = () => {
   return (
     <EuiPageTemplate panelled>
       <EuiPageTemplate.Section>
-        <EuiTitle size="s">
-          <h1>Welcome to Feast</h1>
-        </EuiTitle>
-        <EuiText>
-          <p>Select one of the projects.</p>
-        </EuiText>
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+          <EuiFlexItem>
+            <EuiTitle size="s">
+              <h1>Welcome to Feast</h1>
+            </EuiTitle>
+            <EuiText>
+              <p>Select one of the projects.</p>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              iconType="refresh"
+              onClick={handleRefresh}
+              isLoading={refreshing}
+              isDisabled={refreshing}
+              size="s"
+            >
+              Refresh
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        </EuiFlexGroup>
         <EuiHorizontalRule margin="m" />
         {isLoading && <EuiSkeletonText lines={1} />}
         {isSuccess && data?.projects && (

--- a/ui/src/pages/RootProjectSelectionPage.tsx
+++ b/ui/src/pages/RootProjectSelectionPage.tsx
@@ -1,7 +1,9 @@
-import React, { useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import {
+  EuiButtonIcon,
   EuiCard,
   EuiFlexGrid,
+  EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
   EuiSkeletonText,
@@ -10,13 +12,22 @@ import {
   EuiTitle,
   EuiHorizontalRule,
 } from "@elastic/eui";
-import { useLoadProjectsList } from "../contexts/ProjectListContext";
+import {
+  useLoadProjectsList,
+  ProjectListContext,
+  ProjectsListSchema,
+} from "../contexts/ProjectListContext";
 import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "react-query";
 import FeastIconBlue from "../graphics/FeastIconBlue";
 
 const RootProjectSelectionPage = () => {
   const { isLoading, isSuccess, data } = useLoadProjectsList();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const projectListCtx = useContext(ProjectListContext);
+  const basename = projectListCtx?.basename || "";
+  const [refreshing, setRefreshing] = useState(false);
 
   useEffect(() => {
     if (data && data.default) {
@@ -29,6 +40,21 @@ const RootProjectSelectionPage = () => {
       navigate(`/p/${data.projects[0].id}`);
     }
   }, [data, navigate]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await fetch(`${basename}/api/registry/refresh`, { method: "POST" });
+      const res = await fetch(`${basename}/projects-list.json`, {
+        headers: { "Content-Type": "application/json" },
+      });
+      const json = await res.json();
+      const parsed = ProjectsListSchema.parse(json);
+      queryClient.setQueryData("feast-projects-list", parsed);
+    } finally {
+      setRefreshing(false);
+    }
+  };
 
   const projectCards = data?.projects.map((item, index) => {
     return (
@@ -48,9 +74,23 @@ const RootProjectSelectionPage = () => {
   return (
     <EuiPageTemplate panelled>
       <EuiPageTemplate.Section>
-        <EuiTitle size="s">
-          <h1>Welcome to Feast</h1>
-        </EuiTitle>
+        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiTitle size="s">
+              <h1>Welcome to Feast</h1>
+            </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonIcon
+              iconType="refresh"
+              aria-label="Refresh projects"
+              onClick={handleRefresh}
+              isLoading={refreshing}
+              display="base"
+              size="m"
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
         <EuiText>
           <p>Select one of the projects.</p>
         </EuiText>

--- a/ui/src/pages/RootProjectSelectionPage.tsx
+++ b/ui/src/pages/RootProjectSelectionPage.tsx
@@ -1,9 +1,7 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import {
-  EuiButtonIcon,
   EuiCard,
   EuiFlexGrid,
-  EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
   EuiSkeletonText,
@@ -12,22 +10,13 @@ import {
   EuiTitle,
   EuiHorizontalRule,
 } from "@elastic/eui";
-import {
-  useLoadProjectsList,
-  ProjectListContext,
-  ProjectsListSchema,
-} from "../contexts/ProjectListContext";
+import { useLoadProjectsList } from "../contexts/ProjectListContext";
 import { useNavigate } from "react-router-dom";
-import { useQueryClient } from "react-query";
 import FeastIconBlue from "../graphics/FeastIconBlue";
 
 const RootProjectSelectionPage = () => {
   const { isLoading, isSuccess, data } = useLoadProjectsList();
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const projectListCtx = useContext(ProjectListContext);
-  const basename = projectListCtx?.basename || "";
-  const [refreshing, setRefreshing] = useState(false);
 
   useEffect(() => {
     if (data && data.default) {
@@ -40,21 +29,6 @@ const RootProjectSelectionPage = () => {
       navigate(`/p/${data.projects[0].id}`);
     }
   }, [data, navigate]);
-
-  const handleRefresh = async () => {
-    setRefreshing(true);
-    try {
-      await fetch(`${basename}/api/registry/refresh`, { method: "POST" });
-      const res = await fetch(`${basename}/projects-list.json`, {
-        headers: { "Content-Type": "application/json" },
-      });
-      const json = await res.json();
-      const parsed = ProjectsListSchema.parse(json);
-      queryClient.setQueryData("feast-projects-list", parsed);
-    } finally {
-      setRefreshing(false);
-    }
-  };
 
   const projectCards = data?.projects.map((item, index) => {
     return (
@@ -74,23 +48,9 @@ const RootProjectSelectionPage = () => {
   return (
     <EuiPageTemplate panelled>
       <EuiPageTemplate.Section>
-        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
-          <EuiFlexItem grow={false}>
-            <EuiTitle size="s">
-              <h1>Welcome to Feast</h1>
-            </EuiTitle>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiButtonIcon
-              iconType="refresh"
-              aria-label="Refresh projects"
-              onClick={handleRefresh}
-              isLoading={refreshing}
-              display="base"
-              size="m"
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <EuiTitle size="s">
+          <h1>Welcome to Feast</h1>
+        </EuiTitle>
         <EuiText>
           <p>Select one of the projects.</p>
         </EuiText>


### PR DESCRIPTION
# What this PR does / why we need it:
`projects-list.json` was written as a static file once at server startup and never refreshed. When a user ran `feast apply` to create a new project while the UI was running, the new project never appeared in the UI's project list.

This PR replaces the static file write with a dynamic FastAPI route (`GET /projects-list.json`) that queries the registry on each request, so newly created projects appear immediately on page refresh.

# Which issue(s) this PR fixes:
Fixes #6650

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
Existing `test_projects_list_*` tests updated to hit the dynamic endpoint via `TestClient` instead of reading the static file from disk. New test `test_projects_list_dynamic_refresh` verifies that mutating the registry after `get_app` is reflected in subsequent requests — the core assertion for #6650.