### PR TITLE
fix: RemoteRegistry.apply_saved_dataset() calls the wrong RPC

### DIFF
--- a/sdk/python/feast/infra/registry/remote.py
+++ b/sdk/python/feast/infra/registry/remote.py
@@ -489,7 +489,7 @@ class RemoteRegistry(BaseRegistry):
         request = RegistryServer_pb2.ApplySavedDatasetRequest(
             saved_dataset=saved_dataset.to_proto(), project=project, commit=commit
         )
-        self.stub.ApplyFeatureService(request)
+        self.stub.ApplySavedDataset(request)
 
     def delete_saved_dataset(self, name: str, project: str, commit: bool = True):
         request = RegistryServer_pb2.DeleteSavedDatasetRequest(

--- a/sdk/python/tests/unit/infra/registry/test_remote_registry.py
+++ b/sdk/python/tests/unit/infra/registry/test_remote_registry.py
@@ -18,8 +18,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 
+from feast.infra.offline_stores.file_source import SavedDatasetFileStorage
 from feast.infra.registry.remote import RemoteRegistry
 from feast.protos.feast.registry import RegistryServer_pb2
+from feast.saved_dataset import SavedDataset
 
 
 @pytest.fixture
@@ -83,3 +85,29 @@ def test_updated_since_none(remote_registry):
         remote_registry.stub.ListAllFeatureViews.call_args[0][0]
     )
     assert not request.HasField("updated_since")
+
+
+def test_apply_saved_dataset_calls_apply_saved_dataset_rpc(remote_registry):
+    """apply_saved_dataset() must invoke the ApplySavedDataset RPC, not
+    ApplyFeatureService -- calling the wrong RPC means the server tries to
+    deserialize an ApplySavedDatasetRequest as an ApplyFeatureServiceRequest,
+    which the server cannot handle correctly."""
+    saved_dataset = SavedDataset(
+        name="test_saved_dataset",
+        features=["feature_view:feature"],
+        join_keys=["entity_id"],
+        storage=SavedDatasetFileStorage(path="/tmp/does-not-need-to-exist.parquet"),
+        tags={},
+    )
+
+    remote_registry.apply_saved_dataset(saved_dataset, "project", commit=True)
+
+    remote_registry.stub.ApplySavedDataset.assert_called_once()
+    remote_registry.stub.ApplyFeatureService.assert_not_called()
+
+    request: RegistryServer_pb2.ApplySavedDatasetRequest = (
+        remote_registry.stub.ApplySavedDataset.call_args[0][0]
+    )
+    assert request.saved_dataset.spec.name == "test_saved_dataset"
+    assert request.project == "project"
+    assert request.commit is True


### PR DESCRIPTION
# What this PR does / why we need it:
`RemoteRegistry.apply_saved_dataset()` (`sdk/python/feast/infra/registry/remote.py`) builds an `ApplySavedDatasetRequest`, but sends it through the `ApplyFeatureService` RPC instead of the dedicated `ApplySavedDataset` RPC:

```python
def apply_saved_dataset(
    self,
    saved_dataset: SavedDataset,
    project: str,
    commit: bool = True,
):
    request = RegistryServer_pb2.ApplySavedDatasetRequest(
        saved_dataset=saved_dataset.to_proto(), project=project, commit=commit
    )
    self.stub.ApplyFeatureService(request)  # <-- wrong RPC
```

The server (`sdk/python/feast/registry_server.py`) already implements a correct `ApplySavedDataset` handler that expects exactly this request shape and forwards it to `proxied_registry.apply_saved_dataset(...)`. Because the client calls `ApplyFeatureService` instead, the server tries to handle an `ApplySavedDatasetRequest` payload through the `ApplyFeatureService` RPC/`ApplyFeatureServiceRequest` shape, so registering a `SavedDataset` against a remote registry (`registry_type: remote`) never reaches the intended handler and the saved dataset is not correctly persisted.

This was found while working with a Feast deployment using a remote registry (Feast Operator / OpenShift), trying to register a `SavedDataset` via `store.registry.apply_saved_dataset(...)` after using `store.create_saved_dataset()`'s `.persist()` step wasn't an option for the offline store in use.

The fix is a one-line change: call `self.stub.ApplySavedDataset(request)` instead of `self.stub.ApplyFeatureService(request)`.

# Which issue(s) this PR fixes:
None filed yet — I searched open/closed issues and PRs for `ApplySavedDataset` / `apply_saved_dataset` and didn't find an existing report.

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests

Added `test_apply_saved_dataset_calls_apply_saved_dataset_rpc` to `sdk/python/tests/unit/infra/registry/test_remote_registry.py`, following the existing `remote_registry` fixture pattern in that file. Verified locally:
- Test fails against the pre-fix code (`ApplyFeatureService.assert_not_called()` fails because it *was* called).
- Test passes with the fix applied, and confirms the request payload (`ApplySavedDatasetRequest`) is unchanged, only the RPC method changes.
- Full `test_remote_registry.py` suite (5 tests) passes.

# Misc
Small, isolated fix — one production line changed, plus a regression test. No API changes.