### PR TITLE
test: Add cron job check for e2e test runTestDeploySimpleCRFunc

### DIFF
--- a/infra/feast-operator/test/utils/test_util.go
+++ b/infra/feast-operator/test/utils/test_util.go
@@ -176,6 +176,27 @@ func checkIfKubernetesServiceExists(namespace, serviceName string) error {
 	return nil
 }
 
+// validates if a CronJob exists using the kubectl CLI.
+func checkIfCronJobExists(namespace, cronJobName string) error {
+	cmd := exec.Command("kubectl", "get", "cronjob", cronJobName, "-n", namespace)
+
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to find CronJob %s in namespace %s. Error: %v. Stderr: %s",
+			cronJobName, namespace, err, stderr.String())
+	}
+
+	if !strings.Contains(out.String(), cronJobName) {
+		return fmt.Errorf("CronJob %s not found in namespace %s", cronJobName, namespace)
+	}
+
+	return nil
+}
+
 func isFeatureStoreHavingRemoteRegistry(namespace, featureStoreName string) (bool, error) {
 	timeout := 5 * time.Minute
 	interval := time.Second * 2 // Poll every 2 seconds
@@ -287,6 +308,14 @@ func validateTheFeatureStoreCustomResource(namespace string, featureStoreName st
 		))
 		fmt.Printf("kubernetes service %s is available\n", serviceName)
 	}
+
+	By(fmt.Sprintf("validate the feast CronJob: %s exists.", feastResourceName))
+	err = checkIfCronJobExists(namespace, feastResourceName)
+	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf(
+		"CronJob %s does not exist in namespace %s. Error: %v",
+		feastResourceName, namespace, err,
+	))
+	fmt.Printf("CronJob %s exists in namespace %s\n", feastResourceName, namespace)
 
 	By(fmt.Sprintf("Checking FeatureStore customer resource: %s is in Ready Status.", featureStoreName))
 	err = checkIfFeatureStoreCustomResourceConditionsInReady(featureStoreName, namespace)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#code-style-and-linting
2. Run unit tests and ensure that they are passing: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#unit-tests
3. If your change introduces any API changes, make sure to update the integration tests here: https://github.com/feast-dev/feast/tree/master/sdk/python/tests
4. Make sure documentation is updated for your PR!
5. Make sure your commits are signed: https://github.com/feast-dev/feast/blob/master/CONTRIBUTING.md#signing-off-commits
6. Make sure your PR title follows conventional commits (e.g. fix: [Description of ...], feat: [Description of ...], chore: [Description of ...], refactor: [Description of ...])

-->

# What this PR does / why we need it:
<!--
Outline what you're doing and why.
-->
- Add `checkIfCronJobExists` helper in feast-operator e2e utils
- Validate CronJob `feast-<featureStoreName>` exists in `validateTheFeatureStoreCustomResource` before FeatureStore Ready checks
- Covers `runTestDeploySimpleCRFunc` and the remote-registry deploy path that share this validation

# Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

# Misc
<!--
Feel free to leave additional thoughts or tag people as you see fit
-->
