### PR TITLE
fix: Resolve write_to_offline_store feature view with a single registry lookup

### DIFF
--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -3647,20 +3647,19 @@ class FeatureStore:
         Fails if the dataframe columns do not match the columns of the batch data source. Optionally
         reorders the columns of the dataframe to match.
         """
-        # TODO: restrict this to work with online StreamFeatureViews and validate the FeatureView type
-        try:
-            feature_view: FeatureView = self.get_stream_feature_view(
-                feature_view_name, allow_registry_cache=allow_registry_cache
-            )
-        except FeatureViewNotFoundException:
-            try:
-                feature_view = self.get_feature_view(
-                    feature_view_name, allow_registry_cache=allow_registry_cache
-                )
-            except FeatureViewNotFoundException:
-                feature_view = self.get_label_view(  # type: ignore[assignment]
-                    feature_view_name, allow_registry_cache=allow_registry_cache
-                )
+        # Resolve the feature view with a single registry lookup regardless of its
+        # type. The previous try/except chain tried get_stream_feature_view, then
+        # get_feature_view, then get_label_view in turn, so the common plain
+        # FeatureView always paid one guaranteed-miss lookup first. On a
+        # RemoteRegistry each miss is a wasted gRPC round-trip on this per-batch
+        # write path (see #6671).
+        # TODO: validate that the resolved feature view type supports offline writes.
+        feature_view = cast(
+            FeatureView,
+            self.registry.get_any_feature_view(
+                feature_view_name, self.project, allow_cache=allow_registry_cache
+            ),
+        )
 
         provider = self._get_provider()
         # Get columns of the batch source and the input dataframe.

--- a/sdk/python/feast/feature_store.py
+++ b/sdk/python/feast/feature_store.py
@@ -3806,20 +3806,19 @@ class FeatureStore:
         Fails if the dataframe columns do not match the columns of the batch data source. Optionally
         reorders the columns of the dataframe to match.
         """
-        # TODO: restrict this to work with online StreamFeatureViews and validate the FeatureView type
-        try:
-            feature_view: FeatureView = self.get_stream_feature_view(
-                feature_view_name, allow_registry_cache=allow_registry_cache
-            )
-        except FeatureViewNotFoundException:
-            try:
-                feature_view = self.get_feature_view(
-                    feature_view_name, allow_registry_cache=allow_registry_cache
-                )
-            except FeatureViewNotFoundException:
-                feature_view = self.get_label_view(  # type: ignore[assignment]
-                    feature_view_name, allow_registry_cache=allow_registry_cache
-                )
+        # Resolve the feature view with a single registry lookup regardless of its
+        # type. The previous try/except chain tried get_stream_feature_view, then
+        # get_feature_view, then get_label_view in turn, so the common plain
+        # FeatureView always paid one guaranteed-miss lookup first. On a
+        # RemoteRegistry each miss is a wasted gRPC round-trip on this per-batch
+        # write path (see #6671).
+        # TODO: validate that the resolved feature view type supports offline writes.
+        feature_view = cast(
+            FeatureView,
+            self.registry.get_any_feature_view(
+                feature_view_name, self.project, allow_cache=allow_registry_cache
+            ),
+        )
 
         provider = self._get_provider()
         # Get columns of the batch source and the input dataframe.

--- a/sdk/python/tests/unit/test_unit_feature_store.py
+++ b/sdk/python/tests/unit/test_unit_feature_store.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass
 from typing import Dict, List
+from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from feast import utils
+from feast.feature_store import FeatureStore
 from feast.protos.feast.types.Value_pb2 import Value
 
 
@@ -129,3 +132,52 @@ def test_get_unique_entities_missing_all_join_keys_error():
         in error_message
     )
     assert "Provided join_key_values: ['entity_3']" in error_message
