### PR TITLE
docs: Correct what _validate_token claims to do

### DIFF
--- a/sdk/python/feast/permissions/auth/oidc_token_parser.py
+++ b/sdk/python/feast/permissions/auth/oidc_token_parser.py
@@ -43,8 +43,17 @@ class OidcTokenParser(TokenParser):
         self._k8s_auth_api = None
 
     async def _validate_token(self, access_token: str):
-        """
-        Validate the token extracted from the header of the user request against the OAuth2 server.
+        """Check that the provider's discovery document exposes the OAuth2 endpoints.
+
+        This does **not** verify *access_token*, despite taking it: the bearer
+        scheme below only parses an ``Authorization`` header, and this method
+        supplies that header itself, so any token value passes. The token is
+        genuinely verified in ``_decode_token``, which checks the signature
+        against the provider's JWKS and validates the claims.
+
+        What can fail here is constructing the scheme, which reads the token
+        and authorization endpoints from the discovery document. A document
+        missing either one raises before any token is inspected.
         """
         # FastAPI's OAuth2AuthorizationCodeBearer requires a Request type but actually uses only the headers field
         # https://github.com/tiangolo/fastapi/blob/eca465f4c96acc5f6a22e92fd2211675ca8a20c8/fastapi/security/oauth2.py#L380
@@ -198,7 +207,7 @@ class OidcTokenParser(TokenParser):
         # Standard OIDC / Keycloak flow
         try:
             await self._validate_token(access_token)
-            logger.debug("Token successfully validated.")
+            logger.debug("OIDC discovery document exposes the expected endpoints.")
         except Exception as e:
             if self._is_ssl_error(e):
                 logger.error(

--- a/sdk/python/feast/permissions/auth/oidc_token_parser.py
+++ b/sdk/python/feast/permissions/auth/oidc_token_parser.py
@@ -77,7 +77,7 @@ class OidcTokenParser(TokenParser):
             )
         return self._jwks_client
 
-    async def _validate_token(self, access_token: str):
+    async def _check_discovery_endpoints(self, access_token: str):
         """Check that the provider's discovery document exposes the OAuth2 endpoints.
 
         This does **not** verify *access_token*, despite taking it: the bearer
@@ -227,7 +227,7 @@ class OidcTokenParser(TokenParser):
 
         # Standard OIDC / Keycloak flow
         try:
-            await self._validate_token(access_token)
+            await self._check_discovery_endpoints(access_token)
             logger.debug("OIDC discovery document exposes the expected endpoints.")
         except Exception as e:
             if self._is_ssl_error(e):

--- a/sdk/python/feast/permissions/auth/oidc_token_parser.py
+++ b/sdk/python/feast/permissions/auth/oidc_token_parser.py
@@ -78,8 +78,17 @@ class OidcTokenParser(TokenParser):
         return self._jwks_client
 
     async def _validate_token(self, access_token: str):
-        """
-        Validate the token extracted from the header of the user request against the OAuth2 server.
+        """Check that the provider's discovery document exposes the OAuth2 endpoints.
+
+        This does **not** verify *access_token*, despite taking it: the bearer
+        scheme below only parses an ``Authorization`` header, and this method
+        supplies that header itself, so any token value passes. The token is
+        genuinely verified in ``_decode_token``, which checks the signature
+        against the provider's JWKS and validates the claims.
+
+        What can fail here is constructing the scheme, which reads the token
+        and authorization endpoints from the discovery document. A document
+        missing either one raises before any token is inspected.
         """
         # FastAPI's OAuth2AuthorizationCodeBearer requires a Request type but actually uses only the headers field
         # https://github.com/tiangolo/fastapi/blob/eca465f4c96acc5f6a22e92fd2211675ca8a20c8/fastapi/security/oauth2.py#L380
@@ -219,7 +228,7 @@ class OidcTokenParser(TokenParser):
         # Standard OIDC / Keycloak flow
         try:
             await self._validate_token(access_token)
-            logger.debug("Token successfully validated.")
+            logger.debug("OIDC discovery document exposes the expected endpoints.")
         except Exception as e:
             if self._is_ssl_error(e):
                 logger.error(


### PR DESCRIPTION
# What this PR does / why we need it

`OidcTokenParser._validate_token` is named validate, its docstring says it validates the token against the OAuth2 server, and the caller logs "Token successfully validated" afterwards. None of that is accurate. The bearer scheme only parses an `Authorization` header, and the method constructs that header itself from the token it was handed, so every value passes. Verified against fastapi 0.139.2: the empty string, whitespace, and arbitrary garbage are all accepted.

The token is genuinely verified a few lines later in `_decode_token`, which fetches the JWKS signing key and validates the signature and claims. So authentication is sound. The problem is that anyone auditing this path reads a verification step that does not exist, and a debug log that confirms it.

This changes the docstring to describe what the call actually checks (that the discovery document exposes the OAuth2 endpoints, which is the only thing that can make it fail) and changes the log line to match.

No behavior change: docstring and one log string only. Existing tests pass unmodified.

Whether the call should exist at all is a separate question, asked in #6688, since removing it would change behavior for providers whose discovery document omits a token endpoint. This PR deliberately does not pre-empt that answer.

# Which issue(s) this PR fixes

Relates to #6688
