### PR TITLE
fix: Use correct image name in multi-arch imagetools push step

### DIFF
--- a/.github/workflows/master_only.yml
+++ b/.github/workflows/master_only.yml
@@ -94,14 +94,17 @@ jobs:
         include:
           - component: feature-server-dev
             target: feature-server-dev
+            image_name: feature-server
             build_args: DOCKER_PUSH=true DOCKER_PLATFORMS=linux/amd64,linux/arm64
             push_mode: imagetools
           - component: feature-transformation-server
             target: feature-transformation-server
+            image_name: feature-transformation-server
             build_args: ""
             push_mode: all_tags
           - component: feast-operator
             target: feast-operator
+            image_name: feast-operator
             build_args: DOCKER_PUSH=true DOCKER_PLATFORMS=linux/amd64,linux/arm64
             push_mode: imagetools
     env:
@@ -135,7 +138,7 @@ jobs:
       - name: Push image
         run: |
           if [[ "${{ matrix.push_mode }}" == "imagetools" ]]; then
-            docker buildx imagetools create -t ${REGISTRY}/${{ matrix.target }}:develop ${REGISTRY}/${{ matrix.target }}:${GITHUB_SHA}
+            docker buildx imagetools create -t ${REGISTRY}/${{ matrix.image_name }}:develop ${REGISTRY}/${{ matrix.image_name }}:${GITHUB_SHA}
           else
-            docker tag ${REGISTRY}/${{ matrix.target }}:${GITHUB_SHA} ${REGISTRY}/${{ matrix.target }}:develop && docker push ${REGISTRY}/${{ matrix.target }} --all-tags
+            docker tag ${REGISTRY}/${{ matrix.image_name }}:${GITHUB_SHA} ${REGISTRY}/${{ matrix.image_name }}:develop && docker push ${REGISTRY}/${{ matrix.image_name }} --all-tags
           fi

--- a/pixi.lock
+++ b/pixi.lock
@@ -2429,6 +2429,7 @@ packages:
   - snowflake-connector-python[pandas]>=3.7,<5 ; extra == 'snowflake'
   - sqlite-vec==0.1.6 ; extra == 'sqlite-vec'
   - fastapi-mcp ; extra == 'mcp'
+  - mcp>=1.0,<2 ; extra == 'mcp'
   - mlflow>=2.10.0 ; extra == 'mlflow'
   - dbt-artifacts-parser ; extra == 'dbt'
   - pytest>=6.0.0,<8 ; extra == 'test'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ snowflake = [
     "snowflake-connector-python[pandas]>=3.7,<5",
 ]
 sqlite_vec = ["sqlite-vec==v0.1.6"]
-mcp = ["fastapi_mcp"]
+mcp = ["fastapi_mcp", "mcp>=1.0,<2"]
 mlflow = ["mlflow>=2.10.0"]
 
 dbt = ["dbt-artifacts-parser"]


### PR DESCRIPTION

# What this PR does / why we need it:

Fixes https://github.com/feast-dev/feast/actions/runs/30605307522/job/91076222086

The `build-all-docker-images` job in `master_only.yml` was failing for the
`feature-server-dev` matrix entry because the "Push image" step used
`matrix.target` (`feature-server-dev`) as the image name, while the Makefile
target `build-feature-server-dev-docker` actually pushes to
`feature-server` (without the `-dev` suffix).

This mismatch was introduced when the push step was generalized from a
hardcoded `feature-server` reference to `${{ matrix.target }}` as part of
adding multi-arch support for the feast-operator image.

Added an `image_name` field to the build matrix to decouple the Makefile
target name from the registry image name, and updated the "Push image" step
to use `matrix.image_name`.
