### PR TITLE
fix: Reset the global security manager after the permissions test fixture

### DIFF
--- a/sdk/python/tests/unit/permissions/conftest.py
+++ b/sdk/python/tests/unit/permissions/conftest.py
@@ -1,3 +1,4 @@
+from typing import Iterator
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -11,6 +12,7 @@ from feast.permissions.permission import AuthzedAction, Permission
 from feast.permissions.policy import RoleBasedPolicy
 from feast.permissions.security_manager import (
     SecurityManager,
+    no_security_manager,
     set_security_manager,
 )
 from feast.permissions.user import User
@@ -63,7 +65,7 @@ def users() -> list[User]:
 
 
 @pytest.fixture
-def security_manager() -> SecurityManager:
+def security_manager() -> Iterator[SecurityManager]:
     permissions = []
     permissions.append(
         Permission(
@@ -111,4 +113,9 @@ def security_manager() -> SecurityManager:
     registry.list_permissions = Mock(return_value=permissions)
     sm = SecurityManager(project="any", registry=registry)
     set_security_manager(sm)
-    return sm
+    yield sm
+    # `set_security_manager` populates a module-level singleton that outlives
+    # this fixture. Reset it, or every later test in the same process that
+    # serves a request (e.g. the feature server tests) runs against this mock
+    # security manager and is rejected with 401 Unauthorized.
+    no_security_manager()


### PR DESCRIPTION
# What this PR does / why we need it

The `security_manager` fixture in `tests/unit/permissions/conftest.py` sets the module-level security manager singleton and never resets it, so any later test in the same pytest process that serves a request runs against the leaked mock manager and gets 401 Unauthorized. On master, running `tests/unit/permissions/` together with `tests/unit/test_feature_server.py` in one process fails 26 feature server tests; CI masks it because xdist distributes the modules across workers, but scoped local runs hit it.

This converts the fixture to yield and resets via `no_security_manager()` on teardown, the same cleanup the integration auth tests already use. Test-only change.

After the fix, the combined run passes (332 passed), and the permissions suite alone is unchanged (307 passed).

# Which issue(s) this PR fixes

Fixes #6674
