### PR TITLE
fix: Allow remote-registry first apply for new projects

### DIFF
--- a/sdk/python/feast/registry_server.py
+++ b/sdk/python/feast/registry_server.py
@@ -12,7 +12,7 @@ from feast import FeatureService, FeatureStore
 from feast.base_feature_view import BaseFeatureView
 from feast.data_source import DataSource
 from feast.entity import Entity
-from feast.errors import FeastObjectNotFoundException
+from feast.errors import FeastObjectNotFoundException, FeastPermissionError
 from feast.feast_object import FeastObject
 from feast.feature_view import FeatureView
 from feast.grpc_error_interceptor import ErrorInterceptor
@@ -24,6 +24,8 @@ from feast.permissions.permission import Permission
 from feast.permissions.security_manager import (
     assert_permissions,
     assert_permissions_to_update,
+    get_security_manager,
+    is_auth_necessary,
     permitted_resources,
 )
 from feast.permissions.server.grpc import AuthInterceptor
@@ -1603,16 +1605,37 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
         )
 
     def Commit(self, request, context):
-        for project in self.proxied_registry.list_projects(allow_cache=True):
-            assert_permissions(resource=project, actions=[AuthzedAction.UPDATE])
+        # Per-object mutations are authorized in Apply*/Delete* RPCs.
+        # Requiring UPDATE on every project breaks shared-registry multi-tenant
+        # commits (remote feastRef with different feastProjects). Require CREATE
+        # or UPDATE on at least one project when auth is enabled instead.
+        projects = cast(
+            list[FeastObject],
+            list(self.proxied_registry.list_projects(allow_cache=True)),
+        )
+        if projects and is_auth_necessary(get_security_manager()):
+            can_update = permitted_resources(
+                resources=projects, actions=AuthzedAction.UPDATE
+            )
+            can_create = permitted_resources(
+                resources=projects, actions=AuthzedAction.CREATE
+            )
+            if not can_update and not can_create:
+                raise FeastPermissionError(
+                    "Not authorized to commit registry changes: "
+                    "CREATE or UPDATE permission required on at least one project"
+                )
         self.proxied_registry.commit()
         return Empty()
 
     def Refresh(self, request, context):
