### PR TITLE
fix: Use batch source timestamp column names in remote online writes

### DIFF
--- a/sdk/python/feast/infra/online_stores/remote.py
+++ b/sdk/python/feast/infra/online_stores/remote.py
@@ -260,6 +260,16 @@ class RemoteOnlineStore(OnlineStore):
 
         columnar_data: Dict[str, List[Any]] = defaultdict(list)
 
+        # The server resolves the timestamp columns by the names the batch source
+        # configures, so label them the same way here rather than with literals.
+        batch_source = getattr(table, "batch_source", None)
+        event_timestamp_column = (
+            getattr(batch_source, "timestamp_field", None) or "event_timestamp"
+        )
+        created_timestamp_column = (
+            getattr(batch_source, "created_timestamp_column", None) or "created"
+        )
+
         # Iterate through each row to populate columnar data directly
         for entity_key_proto, feature_values_proto, event_ts, created_ts in data:
             # Populate entity key values
@@ -277,8 +287,10 @@ class RemoteOnlineStore(OnlineStore):
                 )
 
             # Populate timestamps
-            columnar_data["event_timestamp"].append(_to_naive_utc(event_ts).isoformat())
-            columnar_data["created"].append(
+            columnar_data[event_timestamp_column].append(
+                _to_naive_utc(event_ts).isoformat()
+            )
+            columnar_data[created_timestamp_column].append(
                 _to_naive_utc(created_ts).isoformat() if created_ts else None
             )
 

--- a/sdk/python/tests/unit/infra/online_store/test_remote_online_store.py
+++ b/sdk/python/tests/unit/infra/online_store/test_remote_online_store.py
@@ -779,3 +779,106 @@ class TestRemoteOnlineStoreWriteBatch:
 
         # Event timestamps should be ISO strings as before
         assert df["event_timestamp"] == ["2023-11-15T00:00:00"]
+
+    @pytest.fixture
+    def feature_view_custom_timestamps(self):
+        """A feature view whose batch source uses non-default timestamp columns."""
+        entity = Entity(
+            name="user_id", description="User ID", value_type=ValueType.INT64
+        )
+        source = FileSource(
+            path="test.parquet",
+            timestamp_field="ingested_at",
+            created_timestamp_column="created_at",
+        )
+        return FeatureView(
+            name="test_feature_view",
+            entities=[entity],
+            ttl=timedelta(days=1),
+            schema=[
+                Field(name="user_id", dtype=Int64),
+                Field(name="feature1", dtype=String),
+            ],
+            source=source,
+        )
+
+    @patch("feast.infra.online_stores.remote.post_remote_online_write")
+    def test_timestamp_columns_use_batch_source_names(
+        self, mock_post, remote_store, config, feature_view_custom_timestamps
+    ):
+        """The request body must label the timestamps with the batch source's
+        configured column names, since that is how the server resolves them."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        data = [
+            (
+                EntityKeyProto(
+                    join_keys=["user_id"], entity_values=[ValueProto(int64_val=42)]
+                ),
+                {"feature1": ValueProto(string_val="hello")},
+                datetime(2023, 11, 15, 0, 0, 0),
+                datetime(2023, 11, 14, 0, 0, 0),
+            )
+        ]
+
+        remote_store.online_write_batch(
+            config=config,
+            table=feature_view_custom_timestamps,
+            data=data,
+            progress=None,
+        )
+
+        df = mock_post.call_args[1]["req_body"]["df"]
+        assert df["ingested_at"] == ["2023-11-15T00:00:00"]
+        assert df["created_at"] == ["2023-11-14T00:00:00"]
+
+    @patch("feast.infra.online_stores.remote.post_remote_online_write")
+    def test_write_batch_payload_round_trips_through_server_conversion(
+        self, mock_post, remote_store, config, feature_view_custom_timestamps
+    ):
+        """The payload this client sends must be convertible by the server, which
+        rebuilds the frame and calls `_convert_arrow_fv_to_proto` on it."""
+        import pandas as pd
+        import pyarrow as pa
+
+        from feast.utils import _convert_arrow_fv_to_proto
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        event_ts = datetime(2023, 11, 15, 0, 0, 0)
+        created_ts = datetime(2023, 11, 14, 0, 0, 0)
+        data = [
+            (
+                EntityKeyProto(
+                    join_keys=["user_id"], entity_values=[ValueProto(int64_val=42)]
+                ),
+                {"feature1": ValueProto(string_val="hello")},
+                event_ts,
+                created_ts,
+            )
+        ]
+
+        remote_store.online_write_batch(
+            config=config,
+            table=feature_view_custom_timestamps,
+            data=data,
+            progress=None,
+        )
+
+        # Mirror the server: rebuild the frame and run the standard conversion.
+        server_df = pd.DataFrame(mock_post.call_args[1]["req_body"]["df"])
+        rows = _convert_arrow_fv_to_proto(
+            pa.Table.from_pandas(server_df),
+            feature_view_custom_timestamps,
+            {"user_id": ValueType.INT64},
+        )
+
+        assert len(rows) == 1
+        _, features, out_event_ts, out_created_ts = rows[0]
+        assert features["feature1"].string_val == "hello"
+        assert out_event_ts.replace(tzinfo=None) == event_ts
+        assert out_created_ts.replace(tzinfo=None) == created_ts


### PR DESCRIPTION
## What this fixes

Closes #6595.

`RemoteOnlineStore.online_write_batch` labelled the timestamps in its request body
with the literals `"event_timestamp"` and `"created"`:

```python
columnar_data["event_timestamp"].append(_to_naive_utc(event_ts).isoformat())
columnar_data["created"].append(...)
```

The feature server rebuilds that frame verbatim (`pd.DataFrame(request.df)` in
`feature_server.py`) and hands it to the standard conversion, which resolves the
timestamp columns by the names the feature view's **batch source** configures
(`sdk/python/feast/utils.py`, `_convert_arrow_fv_to_proto`):

```python
table.column(feature_view.batch_source.timestamp_field)
table.column(feature_view.batch_source.created_timestamp_column)
```

So for any feature view whose source sets `timestamp_field` or
`created_timestamp_column` to something other than those two literals, the client
emits the column under one name and the server looks it up under another:

```
KeyError: 'Field "created_at" does not exist in schema'
```

The timestamp value is never lost — it is on the wire, just labelled with a name the
server does not look up. Client and server simply disagree on the column names.

## The change

Resolve both column names from the feature view's batch source, falling back to the
previous literals when a name is not configured. That keeps the payload byte-identical
for the default-named case (which is why the existing
`test_unix_timestamp_value_serialized_as_int` still passes unchanged) and makes the
custom-named case round-trip.

This is the only site with the hardcoding — `_convert_arrow_odfv_to_proto` synthesizes
its own timestamps and is unaffected, and no other caller builds this payload.

## Tests

Two tests in `TestRemoteOnlineStoreWriteBatch`, both failing before the change:

- `test_timestamp_columns_use_batch_source_names` — asserts the request body labels the
  timestamps with the configured names.
- `test_write_batch_payload_round_trips_through_server_conversion` — the one that
  actually pins the contract: it takes the payload this client produced, rebuilds the
  frame the way the server does, runs `_convert_arrow_fv_to_proto` on it, and asserts
  both timestamps survive. Without the fix this test reproduces the reported
  `KeyError: 'Field "..." does not exist in schema'` directly.

```
sdk/python/tests/unit/infra/online_store/test_remote_online_store.py  30 passed
```

Wider check: every unit test file touching the remote / `write_to_online_store` /
`_convert_arrow` paths (22 files) gives 219 passed, 5 skipped both with and without this
change. The 11 collection errors in that set are pre-existing missing optional
dependencies in my environment (`sqlite_vec`, `boto3`, `redis`, …), identical on both
sides. `ruff check`, `ruff format` and `mypy feast/infra/online_stores/remote.py` are
clean.

---
🤖 Written with [Claude Code](https://claude.com/claude-code) (Claude Opus 5), reviewed by @arose26.
