### PR TITLE
fix: Reuse the OIDC JWKS client across requests

### DIFF
--- a/docs/getting-started/components/authz_manager.md
+++ b/docs/getting-started/components/authz_manager.md
@@ -122,6 +122,19 @@ A token whose `aud` (or `iss`) claim does not match is rejected at authenticatio
 Set these to the values your IdP puts **in the token itself**, which are not always the ones in the discovery document. For example, Microsoft Entra ID commonly issues v1.0 tokens (`iss: https://sts.windows.net/<tenant-id>/`, `aud: api://<app-id-uri>`) even when `auth_discovery_url` points at the v2.0 endpoint. That setup keeps working with these options unset, or set to the v1.0 values — but copying the v2.0 issuer from the discovery document would reject every v1.0 token.
 {% endhint %}
 
+To validate token signatures the server fetches the provider's JWKS document and caches it, refetching when the cache expires or when a token presents an unknown key id. Two options tune that behavior:
+
+```yaml
+auth:
+  type: oidc
+  client_id: _CLIENT_ID_
+  auth_discovery_url: https://login.example.com/.well-known/openid-configuration
+  jwks_cache_lifespan_seconds: 300   # default; how long the fetched key set is reused
+  jwks_request_timeout_seconds: 10   # default; network timeout for the JWKS fetch
+```
+
+`jwks_cache_lifespan_seconds` also bounds how long a key the provider has **revoked** continues to validate tokens, so lower it if your provider rotates or revokes aggressively; each reduction costs proportionally more JWKS fetches. Key rotations that introduce a new key id are picked up immediately regardless of this setting, because an unknown key id triggers a refetch. `jwks_request_timeout_seconds` bounds how long an unresponsive provider can block request serving. Both must be greater than zero.
+
 #### Client-Side Configuration
 
 The client supports multiple token source modes. The SDK resolves tokens in the following priority order:

--- a/pixi.lock
+++ b/pixi.lock
@@ -2353,7 +2353,7 @@ packages:
   - prometheus-client>=0.20.0,<0.25.0
   - psutil
   - bigtree>=0.19.2
-  - pyjwt
+  - pyjwt>=2.13.0
   - aerospike>=19.0.0,<20.0.0 ; extra == 'aerospike'
   - boto3>=1.38.27 ; extra == 'aws'
   - fsspec>=2024.1.0 ; extra == 'aws'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,9 @@ dependencies = [
     "prometheus_client>=0.20.0,<0.25.0",
     "psutil",
     "bigtree>=0.19.2",
-    "pyjwt",
+    # >=2.13 for PyJWKClient's JWK-set cache surviving transient fetch
+    # failures; the OIDC token parser reuses one client and relies on it.
+    "pyjwt>=2.13.0",
 ]
 
 [project.optional-dependencies]

--- a/sdk/python/feast/permissions/auth/oidc_token_parser.py
+++ b/sdk/python/feast/permissions/auth/oidc_token_parser.py
@@ -41,6 +41,34 @@ class OidcTokenParser(TokenParser):
             ca_cert_path=self._auth_config.ca_cert_path,
         )
         self._k8s_auth_api = None
+        self._jwks_client: Optional[PyJWKClient] = None  # Initialize it lazily.
+
+    def _get_jwks_client(self) -> PyJWKClient:
+        """Lazily build and cache a parser-lifetime ``PyJWKClient``.
+
+        A per-request client starts with a cold JWK-set cache, so every
+        authenticated request pays a full HTTPS fetch of the JWKS document
+        (TLS handshake included) before signature verification, and
+        concurrent requests serialize behind that blocking I/O. Reusing one
+        client lets PyJWT's built-in JWK-set cache do its job; on IdP key
+        rotation the client refetches automatically when it sees an unknown
+        ``kid`` (``PyJWKClient.get_signing_key`` refreshes and retries once).
+        """
+        if self._jwks_client is None:
+            ssl_ctx = ssl.create_default_context()
+            if not self._auth_config.verify_ssl:
+                ssl_ctx.check_hostname = False
+                ssl_ctx.verify_mode = ssl.CERT_NONE
+            elif self._auth_config.ca_cert_path and os.path.exists(
+                self._auth_config.ca_cert_path
+            ):
+                ssl_ctx.load_verify_locations(self._auth_config.ca_cert_path)
+            self._jwks_client = PyJWKClient(
+                self.oidc_discovery_service.get_jwks_url(),
+                headers={"User-agent": "custom-user-agent"},
+                ssl_context=ssl_ctx,
+            )
+        return self._jwks_client
 
     async def _validate_token(self, access_token: str):
         """
@@ -125,21 +153,7 @@ class OidcTokenParser(TokenParser):
         metadata (e.g. Entra ID v1.0 tokens validated against a v2.0
         discovery document).
         """
