### PR TITLE
fix: Preinstall DuckDB delta extension for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,7 +324,8 @@ python = "~=3.10.0"
 feast = { path = ".", editable = true, extras = ["duckdb", "delta", "grpcio", "test"] }
 
 [tool.pixi.feature.duckdb-tests.tasks]
-test = { cmd = "python -m pytest -n 8 --integration -m 'not ray_offline_stores_only' --ignore=sdk/python/tests/integration/offline_store/test_dqm_validation.py sdk/python/tests/integration/offline_store", env = { PYTHONPATH = ".", FULL_REPO_CONFIGS_MODULE = "sdk.python.tests.universal.feature_repos.duckdb_repo_configuration", FEAST_IS_LOCAL_TEST = "True" } }
+install-delta-extension = "python -c \"import duckdb; duckdb.connect().install_extension('delta')\""
+test = { depends-on = ["install-delta-extension"], cmd = "python -m pytest -n 8 --integration -m 'not ray_offline_stores_only' --ignore=sdk/python/tests/integration/offline_store/test_dqm_validation.py sdk/python/tests/integration/offline_store", env = { PYTHONPATH = ".", FULL_REPO_CONFIGS_MODULE = "sdk.python.tests.universal.feature_repos.duckdb_repo_configuration", FEAST_IS_LOCAL_TEST = "True" } }
 
 [tool.pixi.feature.ray-tests.pypi-dependencies]
 feast = { path = ".", editable = true, extras = ["ray", "grpcio", "test"] }


### PR DESCRIPTION
# What this PR does / why we need it:

The DuckDB offline suite starts 8 pytest workers against a shared extension cache. On a fresh Linux runner, multiple workers can decide the `delta` extension is missing and race to install it. This has failed 3 unrelated CI runs with a DuckDB extension-file lock conflict.

This adds a serial Pixi task that installs `delta` before pytest starts. The existing test task depends on it, so workers only need to load the installed extension.

# Which issue(s) this PR fixes:

Fixes #6743

# Checks

- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy

- [ ] Unit tests
- [x] Integration tests
- [x] Manual tests
- [ ] Testing is not required for this change

Ran the task from an empty DuckDB cache and confirmed Pixi completed `install-delta-extension` before starting pytest. A fresh connection reported `delta` as installed and not loaded. The complete 8-worker suite passed with 84 tests passed and 5 skipped.

## Self-review

No issues found in the one-file task configuration change.

# Misc

Please add `kind/bug` and `ok-to-test`.
