### PR TITLE
fix: Resolve kserve with pip --dry-run instead of installing it

### DIFF
--- a/sdk/python/tests/unit/infra/test_dependency_conflicts.py
+++ b/sdk/python/tests/unit/infra/test_dependency_conflicts.py
@@ -8,11 +8,29 @@ logger.setLevel(logging.DEBUG)
 
 class TestDependencyConflicts:
     def test_install_kserve_with_feast(self):
-        """Test installing KServe in the current environment where Feast is already installed.
-        Ensures no dependency conflict errors occur.
+        """Resolve KServe against the environment Feast is installed in.
+
+        ``--dry-run`` makes pip resolve the full dependency set and report what
+        it would install, without installing anything. Resolution is the part
+        this test cares about: pip exits non-zero when the versions cannot be
+        satisfied together, which is the conflict being guarded against.
+
+        Installing for real would mutate the interpreter running the suite.
+        Feast pins ``psutil==5.9.0`` while KServe requires ``psutil>=5.9.6``, so
+        pip has to uninstall psutil before reinstalling it, and the unit suite
+        runs under ``pytest -n 8`` against a single environment. Any test that
+        imports psutil during that window fails, including every test that
+        shells out to the CLI, since ``feast.metrics`` imports it at module
+        scope. It also left the environment inconsistent for the next run.
         """
-        # Command to install KServe
-        command = [sys.executable, "-m", "pip", "install", "kserve==0.15.2"]
+        command = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--dry-run",
+            "kserve==0.15.2",
+        ]
 
         process = subprocess.Popen(
             command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
@@ -26,7 +44,10 @@ class TestDependencyConflicts:
         logger.debug(out)
         logger.debug(err)
 
-        # Assertions
-        assert exit_code == 0
-        conflict_occured = "dependency conflicts" in err and "ERROR" not in err
-        assert not conflict_occured, "Dependency conflict detected during installation"
+        # pip reports an unsatisfiable set on stdout and exits non-zero, so the
+        # exit code is the assertion that matters; the message is for the
+        # failure output.
+        assert exit_code == 0, (
+            f"pip could not resolve kserve==0.15.2 against the current "
+            f"environment:\n{out}\n{err}"
+        )


### PR DESCRIPTION
## What this PR does / why we need it

`test_install_kserve_with_feast` installs kserve into the interpreter running the unit suite, with no isolation and no cleanup, so it mutates the environment every other test is using.

Feast pins `psutil==5.9.0` and kserve 0.15.2 requires `psutil<6.0.0,>=5.9.6`, so pip cannot leave the installed version in place — it uninstalls psutil, then installs 5.9.8:

```
Attempting uninstall: psutil
  Found existing installation: psutil 5.9.0
  Uninstalling psutil-5.9.0:
    Successfully uninstalled psutil-5.9.0
Installing collected packages: … psutil …
```

`make test-python-unit` runs `pytest -n 8`, so eight workers share one environment. Any test importing psutil during that window fails, including every test that shells out to the CLI, since `feast/metrics.py` imports it at module scope. That is how an unrelated docs PR picked up a red `unit-test-python (3.12, ubuntu-latest)` on `test_3rd_party_providers` with `ModuleNotFoundError: No module named 'psutil'`. Because it depends on worker timing, a re-run usually passes and it reads as flake.

kserve also pulls protobuf down to 4.25.x, which leaves the environment broken for the *next* run: the installed `grpcio-health-checking` ships protobuf 6.x generated code importing `google.protobuf.runtime_version`. The first run passes, because collection imports precede the mid-run install; the second fails at collection.

`--dry-run` performs the same resolution and still exits non-zero when the versions cannot be satisfied together, which is what the test guards against, without installing anything.

This also replaces the conflict assertion, which was inverted:

```python
conflict_occured = "dependency conflicts" in err and "ERROR" not in err
```

That is only true when pip reports conflicts *without* an error, so a run failing loudly set it to `False`. The `exit_code == 0` assertion was already doing the real work; it now carries pip's output for diagnosis.

## Which issue(s) this PR fixes

Closes #6732

## Misc

Verified both directions, so the detection is unchanged rather than merely quieter:

- clean resolution exits 0, performs the full resolve (`Would install … psutil-5.9.8 …`), and leaves psutil at 5.9.0 with kserve not importable afterwards
- `pip install --dry-run kserve==0.15.2 psutil==5.9.0` exits 1 with `Cannot install kserve==0.15.2 and psutil==5.9.0 because these package versions have conflicting dependencies`

The full unit suite now passes twice in a row — 2529 passed, 20 skipped both times, with psutil still 5.9.0 and protobuf still 6.33.6 after the first. Previously the second run produced 31 failures and 8 collection errors. The test also drops from about 13s to under 2s.

This needs a `kind/` label, which I cannot add as an outside contributor.