### PR TITLE
fix: Add remote registry client extra

### DIFF
--- a/docs/reference/registries/remote.md
+++ b/docs/reference/registries/remote.md
@@ -4,6 +4,16 @@
 
 The Remote Registry is a gRPC client for the registry that implements the `RemoteRegistry` class using the existing `BaseRegistry` interface.
 
+## Installing the client dependency
+
+The remote registry client requires `grpcio`. Install the dedicated client extra before using `registry_type: remote`:
+
+```bash
+pip install "feast[remote]"
+```
+
+The existing `grpcio` extra remains available when running the registry server and includes its reflection and health-checking dependencies.
+
 ## How to configure the client
 
 User needs to create a client side `feature_store.yaml` file, set the `registry_type` to `remote` and provide the server connection configuration.

--- a/pixi.lock
+++ b/pixi.lock
@@ -2387,6 +2387,7 @@ packages:
   - grpcio>=1.56.2 ; extra == 'grpcio'
   - grpcio-reflection>=1.56.2 ; extra == 'grpcio'
   - grpcio-health-checking>=1.56.2 ; extra == 'grpcio'
+  - grpcio>=1.56.2 ; extra == 'remote'
   - hazelcast-python-client>=5.1 ; extra == 'hazelcast'
   - happybase>=1.2.0,<3 ; extra == 'hbase'
   - ibis-framework>=10.0.0 ; extra == 'ibis'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ grpcio = [
     "grpcio-reflection>=1.56.2",
     "grpcio-health-checking>=1.56.2",
 ]
+remote = ["grpcio>=1.56.2"]
 hazelcast = ["hazelcast-python-client>=5.1"]
 hbase = ["happybase>=1.2.0,<3"]
 ibis = [


### PR DESCRIPTION
## What this PR does

Fixes #6666. `RemoteRegistry` imports `grpc` unconditionally, but `grpcio` was only available through the unrelated server-oriented `grpcio` extra. Users installing a normal provider extra could therefore configure `registry_type: remote` and receive `ModuleNotFoundError` at runtime.

This adds a focused `remote` optional dependency containing only `grpcio` and documents `pip install "feast[remote]"` next to the remote registry configuration. The existing `grpcio` extra remains unchanged for registry/feature-server deployments that need reflection and health-checking packages.

## Validation

- Verified the final branch diff contains only `pyproject.toml` and `docs/reference/registries/remote.md`.
- Verified the TOML extra and documentation text from the master blobs.
- Full Feast dependency installation and unit test suite were not runnable locally because the network clone did not complete; CI should exercise package metadata and docs checks.

## Release notes

NONE