### PR TITLE
fix: Remote feastRef FeatureStore fails first apply for a new feastProject

### DIFF
--- a/sdk/python/feast/registry_server.py
+++ b/sdk/python/feast/registry_server.py
@@ -1376,10 +1376,12 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
         return Empty()
 
     def UpdateInfra(self, request: RegistryServer_pb2.UpdateInfraRequest, context):
-        project = self.proxied_registry.get_project(
-            name=request.project, allow_cache=True
+        # Create-or-update so first remote apply can write infra for a new project.
+        assert_permissions_to_update(
+            resource=Project(name=request.project),
+            getter=self.proxied_registry.get_project,
+            project=request.project,
         )
-        assert_permissions(resource=project, actions=[AuthzedAction.UPDATE])
         self.proxied_registry.update_infra(
             infra=Infra.from_proto(request.infra),
             project=request.project,
@@ -1388,10 +1390,19 @@ class RegistryServer(RegistryServer_pb2_grpc.RegistryServerServicer):
         return Empty()
 
     def GetInfra(self, request: RegistryServer_pb2.GetInfraRequest, context):
-        project = self.proxied_registry.get_project(
-            name=request.project, allow_cache=True
-        )
-        assert_permissions(resource=project, actions=[AuthzedAction.DESCRIBE])
+        # plan() calls get_infra before the project is created on a shared remote
+        # registry. Mirror ListProjectMetadata: authorize when present, and for a
+        # missing project require CREATE (or allow when auth is off).
+        try:
+            project = self.proxied_registry.get_project(
+                name=request.project, allow_cache=True
+            )
+            assert_permissions(resource=project, actions=[AuthzedAction.DESCRIBE])
+        except FeastObjectNotFoundException:
+            assert_permissions(
+                resource=Project(name=request.project),
+                actions=[AuthzedAction.CREATE],
+            )
         return self.proxied_registry.get_infra(
             project=request.project, allow_cache=request.allow_cache
         ).to_proto()

--- a/sdk/python/tests/unit/test_registry_server_commit_refresh.py
+++ b/sdk/python/tests/unit/test_registry_server_commit_refresh.py
@@ -4,6 +4,7 @@ import pytest
 from google.protobuf.empty_pb2 import Empty
 
 from feast.errors import FeastPermissionError, ProjectObjectNotFoundException
+from feast.infra.infra_object import Infra
 from feast.permissions.permission import AuthzedAction, Permission
 from feast.permissions.policy import RoleBasedPolicy
 from feast.permissions.security_manager import (
@@ -75,6 +76,8 @@ def _server_with_projects(*project_names: str) -> tuple[RegistryServer, Mock]:
     registry.get_project = Mock(side_effect=get_project)
     registry.refresh = Mock()
     registry.commit = Mock()
+    registry.get_infra = Mock(return_value=Infra())
+    registry.update_infra = Mock()
     return RegistryServer(registry=registry), registry
 
 
@@ -193,3 +196,81 @@ def test_commit_allows_with_only_create_permission_on_new_project(
 
     assert response == Empty()
     registry.commit.assert_called_once()
+
+
+def test_get_infra_allows_missing_project_without_auth():
+    no_security_manager()
+    server, registry = _server_with_projects("existing")
+
+    response = server.GetInfra(
+        RegistryServer_pb2.GetInfraRequest(project="brand-new", allow_cache=True),
+        None,
+    )
+
+    assert response == Infra().to_proto()
+    registry.get_infra.assert_called_once_with(project="brand-new", allow_cache=True)
+
+
+def test_get_infra_allows_missing_project_with_create_permission(auth_security_manager):
+    auth_security_manager.set_current_user(User("creator", ["team-a-creator"]))
+    server, registry = _server_with_projects("team-b-project")
+
+    response = server.GetInfra(
+        RegistryServer_pb2.GetInfraRequest(project="team-a-new", allow_cache=True),
+        None,
+    )
+
+    assert response == Infra().to_proto()
+    registry.get_infra.assert_called_once_with(project="team-a-new", allow_cache=True)
+
+
+def test_get_infra_denies_missing_project_without_create_permission(
+    auth_security_manager,
+):
+    auth_security_manager.set_current_user(User("bob", ["team-b"]))
+    server, _ = _server_with_projects("team-b-project")
+
+    with pytest.raises(FeastPermissionError):
+        server.GetInfra(
+            RegistryServer_pb2.GetInfraRequest(project="team-a-new", allow_cache=True),
+            None,
+        )
+
+
+def test_get_infra_requires_describe_for_existing_project(auth_security_manager):
+    auth_security_manager.set_current_user(User("alice", ["team-a"]))
+    server, registry = _server_with_projects("team-a-project", "team-b-project")
+
+    response = server.GetInfra(
+        RegistryServer_pb2.GetInfraRequest(project="team-a-project", allow_cache=True),
+        None,
+    )
+    assert response == Infra().to_proto()
+    registry.get_infra.assert_called_once_with(
+        project="team-a-project", allow_cache=True
+    )
+
+    with pytest.raises(FeastPermissionError):
+        server.GetInfra(
+            RegistryServer_pb2.GetInfraRequest(
+                project="team-b-project", allow_cache=True
+            ),
+            None,
+        )
+
+
+def test_update_infra_allows_missing_project_with_create_permission(
+    auth_security_manager,
+):
+    auth_security_manager.set_current_user(User("creator", ["team-a-creator"]))
+    server, registry = _server_with_projects("team-b-project")
+
+    response = server.UpdateInfra(
+        RegistryServer_pb2.UpdateInfraRequest(
+            infra=Infra().to_proto(), project="team-a-new", commit=True
+        ),
+        None,
+    )
+
+    assert response == Empty()
+    registry.update_infra.assert_called_once()


### PR DESCRIPTION

# What this PR does / why we need it:

When a FeatureStore CR uses `spec.services.registry.remote.feastRef` to share another CR’s registry and sets a **new** `feastProject`, `feast apply` fails during init with:

`feast.errors.ProjectObjectNotFoundException: Project does not exist`


The remote reference itself is fine (registry hostname resolves). The failure is on the registry server during first apply of a project that does not exist yet.

## Expected behavior
Remote `feastRef` should:
1. Not deploy a local registry for the secondary CR
2. Reuse the primary registry
3. Allow the secondary CR’s own `feastProject` to be created on that shared registry on first apply

## Actual behavior
`feast apply` → `plan()` fails before the project can be registered.

### Failure sequence (after partial fix)
1. `Refresh(project)` — originally failed on hard `get_project` + `UPDATE`
2. After Refresh fix: `GetInfra(project)` — same pattern (`get_project` + `DESCRIBE`)
3. `UpdateInfra` / `Commit` also had overly strict project existence / all-projects `UPDATE` checks

## Root cause
RBAC hardening on registry-server RPCs calls `get_project` **before** apply can create the project:

- `Refresh` / `GetInfra` / `UpdateInfra` assume the project already exists
- Local registry apply can auto-create missing projects; remote path cannot get past these RPCs