-        project = self.proxied_registry.get_project(
-            name=request.project, allow_cache=True
+        # Use create-or-update authorization so first apply of a new project over
+        # a remote registry can refresh before the project exists yet.
+        assert_permissions_to_update(
+            resource=Project(name=request.project),
+            getter=self.proxied_registry.get_project,
+            project=request.project,
         )
-        assert_permissions(resource=project, actions=[AuthzedAction.UPDATE])
         self.proxied_registry.refresh(request.project)
         return Empty()
 

--- a/sdk/python/tests/unit/test_registry_server_commit_refresh.py
+++ b/sdk/python/tests/unit/test_registry_server_commit_refresh.py
@@ -1,0 +1,195 @@
+from unittest.mock import Mock
+
+import pytest
+from google.protobuf.empty_pb2 import Empty
+
+from feast.errors import FeastPermissionError, ProjectObjectNotFoundException
+from feast.permissions.permission import AuthzedAction, Permission
+from feast.permissions.policy import RoleBasedPolicy
+from feast.permissions.security_manager import (
+    SecurityManager,
+    no_security_manager,
+    set_security_manager,
+)
+from feast.permissions.user import User
+from feast.project import Project
+from feast.protos.feast.registry import RegistryServer_pb2
+from feast.registry_server import RegistryServer
+
+
+@pytest.fixture
+def project_permissions():
+    return [
+        Permission(
+            name="project_updater",
+            types=Project,
+            name_patterns="team-a.*",
+            policy=RoleBasedPolicy(roles=["team-a"]),
+            actions=[AuthzedAction.DESCRIBE, AuthzedAction.UPDATE],
+        ),
+        Permission(
+            name="project_creator",
+            types=Project,
+            name_patterns="team-a.*",
+            policy=RoleBasedPolicy(roles=["team-a"]),
+            actions=[AuthzedAction.CREATE],
+        ),
+        Permission(
+            name="project_a_create_only",
+            types=Project,
+            name_patterns="team-a.*",
+            policy=RoleBasedPolicy(roles=["team-a-creator"]),
+            actions=[AuthzedAction.CREATE],
+        ),
+        Permission(
+            name="project_b_updater",
+            types=Project,
+            name_patterns="team-b.*",
+            policy=RoleBasedPolicy(roles=["team-b"]),
+            actions=[AuthzedAction.DESCRIBE, AuthzedAction.UPDATE],
+        ),
+    ]
+
+
+@pytest.fixture
+def auth_security_manager(project_permissions):
+    registry = Mock()
+    registry.list_permissions = Mock(return_value=project_permissions)
+    sm = SecurityManager(project="any", registry=registry)
+    set_security_manager(sm)
+    yield sm
+    no_security_manager()
+
+
+def _server_with_projects(*project_names: str) -> tuple[RegistryServer, Mock]:
+    registry = Mock()
+    projects = [Project(name=name) for name in project_names]
+    registry.list_projects = Mock(return_value=projects)
+
+    def get_project(name: str, allow_cache: bool = False):
+        for project in projects:
+            if project.name == name:
+                return project
+        raise ProjectObjectNotFoundException(name=name)
+
+    registry.get_project = Mock(side_effect=get_project)
+    registry.refresh = Mock()
+    registry.commit = Mock()
+    return RegistryServer(registry=registry), registry
+
+
+def test_refresh_allows_missing_project_without_auth():
+    no_security_manager()
+    server, registry = _server_with_projects("existing")
+
+    response = server.Refresh(
+        RegistryServer_pb2.RefreshRequest(project="brand-new"), None
+    )
+
+    assert response == Empty()
+    registry.refresh.assert_called_once_with("brand-new")
+
+
+def test_refresh_allows_missing_project_with_create_permission(auth_security_manager):
+    auth_security_manager.set_current_user(User("alice", ["team-a"]))
+    server, registry = _server_with_projects("team-b-project")
+
+    response = server.Refresh(
+        RegistryServer_pb2.RefreshRequest(project="team-a-new"), None
+    )
+
+    assert response == Empty()
+    registry.refresh.assert_called_once_with("team-a-new")
+
+
+def test_refresh_denies_missing_project_without_create_permission(
+    auth_security_manager,
+):
+    auth_security_manager.set_current_user(User("bob", ["team-b"]))
+    server, _ = _server_with_projects("team-b-project")
+
+    with pytest.raises(FeastPermissionError):
+        server.Refresh(RegistryServer_pb2.RefreshRequest(project="team-a-new"), None)
+
+
+def test_refresh_requires_update_for_existing_project(auth_security_manager):
+    auth_security_manager.set_current_user(User("alice", ["team-a"]))
+    server, registry = _server_with_projects("team-a-project", "team-b-project")
+
+    response = server.Refresh(
+        RegistryServer_pb2.RefreshRequest(project="team-a-project"), None
+    )
+    assert response == Empty()
+    registry.refresh.assert_called_once_with("team-a-project")
+
+    with pytest.raises(FeastPermissionError):
+        server.Refresh(
+            RegistryServer_pb2.RefreshRequest(project="team-b-project"), None
+        )
+
+
+def test_commit_allows_when_caller_can_update_one_shared_project(auth_security_manager):
+    auth_security_manager.set_current_user(User("alice", ["team-a"]))
+    server, registry = _server_with_projects("team-a-project", "team-b-project")
+
+    response = server.Commit(Empty(), None)
+
+    assert response == Empty()
+    registry.commit.assert_called_once()
+
+
+def test_commit_denies_when_caller_cannot_create_or_update_any_project(
+    auth_security_manager,
+):
+    auth_security_manager.set_current_user(User("nobody", ["other"]))
+    server, _ = _server_with_projects("team-a-project", "team-b-project")
+
+    with pytest.raises(FeastPermissionError):
+        server.Commit(Empty(), None)
+
+
+def test_commit_allows_without_auth():
+    no_security_manager()
+    server, registry = _server_with_projects("a", "b")
+
+    response = server.Commit(Empty(), None)
+
+    assert response == Empty()
+    registry.commit.assert_called_once()
+
+
+def test_commit_allows_empty_registry_with_auth(auth_security_manager):
+    # No projects yet — same as old behavior (empty permission loop).
+    auth_security_manager.set_current_user(User("nobody", ["other"]))
+    server, registry = _server_with_projects()
+
+    response = server.Commit(Empty(), None)
+
+    assert response == Empty()
+    registry.commit.assert_called_once()
+
+
+def test_refresh_existing_project_without_auth():
+    no_security_manager()
+    server, registry = _server_with_projects("existing")
+
+    response = server.Refresh(
+        RegistryServer_pb2.RefreshRequest(project="existing"), None
+    )
+
+    assert response == Empty()
+    registry.refresh.assert_called_once_with("existing")
+
+
+def test_commit_allows_with_only_create_permission_on_new_project(
+    auth_security_manager,
+):
+    # After ApplyProject(commit=False), project exists in cache but caller may
+    # only have CREATE (not UPDATE) for that first apply transaction.
+    auth_security_manager.set_current_user(User("creator", ["team-a-creator"]))
+    server, registry = _server_with_projects("team-a-new")
+
+    response = server.Commit(Empty(), None)
+
+    assert response == Empty()
+    registry.commit.assert_called_once()


### PR DESCRIPTION

# What this PR does / why we need it:

Remote FeatureStore CRs that point at another CR's registry (`registry.remote.feastRef`) and use a new `feastProject` failed during apply with:
`ProjectObjectNotFoundException: Project <name> does not exist`
Cause: Refresh called `get_project` before auth short-circuit / create-or-update handling, so the project had to already exist before apply could create it.

- Fix `RegistryServer.Refresh` to use `assert_permissions_to_update` so a missing project is authorized with `CREATE` (existing projects still require `UPDATE`), unblocking first `feast apply` over a remote/`feastRef` shared registry.
- Relax `RegistryServer.Commit` auth from requiring `UPDATE` on every project to requiring `CREATE` or `UPDATE` on at least one project, so shared-registry multi-project commits work. Per-object Apply/Delete checks remain unchanged.
- Add unit coverage for missing-project refresh, create-only commit, multi-project commit, and deny paths.
