### PR TITLE
fix: Strip trailing space from INT32_LIST type-string key

### DIFF
--- a/sdk/python/feast/type_map.py
+++ b/sdk/python/feast/type_map.py
@@ -562,7 +562,7 @@ def _convert_value_type_str_to_value_type(type_str: str) -> ValueType:
         "UNIX_TIMESTAMP": ValueType.UNIX_TIMESTAMP,
         "BYTES_LIST": ValueType.BYTES_LIST,
         "STRING_LIST": ValueType.STRING_LIST,
-        "INT32_LIST ": ValueType.INT32_LIST,
+        "INT32_LIST": ValueType.INT32_LIST,
         "INT64_LIST": ValueType.INT64_LIST,
         "DOUBLE_LIST": ValueType.DOUBLE_LIST,
         "FLOAT_LIST": ValueType.FLOAT_LIST,

--- a/sdk/python/tests/unit/test_type_map.py
+++ b/sdk/python/tests/unit/test_type_map.py
@@ -50,6 +50,12 @@ def test_null_unix_timestamp_list():
     assert converted[0] is None
 
 
+def test_convert_value_type_str_to_value_type_int_lists():
+    # Regression: "INT32_LIST" once had a trailing space and fell through to STRING.
+    assert _convert_value_type_str_to_value_type("INT32_LIST") == ValueType.INT32_LIST
+    assert _convert_value_type_str_to_value_type("INT64_LIST") == ValueType.INT64_LIST
+
+
 @pytest.mark.parametrize(
     "values",
     (


### PR DESCRIPTION
`_convert_value_type_str_to_value_type` keys the `INT32_LIST` entry as `"INT32_LIST "` (trailing space), so the string `"INT32_LIST"` never matches and silently falls back to `ValueType.STRING`. This removes the stray space so it maps to `ValueType.INT32_LIST`, and adds a regression test (`INT64_LIST` is the unaffected control).

<sub>Developed with AI assistance (Claude Code); I directed the change, reviewed it, and included DCO sign-off.</sub>
