### PR TITLE
fix(python): allow feast init to accept path as PROJECT_DIRECTORY

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -573,6 +573,17 @@ def init_repo(repo_name: str, template: str, repo_path: Optional[str] = None):
 
     from colorama import Fore, Style
 
+    # PROJECT_DIRECTORY may be provided as a path, e.g. ``feast init /tmp/test``
+    # or ``feast init my/sub/dir``. When no explicit ``--repo-path`` is given,
+    # treat the argument as the target directory and derive the Feast project
+    # name from its final path component, so project-name validation runs
+    # against the name rather than the whole path.
+    if repo_path is None and (
+        os.sep in repo_name or (os.altsep and os.altsep in repo_name)
+    ):
+        repo_path = repo_name
+        repo_name = Path(repo_name).name
+
     # Validate project name
     if not is_valid_name(repo_name):
         raise BadParameter(

--- a/sdk/python/tests/unit/local_feast_tests/test_init.py
+++ b/sdk/python/tests/unit/local_feast_tests/test_init.py
@@ -69,6 +69,26 @@ def test_repo_init_with_underscore_in_project_name() -> None:
         assert result.returncode != 0
 
 
+def test_repo_init_with_path_argument() -> None:
+    """
+    `feast init <path>` should accept a path as PROJECT_DIRECTORY, create the
+    repository at that path, and derive the project name from the final path
+    component (regression test for #6134).
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        runner = CliRunner()
+
+        target = temp_path / "nested" / "my_repo"
+        result = runner.run(["init", str(target)], cwd=temp_path)
+        assert result.returncode == 0
+
+        feature_store_yaml = target / "feature_repo" / "feature_store.yaml"
+        assert feature_store_yaml.exists()
+        # project name is derived from the final path component, not the path
+        assert "project: my_repo" in feature_store_yaml.read_text()
+
+
 def test_postgres_template_registry_path_is_parameterized() -> None:
     template_fs_yaml = (
         Path(__file__).resolve().parents[3]


### PR DESCRIPTION
## What this PR does / why we need it

`feast init` accepts a positional `PROJECT_DIRECTORY` argument, but passing a **path** currently fails:

```console
$ feast init /tmp/test
Error: Invalid value for PROJECT_DIRECTORY: Name should be alphanumeric values,
underscores, and hyphens but not start with an underscore or hyphen.
```

The argument is validated *as a project name* (`is_valid_name`), so any path separator (`/`, `\`) is rejected — even though the argument is literally named `PROJECT_DIRECTORY` and users reasonably expect to scaffold into a directory (e.g. `feast init /tmp/test` or `feast init my/sub/dir`).

## Change

In `init_repo`, when `PROJECT_DIRECTORY` contains a path separator and no explicit `--repo-path` is provided, treat the argument as the **target directory** and derive the **project name** from its final path component. The derived name is then validated as before.

```console
$ feast init /tmp/test        # creates repo at /tmp/test, project name "test"
$ feast init my/sub/dir       # creates repo at my/sub/dir, project name "dir"
$ feast init my_project       # unchanged
$ feast init /tmp/_bad        # still rejected: basename "_bad" is invalid
```

Behavior with an explicit `--repo-path`, and plain project names, is unchanged.

## Which issue(s) this PR fixes

Fixes #6134

## Testing

- Added `test_repo_init_with_path_argument` in `sdk/python/tests/unit/local_feast_tests/test_init.py` — runs `feast init <path>` via the CLI runner and asserts the repo is scaffolded at the path with the project name derived from the basename.
- Verified the name-derivation + validation logic against the reporter's case and edge cases (`/tmp/test` → `test`; `my/sub/dir` → `dir`; `/tmp/_bad` still rejected; explicit `--repo-path` unchanged).

Note: I couldn't run the full test suite locally — `import feast` fails on my machine due to a `pyarrow` `_substrait` DLL being blocked by an OS Application-Control policy (unrelated to this change). The validation/derivation logic is small and pure, and the added regression test exercises the end-to-end CLI path in CI.
