### PR TITLE
fix: Give RemoteRegistry a client-side cache so allow_cache reads skip the RPC

### DIFF
--- a/sdk/python/feast/infra/registry/caching_registry.py
+++ b/sdk/python/feast/infra/registry/caching_registry.py
@@ -36,8 +36,19 @@ class CachingRegistry(BaseRegistry):
         self.cached_registry_proto_ttl = timedelta(
             seconds=cache_ttl_seconds if cache_ttl_seconds is not None else 0
         )
-        self.cached_registry_proto = self.proto()
         self.cached_registry_proto_created = _utc_now()
+        try:
+            self.cached_registry_proto = self.proto()
+            self.cached_registry_proto_created = _utc_now()
+        except Exception as e:
+            # A backing store that is unreachable at construction time must not
+            # make the registry unconstructable. Leaving the cache empty keeps
+            # is_cache_valid() False, so the first cache-allowed read triggers a
+            # refresh once the backend is reachable. Mirrors refresh()'s handling.
+            logger.debug(
+                f"Error while performing initial registry cache load: {e}",
+                exc_info=True,
+            )
         if cache_mode == "thread":
             self._start_thread_async_refresh(cache_ttl_seconds)
             atexit.register(self._exit_handler)

--- a/sdk/python/feast/infra/registry/remote.py
+++ b/sdk/python/feast/infra/registry/remote.py
@@ -175,17 +175,36 @@ class RemoteRegistry(CachingRegistry):
         if self.channel:
             self.channel.close()
 
