### PR TITLE
fix: Add gRPC timeout and keepalive to RemoteRegistry

### DIFF
--- a/docs/reference/registries/remote.md
+++ b/docs/reference/registries/remote.md
@@ -26,6 +26,11 @@ For **mutual TLS (mTLS)**, you can also configure:
 When connecting through a tunnel or proxy where the connection address differs from the server hostname, set:
 * `authority` — Overrides the gRPC `:authority` header so the server certificate is validated against the correct hostname.
 
+For **connection tuning and timeout controls**, you can also configure:
+* `timeout` — Default deadline in seconds for registry gRPC calls (e.g. 5).
+* `keepalive_time_ms` — Interval in milliseconds after which keepalive pings are sent on the transport.
+* `keepalive_timeout_ms` — Timeout in milliseconds for keepalive ping acknowledgement.
+
 {% code title="feature_store.yaml" %}
 ```yaml
 registry:
@@ -35,6 +40,9 @@ registry:
   client_cert: /path/to/tls.crt
   client_key: /path/to/tls.key
   authority: feature-registry.example.com
+  timeout: 5
+  keepalive_time_ms: 10000
+  keepalive_timeout_ms: 5000
 ```
 {% endcode %}
 

--- a/docs/reference/registries/remote.md
+++ b/docs/reference/registries/remote.md
@@ -27,9 +27,9 @@ When connecting through a tunnel or proxy where the connection address differs f
 * `authority` — Overrides the gRPC `:authority` header so the server certificate is validated against the correct hostname.
 
 For **connection tuning and timeout controls**, you can also configure:
