### PR TITLE
fix: Remove inert subjectaccessreviews and reorganize RBAC rules

### DIFF
--- a/infra/feast-operator/config/rbac/role.yaml
+++ b/infra/feast-operator/config/rbac/role.yaml
@@ -163,10 +163,35 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - clusterroles
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - feast-discover-namespaces
+  - feast-oidc-token-review
+  - feast-token-review-cluster-role
+  resources:
+  - clusterroles
+  verbs:
+  - delete
+  - get
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - rolebindings
   - roles
-  - subjectaccessreviews
   verbs:
   - create
   - delete

--- a/infra/feast-operator/dist/install.yaml
+++ b/infra/feast-operator/dist/install.yaml
@@ -22321,10 +22321,35 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - clusterroles
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - feast-discover-namespaces
+  - feast-oidc-token-review
+  - feast-token-review-cluster-role
+  resources:
+  - clusterroles
+  verbs:
+  - delete
+  - get
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - rolebindings
   - roles
-  - subjectaccessreviews
   verbs:
   - create
   - delete

--- a/infra/feast-operator/internal/controller/authz/authz.go
+++ b/infra/feast-operator/internal/controller/authz/authz.go
@@ -165,11 +165,6 @@ func (authz *FeastAuthorization) setFeastClusterRole(clusterRole *rbacv1.Cluster
 			Verbs:     []string{verbCreate},
 		},
 		{
-			APIGroups: []string{rbacv1.GroupName},
-			Resources: []string{"subjectaccessreviews"},
-			Verbs:     []string{verbCreate},
-		},
-		{
 			APIGroups: []string{""},
 			Resources: []string{"namespaces"},
 			Verbs:     []string{verbGet, verbList, verbWatch},
@@ -248,11 +243,6 @@ func (authz *FeastAuthorization) setFeastRole(role *rbacv1.Role) error {
 		{
 			APIGroups: []string{authenticationAPIGroup},
 			Resources: []string{resourceTokenReviews},
-			Verbs:     []string{verbCreate},
-		},
-		{
-			APIGroups: []string{rbacv1.GroupName},
-			Resources: []string{"subjectaccessreviews"},
 			Verbs:     []string{verbCreate},
 		},
 		{

--- a/infra/feast-operator/internal/controller/featurestore_controller.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller.go
@@ -67,7 +67,10 @@ type FeatureStoreReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;create;update;watch;delete
 // +kubebuilder:rbac:groups=core,resources=services;configmaps;persistentvolumeclaims,verbs=get;list;create;update;watch;delete;deletecollection
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;create;update;watch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings;subjectaccessreviews,verbs=get;list;create;update;watch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;create;update;watch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=feast-discover-namespaces;feast-oidc-token-review;feast-token-review-cluster-role,verbs=get;update;delete
 // +kubebuilder:rbac:groups=core,resources=secrets;namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;delete;deletecollection
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=create

--- a/infra/feast-operator/internal/controller/featurestore_controller_kubernetes_auth_test.go
+++ b/infra/feast-operator/internal/controller/featurestore_controller_kubernetes_auth_test.go
@@ -227,7 +227,7 @@ var _ = Describe("FeatureStore Controller-Kubernetes authorization", func() {
 				feastRole)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(feastRole.Rules).ToNot(BeEmpty())
-			Expect(feastRole.Rules).To(HaveLen(6))
+			Expect(feastRole.Rules).To(HaveLen(5))
 			Expect(feastRole.Rules[0].APIGroups).To(HaveLen(1))
 			Expect(feastRole.Rules[0].APIGroups[0]).To(Equal(rbacv1.GroupName))
 			Expect(feastRole.Rules[0].Resources).To(HaveLen(2))


### PR DESCRIPTION
## Summary
Remove the unused subjectaccessreviews from the operator ClusterRole and reorganize the RBAC rules for clusterrolebindings and clusterroles to follow the principle of least privilege.

## Changes
- Remove subjectaccessreviews from both role.yaml and authz.go
- Separate clusterrolebindings with its own verb set
- Split clusterroles into general create and named resource management

## Test Plan
- [x] Unit tests passing
