### PR TITLE
docs: Fix broken GitHub star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,11 +283,11 @@ Feast is a community project and is still under active development. Please have 
 
 ## 🌟 GitHub Star History
 <p align="center">
-<a href="https://star-history.com/#feast-dev/feast&Date">
+<a href="https://star-history.dera.page/#feast-dev/feast&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=feast-dev/feast&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=feast-dev/feast&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=feast-dev/feast&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=feast-dev/feast&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=feast-dev/feast&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=feast-dev/feast&type=Date" />
  </picture>
 </a>
 </p>

--- a/infra/templates/README.md.jinja2
+++ b/infra/templates/README.md.jinja2
@@ -182,11 +182,11 @@ Feast is a community project and is still under active development. Please have 
 
 ## 🌟 GitHub Star History
 <p align="center">
-<a href="https://star-history.com/#feast-dev/feast&Date">
+<a href="https://star-history.dera.page/#feast-dev/feast&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=feast-dev/feast&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=feast-dev/feast&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=feast-dev/feast&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=feast-dev/feast&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=feast-dev/feast&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=feast-dev/feast&type=Date" />
  </picture>
 </a>
 </p>


### PR DESCRIPTION
The GitHub star history chart shown near the bottom of the README is currently broken due to restrictions on the GitHub stargazer API, so the chart no longer renders for readers. This change points the chart (and its surrounding link) at a working alternative so the star history is visible again. The underlying SVG chart endpoint and the hash-based link are both updated consistently in the README and the template used to generate it.