### PR TITLE
fix: Fix mypy TorchTensor type alias error

### DIFF
--- a/sdk/python/feast/online_response.py
+++ b/sdk/python/feast/online_response.py
@@ -25,7 +25,6 @@ from feast.type_map import feast_value_type_to_python_type
 from feast.value_type import ValueType
 
 if TYPE_CHECKING:
-    import torch
     from torch import Tensor as TorchTensor
 else:
     TorchTensor = Any

--- a/sdk/python/feast/online_response.py
+++ b/sdk/python/feast/online_response.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import uuid as uuid_module
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeAlias, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import pandas as pd
 import pyarrow as pa
@@ -26,10 +26,9 @@ from feast.value_type import ValueType
 
 if TYPE_CHECKING:
     import torch
-
-    TorchTensor: TypeAlias = torch.Tensor
+    from torch import Tensor as TorchTensor
 else:
-    TorchTensor: TypeAlias = Any
+    TorchTensor = Any
 
 TIMESTAMP_POSTFIX: str = "__ts"
 


### PR DESCRIPTION
## What this PR does / why we need it
In `online_response.py`, `TorchTensor` is defined using `TypeAlias` inside both conditional branches of `if TYPE_CHECKING:`. Mypy complains: `Variable "feast.online_response.TorchTensor" is not valid as a type` because it parses it as a variable inside the runtime fallback branch.
This PR fixes the typing syntax in `online_response.py` by defining `TorchTensor` cleanly without `TypeAlias` in the fallback branch so mypy parses the type correctly.

## Which issue(s) this PR fixes
Fixes #5563

## Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows conventional commits format