+    def _refresh_cache_after_mutation(self, commit: bool = True):
+        # Now that RemoteRegistry caches the registry proto client-side, a
+        # mutation issued over gRPC would otherwise leave the local cache stale
+        # until the TTL expires -- so a subsequent allow_cache read on the same
+        # client (e.g. apply_feature_view() then get_feature_view(...,
+        # allow_cache=True)) would return the pre-mutation object. Mirror
+        # SqlRegistry and reload the client-side cache after the change lands.
+        #
+        # Only refresh once the write is committed on the server. Uncommitted
+        # (commit=False) writes -- e.g. the batched applies in
+        # FeatureStore.apply() -- are flushed by the trailing commit(), which
+        # refreshes then, so we avoid a full Proto() round-trip per object.
+        # In "thread" cache mode the background refresh thread owns freshness,
+        # matching the SqlRegistry contract.
+        if commit and self.cache_mode == "sync":
+            self.refresh()
+
     def apply_entity(self, entity: Entity, project: str, commit: bool = True):
         request = RegistryServer_pb2.ApplyEntityRequest(
             entity=entity.to_proto(), project=project, commit=commit
         )
         self.stub.ApplyEntity(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_entity(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteEntityRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteEntity(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_entity(self, name: str, project: str) -> Entity:
         request = RegistryServer_pb2.GetEntityRequest(name=name, project=project)
@@ -208,12 +227,14 @@ class RemoteRegistry(CachingRegistry):
             data_source=data_source.to_proto(), project=project, commit=commit
         )
         self.stub.ApplyDataSource(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_data_source(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteDataSourceRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteDataSource(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_data_source(self, name: str, project: str) -> DataSource:
         request = RegistryServer_pb2.GetDataSourceRequest(name=name, project=project)
@@ -238,12 +259,14 @@ class RemoteRegistry(CachingRegistry):
             feature_service=feature_service.to_proto(), project=project, commit=commit
         )
         self.stub.ApplyFeatureService(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_feature_service(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteFeatureServiceRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteFeatureService(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_feature_service(self, name: str, project: str) -> FeatureService:
         request = RegistryServer_pb2.GetFeatureServiceRequest(
@@ -302,12 +325,14 @@ class RemoteRegistry(CachingRegistry):
         )
 
         self.stub.ApplyFeatureView(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_feature_view(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteFeatureViewRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteFeatureView(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_stream_feature_view(self, name: str, project: str) -> StreamFeatureView:
         request = RegistryServer_pb2.GetStreamFeatureViewRequest(
@@ -457,6 +482,7 @@ class RemoteRegistry(CachingRegistry):
             commit=commit,
         )
         self.stub.ApplyMaterialization(request)
+        self._refresh_cache_after_mutation(commit)
 
     def apply_saved_dataset(
         self,
@@ -468,12 +494,14 @@ class RemoteRegistry(CachingRegistry):
             saved_dataset=saved_dataset.to_proto(), project=project, commit=commit
         )
         self.stub.ApplyFeatureService(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_saved_dataset(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteSavedDatasetRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteSavedDataset(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_saved_dataset(self, name: str, project: str) -> SavedDataset:
         request = RegistryServer_pb2.GetSavedDatasetRequest(name=name, project=project)
@@ -511,12 +539,14 @@ class RemoteRegistry(CachingRegistry):
             commit=commit,
         )
         self.stub.ApplyValidationReference(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_validation_reference(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteValidationReferenceRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteValidationReference(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_validation_reference(self, name: str, project: str) -> ValidationReference:
         request = RegistryServer_pb2.GetValidationReferenceRequest(
@@ -549,6 +579,7 @@ class RemoteRegistry(CachingRegistry):
             infra=infra.to_proto(), project=project, commit=commit
         )
         self.stub.UpdateInfra(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_infra(self, project: str) -> Infra:
         request = RegistryServer_pb2.GetInfraRequest(project=project)
@@ -578,12 +609,14 @@ class RemoteRegistry(CachingRegistry):
             permission=permission_proto, project=project, commit=commit
         )
         self.stub.ApplyPermission(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_permission(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeletePermissionRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeletePermission(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_permission(self, name: str, project: str) -> Permission:
         request = RegistryServer_pb2.GetPermissionRequest(name=name, project=project)
@@ -613,6 +646,7 @@ class RemoteRegistry(CachingRegistry):
             project=project_proto, commit=commit
         )
         self.stub.ApplyProject(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_project(
         self,
@@ -621,6 +655,7 @@ class RemoteRegistry(CachingRegistry):
     ):
         request = RegistryServer_pb2.DeleteProjectRequest(name=name, commit=commit)
         self.stub.DeleteProject(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_project(
         self,
@@ -658,6 +693,9 @@ class RemoteRegistry(CachingRegistry):
 
     def commit(self):
         self.stub.Commit(Empty())
+        # commit() flushes writes staged with commit=False (e.g. the batch in
+        # FeatureStore.apply()), so refresh the client-side cache here too.
+        self._refresh_cache_after_mutation(commit=True)
 
     def refresh(self, project: Optional[str] = None):
         # Reload our client-side cache from the server; this is what makes

--- a/sdk/python/feast/infra/registry/remote.py
+++ b/sdk/python/feast/infra/registry/remote.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import weakref
 from datetime import datetime
@@ -16,7 +17,7 @@ from feast.entity import Entity
 from feast.feature_service import FeatureService
 from feast.feature_view import FeatureView
 from feast.infra.infra_object import Infra
-from feast.infra.registry.base_registry import BaseRegistry
+from feast.infra.registry.caching_registry import CachingRegistry
 from feast.labeling.label_view import LabelView
 from feast.on_demand_feature_view import OnDemandFeatureView
 from feast.permissions.auth_model import AuthConfig, NoAuthConfig
@@ -31,6 +32,8 @@ from feast.protos.feast.registry import RegistryServer_pb2, RegistryServer_pb2_g
 from feast.repo_config import RegistryConfig
 from feast.saved_dataset import SavedDataset, ValidationReference
 from feast.stream_feature_view import StreamFeatureView
+
+logger = logging.getLogger(__name__)
 
 
 def extract_base_feature_view(
@@ -94,7 +97,7 @@ class RemoteRegistryConfig(RegistryConfig):
     e.g. when connecting through a tunnel or proxy for local development. """
 
 
-class RemoteRegistry(BaseRegistry):
+class RemoteRegistry(CachingRegistry):
     def __init__(
         self,
         registry_config: Union[RegistryConfig, RemoteRegistryConfig],
@@ -110,6 +113,17 @@ class RemoteRegistry(BaseRegistry):
         auth_header_interceptor = GrpcClientAuthHeaderInterceptor(auth_config)
         self.channel = grpc.intercept_channel(self.channel, auth_header_interceptor)
         self.stub = RegistryServer_pb2_grpc.RegistryServerStub(self.channel)
+
+        # Maintain a client-side cache like every other registry implementation.
+        # CachingRegistry serves allow_cache=True reads from cached_registry_proto
+        # (populated by proto(), the server's Proto RPC), so allow_cache stops
+        # meaning "one RPC per read" for the remote registry and acquires the same
+        # meaning it already has for the SQL/file/Snowflake registries.
+        super().__init__(
+            project=project,
+            cache_ttl_seconds=registry_config.cache_ttl_seconds,
+            cache_mode=registry_config.cache_mode,
+        )
 
     def _create_grpc_channel(self, registry_config):
         assert isinstance(registry_config, RemoteRegistryConfig)
@@ -173,22 +187,17 @@ class RemoteRegistry(BaseRegistry):
         )
         self.stub.DeleteEntity(request)
 
-    def get_entity(self, name: str, project: str, allow_cache: bool = False) -> Entity:
-        request = RegistryServer_pb2.GetEntityRequest(
-            name=name, project=project, allow_cache=allow_cache
-        )
+    def _get_entity(self, name: str, project: str) -> Entity:
+        request = RegistryServer_pb2.GetEntityRequest(name=name, project=project)
         response = self.stub.GetEntity(request)
         return Entity.from_proto(response)
 
-    def list_entities(
+    def _list_entities(
         self,
         project: str,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[Entity]:
-        request = RegistryServer_pb2.ListEntitiesRequest(
-            project=project, allow_cache=allow_cache, tags=tags
-        )
+        request = RegistryServer_pb2.ListEntitiesRequest(project=project, tags=tags)
         response = self.stub.ListEntities(request)
         return [Entity.from_proto(entity) for entity in response.entities]
 
@@ -206,24 +215,17 @@ class RemoteRegistry(BaseRegistry):
         )
         self.stub.DeleteDataSource(request)
 
-    def get_data_source(
-        self, name: str, project: str, allow_cache: bool = False
-    ) -> DataSource:
-        request = RegistryServer_pb2.GetDataSourceRequest(
-            name=name, project=project, allow_cache=allow_cache
-        )
+    def _get_data_source(self, name: str, project: str) -> DataSource:
+        request = RegistryServer_pb2.GetDataSourceRequest(name=name, project=project)
         response = self.stub.GetDataSource(request)
         return DataSource.from_proto(response)
 
-    def list_data_sources(
+    def _list_data_sources(
         self,
         project: str,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[DataSource]:
-        request = RegistryServer_pb2.ListDataSourcesRequest(
-            project=project, allow_cache=allow_cache, tags=tags
-        )
+        request = RegistryServer_pb2.ListDataSourcesRequest(project=project, tags=tags)
         response = self.stub.ListDataSources(request)
         return [
             DataSource.from_proto(data_source) for data_source in response.data_sources
@@ -243,23 +245,20 @@ class RemoteRegistry(BaseRegistry):
         )
         self.stub.DeleteFeatureService(request)
 
-    def get_feature_service(
-        self, name: str, project: str, allow_cache: bool = False
-    ) -> FeatureService:
+    def _get_feature_service(self, name: str, project: str) -> FeatureService:
         request = RegistryServer_pb2.GetFeatureServiceRequest(
-            name=name, project=project, allow_cache=allow_cache
+            name=name, project=project
         )
         response = self.stub.GetFeatureService(request)
         return FeatureService.from_proto(response)
 
-    def list_feature_services(
+    def _list_feature_services(
         self,
         project: str,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[FeatureService]:
         request = RegistryServer_pb2.ListFeatureServicesRequest(
-            project=project, allow_cache=allow_cache, tags=tags
+            project=project, tags=tags
         )
         response = self.stub.ListFeatureServices(request)
         return [
@@ -310,24 +309,21 @@ class RemoteRegistry(BaseRegistry):
         )
         self.stub.DeleteFeatureView(request)
 
-    def get_stream_feature_view(
-        self, name: str, project: str, allow_cache: bool = False
-    ) -> StreamFeatureView:
+    def _get_stream_feature_view(self, name: str, project: str) -> StreamFeatureView:
         request = RegistryServer_pb2.GetStreamFeatureViewRequest(
-            name=name, project=project, allow_cache=allow_cache
+            name=name, project=project
         )
         response = self.stub.GetStreamFeatureView(request)
         return StreamFeatureView.from_proto(response)
 
-    def list_stream_feature_views(
+    def _list_stream_feature_views(
         self,
         project: str,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
-        skip_udf: bool = False,
+        **kwargs: Any,
     ) -> List[StreamFeatureView]:
         request = RegistryServer_pb2.ListStreamFeatureViewsRequest(
-            project=project, allow_cache=allow_cache, tags=tags
+            project=project, tags=tags
         )
         response = self.stub.ListStreamFeatureViews(request)
         return [
@@ -335,24 +331,23 @@ class RemoteRegistry(BaseRegistry):
             for stream_feature_view in response.stream_feature_views
         ]
 
-    def get_on_demand_feature_view(
-        self, name: str, project: str, allow_cache: bool = False
+    def _get_on_demand_feature_view(
+        self, name: str, project: str
     ) -> OnDemandFeatureView:
         request = RegistryServer_pb2.GetOnDemandFeatureViewRequest(
-            name=name, project=project, allow_cache=allow_cache
+            name=name, project=project
         )
         response = self.stub.GetOnDemandFeatureView(request)
         return OnDemandFeatureView.from_proto(response)
 
-    def list_on_demand_feature_views(
+    def _list_on_demand_feature_views(
         self,
         project: str,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
-        skip_udf: bool = False,
+        **kwargs: Any,
     ) -> List[OnDemandFeatureView]:
         request = RegistryServer_pb2.ListOnDemandFeatureViewsRequest(
-            project=project, allow_cache=allow_cache, tags=tags
+            project=project, tags=tags
         )
         response = self.stub.ListOnDemandFeatureViews(request)
         return [
@@ -360,35 +355,27 @@ class RemoteRegistry(BaseRegistry):
             for on_demand_feature_view in response.on_demand_feature_views
         ]
 
-    def get_label_view(
-        self, name: str, project: str, allow_cache: bool = False
-    ) -> LabelView:
-        request = RegistryServer_pb2.GetLabelViewRequest(
-            name=name, project=project, allow_cache=allow_cache
-        )
+    def _get_label_view(self, name: str, project: str) -> LabelView:
+        request = RegistryServer_pb2.GetLabelViewRequest(name=name, project=project)
         response = self.stub.GetLabelView(request)
         return LabelView.from_proto(response)
 
-    def list_label_views(
+    def _list_label_views(
         self,
         project: str,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
+        **kwargs: Any,
     ) -> List[LabelView]:
-        request = RegistryServer_pb2.ListLabelViewsRequest(
-            project=project, allow_cache=allow_cache, tags=tags
-        )
+        request = RegistryServer_pb2.ListLabelViewsRequest(project=project, tags=tags)
         response = self.stub.ListLabelViews(request)
         return [LabelView.from_proto(label_view) for label_view in response.label_views]
 
     def delete_label_view(self, name: str, project: str, commit: bool = True):
         self.delete_feature_view(name, project, commit)
 
-    def get_any_feature_view(
-        self, name: str, project: str, allow_cache: bool = False
-    ) -> BaseFeatureView:
+    def _get_any_feature_view(self, name: str, project: str) -> BaseFeatureView:
         request = RegistryServer_pb2.GetAnyFeatureViewRequest(
-            name=name, project=project, allow_cache=allow_cache
+            name=name, project=project
         )
 
         response: RegistryServer_pb2.GetAnyFeatureViewResponse = (
@@ -397,13 +384,12 @@ class RemoteRegistry(BaseRegistry):
         any_feature_view = response.any_feature_view
         return extract_base_feature_view(any_feature_view)
 
-    def list_all_feature_views(
+    def _list_all_feature_views(
         self,
         project: str,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
-        skip_udf: bool = False,
         updated_since: Optional[datetime] = None,
+        **kwargs: Any,
     ) -> List[BaseFeatureView]:
         updated_since_proto = None
         if updated_since is not None:
@@ -412,7 +398,6 @@ class RemoteRegistry(BaseRegistry):
             updated_since_proto = ts
         request = RegistryServer_pb2.ListAllFeatureViewsRequest(
             project=project,
-            allow_cache=allow_cache,
             tags=tags,
             updated_since=updated_since_proto,
         )
@@ -425,25 +410,18 @@ class RemoteRegistry(BaseRegistry):
             for any_feature_view in response.feature_views
         ]
 
-    def get_feature_view(
-        self, name: str, project: str, allow_cache: bool = False
-    ) -> FeatureView:
-        request = RegistryServer_pb2.GetFeatureViewRequest(
-            name=name, project=project, allow_cache=allow_cache
-        )
+    def _get_feature_view(self, name: str, project: str) -> FeatureView:
+        request = RegistryServer_pb2.GetFeatureViewRequest(name=name, project=project)
         response = self.stub.GetFeatureView(request)
         return FeatureView.from_proto(response)
 
-    def list_feature_views(
+    def _list_feature_views(
         self,
         project: str,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
-        skip_udf: bool = False,
+        **kwargs: Any,
     ) -> List[FeatureView]:
-        request = RegistryServer_pb2.ListFeatureViewsRequest(
-            project=project, allow_cache=allow_cache, tags=tags
-        )
+        request = RegistryServer_pb2.ListFeatureViewsRequest(project=project, tags=tags)
         response = self.stub.ListFeatureViews(request)
 
         return [
@@ -497,26 +475,20 @@ class RemoteRegistry(BaseRegistry):
         )
         self.stub.DeleteSavedDataset(request)
 
-    def get_saved_dataset(
-        self, name: str, project: str, allow_cache: bool = False
-    ) -> SavedDataset:
-        request = RegistryServer_pb2.GetSavedDatasetRequest(
-            name=name, project=project, allow_cache=allow_cache
-        )
+    def _get_saved_dataset(self, name: str, project: str) -> SavedDataset:
+        request = RegistryServer_pb2.GetSavedDatasetRequest(name=name, project=project)
         response = self.stub.GetSavedDataset(request)
         return SavedDataset.from_proto(response)
 
-    def list_saved_datasets(
+    def _list_saved_datasets(
         self,
         project: str,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
         namespace: Optional[str] = None,
         collection: Optional[str] = None,
     ) -> List[SavedDataset]:
         request = RegistryServer_pb2.ListSavedDatasetsRequest(
             project=project,
-            allow_cache=allow_cache,
             tags=tags,
             namespace=namespace or "",
             collection=collection or "",
@@ -546,23 +518,20 @@ class RemoteRegistry(BaseRegistry):
         )
         self.stub.DeleteValidationReference(request)
 
-    def get_validation_reference(
-        self, name: str, project: str, allow_cache: bool = False
-    ) -> ValidationReference:
+    def _get_validation_reference(self, name: str, project: str) -> ValidationReference:
         request = RegistryServer_pb2.GetValidationReferenceRequest(
-            name=name, project=project, allow_cache=allow_cache
+            name=name, project=project
         )
         response = self.stub.GetValidationReference(request)
         return ValidationReference.from_proto(response)
 
-    def list_validation_references(
+    def _list_validation_references(
         self,
         project: str,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[ValidationReference]:
         request = RegistryServer_pb2.ListValidationReferencesRequest(
-            project=project, allow_cache=allow_cache, tags=tags
+            project=project, tags=tags
         )
         response = self.stub.ListValidationReferences(request)
         return [
@@ -570,12 +539,8 @@ class RemoteRegistry(BaseRegistry):
             for validation_reference in response.validation_references
         ]
 
-    def list_project_metadata(
-        self, project: str, allow_cache: bool = False
-    ) -> List[ProjectMetadata]:
-        request = RegistryServer_pb2.ListProjectMetadataRequest(
-            project=project, allow_cache=allow_cache
-        )
+    def _list_project_metadata(self, project: str) -> List[ProjectMetadata]:
+        request = RegistryServer_pb2.ListProjectMetadataRequest(project=project)
         response = self.stub.ListProjectMetadata(request)
         return [ProjectMetadata.from_proto(pm) for pm in response.project_metadata]
 
@@ -585,10 +550,8 @@ class RemoteRegistry(BaseRegistry):
         )
         self.stub.UpdateInfra(request)
 
-    def get_infra(self, project: str, allow_cache: bool = False) -> Infra:
-        request = RegistryServer_pb2.GetInfraRequest(
-            project=project, allow_cache=allow_cache
-        )
+    def _get_infra(self, project: str) -> Infra:
+        request = RegistryServer_pb2.GetInfraRequest(project=project)
         response = self.stub.GetInfra(request)
         return Infra.from_proto(response)
 
@@ -622,25 +585,18 @@ class RemoteRegistry(BaseRegistry):
         )
         self.stub.DeletePermission(request)
 
-    def get_permission(
-        self, name: str, project: str, allow_cache: bool = False
-    ) -> Permission:
-        request = RegistryServer_pb2.GetPermissionRequest(
-            name=name, project=project, allow_cache=allow_cache
-        )
+    def _get_permission(self, name: str, project: str) -> Permission:
+        request = RegistryServer_pb2.GetPermissionRequest(name=name, project=project)
         response = self.stub.GetPermission(request)
 
         return Permission.from_proto(response)
 
-    def list_permissions(
+    def _list_permissions(
         self,
         project: str,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[Permission]:
-        request = RegistryServer_pb2.ListPermissionsRequest(
-            project=project, allow_cache=allow_cache, tags=tags
-        )
+        request = RegistryServer_pb2.ListPermissionsRequest(project=project, tags=tags)
         response = self.stub.ListPermissions(request)
         return [
             Permission.from_proto(permission) for permission in response.permissions
@@ -666,26 +622,20 @@ class RemoteRegistry(BaseRegistry):
         request = RegistryServer_pb2.DeleteProjectRequest(name=name, commit=commit)
         self.stub.DeleteProject(request)
 
-    def get_project(
+    def _get_project(
         self,
         name: str,
-        allow_cache: bool = False,
     ) -> Project:
-        request = RegistryServer_pb2.GetProjectRequest(
-            name=name, allow_cache=allow_cache
-        )
+        request = RegistryServer_pb2.GetProjectRequest(name=name)
         response = self.stub.GetProject(request)
 
         return Project.from_proto(response)
 
-    def list_projects(
+    def _list_projects(
         self,
-        allow_cache: bool = False,
         tags: Optional[dict[str, str]] = None,
     ) -> List[Project]:
-        request = RegistryServer_pb2.ListProjectsRequest(
-            allow_cache=allow_cache, tags=tags
-        )
+        request = RegistryServer_pb2.ListProjectsRequest(tags=tags)
         response = self.stub.ListProjects(request)
         return [Project.from_proto(project) for project in response.projects]
 
@@ -710,8 +660,23 @@ class RemoteRegistry(BaseRegistry):
         self.stub.Commit(Empty())
 
     def refresh(self, project: Optional[str] = None):
-        request = RegistryServer_pb2.RefreshRequest(project=str(project))
-        self.stub.Refresh(request)
+        # Reload our client-side cache from the server; this is what makes
+        # allow_cache reads correct. The server rebuilds its Proto response from
+        # fresh reads, so no server-side refresh is required for the client to
+        # see current data.
+        super().refresh(project)
+        # On an explicit, project-scoped refresh, also ask the server to refresh
+        # its own cache, preserving the historical RemoteRegistry.refresh() side
+        # effect for other consumers. Internal TTL refreshes pass no project and
+        # skip this to avoid an extra RPC per cache cycle; a failure here must not
+        # invalidate the client-cache reload above.
+        if project is not None:
+            try:
+                self.stub.Refresh(RegistryServer_pb2.RefreshRequest(project=project))
+            except Exception as e:
+                logger.debug(
+                    f"Remote registry server-side refresh failed: {e}", exc_info=True
+                )
 
     # Lineage operations
     def get_registry_lineage(

--- a/sdk/python/feast/infra/registry/remote.py
+++ b/sdk/python/feast/infra/registry/remote.py
@@ -175,17 +175,36 @@ class RemoteRegistry(CachingRegistry):
         if self.channel:
             self.channel.close()
 
+    def _refresh_cache_after_mutation(self, commit: bool = True):
+        # Now that RemoteRegistry caches the registry proto client-side, a
+        # mutation issued over gRPC would otherwise leave the local cache stale
+        # until the TTL expires -- so a subsequent allow_cache read on the same
+        # client (e.g. apply_feature_view() then get_feature_view(...,
+        # allow_cache=True)) would return the pre-mutation object. Mirror
+        # SqlRegistry and reload the client-side cache after the change lands.
+        #
+        # Only refresh once the write is committed on the server. Uncommitted
+        # (commit=False) writes -- e.g. the batched applies in
+        # FeatureStore.apply() -- are flushed by the trailing commit(), which
+        # refreshes then, so we avoid a full Proto() round-trip per object.
+        # In "thread" cache mode the background refresh thread owns freshness,
+        # matching the SqlRegistry contract.
+        if commit and self.cache_mode == "sync":
+            self.refresh()
+
     def apply_entity(self, entity: Entity, project: str, commit: bool = True):
         request = RegistryServer_pb2.ApplyEntityRequest(
             entity=entity.to_proto(), project=project, commit=commit
         )
         self.stub.ApplyEntity(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_entity(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteEntityRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteEntity(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_entity(self, name: str, project: str) -> Entity:
         request = RegistryServer_pb2.GetEntityRequest(name=name, project=project)
@@ -208,12 +227,14 @@ class RemoteRegistry(CachingRegistry):
             data_source=data_source.to_proto(), project=project, commit=commit
         )
         self.stub.ApplyDataSource(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_data_source(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteDataSourceRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteDataSource(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_data_source(self, name: str, project: str) -> DataSource:
         request = RegistryServer_pb2.GetDataSourceRequest(name=name, project=project)
@@ -238,12 +259,14 @@ class RemoteRegistry(CachingRegistry):
             feature_service=feature_service.to_proto(), project=project, commit=commit
         )
         self.stub.ApplyFeatureService(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_feature_service(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteFeatureServiceRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteFeatureService(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_feature_service(self, name: str, project: str) -> FeatureService:
         request = RegistryServer_pb2.GetFeatureServiceRequest(
@@ -302,12 +325,14 @@ class RemoteRegistry(CachingRegistry):
         )
 
         self.stub.ApplyFeatureView(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_feature_view(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteFeatureViewRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteFeatureView(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_stream_feature_view(self, name: str, project: str) -> StreamFeatureView:
         request = RegistryServer_pb2.GetStreamFeatureViewRequest(
@@ -457,6 +482,7 @@ class RemoteRegistry(CachingRegistry):
             commit=commit,
         )
         self.stub.ApplyMaterialization(request)
+        self._refresh_cache_after_mutation(commit)
 
     def apply_saved_dataset(
         self,
@@ -468,12 +494,14 @@ class RemoteRegistry(CachingRegistry):
             saved_dataset=saved_dataset.to_proto(), project=project, commit=commit
         )
         self.stub.ApplySavedDataset(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_saved_dataset(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteSavedDatasetRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteSavedDataset(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_saved_dataset(self, name: str, project: str) -> SavedDataset:
         request = RegistryServer_pb2.GetSavedDatasetRequest(name=name, project=project)
@@ -511,12 +539,14 @@ class RemoteRegistry(CachingRegistry):
             commit=commit,
         )
         self.stub.ApplyValidationReference(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_validation_reference(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteValidationReferenceRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeleteValidationReference(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_validation_reference(self, name: str, project: str) -> ValidationReference:
         request = RegistryServer_pb2.GetValidationReferenceRequest(
@@ -549,6 +579,7 @@ class RemoteRegistry(CachingRegistry):
             infra=infra.to_proto(), project=project, commit=commit
         )
         self.stub.UpdateInfra(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_infra(self, project: str) -> Infra:
         request = RegistryServer_pb2.GetInfraRequest(project=project)
@@ -578,12 +609,14 @@ class RemoteRegistry(CachingRegistry):
             permission=permission_proto, project=project, commit=commit
         )
         self.stub.ApplyPermission(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_permission(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeletePermissionRequest(
             name=name, project=project, commit=commit
         )
         self.stub.DeletePermission(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_permission(self, name: str, project: str) -> Permission:
         request = RegistryServer_pb2.GetPermissionRequest(name=name, project=project)
@@ -613,6 +646,7 @@ class RemoteRegistry(CachingRegistry):
             project=project_proto, commit=commit
         )
         self.stub.ApplyProject(request)
+        self._refresh_cache_after_mutation(commit)
 
     def delete_project(
         self,
@@ -621,6 +655,7 @@ class RemoteRegistry(CachingRegistry):
     ):
         request = RegistryServer_pb2.DeleteProjectRequest(name=name, commit=commit)
         self.stub.DeleteProject(request)
+        self._refresh_cache_after_mutation(commit)
 
     def _get_project(
         self,
@@ -658,6 +693,9 @@ class RemoteRegistry(CachingRegistry):
 
     def commit(self):
         self.stub.Commit(Empty())
+        # commit() flushes writes staged with commit=False (e.g. the batch in
+        # FeatureStore.apply()), so refresh the client-side cache here too.
+        self._refresh_cache_after_mutation(commit=True)
 
     def refresh(self, project: Optional[str] = None):
         # Reload our client-side cache from the server; this is what makes

--- a/sdk/python/feast/registry_server.py
+++ b/sdk/python/feast/registry_server.py
@@ -204,6 +204,22 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
 
         registry_proto = RegistryProto()
 
+        # The per-project list_* calls return objects that know their project
+        # contextually, but obj.to_proto() does not serialize it (the project is
+        # stamped only when the backing registry assembles a full proto). Stamp it
+        # back on here so this rebuilt proto matches proxied_registry.proto();
+        # otherwise consumers that look objects up by project — proto_registry_utils,
+        # and therefore RemoteRegistry's client-side cache — never find them
+        # (feast#6672). Most objects carry it at spec.project; DataSource and
+        # ValidationReference carry it as a top-level field.
+        def _spec_project(obj_proto, name):
+            obj_proto.spec.project = name
+            return obj_proto
+
+        def _project(obj_proto, name):
+            obj_proto.project = name
+            return obj_proto
+
         for project in describable(self.proxied_registry.list_projects()):
             registry_proto.projects.append(project.to_proto())
             project_name = project.name
@@ -211,58 +227,72 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             for entity in describable(
                 self.proxied_registry.list_entities(project=project_name)
             ):
-                registry_proto.entities.append(entity.to_proto())
+                registry_proto.entities.append(
+                    _spec_project(entity.to_proto(), project_name)
+                )
 
             for data_source in describable(
                 self.proxied_registry.list_data_sources(project=project_name)
             ):
-                registry_proto.data_sources.append(data_source.to_proto())
+                registry_proto.data_sources.append(
+                    _project(data_source.to_proto(), project_name)
+                )
 
             for feature_view in describable(
                 self.proxied_registry.list_feature_views(project=project_name)
             ):
-                registry_proto.feature_views.append(feature_view.to_proto())
+                registry_proto.feature_views.append(
+                    _spec_project(feature_view.to_proto(), project_name)
+                )
 
             for stream_feature_view in describable(
                 self.proxied_registry.list_stream_feature_views(project=project_name)
             ):
                 registry_proto.stream_feature_views.append(
-                    stream_feature_view.to_proto()
+                    _spec_project(stream_feature_view.to_proto(), project_name)
                 )
 
             for on_demand_feature_view in describable(
                 self.proxied_registry.list_on_demand_feature_views(project=project_name)
             ):
                 registry_proto.on_demand_feature_views.append(
-                    on_demand_feature_view.to_proto()
+                    _spec_project(on_demand_feature_view.to_proto(), project_name)
                 )
 
             for label_view in describable(
                 self.proxied_registry.list_label_views(project=project_name)
             ):
-                registry_proto.label_views.append(label_view.to_proto())
+                registry_proto.label_views.append(
+                    _spec_project(label_view.to_proto(), project_name)
+                )
 
             for feature_service in describable(
                 self.proxied_registry.list_feature_services(project=project_name)
             ):
-                registry_proto.feature_services.append(feature_service.to_proto())
+                registry_proto.feature_services.append(
+                    _spec_project(feature_service.to_proto(), project_name)
+                )
 
             for saved_dataset in describable(
                 self.proxied_registry.list_saved_datasets(project=project_name)
             ):
-                registry_proto.saved_datasets.append(saved_dataset.to_proto())
+                registry_proto.saved_datasets.append(
+                    _spec_project(saved_dataset.to_proto(), project_name)
+                )
 
             for validation_reference in describable(
                 self.proxied_registry.list_validation_references(project=project_name)
             ):
                 registry_proto.validation_references.append(
-                    validation_reference.to_proto()
+                    _project(validation_reference.to_proto(), project_name)
                 )
 
             for permission in describable(
                 self.proxied_registry.list_permissions(project=project_name)
             ):
-                registry_proto.permissions.append(permission.to_proto())
+                registry_proto.permissions.append(
+                    _spec_project(permission.to_proto(), project_name)
+                )
 
         # Carry the registry's real last_updated/version_id rather than stamping "now":
         # this proto is rebuilt from individual list calls (for RBAC filtering), but it must

--- a/sdk/python/feast/registry_server.py
+++ b/sdk/python/feast/registry_server.py
@@ -282,6 +282,22 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
 
         registry_proto = RegistryProto()
 
+        # The per-project list_* calls return objects that know their project
+        # contextually, but obj.to_proto() does not serialize it (the project is
+        # stamped only when the backing registry assembles a full proto). Stamp it
+        # back on here so this rebuilt proto matches proxied_registry.proto();
+        # otherwise consumers that look objects up by project — proto_registry_utils,
+        # and therefore RemoteRegistry's client-side cache — never find them
+        # (feast#6672). Most objects carry it at spec.project; DataSource and
+        # ValidationReference carry it as a top-level field.
+        def _spec_project(obj_proto, name):
+            obj_proto.spec.project = name
+            return obj_proto
+
+        def _project(obj_proto, name):
+            obj_proto.project = name
+            return obj_proto
+
         for project in describable(self.proxied_registry.list_projects()):
             registry_proto.projects.append(project.to_proto())
             project_name = project.name
@@ -289,58 +305,72 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
             for entity in describable(
                 self.proxied_registry.list_entities(project=project_name)
             ):
-                registry_proto.entities.append(entity.to_proto())
+                registry_proto.entities.append(
+                    _spec_project(entity.to_proto(), project_name)
+                )
 
             for data_source in describable(
                 self.proxied_registry.list_data_sources(project=project_name)
             ):
-                registry_proto.data_sources.append(data_source.to_proto())
+                registry_proto.data_sources.append(
+                    _project(data_source.to_proto(), project_name)
+                )
 
             for feature_view in describable(
                 self.proxied_registry.list_feature_views(project=project_name)
             ):
-                registry_proto.feature_views.append(feature_view.to_proto())
+                registry_proto.feature_views.append(
+                    _spec_project(feature_view.to_proto(), project_name)
+                )
 
             for stream_feature_view in describable(
                 self.proxied_registry.list_stream_feature_views(project=project_name)
             ):
                 registry_proto.stream_feature_views.append(
-                    stream_feature_view.to_proto()
+                    _spec_project(stream_feature_view.to_proto(), project_name)
                 )
 
             for on_demand_feature_view in describable(
                 self.proxied_registry.list_on_demand_feature_views(project=project_name)
             ):
                 registry_proto.on_demand_feature_views.append(
-                    on_demand_feature_view.to_proto()
+                    _spec_project(on_demand_feature_view.to_proto(), project_name)
                 )
 
             for label_view in describable(
                 self.proxied_registry.list_label_views(project=project_name)
             ):
-                registry_proto.label_views.append(label_view.to_proto())
+                registry_proto.label_views.append(
+                    _spec_project(label_view.to_proto(), project_name)
+                )
 
             for feature_service in describable(
                 self.proxied_registry.list_feature_services(project=project_name)
             ):
-                registry_proto.feature_services.append(feature_service.to_proto())
+                registry_proto.feature_services.append(
+                    _spec_project(feature_service.to_proto(), project_name)
+                )
 
             for saved_dataset in describable(
                 self.proxied_registry.list_saved_datasets(project=project_name)
             ):
-                registry_proto.saved_datasets.append(saved_dataset.to_proto())
+                registry_proto.saved_datasets.append(
+                    _spec_project(saved_dataset.to_proto(), project_name)
+                )
 
             for validation_reference in describable(
                 self.proxied_registry.list_validation_references(project=project_name)
             ):
                 registry_proto.validation_references.append(
-                    validation_reference.to_proto()
+                    _project(validation_reference.to_proto(), project_name)
                 )
 
             for permission in describable(
                 self.proxied_registry.list_permissions(project=project_name)
             ):
-                registry_proto.permissions.append(permission.to_proto())
+                registry_proto.permissions.append(
+                    _spec_project(permission.to_proto(), project_name)
+                )
 
         # Carry the registry's real last_updated/version_id rather than stamping "now":
         # this proto is rebuilt from individual list calls (for RBAC filtering), but it must

--- a/sdk/python/tests/unit/infra/registry/test_registry_server_proto.py
+++ b/sdk/python/tests/unit/infra/registry/test_registry_server_proto.py
@@ -130,3 +130,25 @@ def test_proto_empty_registry():
 
     assert len(result.projects) == 0
     assert len(result.entities) == 0
+
+
+def test_proto_stamps_project_on_each_object():
+    """Each rebuilt object must carry its project (feast#6672).
+
+    ``obj.to_proto()`` does not serialize the project, so without stamping the
+    rebuilt proto has project-less objects and any consumer that looks them up by
+    project (proto_registry_utils -> RemoteRegistry's client cache) never finds
+    them. Project lives at ``spec.project`` for most objects and as a top-level
+    ``project`` field for data sources.
+    """
+    server, _ = _build_server()
+
+    result = server.Proto(Empty(), context=None)
+
+    entity_projects = {e.spec.name: e.spec.project for e in result.entities}
+    assert entity_projects == {
+        "driver": "proj_a",
+        "customer": "proj_a",
+        "merchant": "proj_b",
+    }
+    assert {(d.name, d.project) for d in result.data_sources} == {("src_a", "proj_a")}

--- a/sdk/python/tests/unit/infra/registry/test_remote_registry.py
+++ b/sdk/python/tests/unit/infra/registry/test_remote_registry.py
@@ -18,8 +18,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 
+from feast import Entity, FeatureView, Field, FileSource
+from feast.infra.registry.caching_registry import CachingRegistry
 from feast.infra.registry.remote import RemoteRegistry
+from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.protos.feast.registry import RegistryServer_pb2
+from feast.types import Int64
+from feast.value_type import ValueType
 
 
 @pytest.fixture
@@ -83,3 +88,110 @@ def test_updated_since_none(remote_registry):
         remote_registry.stub.ListAllFeatureViews.call_args[0][0]
     )
     assert not request.HasField("updated_since")
+
+
+PROJECT = "demo"
+
+
+def _registry_proto_with_feature_view() -> tuple[RegistryProto, object]:
+    """A RegistryProto holding one feature view, as the server's Proto RPC returns."""
+    entity = Entity(name="driver", join_keys=["driver_id"], value_type=ValueType.INT64)
+    source = FileSource(name="src", path="foo.parquet", timestamp_field="ts")
+    fv = FeatureView(
+        name="my_fv",
+        entities=[entity],
+        schema=[
+            Field(name="driver_id", dtype=Int64),
+            Field(name="conv_rate", dtype=Int64),
+        ],
+        source=source,
+    )
+    fv_proto = fv.to_proto()
+    fv_proto.spec.project = PROJECT
+    registry_proto = RegistryProto()
+    registry_proto.feature_views.append(fv_proto)
+    return registry_proto, fv_proto
+
+
+@pytest.fixture
+def cached_remote_registry():
+    """A RemoteRegistry with its client-side cache warmed from a mocked server."""
+    registry_proto, fv_proto = _registry_proto_with_feature_view()
+    stub = MagicMock()
+    stub.Proto.return_value = registry_proto
+    stub.GetFeatureView.return_value = fv_proto
+
+    registry = RemoteRegistry.__new__(RemoteRegistry)
+    registry.stub = stub
+    CachingRegistry.__init__(
+        registry, project=PROJECT, cache_ttl_seconds=600, cache_mode="sync"
+    )
+    return registry
+
+
+def test_remote_registry_is_a_caching_registry(cached_remote_registry):
+    assert isinstance(cached_remote_registry, CachingRegistry)
+
+
+def test_allow_cache_true_serves_from_client_cache(cached_remote_registry):
+    """allow_cache=True must not issue one RPC per read (feast#6672)."""
+    stub = cached_remote_registry.stub
+    proto_calls_after_warmup = stub.Proto.call_count
+    stub.GetFeatureView.reset_mock()
+
+    for _ in range(100):
+        fv = cached_remote_registry.get_feature_view("my_fv", PROJECT, allow_cache=True)
+        assert fv.name == "my_fv"
+
+    assert stub.GetFeatureView.call_count == 0, (
+        "allow_cache=True reads must be served from the client cache, not gRPC"
+    )
+    # No extra full-registry refreshes within the TTL either.
+    assert stub.Proto.call_count == proto_calls_after_warmup
+
+
+def test_allow_cache_false_still_issues_rpc(cached_remote_registry):
+    """allow_cache=False keeps the fresh-read contract: one RPC per read."""
+    stub = cached_remote_registry.stub
+    stub.GetFeatureView.reset_mock()
+
+    for _ in range(5):
+        cached_remote_registry.get_feature_view("my_fv", PROJECT, allow_cache=False)
+
+    assert stub.GetFeatureView.call_count == 5
+
+
+def test_is_cache_valid_true_after_warmup(cached_remote_registry):
+    """RemoteRegistry now advertises a valid client cache, unlike before."""
+    assert cached_remote_registry.is_cache_valid() is True
+
+
+def test_explicit_refresh_reloads_cache_and_pokes_server(cached_remote_registry):
+    """A project-scoped refresh reloads the client cache and pokes the server."""
+    stub = cached_remote_registry.stub
+    stub.Refresh.reset_mock()
+    proto_calls_before = stub.Proto.call_count
+
+    cached_remote_registry.refresh(PROJECT)
+
+    # Client cache reloaded via the Proto RPC ...
+    assert stub.Proto.call_count == proto_calls_before + 1
+    # ... and the historical server-side refresh side effect is preserved.
+    assert stub.Refresh.call_count == 1
+
+
+def test_internal_refresh_reloads_cache_without_poking_server(cached_remote_registry):
+    """A refresh with no project (internal TTL path) must not RPC Refresh.
+
+    _refresh_cached_registry_if_necessary calls refresh() with no project, so a
+    server-side Refresh here would both add load and, if it raised, abort the
+    client-cache reload that keeps allow_cache reads correct (feast#6672).
+    """
+    stub = cached_remote_registry.stub
+    stub.Refresh.reset_mock()
+    proto_calls_before = stub.Proto.call_count
+
+    cached_remote_registry.refresh()
+
+    assert stub.Proto.call_count == proto_calls_before + 1
+    assert stub.Refresh.call_count == 0

--- a/sdk/python/tests/unit/infra/registry/test_remote_registry.py
+++ b/sdk/python/tests/unit/infra/registry/test_remote_registry.py
@@ -19,6 +19,7 @@ import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from feast import Entity, FeatureView, Field, FileSource
+from feast.errors import FeatureViewNotFoundException
 from feast.infra.registry.caching_registry import CachingRegistry
 from feast.infra.registry.remote import RemoteRegistry
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
@@ -195,3 +196,108 @@ def test_internal_refresh_reloads_cache_without_poking_server(cached_remote_regi
 
     assert stub.Proto.call_count == proto_calls_before + 1
     assert stub.Refresh.call_count == 0
+
+
+def _second_feature_view_proto():
+    """A distinct feature view ("my_fv2") not present in the warmed cache."""
+    entity = Entity(name="driver", join_keys=["driver_id"], value_type=ValueType.INT64)
+    source = FileSource(name="src2", path="bar.parquet", timestamp_field="ts")
+    fv = FeatureView(
+        name="my_fv2",
+        entities=[entity],
+        schema=[
+            Field(name="driver_id", dtype=Int64),
+            Field(name="acc_rate", dtype=Int64),
+        ],
+        source=source,
+    )
+    fv_proto = fv.to_proto()
+    fv_proto.spec.project = PROJECT
+    return fv, fv_proto
+
+
+def test_apply_with_commit_refreshes_client_cache(cached_remote_registry):
+    """A committed mutation must invalidate the client cache on the same client.
+
+    Regression for the RemoteRegistry->CachingRegistry change (feast#6672): once
+    reads are served from the client cache, apply_feature_view(commit=True)
+    followed by get_feature_view(..., allow_cache=True) on the same client used
+    to return the pre-apply snapshot until the TTL expired. The old
+    (non-caching) RemoteRegistry forwarded the read to the server, so it was
+    always fresh; the mutation must now refresh the client cache.
+    """
+    stub = cached_remote_registry.stub
+    fv2, fv2_proto = _second_feature_view_proto()
+
+    # The cache is warmed with only "my_fv".
+    with pytest.raises(FeatureViewNotFoundException):
+        cached_remote_registry.get_feature_view("my_fv2", PROJECT, allow_cache=True)
+
+    # The server now knows about "my_fv2"; a refresh would pick it up.
+    updated_proto, _ = _registry_proto_with_feature_view()
+    updated_proto.feature_views.append(fv2_proto)
+    stub.Proto.return_value = updated_proto
+
+    cached_remote_registry.apply_feature_view(fv2, PROJECT, commit=True)
+
+    # The committed apply refreshed the client cache, so the cached read sees it.
+    fetched = cached_remote_registry.get_feature_view(
+        "my_fv2", PROJECT, allow_cache=True
+    )
+    assert fetched.name == "my_fv2"
+
+
+def test_commit_false_defers_refresh_until_commit(cached_remote_registry):
+    """commit=False must not refresh per-op; the trailing commit() refreshes once.
+
+    FeatureStore.apply() stages every object with commit=False and calls commit()
+    once at the end, so refreshing on each uncommitted write would fire a full
+    Proto() round-trip per object (and read pre-commit state). The client cache
+    should only be reloaded when the change is actually committed.
+    """
+    stub = cached_remote_registry.stub
+    fv2, fv2_proto = _second_feature_view_proto()
+
+    updated_proto, _ = _registry_proto_with_feature_view()
+    updated_proto.feature_views.append(fv2_proto)
+    stub.Proto.return_value = updated_proto
+
+    proto_calls_before = stub.Proto.call_count
+    cached_remote_registry.apply_feature_view(fv2, PROJECT, commit=False)
+
+    # No refresh yet: the cache is untouched and still lacks "my_fv2".
+    assert stub.Proto.call_count == proto_calls_before
+    with pytest.raises(FeatureViewNotFoundException):
+        cached_remote_registry.get_feature_view("my_fv2", PROJECT, allow_cache=True)
+
+    # commit() flushes the staged writes and refreshes the client cache once.
+    cached_remote_registry.commit()
+    assert stub.Proto.call_count == proto_calls_before + 1
+    fetched = cached_remote_registry.get_feature_view(
+        "my_fv2", PROJECT, allow_cache=True
+    )
+    assert fetched.name == "my_fv2"
+
+
+def test_thread_cache_mode_skips_refresh_on_mutation():
+    """In "thread" cache mode the background thread owns freshness, not mutations."""
+    registry_proto, _ = _registry_proto_with_feature_view()
+    stub = MagicMock()
+    stub.Proto.return_value = registry_proto
+
+    registry = RemoteRegistry.__new__(RemoteRegistry)
+    registry.stub = stub
+    # A long TTL keeps the background timer from firing during the test.
+    CachingRegistry.__init__(
+        registry, project=PROJECT, cache_ttl_seconds=3600, cache_mode="thread"
+    )
+    try:
+        fv2, _ = _second_feature_view_proto()
+        proto_calls_before = stub.Proto.call_count
+        registry.apply_feature_view(fv2, PROJECT, commit=True)
+
+        # No synchronous refresh: thread mode is eventually consistent, like
+        # SqlRegistry -- the background thread owns freshness.
+        assert stub.Proto.call_count == proto_calls_before
+    finally:
+        registry.registry_refresh_thread.cancel()

--- a/sdk/python/tests/unit/infra/registry/test_remote_registry.py
+++ b/sdk/python/tests/unit/infra/registry/test_remote_registry.py
@@ -18,15 +18,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 
-from feast.infra.offline_stores.file_source import SavedDatasetFileStorage
-
 from feast import Entity, FeatureView, Field, FileSource
+from feast.errors import FeatureViewNotFoundException
+from feast.infra.offline_stores.file_source import SavedDatasetFileStorage
 from feast.infra.registry.caching_registry import CachingRegistry
 from feast.infra.registry.remote import RemoteRegistry
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.protos.feast.registry import RegistryServer_pb2
 from feast.saved_dataset import SavedDataset
-
 from feast.types import Int64
 from feast.value_type import ValueType
 
@@ -38,6 +37,12 @@ def remote_registry():
         registry.stub = MagicMock()
         registry.stub.ListAllFeatureViews.return_value = (
             RegistryServer_pb2.ListAllFeatureViewsResponse(feature_views=[])
+        )
+        registry.stub.Proto.return_value = RegistryProto()
+        # RemoteRegistry is a CachingRegistry, so a stand-in that skips
+        # __init__ still needs the caching state the mutation methods read.
+        CachingRegistry.__init__(
+            registry, project="project", cache_ttl_seconds=600, cache_mode="sync"
         )
         yield registry
 
@@ -118,6 +123,7 @@ def test_apply_saved_dataset_calls_apply_saved_dataset_rpc(remote_registry):
     assert request.saved_dataset.spec.name == "test_saved_dataset"
     assert request.project == "project"
     assert request.commit is True
+
 
 PROJECT = "demo"
 
@@ -224,3 +230,108 @@ def test_internal_refresh_reloads_cache_without_poking_server(cached_remote_regi
 
     assert stub.Proto.call_count == proto_calls_before + 1
     assert stub.Refresh.call_count == 0
+
+
+def _second_feature_view_proto():
+    """A distinct feature view ("my_fv2") not present in the warmed cache."""
+    entity = Entity(name="driver", join_keys=["driver_id"], value_type=ValueType.INT64)
+    source = FileSource(name="src2", path="bar.parquet", timestamp_field="ts")
+    fv = FeatureView(
+        name="my_fv2",
+        entities=[entity],
+        schema=[
+            Field(name="driver_id", dtype=Int64),
+            Field(name="acc_rate", dtype=Int64),
+        ],
+        source=source,
+    )
+    fv_proto = fv.to_proto()
+    fv_proto.spec.project = PROJECT
+    return fv, fv_proto
+
+
+def test_apply_with_commit_refreshes_client_cache(cached_remote_registry):
+    """A committed mutation must invalidate the client cache on the same client.
+
+    Regression for the RemoteRegistry->CachingRegistry change (feast#6672): once
+    reads are served from the client cache, apply_feature_view(commit=True)
+    followed by get_feature_view(..., allow_cache=True) on the same client used
+    to return the pre-apply snapshot until the TTL expired. The old
+    (non-caching) RemoteRegistry forwarded the read to the server, so it was
+    always fresh; the mutation must now refresh the client cache.
+    """
+    stub = cached_remote_registry.stub
+    fv2, fv2_proto = _second_feature_view_proto()
+
+    # The cache is warmed with only "my_fv".
+    with pytest.raises(FeatureViewNotFoundException):
+        cached_remote_registry.get_feature_view("my_fv2", PROJECT, allow_cache=True)
+
+    # The server now knows about "my_fv2"; a refresh would pick it up.
+    updated_proto, _ = _registry_proto_with_feature_view()
+    updated_proto.feature_views.append(fv2_proto)
+    stub.Proto.return_value = updated_proto
+
+    cached_remote_registry.apply_feature_view(fv2, PROJECT, commit=True)
+
+    # The committed apply refreshed the client cache, so the cached read sees it.
+    fetched = cached_remote_registry.get_feature_view(
+        "my_fv2", PROJECT, allow_cache=True
+    )
+    assert fetched.name == "my_fv2"
+
+
+def test_commit_false_defers_refresh_until_commit(cached_remote_registry):
+    """commit=False must not refresh per-op; the trailing commit() refreshes once.
+
+    FeatureStore.apply() stages every object with commit=False and calls commit()
+    once at the end, so refreshing on each uncommitted write would fire a full
+    Proto() round-trip per object (and read pre-commit state). The client cache
+    should only be reloaded when the change is actually committed.
+    """
+    stub = cached_remote_registry.stub
+    fv2, fv2_proto = _second_feature_view_proto()
+
+    updated_proto, _ = _registry_proto_with_feature_view()
+    updated_proto.feature_views.append(fv2_proto)
+    stub.Proto.return_value = updated_proto
+
+    proto_calls_before = stub.Proto.call_count
+    cached_remote_registry.apply_feature_view(fv2, PROJECT, commit=False)
+
+    # No refresh yet: the cache is untouched and still lacks "my_fv2".
+    assert stub.Proto.call_count == proto_calls_before
+    with pytest.raises(FeatureViewNotFoundException):
+        cached_remote_registry.get_feature_view("my_fv2", PROJECT, allow_cache=True)
+
+    # commit() flushes the staged writes and refreshes the client cache once.
+    cached_remote_registry.commit()
+    assert stub.Proto.call_count == proto_calls_before + 1
+    fetched = cached_remote_registry.get_feature_view(
+        "my_fv2", PROJECT, allow_cache=True
+    )
+    assert fetched.name == "my_fv2"
+
+
+def test_thread_cache_mode_skips_refresh_on_mutation():
+    """In "thread" cache mode the background thread owns freshness, not mutations."""
+    registry_proto, _ = _registry_proto_with_feature_view()
+    stub = MagicMock()
+    stub.Proto.return_value = registry_proto
+
+    registry = RemoteRegistry.__new__(RemoteRegistry)
+    registry.stub = stub
+    # A long TTL keeps the background timer from firing during the test.
+    CachingRegistry.__init__(
+        registry, project=PROJECT, cache_ttl_seconds=3600, cache_mode="thread"
+    )
+    try:
+        fv2, _ = _second_feature_view_proto()
+        proto_calls_before = stub.Proto.call_count
+        registry.apply_feature_view(fv2, PROJECT, commit=True)
+
+        # No synchronous refresh: thread mode is eventually consistent, like
+        # SqlRegistry -- the background thread owns freshness.
+        assert stub.Proto.call_count == proto_calls_before
+    finally:
+        registry.registry_refresh_thread.cancel()

--- a/sdk/python/tests/unit/infra/registry/test_remote_registry.py
+++ b/sdk/python/tests/unit/infra/registry/test_remote_registry.py
@@ -19,9 +19,16 @@ import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from feast.infra.offline_stores.file_source import SavedDatasetFileStorage
+
+from feast import Entity, FeatureView, Field, FileSource
+from feast.infra.registry.caching_registry import CachingRegistry
 from feast.infra.registry.remote import RemoteRegistry
+from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.protos.feast.registry import RegistryServer_pb2
 from feast.saved_dataset import SavedDataset
+
+from feast.types import Int64
+from feast.value_type import ValueType
 
 
 @pytest.fixture
@@ -111,3 +118,109 @@ def test_apply_saved_dataset_calls_apply_saved_dataset_rpc(remote_registry):
     assert request.saved_dataset.spec.name == "test_saved_dataset"
     assert request.project == "project"
     assert request.commit is True
+
+PROJECT = "demo"
+
+
+def _registry_proto_with_feature_view() -> tuple[RegistryProto, object]:
+    """A RegistryProto holding one feature view, as the server's Proto RPC returns."""
+    entity = Entity(name="driver", join_keys=["driver_id"], value_type=ValueType.INT64)
+    source = FileSource(name="src", path="foo.parquet", timestamp_field="ts")
+    fv = FeatureView(
+        name="my_fv",
+        entities=[entity],
+        schema=[
+            Field(name="driver_id", dtype=Int64),
+            Field(name="conv_rate", dtype=Int64),
+        ],
+        source=source,
+    )
+    fv_proto = fv.to_proto()
+    fv_proto.spec.project = PROJECT
+    registry_proto = RegistryProto()
+    registry_proto.feature_views.append(fv_proto)
+    return registry_proto, fv_proto
+
+
+@pytest.fixture
+def cached_remote_registry():
+    """A RemoteRegistry with its client-side cache warmed from a mocked server."""
+    registry_proto, fv_proto = _registry_proto_with_feature_view()
+    stub = MagicMock()
+    stub.Proto.return_value = registry_proto
+    stub.GetFeatureView.return_value = fv_proto
+
+    registry = RemoteRegistry.__new__(RemoteRegistry)
+    registry.stub = stub
+    CachingRegistry.__init__(
+        registry, project=PROJECT, cache_ttl_seconds=600, cache_mode="sync"
+    )
+    return registry
+
+
+def test_remote_registry_is_a_caching_registry(cached_remote_registry):
+    assert isinstance(cached_remote_registry, CachingRegistry)
+
+
+def test_allow_cache_true_serves_from_client_cache(cached_remote_registry):
+    """allow_cache=True must not issue one RPC per read (feast#6672)."""
+    stub = cached_remote_registry.stub
+    proto_calls_after_warmup = stub.Proto.call_count
+    stub.GetFeatureView.reset_mock()
+
+    for _ in range(100):
+        fv = cached_remote_registry.get_feature_view("my_fv", PROJECT, allow_cache=True)
+        assert fv.name == "my_fv"
+
+    assert stub.GetFeatureView.call_count == 0, (
+        "allow_cache=True reads must be served from the client cache, not gRPC"
+    )
+    # No extra full-registry refreshes within the TTL either.
+    assert stub.Proto.call_count == proto_calls_after_warmup
+
+
+def test_allow_cache_false_still_issues_rpc(cached_remote_registry):
+    """allow_cache=False keeps the fresh-read contract: one RPC per read."""
+    stub = cached_remote_registry.stub
+    stub.GetFeatureView.reset_mock()
+
+    for _ in range(5):
+        cached_remote_registry.get_feature_view("my_fv", PROJECT, allow_cache=False)
+
+    assert stub.GetFeatureView.call_count == 5
+
+
+def test_is_cache_valid_true_after_warmup(cached_remote_registry):
+    """RemoteRegistry now advertises a valid client cache, unlike before."""
+    assert cached_remote_registry.is_cache_valid() is True
+
+
+def test_explicit_refresh_reloads_cache_and_pokes_server(cached_remote_registry):
+    """A project-scoped refresh reloads the client cache and pokes the server."""
+    stub = cached_remote_registry.stub
+    stub.Refresh.reset_mock()
+    proto_calls_before = stub.Proto.call_count
+
+    cached_remote_registry.refresh(PROJECT)
+
+    # Client cache reloaded via the Proto RPC ...
+    assert stub.Proto.call_count == proto_calls_before + 1
+    # ... and the historical server-side refresh side effect is preserved.
+    assert stub.Refresh.call_count == 1
+
+
+def test_internal_refresh_reloads_cache_without_poking_server(cached_remote_registry):
+    """A refresh with no project (internal TTL path) must not RPC Refresh.
+
+    _refresh_cached_registry_if_necessary calls refresh() with no project, so a
+    server-side Refresh here would both add load and, if it raised, abort the
+    client-cache reload that keeps allow_cache reads correct (feast#6672).
+    """
+    stub = cached_remote_registry.stub
+    stub.Refresh.reset_mock()
+    proto_calls_before = stub.Proto.call_count
+
+    cached_remote_registry.refresh()
+
+    assert stub.Proto.call_count == proto_calls_before + 1
+    assert stub.Refresh.call_count == 0


### PR DESCRIPTION
## What this does

Fixes #6672.

`RemoteRegistry` held no client-side cache, so `allow_cache=True` was forwarded to the server as a hint and still issued **one gRPC round-trip per read**. Every other registry (`SqlRegistry`, `Registry`, `SnowflakeRegistry`) serves `allow_cache=True` from an in-process cache, so the same argument meant "may skip the backend" on four registries and "always one round-trip" on the fifth. Long-running batch jobs paid a `GetFeatureView` RPC per batch even with `allow_registry_cache=True` and a single long-lived `FeatureStore`.

This takes the smaller of the two directions in the issue: **make `RemoteRegistry` extend `CachingRegistry`**.

## Changes

**`infra/registry/remote.py`** — `RemoteRegistry(CachingRegistry)`. The 28 `allow_cache` read methods become `_get_*`/`_list_*` hooks that issue the fresh-read RPC; the shared base serves `allow_cache=True` from `cached_registry_proto` (populated once by the server's `Proto` RPC, refreshed on TTL). `allow_cache` now means the same thing on every registry, and `is_cache_valid()` reports a real cache. `refresh()` reloads the client cache and, on an explicit project-scoped call, still pokes the server-side `Refresh` RPC (preserving the historical side effect); internal TTL refreshes pass no project and skip it, so a server refresh failure can't abort the client-cache reload.

Two supporting fixes were required for the client cache to actually resolve reads:

**`registry_server.py`** — `RegistryServer.Proto` rebuilt the registry from `list_*() + obj.to_proto()` for RBAC filtering, but `to_proto()` does not serialize the project, so the assembled proto contained **project-less objects** that `proto_registry_utils` (which filters by project) could never find. This was latent because the aggregate `Proto` response wasn't previously used for per-object lookups. Stamp the known `project` back onto each object during the rebuild so the response matches `proxied_registry.proto()` (most objects at `spec.project`; `DataSource`/`ValidationReference` as a top-level field). RBAC filtering is unchanged.

**`infra/registry/caching_registry.py`** — the eager cache warm-up in `__init__` made a `RemoteRegistry` unconstructable when the server is unreachable at construction time (all other backends are reachable locally). Guard the initial load, mirroring `refresh()`'s existing error handling: an empty cache is left behind (`is_cache_valid()` stays `False`) and the first cache-allowed read refreshes it.

## Tests

- `test_remote_registry.py`: `allow_cache=True` serves 100 reads from the client cache with **0** `GetFeatureView` RPCs; `allow_cache=False` still issues one RPC per read; `is_cache_valid()` is `True`; explicit vs internal `refresh()` behaviour.
- `test_registry_server_proto.py`: each rebuilt object carries its project (`spec.project` and top-level shapes).
- Existing remote/mTLS, SQL-registry, server-`Proto`, and permissions/RBAC unit tests pass unchanged.

Verified end-to-end by driving the real `RegistryServer` over an in-memory channel: construction tolerates an unreachable server, then `allow_cache=True` reads for feature view, entity, feature service, and data source all resolve from the client cache.