### PR TITLE
fix: Widen Athena integer type mapping for unsigned ints

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -2291,10 +2291,14 @@ def pa_to_athena_value_type(pa_type: "pyarrow.DataType") -> str:
         "int16": "smallint",
         "int32": "int",
         "int64": "bigint",
-        "uint8": "tinyint",
-        "uint16": "tinyint",
-        "uint32": "tinyint",
-        "uint64": "tinyint",
+        # Athena integer types are signed, so unsigned Arrow types must be
+        # widened to the next-larger signed type to avoid overflow in the
+        # generated DDL (e.g. uint32 exceeds signed int's max). This mirrors
+        # the widening already done in arrow_to_pg_type for Postgres.
+        "uint8": "smallint",
+        "uint16": "int",
+        "uint32": "bigint",
+        "uint64": "bigint",
         "float": "float",
         "double": "double",
         "binary": "binary",

--- a/sdk/python/tests/unit/test_type_map.py
+++ b/sdk/python/tests/unit/test_type_map.py
@@ -14,6 +14,7 @@ from feast.type_map import (
     arrow_to_pg_type,
     feast_value_type_to_pa,
     feast_value_type_to_python_type,
+    pa_to_athena_value_type,
     pa_to_feast_value_type,
     pa_to_redshift_value_type,
     pg_type_to_feast_value_type,
@@ -530,6 +531,25 @@ class TestMapArrowTypeSupport:
         """Test that Arrow map type converts to Postgres jsonb."""
         assert arrow_to_pg_type("map<string, string>") == "jsonb"
         assert arrow_to_pg_type("map<string, int64>") == "jsonb"
+
+    def test_pa_to_athena_value_type_unsigned_ints_widen(self):
+        """Unsigned Arrow ints must widen to a signed Athena type that can
+        hold their full range. Athena has no unsigned integer types, so
+        mapping every uintN to tinyint (signed -128..127) overflows for any
+        value above 127 in the generated CREATE TABLE DDL. Each uintN must map
+        to the next-larger signed type, matching arrow_to_pg_type's widening.
+        """
+        assert pa_to_athena_value_type(pyarrow.uint8()) == "smallint"
+        assert pa_to_athena_value_type(pyarrow.uint16()) == "int"
+        assert pa_to_athena_value_type(pyarrow.uint32()) == "bigint"
+        assert pa_to_athena_value_type(pyarrow.uint64()) == "bigint"
+
+    def test_pa_to_athena_value_type_signed_ints_unchanged(self):
+        """Signed Arrow ints keep their same-width Athena type (no regression)."""
+        assert pa_to_athena_value_type(pyarrow.int8()) == "tinyint"
+        assert pa_to_athena_value_type(pyarrow.int16()) == "smallint"
+        assert pa_to_athena_value_type(pyarrow.int32()) == "int"
+        assert pa_to_athena_value_type(pyarrow.int64()) == "bigint"
 
     def test_pg_type_to_feast_value_type_json(self):
         """Test that Postgres json/jsonb types convert to ValueType.MAP."""


### PR DESCRIPTION
### What

`pa_to_athena_value_type` in `sdk/python/feast/type_map.py` maps **every** unsigned Arrow int (`uint8`/`uint16`/`uint32`/`uint64`) to Athena `tinyint`. Athena `tinyint` is signed 8-bit (-128..127), so any unsigned value above 127 — e.g. a `uint32` column — overflows the type in the generated `CREATE TABLE` DDL.

### Fix

Widen each unsigned type to the next-larger signed Athena type that holds its full range (Athena has no unsigned integer types):

| Arrow | before | after |
|---|---|---|
| `uint8` | `tinyint` | `smallint` |
| `uint16` | `tinyint` | `int` |
| `uint32` | `tinyint` | `bigint` |
| `uint64` | `tinyint` | `bigint` |

Same widening `arrow_to_pg_type` already applies for Postgres. (`pa_to_mssql_type` keeps `uint8->tinyint` because SQL Server's `tinyint` is unsigned.) Signed inputs are unchanged.

### Test

Regression test in `sdk/python/tests/unit/test_type_map.py`: fails before (`assert 'tinyint' == 'smallint'`), `2 passed` after.

---
_drafted with AI assistance; verified locally (red -> green on the added test)._
