### PR TITLE
test(openlineage): Make test_ordering deterministic instead of sleeping

### DIFF
--- a/sdk/python/tests/unit/openlineage/test_store.py
+++ b/sdk/python/tests/unit/openlineage/test_store.py
@@ -269,10 +269,18 @@ class TestGetRuns:
         runs = store.get_runs(limit=10, offset=3)
         assert len(runs) == 2
 
-    def test_ordering(self, store):
+    def test_ordering(self, store, monkeypatch):
+        # updated_at has millisecond resolution and get_runs orders by it with no
+        # tiebreaker, so give each upsert a distinct, increasing timestamp instead
+        # of sleeping and hoping the wall clock advances a millisecond.
+        import itertools
+
+        from feast.openlineage import store as store_module
+
+        counter = itertools.count(1_000_000)
+        monkeypatch.setattr(store_module.time, "time", lambda: next(counter) / 1000)
         store.upsert_job("ns", "j1", {"facets": {}})
         store.upsert_run("r1", "ns", "j1", "START")
-        time.sleep(0.01)
         store.upsert_run("r2", "ns", "j1", "COMPLETE")
         runs = store.get_runs()
         assert runs[0]["run_id"] == "r2"


### PR DESCRIPTION
`TestGetRuns::test_ordering` asserts the most recently upserted run sorts first. `get_runs()` orders by `updated_at`, which each upsert stamps as `int(time.time() * 1000)` — millisecond resolution, with no secondary sort key. The test slept `time.sleep(0.01)` between the two upserts so `r2`'s timestamp would exceed `r1`'s.

On a coarse-clock platform (e.g. ~15.6 ms timer granularity) a 10 ms sleep can fail to advance the millisecond, so both runs get the *same* `updated_at`, the tie falls back to insertion order, and `r1` sorts first — the assertion flakes.

This replaces the sleep with a monotonic clock injected via `monkeypatch`, so each upsert gets a strictly increasing timestamp deterministically — no wall-clock dependence, no sleep.

Verified against the real `OpenLineageStore` SQL: with a same-millisecond clock the old test returns `r1` (reproduces the flake); with the injected clock it returns `r2` on 200/200 runs.

Release note: NONE

<sub>Developed with AI assistance (Claude Code); I directed, reviewed, and verified it locally.</sub>
