### PR TITLE
docs: Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+The Feast community takes security bugs seriously, and we appreciate the effort it takes to find and report them. We follow [GitHub's coordinated disclosure process](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/about-coordinated-disclosure-of-security-vulnerabilities) so that a fix can be prepared before details become public.
+
+## Reporting a vulnerability
+
+Report vulnerabilities privately through GitHub, using **[Report a vulnerability](https://github.com/feast-dev/feast/security/advisories/new)** on this repository's Security tab. Only the maintainers can see the report, and you will be credited on the published advisory if you would like to be.
+
+Please include enough detail to reproduce the issue: the affected version or commit, the configuration involved, and the steps or proof of concept that demonstrate the impact.
+
+> [!WARNING]
+> Do not open a public GitHub issue, pull request, or Slack message for a security vulnerability. Those are visible to everyone and disclose the problem before a fix exists.
+
+For anything that is not a vulnerability, including hardening suggestions and questions about how Feast's authentication and authorization work, a normal [GitHub issue](https://github.com/feast-dev/feast/issues) is the right place.
+
+## Supported versions
+
+Security fixes are applied to the latest release. Feast releases roughly monthly and offers best-effort community support, as described in the [versioning policy](docs/project/versioning-policy.md); there is no long-term support branch, so upgrading to the current release is the supported way to receive a fix.
+
+## Published advisories
+
+Past advisories for this project are listed under [Security advisories](https://github.com/feast-dev/feast/security/advisories).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,15 @@ The Feast community takes security bugs seriously, and we appreciate the effort 
 
 Report vulnerabilities privately through GitHub, using **[Report a vulnerability](https://github.com/feast-dev/feast/security/advisories/new)** on this repository's Security tab. Only the maintainers can see the report, and you will be credited on the published advisory if you would like to be.
 
-Please include enough detail to reproduce the issue: the affected version or commit, the configuration involved, and the steps or proof of concept that demonstrate the impact.
+Before reporting, please check the [published advisories](https://github.com/feast-dev/feast/security/advisories) to confirm the issue has not already been addressed.
+
+A report needs to show a clear, reproducible security impact. Please include:
+
+- the affected version or commit, and the configuration involved
+- a proof of concept, or steps that reproduce the issue
+- the actual impact, rather than a theoretical concern
+
+Raw scanner or dependency-audit output does not meet that bar on its own, since it does not establish that the issue is reachable in Feast. Reports that have not been manually verified against Feast, including bulk, automated, or AI-generated submissions, may be closed without further response.
 
 > [!WARNING]
 > Do not open a public GitHub issue, pull request, or Slack message for a security vulnerability. Those are visible to everyone and disclose the problem before a fix exists.

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -5,6 +5,8 @@ After familiarizing yourself with the documentation, the simplest way to get sta
 1. Setup your developer environment by following [development guide](development-guide.md). 
 2. Either create a [GitHub issue](https://github.com/feast-dev/feast/issues) or make a draft PR (following [development guide](development-guide.md)) to get the ball rolling!
 
+> **Reporting a security vulnerability?** Do not open an issue or PR. Report it privately through [GitHub's advisory form](https://github.com/feast-dev/feast/security/advisories/new); see the [security policy](https://github.com/feast-dev/feast/blob/master/SECURITY.md).
+
 ## Decision making process
 *See [governance](../../community/governance.md) for more details here*
 


### PR DESCRIPTION
# What this PR does / why we need it

Adds a `SECURITY.md` so the vulnerability reporting path is discoverable.

Private vulnerability reporting is already enabled on this repository and in active use (CVE-2026-55563, published in June, credits an outside reporter). But there is no policy file in the repo root, `.github/`, `docs/`, or the org-level `feast-dev/.github` repo, and neither the README nor the contributing guide mentions security reporting. Without a policy file GitHub only surfaces the option on the Security tab, so a reporter has to already know to look there.

The policy routes to the advisory form, states plainly that vulnerabilities must not go in issues, PRs, or Slack, and notes that fixes land in the latest release, consistent with the versioning policy's best-effort community support and no LTS branch.

This also adds one line to the contributing guide's getting-started step, which currently directs everything to "create a GitHub issue or make a draft PR". That is exactly the advice that misfires for a vulnerability report.

Deliberately omitted: any response-time commitment, triage roster, or contact email. Those are the maintainers' to make rather than mine to assert, and #3684 records a mailing list address that turned out to bounce, so an address seems worth confirming before publishing one. Happy to add any of it if you would like it included.

# Which issue(s) this PR fixes

Fixes #6691
