### PR TITLE
fix: Report single-feature-view spark_application materialization success

### DIFF
--- a/sdk/python/feast/infra/compute_engines/spark_application/compute.py
+++ b/sdk/python/feast/infra/compute_engines/spark_application/compute.py
@@ -223,7 +223,7 @@ class SparkApplicationComputeEngine(ComputeEngine):
         )
         try:
             self._wait_for_completion(job)
-            return self._build_per_fv_jobs(registry, tasks, job_id, job)
+            return self._build_per_fv_jobs(registry, tasks, job_id)
         finally:
             self._cleanup(job_id)
 
@@ -252,7 +252,6 @@ class SparkApplicationComputeEngine(ComputeEngine):
         registry: BaseRegistry,
         tasks: List[MaterializationTask],
         job_id: str,
-        job: SparkApplicationMaterializationJob,
     ) -> List[MaterializationJob]:
         """Build one independent job object per FV from registry state.
 
@@ -262,10 +261,15 @@ class SparkApplicationComputeEngine(ComputeEngine):
 
         Each returned job is an independent object so that a failed
         SparkApplication does not pollute the status of succeeded FVs.
-        """
-        if len(tasks) <= 1:
-            return [job for _ in tasks]
 
+        The per-FV outcome is resolved from registry state — never from the live
+        polling job — for every task count. ``materialize()`` deletes the
+        SparkApplication CR in its ``finally`` immediately after this returns, and
+        ``FeatureStore`` then re-checks ``status()``; a job that re-queried the
+        now-deleted CR would 404 and report a false failure for a materialization
+        that actually succeeded (#6673). ``CompletedMaterializationJob`` reports
+        SUCCEEDED without any Kubernetes call, so it is safe after cleanup.
+        """
         jobs: List[MaterializationJob] = []
         for task in tasks:
             fv = registry.get_feature_view(task.feature_view.name, task.project)

--- a/sdk/python/tests/unit/infra/compute_engines/test_spark_application.py
+++ b/sdk/python/tests/unit/infra/compute_engines/test_spark_application.py
@@ -313,8 +313,7 @@ def test_build_per_fv_jobs_all_succeeded():
     task2.feature_view.name = "fv_2"
     task2.project = "test"
 
-    parent_job = SparkApplicationMaterializationJob("job1", "default", MagicMock())
-    jobs = engine._build_per_fv_jobs(mock_registry, [task1, task2], "job1", parent_job)
+    jobs = engine._build_per_fv_jobs(mock_registry, [task1, task2], "job1")
 
     assert len(jobs) == 2
     assert all(isinstance(j, CompletedMaterializationJob) for j in jobs)
@@ -343,10 +342,7 @@ def test_build_per_fv_jobs_partial_failure():
     task_fail.feature_view.name = "fv_fail"
     task_fail.project = "test"
 
-    parent_job = SparkApplicationMaterializationJob("job1", "default", MagicMock())
-    jobs = engine._build_per_fv_jobs(
-        mock_registry, [task_ok, task_fail], "job1", parent_job
-    )
+    jobs = engine._build_per_fv_jobs(mock_registry, [task_ok, task_fail], "job1")
 
     assert len(jobs) == 2
     assert isinstance(jobs[0], CompletedMaterializationJob)
@@ -355,22 +351,61 @@ def test_build_per_fv_jobs_partial_failure():
     assert "fv_fail" in str(jobs[1].error())
 
 
-# ── Test 15: _build_per_fv_jobs — single task returns parent job directly ──
+# ── Test 15: _build_per_fv_jobs — single succeeded task resolves from registry ──
 
 
-def test_build_per_fv_jobs_single_task():
+def test_build_per_fv_jobs_single_task_succeeded():
+    """Regression for #6673.
+
+    A single successful FV must resolve to a CompletedMaterializationJob from
+    registry state, not to the live polling job. materialize() deletes the CR
+    right after this returns, so a live job would 404 on FeatureStore's follow-up
+    status() check and report a false failure. CompletedMaterializationJob needs
+    no Kubernetes call.
+    """
     engine = _make_engine()
     mock_registry = MagicMock()
+    fv = MagicMock()
+    fv.name = "fv_1"
+    fv.state = FeatureViewState.AVAILABLE_ONLINE
+    mock_registry.get_feature_view.return_value = fv
+
     task = MagicMock()
     task.feature_view.name = "fv_1"
     task.project = "test"
 
-    parent_job = SparkApplicationMaterializationJob("job1", "default", MagicMock())
-    jobs = engine._build_per_fv_jobs(mock_registry, [task], "job1", parent_job)
+    jobs = engine._build_per_fv_jobs(mock_registry, [task], "job1")
 
     assert len(jobs) == 1
-    assert jobs[0] is parent_job
-    mock_registry.get_feature_view.assert_not_called()
+    assert isinstance(jobs[0], CompletedMaterializationJob)
+    assert jobs[0].status() == MaterializationJobStatus.SUCCEEDED
+    mock_registry.get_feature_view.assert_called_once_with("fv_1", "test")
+    # No live SparkApplication CR is queried (it is about to be deleted).
+    engine.custom_api.get_namespaced_custom_object.assert_not_called()
+
+
+# ── Test 15b: _build_per_fv_jobs — single failed task reports error, no CR query ──
+
+
+def test_build_per_fv_jobs_single_task_failed():
+    """A single unmaterialized FV reports ERROR without querying the (deleted) CR."""
+    engine = _make_engine()
+    mock_registry = MagicMock()
+    fv = MagicMock()
+    fv.name = "fv_1"
+    fv.state = FeatureViewState.MATERIALIZING
+    mock_registry.get_feature_view.return_value = fv
+
+    task = MagicMock()
+    task.feature_view.name = "fv_1"
+    task.project = "test"
+
+    jobs = engine._build_per_fv_jobs(mock_registry, [task], "job1")
+
+    assert len(jobs) == 1
+    assert jobs[0].status() == MaterializationJobStatus.ERROR
+    assert "fv_1" in str(jobs[0].error())
+    engine.custom_api.get_namespaced_custom_object.assert_not_called()
 
 
 # ── Test 16: CompletedMaterializationJob is always SUCCEEDED ──


### PR DESCRIPTION
## What this does

Fixes #6673.

Every **single**-feature-view materialization on the `spark_application` batch engine is reported as a failure:

```text
Exception: SparkApplication feast-sa-<job-id> not found
```

even though the Spark driver already materialized the features and updated the registry. Automation calling `feast materialize` or the feature server's `/materialize` endpoint sees a failure and may retry work that already succeeded. It is deterministic for exactly one feature view.

## Root cause

`materialize()` deletes the SparkApplication CR in its `finally` immediately after `_build_per_fv_jobs()` returns:

```python
try:
    self._wait_for_completion(job)
    return self._build_per_fv_jobs(registry, tasks, job_id, job)
finally:
    self._cleanup(job_id)          # deletes the CR
```

For a single feature view, `_build_per_fv_jobs()` short-circuited and returned the **live polling job**:

```python
if len(tasks) <= 1:
    return [job for _ in tasks]
```

`FeatureStore._submit_and_process_materialization_jobs()` then re-checks `job.status()`. On success the job has no captured error, so `status()` re-queries the CR that `_cleanup()` just deleted → 404 → `_error` set → `ERROR` raised. (On genuine failure `job._error` is already set and `status()` short-circuits, so only the **success** path 404s.)

## Fix

Resolve the per-FV outcome from **registry state** for every task count — exactly what the multi-FV path already does. The driver pod sets each materialized FV to `AVAILABLE_ONLINE`, so:

- materialized FV → `CompletedMaterializationJob`, which reports `SUCCEEDED` with **no Kubernetes call** and is safe after cleanup;
- unmaterialized FV → `ERROR` (`was not materialized …`), consistent with the existing multi-FV behavior; the Spark driver's error detail is already logged by `_wait_for_completion`.

The now-unused `job` parameter to `_build_per_fv_jobs()` is dropped.

## Tests

The existing single-task test asserted the buggy behavior (return the live job, skip the registry). Rewrote it to require resolution from registry state with **no CR query**, and added a single-**failed**-FV case. All `spark_application` unit tests pass; the fix is exercised entirely with mocked K8s/registry — no live cluster needed.

Verified the before/after on the real classes: a live job re-checked after CR deletion returns `ERROR "… not found"` (the reported symptom), while the fixed single-FV path returns `SUCCEEDED` and makes no `get_namespaced_custom_object` call.