### PR TITLE
fix: Handle empty Arrow tables in write conversion

### DIFF
--- a/sdk/python/feast/utils.py
+++ b/sdk/python/feast/utils.py
@@ -431,6 +431,8 @@ def _convert_arrow_fv_to_proto(
 ) -> List[Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]]:
     # Avoid ChunkedArrays which guarantees `zero_copy_only` available.
     if isinstance(table, pyarrow.Table):
+        if table.num_rows == 0:
+            return []
         table = table.to_batches()[0]
 
     if feature_view.batch_source is None:
@@ -489,6 +491,8 @@ def _convert_arrow_odfv_to_proto(
 ) -> List[Tuple[EntityKeyProto, Dict[str, ValueProto], datetime, Optional[datetime]]]:
     # Avoid ChunkedArrays which guarantees `zero_copy_only` available.
     if isinstance(table, pyarrow.Table):
+        if table.num_rows == 0:
+            return []
         table = table.to_batches()[0]
 
     columns = [

--- a/sdk/python/tests/unit/test_utils.py
+++ b/sdk/python/tests/unit/test_utils.py
@@ -9,12 +9,18 @@ populates the GetOnlineFeaturesResponse.
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
+import pyarrow as pa
+
 from feast.protos.feast.serving.ServingService_pb2 import (
     FieldStatus,
     GetOnlineFeaturesResponse,
 )
 from feast.protos.feast.types.Value_pb2 import Value as ValueProto
-from feast.utils import _populate_response_from_feature_data
+from feast.utils import (
+    _convert_arrow_fv_to_proto,
+    _convert_arrow_odfv_to_proto,
+    _populate_response_from_feature_data,
+)
 
 
 def _make_table(name="test_fv"):
@@ -24,6 +30,14 @@ def _make_table(name="test_fv"):
     table.projection.name_alias = None
     table.projection.name = name
     return table
+
+
+def test_convert_empty_arrow_table_to_proto_returns_no_rows():
+    """A zero-row Arrow Table has no record batches and is a valid empty write."""
+    table = pa.table({"unused": pa.array([], type=pa.string())})
+
+    assert _convert_arrow_fv_to_proto(table, MagicMock(), {}) == []
+    assert _convert_arrow_odfv_to_proto(table, MagicMock(), {}) == []
 
 
 class TestPopulateResponseFromFeatureData:


### PR DESCRIPTION
## What this PR does\n\nFixes #6796.\n\n`_convert_arrow_fv_to_proto` and `_convert_arrow_odfv_to_proto` converted every `pyarrow.Table` by accessing `table.to_batches()[0]`. Zero-row Arrow tables legitimately contain no record batches, making that access raise `IndexError`.\n\nThe helpers now return an empty write payload before converting the table to a record batch. This preserves the natural conversion invariant: zero input rows produce zero output rows.\n\n## User-facing changes\n\nNONE\n\n## Testing\n\nAdded a regression test that passes a zero-row Arrow table to both FeatureView and OnDemandFeatureView conversion paths.\n\n`python -m pytest sdk/python/tests/unit/test_utils.py -q` — 14 passed.