+
+
+def test_write_to_offline_store_resolves_feature_view_with_single_lookup():
+    """``write_to_offline_store`` must resolve the feature view with a single
+    registry lookup via ``get_any_feature_view`` rather than the legacy
+    per-type try/except chain.
+
+    The old chain called ``get_stream_feature_view`` first, so the common plain
+    ``FeatureView`` always paid a guaranteed-miss lookup before the one that
+    could succeed. On a ``RemoteRegistry`` each miss is a wasted gRPC round-trip
+    on this per-batch write path (#6671).
+    """
+    store = FeatureStore.__new__(FeatureStore)
+
+    feature_view = MagicMock()
+    feature_view.name = "driver_hourly_stats"
+    feature_view.batch_source = MagicMock()
+
+    registry = MagicMock()
+    registry.get_any_feature_view.return_value = feature_view
+    store._registry = registry
+
+    current_project = MagicMock()
+    current_project.get.return_value = "test_project"
+    store._current_project = current_project
+    store.config = MagicMock()
+
+    provider = MagicMock()
+    provider.get_table_column_names_and_types_from_data_source.return_value = [
+        ("driver_id", "INT64"),
+    ]
+
+    df = pd.DataFrame({"driver_id": [1, 2, 3]})
+
+    with patch.object(FeatureStore, "_get_provider", return_value=provider):
+        store.write_to_offline_store("driver_hourly_stats", df, reorder_columns=False)
+
+    # A single unified lookup, with the default allow_registry_cache=True
+    # forwarded as allow_cache.
+    registry.get_any_feature_view.assert_called_once_with(
+        "driver_hourly_stats", "test_project", allow_cache=True
+    )
+    # None of the legacy per-type getters are used, so there is no
+    # guaranteed-miss lookup before the real one.
+    registry.get_stream_feature_view.assert_not_called()
+    registry.get_feature_view.assert_not_called()
+    registry.get_label_view.assert_not_called()
+
+    provider.ingest_df_to_offline_store.assert_called_once()


### PR DESCRIPTION
## What this does

`FeatureStore.write_to_offline_store` resolved the feature view with a try/except chain (`sdk/python/feast/feature_store.py`):

```python
try:
    feature_view = self.get_stream_feature_view(...)
except FeatureViewNotFoundException:
    try:
        feature_view = self.get_feature_view(...)
    except FeatureViewNotFoundException:
        feature_view = self.get_label_view(...)
```

For a plain `FeatureView` — the common case — the first lookup can never succeed. It is issued, raises `FeatureViewNotFoundException`, and is discarded, and only then does the lookup that can succeed run. A `LabelView` pays two failed lookups before the third.

Every getter forwards `allow_registry_cache` as the registry's `allow_cache`. On a `CachingRegistry` the failed attempts come from the cached proto and cost little. On a **`RemoteRegistry`** each is a gRPC round-trip to the registry server (it keeps no client-side cache and forwards `allow_cache` to the server as a request field). This sits on a **per-batch** write path, so a backfill pays a guaranteed-miss registry RPC before the real one on every batch, and `allow_registry_cache=True` (the default) does not avoid it.

## The fix

Resolve the feature view with a single `registry.get_any_feature_view(name, project, allow_cache=...)` lookup — the unified accessor added in #4235 for exactly the case where a caller holds only a name. It covers `FeatureView`, `StreamFeatureView`, `OnDemandFeatureView`, and `LabelView`, so it is a behaviour-preserving replacement for the chain while collapsing up to three registry lookups into one.

`#4235` introduced `get_any_feature_view` to address this same three-getters asymmetry in `BaseRegistry` and was closed as completed, but this call site was never migrated — it still performed the try/except chain, and a third branch (`get_label_view`) has been added since.

## Testing

Added `test_write_to_offline_store_resolves_feature_view_with_single_lookup` (`sdk/python/tests/unit/test_unit_feature_store.py`): it asserts exactly one `get_any_feature_view` call and that none of the legacy per-type getters fire. The test fails against `master` (the chain calls `get_stream_feature_view`, not `get_any_feature_view`) and passes with this change.

`ruff check`/`ruff format` clean on both files; `mypy` clean on `feature_store.py`.

Fixes #6671.
