### PR TITLE
feat: Set S3 registry user agent, document endpoint override

### DIFF
--- a/docs/reference/registries/s3.md
+++ b/docs/reference/registries/s3.md
@@ -21,3 +21,13 @@ offline_store:
   type: dask
 ```
 {% endcode %}
+
+## S3-compatible object stores
+
+The `FEAST_S3_ENDPOINT_URL` environment variable overrides the endpoint the registry store connects to. Leave it unset to use Amazon S3, or set it to point the registry at an S3-compatible object store such as Backblaze B2, Cloudflare R2, or MinIO:
+
+```bash
+export FEAST_S3_ENDPOINT_URL=https://s3.example-region.example.com
+```
+
+`registry.path` keeps its `s3://` form. Credentials are resolved by boto3 as usual, so `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` hold the credentials for that store and `AWS_DEFAULT_REGION` its region.

--- a/sdk/python/feast/infra/registry/s3.py
+++ b/sdk/python/feast/infra/registry/s3.py
@@ -10,10 +10,11 @@ from feast.errors import S3RegistryBucketForbiddenAccess, S3RegistryBucketNotExi
 from feast.infra.registry.registry_store import RegistryStore
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.repo_config import RegistryConfig
-from feast.utils import _utc_now
+from feast.utils import _utc_now, get_user_agent
 
 try:
     import boto3
+    from botocore.config import Config
 except ImportError as e:
     from feast.errors import FeastExtrasDependencyImportError
 
@@ -29,7 +30,9 @@ class S3RegistryStore(RegistryStore):
         self._boto_extra_args = registry_config.s3_additional_kwargs or {}
 
         self.s3_client = boto3.resource(
-            "s3", endpoint_url=os.environ.get("FEAST_S3_ENDPOINT_URL")
+            "s3",
+            endpoint_url=os.environ.get("FEAST_S3_ENDPOINT_URL"),
+            config=Config(user_agent_extra=get_user_agent()),
         )
 
     def get_registry_proto(self):


### PR DESCRIPTION
# What this PR does / why we need it:

`S3RegistryStore` already reads `FEAST_S3_ENDPOINT_URL` and hands it to boto3, so the registry can live on an S3-compatible object store, but the variable is not mentioned anywhere in the registry reference docs. The repo already depends on it in practice (`examples/python-helm-demo/minio.env`, the Helm example's Kubernetes env patch, and the MinIO container in `test_universal_registry.py`), so this adds a short section to `docs/reference/registries/s3.md` covering the variable and the credentials boto3 resolves alongside it.

It also sets the Feast user agent on the S3 registry's boto3 client. Feast already tags its BigQuery, Datastore, DynamoDB, Redshift and Athena clients with `get_user_agent()`, and the S3 registry client was the remaining gap. This passes it as `user_agent_extra` rather than `user_agent` so the Feast tag is appended to botocore's default string instead of replacing it, which keeps the botocore, OS and Python metadata intact:

```
Boto3/1.43.22 md/Botocore#1.43.22 ua/2.1 os/macos#25.6.0 md/arch#arm64 lang/python#3.11.15 md/pyimpl#CPython m/N,g Botocore/1.43.22 feast-dev/feast/0.65.0
```

The tag reuses the existing `feast.utils.get_user_agent()` helper, whose version already resolves from package metadata with an `"unknown"` fallback. No new config keys, no new dependencies, and no behavior change for existing users.

# Which issue(s) this PR fixes:

None.

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Testing is not required for this change

# Misc

`ruff check` and `ruff format --check` are clean on `sdk/python/feast/infra/registry/s3.py`, and `mypy feast/infra/registry/s3.py` reports nothing in that file.

I ran `tests/unit/test_registry_string_config.py`, the only unit file that references `S3RegistryStore`, and `test_s3_scheme_selects_s3_registry_store` passes. The other failures in that file come from a missing optional `redis` extra in my environment and reproduce identically on a clean `master`, so they are unrelated to this change.

I also confirmed by hand that `S3RegistryStore` still honors `FEAST_S3_ENDPOINT_URL` and that the resolved user agent keeps botocore's default prefix with `feast-dev/feast/<version>` appended (the string quoted above). Happy to split the docs and client changes into separate PRs, or to switch to `user_agent=` for consistency with the other clients, if you'd prefer either.