### PR TITLE
fix: Feature freshness logic updated

### DIFF
--- a/docs/how-to-guides/feature-monitoring.md
+++ b/docs/how-to-guides/feature-monitoring.md
@@ -219,6 +219,7 @@ GET /monitoring/metrics/features?project=my_project&feature_view_name=driver_sta
     "feature_name": "conv_rate",
     "feature_type": "numeric",
     "metric_date": "2025-03-26",
+    "max_event_timestamp": "2025-03-27T14:30:00+00:00",
     "granularity": "daily",
     "data_source_type": "batch",
     "row_count": 15000,
@@ -241,6 +242,8 @@ GET /monitoring/metrics/features?project=my_project&feature_view_name=driver_sta
   }
 ]
 ```
+
+The UI **Freshness** column uses `max_event_timestamp` — `MAX(event_timestamp)` from the source — not `metric_date` (the DQM window start). Age is `now − max_event_timestamp`.
 
 ### Per-feature-view aggregates
 

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -693,7 +693,7 @@ def _bq_scalar_param_type(column: str) -> str:
         return "BOOL"
     if column == "metric_date":
         return "DATE"
-    if column == "computed_at":
+    if column in ("computed_at", "max_event_timestamp"):
         return "TIMESTAMP"
     if column in {
         "row_count",
@@ -889,6 +889,7 @@ CREATE TABLE IF NOT EXISTS `{proj}.{ds}.{MON_TABLE_FEATURE}` (
   granularity STRING NOT NULL,
   data_source_type STRING NOT NULL,
   computed_at TIMESTAMP NOT NULL,
+  max_event_timestamp TIMESTAMP,
   is_baseline BOOL NOT NULL,
   feature_type STRING NOT NULL,
   row_count INT64,
@@ -915,6 +916,7 @@ CREATE TABLE IF NOT EXISTS `{proj}.{ds}.{MON_TABLE_FEATURE_VIEW}` (
   granularity STRING NOT NULL,
   data_source_type STRING NOT NULL,
   computed_at TIMESTAMP NOT NULL,
+  max_event_timestamp TIMESTAMP,
   is_baseline BOOL NOT NULL,
   total_row_count INT64,
   total_features INT64,
@@ -932,6 +934,7 @@ CREATE TABLE IF NOT EXISTS `{proj}.{ds}.{MON_TABLE_FEATURE_SERVICE}` (
   granularity STRING NOT NULL,
   data_source_type STRING NOT NULL,
   computed_at TIMESTAMP NOT NULL,
+  max_event_timestamp TIMESTAMP,
   is_baseline BOOL NOT NULL,
   total_feature_views INT64,
   total_features INT64,
@@ -958,6 +961,11 @@ PRIMARY KEY (job_id) NOT ENFORCED
 """
     for ddl in (feature_ddl, view_ddl, service_ddl, job_ddl):
         client.query(ddl).result()
+    for tbl in (MON_TABLE_FEATURE, MON_TABLE_FEATURE_VIEW, MON_TABLE_FEATURE_SERVICE):
+        client.query(
+            f"ALTER TABLE `{proj}.{ds}.{tbl}` "
+            "ADD COLUMN IF NOT EXISTS max_event_timestamp TIMESTAMP"
+        ).result()
 
 
 def _bq_get_monitoring_max_timestamp(

--- a/sdk/python/feast/infra/offline_stores/contrib/oracle_offline_store/oracle.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/oracle_offline_store/oracle.py
@@ -715,6 +715,7 @@ class OracleOfflineStore(OfflineStore):
               granularity        VARCHAR2(20) DEFAULT 'daily' NOT NULL,
               data_source_type   VARCHAR2(50) DEFAULT 'batch' NOT NULL,
               computed_at        TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+              max_event_timestamp TIMESTAMP WITH TIME ZONE,
               is_baseline        NUMBER(1) DEFAULT 0 NOT NULL,
               feature_type       VARCHAR2(50) NOT NULL,
               row_count          NUMBER,
@@ -746,6 +747,7 @@ class OracleOfflineStore(OfflineStore):
               granularity        VARCHAR2(20) DEFAULT 'daily' NOT NULL,
               data_source_type   VARCHAR2(50) DEFAULT 'batch' NOT NULL,
               computed_at        TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+              max_event_timestamp TIMESTAMP WITH TIME ZONE,
               is_baseline        NUMBER(1) DEFAULT 0 NOT NULL,
               total_row_count    NUMBER,
               total_features     NUMBER,
@@ -768,6 +770,7 @@ class OracleOfflineStore(OfflineStore):
               granularity          VARCHAR2(20) DEFAULT 'daily' NOT NULL,
               data_source_type     VARCHAR2(50) DEFAULT 'batch' NOT NULL,
               computed_at          TIMESTAMP WITH TIME ZONE DEFAULT SYSTIMESTAMP NOT NULL,
+              max_event_timestamp  TIMESTAMP WITH TIME ZONE,
               is_baseline          NUMBER(1) DEFAULT 0 NOT NULL,
               total_feature_views  NUMBER,
               total_features       NUMBER,
@@ -777,6 +780,19 @@ class OracleOfflineStore(OfflineStore):
                 metric_date, granularity, data_source_type)
             )
             """,
+        )
+
+        _oracle_try_execute_ddl(
+            con,
+            f"ALTER TABLE {MON_TABLE_FEATURE} ADD (max_event_timestamp TIMESTAMP WITH TIME ZONE)",
+        )
+        _oracle_try_execute_ddl(
+            con,
+            f"ALTER TABLE {MON_TABLE_FEATURE_VIEW} ADD (max_event_timestamp TIMESTAMP WITH TIME ZONE)",
+        )
+        _oracle_try_execute_ddl(
+            con,
+            f"ALTER TABLE {MON_TABLE_FEATURE_SERVICE} ADD (max_event_timestamp TIMESTAMP WITH TIME ZONE)",
         )
 
         _oracle_try_execute_ddl(

--- a/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/postgres_offline_store/postgres.py
@@ -429,6 +429,7 @@ class PostgreSQLOfflineStore(OfflineStore):
                     granularity       VARCHAR(20)  NOT NULL DEFAULT 'daily',
                     data_source_type  VARCHAR(50)  NOT NULL DEFAULT 'batch',
                     computed_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+                    max_event_timestamp TIMESTAMPTZ,
                     is_baseline       BOOLEAN      NOT NULL DEFAULT FALSE,
                     feature_type      VARCHAR(50)  NOT NULL,
                     row_count         BIGINT,
@@ -468,6 +469,7 @@ class PostgreSQLOfflineStore(OfflineStore):
                     granularity       VARCHAR(20)  NOT NULL DEFAULT 'daily',
                     data_source_type  VARCHAR(50)  NOT NULL DEFAULT 'batch',
                     computed_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+                    max_event_timestamp TIMESTAMPTZ,
                     is_baseline       BOOLEAN      NOT NULL DEFAULT FALSE,
                     total_row_count   BIGINT,
                     total_features    INTEGER,
@@ -487,6 +489,7 @@ class PostgreSQLOfflineStore(OfflineStore):
                     granularity          VARCHAR(20)  NOT NULL DEFAULT 'daily',
                     data_source_type     VARCHAR(50)  NOT NULL DEFAULT 'batch',
                     computed_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+                    max_event_timestamp  TIMESTAMPTZ,
                     is_baseline          BOOLEAN      NOT NULL DEFAULT FALSE,
                     total_feature_views  INTEGER,
                     total_features       INTEGER,
@@ -495,6 +498,15 @@ class PostgreSQLOfflineStore(OfflineStore):
                     PRIMARY KEY (project_id, feature_service_name, metric_date,
                                  granularity, data_source_type)
                 );
+            """)
+
+            cur.execute(f"""
+                ALTER TABLE {MON_TABLE_FEATURE}
+                    ADD COLUMN IF NOT EXISTS max_event_timestamp TIMESTAMPTZ;
+                ALTER TABLE {MON_TABLE_FEATURE_VIEW}
+                    ADD COLUMN IF NOT EXISTS max_event_timestamp TIMESTAMPTZ;
+                ALTER TABLE {MON_TABLE_FEATURE_SERVICE}
+                    ADD COLUMN IF NOT EXISTS max_event_timestamp TIMESTAMPTZ;
             """)
 
             cur.execute(f"""

--- a/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
+++ b/sdk/python/feast/infra/offline_stores/contrib/spark_offline_store/spark.py
@@ -574,6 +574,18 @@ class SparkOfflineStore(OfflineStore):
         )
         for stmt in _SPARK_MONITORING_DDL_STATEMENTS:
             spark_session.sql(stmt)
+        from pyspark.sql.utils import AnalysisException
+
+        for stmt in (
+            f"ALTER TABLE {MON_TABLE_FEATURE} ADD COLUMNS (max_event_timestamp TIMESTAMP)",
+            f"ALTER TABLE {MON_TABLE_FEATURE_VIEW} ADD COLUMNS (max_event_timestamp TIMESTAMP)",
+            f"ALTER TABLE {MON_TABLE_FEATURE_SERVICE} ADD COLUMNS (max_event_timestamp TIMESTAMP)",
+        ):
+            try:
+                spark_session.sql(stmt)
+            except AnalysisException:
+                # Column already exists on newly created tables.
+                pass
 
     @staticmethod
     def save_monitoring_metrics(
@@ -678,6 +690,7 @@ CREATE TABLE IF NOT EXISTS {MON_TABLE_FEATURE} (
     granularity       STRING NOT NULL,
     data_source_type  STRING NOT NULL,
     computed_at       TIMESTAMP NOT NULL,
+    max_event_timestamp TIMESTAMP,
     is_baseline       BOOLEAN NOT NULL,
     feature_type      STRING NOT NULL,
     row_count         BIGINT,
@@ -703,6 +716,7 @@ CREATE TABLE IF NOT EXISTS {MON_TABLE_FEATURE_VIEW} (
     granularity       STRING NOT NULL,
     data_source_type  STRING NOT NULL,
     computed_at       TIMESTAMP NOT NULL,
+    max_event_timestamp TIMESTAMP,
     is_baseline       BOOLEAN NOT NULL,
     total_row_count   BIGINT,
     total_features    INT,
@@ -719,6 +733,7 @@ CREATE TABLE IF NOT EXISTS {MON_TABLE_FEATURE_SERVICE} (
     granularity          STRING NOT NULL,
     data_source_type     STRING NOT NULL,
     computed_at          TIMESTAMP NOT NULL,
+    max_event_timestamp  TIMESTAMP,
     is_baseline          BOOLEAN NOT NULL,
     total_feature_views  INT,
     total_features       INT,

--- a/sdk/python/feast/infra/offline_stores/dask.py
+++ b/sdk/python/feast/infra/offline_stores/dask.py
@@ -40,6 +40,7 @@ from feast.infra.registry.base_registry import BaseRegistry
 from feast.monitoring.monitoring_utils import (
     MONITORING_DIR,
     MONITORING_PARQUET_FILES,
+    MONITORING_TIMESTAMP_FIELDS,
     monitoring_parquet_meta,
     normalize_monitoring_row,
     opt_float,
@@ -968,7 +969,7 @@ def _dask_parquet_query(
     for _, row in df.iterrows():
         record = {c: row.get(c) for c in columns}
         normalize_monitoring_row(record)
-        for key in ("metric_date", "computed_at"):
+        for key in MONITORING_TIMESTAMP_FIELDS:
             val = record.get(key)
             if (
                 val is not None

--- a/sdk/python/feast/infra/offline_stores/duckdb.py
+++ b/sdk/python/feast/infra/offline_stores/duckdb.py
@@ -39,6 +39,7 @@ from feast.infra.registry.base_registry import BaseRegistry
 from feast.monitoring.monitoring_utils import (
     MONITORING_DIR,
     MONITORING_PARQUET_FILES,
+    MONITORING_TIMESTAMP_FIELDS,
     empty_categorical_metric,
     empty_numeric_metric,
     monitoring_parquet_meta,
@@ -487,7 +488,7 @@ def _duckdb_parquet_query(
     for _, row in df.iterrows():
         record = {c: row.get(c) for c in columns}
         normalize_monitoring_row(record)
-        for key in ("metric_date", "computed_at"):
+        for key in MONITORING_TIMESTAMP_FIELDS:
             val = record.get(key)
             if (
                 val is not None

--- a/sdk/python/feast/infra/offline_stores/redshift.py
+++ b/sdk/python/feast/infra/offline_stores/redshift.py
@@ -555,6 +555,7 @@ CREATE TABLE IF NOT EXISTS {MON_TABLE_FEATURE} (
     granularity       VARCHAR(20)  NOT NULL DEFAULT 'daily',
     data_source_type  VARCHAR(50)  NOT NULL DEFAULT 'batch',
     computed_at       TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    max_event_timestamp TIMESTAMPTZ,
     is_baseline       BOOLEAN      NOT NULL DEFAULT FALSE,
     feature_type      VARCHAR(50)  NOT NULL,
     row_count         BIGINT,
@@ -582,6 +583,7 @@ CREATE TABLE IF NOT EXISTS {MON_TABLE_FEATURE_VIEW} (
     granularity       VARCHAR(20)  NOT NULL DEFAULT 'daily',
     data_source_type  VARCHAR(50)  NOT NULL DEFAULT 'batch',
     computed_at       TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    max_event_timestamp TIMESTAMPTZ,
     is_baseline       BOOLEAN      NOT NULL DEFAULT FALSE,
     total_row_count   BIGINT,
     total_features    INTEGER,
@@ -600,6 +602,7 @@ CREATE TABLE IF NOT EXISTS {MON_TABLE_FEATURE_SERVICE} (
     granularity          VARCHAR(20)  NOT NULL DEFAULT 'daily',
     data_source_type     VARCHAR(50)  NOT NULL DEFAULT 'batch',
     computed_at          TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    max_event_timestamp  TIMESTAMPTZ,
     is_baseline          BOOLEAN      NOT NULL DEFAULT FALSE,
     total_feature_views  INTEGER,
     total_features       INTEGER,
@@ -625,6 +628,9 @@ CREATE TABLE IF NOT EXISTS {MON_TABLE_JOB} (
     PRIMARY KEY (job_id)
 );
 """,
+    f"ALTER TABLE {MON_TABLE_FEATURE} ADD COLUMN IF NOT EXISTS max_event_timestamp TIMESTAMPTZ",
+    f"ALTER TABLE {MON_TABLE_FEATURE_VIEW} ADD COLUMN IF NOT EXISTS max_event_timestamp TIMESTAMPTZ",
+    f"ALTER TABLE {MON_TABLE_FEATURE_SERVICE} ADD COLUMN IF NOT EXISTS max_event_timestamp TIMESTAMPTZ",
 ]
 
 

--- a/sdk/python/feast/infra/offline_stores/snowflake.py
+++ b/sdk/python/feast/infra/offline_stores/snowflake.py
@@ -564,6 +564,7 @@ class SnowflakeOfflineStore(OfflineStore):
                 "granularity"       VARCHAR(20)  NOT NULL DEFAULT 'daily',
                 "data_source_type"  VARCHAR(50)  NOT NULL DEFAULT 'batch',
                 "computed_at"       TIMESTAMP_TZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+                "max_event_timestamp" TIMESTAMP_TZ,
                 "is_baseline"       BOOLEAN      NOT NULL DEFAULT FALSE,
                 "feature_type"      VARCHAR(50)  NOT NULL,
                 "row_count"         BIGINT,
@@ -591,6 +592,7 @@ class SnowflakeOfflineStore(OfflineStore):
                 "granularity"       VARCHAR(20)  NOT NULL DEFAULT 'daily',
                 "data_source_type"  VARCHAR(50)  NOT NULL DEFAULT 'batch',
                 "computed_at"       TIMESTAMP_TZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+                "max_event_timestamp" TIMESTAMP_TZ,
                 "is_baseline"       BOOLEAN      NOT NULL DEFAULT FALSE,
                 "total_row_count"   BIGINT,
                 "total_features"    INTEGER,
@@ -609,6 +611,7 @@ class SnowflakeOfflineStore(OfflineStore):
                 "granularity"          VARCHAR(20)  NOT NULL DEFAULT 'daily',
                 "data_source_type"     VARCHAR(50)  NOT NULL DEFAULT 'batch',
                 "computed_at"          TIMESTAMP_TZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+                "max_event_timestamp"  TIMESTAMP_TZ,
                 "is_baseline"          BOOLEAN      NOT NULL DEFAULT FALSE,
                 "total_feature_views"  INTEGER,
                 "total_features"       INTEGER,
@@ -642,6 +645,11 @@ class SnowflakeOfflineStore(OfflineStore):
             execute_snowflake_statement(conn, ddl_view)
             execute_snowflake_statement(conn, ddl_service)
             execute_snowflake_statement(conn, ddl_job)
+            for fq in (fq_feature, fq_view, fq_service):
+                execute_snowflake_statement(
+                    conn,
+                    f'ALTER TABLE {fq} ADD COLUMN IF NOT EXISTS "max_event_timestamp" TIMESTAMP_TZ',
+                )
 
     @staticmethod
     def save_monitoring_metrics(

--- a/sdk/python/feast/monitoring/monitoring_service.py
+++ b/sdk/python/feast/monitoring/monitoring_service.py
@@ -29,6 +29,37 @@ GRANULARITY_WINDOWS = {
     "quarterly": timedelta(days=90),
 }
 
+
+def _as_utc_datetime(val: Any) -> Optional[datetime]:
+    """Parse a timestamp-like value to a timezone-aware UTC datetime."""
+    if val is None:
+        return None
+    if isinstance(val, datetime):
+        return val if val.tzinfo else val.replace(tzinfo=timezone.utc)
+    if isinstance(val, date):
+        return datetime.combine(val, datetime.min.time(), tzinfo=timezone.utc)
+    if isinstance(val, str):
+        parsed = datetime.fromisoformat(val.replace("Z", "+00:00"))
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return None
+
+
+def _newest_event_in_window(
+    max_ts: Optional[datetime],
+    start_dt: datetime,
+    end_dt: datetime,
+) -> Optional[datetime]:
+    """Newest source event that falls inside ``[start_dt, end_dt]``.
+
+    ``max_ts`` is MAX(event_timestamp) over the whole source. If that
+    timestamp is after the window, the window end is used as an upper bound.
+    """
+    aware_max = _as_utc_datetime(max_ts)
+    if aware_max is None or aware_max < start_dt:
+        return None
+    return min(aware_max, end_dt)
+
+
 _FLOAT_FIELDS = frozenset(
     {
         "null_rate",
@@ -146,6 +177,7 @@ class MonitoringService:
                             granularity="baseline",
                             set_baseline=True,
                             now=now,
+                            max_event_timestamp=max_ts,
                         )
                         baseline_features += len(bl_metrics)
 
@@ -165,6 +197,7 @@ class MonitoringService:
                         granularity=granularity,
                         set_baseline=False,
                         now=now,
+                        max_event_timestamp=max_ts,
                     )
                     self._compute_feature_service_metrics(
                         project=project,
@@ -251,6 +284,11 @@ class MonitoringService:
             granularity=granularity,
             set_baseline=set_baseline,
             now=now,
+            max_event_timestamp=_newest_event_in_window(
+                self._get_max_timestamp_for_source(data_source, ts_field),
+                start_dt,
+                end_dt,
+            ),
         )
 
         duration_ms = int((time.time() - start_time) * 1000)
@@ -324,6 +362,7 @@ class MonitoringService:
                         granularity=gran,
                         set_baseline=False,
                         now=now,
+                        max_event_timestamp=max_ts,
                     )
                     total_features += len(metrics_list)
                     granularities_computed.add(gran)
@@ -402,6 +441,7 @@ class MonitoringService:
                     granularity="baseline",
                     set_baseline=True,
                     now=now,
+                    max_event_timestamp=self._get_max_timestamp(fv),
                 )
 
                 total_features += len(metrics_list)
@@ -834,6 +874,7 @@ class MonitoringService:
         granularity: str,
         set_baseline: bool,
         now: datetime,
+        max_event_timestamp: Optional[datetime] = None,
     ) -> None:
         if not metrics_list:
             return
@@ -855,6 +896,7 @@ class MonitoringService:
             m["granularity"] = granularity
             m["data_source_type"] = "batch"
             m["computed_at"] = now
+            m["max_event_timestamp"] = max_event_timestamp
             m["is_baseline"] = set_baseline
 
         offline_store.save_monitoring_metrics(config, "feature", metrics_list)
@@ -866,6 +908,7 @@ class MonitoringService:
             "granularity": granularity,
             "data_source_type": "batch",
             "computed_at": now,
+            "max_event_timestamp": max_event_timestamp,
             "is_baseline": set_baseline,
             **build_view_aggregate(metrics_list),
         }
@@ -950,6 +993,11 @@ class MonitoringService:
             granularity=granularity,
             set_baseline=set_baseline,
             now=now,
+            max_event_timestamp=_newest_event_in_window(
+                self._get_max_timestamp(feature_view),
+                start_dt,
+                end_dt,
+            ),
         )
 
         return {"feature_count": len(metrics_list), "dates": {metric_date}}
@@ -1119,6 +1167,7 @@ class MonitoringService:
         granularity: str,
         set_baseline: bool,
         now: datetime,
+        max_event_timestamp: Optional[datetime] = None,
     ) -> None:
         """Save log-sourced metrics tagged with data_source_type='log'.
 
@@ -1145,6 +1194,7 @@ class MonitoringService:
             m["granularity"] = granularity
             m["data_source_type"] = "log"
             m["computed_at"] = now
+            m["max_event_timestamp"] = max_event_timestamp
             m["is_baseline"] = set_baseline
 
         offline_store.save_monitoring_metrics(config, "feature", metrics_list)
@@ -1162,6 +1212,7 @@ class MonitoringService:
                 "granularity": granularity,
                 "data_source_type": "log",
                 "computed_at": now,
+                "max_event_timestamp": max_event_timestamp,
                 "is_baseline": set_baseline,
                 **build_view_aggregate(vmetrics),
             }
@@ -1178,6 +1229,7 @@ class MonitoringService:
             "granularity": granularity,
             "data_source_type": "log",
             "computed_at": now,
+            "max_event_timestamp": max_event_timestamp,
             "is_baseline": set_baseline,
             "total_feature_views": len(by_view),
             "total_features": svc_agg["total_features"],
@@ -1252,6 +1304,15 @@ class MonitoringService:
                         if m.get("avg_null_rate") is not None
                     ]
 
+                    newest_events = [
+                        ts
+                        for ts in (
+                            _as_utc_datetime(m.get("max_event_timestamp"))
+                            for m in relevant
+                        )
+                        if ts is not None
+                    ]
+
                     service_metric = {
                         "project_id": project,
                         "feature_service_name": fs.name,
@@ -1261,6 +1322,9 @@ class MonitoringService:
                         "granularity": granularity,
                         "data_source_type": "batch",
                         "computed_at": now,
+                        "max_event_timestamp": max(newest_events)
+                        if newest_events
+                        else None,
                         "is_baseline": set_baseline,
                         "total_feature_views": len(relevant),
                         "total_features": sum(

--- a/sdk/python/feast/monitoring/monitoring_service.py
+++ b/sdk/python/feast/monitoring/monitoring_service.py
@@ -493,6 +493,7 @@ class MonitoringService:
 
         for fv in feature_views:
             try:
+                max_ts = self._get_max_timestamp(fv)
                 fv_metrics = self._compute_for_feature_view(
                     project=project,
                     feature_view=fv,
@@ -501,6 +502,7 @@ class MonitoringService:
                     end_dt=end_dt,
                     granularity=granularity,
                     set_baseline=set_baseline,
+                    max_event_timestamp=max_ts,
                 )
                 total_features += fv_metrics["feature_count"]
                 total_views += 1
@@ -968,6 +970,7 @@ class MonitoringService:
         end_dt: datetime,
         granularity: str,
         set_baseline: bool,
+        max_event_timestamp: Optional[datetime] = None,
     ) -> Dict[str, Any]:
         feature_fields = self._classify_fields(
             feature_view, feature_names=feature_names
@@ -994,7 +997,7 @@ class MonitoringService:
             set_baseline=set_baseline,
             now=now,
             max_event_timestamp=_newest_event_in_window(
-                self._get_max_timestamp(feature_view),
+                max_event_timestamp,
                 start_dt,
                 end_dt,
             ),

--- a/sdk/python/feast/monitoring/monitoring_utils.py
+++ b/sdk/python/feast/monitoring/monitoring_utils.py
@@ -32,6 +32,13 @@ MONITORING_PARQUET_FILES: Dict[str, str] = {
 #  Column definitions — (ordered, used by INSERT / SELECT / Parquet)
 # ------------------------------------------------------------------ #
 
+# Datetime fields serialized to ISO-8601 on read.
+MONITORING_TIMESTAMP_FIELDS: Tuple[str, ...] = (
+    "metric_date",
+    "computed_at",
+    "max_event_timestamp",
+)
+
 FEATURE_METRICS_COLUMNS: List[str] = [
     "project_id",
     "feature_view_name",
@@ -40,6 +47,7 @@ FEATURE_METRICS_COLUMNS: List[str] = [
     "granularity",
     "data_source_type",
     "computed_at",
+    "max_event_timestamp",
     "is_baseline",
     "feature_type",
     "row_count",
@@ -73,6 +81,7 @@ FEATURE_VIEW_METRICS_COLUMNS: List[str] = [
     "granularity",
     "data_source_type",
     "computed_at",
+    "max_event_timestamp",
     "is_baseline",
     "total_row_count",
     "total_features",
@@ -96,6 +105,7 @@ FEATURE_SERVICE_METRICS_COLUMNS: List[str] = [
     "granularity",
     "data_source_type",
     "computed_at",
+    "max_event_timestamp",
     "is_baseline",
     "total_feature_views",
     "total_features",
@@ -238,7 +248,8 @@ def normalize_monitoring_row(record: Dict[str, Any]) -> Dict[str, Any]:
 
     - Replaces float NaN / Inf with None (not JSON-serializable).
     - Parses ``histogram`` from JSON string if needed.
-    - Converts ``metric_date`` / ``computed_at`` to ISO strings.
+    - Converts ``metric_date`` / ``computed_at`` / ``max_event_timestamp``
+      to ISO strings.
     - Normalizes ``is_baseline`` to Python bool.
     """
     import math
@@ -254,8 +265,14 @@ def normalize_monitoring_row(record: Dict[str, Any]) -> Dict[str, Any]:
         except (json.JSONDecodeError, TypeError):
             pass
 
-    for key in ("metric_date", "computed_at"):
+    for key in MONITORING_TIMESTAMP_FIELDS:
         val = record.get(key)
+        if val is None:
+            continue
+        # pandas NaT / NaN leak through parquet reads as non-datetime sentinels.
+        if val is not val or str(val) == "NaT":
+            record[key] = None
+            continue
         if isinstance(val, (date, datetime)):
             record[key] = val.isoformat()
 

--- a/sdk/python/tests/integration/monitoring/test_monitoring_integration.py
+++ b/sdk/python/tests/integration/monitoring/test_monitoring_integration.py
@@ -780,6 +780,16 @@ class TestComputeEngineDispatch:
         provider.offline_store.compute_monitoring_metrics.assert_called()
         provider.offline_store.pull_all_from_table_or_query.assert_not_called()
 
+        newest = datetime(2025, 3, 27, tzinfo=timezone.utc)
+        feature_saves = [
+            call
+            for call in provider.offline_store.save_monitoring_metrics.call_args_list
+            if call.args[1] == "feature"
+        ]
+        assert feature_saves
+        saved = feature_saves[0].args[2]
+        assert all(row["max_event_timestamp"] == newest for row in saved)
+
 
 # ------------------------------------------------------------------ #
 #  Test: Native storage dispatch

--- a/sdk/python/tests/unit/monitoring/test_feature_freshness.py
+++ b/sdk/python/tests/unit/monitoring/test_feature_freshness.py
@@ -1,0 +1,85 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from feast.monitoring.monitoring_service import (
+    MonitoringService,
+    _newest_event_in_window,
+)
+from feast.types import PrimitiveFeastType
+
+
+class TestNewestEventInWindow:
+    def test_uses_source_max_when_inside_window(self):
+        max_ts = datetime(2025, 3, 26, 14, 30, tzinfo=timezone.utc)
+        start = datetime(2025, 3, 25, 14, 30, tzinfo=timezone.utc)
+        end = datetime(2025, 3, 26, 14, 30, tzinfo=timezone.utc)
+        assert _newest_event_in_window(max_ts, start, end) == max_ts
+
+    def test_clamps_to_window_end_when_source_is_newer(self):
+        max_ts = datetime(2025, 4, 1, tzinfo=timezone.utc)
+        start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2025, 1, 15, tzinfo=timezone.utc)
+        assert _newest_event_in_window(max_ts, start, end) == end
+
+    def test_returns_none_when_source_is_before_window(self):
+        max_ts = datetime(2024, 12, 1, tzinfo=timezone.utc)
+        start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2025, 1, 15, tzinfo=timezone.utc)
+        assert _newest_event_in_window(max_ts, start, end) is None
+
+
+def test_auto_compute_persists_newest_event_timestamp():
+    field = MagicMock()
+    field.name = "conv_rate"
+    field.dtype = PrimitiveFeastType.FLOAT64
+    fv = MagicMock()
+    fv.name = "driver_stats"
+    fv.features = [field]
+    fv.entities = []
+    fv.batch_source.timestamp_field = "event_timestamp"
+    fv.batch_source.created_timestamp_column = ""
+
+    store = MagicMock()
+    store.config.project = "test_project"
+    store.registry.list_feature_views.return_value = [fv]
+    store.registry.list_entities.return_value = []
+    store.registry.list_feature_services.return_value = []
+    store.registry.get_feature_view.return_value = fv
+
+    newest = datetime(2025, 3, 27, 14, 30, tzinfo=timezone.utc)
+    provider = store._get_provider.return_value
+    provider.offline_store.get_monitoring_max_timestamp.side_effect = None
+    provider.offline_store.get_monitoring_max_timestamp.return_value = newest
+    provider.offline_store.compute_monitoring_metrics.side_effect = None
+    provider.offline_store.compute_monitoring_metrics.return_value = [
+        {
+            "feature_name": "conv_rate",
+            "feature_type": "numeric",
+            "row_count": 5,
+            "null_count": 0,
+            "null_rate": 0.0,
+            "mean": 0.5,
+            "stddev": 0.2,
+            "min_val": 0.1,
+            "max_val": 0.9,
+            "p50": 0.5,
+            "p75": 0.7,
+            "p90": 0.9,
+            "p95": 0.9,
+            "p99": 0.9,
+            "histogram": None,
+        },
+    ]
+    provider.offline_store.query_monitoring_metrics.return_value = []
+
+    result = MonitoringService(store).auto_compute(project="test_project")
+    assert result["status"] == "completed"
+
+    feature_saves = [
+        call
+        for call in provider.offline_store.save_monitoring_metrics.call_args_list
+        if call.args[1] == "feature"
+    ]
+    assert feature_saves
+    saved = feature_saves[0].args[2]
+    assert all(row["max_event_timestamp"] == newest for row in saved)

--- a/ui/src/pages/monitoring/FeatureMetricsTable.tsx
+++ b/ui/src/pages/monitoring/FeatureMetricsTable.tsx
@@ -39,9 +39,10 @@ const formatNum = (val: number | null, decimals = 2): string => {
   return val.toFixed(decimals);
 };
 
-const formatFreshness = (computedAt: string | null): string => {
-  if (!computedAt) return "—";
-  const diff = Date.now() - new Date(computedAt).getTime();
+const formatFreshness = (timestamp: string | null): string => {
+  if (!timestamp) return "—";
+  const diff = Date.now() - new Date(timestamp).getTime();
+  if (Number.isNaN(diff)) return "—";
   const mins = Math.floor(diff / 60_000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;
@@ -52,13 +53,17 @@ const formatFreshness = (computedAt: string | null): string => {
   return `${Math.floor(days / 30)}mo ago`;
 };
 
-const freshnessColor = (computedAt: string | null): string => {
-  if (!computedAt) return "subdued";
-  const hrs = (Date.now() - new Date(computedAt).getTime()) / 3_600_000;
+const freshnessColor = (timestamp: string | null): string => {
+  if (!timestamp) return "subdued";
+  const hrs = (Date.now() - new Date(timestamp).getTime()) / 3_600_000;
+  if (Number.isNaN(hrs)) return "subdued";
   if (hrs < 24) return "success";
   if (hrs < 72) return "warning";
   return "danger";
 };
+
+const freshnessTimestamp = (metric: FeatureMetric): string | null =>
+  metric.max_event_timestamp || metric.metric_date || null;
 
 const MiniHistogram = ({ metric }: { metric: FeatureMetric }) => {
   if (!metric.histogram) return <span style={{ color: "#98A2B3" }}>—</span>;
@@ -257,7 +262,7 @@ const FeatureMetricsTable = ({
     {
       title: "Freshness",
       description:
-        "Recency of the underlying data. Green (< 24h old), Yellow (24–72h), Red (> 72h). Hover for the data date.",
+        "Age of the newest source event (MAX of the event timestamp). Green (< 24h old), Yellow (24–72h), Red (> 72h). Hover for the exact event time.",
     },
     {
       title: "Source",
@@ -346,17 +351,20 @@ const FeatureMetricsTable = ({
       render: (val: number | null) => formatNum(val),
     },
     {
-      field: "metric_date",
+      field: "max_event_timestamp",
       name: "Freshness",
       sortable: true,
       width: "110px",
-      render: (val: string) => (
-        <EuiToolTip content={val ? `Data from: ${val}` : "Unknown"}>
-          <EuiHealth color={freshnessColor(val)}>
-            {formatFreshness(val)}
-          </EuiHealth>
-        </EuiToolTip>
-      ),
+      render: (_val: string | null, item: FeatureMetric) => {
+        const ts = freshnessTimestamp(item);
+        return (
+          <EuiToolTip content={ts ? `Newest event: ${ts}` : "Unknown"}>
+            <EuiHealth color={freshnessColor(ts)}>
+              {formatFreshness(ts)}
+            </EuiHealth>
+          </EuiToolTip>
+        );
+      },
     },
     {
       field: "data_source_type",

--- a/ui/src/queries/useMonitoringApi.ts
+++ b/ui/src/queries/useMonitoringApi.ts
@@ -12,6 +12,7 @@ interface FeatureMetric {
   granularity: string;
   data_source_type: string;
   computed_at: string;
+  max_event_timestamp: string | null;
   is_baseline: boolean;
   feature_type: string;
   row_count: number;
@@ -48,6 +49,7 @@ interface FeatureViewMetric {
   granularity: string;
   data_source_type: string;
   computed_at: string;
+  max_event_timestamp: string | null;
   is_baseline: boolean;
   total_row_count: number;
   total_features: number;
@@ -63,6 +65,7 @@ interface FeatureServiceMetric {
   granularity: string;
   data_source_type: string;
   computed_at: string;
+  max_event_timestamp: string | null;
   is_baseline: boolean;
   total_feature_views: number;
   total_features: number;
@@ -188,6 +191,7 @@ const aggregateToFeatureViewMetrics = (
       granularity: feats[0].granularity,
       data_source_type: feats[0].data_source_type,
       computed_at: feats[0].computed_at,
+      max_event_timestamp: feats[0].max_event_timestamp,
       is_baseline: feats[0].is_baseline,
       total_row_count: maxRowCount,
       total_features: feats.length,


### PR DESCRIPTION
# What this PR does / why we need it:

The monitoring UI **Freshness** column previously used `metric_date` (the DQM computation window start) as a proxy for data freshness. This was misleading — `metric_date` reflects *when metrics were computed*, not *how fresh the underlying data is*.

This PR introduces a new `max_event_timestamp` field that stores `MAX(event_timestamp)` from the actual data source. The UI now displays age relative to the newest source event, giving an accurate picture of data staleness.

### Changes

**Backend — `monitoring_service.py`**
- Added `_as_utc_datetime()` helper to normalize timestamp-like values to timezone-aware UTC datetimes.
- Added `_newest_event_in_window()` to clamp the source's max timestamp to the computation window.
- All metric save paths (`_save_computed_metrics`, `_save_log_metrics`) now propagate `max_event_timestamp`.
- Feature service metrics aggregate `max_event_timestamp` across contributing feature views.

**Backend — `monitoring_utils.py`**
- Added `MONITORING_TIMESTAMP_FIELDS` constant to DRY-up timestamp field lists across offline stores.
- Added `max_event_timestamp` to all three column definition lists (feature, feature_view, feature_service).
- `normalize_monitoring_row` now handles pandas NaT/NaN for the new field.

**Schema — all offline stores** (BigQuery, Snowflake, Redshift, Postgres, Spark, Oracle, Dask, DuckDB)
- Added `max_event_timestamp` column to CREATE TABLE DDLs for all three monitoring tables.
- Added `ALTER TABLE … ADD COLUMN` migration for existing tables.

**UI — `FeatureMetricsTable.tsx` / `useMonitoringApi.ts`**
- Freshness column now uses `max_event_timestamp` with a fallback to `metric_date`.
- Fixed `render` function signature (`(_val, item)`) so the full `FeatureMetric` object is passed to the freshness logic.
- Added `Number.isNaN` guards for robustness.
- Updated tooltip to show "Newest event" instead of "Data from".

**Docs**
- Updated `feature-monitoring.md` with `max_event_timestamp` in the example response and clarified the freshness semantics.

# Which issue(s) this PR fixes:

Fixes inaccurate freshness display in the monitoring UI — the column previously showed `metric_date` (computation window) instead of actual data recency.

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [x] Integration tests
- [x] Manual tests

### Tests added
- **`tests/unit/monitoring/test_feature_freshness.py`** — unit tests for `_newest_event_in_window` (inside window, clamped, before window) and end-to-end `auto_compute` verification that `max_event_timestamp` is persisted.
- **`tests/integration/monitoring/test_monitoring_integration.py`** — extended `test_auto_compute_uses_pushdown_for_max_timestamp` to verify `max_event_timestamp` in saved metrics.
- **Manual** — verified on a live cluster with Dask offline store that freshness correctly reflects `MAX(event_timestamp)` from source parquet files.

# Misc

The new column is nullable and added via `ADD COLUMN IF NOT EXISTS` migrations, so this is backward-compatible with existing monitoring tables.