### PR TITLE
feat: Add feature view versioning to Qdrant online store

### DIFF
--- a/sdk/python/feast/infra/online_stores/qdrant_online_store/qdrant.py
+++ b/sdk/python/feast/infra/online_stores/qdrant_online_store/qdrant.py
@@ -14,6 +14,7 @@ from feast.infra.key_encoding_utils import (
     get_list_val_str,
     serialize_entity_key,
 )
+from feast.infra.online_stores.helpers import compute_versioned_name
 from feast.infra.online_stores.online_store import OnlineStore
 from feast.infra.online_stores.vector_store import VectorStoreConfig
 from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
@@ -26,6 +27,21 @@ from feast.utils import (
 )
 
 SCROLL_SIZE = 1000
+
+
+def _collection_name(config: RepoConfig, table: FeatureView) -> str:
+    """Qdrant collection backing a feature view, suffixed with ``_v{N}`` when
+    online feature view versioning is enabled.
+
+    Deliberately built from ``compute_versioned_name`` rather than
+    ``compute_table_id``: Qdrant collections have always been named by the bare
+    feature view name, so adding the ``{project}_`` prefix that other stores use
+    would orphan every existing collection.
+    """
+    return compute_versioned_name(
+        table, config.registry.enable_online_feature_view_versioning
+    )
+
 
 DISTANCE_MAPPING = {
     "cosine": models.Distance.COSINE,
@@ -139,7 +155,7 @@ class QdrantOnlineStore(OnlineStore):
                 )
 
         self._get_client(config).upload_points(
-            collection_name=table.name,
+            collection_name=_collection_name(config, table),
             batch_size=config.online_store.write_batch_size,
             points=points,
             wait=True,
@@ -172,7 +188,7 @@ class QdrantOnlineStore(OnlineStore):
         stop_scrolling = False
         while not stop_scrolling:
             records, next_offset = self._get_client(config).scroll(
-                collection_name=config.online_store.collection_name,
+                collection_name=_collection_name(config, table),
                 limit=SCROLL_SIZE,
                 offset=next_offset,
                 with_payload=True,
@@ -209,7 +225,7 @@ class QdrantOnlineStore(OnlineStore):
         client: QdrantClient = self._get_client(config)
 
         client.create_collection(
-            collection_name=table.name,
+            collection_name=_collection_name(config, table),
             vectors_config={
                 config.online_store.vector_name: models.VectorParams(
                     size=vector_field_length,
@@ -218,12 +234,12 @@ class QdrantOnlineStore(OnlineStore):
             },
         )
         client.create_payload_index(
-            collection_name=table.name,
+            collection_name=_collection_name(config, table),
             field_name="entity_key",
             field_schema=models.PayloadSchemaType.KEYWORD,
         )
         client.create_payload_index(
-            collection_name=table.name,
+            collection_name=_collection_name(config, table),
             field_name="feature_name",
             field_schema=models.PayloadSchemaType.KEYWORD,
         )
@@ -238,7 +254,9 @@ class QdrantOnlineStore(OnlineStore):
         partial: bool,
     ):
         for table in tables_to_delete:
-            self._get_client(config).delete_collection(collection_name=table.name)
+            self._get_client(config).delete_collection(
+                collection_name=_collection_name(config, table)
+            )
         for table in tables_to_keep:
             self.create_collection(config, table)
 
@@ -251,7 +269,9 @@ class QdrantOnlineStore(OnlineStore):
         project = config.project
         try:
             for table in tables:
-                self._get_client(config).delete_collection(collection_name=table.name)
+                self._get_client(config).delete_collection(
+                    collection_name=_collection_name(config, table)
+                )
         except Exception as e:
             logging.exception(f"Error deleting collection in project {project}: {e}")
             raise
@@ -288,7 +308,7 @@ class QdrantOnlineStore(OnlineStore):
         points = (
             self._get_client(config)
             .query_points(
-                collection_name=table.name,
+                collection_name=_collection_name(config, table),
                 query=embedding,
                 limit=top_k,
                 with_payload=True,

--- a/sdk/python/tests/unit/infra/online_store/test_qdrant_online_store.py
+++ b/sdk/python/tests/unit/infra/online_store/test_qdrant_online_store.py
@@ -1,0 +1,137 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from feast import Entity, FeatureView, Field, FileSource, RepoConfig
+from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
+from feast.protos.feast.types.Value_pb2 import Value as ValueProto
+from feast.types import Int64, String
+from feast.value_type import ValueType
+
+qdrant = pytest.importorskip("qdrant_client")
+
+from feast.infra.online_stores.qdrant_online_store.qdrant import (  # noqa: E402
+    QdrantOnlineStore,
+    QdrantOnlineStoreConfig,
+    _collection_name,
+)
+
+
+def _config(versioning: bool) -> RepoConfig:
+    return RepoConfig(
+        project="test_project",
+        online_store=QdrantOnlineStoreConfig(
+            type="qdrant",
+            location=":memory:",
+            vector_enabled=True,
+            similarity="cosine",
+        ),
+        registry={
+            "path": "dummy_registry",
+            "enable_online_feature_view_versioning": versioning,
+        },
+        entity_key_serialization_version=3,
+    )
+
+
+def _feature_view(version: int = 0) -> FeatureView:
+    fv = FeatureView(
+        name="driver_stats",
+        entities=[Entity(name="driver_id", value_type=ValueType.INT64)],
+        ttl=timedelta(days=1),
+        schema=[
+            Field(name="driver_id", dtype=Int64),
+            Field(name="trips", dtype=String),
+        ],
+        source=FileSource(path="driver.parquet", timestamp_field="event_timestamp"),
+    )
+    if version:
+        fv.projection.version_tag = version
+    return fv
+
+
+def _write(store, config, fv, value):
+    entity_key = EntityKeyProto(
+        join_keys=["driver_id"], entity_values=[ValueProto(int64_val=1)]
+    )
+    store.online_write_batch(
+        config,
+        fv,
+        [
+            (
+                entity_key,
+                {"trips": ValueProto(string_val=value)},
+                datetime(2024, 1, 1),
+                None,
+            )
+        ],
+        None,
+    )
+
+
+class TestQdrantCollectionNaming:
+    def test_unversioned_name_is_unchanged(self):
+        """Existing deployments must keep their current collection names."""
+        assert _collection_name(_config(False), _feature_view()) == "driver_stats"
+
+    def test_versioning_disabled_ignores_the_version_tag(self):
+        assert (
+            _collection_name(_config(False), _feature_view(version=2)) == "driver_stats"
+        )
+
+    def test_versioned_name_gets_a_suffix(self):
+        assert (
+            _collection_name(_config(True), _feature_view(version=2))
+            == "driver_stats_v2"
+        )
+
+
+class TestQdrantVersionedCollections:
+    """End-to-end against an in-process Qdrant."""
+
+    def test_versions_write_to_separate_collections(self):
+        config = _config(True)
+        store = QdrantOnlineStore()
+        v1, v2 = _feature_view(version=1), _feature_view(version=2)
+
+        store.update(config, [], [v1, v2], [], [], partial=False)
+        names = {
+            c.name for c in store._get_client(config).get_collections().collections
+        }
+        assert {"driver_stats_v1", "driver_stats_v2"} <= names
+
+        _write(store, config, v1, "from_v1")
+        _write(store, config, v2, "from_v2")
+
+        client = store._get_client(config)
+        assert client.count("driver_stats_v1").count == 1
+        assert client.count("driver_stats_v2").count == 1
+
+        payload = client.scroll("driver_stats_v1", limit=10, with_payload=True)[0]
+        assert [p.payload["feature_name"] for p in payload] == ["trips"]
+
+    def test_teardown_removes_only_the_targeted_version(self):
+        config = _config(True)
+        store = QdrantOnlineStore()
+        v1, v2 = _feature_view(version=1), _feature_view(version=2)
+        store.update(config, [], [v1, v2], [], [], partial=False)
+
+        store.teardown(config, [v1], [])
+
+        names = {
+            c.name for c in store._get_client(config).get_collections().collections
+        }
+        assert "driver_stats_v1" not in names
+        assert "driver_stats_v2" in names
+
+    def test_unversioned_store_still_round_trips(self):
+        """The default path must be untouched by the versioning change."""
+        config = _config(False)
+        store = QdrantOnlineStore()
+        fv = _feature_view()
+
+        store.update(config, [], [fv], [], [], partial=False)
+        _write(store, config, fv, "value")
+
+        client = store._get_client(config)
+        assert client.count("driver_stats").count == 1


### PR DESCRIPTION
Closes #6179. Part of #2728.

## What this does

Routes every Qdrant collection reference through one helper, so that with
`registry.enable_online_feature_view_versioning: true` each feature view version gets
its own collection (`driver_stats_v2`) instead of all versions sharing one. Applied to
the write, create, update, teardown and document-retrieval paths.

## One deliberate deviation from the FAISS/Milvus precedent

Those stores use `compute_table_id(project, table, versioning)`, which yields
`{project}_{name}[_v{N}]`. **This PR uses `compute_versioned_name` instead**, which yields
`{name}[_v{N}]` with no project prefix.

The reason is that Qdrant collections have always been named by the bare `table.name` —
unlike Milvus, which already had the `{project}_` prefix before versioning was added to it,
so gaining the flag there was non-breaking. Switching Qdrant to `compute_table_id` would
rename every collection in every existing deployment and orphan their data. With versioning
disabled the collection name here is byte-identical to today's, which
`test_unversioned_store_still_round_trips` pins.

Happy to switch to the project-prefixed form if you'd rather have consistency across
stores and want to handle the migration — just say so.

## Why `online_read` is *not* added to the versioned-read allowlist

I did not add `QdrantOnlineStore` to `OnlineStore._is_versioned_read_supported()`, because
`QdrantOnlineStore.online_read` cannot currently serve any read, versioned or not. It looks
like it has never been exercised — there is no unit test for it, and it fails on two
independent counts before reaching Qdrant:

1. it passes raw `EntityKeyProto` objects into `models.MatchAny(any=entity_keys)`, which
   pydantic rejects (`Input should be a valid string`), and
2. it reads `collection_name=config.online_store.collection_name`, but neither
   `QdrantOnlineStoreConfig` nor `VectorStoreConfig` defines `collection_name`, so that
   line raises `AttributeError`.

It also returns one entry per stored point holding a base64 `str`, where the
`OnlineStore.online_read` contract (see `sqlite.py`) is one entry per requested entity key,
in order, holding `ValueProto` values, with `(None, None)` for a miss.

Reproduction, stock `main`, no external service — an in-process Qdrant is enough:

```python
from datetime import datetime, timedelta
from feast import Entity, FeatureView, Field, FileSource, RepoConfig
from feast.types import Int64, String
from feast.value_type import ValueType
from feast.protos.feast.types.EntityKey_pb2 import EntityKey as EntityKeyProto
from feast.protos.feast.types.Value_pb2 import Value as ValueProto
from feast.infra.online_stores.qdrant_online_store.qdrant import (
    QdrantOnlineStore, QdrantOnlineStoreConfig,
)

cfg = RepoConfig(
    project="proj",
    online_store=QdrantOnlineStoreConfig(
        type="qdrant", location=":memory:", vector_enabled=True, similarity="cosine"
    ),
    registry="dummy",
    entity_key_serialization_version=3,
)
fv = FeatureView(
    name="stats",
    entities=[Entity(name="user_id", value_type=ValueType.INT64)],
    ttl=timedelta(days=1),
    schema=[Field(name="user_id", dtype=Int64), Field(name="f1", dtype=String)],
    source=FileSource(path="t.parquet", timestamp_field="event_timestamp"),
)
store = QdrantOnlineStore()
store.update(cfg, [], [fv], [], [], partial=False)

ek = EntityKeyProto(join_keys=["user_id"], entity_values=[ValueProto(int64_val=1)])
store.online_write_batch(
    cfg, fv, [(ek, {"f1": ValueProto(string_val="v1")}, datetime(2024, 1, 1), None)], None
)          # -> succeeds

store.online_read(cfg, fv, [ek], ["f1"])
# pydantic_core._pydantic_core.ValidationError: 2 validation errors for MatchAny
#   any.list[str].0  Input should be a valid string ... input_type=EntityKey
```

Fixing that properly means deciding how `entity_key` should be stored — it is currently
written into the payload as raw `bytes` from `serialize_entity_key`, which `MatchAny` cannot
filter on, and which `retrieve_online_documents` then reads back through
`str(payload.get("entity_key"))`, producing a `bytes` repr rather than the value
`_build_retrieve_online_document_record` expects. That is a storage-format call I did not
want to make unilaterally inside a versioning PR, so I have kept it out of scope. Happy to
open a separate issue, or to take it in a follow-up once you've said which encoding you want.

So this PR delivers the versioned collection namespace; versioned scalar reads stay
correctly gated behind `VersionedOnlineReadNotSupported` until `online_read` works.

## Tests

New `sdk/python/tests/unit/infra/online_store/test_qdrant_online_store.py`, 6 tests, running
against an in-process Qdrant (`location=":memory:"`) — no service required, and skipped via
`importorskip` when `qdrant-client` is absent.

- naming: unversioned unchanged, version tag ignored when the flag is off, `_v2` when on
- `test_versions_write_to_separate_collections` — v1 and v2 collections both created, one
  point each, no cross-contamination
- `test_teardown_removes_only_the_targeted_version`
- `test_unversioned_store_still_round_trips` — the control

Verified red-before/green-after: with the change reverted, the two versioning behaviour
tests fail while the unversioned control still passes, so they are testing the change rather
than the setup.

Regression check across the 56 unit test files touching online stores: the set of failing
and erroring tests is **identical** with and without this change (`diff` of the sorted
`FAILED`/`ERROR` lines is empty). Those pre-existing failures are missing optional
dependencies in my environment. `ruff check`, `ruff format` and `mypy` are clean on both
files.

---
🤖 Written with [Claude Code](https://claude.com/claude-code) (Claude Opus 5), reviewed by @arose26.