-* `timeout` — Default deadline in seconds for registry gRPC calls (e.g. 5).
-* `keepalive_time_ms` — Interval in milliseconds after which keepalive pings are sent on the transport.
-* `keepalive_timeout_ms` — Timeout in milliseconds for keepalive ping acknowledgement.
+* `timeout` — Deadline in seconds for registry gRPC calls (e.g. 5). Must be strictly positive. If not set, calls will have no deadline.
+* `keepalive_time_ms` — Interval in milliseconds after which keepalive pings are sent on the transport. Must be strictly positive.
+* `keepalive_timeout_ms` — Timeout in milliseconds for keepalive ping acknowledgement. Must be strictly positive.
 
 {% code title="feature_store.yaml" %}
 ```yaml

--- a/sdk/python/feast/infra/registry/remote.py
+++ b/sdk/python/feast/infra/registry/remote.py
@@ -8,7 +8,7 @@ from typing import Any, List, Optional, Union
 import grpc
 from google.protobuf.empty_pb2 import Empty
 from google.protobuf.timestamp_pb2 import Timestamp
-from pydantic import StrictStr
+from pydantic import StrictStr, field_validator
 
 from feast.base_feature_view import BaseFeatureView
 from feast.data_source import DataSource
@@ -94,13 +94,20 @@ class RemoteRegistryConfig(RegistryConfig):
     e.g. when connecting through a tunnel or proxy for local development. """
 
     timeout: Optional[int] = None
-    """ int: Timeout in seconds for registry gRPC calls. """
+    """ int: Timeout in seconds for registry gRPC calls. Must be strictly positive. """
 
     keepalive_time_ms: Optional[int] = None
-    """ int: Period in milliseconds after which a keepalive ping is sent on the transport. """
+    """ int: Period in milliseconds after which a keepalive ping is sent on the transport. Must be strictly positive. """
 
     keepalive_timeout_ms: Optional[int] = None
-    """ int: Timeout in milliseconds for keepalive ping acknowledgement. """
+    """ int: Timeout in milliseconds for keepalive ping acknowledgement. Must be strictly positive. """
+
+    @field_validator("timeout", "keepalive_time_ms", "keepalive_timeout_ms")
+    @classmethod
+    def validate_positive_values(cls, v: Optional[int]) -> Optional[int]:
+        if v is not None and v <= 0:
+            raise ValueError("value must be strictly positive (> 0)")
+        return v
 
 
 class RemoteRegistry(BaseRegistry):

--- a/sdk/python/feast/infra/registry/remote.py
+++ b/sdk/python/feast/infra/registry/remote.py
@@ -93,6 +93,15 @@ class RemoteRegistryConfig(RegistryConfig):
     Required when the connection address differs from the service hostname,
     e.g. when connecting through a tunnel or proxy for local development. """
 
+    timeout: Optional[int] = None
+    """ int: Timeout in seconds for registry gRPC calls. """
+
+    keepalive_time_ms: Optional[int] = None
+    """ int: Period in milliseconds after which a keepalive ping is sent on the transport. """
+
+    keepalive_timeout_ms: Optional[int] = None
+    """ int: Timeout in milliseconds for keepalive ping acknowledgement. """
+
 
 class RemoteRegistry(BaseRegistry):
     def __init__(
@@ -107,12 +116,27 @@ class RemoteRegistry(BaseRegistry):
         self.channel = self._create_grpc_channel(registry_config)
         weakref.finalize(self, self.channel.close)
 
-        auth_header_interceptor = GrpcClientAuthHeaderInterceptor(auth_config)
+        auth_header_interceptor = GrpcClientAuthHeaderInterceptor(
+            auth_config, timeout=registry_config.timeout
+        )
         self.channel = grpc.intercept_channel(self.channel, auth_header_interceptor)
         self.stub = RegistryServer_pb2_grpc.RegistryServerStub(self.channel)
 
     def _create_grpc_channel(self, registry_config):
         assert isinstance(registry_config, RemoteRegistryConfig)
+
+        options = []
+        if registry_config.authority:
+            options.append(("grpc.default_authority", registry_config.authority))
+        if registry_config.keepalive_time_ms is not None:
+            options.append(
+                ("grpc.keepalive_time_ms", registry_config.keepalive_time_ms)
+            )
+        if registry_config.keepalive_timeout_ms is not None:
+            options.append(
+                ("grpc.keepalive_timeout_ms", registry_config.keepalive_timeout_ms)
+            )
+
         if registry_config.cert or registry_config.is_tls:
             cafile = (
                 registry_config.cert
@@ -146,16 +170,12 @@ class RemoteRegistry(BaseRegistry):
                 certificate_chain=certificate_chain,
             )
 
-            options = []
-            if registry_config.authority:
-                options.append(("grpc.default_authority", registry_config.authority))
-
             return grpc.secure_channel(
                 registry_config.path, tls_credentials, options=options
             )
         else:
             # Create an insecure gRPC channel
-            return grpc.insecure_channel(registry_config.path)
+            return grpc.insecure_channel(registry_config.path, options=options)
 
     def close(self):
         if self.channel:

--- a/sdk/python/feast/permissions/client/grpc_client_auth_interceptor.py
+++ b/sdk/python/feast/permissions/client/grpc_client_auth_interceptor.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import grpc
 
@@ -16,8 +17,9 @@ class GrpcClientAuthHeaderInterceptor(
     grpc.StreamUnaryClientInterceptor,
     grpc.StreamStreamClientInterceptor,
 ):
-    def __init__(self, auth_config: AuthConfig):
+    def __init__(self, auth_config: AuthConfig, timeout: Optional[int] = None):
         self._auth_config = auth_config
+        self._timeout = timeout
 
     def intercept_unary_unary(
         self, continuation, client_call_details, request_iterator
@@ -42,6 +44,10 @@ class GrpcClientAuthHeaderInterceptor(
     def _handle_call(self, continuation, client_call_details, request_iterator):
         if self._auth_config.type != AuthType.NONE.value:
             client_call_details = self._append_auth_header_metadata(client_call_details)
+        if self._timeout is not None and client_call_details.timeout is None:
+            client_call_details = client_call_details._replace(
+                timeout=float(self._timeout)
+            )
         result = continuation(client_call_details, request_iterator)
         if result.exception() is not None:
             mapped_error = FeastError.from_error_detail(result.exception().details())

--- a/sdk/python/tests/unit/infra/registry/test_remote_registry.py
+++ b/sdk/python/tests/unit/infra/registry/test_remote_registry.py
@@ -146,3 +146,26 @@ def test_remote_registry_client_timeout_interceptor():
     interceptor._handle_call(mock_continuation, call_details_with_timeout, None)
     passed_details_with_timeout = mock_continuation.call_args[0][0]
     assert passed_details_with_timeout.timeout == 5.0
+
+
+def test_remote_registry_validation_positive_values():
+    from pydantic import ValidationError
+
+    from feast.infra.registry.remote import RemoteRegistryConfig
+
+    # Valid configurations should work
+    config = RemoteRegistryConfig(
+        path="localhost:50051",
+        timeout=5,
+        keepalive_time_ms=1000,
+        keepalive_timeout_ms=500,
+    )
+    assert config.timeout == 5
+    assert config.keepalive_time_ms == 1000
+    assert config.keepalive_timeout_ms == 500
+
+    # Invalid values should throw ValidationError
+    for field in ["timeout", "keepalive_time_ms", "keepalive_timeout_ms"]:
+        for bad_val in [0, -1]:
+            with pytest.raises(ValidationError):
+                RemoteRegistryConfig(path="localhost:50051", **{field: bad_val})

--- a/sdk/python/tests/unit/infra/registry/test_remote_registry.py
+++ b/sdk/python/tests/unit/infra/registry/test_remote_registry.py
@@ -83,3 +83,66 @@ def test_updated_since_none(remote_registry):
         remote_registry.stub.ListAllFeatureViews.call_args[0][0]
     )
     assert not request.HasField("updated_since")
+
+
+@patch("feast.infra.registry.remote.grpc.insecure_channel")
+def test_remote_registry_channel_options(mock_insecure_channel):
+    from feast.infra.registry.remote import RemoteRegistryConfig
+
+    config = RemoteRegistryConfig(
+        path="localhost:50051",
+        keepalive_time_ms=10000,
+        keepalive_timeout_ms=5000,
+    )
+    # We patch grpc.intercept_channel to avoid auth interceptor type checks during test
+    with patch("feast.infra.registry.remote.grpc.intercept_channel"):
+        RemoteRegistry(config, project="test", repo_path=None)
+
+    mock_insecure_channel.assert_called_once()
+    args, kwargs = mock_insecure_channel.call_args
+    assert args[0] == "localhost:50051"
+    options = kwargs.get("options", [])
+    assert ("grpc.keepalive_time_ms", 10000) in options
+    assert ("grpc.keepalive_timeout_ms", 5000) in options
+
+
+def test_remote_registry_client_timeout_interceptor():
+    from feast.permissions.auth_model import AuthConfig
+    from feast.permissions.client.grpc_client_auth_interceptor import (
+        GrpcClientAuthHeaderInterceptor,
+    )
+
+    # Setup interceptor with a default timeout of 10 seconds
+    interceptor = GrpcClientAuthHeaderInterceptor(
+        AuthConfig(type="no_auth"), timeout=10
+    )
+
+    # Mock continuation function
+    mock_continuation = MagicMock()
+
+    # Mock ClientCallDetails
+    class MockClientCallDetails:
+        def __init__(self, timeout=None):
+            self.timeout = timeout
+
+        def _replace(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+            return self
+
+    call_details = MockClientCallDetails(timeout=None)
+
+    # Call handle_call
+    interceptor._handle_call(mock_continuation, call_details, None)
+
+    # Verify continuation was called with modified call_details carrying the default float timeout
+    mock_continuation.assert_called_once()
+    passed_details = mock_continuation.call_args[0][0]
+    assert passed_details.timeout == 10.0
+
+    # If call details already had a timeout, it should NOT be overridden
+    mock_continuation.reset_mock()
+    call_details_with_timeout = MockClientCallDetails(timeout=5.0)
+    interceptor._handle_call(mock_continuation, call_details_with_timeout, None)
+    passed_details_with_timeout = mock_continuation.call_args[0][0]
+    assert passed_details_with_timeout.timeout == 5.0


### PR DESCRIPTION
# What this PR does / why we need it:
Configures a default deadline (timeout) and transport keepalive options (`keepalive_time_ms`, `keepalive_timeout_ms`) for the client-side gRPC channel in `RemoteRegistry`. 

Without these configurations, network drops or silent firewall cuts (blackholes) after a TCP connection is established cause all registry calls to hang indefinitely in `epoll_wait` without raising any errors or timeouts.

# Which issue(s) this PR fixes:
Fixes #6665

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Testing is not required for this change

# Misc
NONE
