### PR TITLE
test: Remove flaky key encoding timing assertion

### DIFF
--- a/sdk/python/tests/unit/infra/test_key_encoding_utils.py
+++ b/sdk/python/tests/unit/infra/test_key_encoding_utils.py
@@ -236,32 +236,6 @@ def test_optimization_preserves_sorting():
     assert [v.string_val for v in deserialized.entity_values] == expected_sorted_values
 
 
-def test_performance_bounds_single_entity():
-    """Regression test to ensure single entity performance meets minimum bounds."""
-    import time
-
-    entity_key = EntityKeyProto(
-        join_keys=["user_id"], entity_values=[ValueProto(string_val="user123")]
-    )
-
-    # Measure serialization time for 1000 operations
-    start = time.perf_counter()
-    for _ in range(1000):
-        serialize_entity_key(entity_key, entity_key_serialization_version=3)
-    serialize_time = time.perf_counter() - start
-
-    # Measure deserialization time
-    serialized = serialize_entity_key(entity_key, entity_key_serialization_version=3)
-    start = time.perf_counter()
-    for _ in range(1000):
-        deserialize_entity_key(serialized, entity_key_serialization_version=3)
-    deserialize_time = time.perf_counter() - start
-
-    # Performance bounds with generous thresholds to avoid flaky failures on CI runners
-    assert serialize_time < 0.2, f"Serialization too slow: {serialize_time:.4f}s"
-    assert deserialize_time < 0.2, f"Deserialization too slow: {deserialize_time:.4f}s"
-
-
 def test_non_ascii_prefix_compatibility():
     """Critical test: ensure prefix serialization matches full entity key serialization for non-ASCII keys."""
     # Test with non-ASCII characters that have different byte vs character lengths


### PR DESCRIPTION
## What this PR does

Removes `test_performance_bounds_single_entity` from the parallel unit suite. The test measures 1,000 operations against an absolute 0.2-second wall-clock limit, which remains sensitive to shared-runner contention after two earlier threshold increases.

Correctness remains covered by `test_single_entity_fast_path`. Performance remains covered by `sdk/python/tests/benchmarks/test_key_encoding_benchmarks.py`, where pytest-benchmark reports calibrated results instead of enforcing an absolute wall-clock assertion in the unit suite.

## Testing

- Key encoding unit module: 14 passed
- Key encoding benchmarks: 2 passed (about 916k serialization and 714k deserialization operations per second locally)
- Python unit suite: 2,536 passed, 20 skipped
- Ruff and pre-commit checks passed

## Review requests

- `kind/bug`
- `ok-to-test`

Fixes #6745
