### PR TITLE
fix: Isolate projection join key maps

### DIFF
--- a/sdk/python/feast/feature_view_projection.py
+++ b/sdk/python/feast/feature_view_projection.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-from attr import dataclass
+from attr import dataclass, field
 
 from feast.data_source import DataSource
 from feast.field import Field
@@ -42,7 +42,7 @@ class FeatureViewProjection:
     name_alias: Optional[str]
     desired_features: List[str]
     features: List[Field]
-    join_key_map: Dict[str, str] = {}
+    join_key_map: Dict[str, str] = field(factory=dict)
     timestamp_field: Optional[str] = None
     date_partition_column: Optional[str] = None
     created_timestamp_column: Optional[str] = None

--- a/sdk/python/tests/unit/test_feature_service.py
+++ b/sdk/python/tests/unit/test_feature_service.py
@@ -121,6 +121,25 @@ def test_prepare_for_apply_keeps_complete_projection():
     assert feature_service.feature_view_projections[0] == original_projection
 
 
+def test_feature_view_projections_have_independent_join_key_maps():
+    first_projection = FeatureViewProjection(
+        name="first",
+        name_alias=None,
+        desired_features=[],
+        features=[],
+    )
+    second_projection = FeatureViewProjection(
+        name="second",
+        name_alias=None,
+        desired_features=[],
+        features=[],
+    )
+
+    first_projection.join_key_map["entity_id"] = "aliased_entity_id"
+
+    assert second_projection.join_key_map == {}
+
+
 def test_build_apply_request():
     request = FeatureService.build_apply_request(
         name="my-feature-service",


### PR DESCRIPTION
# What this PR does / why we need it:

`FeatureViewProjection.join_key_map` previously used a dictionary created at class definition time. Projections constructed without an explicit mapping therefore shared that dictionary, so mutating one projection's entity remapping could leak into an unrelated feature view projection.

This change uses an attrs dictionary factory to give every projection its own mapping and adds a regression test that mutates one projection and verifies another remains empty.

# Which issue(s) this PR fixes:

No existing issue or pull request matched this bug. The draft PR starts the discussion as allowed by Feast's contribution guide.

# Checks

- [x] I've made sure the focused regression test is passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
- [ ] Testing is not required for this change

Validation performed:

- `uvx ruff check sdk/python/feast/feature_view_projection.py sdk/python/tests/unit/test_feature_service.py`
- `uvx ruff format --check sdk/python/feast/feature_view_projection.py sdk/python/tests/unit/test_feature_service.py`
- isolated execution of the new projection regression test ? 1 passed

The repository's complete dependency environment was not available locally, so that limitation is documented here and the standard unit file is left for CI.

# Misc

## Release note

```release-note
Fix feature view projections sharing a mutable default join-key mapping.
```

## AI assistance disclosure

I identified and reproduced the issue, then used OpenAI Codex to assist with the implementation and regression-test work. I personally reviewed the resulting diff and ran the validation commands listed above to verify the fix. Any full-suite or local-environment limitations are documented in the validation section.