### PR TITLE
fix: Support SQL registry dump

### DIFF
--- a/sdk/python/feast/repo_operations.py
+++ b/sdk/python/feast/repo_operations.py
@@ -26,7 +26,7 @@ from feast.feature_store import FeatureStore
 from feast.feature_view import DUMMY_ENTITY, FeatureView
 from feast.file_utils import replace_str_in_file
 from feast.infra.registry.base_registry import BaseRegistry
-from feast.infra.registry.registry import FEAST_OBJECT_TYPES, FeastObjectType, Registry
+from feast.infra.registry.registry import FEAST_OBJECT_TYPES, FeastObjectType
 from feast.labeling.label_view import LabelView
 from feast.names import adjectives, animals
 from feast.on_demand_feature_view import OnDemandFeatureView
@@ -544,15 +544,9 @@ def teardown(repo_config: RepoConfig, repo_path: Optional[str]):
 
 def registry_dump(repo_config: RepoConfig, repo_path: Path) -> str:
     """For debugging only: output contents of the metadata registry"""
-    registry_config = repo_config.registry
     project = repo_config.project
-    registry = Registry(
-        project,
-        registry_config=registry_config,
-        repo_path=repo_path,
-        auth_config=repo_config.auth_config,
-    )
-    registry_dict = registry.to_dict(project=project)
+    feature_store = FeatureStore(repo_path=str(repo_path), config=repo_config)
+    registry_dict = feature_store.registry.to_dict(project=project)
     return json.dumps(registry_dict, indent=2, sort_keys=True)
 
 

--- a/sdk/python/tests/unit/test_repo_operations_registry_dump.py
+++ b/sdk/python/tests/unit/test_repo_operations_registry_dump.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+
+from feast import Entity, FeatureStore
+from feast.infra.registry.sql import SqlRegistryConfig
+from feast.repo_config import RepoConfig
+from feast.repo_operations import registry_dump
+from feast.value_type import ValueType
+
+
+def test_registry_dump_uses_configured_sql_registry(tmp_path):
+    project = "test_project"
+    config = RepoConfig(
+        project=project,
+        registry=SqlRegistryConfig(path=f"sqlite:///{tmp_path / 'registry.db'}"),
+        provider="local",
+        online_store={"type": "sqlite", "path": str(tmp_path / "online.db")},
+        offline_store={"type": "file"},
+    )
+    store = FeatureStore(repo_path=tmp_path, config=config)
+    store.registry.apply_entity(
+        Entity(
+            name="driver",
+            join_keys=["driver_id"],
+            value_type=ValueType.INT64,
+        ),
+        project,
+    )
+
+    dumped_registry = json.loads(registry_dump(config, tmp_path))
+
+    assert dumped_registry["project"] == project
+    assert [entity["spec"]["name"] for entity in dumped_registry["entities"]] == [
+        "driver"
+    ]


### PR DESCRIPTION
# What this PR does / why we need it:

`feast registry-dump` always instantiated the file-backed `Registry` directly. As a result, a valid SQL registry URL such as `postgresql+psycopg://...` was parsed as if it were an object-storage URI and rejected as an unsupported scheme before any registry data could be read.

This change routes `registry-dump` through `FeatureStore.registry`, the same backend-selection path used by the rest of Feast. SQL, Snowflake, remote, and file-backed registries therefore use their configured implementations, while the repository path is still supplied for relative file registry paths.

The regression test creates a real SQLite-backed SQL registry, writes an entity through `SqlRegistry`, and verifies that `registry_dump()` reads the entity back as JSON. The test fails on `master` with `unsupported scheme sqlite` and passes with this change.

# Which issue(s) this PR fixes:

Fixes #6764

# Checks
- [x] I've made sure the tests are passing.
- [x] My commits are signed off (`git commit -s`)
- [x] My PR title follows [conventional commits](https://www.conventionalcommits.org/) format

## Testing Strategy
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests
- [ ] Testing is not required for this change

Tests and checks run:

- `python -m pytest -q sdk/python/tests/unit/test_repo_operations_registry_dump.py sdk/python/tests/unit/infra/registry/test_sql_registry.py sdk/python/tests/unit/test_registry_string_config.py sdk/python/tests/unit/cli/test_cli_chdir.py` (41 passed)
- `python -m pytest -q -n 0 sdk/python/tests/unit/cli sdk/python/tests/unit/test_repo_operations_registry_dump.py sdk/python/tests/unit/test_repo_operations_validate_feast_project_name.py sdk/python/tests/unit/infra/scaffolding/test_repo_operations.py` (15 passed)
- `pre-commit run --files sdk/python/feast/repo_operations.py sdk/python/tests/unit/test_repo_operations_registry_dump.py`
- `mypy feast/repo_operations.py`
- Manual pre-fix reproduction with a populated SQLite SQL registry, followed by successful JSON output on this branch

# Misc

No documentation changes are needed because this restores the documented backend-independent behavior of `registry-dump`.