-        optional_custom_headers = {"User-agent": "custom-user-agent"}
-        ssl_ctx = ssl.create_default_context()
-        if not self._auth_config.verify_ssl:
-            ssl_ctx.check_hostname = False
-            ssl_ctx.verify_mode = ssl.CERT_NONE
-        elif self._auth_config.ca_cert_path and os.path.exists(
-            self._auth_config.ca_cert_path
-        ):
-            ssl_ctx.load_verify_locations(self._auth_config.ca_cert_path)
-        jwks_client = PyJWKClient(
-            self.oidc_discovery_service.get_jwks_url(),
-            headers=optional_custom_headers,
-            ssl_context=ssl_ctx,
-        )
-        signing_key = jwks_client.get_signing_key_from_jwt(access_token)
+        signing_key = self._get_jwks_client().get_signing_key_from_jwt(access_token)
         expected_audience = self._auth_config.audience
         expected_issuer = self._auth_config.issuer
         return jwt.decode(

--- a/sdk/python/feast/permissions/auth/oidc_token_parser.py
+++ b/sdk/python/feast/permissions/auth/oidc_token_parser.py
@@ -49,12 +49,12 @@ class OidcTokenParser(TokenParser):
         A per-request client starts with a cold JWK-set cache, forcing a
         full HTTPS fetch of the JWKS document on every authenticated
         request. Reusing one client lets PyJWT cache the JWK set for
-        ``lifespan`` seconds, which also bounds two staleness windows: a
-        key the IdP has removed keeps validating, and a rotation that
-        reuses an existing ``kid`` keeps failing, for at most that long.
-        Rotations that introduce a new ``kid`` recover immediately
-        (``PyJWKClient.get_signing_key`` refreshes and retries once on a
-        cache miss).
+        ``jwks_cache_lifespan_seconds``, which also bounds two staleness
+        windows: a key the IdP has removed keeps validating, and a
+        rotation that reuses an existing ``kid`` keeps failing, for at
+        most that long. Rotations that introduce a new ``kid`` recover
+        immediately (``PyJWKClient.get_signing_key`` refreshes and
+        retries once on a cache miss).
         """
         if self._jwks_client is None:
             ssl_ctx = ssl.create_default_context()
@@ -72,8 +72,8 @@ class OidcTokenParser(TokenParser):
                 # Explicit so upgrades cannot silently change the staleness
                 # window documented above, and so a hung IdP bounds how long
                 # a fetch can block the serving path.
-                lifespan=300,
-                timeout=10,
+                lifespan=self._auth_config.jwks_cache_lifespan_seconds,
+                timeout=self._auth_config.jwks_request_timeout_seconds,
             )
         return self._jwks_client
 

--- a/sdk/python/feast/permissions/auth/oidc_token_parser.py
+++ b/sdk/python/feast/permissions/auth/oidc_token_parser.py
@@ -46,13 +46,15 @@ class OidcTokenParser(TokenParser):
     def _get_jwks_client(self) -> PyJWKClient:
         """Lazily build and cache a parser-lifetime ``PyJWKClient``.
 
-        A per-request client starts with a cold JWK-set cache, so every
-        authenticated request pays a full HTTPS fetch of the JWKS document
-        (TLS handshake included) before signature verification, and
-        concurrent requests serialize behind that blocking I/O. Reusing one
-        client lets PyJWT's built-in JWK-set cache do its job; on IdP key
-        rotation the client refetches automatically when it sees an unknown
-        ``kid`` (``PyJWKClient.get_signing_key`` refreshes and retries once).
+        A per-request client starts with a cold JWK-set cache, forcing a
+        full HTTPS fetch of the JWKS document on every authenticated
+        request. Reusing one client lets PyJWT cache the JWK set for
+        ``lifespan`` seconds, which also bounds two staleness windows: a
+        key the IdP has removed keeps validating, and a rotation that
+        reuses an existing ``kid`` keeps failing, for at most that long.
+        Rotations that introduce a new ``kid`` recover immediately
+        (``PyJWKClient.get_signing_key`` refreshes and retries once on a
+        cache miss).
         """
         if self._jwks_client is None:
             ssl_ctx = ssl.create_default_context()
@@ -67,6 +69,11 @@ class OidcTokenParser(TokenParser):
                 self.oidc_discovery_service.get_jwks_url(),
                 headers={"User-agent": "custom-user-agent"},
                 ssl_context=ssl_ctx,
+                # Explicit so upgrades cannot silently change the staleness
+                # window documented above, and so a hung IdP bounds how long
+                # a fetch can block the serving path.
+                lifespan=300,
+                timeout=10,
             )
         return self._jwks_client
 

--- a/sdk/python/feast/permissions/auth_model.py
+++ b/sdk/python/feast/permissions/auth_model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal, Optional, Tuple
 
-from pydantic import ConfigDict, model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from feast.repo_config import FeastConfigBaseModel
 
@@ -47,6 +47,15 @@ class OidcAuthConfig(AuthConfig):
     # against a v2.0 discovery URL).
     audience: Optional[str] = None
     issuer: Optional[str] = None
+    # How long the fetched JWK set is reused before the server refetches it.
+    # This also bounds how long a key the IdP has revoked keeps validating
+    # tokens, so lower it if your provider rotates or revokes aggressively;
+    # every reduction costs a corresponding increase in JWKS fetches.
+    jwks_cache_lifespan_seconds: int = Field(default=300, gt=0)
+    # Network timeout for the JWKS fetch. This fetch happens inline on the
+    # request path, so an unresponsive IdP blocks serving for at most this
+    # long.
+    jwks_request_timeout_seconds: float = Field(default=10, gt=0)
 
 
 class OidcClientAuthConfig(OidcAuthConfig):

--- a/sdk/python/tests/unit/permissions/auth/test_token_parser.py
+++ b/sdk/python/tests/unit/permissions/auth/test_token_parser.py
@@ -671,6 +671,38 @@ def test_oidc_default_supports_v1_tokens_against_v2_discovery(
         assertpy.assert_that(user.roles).is_equal_to(["reader"])
 
 
+@patch(
+    "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
+)
+@patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
+@patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
+@patch("feast.permissions.auth.oidc_token_parser.PyJWKClient")
+def test_oidc_jwks_client_is_reused_across_requests(
+    mock_jwks_client_cls,
+    mock_discovery_data,
+    mock_jwt,
+    mock_oauth2,
+    oidc_config,
+    discovery_data,
+):
+    """The JWKS client must be built once per parser, not once per request:
+    a fresh client starts with a cold JWK-set cache, which forces a full
+    HTTPS fetch of the JWKS document on every authenticated call."""
+    mock_discovery_data.return_value = discovery_data
+    mock_jwt.return_value = {"preferred_username": "my-name"}
+
+    token_parser = OidcTokenParser(auth_config=oidc_config)
+    for _ in range(3):
+        asyncio.run(
+            token_parser.user_details_from_access_token(access_token="aaa-bbb-ccc")
+        )
+
+    assertpy.assert_that(mock_jwks_client_cls.call_count).is_equal_to(1)
+    assertpy.assert_that(
+        mock_jwks_client_cls.return_value.get_signing_key_from_jwt.call_count
+    ).is_equal_to(3)
+
+
 # TODO RBAC: Move role bindings to a reusable fixture
 @patch("feast.permissions.auth.kubernetes_token_parser.config.load_incluster_config")
 @patch("feast.permissions.auth.kubernetes_token_parser.jwt.decode")

--- a/sdk/python/tests/unit/permissions/auth/test_token_parser.py
+++ b/sdk/python/tests/unit/permissions/auth/test_token_parser.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import assertpy
 import jwt
 import pytest
+from pydantic import ValidationError
 from starlette.authentication import (
     AuthenticationError,
 )
@@ -547,6 +548,67 @@ def test_oidc_jwks_client_ssl_context_follows_config(
     else:
         assertpy.assert_that(ssl_ctx.verify_mode).is_equal_to(ssl.CERT_NONE)
         assertpy.assert_that(ssl_ctx.check_hostname).is_false()
+
+
+@pytest.mark.parametrize(
+    "overrides,expected_lifespan,expected_timeout",
+    [
+        ({}, 300, 10),
+        (
+            {
+                "jwks_cache_lifespan_seconds": 60,
+                "jwks_request_timeout_seconds": 2.5,
+            },
+            60,
+            2.5,
+        ),
+    ],
+)
+@patch(
+    "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
+)
+@patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
+@patch("feast.permissions.auth.oidc_token_parser.PyJWKClient")
+@patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
+def test_oidc_jwks_client_cache_and_timeout_follow_config(
+    mock_discovery_data,
+    mock_jwks_client_cls,
+    mock_jwt,
+    mock_oauth2,
+    overrides,
+    expected_lifespan,
+    expected_timeout,
+    discovery_data,
+):
+    """The JWK-set cache lifespan and the fetch timeout are operator-tunable:
+    the lifespan bounds how long a revoked key keeps validating, and the
+    timeout bounds how long an unresponsive IdP blocks the serving path."""
+    mock_discovery_data.return_value = discovery_data
+    mock_jwt.return_value = {"preferred_username": "my-name"}
+
+    token_parser = OidcTokenParser(auth_config=_oidc_config_with(**overrides))
+    asyncio.run(token_parser.user_details_from_access_token(access_token="aaa-bbb-ccc"))
+
+    kwargs = mock_jwks_client_cls.call_args.kwargs
+    assertpy.assert_that(kwargs["lifespan"]).is_equal_to(expected_lifespan)
+    assertpy.assert_that(kwargs["timeout"]).is_equal_to(expected_timeout)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"jwks_cache_lifespan_seconds": 0},
+        {"jwks_cache_lifespan_seconds": -1},
+        {"jwks_request_timeout_seconds": 0},
+        {"jwks_request_timeout_seconds": -1},
+    ],
+)
+def test_oidc_jwks_tunables_reject_non_positive_values(overrides):
+    """A non-positive lifespan would expire the cache immediately, silently
+    restoring a JWKS fetch per request; a non-positive timeout is equally
+    meaningless. Reject both at config load rather than at serving time."""
+    with pytest.raises(ValidationError):
+        _oidc_config_with(**overrides)
 
 
 @patch(

--- a/sdk/python/tests/unit/permissions/auth/test_token_parser.py
+++ b/sdk/python/tests/unit/permissions/auth/test_token_parser.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import ssl
 import time
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -473,6 +474,116 @@ def test_oidc_inter_server_comm(
 
 
 # ---------------------------------------------------------------------------
+# JWKS client lifecycle (one lazy client per parser)
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
+)
+@patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
+@patch("feast.permissions.auth.oidc_token_parser.PyJWKClient")
+@patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
+def test_oidc_jwks_client_is_lazy_and_reused_per_parser(
+    mock_discovery_data,
+    mock_jwks_client_cls,
+    mock_jwt,
+    mock_oauth2,
+    oidc_config,
+    discovery_data,
+):
+    """One JWKS client per parser: built on the first request (not at
+    construction, which would move a blocking discovery fetch into server
+    startup), reused across requests, and scoped to the parser instance."""
+    mock_discovery_data.return_value = discovery_data
+    mock_jwt.return_value = {"preferred_username": "my-name"}
+
+    token_parser = OidcTokenParser(auth_config=oidc_config)
+    assertpy.assert_that(mock_jwks_client_cls.call_count).is_equal_to(0)
+
+    for _ in range(3):
+        asyncio.run(
+            token_parser.user_details_from_access_token(access_token="aaa-bbb-ccc")
+        )
+    assertpy.assert_that(mock_jwks_client_cls.call_count).is_equal_to(1)
+
+    # A second parser must not see the first parser's client: each parser
+    # verifies against the JWKS of its own configured provider.
+    other_parser = OidcTokenParser(auth_config=oidc_config)
+    asyncio.run(other_parser.user_details_from_access_token(access_token="aaa-bbb-ccc"))
+    assertpy.assert_that(mock_jwks_client_cls.call_count).is_equal_to(2)
+
+
+@pytest.mark.parametrize("verify_ssl", [True, False])
+@patch(
+    "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
+)
+@patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
+@patch("feast.permissions.auth.oidc_token_parser.PyJWKClient")
+@patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
+def test_oidc_jwks_client_ssl_context_follows_config(
+    mock_discovery_data,
+    mock_jwks_client_cls,
+    mock_jwt,
+    mock_oauth2,
+    verify_ssl,
+    discovery_data,
+):
+    """The client is built with the discovery JWKS URL and an SSL context
+    matching verify_ssl: default configs must keep certificate verification
+    on, and verify_ssl=False must be the only way to turn it off."""
+    mock_discovery_data.return_value = discovery_data
+    mock_jwt.return_value = {"preferred_username": "my-name"}
+
+    token_parser = OidcTokenParser(auth_config=_oidc_config_with(verify_ssl=verify_ssl))
+    asyncio.run(token_parser.user_details_from_access_token(access_token="aaa-bbb-ccc"))
+
+    call = mock_jwks_client_cls.call_args
+    assertpy.assert_that(call.args[0]).is_equal_to(discovery_data["jwks_uri"])
+    ssl_ctx = call.kwargs["ssl_context"]
+    if verify_ssl:
+        assertpy.assert_that(ssl_ctx.verify_mode).is_equal_to(ssl.CERT_REQUIRED)
+        assertpy.assert_that(ssl_ctx.check_hostname).is_true()
+    else:
+        assertpy.assert_that(ssl_ctx.verify_mode).is_equal_to(ssl.CERT_NONE)
+        assertpy.assert_that(ssl_ctx.check_hostname).is_false()
+
+
+@patch(
+    "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
+)
+@patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
+@patch("feast.permissions.auth.oidc_token_parser.PyJWKClient")
+@patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
+def test_oidc_jwks_client_construction_failure_is_retried(
+    mock_discovery_data,
+    mock_jwks_client_cls,
+    mock_jwt,
+    mock_oauth2,
+    oidc_config,
+    discovery_data,
+):
+    """A failed first construction must leave the parser able to retry on
+    the next request: the parser is a process singleton, so caching a failed
+    or half-built client would wedge authentication until restart."""
+    mock_discovery_data.return_value = discovery_data
+    mock_jwt.return_value = {"preferred_username": "my-name"}
+    mock_jwks_client_cls.side_effect = [RuntimeError("IdP unreachable"), MagicMock()]
+
+    token_parser = OidcTokenParser(auth_config=oidc_config)
+    with pytest.raises(RuntimeError):
+        asyncio.run(
+            token_parser.user_details_from_access_token(access_token="aaa-bbb-ccc")
+        )
+
+    user = asyncio.run(
+        token_parser.user_details_from_access_token(access_token="aaa-bbb-ccc")
+    )
+    assertpy.assert_that(user.username).is_equal_to("my-name")
+    assertpy.assert_that(mock_jwks_client_cls.call_count).is_equal_to(2)
+
+
+# ---------------------------------------------------------------------------
 # Optional audience / issuer verification (opt-in via OidcAuthConfig)
 # ---------------------------------------------------------------------------
 
@@ -669,38 +780,6 @@ def test_oidc_default_supports_v1_tokens_against_v2_discovery(
     if isinstance(user, User):
         assertpy.assert_that(user.username).is_equal_to("client-app-id")
         assertpy.assert_that(user.roles).is_equal_to(["reader"])
-
-
-@patch(
-    "feast.permissions.auth.oidc_token_parser.OAuth2AuthorizationCodeBearer.__call__"
-)
-@patch("feast.permissions.auth.oidc_token_parser.jwt.decode")
-@patch("feast.permissions.oidc_service.OIDCDiscoveryService._fetch_discovery_data")
-@patch("feast.permissions.auth.oidc_token_parser.PyJWKClient")
-def test_oidc_jwks_client_is_reused_across_requests(
-    mock_jwks_client_cls,
-    mock_discovery_data,
-    mock_jwt,
-    mock_oauth2,
-    oidc_config,
-    discovery_data,
-):
-    """The JWKS client must be built once per parser, not once per request:
-    a fresh client starts with a cold JWK-set cache, which forces a full
-    HTTPS fetch of the JWKS document on every authenticated call."""
-    mock_discovery_data.return_value = discovery_data
-    mock_jwt.return_value = {"preferred_username": "my-name"}
-
-    token_parser = OidcTokenParser(auth_config=oidc_config)
-    for _ in range(3):
-        asyncio.run(
-            token_parser.user_details_from_access_token(access_token="aaa-bbb-ccc")
-        )
-
-    assertpy.assert_that(mock_jwks_client_cls.call_count).is_equal_to(1)
-    assertpy.assert_that(
-        mock_jwks_client_cls.return_value.get_signing_key_from_jwt.call_count
-    ).is_equal_to(3)
 
 
 # TODO RBAC: Move role bindings to a reusable fixture


### PR DESCRIPTION
# What this PR does / why we need it

`OidcTokenParser._decode_token` builds a fresh `PyJWKClient` on every call. The JWK-set cache lives on the instance, so every authenticated request starts cold and pays a full HTTPS fetch of the JWKS document (TLS handshake included) before signature verification. On a production-shaped deployment that fetch measured 124-196 ms against the IdP, dominating single-entity online reads (server-side p50 247 ms while the online store idled), and because it's blocking I/O on the event loop, concurrent requests serialize behind it: 3 parallel readers measured an exact 3x of single-request latency, and 10 produced load-balancer 502s from a healthy process.

The fix builds the client lazily once per parser (the parser is a process singleton created by `init_auth_manager`), letting PyJWT's JWK-set cache work. Reproducible benchmark against a counting mock JWKS endpoint with real RS256 tokens: 25 authenticated decodes performed 25 JWKS fetches before, 1 after.

Details worth reviewer attention:

- `pyjwt` now has a `>=2.13.0` floor: the reuse makes PyJWT's cache semantics load-bearing, and only 2.13+ keeps the cache through transient fetch failures (2.5-2.12 wipe it on one failed fetch; pre-2.5 has no cache at all, silently reverting the fix). The lockfiles already resolve 2.13.0, so no lock changes.
- `lifespan=300` and `timeout=10` are passed explicitly so upgrades can't silently change behavior. The lifespan bounds two staleness windows that were zero with per-request clients and are documented in the code: a key the IdP removed keeps validating, and a rotation that reuses a `kid` keeps failing, each for at most 300 s. Rotations that mint a new `kid` (the common case) recover immediately because `PyJWKClient.get_signing_key` refreshes and retries on a cache miss.
- Tests pin the behaviors a refactor could silently break: client built with the right JWKS URL and an SSL context matching `verify_ssl` (mutation testing showed the SSL branch previously had zero coverage), laziness (no construction before the first request, keeping the blocking discovery fetch out of server boot), per-parser scoping, reuse across requests, and recovery after a failed first construction (the parser is a process singleton, so a wedged client would require a restart).

Known accepted residuals, for transparency: on the threaded Arrow Flight server a cold-start burst can still build the client more than once (benign, self-heals, and PyJWT's own cold-fetch path has the same property); PyJWT's JWK-set cache is unlocked so simultaneous expiry can trigger redundant refetches (bounded by concurrency). Both are strictly better than the guaranteed fetch-per-request they replace. The client-side token fetch (`client_secret` flow) has the same per-request pattern and is a natural follow-up.

To be precise about the concurrency claim: this removes the accidental serialization behind per-request network I/O; it does not add parallelism to the server.

Testing: 311 permissions unit tests pass (including the new lifecycle tests); full unit suite green (2488 passed); ruff and mypy clean.

# Which issue(s) this PR fixes

Fixes #6682
